### PR TITLE
feat(skills): add frontmatter and content improvements to all 4 existing skills

### DIFF
--- a/.agents/skills/delegate-to-agent/SKILL.md
+++ b/.agents/skills/delegate-to-agent/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: delegate-to-agent
+description: >-
+  How to delegate all AI work to the agent chat. Use when delegating AI work
+  from UI or scripts to the agent, when tempted to add inline LLM calls, or
+  when sending messages to the agent from application code.
+---
+
 # Delegate All AI to the Agent
 
 ## Rule
@@ -16,7 +24,7 @@ import { sendToAgentChat } from "@agent-native/core";
 
 sendToAgentChat({
   message: "Generate a summary of this document",
-  context: documentContent,  // optional context to include
+  context: documentContent,  // optional hidden context (not shown in chat UI)
   submit: true,              // auto-submit to the agent
 });
 ```
@@ -38,6 +46,27 @@ function MyComponent() {
 }
 ```
 
+## `submit` vs Prefill
+
+The `submit` option controls whether the message is sent automatically or placed in the chat input for user review:
+
+| `submit` value | Behavior | Use when |
+|---|---|---|
+| `true` | Auto-submits to the agent immediately | Routine operations the user has already approved |
+| `false` | Prefills the chat input for user review | High-stakes operations (deleting data, modifying code, API calls with side effects) |
+| omitted | Uses the project's default setting | General-purpose delegation |
+
+```ts
+// Auto-submit: routine operation
+sendToAgentChat({ message: "Update the project summary", submit: true });
+
+// Prefill: let user review before sending
+sendToAgentChat({
+  message: "Delete all projects older than 30 days",
+  submit: false,
+});
+```
+
 ## Don't
 
 - Don't `import Anthropic from "@anthropic-ai/sdk"` in client or server code
@@ -49,3 +78,10 @@ function MyComponent() {
 ## Exception
 
 Scripts may call external APIs (image generation, search, etc.) — but the AI reasoning and orchestration still goes through the agent. A script is a tool the agent uses, not a replacement for the agent.
+
+## Related Skills
+
+- **scripts** — The agent invokes scripts via `pnpm script <name>` to perform complex operations
+- **self-modifying-code** — The agent operates through the chat bridge to make code changes
+- **files-as-database** — The agent writes results to data files after processing requests
+- **sse-file-watcher** — The UI updates automatically when the agent writes files

--- a/.agents/skills/files-as-database/SKILL.md
+++ b/.agents/skills/files-as-database/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: files-as-database
+description: >-
+  How to store and manage application state as JSON/markdown files in data/.
+  Use when adding data models, creating file-based state, deciding where to
+  store data, or reading/writing application data files.
+---
+
 # Files as Database
 
 ## Rule
@@ -22,16 +30,59 @@ Files are the shared interface between the AI agent and the UI. The agent reads 
 - Don't store app state in localStorage, sessionStorage, or cookies
 - Don't keep state only in memory (server variables, global stores)
 - Don't use Redis or any external state store
+- Don't interpolate user input directly into file paths (see Security below)
 
 ## Example
 
 ```ts
+import fs from "fs";
+
 // Writing state (agent or script)
 fs.writeFileSync("data/projects/my-project.json", JSON.stringify(project, null, 2));
 
-// Reading state (server route)
+// Reading state (server route) — note the path sanitization
 app.get("/api/projects/:id", (req, res) => {
-  const data = fs.readFileSync(`data/projects/${req.params.id}.json`, "utf-8");
+  const id = req.params.id.replace(/[^a-zA-Z0-9_-]/g, "");
+  const data = fs.readFileSync(`data/projects/${id}.json`, "utf-8");
   res.json(JSON.parse(data));
 });
 ```
+
+## Creating a New Data Model
+
+When adding a new data entity (e.g., projects, tasks, settings):
+
+1. **Define the type** in `shared/` so both client and server import it
+2. **Create the data directory** — `data/<model>/<id>.json` (one file per item) or `data/<model>.json` (single collection)
+3. **Add API routes** in `server/` that read/write the files (sanitize IDs from params)
+4. **Wire SSE invalidation** — Add the query key to `useFileWatcher()` so the UI refreshes on changes
+
+## Judgment Criteria
+
+| Question | Single file | Directory of files |
+|---|---|---|
+| Are items independently addressable? | No — use one file | Yes — one file per item |
+| Will there be >50 items? | Probably fine | Definitely split |
+| Do items need individual URLs? | No | Yes |
+| Do items change independently? | No | Yes — avoids write conflicts |
+
+## Scaling Guidance
+
+| File Count | Recommendation |
+|---|---|
+| Under 50 | Read-all with `readdirSync` + `readFileSync` is fine |
+| 50–200 | Add an index file (`data/<model>/_index.json`) with IDs and summaries |
+| 200+ | Partition into subdirectories |
+
+For list endpoints serving many files, use `fs.promises.readFile` instead of `readFileSync` to avoid blocking the event loop.
+
+## Security
+
+- **Path sanitization** — Always sanitize IDs from request params before constructing file paths. Use `id.replace(/[^a-zA-Z0-9_-]/g, "")` or the core utility `isValidPath()`. Without this, `../../.env` as an ID reads your environment file.
+- **Validate before writing** — Check data shape before writing files, especially for user-submitted data. A malformed write can break all subsequent reads.
+
+## Related Skills
+
+- **sse-file-watcher** — Set up real-time sync so the UI updates when data files change
+- **scripts** — Create scripts that read/write data files for complex operations
+- **self-modifying-code** — The agent writes data files as Tier 1 (auto-apply) modifications

--- a/.agents/skills/scripts/SKILL.md
+++ b/.agents/skills/scripts/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: scripts
+description: >-
+  How to create and run agent-callable scripts in scripts/. Use when creating
+  a new script, adding an API integration, implementing a complex agent
+  operation, or running pnpm script commands.
+---
+
 # Agent Scripts
 
 ## Rule
@@ -13,23 +21,22 @@ Scripts give the agent callable tools with structured input/output. They keep th
 Create `scripts/my-script.ts`:
 
 ```ts
-import { parseArgs, loadEnv, fail } from "@agent-native/core";
-import { agentChat } from "@agent-native/core";
+import fs from "fs";
+import { parseArgs, loadEnv, fail, agentChat } from "@agent-native/core";
 
 export default async function myScript(args: string[]) {
-  loadEnv(); // loads .env
+  loadEnv();
 
-  const { input, output } = parseArgs(args);
+  const parsed = parseArgs(args);
+  const input = parsed.input;
   if (!input) fail("--input is required");
 
-  // Do the work...
-  const result = processData(input);
+  const outputPath = parsed.output ?? "data/result.json";
+  const raw = fs.readFileSync(input, "utf-8");
+  const data = JSON.parse(raw) as unknown;
 
-  // Write result to a file
-  fs.writeFileSync(output || "data/result.json", JSON.stringify(result, null, 2));
-
-  // Optionally report back to agent chat
-  agentChat.submit(`Processed ${input}, result saved to ${output}`);
+  fs.writeFileSync(outputPath, JSON.stringify(data, null, 2));
+  agentChat.submit(`Processed ${input}, result saved to ${outputPath}`);
 }
 ```
 
@@ -39,23 +46,41 @@ export default async function myScript(args: string[]) {
 pnpm script my-script --input data/source.json --output data/result.json
 ```
 
-The script dispatcher (`scripts/run.ts`) dynamically imports the script file and calls its default export.
+## Script Dispatcher
+
+The default template uses core's `runScript()` in `scripts/run.ts`:
+
+```ts
+import { runScript } from "@agent-native/core";
+runScript();
+```
+
+This is the canonical approach for new apps. Script names must be lowercase with hyphens only (e.g., `my-script`).
 
 ## Guidelines
 
-- **One script, one job.** Keep scripts focused on a single operation.
-- **Use `parseArgs()`** for structured argument parsing. It converts `--key value` pairs to an object.
+- **One script, one job.** Keep scripts focused on a single operation. The agent composes multiple script calls for complex operations.
+- **Use `parseArgs()`** for structured argument parsing. It converts `--key value` pairs to a `Record<string, string>`.
 - **Use `loadEnv()`** if the script needs environment variables (API keys, etc.).
 - **Use `fail()`** for user-friendly error messages (exits with message, no stack trace).
 - **Write results to files.** The agent and UI will pick them up via the file watcher.
 - **Use `agentChat.submit()`** to report results or errors back to the agent chat.
+- **Import from `@agent-native/core`** — Don't redefine `parseArgs()` or other utilities locally.
 
 ## Common Patterns
 
 **API integration script** (e.g., image generation):
 ```ts
+import fs from "fs";
+import { parseArgs, loadEnv, fail } from "@agent-native/core";
+
 export default async function generateImage(args: string[]) {
-  const { prompt, outputPath } = parseArgs(args);
+  loadEnv();
+  const parsed = parseArgs(args);
+  const prompt = parsed.prompt;
+  if (!prompt) fail("--prompt is required");
+
+  const outputPath = parsed.output ?? "data/generated-image.png";
   const imageUrl = await callImageAPI(prompt);
   const buffer = await fetch(imageUrl).then(r => r.arrayBuffer());
   fs.writeFileSync(outputPath, Buffer.from(buffer));
@@ -64,10 +89,28 @@ export default async function generateImage(args: string[]) {
 
 **Data processing script:**
 ```ts
+import fs from "fs";
+import { parseArgs, fail } from "@agent-native/core";
+
 export default async function transform(args: string[]) {
-  const { source } = parseArgs(args);
-  const data = JSON.parse(fs.readFileSync(source, "utf-8"));
+  const parsed = parseArgs(args);
+  const source = parsed.source;
+  if (!source) fail("--source is required");
+
+  const data = JSON.parse(fs.readFileSync(source, "utf-8")) as unknown[];
   const result = data.map(transformItem);
   fs.writeFileSync(source, JSON.stringify(result, null, 2));
 }
 ```
+
+## Troubleshooting
+
+- **Script not found** — Check that the filename matches the command name exactly. `pnpm script foo-bar` looks for `scripts/foo-bar.ts`.
+- **Args not parsing** — Ensure args use `--key value` or `--key=value` format. Boolean flags use `--flag` (sets value to `"true"`).
+- **Script runs but UI doesn't update** — Make sure results are written to a path under `data/` that the file watcher monitors.
+
+## Related Skills
+
+- **files-as-database** — Scripts read/write data files in `data/`
+- **delegate-to-agent** — The agent invokes scripts via `pnpm script <name>`
+- **sse-file-watcher** — File writes from scripts trigger SSE events to update the UI

--- a/.agents/skills/sse-file-watcher/SKILL.md
+++ b/.agents/skills/sse-file-watcher/SKILL.md
@@ -1,8 +1,20 @@
+---
+name: sse-file-watcher
+description: >-
+  How to keep the UI in sync with agent changes via Server-Sent Events. Use
+  when setting up real-time file sync, adding SSE to a new data directory,
+  wiring query invalidation for new data models, or debugging UI not updating.
+---
+
 # SSE File Watcher
 
 ## Rule
 
 The UI stays in sync with agent changes through Server-Sent Events. When the agent writes a file, the UI updates automatically — no polling, no manual refresh.
+
+## Why
+
+The agent modifies files on disk, but the UI runs in the browser. SSE bridges this gap: a file watcher on the server detects changes, streams them to the browser, and React Query invalidates the relevant caches. This is what makes the "files as database" pattern feel real-time.
 
 ## How It Works
 
@@ -21,10 +33,78 @@ The UI stays in sync with agent changes through Server-Sent Events. When the age
 
 3. When the agent writes to `data/`, chokidar detects it, SSE pushes the event, and React Query refetches the affected queries.
 
-## Guidelines
+## Don't
 
-- Watch the `data/` directory (or wherever your app stores state files).
-- List the React Query keys that should refresh when files change in `queryKeys`.
-- The watcher uses `ignoreInitial: true` — it only fires on changes after startup.
-- Don't poll for changes. SSE handles it.
-- For production, `createProductionServer()` handles graceful shutdown of watchers.
+- Don't poll for changes — SSE handles it
+- Don't create per-model `fs.watch()` instances — `createFileWatcher("./data")` watches recursively. One watcher is enough.
+- Don't spread `queryKeys` inline on every render — use a stable reference (see Dependency Array below)
+- Don't create your own EventSource connections alongside `useFileWatcher` — use the `onEvent` callback for custom handling
+
+## Query Key Mapping
+
+By default, `useFileWatcher` invalidates all listed query keys on every file change. For apps with multiple data models, this causes unnecessary refetches. Use path-based filtering via the `onEvent` callback:
+
+```ts
+useFileWatcher({
+  queryClient,
+  queryKeys: [], // don't auto-invalidate everything
+  onEvent: (data) => {
+    if (data.path?.includes("projects")) {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+    } else if (data.path?.includes("settings")) {
+      queryClient.invalidateQueries({ queryKey: ["settings"] });
+    }
+  },
+});
+```
+
+To prevent cache thrashing during rapid agent writes, set `staleTime` on your queries:
+
+```ts
+useQuery({
+  queryKey: ["projects"],
+  queryFn: fetchProjects,
+  staleTime: 2000, // don't refetch within 2 seconds
+});
+```
+
+## Dependency Array
+
+The `useFileWatcher` hook spreads `queryKeys` into its `useEffect` dependency array. If `queryKeys` is a new array reference on every render, the EventSource will disconnect and reconnect on every render. Fix: use a stable reference.
+
+```ts
+// Bad: new array every render → reconnects constantly
+useFileWatcher({ queryClient, queryKeys: ["projects", "tasks"] });
+
+// Good: stable reference
+const QUERY_KEYS = ["projects", "tasks"];
+useFileWatcher({ queryClient, queryKeys: QUERY_KEYS });
+
+// Also good: useMemo
+const keys = useMemo(() => ["projects", "tasks"], []);
+useFileWatcher({ queryClient, queryKeys: keys });
+```
+
+## Performance
+
+When the agent writes many files rapidly (e.g., during self-modification), each write fires a chokidar event → SSE broadcast → React Query invalidation. This can cause excessive refetching.
+
+Mitigations:
+- Use `staleTime: 2000` on React Query to debounce refetches
+- Use path-based filtering (see Query Key Mapping) to limit which queries invalidate
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| UI not updating after agent writes | Is `useFileWatcher` called with the correct `queryClient`? Are the `queryKeys` matching your `useQuery` keys? |
+| SSE not firing | Open browser devtools → Network tab → filter by EventStream. Is `/api/events` connected? Is the server running? |
+| Watcher not detecting changes | Is the path correct? `createFileWatcher("./data")` is relative to CWD. Check the server's working directory. |
+| Constant reconnections | Check if `queryKeys` is a stable reference (see Dependency Array above). Also check for server crashes in terminal output. |
+| High CPU / event storms | The agent is writing many files rapidly. Add `staleTime` to queries and use path-based filtering. |
+
+## Related Skills
+
+- **files-as-database** — SSE watches the data files that store application state
+- **scripts** — Script outputs written to `data/` trigger SSE events
+- **self-modifying-code** — Agent code edits trigger SSE events; rapid edits can cause event storms


### PR DESCRIPTION
## Summary
- **files-as-database**: Fix path traversal bug in example, add data model checklist, judgment criteria table, scaling guidance, security section
- **scripts**: Fix template bugs (missing `fs` import, `output` logic, duplicate imports), add dispatcher docs, troubleshooting
- **delegate-to-agent**: Add `submit` vs prefill distinction with guidance table
- **sse-file-watcher**: Normalize structure (add Why/Don't sections), add query key mapping, dependency array gotcha, performance guidance, troubleshooting table

All 4 skills now have YAML frontmatter (`name`, `description`) for auto-discovery and related skills sections for composability.

## Test plan
- [ ] Verify YAML frontmatter parses correctly on all 4 skills
- [ ] Review that all code examples reference real `@agent-native/core` exports
- [ ] Confirm no example-app-specific references remain