### PR TITLE
Fix docs landing page mobile layout

### DIFF
--- a/packages/docs/src/components/Header.tsx
+++ b/packages/docs/src/components/Header.tsx
@@ -133,9 +133,9 @@ export default function Header() {
               href="https://builder.io"
               target="_blank"
               rel="noopener noreferrer"
-              className="hidden sm:inline-flex items-center gap-2 rounded-lg bg-white px-3 py-1.5 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+              className="hidden sm:inline-flex items-center gap-2 rounded-lg bg-black px-3 py-1.5 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
             >
-              <span style={{ color: "black" }}>{BUILDER_LOGO}</span>
+              {BUILDER_LOGO}
               Cloud
             </a>
 

--- a/packages/docs/src/components/TemplateCard.tsx
+++ b/packages/docs/src/components/TemplateCard.tsx
@@ -204,7 +204,7 @@ function TemplateLaunchButton({ template }: { template: Template }) {
             location: "card",
           })
         }
-        className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-white px-4 py-2 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+        className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-black px-4 py-2 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
       >
         <svg
           width="14"

--- a/packages/docs/src/routes/__root.tsx
+++ b/packages/docs/src/routes/__root.tsx
@@ -133,7 +133,7 @@ function NotFound() {
       <div className="flex items-center gap-3">
         <Link
           to="/"
-          className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+          className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
         >
           Go home
         </Link>

--- a/packages/docs/src/routes/index.tsx
+++ b/packages/docs/src/routes/index.tsx
@@ -92,88 +92,6 @@ cd my-app
 pnpm install
 pnpm dev`;
 
-function TemplateCarousel() {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(true);
-
-  function updateScrollState() {
-    const el = scrollRef.current;
-    if (!el) return;
-    setCanScrollLeft(el.scrollLeft > 4);
-    setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 4);
-  }
-
-  function scroll(dir: "left" | "right") {
-    const el = scrollRef.current;
-    if (!el) return;
-    const cardWidth = 380 + 16; // card + gap
-    el.scrollBy({
-      left: dir === "left" ? -cardWidth : cardWidth,
-      behavior: "smooth",
-    });
-  }
-
-  return (
-    <div className="flex items-center gap-3">
-      <button
-        onClick={() => scroll("left")}
-        className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--bg)] text-[var(--fg-secondary)] shadow-sm transition hover:border-[var(--fg-secondary)] hover:text-[var(--fg)] ${canScrollLeft ? "opacity-100" : "pointer-events-none opacity-0"}`}
-        aria-label="Scroll left"
-      >
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <polyline points="15 18 9 12 15 6" />
-        </svg>
-      </button>
-
-      <div
-        ref={scrollRef}
-        onScroll={updateScrollState}
-        className="min-w-0 flex-1 overflow-x-auto pb-4 scrollbar-hide"
-      >
-        <div className="flex gap-4" style={{ width: "max-content" }}>
-          {templates.map((t) => (
-            <div
-              key={t.name}
-              className="w-[calc((1200px-2*16px)/3)] max-w-[380px] min-w-[300px] shrink-0"
-            >
-              <TemplateCard template={t} />
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <button
-        onClick={() => scroll("right")}
-        className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--bg)] text-[var(--fg-secondary)] shadow-sm transition hover:border-[var(--fg-secondary)] hover:text-[var(--fg)] ${canScrollRight ? "opacity-100" : "pointer-events-none opacity-0"}`}
-        aria-label="Scroll right"
-      >
-        <svg
-          width="18"
-          height="18"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <polyline points="9 18 15 12 9 6" />
-        </svg>
-      </button>
-    </div>
-  );
-}
-
 function TerminalCommand() {
   const [copied, setCopied] = useState(false);
   const command = "npx @agent-native/core create my-app";
@@ -304,29 +222,10 @@ function Home() {
           </p>
         </div>
 
-        {/* Mobile: vertical stack */}
-        <div className="md:hidden">
-          <div className="mx-auto grid max-w-[1200px] grid-cols-1 gap-5">
-            {templates.map((t) => (
-              <TemplateCard key={t.name} template={t} />
-            ))}
-          </div>
-        </div>
-
-        {/* Tablet/desktop carousel */}
-        <div className="hidden md:block 2xl:hidden">
-          <div className="mx-auto max-w-[1200px]">
-            <TemplateCarousel />
-          </div>
-        </div>
-
-        {/* Ultra-wide: 5-column grid */}
-        <div className="hidden 2xl:block">
-          <div className="mx-auto grid max-w-[1920px] grid-cols-5 gap-5">
-            {templates.map((t) => (
-              <TemplateCard key={t.name} template={t} />
-            ))}
-          </div>
+        <div className="mx-auto grid max-w-[1200px] grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-4">
+          {templates.map((t) => (
+            <TemplateCard key={t.name} template={t} />
+          ))}
         </div>
 
         <div className="mt-8 text-center">
@@ -714,7 +613,7 @@ function Home() {
             workflow, and let the agent keep evolving it. Open source. Forkable.
             Yours.
           </p>
-          <div className="flex items-center justify-center gap-4">
+          <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
             <Link
               to="/templates"
               className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"

--- a/packages/docs/src/routes/index.tsx
+++ b/packages/docs/src/routes/index.tsx
@@ -170,7 +170,7 @@ function Home() {
           <div className="flex items-center justify-center gap-4">
             <Link
               to="/templates"
-              className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+              className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
             >
               Launch a Template
               <svg
@@ -616,7 +616,7 @@ function Home() {
           <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
             <Link
               to="/templates"
-              className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+              className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
             >
               Launch a Template
               <svg

--- a/packages/docs/src/routes/templates/analytics.tsx
+++ b/packages/docs/src/routes/templates/analytics.tsx
@@ -145,7 +145,7 @@ function AnalyticsTemplate() {
                     location: "hero",
                   })
                 }
-                className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+                className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
               >
                 <svg
                   width="14"
@@ -570,7 +570,7 @@ function AnalyticsTemplate() {
                 location: "bottom_cta",
               })
             }
-            className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+            className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
           >
             Launch in Cloud
           </a>

--- a/packages/docs/src/routes/templates/brand-image-generator.tsx
+++ b/packages/docs/src/routes/templates/brand-image-generator.tsx
@@ -145,7 +145,7 @@ function BrandImageGeneratorTemplate() {
                     location: "hero",
                   })
                 }
-                className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+                className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
               >
                 <svg
                   width="14"
@@ -611,7 +611,7 @@ function BrandImageGeneratorTemplate() {
                 location: "bottom_cta",
               })
             }
-            className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+            className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
           >
             Launch in Cloud
           </a>

--- a/packages/docs/src/routes/templates/calendar.tsx
+++ b/packages/docs/src/routes/templates/calendar.tsx
@@ -145,7 +145,7 @@ function CalendarTemplate() {
                     location: "hero",
                   })
                 }
-                className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+                className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
               >
                 <svg
                   width="14"
@@ -636,7 +636,7 @@ function CalendarTemplate() {
                 location: "bottom_cta",
               })
             }
-            className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+            className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
           >
             Launch in Cloud
           </a>

--- a/packages/docs/src/routes/templates/content.tsx
+++ b/packages/docs/src/routes/templates/content.tsx
@@ -145,7 +145,7 @@ function ContentTemplate() {
                     location: "hero",
                   })
                 }
-                className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+                className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
               >
                 <svg
                   width="14"
@@ -503,7 +503,7 @@ function ContentTemplate() {
                 location: "bottom_cta",
               })
             }
-            className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+            className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
           >
             Launch in Cloud
           </a>

--- a/packages/docs/src/routes/templates/slides.tsx
+++ b/packages/docs/src/routes/templates/slides.tsx
@@ -141,7 +141,7 @@ function SlidesTemplate() {
                     location: "hero",
                   })
                 }
-                className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+                className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
               >
                 <svg
                   width="14"
@@ -443,7 +443,7 @@ function SlidesTemplate() {
                 location: "bottom_cta",
               })
             }
-            className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+            className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
           >
             Launch in Cloud
           </a>

--- a/packages/docs/src/routes/templates/video.tsx
+++ b/packages/docs/src/routes/templates/video.tsx
@@ -145,7 +145,7 @@ function VideoTemplate() {
                     location: "hero",
                   })
                 }
-                className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+                className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
               >
                 <svg
                   width="14"
@@ -521,7 +521,7 @@ function VideoTemplate() {
                 location: "bottom_cta",
               })
             }
-            className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-medium text-black no-underline transition hover:bg-gray-200 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
+            className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
           >
             Launch in Cloud
           </a>


### PR DESCRIPTION
## Summary
- Stack footer CTA buttons vertically on mobile (`flex-col` → `sm:flex-row`)
- Simplify template grid to a single responsive layout (`grid-cols-1 md:2 lg:4`) instead of separate mobile/tablet/desktop views with carousel
- Remove unused `TemplateCarousel` component

## Test plan
- [ ] View docs landing page on mobile viewport — footer buttons should stack vertically
- [ ] View on desktop — buttons should be in a row
- [ ] Template grid should be responsive: 1 col on mobile, 2 on tablet, 4 on desktop