### PR TITLE
Improve AI email draft editing UX in compose toolbar

### DIFF
--- a/templates/mail/client/components/email/ComposeBubbleToolbar.tsx
+++ b/templates/mail/client/components/email/ComposeBubbleToolbar.tsx
@@ -69,7 +69,7 @@ export function ComposeBubbleToolbar({
 
     sendToAgent({
       message: aiPrompt.trim(),
-      context: `The user has selected text in their email draft and wants you to modify it. The current draft is saved in application-state/compose.json. You can read and update it directly.\n\nSelected text:\n"${selectedText}"`,
+      context: `The user has selected specific text in their email draft and wants you to edit ONLY that selected portion. You MUST:\n1. Read the full draft from application-state/compose.json\n2. Find and replace ONLY the selected text (shown below) with your edited version based on the user's instruction\n3. Preserve ALL other content exactly as-is — subject, recipients, and every other part of the body that was not selected\n4. Write the updated draft back to application-state/compose.json\n\nSelected text to edit:\n"${selectedText}"`,
       submit: true,
     });
 
@@ -163,29 +163,32 @@ export function ComposeBubbleToolbar({
             </>
           ) : (
             <>
-              <input
+              <textarea
                 autoFocus
-                type="text"
                 placeholder="e.g. make more formal..."
                 value={aiPrompt}
+                rows={2}
                 onChange={(e) => setAiPrompt(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") {
+                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
                     e.preventDefault();
+                    e.stopPropagation();
                     void handleAiAssist();
                   }
                   if (e.key === "Escape") {
+                    e.preventDefault();
                     setShowAiInput(false);
                     setAiPrompt("");
                   }
                 }}
-                className="bg-transparent border-none outline-none text-white text-sm w-52 px-1 py-0.5 placeholder:text-gray-400"
+                className="bg-transparent border-none outline-none text-white text-sm w-52 px-1 py-0.5 placeholder:text-gray-400 resize-none leading-snug"
               />
               <button
                 onClick={() => void handleAiAssist()}
-                className="text-xs text-blue-400 hover:text-blue-300 px-1.5 py-0.5 font-medium"
+                title="Generate (⌘Enter)"
+                className="text-xs text-blue-400 hover:text-blue-300 px-1.5 py-0.5 font-medium shrink-0 self-end pb-1"
               >
-                Send
+                Generate
               </button>
             </>
           )}


### PR DESCRIPTION
### Summary
Improves the AI-assisted text editing flow in the email compose toolbar by ensuring the AI only edits selected text, adding a Cmd/Ctrl+Enter keyboard shortcut, and upgrading the prompt input to a multi-line textarea.

### Problem
The AI generation prompt lacked clear instructions to preserve unselected content, potentially causing it to regenerate the entire email draft. The single-line input was limiting for complex editing instructions, and there was no keyboard shortcut to submit the prompt without accidentally sending the email.

### Solution
Updated the AI context prompt to explicitly instruct the agent to edit only the selected text and preserve everything else. Replaced the single-line `<input>` with a `<textarea>` for multi-line prompts, and wired up Cmd/Ctrl+Enter as the keyboard shortcut to trigger generation.

### Key Changes
- **Scoped AI context prompt**: Updated the `context` string sent to the agent to explicitly require reading the full draft, replacing only the selected text, and preserving all other content (subject, recipients, body) unchanged
- **Multi-line textarea**: Replaced the `<input type="text">` with a `<textarea rows={2}` with `resize-none` styling for a consistent look while supporting multi-line prompts
- **Cmd/Ctrl+Enter shortcut**: Changed the `onKeyDown` handler from plain `Enter` to `metaKey || ctrlKey + Enter` to submit the AI prompt without risking accidental email sends; added `e.stopPropagation()` for safety
- **Escape key fix**: Added `e.preventDefault()` to the Escape handler for consistent dismissal behavior
- **Button label + tooltip**: Renamed the submit button from "Send" to "Generate" and added a `title="Generate (⌘Enter)"` tooltip to surface the keyboard shortcut
- **Button alignment**: Added `shrink-0 self-end pb-1` to keep the Generate button properly aligned with the textarea

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/sky-section-lqd7fvbp"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-sky-section-lqd7fvbp_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 48`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>sky-section-lqd7fvbp</branchName>-->