### PR TITLE
feat(skills): add create-skill and capture-learnings skills

### DIFF
--- a/.agents/skills/capture-learnings/SKILL.md
+++ b/.agents/skills/capture-learnings/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: capture-learnings
+description: >-
+  Capture and apply accumulated knowledge in learnings.md. Use when the user
+  corrects a mistake, when debugging reveals unexpected behavior, or when an
+  architectural decision should be recorded for future reference.
+user-invocable: false
+---
+
+# Capture Learnings
+
+This is background knowledge, not a slash command. Read `learnings.md` before starting significant work. Update it when you discover something worth remembering.
+
+## When to Capture
+
+Use judgment, not rules. Capture when:
+
+- **Surprising behavior** — Something didn't work as expected and you figured out why
+- **Repeated friction** — You hit the same issue twice; write it down so there's no third time
+- **Architectural decisions** — Why something is done a certain way (the "why" isn't in the code)
+- **API/library quirks** — Undocumented behavior, version-specific gotchas
+- **Performance insights** — What's slow and what fixed it
+
+Don't capture:
+- Things that are obvious from reading the code
+- Standard language/framework behavior
+- Temporary debugging notes
+
+## Format
+
+Add entries to `learnings.md` at the project root. Match the existing format — typically a heading per topic with a brief explanation:
+
+```markdown
+## [Topic]
+
+[What you learned and why it matters. Keep it to 2-3 sentences.]
+```
+
+## Graduation
+
+When a learning is referenced repeatedly, it's outgrowing `learnings.md`. Propose adding it to the relevant skill or creating a new skill via `create-skill`.
+
+- Updating `learnings.md` is a Tier 1 modification (data — auto-apply)
+- Updating a SKILL.md based on learnings is Tier 2 (source — verify after)
+
+## Related Skills
+
+- **self-modifying-code** — Learnings.md updates are Tier 1; skill updates are Tier 2
+- **create-skill** — When a learning graduates, create a skill from it

--- a/.agents/skills/create-skill/SKILL.md
+++ b/.agents/skills/create-skill/SKILL.md
@@ -123,14 +123,6 @@ description: >-
 - Pattern skills: descriptive names (`files-as-database`, `delegate-to-agent`)
 - Workflow/generator skills: verb-noun (`create-script`, `capture-learnings`)
 
-## Constraints
-
-- **Description under 40 words** — Skills are loaded into context. Keep descriptions tight.
-- **SKILL.md under 500 lines** — Move detailed content to `references/` files.
-- **Every skill needs a "Related Skills" section** — Skills compose with each other.
-- **Every skill should relate to one of the 5 rules** — Or be explicitly "utility."
-- **Standard markdown headings** — No XML tags or custom formats.
-
 ## Anti-Patterns
 
 - **Inline LLM calls** — Skills must not call LLMs directly (violates Rule 2)

--- a/.agents/skills/create-skill/SKILL.md
+++ b/.agents/skills/create-skill/SKILL.md
@@ -123,6 +123,12 @@ description: >-
 - Pattern skills: descriptive names (`files-as-database`, `delegate-to-agent`)
 - Workflow/generator skills: verb-noun (`create-script`, `capture-learnings`)
 
+## Tips
+
+- **Keep descriptions under 40 words** — They're loaded into context on every conversation.
+- **Keep SKILL.md under 500 lines** — Move detailed content to `references/` files.
+- **Use standard markdown headings** — No XML tags or custom formats.
+
 ## Anti-Patterns
 
 - **Inline LLM calls** — Skills must not call LLMs directly (violates Rule 2)

--- a/.agents/skills/create-skill/SKILL.md
+++ b/.agents/skills/create-skill/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: create-skill
+description: >-
+  How to create new skills for an agent-native app. Use when adding a new
+  skill, documenting a pattern the agent should follow, or creating reusable
+  guidance for the agent.
+---
+
+# Create a Skill
+
+## When to Use
+
+Create a new skill when:
+- There's a pattern the agent should follow repeatedly
+- A workflow needs step-by-step guidance
+- You want to scaffold files from a template
+
+Don't create a skill when:
+- The guidance already exists in another skill (extend it instead)
+- You're documenting something the agent already knows (e.g., how to write TypeScript)
+- The guidance is a one-off — put it in `AGENTS.md` or `learnings.md` instead
+
+## 5-Question Interview
+
+Before writing the skill, answer these:
+
+1. **What should this skill enable?** — The core purpose in one sentence.
+2. **Which agent-native rule does it serve?** — Rule 1 (files), Rule 2 (delegate), Rule 3 (scripts), Rule 4 (SSE), Rule 5 (self-modify), or "utility."
+3. **When should it trigger?** — Describe the situations in natural language. Be slightly pushy — over-triggering is better than under-triggering.
+4. **What type of skill?** — Pattern, Workflow, or Generator (see templates below).
+5. **Does it need supporting files?** — References (read-only context) or none. Keep it minimal.
+
+## Skill Types and Templates
+
+### Pattern (architectural rule)
+
+For documenting how things should be done:
+
+```markdown
+---
+name: my-pattern
+description: >-
+  [Under 40 words. When should this trigger?]
+---
+
+# [Pattern Name]
+
+## Rule
+[One sentence: what must be true]
+
+## Why
+[Why this rule exists]
+
+## How
+[How to follow it, with code examples]
+
+## Don't
+[Common violations]
+
+## Related Skills
+[Which skills compose with this one]
+```
+
+### Workflow (step-by-step)
+
+For multi-step implementation tasks:
+
+```markdown
+---
+name: my-workflow
+description: >-
+  [Under 40 words. When should this trigger?]
+---
+
+# [Workflow Name]
+
+## Prerequisites
+[What must be in place first]
+
+## Steps
+[Numbered steps with code examples]
+
+## Verification
+[How to confirm it worked]
+
+## Troubleshooting
+[Common issues and fixes]
+
+## Related Skills
+```
+
+### Generator (scaffolding)
+
+For creating files from templates:
+
+```markdown
+---
+name: my-generator
+description: >-
+  [Under 40 words. When should this trigger?]
+---
+
+# [Generator Name]
+
+## Usage
+[How to invoke — what args/inputs are needed]
+
+## What Gets Created
+[List of files and their purpose]
+
+## Template
+[The template content with placeholders]
+
+## After Generation
+[What to do next — wire up SSE, add routes, etc.]
+
+## Related Skills
+```
+
+## Naming Conventions
+
+- Hyphen-case only: `[a-z0-9-]`, max 64 characters
+- Pattern skills: descriptive names (`files-as-database`, `delegate-to-agent`)
+- Workflow/generator skills: verb-noun (`create-script`, `capture-learnings`)
+
+## Constraints
+
+- **Description under 40 words** — Skills are loaded into context. Keep descriptions tight.
+- **SKILL.md under 500 lines** — Move detailed content to `references/` files.
+- **Every skill needs a "Related Skills" section** — Skills compose with each other.
+- **Every skill should relate to one of the 5 rules** — Or be explicitly "utility."
+- **Standard markdown headings** — No XML tags or custom formats.
+
+## Anti-Patterns
+
+- **Inline LLM calls** — Skills must not call LLMs directly (violates Rule 2)
+- **Database patterns** — Skills must not introduce databases (violates Rule 1)
+- **Ignoring SSE** — If a skill creates data files, mention wiring up `useFileWatcher`
+- **Vague descriptions** — "Helps with development" won't trigger. Be specific about *when*.
+- **Pure documentation** — Skills should guide action, not just explain concepts
+
+## File Structure
+
+```
+.agents/skills/my-skill/
+├── SKILL.md              # Main skill (required)
+└── references/           # Optional supporting context
+    └── detailed-guide.md
+```
+
+## Related Skills
+
+- **capture-learnings** — When a learning graduates to reusable guidance, create a skill
+- **self-modifying-code** — The agent can create new skills (Tier 2 modification)


### PR DESCRIPTION
## Summary
Two new skills completing the agent-native skill system:

- **create-skill**: Guides creation of new skills with a 5-question interview flow, 3 templates (pattern, workflow, generator), naming conventions, and agent-native-specific anti-patterns to avoid
- **capture-learnings**: Background skill (`user-invocable: false`) for recording discoveries to `learnings.md`. Includes when to capture, format, and graduation path (when a learning outgrows learnings.md, it becomes a skill)

This brings the total skill count to 7, covering all 5 architectural rules plus skill creation and knowledge capture.

## Test plan
- [ ] Verify YAML frontmatter parses correctly on both skills
- [ ] Confirm `capture-learnings` has `user-invocable: false`
- [ ] Check related skills references match existing skill names