### PR TITLE
feat(skills): upgrade delegate-to-agent skill with frontmatter and content

### DIFF
--- a/.agents/skills/delegate-to-agent/SKILL.md
+++ b/.agents/skills/delegate-to-agent/SKILL.md
@@ -58,7 +58,7 @@ The `submit` option controls whether the message is sent automatically or placed
 
 ```ts
 // Auto-submit: routine operation
-sendToAgentChat({ message: "Regenerate the slide thumbnails", submit: true });
+sendToAgentChat({ message: "Update the project summary", submit: true });
 
 // Prefill: let user review before sending
 sendToAgentChat({
@@ -66,29 +66,6 @@ sendToAgentChat({
   submit: false,
 });
 ```
-
-## Handling Delegated Requests
-
-When the agent receives a message via `sendToAgentChat()`, the typical workflow is:
-
-1. **Read current state** — Check `data/` files for context
-2. **Check UI state** — Read `data-*` attributes on `document.documentElement` or `window.__appState` for current selection/context
-3. **Do the work** — Write results to files in `data/`
-4. **Optionally run scripts** — Use `pnpm script <name>` for complex operations
-5. **Verify** — The SSE watcher updates the UI automatically; no explicit notification needed
-
-## How the Transport Works
-
-`sendToAgentChat()` sends messages via `postMessage` to the parent window (or `window` itself if top-level). The harness (e.g., `harness-claude-code`) receives these messages and forwards them to the agent.
-
-```
-UI Component → sendToAgentChat() → postMessage → Harness → Agent
-```
-
-If `sendToAgentChat()` isn't reaching the agent, check:
-- Is the app running inside the harness iframe?
-- Is the harness listening for `builder.submitChat` messages?
-- Check browser devtools console for postMessage errors
 
 ## Don't
 
@@ -101,11 +78,6 @@ If `sendToAgentChat()` isn't reaching the agent, check:
 ## Exception
 
 Scripts may call external APIs (image generation, search, etc.) — but the AI reasoning and orchestration still goes through the agent. A script is a tool the agent uses, not a replacement for the agent.
-
-## Security
-
-- **`postMessage` wildcard origin** — `sendToAgentChat()` uses `target.postMessage(payload, "*")` which sends to any origin. This is acceptable for local development but must specify the target origin in production deployments.
-- **Prompt injection from user input** — When constructing messages from user input (form fields, selected text), be aware that the user's content becomes part of the agent's prompt. Sanitize or clearly delineate user-provided content from instructions.
 
 ## Related Skills
 

--- a/.agents/skills/delegate-to-agent/SKILL.md
+++ b/.agents/skills/delegate-to-agent/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: delegate-to-agent
+description: >-
+  How to delegate all AI work to the agent chat. Use when delegating AI work
+  from UI or scripts to the agent, when tempted to add inline LLM calls, or
+  when sending messages to the agent from application code.
+---
+
 # Delegate All AI to the Agent
 
 ## Rule
@@ -16,7 +24,7 @@ import { sendToAgentChat } from "@agent-native/core";
 
 sendToAgentChat({
   message: "Generate a summary of this document",
-  context: documentContent,  // optional context to include
+  context: documentContent,  // optional hidden context (not shown in chat UI)
   submit: true,              // auto-submit to the agent
 });
 ```
@@ -38,6 +46,50 @@ function MyComponent() {
 }
 ```
 
+## `submit` vs Prefill
+
+The `submit` option controls whether the message is sent automatically or placed in the chat input for user review:
+
+| `submit` value | Behavior | Use when |
+|---|---|---|
+| `true` | Auto-submits to the agent immediately | Routine operations the user has already approved |
+| `false` | Prefills the chat input for user review | High-stakes operations (deleting data, modifying code, API calls with side effects) |
+| omitted | Uses the project's default setting | General-purpose delegation |
+
+```ts
+// Auto-submit: routine operation
+sendToAgentChat({ message: "Regenerate the slide thumbnails", submit: true });
+
+// Prefill: let user review before sending
+sendToAgentChat({
+  message: "Delete all projects older than 30 days",
+  submit: false,
+});
+```
+
+## Handling Delegated Requests
+
+When the agent receives a message via `sendToAgentChat()`, the typical workflow is:
+
+1. **Read current state** — Check `data/` files for context
+2. **Check UI state** — Read `data-*` attributes on `document.documentElement` or `window.__appState` for current selection/context
+3. **Do the work** — Write results to files in `data/`
+4. **Optionally run scripts** — Use `pnpm script <name>` for complex operations
+5. **Verify** — The SSE watcher updates the UI automatically; no explicit notification needed
+
+## How the Transport Works
+
+`sendToAgentChat()` sends messages via `postMessage` to the parent window (or `window` itself if top-level). The harness (e.g., `harness-claude-code`) receives these messages and forwards them to the agent.
+
+```
+UI Component → sendToAgentChat() → postMessage → Harness → Agent
+```
+
+If `sendToAgentChat()` isn't reaching the agent, check:
+- Is the app running inside the harness iframe?
+- Is the harness listening for `builder.submitChat` messages?
+- Check browser devtools console for postMessage errors
+
 ## Don't
 
 - Don't `import Anthropic from "@anthropic-ai/sdk"` in client or server code
@@ -49,3 +101,19 @@ function MyComponent() {
 ## Exception
 
 Scripts may call external APIs (image generation, search, etc.) — but the AI reasoning and orchestration still goes through the agent. A script is a tool the agent uses, not a replacement for the agent.
+
+## Known Violations
+
+The `GenerateSlidesDialog` pattern (server route calling an LLM directly) is a Rule 2 violation. The correct approach: the UI sends a message to the agent via `sendToAgentChat()`, and the agent generates slides by writing to data files. If you encounter similar patterns, refactor them to go through the agent chat.
+
+## Security
+
+- **`postMessage` wildcard origin** — `sendToAgentChat()` uses `target.postMessage(payload, "*")` which sends to any origin. This is acceptable for local development but must specify the target origin in production deployments.
+- **Prompt injection from user input** — When constructing messages from user input (form fields, selected text), be aware that the user's content becomes part of the agent's prompt. Sanitize or clearly delineate user-provided content from instructions.
+
+## Related Skills
+
+- **scripts** — The agent invokes scripts via `pnpm script <name>` to perform complex operations
+- **self-modifying-code** — The agent operates through the chat bridge to make code changes
+- **files-as-database** — The agent writes results to data files after processing requests
+- **sse-file-watcher** — The UI updates automatically when the agent writes files

--- a/.agents/skills/delegate-to-agent/SKILL.md
+++ b/.agents/skills/delegate-to-agent/SKILL.md
@@ -102,10 +102,6 @@ If `sendToAgentChat()` isn't reaching the agent, check:
 
 Scripts may call external APIs (image generation, search, etc.) — but the AI reasoning and orchestration still goes through the agent. A script is a tool the agent uses, not a replacement for the agent.
 
-## Known Violations
-
-The `GenerateSlidesDialog` pattern (server route calling an LLM directly) is a Rule 2 violation. The correct approach: the UI sends a message to the agent via `sendToAgentChat()`, and the agent generates slides by writing to data files. If you encounter similar patterns, refactor them to go through the agent chat.
-
 ## Security
 
 - **`postMessage` wildcard origin** — `sendToAgentChat()` uses `target.postMessage(payload, "*")` which sends to any origin. This is acceptable for local development but must specify the target origin in production deployments.


### PR DESCRIPTION
## Summary
- Add YAML frontmatter (`name`, `description`) for auto-discovery and slash command invocation
- Document `submit` vs prefill distinction with guidance table for when to use each
- Add "Handling Delegated Requests" section covering the agent-side workflow
- Explain the `postMessage` / harness transport architecture with troubleshooting tips
- Add security notes (wildcard origin warning, prompt injection from user input)
- Add related skills section for composability across the skill system

## Context
Phase 1 of the [skills improvement plan](../workspace/plans/skills-improvement-plan.md) — upgrading existing skills with frontmatter and content fixes. This is the first of 4 PRs, one per skill.

## Test plan
- [ ] Verify YAML frontmatter parses correctly (valid YAML between `---` fences)
- [ ] Review that all code examples reference real `@agent-native/core` exports
- [ ] Confirm no example-app-specific references remain