### PR TITLE
Auto-scroll tabs into view on mobile homepage

### DIFF
--- a/packages/docs/src/routes/index.tsx
+++ b/packages/docs/src/routes/index.tsx
@@ -101,6 +101,7 @@ const bidirectionalTabs = [
 function BidirectionalTabs() {
   const [activeTab, setActiveTab] = useState(0);
   const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
+  const tabButtonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   useEffect(() => {
     videoRefs.current.forEach((video, i) => {
@@ -116,12 +117,29 @@ function BidirectionalTabs() {
 
   const handleTabClick = (index: number) => {
     setActiveTab(index);
+    const btn = tabButtonRefs.current[index];
+    if (btn) {
+      btn.scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+        inline: "center",
+      });
+    }
   };
 
   const handleVideoEnded = (i: number) => {
     setActiveTab((prev) => {
-      if (prev === i) return (i + 1) % bidirectionalTabs.length;
-      return prev;
+      if (prev !== i) return prev;
+      const next = (i + 1) % bidirectionalTabs.length;
+      const btn = tabButtonRefs.current[next];
+      if (btn) {
+        btn.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+          inline: "center",
+        });
+      }
+      return next;
     });
   };
 
@@ -131,6 +149,9 @@ function BidirectionalTabs() {
         {bidirectionalTabs.map((tab, i) => (
           <button
             key={i}
+            ref={(el) => {
+              tabButtonRefs.current[i] = el;
+            }}
             onClick={() => handleTabClick(i)}
             className={`cursor-pointer rounded-xl border p-4 text-left transition-all md:p-5 ${
               i === activeTab


### PR DESCRIPTION
### Summary
Adds automatic horizontal scrolling for tabs on the homepage so that the selected tab is always visible on mobile devices, both on manual click and when tabs advance automatically after a video ends.

### Problem
On mobile, the homepage tabs section requires horizontal scrolling to see all tabs. When a user selected a tab (or when a video ended and advanced to the next tab), the newly active tab could be off-screen or only partially visible, requiring the user to manually scroll to see it.

### Solution
Attach refs to each tab button and call `scrollIntoView` with smooth, centered inline scrolling whenever a tab becomes active — whether triggered by a user click or by the automatic video-end progression.

### Key Changes
- Added a `tabButtonRefs` ref array to track all tab button DOM elements
- Updated `handleTabClick` to call `scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" })` on the selected tab button
- Updated `handleVideoEnded` to similarly scroll the next tab into view when auto-advancing after a video ends
- Assigned `ref` callbacks to each tab `<button>` to populate `tabButtonRefs`
- Desktop behavior is unaffected; `scrollIntoView` is a no-op when the element is already fully visible


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/woven-order-s4a5cdgx"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-woven-order-s4a5cdgx_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 53`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>woven-order-s4a5cdgx</branchName>-->