### PR TITLE
Fix page jump on tab selection in docs homepage

### DIFF
--- a/packages/docs/src/routes/index.tsx
+++ b/packages/docs/src/routes/index.tsx
@@ -102,6 +102,7 @@ function BidirectionalTabs() {
   const [activeTab, setActiveTab] = useState(0);
   const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
   const tabButtonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const tabContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     videoRefs.current.forEach((video, i) => {
@@ -115,37 +116,45 @@ function BidirectionalTabs() {
     });
   }, [activeTab]);
 
-  const handleTabClick = (index: number) => {
-    setActiveTab(index);
+  // Scroll only within the tab container (horizontal, mobile only).
+  // Never calls scrollIntoView so the page never jumps vertically.
+  const scrollTabButtonIntoContainerView = (index: number) => {
     const btn = tabButtonRefs.current[index];
-    if (btn) {
-      btn.scrollIntoView({
+    const container = tabContainerRef.current;
+    if (!btn || !container) return;
+    const btnLeft = btn.offsetLeft;
+    const btnRight = btnLeft + btn.offsetWidth;
+    const { scrollLeft, offsetWidth } = container;
+    if (btnLeft < scrollLeft) {
+      container.scrollTo({ left: btnLeft, behavior: "smooth" });
+    } else if (btnRight > scrollLeft + offsetWidth) {
+      container.scrollTo({
+        left: btnRight - offsetWidth,
         behavior: "smooth",
-        block: "nearest",
-        inline: "center",
       });
     }
+  };
+
+  const handleTabClick = (index: number) => {
+    setActiveTab(index);
+    scrollTabButtonIntoContainerView(index);
   };
 
   const handleVideoEnded = (i: number) => {
     setActiveTab((prev) => {
       if (prev !== i) return prev;
       const next = (i + 1) % bidirectionalTabs.length;
-      const btn = tabButtonRefs.current[next];
-      if (btn) {
-        btn.scrollIntoView({
-          behavior: "smooth",
-          block: "nearest",
-          inline: "center",
-        });
-      }
+      scrollTabButtonIntoContainerView(next);
       return next;
     });
   };
 
   return (
     <div className="mx-auto flex max-w-6xl flex-col gap-6 md:flex-row md:items-start md:gap-8">
-      <div className="flex shrink-0 flex-row gap-2 overflow-x-auto md:w-1/4 md:flex-col md:gap-3">
+      <div
+        ref={tabContainerRef}
+        className="flex shrink-0 flex-row gap-2 overflow-x-auto md:w-1/4 md:flex-col md:gap-3"
+      >
         {bidirectionalTabs.map((tab, i) => (
           <button
             key={i}

--- a/packages/docs/src/routes/index.tsx
+++ b/packages/docs/src/routes/index.tsx
@@ -117,35 +117,42 @@ function BidirectionalTabs() {
   }, [activeTab]);
 
   // Scroll only within the tab container (horizontal, mobile only).
-  // Never calls scrollIntoView so the page never jumps vertically.
-  const scrollTabButtonIntoContainerView = (index: number) => {
+  // Never uses scrollIntoView — that causes full-page vertical jumps.
+  const scrollTabIntoContainerView = (index: number) => {
     const btn = tabButtonRefs.current[index];
     const container = tabContainerRef.current;
     if (!btn || !container) return;
+    // On desktop the container is flex-col with no fixed width overflow,
+    // all tabs are visible — skip entirely if no horizontal overflow.
+    if (container.scrollWidth <= container.clientWidth) return;
     const btnLeft = btn.offsetLeft;
     const btnRight = btnLeft + btn.offsetWidth;
     const { scrollLeft, offsetWidth } = container;
     if (btnLeft < scrollLeft) {
       container.scrollTo({ left: btnLeft, behavior: "smooth" });
     } else if (btnRight > scrollLeft + offsetWidth) {
-      container.scrollTo({
-        left: btnRight - offsetWidth,
-        behavior: "smooth",
-      });
+      container.scrollTo({ left: btnRight - offsetWidth, behavior: "smooth" });
     }
   };
 
-  const handleTabClick = (index: number) => {
+  // Scroll the newly-active tab button into the container's horizontal view
+  // whenever activeTab changes (covers both clicks and auto-advance).
+  useEffect(() => {
+    scrollTabIntoContainerView(activeTab);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab]);
+
+  const handleTabClick = (index: number, btn: HTMLButtonElement | null) => {
     setActiveTab(index);
-    scrollTabButtonIntoContainerView(index);
+    // Re-focus with preventScroll so keyboard a11y is maintained but the
+    // page doesn't jump. (mousedown preventDefault removed native focus.)
+    btn?.focus({ preventScroll: true });
   };
 
   const handleVideoEnded = (i: number) => {
     setActiveTab((prev) => {
       if (prev !== i) return prev;
-      const next = (i + 1) % bidirectionalTabs.length;
-      scrollTabButtonIntoContainerView(next);
-      return next;
+      return (i + 1) % bidirectionalTabs.length;
     });
   };
 
@@ -161,7 +168,14 @@ function BidirectionalTabs() {
             ref={(el) => {
               tabButtonRefs.current[i] = el;
             }}
-            onClick={() => handleTabClick(i)}
+            onMouseDown={(e) => {
+              // Prevent the browser from auto-scrolling the page to the
+              // focused element — we handle container-only scrolling ourselves.
+              e.preventDefault();
+            }}
+            onClick={(e) =>
+              handleTabClick(i, e.currentTarget as HTMLButtonElement)
+            }
             className={`cursor-pointer rounded-xl border p-4 text-left transition-all md:p-5 ${
               i === activeTab
                 ? "border-[var(--accent)] bg-[var(--accent)]/5 shadow-[0_0_0_1px_var(--accent)]"


### PR DESCRIPTION
### Summary
Fixes a regression on the agent-native docs homepage where clicking a tab in the "Agents and UIs — fully connected" section caused the entire page to scroll vertically, making the page difficult to browse.

### Problem
The `BidirectionalTabs` component was calling `btn.scrollIntoView(...)` on both tab click and video end events. While `block: 'nearest'` was intended to minimize vertical movement, it still caused the page to jump vertically when the user was browsing other sections of the page — a disruptive and annoying experience.

### Solution
Replace the `scrollIntoView` calls with a custom scroll helper that operates **only within the tab button container** and only scrolls **horizontally** (for mobile overflow). A `ref` is attached to the tab container `<div>`, and the helper manually computes whether the selected button is out of the container's horizontal scroll bounds before adjusting `scrollLeft`. The page's vertical scroll position is never touched.

### Key Changes
- Added `tabContainerRef` to hold a reference to the tab button container `<div>`.
- Introduced `scrollTabButtonIntoContainerView(index)` — a new helper that performs horizontal-only, container-scoped scrolling using `container.scrollTo()` instead of `btn.scrollIntoView()`.
- Removed all `scrollIntoView` calls from both `handleTabClick` and `handleVideoEnded`.
- The tab container `<div>` now receives the `ref={tabContainerRef}` prop.
- Tab selection behavior, glow/focus styling, and video auto-advance logic are all preserved.

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/ocean-depot-jszvlerg"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-ocean-depot-jszvlerg_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 56`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>ocean-depot-jszvlerg</branchName>-->