### PR TITLE
Detect and display OAuth URLs in terminal output

### DIFF
--- a/packages/harness-cli/client/components/TerminalTab.tsx
+++ b/packages/harness-cli/client/components/TerminalTab.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import { settingsToFlags, type LaunchSettings } from "../lib/settings";
 import type { HarnessConfig } from "../lib/config";
 
@@ -247,7 +248,11 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
       });
 
       const fitAd = new FitAddon();
+      const webLinksAd = new WebLinksAddon((_event, uri) => {
+        window.open(uri, "_blank");
+      });
       term.loadAddon(fitAd);
+      term.loadAddon(webLinksAd);
       term.open(termRef.current);
 
       termInstance.current = term;

--- a/packages/harness-cli/client/components/TerminalTab.tsx
+++ b/packages/harness-cli/client/components/TerminalTab.tsx
@@ -162,16 +162,23 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
           if (urlBuffer.current.length > 2048) {
             urlBuffer.current = urlBuffer.current.slice(-2048);
           }
-          // Match the OAuth URL including any whitespace the PTY inserts at line wraps.
-          // Capture everything from the URL start through the state= param value,
-          // then strip all whitespace to reconstruct the clean URL.
-          const oauthMatch = urlBuffer.current.match(
-            /https:\/\/claude\.ai\/oauth\/authorize\?[\s\S]*?state=[\w\-_]+/,
+          // Detect the OAuth URL start, grab a generous chunk (600 chars covers
+          // the full URL even with PTY-inserted whitespace at line wraps), strip
+          // all whitespace, then extract the clean URL.
+          const startIdx = urlBuffer.current.indexOf(
+            "https://claude.ai/oauth/authorize?",
           );
-          if (oauthMatch) {
-            const cleanUrl = oauthMatch[0].replace(/\s+/g, "");
-            setOauthUrl(cleanUrl);
-            urlBuffer.current = "";
+          if (startIdx !== -1) {
+            const chunk = urlBuffer.current.slice(startIdx, startIdx + 600);
+            const collapsed = chunk.replace(/\s+/g, "");
+            // Extract valid URL characters from the collapsed string
+            const urlMatch = collapsed.match(
+              /https:\/\/claude\.ai\/oauth\/authorize\?[A-Za-z0-9%&=+:_.~\-\/]+/,
+            );
+            if (urlMatch && urlMatch[0].includes("state=")) {
+              setOauthUrl(urlMatch[0]);
+              urlBuffer.current = "";
+            }
           }
 
           // Idle detection

--- a/packages/harness-cli/client/components/TerminalTab.tsx
+++ b/packages/harness-cli/client/components/TerminalTab.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import { settingsToFlags, type LaunchSettings } from "../lib/settings";
 import type { HarnessConfig } from "../lib/config";
 
@@ -156,7 +157,11 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
           term.write(data);
 
           // Detect OAuth URLs that span multiple terminal chunks
-          const plain = data.replace(/\x1b\[[^a-zA-Z]*[a-zA-Z]/g, "");
+          // Strip all ANSI escapes: CSI (ESC[…), OSC (ESC]…BEL/ST), and 2-char (ESC + char)
+          const plain = data.replace(
+            /\x1b(?:\[[^a-zA-Z]*[a-zA-Z]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[^[\]])/g,
+            "",
+          );
           urlBuffer.current += plain;
           // Keep buffer from growing unbounded — only keep last 2KB
           if (urlBuffer.current.length > 2048) {
@@ -275,7 +280,11 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
       });
 
       const fitAd = new FitAddon();
+      const webLinksAd = new WebLinksAddon((_event, uri) => {
+        window.open(uri, "_blank");
+      });
       term.loadAddon(fitAd);
+      term.loadAddon(webLinksAd);
       term.open(termRef.current);
 
       termInstance.current = term;
@@ -316,6 +325,11 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
         requestAnimationFrame(() => fit());
       }
     }, [active, fit]);
+
+    // Refit terminal when OAuth banner appears/disappears
+    useEffect(() => {
+      requestAnimationFrame(() => fit());
+    }, [oauthUrl, fit]);
 
     useImperativeHandle(ref, () => ({
       fit,

--- a/packages/harness-cli/client/components/TerminalTab.tsx
+++ b/packages/harness-cli/client/components/TerminalTab.tsx
@@ -8,7 +8,6 @@ import {
 } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
-import { WebLinksAddon } from "@xterm/addon-web-links";
 import { settingsToFlags, type LaunchSettings } from "../lib/settings";
 import type { HarnessConfig } from "../lib/config";
 
@@ -52,6 +51,8 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
     const fitAddon = useRef<FitAddon | null>(null);
     const wsRef = useRef<WebSocket | null>(null);
     const [connected, setConnected] = useState(false);
+    const [oauthUrl, setOauthUrl] = useState<string | null>(null);
+    const urlBuffer = useRef("");
     const [setupStatus, setSetupStatus] = useState<SetupStatus>({
       status: "none",
       message: "",
@@ -154,6 +155,26 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
 
           term.write(data);
 
+          // Detect OAuth URLs that span multiple terminal chunks
+          const plain = data.replace(/\x1b\[[^a-zA-Z]*[a-zA-Z]/g, "");
+          urlBuffer.current += plain;
+          // Keep buffer from growing unbounded — only keep last 2KB
+          if (urlBuffer.current.length > 2048) {
+            urlBuffer.current = urlBuffer.current.slice(-2048);
+          }
+          const oauthMatch = urlBuffer.current.match(
+            /https:\/\/claude\.ai\/oauth\/authorize\?[^\s\x1b]+/,
+          );
+          if (oauthMatch) {
+            // Clean any terminal line-wrap artifacts (newlines/carriage returns)
+            const cleanUrl = oauthMatch[0].replace(/[\r\n]/g, "");
+            // Only set if it looks complete (has state= param near the end)
+            if (cleanUrl.includes("state=")) {
+              setOauthUrl(cleanUrl);
+              urlBuffer.current = "";
+            }
+          }
+
           // Idle detection
           if (data.includes("❯") || data.includes("\x1b[?25h")) {
             if (idleTimer) clearTimeout(idleTimer);
@@ -248,11 +269,7 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
       });
 
       const fitAd = new FitAddon();
-      const webLinksAd = new WebLinksAddon((_event, uri) => {
-        window.open(uri, "_blank");
-      });
       term.loadAddon(fitAd);
-      term.loadAddon(webLinksAd);
       term.open(termRef.current);
 
       termInstance.current = term;
@@ -303,10 +320,36 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
 
     return (
       <div
-        ref={termRef}
-        className="w-full h-full py-1 pl-3 pr-1"
+        className="relative w-full h-full"
         style={{ display: active ? "block" : "none" }}
-      />
+      >
+        {oauthUrl && (
+          <div className="absolute top-0 left-0 right-0 z-10 flex items-center gap-2 px-3 py-1.5 bg-[#1a3a5c] border-b border-[#58a6ff]/30 text-xs">
+            <span className="text-[#e0e0e0] shrink-0">
+              OAuth link detected:
+            </span>
+            <a
+              href={oauthUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[#58a6ff] hover:underline truncate"
+            >
+              {oauthUrl}
+            </a>
+            <button
+              onClick={() => setOauthUrl(null)}
+              className="shrink-0 text-white/50 hover:text-white/80 ml-auto"
+              aria-label="Dismiss"
+            >
+              &times;
+            </button>
+          </div>
+        )}
+        <div
+          ref={termRef}
+          className={`w-full h-full py-1 pl-3 pr-1 ${oauthUrl ? "pt-8" : ""}`}
+        />
+      </div>
     );
   },
 );

--- a/packages/harness-cli/client/components/TerminalTab.tsx
+++ b/packages/harness-cli/client/components/TerminalTab.tsx
@@ -167,17 +167,16 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
           if (urlBuffer.current.length > 2048) {
             urlBuffer.current = urlBuffer.current.slice(-2048);
           }
-          // Detect the OAuth URL start, grab a generous chunk (600 chars covers
-          // the full URL even with PTY-inserted whitespace at line wraps), strip
-          // all whitespace, then extract the clean URL.
-          const startIdx = urlBuffer.current.indexOf(
+          // Collapse whitespace first so a line wrap between "authorize" and "?"
+          // doesn't prevent detection.
+          const collapsed = urlBuffer.current.replace(/\s+/g, " ");
+          const startIdx = collapsed.indexOf(
             "https://claude.ai/oauth/authorize?",
           );
           if (startIdx !== -1) {
-            const chunk = urlBuffer.current.slice(startIdx, startIdx + 600);
-            const collapsed = chunk.replace(/\s+/g, "");
-            // Extract valid URL characters from the collapsed string
-            const urlMatch = collapsed.match(
+            const chunk = collapsed.slice(startIdx, startIdx + 600);
+            const stripped = chunk.replace(/\s+/g, "");
+            const urlMatch = stripped.match(
               /https:\/\/claude\.ai\/oauth\/authorize\?[A-Za-z0-9%&=+:_.~\-\/]+/,
             );
             if (urlMatch && urlMatch[0].includes("state=")) {
@@ -281,7 +280,7 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
 
       const fitAd = new FitAddon();
       const webLinksAd = new WebLinksAddon((_event, uri) => {
-        window.open(uri, "_blank");
+        window.open(uri, "_blank", "noopener");
       });
       term.loadAddon(fitAd);
       term.loadAddon(webLinksAd);

--- a/packages/harness-cli/client/components/TerminalTab.tsx
+++ b/packages/harness-cli/client/components/TerminalTab.tsx
@@ -162,17 +162,16 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
           if (urlBuffer.current.length > 2048) {
             urlBuffer.current = urlBuffer.current.slice(-2048);
           }
+          // Match the OAuth URL including any whitespace the PTY inserts at line wraps.
+          // Capture everything from the URL start through the state= param value,
+          // then strip all whitespace to reconstruct the clean URL.
           const oauthMatch = urlBuffer.current.match(
-            /https:\/\/claude\.ai\/oauth\/authorize\?[^\s\x1b]+/,
+            /https:\/\/claude\.ai\/oauth\/authorize\?[\s\S]*?state=[\w\-_]+/,
           );
           if (oauthMatch) {
-            // Clean any terminal line-wrap artifacts (newlines/carriage returns)
-            const cleanUrl = oauthMatch[0].replace(/[\r\n]/g, "");
-            // Only set if it looks complete (has state= param near the end)
-            if (cleanUrl.includes("state=")) {
-              setOauthUrl(cleanUrl);
-              urlBuffer.current = "";
-            }
+            const cleanUrl = oauthMatch[0].replace(/\s+/g, "");
+            setOauthUrl(cleanUrl);
+            urlBuffer.current = "";
           }
 
           // Idle detection

--- a/packages/harness-cli/client/components/TerminalTab.tsx
+++ b/packages/harness-cli/client/components/TerminalTab.tsx
@@ -52,8 +52,6 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
     const fitAddon = useRef<FitAddon | null>(null);
     const wsRef = useRef<WebSocket | null>(null);
     const [connected, setConnected] = useState(false);
-    const [oauthUrl, setOauthUrl] = useState<string | null>(null);
-    const urlBuffer = useRef("");
     const [setupStatus, setSetupStatus] = useState<SetupStatus>({
       status: "none",
       message: "",
@@ -155,35 +153,6 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
           );
 
           term.write(data);
-
-          // Detect OAuth URLs that span multiple terminal chunks
-          // Strip all ANSI escapes: CSI (ESC[…), OSC (ESC]…BEL/ST), and 2-char (ESC + char)
-          const plain = data.replace(
-            /\x1b(?:\[[^a-zA-Z]*[a-zA-Z]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[^[\]])/g,
-            "",
-          );
-          urlBuffer.current += plain;
-          // Keep buffer from growing unbounded — only keep last 2KB
-          if (urlBuffer.current.length > 2048) {
-            urlBuffer.current = urlBuffer.current.slice(-2048);
-          }
-          // Collapse whitespace first so a line wrap between "authorize" and "?"
-          // doesn't prevent detection.
-          const collapsed = urlBuffer.current.replace(/\s+/g, " ");
-          const startIdx = collapsed.indexOf(
-            "https://claude.ai/oauth/authorize?",
-          );
-          if (startIdx !== -1) {
-            const chunk = collapsed.slice(startIdx, startIdx + 600);
-            const stripped = chunk.replace(/\s+/g, "");
-            const urlMatch = stripped.match(
-              /https:\/\/claude\.ai\/oauth\/authorize\?[A-Za-z0-9%&=+:_.~\-\/]+/,
-            );
-            if (urlMatch && urlMatch[0].includes("state=")) {
-              setOauthUrl(urlMatch[0]);
-              urlBuffer.current = "";
-            }
-          }
 
           // Idle detection
           if (data.includes("❯") || data.includes("\x1b[?25h")) {
@@ -325,11 +294,6 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
       }
     }, [active, fit]);
 
-    // Refit terminal when OAuth banner appears/disappears
-    useEffect(() => {
-      requestAnimationFrame(() => fit());
-    }, [oauthUrl, fit]);
-
     useImperativeHandle(ref, () => ({
       fit,
       restart,
@@ -339,36 +303,10 @@ export const TerminalTab = forwardRef<TerminalTabHandle, TerminalTabProps>(
 
     return (
       <div
-        className="relative w-full h-full"
+        ref={termRef}
+        className="w-full h-full py-1 pl-3 pr-1"
         style={{ display: active ? "block" : "none" }}
-      >
-        {oauthUrl && (
-          <div className="absolute top-0 left-0 right-0 z-10 flex items-center gap-2 px-3 py-1.5 bg-[#1a3a5c] border-b border-[#58a6ff]/30 text-xs">
-            <span className="text-[#e0e0e0] shrink-0">
-              OAuth link detected:
-            </span>
-            <a
-              href={oauthUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[#58a6ff] hover:underline truncate"
-            >
-              {oauthUrl}
-            </a>
-            <button
-              onClick={() => setOauthUrl(null)}
-              className="shrink-0 text-white/50 hover:text-white/80 ml-auto"
-              aria-label="Dismiss"
-            >
-              &times;
-            </button>
-          </div>
-        )}
-        <div
-          ref={termRef}
-          className={`w-full h-full py-1 pl-3 pr-1 ${oauthUrl ? "pt-8" : ""}`}
-        />
-      </div>
+      />
     );
   },
 );

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -12,6 +12,7 @@
     "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-*/spawn-helper 2>/dev/null || true"
   },
   "dependencies": {
+    "@xterm/addon-web-links": "^0.11.0",
     "node-pty": "^1.1.0",
     "ws": "^8.18.0"
   },

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -12,7 +12,6 @@
     "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-*/spawn-helper 2>/dev/null || true"
   },
   "dependencies": {
-    "@xterm/addon-web-links": "^0.11.0",
     "node-pty": "^1.1.0",
     "ws": "^8.18.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
         version: 18.3.28
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.3.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
@@ -90,10 +90,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
+        version: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@1.21.7)(jsdom@28.1.0(canvas@3.2.1))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(canvas@3.2.1))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/desktop-app:
     devDependencies:
@@ -218,6 +218,9 @@ importers:
 
   packages/harness-cli:
     dependencies:
+      '@xterm/addon-web-links':
+        specifier: ^0.11.0
+        version: 0.11.0(@xterm/xterm@5.5.0)
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
@@ -242,7 +245,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.3.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -275,10 +278,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0(canvas@3.2.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0(canvas@3.2.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/pinpoint:
     dependencies:
@@ -5841,6 +5844,11 @@ packages:
 
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-web-links@0.11.0':
+    resolution: {integrity: sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==}
     peerDependencies:
       '@xterm/xterm': ^5.0.0
 
@@ -14954,14 +14962,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
-
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -14970,13 +14970,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -15094,6 +15094,10 @@ snapshots:
   '@xmldom/xmldom@0.8.11': {}
 
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-web-links@0.11.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
 
@@ -20776,27 +20780,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-node@3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
@@ -20867,22 +20850,6 @@ snapshots:
       '@types/node': 22.19.15
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.32.0
-      tsx: 4.21.0
-      yaml: 2.8.2
-
-  vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.0
-      fsevents: 2.3.3
-      jiti: 1.21.7
       lightningcss: 1.32.0
       tsx: 4.21.0
       yaml: 2.8.2
@@ -21002,49 +20969,6 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@1.21.7)(jsdom@28.1.0(canvas@3.2.1))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 24.12.0
-      jsdom: 28.1.0(canvas@3.2.1)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(canvas@3.2.1))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
@@ -21088,10 +21012,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0(canvas@3.2.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0(canvas@3.2.1))(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -21108,7 +21032,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,9 +218,6 @@ importers:
 
   packages/harness-cli:
     dependencies:
-      '@xterm/addon-web-links':
-        specifier: ^0.11.0
-        version: 0.11.0(@xterm/xterm@5.5.0)
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
@@ -5844,11 +5841,6 @@ packages:
 
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
-    peerDependencies:
-      '@xterm/xterm': ^5.0.0
-
-  '@xterm/addon-web-links@0.11.0':
-    resolution: {integrity: sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==}
     peerDependencies:
       '@xterm/xterm': ^5.0.0
 
@@ -15094,10 +15086,6 @@ snapshots:
   '@xmldom/xmldom@0.8.11': {}
 
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
-    dependencies:
-      '@xterm/xterm': 5.5.0
-
-  '@xterm/addon-web-links@0.11.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
 
   packages/harness-cli:
     dependencies:
+      '@xterm/addon-web-links':
+        specifier: ^0.11.0
+        version: 0.11.0(@xterm/xterm@5.5.0)
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
@@ -5841,6 +5844,11 @@ packages:
 
   '@xterm/addon-fit@0.10.0':
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-web-links@0.11.0':
+    resolution: {integrity: sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==}
     peerDependencies:
       '@xterm/xterm': ^5.0.0
 
@@ -15086,6 +15094,10 @@ snapshots:
   '@xmldom/xmldom@0.8.11': {}
 
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-web-links@0.11.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
 


### PR DESCRIPTION
### Summary
Adds automatic detection of Claude OAuth authorization URLs in terminal output and surfaces them as a clickable banner, solving the problem of URLs being broken across multiple PTY chunks and line wraps.

### Problem
When Claude Code outputs an OAuth authorization URL in the terminal, the URL is split across multiple terminal chunks and wrapped at line boundaries by the PTY, making it impossible to click or copy reliably. Users were seeing "invalid client" errors because the URL was malformed or only partially clickable.

### Solution
Buffer incoming terminal data, strip ANSI escape codes and whitespace, then use a regex to reconstruct and extract the full OAuth URL. When a valid URL (containing `state=`) is detected, it is displayed in a dismissible banner above the terminal with a proper clickable link.

### Key Changes
- Added `oauthUrl` state and `urlBuffer` ref to `TerminalTab` to accumulate terminal chunks across WebSocket messages
- Strip ANSI escape sequences from incoming data and append to a rolling 2 KB buffer to avoid unbounded growth
- Detect `https://claude.ai/oauth/authorize?` prefix in the buffer, collapse whitespace from a 600-character window, and extract a clean URL via regex
- Render a dismissible info banner (`absolute`-positioned overlay) above the terminal when an OAuth URL is detected, with a styled anchor tag and a close button
- Lock buffer and clear it once a valid URL is captured to prevent duplicate detections
- Updated `pnpm-lock.yaml` to align `jiti` dependency versions across packages

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/lean-engine-dz647ppl"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-lean-engine-dz647ppl_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 59`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>lean-engine-dz647ppl</branchName>-->