### PR TITLE
Use GitHub App token for publish workflow to bypass rulesets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,11 +31,18 @@ jobs:
       id-token: write
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.BUILDER_BOT_FOR_LINT_APP_ID }}
+          private-key: ${{ secrets.BUILDER_BOT_FOR_LINT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Use `actions/create-github-app-token` with the Builder bot app to generate a token that can bypass branch protection rulesets
- Replaces `CUSTOM_GITHUB_TOKEN` (classic PAT) which can't bypass rulesets

## Setup required
- [ ] Add `agent-native` to repo access for `BUILDER_BOT_FOR_LINT_APP_ID` org secret
- [ ] Add `agent-native` to repo access for `BUILDER_BOT_FOR_LINT_PRIVATE_KEY` org secret
- [ ] Add the Builder bot app to the ruleset bypass list