### PR TITLE
feat(skills): upgrade files-as-database skill with frontmatter and content

### DIFF
--- a/.agents/skills/files-as-database/SKILL.md
+++ b/.agents/skills/files-as-database/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: files-as-database
+description: >-
+  How to store and manage application state as JSON/markdown files in data/.
+  Use when adding data models, creating file-based state, deciding where to
+  store data, or reading/writing application data files.
+---
+
 # Files as Database
 
 ## Rule
@@ -22,16 +30,96 @@ Files are the shared interface between the AI agent and the UI. The agent reads 
 - Don't store app state in localStorage, sessionStorage, or cookies
 - Don't keep state only in memory (server variables, global stores)
 - Don't use Redis or any external state store
+- Don't interpolate user input directly into file paths (see Security below)
 
 ## Example
 
 ```ts
+import fs from "fs";
+
 // Writing state (agent or script)
 fs.writeFileSync("data/projects/my-project.json", JSON.stringify(project, null, 2));
 
-// Reading state (server route)
+// Reading state (server route) — note the path sanitization
 app.get("/api/projects/:id", (req, res) => {
-  const data = fs.readFileSync(`data/projects/${req.params.id}.json`, "utf-8");
+  const id = req.params.id.replace(/[^a-zA-Z0-9_-]/g, "");
+  const data = fs.readFileSync(`data/projects/${id}.json`, "utf-8");
   res.json(JSON.parse(data));
 });
 ```
+
+## Creating a New Data Model
+
+When adding a new data entity (e.g., projects, tasks, settings), follow this checklist:
+
+1. **Design the JSON schema** — Define the shape in `shared/` so both client and server import the same type:
+   ```ts
+   // shared/api.ts
+   export interface Project {
+     id: string;
+     name: string;
+     createdAt: string;
+   }
+   ```
+
+2. **Create the data directory** — Store items as `data/<model>/<id>.json` (one file per item) or `data/<model>.json` (single collection file).
+
+3. **Add API routes** — CRUD routes in `server/` that read/write the files:
+   ```ts
+   import fs from "fs";
+   import path from "path";
+   import { isValidPath } from "@agent-native/core";
+
+   app.get("/api/projects/:id", (req, res) => {
+     const id = req.params.id.replace(/[^a-zA-Z0-9_-]/g, "");
+     const filePath = path.join("data/projects", `${id}.json`);
+     if (!fs.existsSync(filePath)) return res.status(404).json({ error: "Not found" });
+     const data = JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown;
+     res.json(data);
+   });
+   ```
+
+4. **Wire SSE invalidation** — Add the query key to your `useFileWatcher()` call so the UI refreshes when files change:
+   ```ts
+   useFileWatcher({ queryClient, queryKeys: ["projects", "decks"] });
+   ```
+
+5. **Type your JSON.parse calls** — Every `JSON.parse` is a type safety hole. Use `as Type` for internal data; consider Zod validation for user-submitted data:
+   ```ts
+   const raw = fs.readFileSync(filePath, "utf-8");
+   const project = JSON.parse(raw) as Project;
+   ```
+
+## Judgment Criteria
+
+When deciding how to structure your data files:
+
+| Question | Single file | Directory of files |
+|---|---|---|
+| Are items independently addressable? | No — use one file | Yes — one file per item |
+| Will there be >50 items? | Probably fine | Definitely split |
+| Do items need individual URLs? | No | Yes |
+| Do items change independently? | No | Yes — avoids write conflicts |
+
+## Scaling Guidance
+
+| File Count | Recommendation |
+|---|---|
+| Under 50 | Read-all with `readdirSync` + `readFileSync` is fine |
+| 50–200 | Add an index file (`data/projects/_index.json`) with IDs and summaries |
+| 200+ | Partition into subdirectories (`data/projects/a-f/`, `data/projects/g-m/`, etc.) |
+
+For list endpoints serving many files, use `fs.promises.readFile` instead of `readFileSync` to avoid blocking the event loop.
+
+## Security
+
+- **Path sanitization** — Always sanitize IDs from request params before constructing file paths. Use `id.replace(/[^a-zA-Z0-9_-]/g, "")` or the core utility `isValidPath()`. Without this, `../../.env` as an ID reads your environment file.
+- **JSON schema validation** — Validate data shape before writing files, especially for user-submitted data. A malformed write can break all subsequent reads.
+- **File size limits** — Cap write sizes to prevent denial-of-service via massive payloads (`if (JSON.stringify(data).length > MAX_SIZE) return res.status(413)...`).
+- **Prototype pollution** — Be cautious with `JSON.parse` on untrusted input. Properties like `__proto__` or `constructor` can pollute object prototypes.
+
+## Related Skills
+
+- **sse-file-watcher** — Set up real-time sync so the UI updates when data files change
+- **scripts** — Create scripts that read/write data files for complex operations
+- **self-modifying-code** — The agent writes data files as Tier 1 (auto-apply) modifications

--- a/.agents/skills/files-as-database/SKILL.md
+++ b/.agents/skills/files-as-database/SKILL.md
@@ -50,49 +50,14 @@ app.get("/api/projects/:id", (req, res) => {
 
 ## Creating a New Data Model
 
-When adding a new data entity (e.g., projects, tasks, settings), follow this checklist:
+When adding a new data entity (e.g., projects, tasks, settings):
 
-1. **Design the JSON schema** — Define the shape in `shared/` so both client and server import the same type:
-   ```ts
-   // shared/api.ts
-   export interface Project {
-     id: string;
-     name: string;
-     createdAt: string;
-   }
-   ```
-
-2. **Create the data directory** — Store items as `data/<model>/<id>.json` (one file per item) or `data/<model>.json` (single collection file).
-
-3. **Add API routes** — CRUD routes in `server/` that read/write the files:
-   ```ts
-   import fs from "fs";
-   import path from "path";
-   import { isValidPath } from "@agent-native/core";
-
-   app.get("/api/projects/:id", (req, res) => {
-     const id = req.params.id.replace(/[^a-zA-Z0-9_-]/g, "");
-     const filePath = path.join("data/projects", `${id}.json`);
-     if (!fs.existsSync(filePath)) return res.status(404).json({ error: "Not found" });
-     const data = JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown;
-     res.json(data);
-   });
-   ```
-
-4. **Wire SSE invalidation** — Add the query key to your `useFileWatcher()` call so the UI refreshes when files change:
-   ```ts
-   useFileWatcher({ queryClient, queryKeys: ["projects", "decks"] });
-   ```
-
-5. **Type your JSON.parse calls** — Every `JSON.parse` is a type safety hole. Use `as Type` for internal data; consider Zod validation for user-submitted data:
-   ```ts
-   const raw = fs.readFileSync(filePath, "utf-8");
-   const project = JSON.parse(raw) as Project;
-   ```
+1. **Define the type** in `shared/` so both client and server import it
+2. **Create the data directory** — `data/<model>/<id>.json` (one file per item) or `data/<model>.json` (single collection)
+3. **Add API routes** in `server/` that read/write the files (sanitize IDs from params)
+4. **Wire SSE invalidation** — Add the query key to `useFileWatcher()` so the UI refreshes on changes
 
 ## Judgment Criteria
-
-When deciding how to structure your data files:
 
 | Question | Single file | Directory of files |
 |---|---|---|
@@ -106,17 +71,15 @@ When deciding how to structure your data files:
 | File Count | Recommendation |
 |---|---|
 | Under 50 | Read-all with `readdirSync` + `readFileSync` is fine |
-| 50–200 | Add an index file (`data/projects/_index.json`) with IDs and summaries |
-| 200+ | Partition into subdirectories (`data/projects/a-f/`, `data/projects/g-m/`, etc.) |
+| 50–200 | Add an index file (`data/<model>/_index.json`) with IDs and summaries |
+| 200+ | Partition into subdirectories |
 
 For list endpoints serving many files, use `fs.promises.readFile` instead of `readFileSync` to avoid blocking the event loop.
 
 ## Security
 
 - **Path sanitization** — Always sanitize IDs from request params before constructing file paths. Use `id.replace(/[^a-zA-Z0-9_-]/g, "")` or the core utility `isValidPath()`. Without this, `../../.env` as an ID reads your environment file.
-- **JSON schema validation** — Validate data shape before writing files, especially for user-submitted data. A malformed write can break all subsequent reads.
-- **File size limits** — Cap write sizes to prevent denial-of-service via massive payloads (`if (JSON.stringify(data).length > MAX_SIZE) return res.status(413)...`).
-- **Prototype pollution** — Be cautious with `JSON.parse` on untrusted input. Properties like `__proto__` or `constructor` can pollute object prototypes.
+- **Validate before writing** — Check data shape before writing files, especially for user-submitted data. A malformed write can break all subsequent reads.
 
 ## Related Skills
 


### PR DESCRIPTION
## Summary
- Add YAML frontmatter (`name`, `description`) for auto-discovery
- Fix path traversal vulnerability in example (sanitize `req.params.id`)
- Add concise "Creating a New Data Model" checklist
- Add judgment criteria table (single file vs directory of files)
- Add scaling guidance (under 50, 50-200, 200+ files)
- Add security section with path sanitization guidance
- Add related skills section for composability

## Context
Phase 1 of the skills improvement plan — one of 4 PRs, one per skill.

## Test plan
- [ ] Verify YAML frontmatter parses correctly
- [ ] Review that code examples reference real `@agent-native/core` exports
- [ ] Confirm no example-app-specific references