### PR TITLE
Fix clipped tab glow effect on docs homepage

### DIFF
--- a/packages/docs/src/routes/index.tsx
+++ b/packages/docs/src/routes/index.tsx
@@ -145,7 +145,7 @@ function BidirectionalTabs() {
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-6 md:flex-row md:items-start md:gap-8">
-      <div className="flex shrink-0 flex-row gap-2 overflow-x-auto md:w-1/4 md:flex-col md:gap-3">
+      <div className="flex shrink-0 flex-row gap-2 overflow-x-auto px-1 py-1 md:w-1/4 md:flex-col md:gap-3 md:overflow-visible md:p-0">
         {bidirectionalTabs.map((tab, i) => (
           <button
             key={i}


### PR DESCRIPTION
### Summary
Fixes the focus/glow effect on tabs in the "Agents and UIs — fully connected" section of the docs homepage, which was being clipped by the parent container's `overflow: auto`.

### Problem
When a tab in the `BidirectionalTabs` component received focus or was selected, its glow/focus ring was visually cut off because the parent container used `overflow-x-auto` without any padding to accommodate the overflow of the effect. This made the UI look broken and the focus indicator was not fully visible.

### Solution
Added minimal `px-1 py-1` padding to the tab container on mobile to give the glow effect room to render, and set `md:overflow-visible md:p-0` on larger screens to restore the original layout behavior — preserving alignment and scroll functionality.

### Key Changes
- Added `px-1 py-1` padding to the tab list container so the focus/glow ring is not clipped on mobile/horizontal scroll layouts
- Added `md:overflow-visible md:p-0` to reset overflow and padding on medium+ screens, keeping the desktop layout unchanged


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/amber-division-lfvxn2aj"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-amber-division-lfvxn2aj_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 55`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>amber-division-lfvxn2aj</branchName>-->