### PR TITLE
refactor: Migrate all templates to createFileSync() pattern

### DIFF
--- a/packages/core/src/adapters/sync/create-file-sync.ts
+++ b/packages/core/src/adapters/sync/create-file-sync.ts
@@ -241,6 +241,7 @@ export async function createFileSync(options: {
     appId,
     ownerId,
     contentRoot: options.contentRoot,
+    syncConfigPath: path.resolve(options.contentRoot, "sync-config.json"),
     adapter,
   };
 

--- a/packages/core/src/server/sse.ts
+++ b/packages/core/src/server/sse.ts
@@ -26,9 +26,17 @@ export function createFileWatcher(
   });
 }
 
+/** Any object with on/off methods (compatible with EventEmitter, TypedEventEmitter, etc.). */
+interface EventLike {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string, listener: (...args: any[]) => void): any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  off(event: string, listener: (...args: any[]) => void): any;
+}
+
 export interface SSEHandlerOptions {
   /** Additional EventEmitters to stream events from (e.g. sync events). */
-  extraEmitters?: Array<{ emitter: EventEmitter; event: string }>;
+  extraEmitters?: Array<{ emitter: EventLike; event: string }>;
   /** Content root for computing relative paths. If provided, absolute paths are stripped. */
   contentRoot?: string;
 }

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -102,21 +102,25 @@ File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.en
 | `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
 
 **How sync works:**
+
 - `createFileSync()` factory reads env vars and initializes sync
 - Files matching `sync-config.json` patterns are synced to/from the database
 - Sync events flow through SSE (`source: "sync"`) alongside file change events
 - Conflicts produce `.conflict` sidecar files and notify the agent
 
 **Checking sync status:**
+
 - Read `data/.sync-status.json` for current sync state
 - Read `data/.sync-failures.json` for permanently failed sync operations
 
 **Handling conflicts:**
+
 - When `application-state/sync-conflict.json` appears, resolve the conflict
 - Read the `.conflict` file alongside the original to understand both versions
 - Edit the original file to resolve, then delete the `.conflict` file
 
 **Scratch files (not synced):**
+
 - Prefix temporary files with `_tmp-` to exclude from sync
 
 ## Tech Stack

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -86,6 +86,39 @@ Skills should be **continuously improved** based on learnings and feedback. When
 
 3. **The UI can delegate to the AI agent.** Use `sendToAgentChat()` from `@agent-native/core` to programmatically submit prompts to the agent chat. This lets UI buttons trigger agentic workflows — the button provides the structured prompt, and the agent does the work. This is vastly more flexible than building custom backend endpoints for every feature.
 
+### File Sync (Multi-User Collaboration)
+
+File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.env`.
+
+**Environment variables:**
+
+| Variable                         | Required      | Description                                          |
+| -------------------------------- | ------------- | ---------------------------------------------------- |
+| `FILE_SYNC_ENABLED`              | No            | Set to `"true"` to enable sync                       |
+| `FILE_SYNC_BACKEND`              | When enabled  | `"firestore"`, `"supabase"`, or `"convex"`           |
+| `SUPABASE_URL`                   | For Supabase  | Project URL                                          |
+| `SUPABASE_PUBLISHABLE_KEY`       | For Supabase  | Publishable key (or legacy `SUPABASE_ANON_KEY`)      |
+| `GOOGLE_APPLICATION_CREDENTIALS` | For Firestore | Path to service account JSON                         |
+| `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
+
+**How sync works:**
+- `createFileSync()` factory reads env vars and initializes sync
+- Files matching `sync-config.json` patterns are synced to/from the database
+- Sync events flow through SSE (`source: "sync"`) alongside file change events
+- Conflicts produce `.conflict` sidecar files and notify the agent
+
+**Checking sync status:**
+- Read `data/.sync-status.json` for current sync state
+- Read `data/.sync-failures.json` for permanently failed sync operations
+
+**Handling conflicts:**
+- When `application-state/sync-conflict.json` appears, resolve the conflict
+- Read the `.conflict` file alongside the original to understand both versions
+- Edit the original file to resolve, then delete the `.conflict` file
+
+**Scratch files (not synced):**
+- Prefix temporary files with `_tmp-` to exclude from sync
+
 ## Tech Stack
 
 - **Frontend**: React 18 + React Router 6 (SPA) + TypeScript + Vite + TailwindCSS 3

--- a/templates/analytics/server/index.ts
+++ b/templates/analytics/server/index.ts
@@ -9,7 +9,11 @@ import {
   sendStream,
   setResponseStatus,
 } from "h3";
-import { createServer, createFileWatcher, createSSEHandler } from "@agent-native/core/server";
+import {
+  createServer,
+  createFileWatcher,
+  createSSEHandler,
+} from "@agent-native/core/server";
 import { createFileSync } from "@agent-native/core/adapters/sync";
 import { handleDemo } from "./routes/demo";
 import { handleQuery } from "./routes/query-proxy";
@@ -292,14 +296,26 @@ export async function createAppServer() {
   if (syncResult.status === "error") {
     console.warn(`[app] File sync failed: ${syncResult.reason}`);
   }
-  const extraEmitters = syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+  const extraEmitters =
+    syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
 
-  router.get("/api/file-sync/status", defineEventHandler(() => {
-    if (syncResult.status !== "ready") return { enabled: false, conflicts: 0 };
-    return { enabled: true, connected: true, conflicts: syncResult.fileSync.conflictCount };
-  }));
+  router.get(
+    "/api/file-sync/status",
+    defineEventHandler(() => {
+      if (syncResult.status !== "ready")
+        return { enabled: false, conflicts: 0 };
+      return {
+        enabled: true,
+        connected: true,
+        conflicts: syncResult.fileSync.conflictCount,
+      };
+    }),
+  );
 
-  router.get("/api/events", createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }));
+  router.get(
+    "/api/events",
+    createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }),
+  );
 
   // Graceful shutdown
   process.on("SIGTERM", async () => {
@@ -313,11 +329,16 @@ export async function createAppServer() {
       try {
         if (event.type === "conflict-needs-llm") {
           fs.mkdirSync("application-state", { recursive: true });
-          fs.writeFileSync("application-state/sync-conflict.json", JSON.stringify(event, null, 2));
+          fs.writeFileSync(
+            "application-state/sync-conflict.json",
+            JSON.stringify(event, null, 2),
+          );
         } else if (event.type === "conflict-resolved") {
           fs.rmSync("application-state/sync-conflict.json", { force: true });
         }
-      } catch { /* best-effort */ }
+      } catch {
+        /* best-effort */
+      }
     });
   }
 

--- a/templates/analytics/server/index.ts
+++ b/templates/analytics/server/index.ts
@@ -9,7 +9,8 @@ import {
   sendStream,
   setResponseStatus,
 } from "h3";
-import { createServer } from "@agent-native/core/server";
+import { createServer, createFileWatcher, createSSEHandler } from "@agent-native/core/server";
+import { createFileSync } from "@agent-native/core/adapters/sync";
 import { handleDemo } from "./routes/demo";
 import { handleQuery } from "./routes/query-proxy";
 import {
@@ -111,8 +112,10 @@ import {
   deleteExplorerDashboard,
 } from "./routes/explorer-dashboards";
 
-export function createAppServer() {
+export async function createAppServer() {
   const { app, router } = createServer({ envKeys });
+
+  const watcher = createFileWatcher("./data");
 
   // Serve generated chart images (no auth needed, ephemeral)
   const mediaDir = path.resolve(import.meta.dirname, "../media");
@@ -283,6 +286,40 @@ export function createAppServer() {
   router.get("/api/gamification/leaderboard", handleLeaderboard);
   router.get("/api/gamification/my-stats", handleMyStats);
   router.get("/api/gamification/new-metrics", handleNewMetrics);
+
+  // File sync
+  const syncResult = await createFileSync({ contentRoot: "./data" });
+  if (syncResult.status === "error") {
+    console.warn(`[app] File sync failed: ${syncResult.reason}`);
+  }
+  const extraEmitters = syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+
+  router.get("/api/file-sync/status", defineEventHandler(() => {
+    if (syncResult.status !== "ready") return { enabled: false, conflicts: 0 };
+    return { enabled: true, connected: true, conflicts: syncResult.fileSync.conflictCount };
+  }));
+
+  router.get("/api/events", createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }));
+
+  // Graceful shutdown
+  process.on("SIGTERM", async () => {
+    if (syncResult.status === "ready") await syncResult.shutdown();
+    process.exit(0);
+  });
+
+  // Conflict notification
+  if (syncResult.status === "ready") {
+    syncResult.fileSync.syncEvents.on("sync", (event) => {
+      try {
+        if (event.type === "conflict-needs-llm") {
+          fs.mkdirSync("application-state", { recursive: true });
+          fs.writeFileSync("application-state/sync-conflict.json", JSON.stringify(event, null, 2));
+        } else if (event.type === "conflict-resolved") {
+          fs.rmSync("application-state/sync-conflict.json", { force: true });
+        }
+      } catch { /* best-effort */ }
+    });
+  }
 
   return app;
 }

--- a/templates/analytics/server/node-build.ts
+++ b/templates/analytics/server/node-build.ts
@@ -1,3 +1,3 @@
 import { createProductionServer } from "@agent-native/core/server";
 import { createAppServer } from "./index.js";
-createProductionServer(createAppServer());
+createAppServer().then((app) => createProductionServer(app));

--- a/templates/brand/data/sync-config.json
+++ b/templates/brand/data/sync-config.json
@@ -1,0 +1,7 @@
+{
+  "syncFilePatterns": [
+    "data/brand/**/*.json",
+    "data/generations/**/*.json",
+    "!data/sync-config.json"
+  ]
+}

--- a/templates/brand/server/index.ts
+++ b/templates/brand/server/index.ts
@@ -1,24 +1,78 @@
+import fs from "fs";
+import { defineEventHandler } from "h3";
 import {
   createServer,
   createFileWatcher,
   createSSEHandler,
 } from "@agent-native/core";
+import { createFileSync } from "@agent-native/core/adapters/sync";
 import { envKeys } from "./lib/env-config.js";
 import { registerBrandRoutes } from "./routes/brand.js";
 import { registerGenerationsRoutes } from "./routes/generations.js";
 
-export function createAppServer() {
+export async function createAppServer() {
   const { app, router } = createServer({ envKeys });
 
   // SSE file watcher for real-time sync
   const watcher = createFileWatcher("./data");
-  router.get("/api/events", createSSEHandler(watcher));
+
+  // --- File sync (opt-in via FILE_SYNC_ENABLED=true) ---
+  const syncResult = await createFileSync({ contentRoot: "./data" });
+  if (syncResult.status === "error") {
+    console.warn(`[app] File sync failed: ${syncResult.reason}`);
+  }
+  const extraEmitters =
+    syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+
+  // Diagnostic endpoint
+  router.get(
+    "/api/file-sync/status",
+    defineEventHandler(() => {
+      if (syncResult.status !== "ready")
+        return { enabled: false, conflicts: 0 };
+      return {
+        enabled: true,
+        connected: true,
+        conflicts: syncResult.fileSync.conflictCount,
+      };
+    }),
+  );
+
+  router.get(
+    "/api/events",
+    createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }),
+  );
 
   // Brand asset routes (includes static file serving)
   registerBrandRoutes(router);
 
   // Generations routes (includes static file serving)
   registerGenerationsRoutes(router);
+
+  // Graceful shutdown
+  process.on("SIGTERM", async () => {
+    if (syncResult.status === "ready") await syncResult.shutdown();
+    process.exit(0);
+  });
+
+  // Conflict notification
+  if (syncResult.status === "ready") {
+    syncResult.fileSync.syncEvents.on("sync", (event) => {
+      try {
+        if (event.type === "conflict-needs-llm") {
+          fs.mkdirSync("application-state", { recursive: true });
+          fs.writeFileSync(
+            "application-state/sync-conflict.json",
+            JSON.stringify(event, null, 2),
+          );
+        } else if (event.type === "conflict-resolved") {
+          fs.rmSync("application-state/sync-conflict.json", { force: true });
+        }
+      } catch {
+        /* best-effort */
+      }
+    });
+  }
 
   return app;
 }

--- a/templates/brand/server/node-build.ts
+++ b/templates/brand/server/node-build.ts
@@ -1,3 +1,3 @@
 import { createProductionServer } from "@agent-native/core/server";
 import { createAppServer } from "./index.js";
-createProductionServer(createAppServer());
+createAppServer().then((app) => createProductionServer(app));

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -203,21 +203,25 @@ File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.en
 | `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
 
 **How sync works:**
+
 - `createFileSync()` factory reads env vars and initializes sync
 - Files matching `sync-config.json` patterns are synced to/from the database
 - Sync events flow through SSE (`source: "sync"`) alongside file change events
 - Conflicts produce `.conflict` sidecar files and notify the agent
 
 **Checking sync status:**
+
 - Read `data/.sync-status.json` for current sync state
 - Read `data/.sync-failures.json` for permanently failed sync operations
 
 **Handling conflicts:**
+
 - When `application-state/sync-conflict.json` appears, resolve the conflict
 - Read the `.conflict` file alongside the original to understand both versions
 - Edit the original file to resolve, then delete the `.conflict` file
 
 **Scratch files (not synced):**
+
 - Prefix temporary files with `_tmp-` to exclude from sync
 
 ## Project Structure

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -89,7 +89,7 @@ All state lives in JSON files:
 | `data/availability.json`  | Availability schedule configuration            |
 | `data/settings.json`      | App settings (timezone, booking page config)   |
 | `data/google-auth.json`   | Google OAuth tokens (gitignored, sensitive)    |
-| `data/sync-config.json`   | Firestore sync patterns                        |
+| `data/sync-config.json`   | File sync patterns                             |
 
 ### Skills
 
@@ -187,32 +187,38 @@ agentChat.submit("Google Calendar sync complete — 42 events synced.");
 
 The `@agent-native/core` chat bridge handles the transport automatically — it works in both browser (postMessage) and Node (stdout) contexts. The harness picks up the messages and routes them to the agent.
 
-## Firestore File Sync
+### File Sync (Multi-User Collaboration)
 
-Data files are bidirectionally synced with Firestore so multiple users (and the cloud-hosted Builder harness) share the same state. The sync is powered by `@agent-native/core/adapters/firestore`.
+File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.env`.
 
-**What syncs:** Configured in `data/sync-config.json`:
+**Environment variables:**
 
-- `data/events/**/*.json` — Calendar events
-- `data/bookings/**/*.json` — Bookings
-- `data/availability.json` — Availability config
-- `data/settings.json` — App settings
+| Variable                         | Required      | Description                                          |
+| -------------------------------- | ------------- | ---------------------------------------------------- |
+| `FILE_SYNC_ENABLED`              | No            | Set to `"true"` to enable sync                       |
+| `FILE_SYNC_BACKEND`              | When enabled  | `"firestore"`, `"supabase"`, or `"convex"`           |
+| `SUPABASE_URL`                   | For Supabase  | Project URL                                          |
+| `SUPABASE_PUBLISHABLE_KEY`       | For Supabase  | Publishable key (or legacy `SUPABASE_ANON_KEY`)      |
+| `GOOGLE_APPLICATION_CREDENTIALS` | For Firestore | Path to service account JSON                         |
+| `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
 
-**What doesn't sync:** `data/google-auth.json` (sensitive), code files, sync-config itself.
+**How sync works:**
+- `createFileSync()` factory reads env vars and initializes sync
+- Files matching `sync-config.json` patterns are synced to/from the database
+- Sync events flow through SSE (`source: "sync"`) alongside file change events
+- Conflicts produce `.conflict` sidecar files and notify the agent
 
-**How it works:**
+**Checking sync status:**
+- Read `data/.sync-status.json` for current sync state
+- Read `data/.sync-failures.json` for permanently failed sync operations
 
-- On server start, `initFileSync()` does a startup sync (compare local vs Firestore timestamps, resolve conflicts)
-- A Firestore real-time listener pushes remote changes to disk
-- A file watcher pushes local changes to Firestore
-- Three-way merge resolves conflicts; unresolvable conflicts create `.conflict` sidecar files
+**Handling conflicts:**
+- When `application-state/sync-conflict.json` appears, resolve the conflict
+- Read the `.conflict` file alongside the original to understand both versions
+- Edit the original file to resolve, then delete the `.conflict` file
 
-**Important for agents:**
-
-- Files in `data/events/` and `data/bookings/` are **gitignored** (synced at runtime, not checked in)
-- The `.ignore` file overrides this so agents can still search/grep/read these files
-- When editing data files, the changes are automatically synced to Firestore within seconds
-- Never edit `data/sync-config.json` unless adding new sync patterns
+**Scratch files (not synced):**
+- Prefix temporary files with `_tmp-` to exclude from sync
 
 ## Project Structure
 

--- a/templates/calendar/server/index.ts
+++ b/templates/calendar/server/index.ts
@@ -1,4 +1,7 @@
-import { createServer } from "@agent-native/core";
+import { createServer, createFileWatcher, createSSEHandler } from "@agent-native/core";
+import { defineEventHandler } from "h3";
+import fs from "fs";
+import { createFileSync } from "@agent-native/core/adapters/sync";
 import { envKeys } from "./lib/env-config.js";
 import {
   getGoogleAuthUrl,
@@ -23,8 +26,10 @@ import {
 } from "./routes/bookings.js";
 import { getSettings, updateSettings } from "./routes/settings.js";
 
-export function createAppServer() {
+export async function createAppServer() {
   const { app, router } = createServer({ envKeys });
+
+  const watcher = createFileWatcher("./data");
 
   router.get("/api/ping", () => ({ message: "pong" }));
 
@@ -57,6 +62,40 @@ export function createAppServer() {
   // Settings
   router.get("/api/settings", getSettings);
   router.put("/api/settings", updateSettings);
+
+  // File sync
+  const syncResult = await createFileSync({ contentRoot: "./data" });
+  if (syncResult.status === "error") {
+    console.warn(`[app] File sync failed: ${syncResult.reason}`);
+  }
+  const extraEmitters = syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+
+  router.get("/api/file-sync/status", defineEventHandler(() => {
+    if (syncResult.status !== "ready") return { enabled: false, conflicts: 0 };
+    return { enabled: true, connected: true, conflicts: syncResult.fileSync.conflictCount };
+  }));
+
+  router.get("/api/events", createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }));
+
+  // Graceful shutdown
+  process.on("SIGTERM", async () => {
+    if (syncResult.status === "ready") await syncResult.shutdown();
+    process.exit(0);
+  });
+
+  // Conflict notification
+  if (syncResult.status === "ready") {
+    syncResult.fileSync.syncEvents.on("sync", (event) => {
+      try {
+        if (event.type === "conflict-needs-llm") {
+          fs.mkdirSync("application-state", { recursive: true });
+          fs.writeFileSync("application-state/sync-conflict.json", JSON.stringify(event, null, 2));
+        } else if (event.type === "conflict-resolved") {
+          fs.rmSync("application-state/sync-conflict.json", { force: true });
+        }
+      } catch { /* best-effort */ }
+    });
+  }
 
   return app;
 }

--- a/templates/calendar/server/index.ts
+++ b/templates/calendar/server/index.ts
@@ -88,8 +88,9 @@ export async function createAppServer() {
     }),
   );
 
+  // SSE uses /api/sse to avoid collision with /api/events (calendar CRUD)
   router.get(
-    "/api/events",
+    "/api/sse",
     createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }),
   );
 

--- a/templates/calendar/server/index.ts
+++ b/templates/calendar/server/index.ts
@@ -1,4 +1,8 @@
-import { createServer, createFileWatcher, createSSEHandler } from "@agent-native/core";
+import {
+  createServer,
+  createFileWatcher,
+  createSSEHandler,
+} from "@agent-native/core";
 import { defineEventHandler } from "h3";
 import fs from "fs";
 import { createFileSync } from "@agent-native/core/adapters/sync";
@@ -68,14 +72,26 @@ export async function createAppServer() {
   if (syncResult.status === "error") {
     console.warn(`[app] File sync failed: ${syncResult.reason}`);
   }
-  const extraEmitters = syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+  const extraEmitters =
+    syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
 
-  router.get("/api/file-sync/status", defineEventHandler(() => {
-    if (syncResult.status !== "ready") return { enabled: false, conflicts: 0 };
-    return { enabled: true, connected: true, conflicts: syncResult.fileSync.conflictCount };
-  }));
+  router.get(
+    "/api/file-sync/status",
+    defineEventHandler(() => {
+      if (syncResult.status !== "ready")
+        return { enabled: false, conflicts: 0 };
+      return {
+        enabled: true,
+        connected: true,
+        conflicts: syncResult.fileSync.conflictCount,
+      };
+    }),
+  );
 
-  router.get("/api/events", createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }));
+  router.get(
+    "/api/events",
+    createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }),
+  );
 
   // Graceful shutdown
   process.on("SIGTERM", async () => {
@@ -89,11 +105,16 @@ export async function createAppServer() {
       try {
         if (event.type === "conflict-needs-llm") {
           fs.mkdirSync("application-state", { recursive: true });
-          fs.writeFileSync("application-state/sync-conflict.json", JSON.stringify(event, null, 2));
+          fs.writeFileSync(
+            "application-state/sync-conflict.json",
+            JSON.stringify(event, null, 2),
+          );
         } else if (event.type === "conflict-resolved") {
           fs.rmSync("application-state/sync-conflict.json", { force: true });
         }
-      } catch { /* best-effort */ }
+      } catch {
+        /* best-effort */
+      }
     });
   }
 

--- a/templates/calendar/server/node-build.ts
+++ b/templates/calendar/server/node-build.ts
@@ -1,3 +1,3 @@
 import { createProductionServer } from "@agent-native/core/server";
 import { createAppServer } from "./index.js";
-createProductionServer(createAppServer());
+createAppServer().then((app) => createProductionServer(app));

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -171,21 +171,25 @@ File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.en
 | `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
 
 **How sync works:**
+
 - `createFileSync()` factory reads env vars and initializes sync
 - Files matching `sync-config.json` patterns are synced to/from the database
 - Sync events flow through SSE (`source: "sync"`) alongside file change events
 - Conflicts produce `.conflict` sidecar files and notify the agent
 
 **Checking sync status:**
+
 - Read `content/.sync-status.json` for current sync state
 - Read `content/.sync-failures.json` for permanently failed sync operations
 
 **Handling conflicts:**
+
 - When `application-state/sync-conflict.json` appears, resolve the conflict
 - Read the `.conflict` file alongside the original to understand both versions
 - Edit the original file to resolve, then delete the `.conflict` file
 
 **Scratch files (not synced):**
+
 - Prefix temporary files with `_tmp-` to exclude from sync
 
 ---

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -155,6 +155,39 @@ agentChat.send({
 
 **Why this matters:** Instead of building custom AI integrations for each feature, wire a button to `sendToAgentChat()` with the right prompt and context. The AI handles the rest. Each call is isolated with exactly the context it needs — no bloat from unrelated skills or files.
 
+### File Sync (Multi-User Collaboration)
+
+File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.env`.
+
+**Environment variables:**
+
+| Variable                         | Required      | Description                                          |
+| -------------------------------- | ------------- | ---------------------------------------------------- |
+| `FILE_SYNC_ENABLED`              | No            | Set to `"true"` to enable sync                       |
+| `FILE_SYNC_BACKEND`              | When enabled  | `"firestore"`, `"supabase"`, or `"convex"`           |
+| `SUPABASE_URL`                   | For Supabase  | Project URL                                          |
+| `SUPABASE_PUBLISHABLE_KEY`       | For Supabase  | Publishable key (or legacy `SUPABASE_ANON_KEY`)      |
+| `GOOGLE_APPLICATION_CREDENTIALS` | For Firestore | Path to service account JSON                         |
+| `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
+
+**How sync works:**
+- `createFileSync()` factory reads env vars and initializes sync
+- Files matching `sync-config.json` patterns are synced to/from the database
+- Sync events flow through SSE (`source: "sync"`) alongside file change events
+- Conflicts produce `.conflict` sidecar files and notify the agent
+
+**Checking sync status:**
+- Read `content/.sync-status.json` for current sync state
+- Read `content/.sync-failures.json` for permanently failed sync operations
+
+**Handling conflicts:**
+- When `application-state/sync-conflict.json` appears, resolve the conflict
+- Read the `.conflict` file alongside the original to understand both versions
+- Edit the original file to resolve, then delete the `.conflict` file
+
+**Scratch files (not synced):**
+- Prefix temporary files with `_tmp-` to exclude from sync
+
 ---
 
 ## Agent Rules — MANDATORY

--- a/templates/content/server/index.ts
+++ b/templates/content/server/index.ts
@@ -4,6 +4,8 @@ import chokidar from "chokidar";
 import type { FSWatcher } from "chokidar";
 import path from "path";
 import { createServer, createSSEHandler } from "@agent-native/core";
+import { defineEventHandler } from "h3";
+import { createFileSync } from "@agent-native/core/adapters/sync";
 import { envKeys } from "./lib/env-config.js";
 import {
   listProjects,
@@ -184,7 +186,7 @@ function getContentWatcher() {
   return contentWatcher;
 }
 
-export function createAppServer() {
+export async function createAppServer() {
   const { app, router } = createServer({ envKeys });
 
   // Pages API (unified page tree)
@@ -349,10 +351,60 @@ export function createAppServer() {
 
   // SSE for File Watching (keep last)
   const watcher = getContentWatcher();
-  router.get("/api/events", createSSEHandler(watcher));
+
+  // File sync (multi-user collaboration)
+  const syncResult = await createFileSync({ contentRoot: "./content" });
+  if (syncResult.status === "error") {
+    console.warn(`[app] File sync failed: ${syncResult.reason}`);
+  }
+  const extraEmitters =
+    syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+
+  router.get(
+    "/api/file-sync/status",
+    defineEventHandler(() => {
+      if (syncResult.status !== "ready")
+        return { enabled: false, conflicts: 0 };
+      return {
+        enabled: true,
+        connected: true,
+        conflicts: syncResult.fileSync.conflictCount,
+      };
+    }),
+  );
+
+  router.get(
+    "/api/events",
+    createSSEHandler(watcher, { extraEmitters, contentRoot: "./content" }),
+  );
 
   // Feedback
   router.post("/api/feedback", sendFeedback);
+
+  // Graceful shutdown
+  process.on("SIGTERM", async () => {
+    if (syncResult.status === "ready") await syncResult.shutdown();
+    process.exit(0);
+  });
+
+  // Conflict notification
+  if (syncResult.status === "ready") {
+    syncResult.fileSync.syncEvents.on("sync", (event) => {
+      try {
+        if (event.type === "conflict-needs-llm") {
+          fs.mkdirSync("application-state", { recursive: true });
+          fs.writeFileSync(
+            "application-state/sync-conflict.json",
+            JSON.stringify(event, null, 2),
+          );
+        } else if (event.type === "conflict-resolved") {
+          fs.rmSync("application-state/sync-conflict.json", { force: true });
+        }
+      } catch {
+        /* best-effort */
+      }
+    });
+  }
 
   return app;
 }

--- a/templates/content/server/node-build.ts
+++ b/templates/content/server/node-build.ts
@@ -1,3 +1,3 @@
 import { createProductionServer } from "@agent-native/core/server";
 import { createAppServer } from "./index.js";
-createProductionServer(createAppServer());
+createAppServer().then((app) => createProductionServer(app));

--- a/templates/imagegen/AGENTS.md
+++ b/templates/imagegen/AGENTS.md
@@ -45,21 +45,25 @@ File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.en
 | `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
 
 **How sync works:**
+
 - `createFileSync()` factory reads env vars and initializes sync
 - Files matching `sync-config.json` patterns are synced to/from the database
 - Sync events flow through SSE (`source: "sync"`) alongside file change events
 - Conflicts produce `.conflict` sidecar files and notify the agent
 
 **Checking sync status:**
+
 - Read `data/.sync-status.json` for current sync state
 - Read `data/.sync-failures.json` for permanently failed sync operations
 
 **Handling conflicts:**
+
 - When `application-state/sync-conflict.json` appears, resolve the conflict
 - Read the `.conflict` file alongside the original to understand both versions
 - Edit the original file to resolve, then delete the `.conflict` file
 
 **Scratch files (not synced):**
+
 - Prefix temporary files with `_tmp-` to exclude from sync
 
 ## Architecture

--- a/templates/imagegen/AGENTS.md
+++ b/templates/imagegen/AGENTS.md
@@ -29,6 +29,39 @@ See `.agents/skills/` for the framework rules that apply to all agent-native app
 
 Keep entries concise and actionable. Group by category. This file is gitignored so personal data stays local.
 
+### File Sync (Multi-User Collaboration)
+
+File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.env`.
+
+**Environment variables:**
+
+| Variable                         | Required      | Description                                          |
+| -------------------------------- | ------------- | ---------------------------------------------------- |
+| `FILE_SYNC_ENABLED`              | No            | Set to `"true"` to enable sync                       |
+| `FILE_SYNC_BACKEND`              | When enabled  | `"firestore"`, `"supabase"`, or `"convex"`           |
+| `SUPABASE_URL`                   | For Supabase  | Project URL                                          |
+| `SUPABASE_PUBLISHABLE_KEY`       | For Supabase  | Publishable key (or legacy `SUPABASE_ANON_KEY`)      |
+| `GOOGLE_APPLICATION_CREDENTIALS` | For Firestore | Path to service account JSON                         |
+| `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
+
+**How sync works:**
+- `createFileSync()` factory reads env vars and initializes sync
+- Files matching `sync-config.json` patterns are synced to/from the database
+- Sync events flow through SSE (`source: "sync"`) alongside file change events
+- Conflicts produce `.conflict` sidecar files and notify the agent
+
+**Checking sync status:**
+- Read `data/.sync-status.json` for current sync state
+- Read `data/.sync-failures.json` for permanently failed sync operations
+
+**Handling conflicts:**
+- When `application-state/sync-conflict.json` appears, resolve the conflict
+- Read the `.conflict` file alongside the original to understand both versions
+- Edit the original file to resolve, then delete the `.conflict` file
+
+**Scratch files (not synced):**
+- Prefix temporary files with `_tmp-` to exclude from sync
+
 ## Architecture
 
 Files are the database. All state lives in `data/`:

--- a/templates/imagegen/server/index.ts
+++ b/templates/imagegen/server/index.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import path from "path";
 import { createReadStream } from "fs";
 import { stat } from "fs/promises";
@@ -7,16 +8,43 @@ import {
   createFileWatcher,
   createSSEHandler,
 } from "@agent-native/core";
+import { createFileSync } from "@agent-native/core/adapters/sync";
 import { envKeys } from "./lib/env-config.js";
 import { registerBrandRoutes } from "./routes/brand.js";
 import { registerGenerationsRoutes } from "./routes/generations.js";
 
-export function createAppServer() {
+export async function createAppServer() {
   const { app, router } = createServer({ envKeys });
 
   // SSE file watcher for real-time sync
   const watcher = createFileWatcher("./data");
-  router.get("/api/events", createSSEHandler(watcher));
+
+  // --- File sync (opt-in via FILE_SYNC_ENABLED=true) ---
+  const syncResult = await createFileSync({ contentRoot: "./data" });
+  if (syncResult.status === "error") {
+    console.warn(`[app] File sync failed: ${syncResult.reason}`);
+  }
+  const extraEmitters =
+    syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+
+  // Diagnostic endpoint
+  router.get(
+    "/api/file-sync/status",
+    defineEventHandler(() => {
+      if (syncResult.status !== "ready")
+        return { enabled: false, conflicts: 0 };
+      return {
+        enabled: true,
+        connected: true,
+        conflicts: syncResult.fileSync.conflictCount,
+      };
+    }),
+  );
+
+  router.get(
+    "/api/events",
+    createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }),
+  );
 
   // Serve uploaded brand assets
   router.get(
@@ -63,6 +91,31 @@ export function createAppServer() {
   // Mount routes
   registerBrandRoutes(router);
   registerGenerationsRoutes(router);
+
+  // Graceful shutdown
+  process.on("SIGTERM", async () => {
+    if (syncResult.status === "ready") await syncResult.shutdown();
+    process.exit(0);
+  });
+
+  // Conflict notification
+  if (syncResult.status === "ready") {
+    syncResult.fileSync.syncEvents.on("sync", (event) => {
+      try {
+        if (event.type === "conflict-needs-llm") {
+          fs.mkdirSync("application-state", { recursive: true });
+          fs.writeFileSync(
+            "application-state/sync-conflict.json",
+            JSON.stringify(event, null, 2),
+          );
+        } else if (event.type === "conflict-resolved") {
+          fs.rmSync("application-state/sync-conflict.json", { force: true });
+        }
+      } catch {
+        /* best-effort */
+      }
+    });
+  }
 
   return app;
 }

--- a/templates/imagegen/server/node-build.ts
+++ b/templates/imagegen/server/node-build.ts
@@ -1,3 +1,3 @@
 import { createProductionServer } from "@agent-native/core/server";
 import { createAppServer } from "./index.js";
-createProductionServer(createAppServer());
+createAppServer().then((app) => createProductionServer(app));

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -61,6 +61,39 @@ To check the current state:
             └───────────────┘
 ```
 
+### File Sync (Multi-User Collaboration)
+
+File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.env`.
+
+**Environment variables:**
+
+| Variable                         | Required      | Description                                          |
+| -------------------------------- | ------------- | ---------------------------------------------------- |
+| `FILE_SYNC_ENABLED`              | No            | Set to `"true"` to enable sync                       |
+| `FILE_SYNC_BACKEND`              | When enabled  | `"firestore"`, `"supabase"`, or `"convex"`           |
+| `SUPABASE_URL`                   | For Supabase  | Project URL                                          |
+| `SUPABASE_PUBLISHABLE_KEY`       | For Supabase  | Publishable key (or legacy `SUPABASE_ANON_KEY`)      |
+| `GOOGLE_APPLICATION_CREDENTIALS` | For Firestore | Path to service account JSON                         |
+| `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
+
+**How sync works:**
+- `createFileSync()` factory reads env vars and initializes sync
+- Files matching `sync-config.json` patterns are synced to/from the database
+- Sync events flow through SSE (`source: "sync"`) alongside file change events
+- Conflicts produce `.conflict` sidecar files and notify the agent
+
+**Checking sync status:**
+- Read `data/.sync-status.json` for current sync state
+- Read `data/.sync-failures.json` for permanently failed sync operations
+
+**Handling conflicts:**
+- When `application-state/sync-conflict.json` appears, resolve the conflict
+- Read the `.conflict` file alongside the original to understand both versions
+- Edit the original file to resolve, then delete the `.conflict` file
+
+**Scratch files (not synced):**
+- Prefix temporary files with `_tmp-` to exclude from sync
+
 ## Data Model
 
 Local state is in JSON files in `data/`. When a Google account is connected, the API serves emails from Gmail instead — `data/emails.json` is only used as a fallback when no account is connected (and starts empty).

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -77,21 +77,25 @@ File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.en
 | `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
 
 **How sync works:**
+
 - `createFileSync()` factory reads env vars and initializes sync
 - Files matching `sync-config.json` patterns are synced to/from the database
 - Sync events flow through SSE (`source: "sync"`) alongside file change events
 - Conflicts produce `.conflict` sidecar files and notify the agent
 
 **Checking sync status:**
+
 - Read `data/.sync-status.json` for current sync state
 - Read `data/.sync-failures.json` for permanently failed sync operations
 
 **Handling conflicts:**
+
 - When `application-state/sync-conflict.json` appears, resolve the conflict
 - Read the `.conflict` file alongside the original to understand both versions
 - Edit the original file to resolve, then delete the `.conflict` file
 
 **Scratch files (not synced):**
+
 - Prefix temporary files with `_tmp-` to exclude from sync
 
 ## Data Model

--- a/templates/mail/data/sync-config.json
+++ b/templates/mail/data/sync-config.json
@@ -1,0 +1,8 @@
+{
+  "syncFilePatterns": [
+    "data/emails.json",
+    "data/**/*.json",
+    "!data/google-auth.json",
+    "!data/sync-config.json"
+  ]
+}

--- a/templates/mail/server/index.ts
+++ b/templates/mail/server/index.ts
@@ -1,9 +1,12 @@
 import "dotenv/config";
+import fs from "fs";
 import {
   createServer,
   createFileWatcher,
   createSSEHandler,
 } from "@agent-native/core";
+import { defineEventHandler } from "h3";
+import { createFileSync } from "@agent-native/core/adapters/sync";
 import type { EnvKeyConfig } from "@agent-native/core/server";
 import {
   listEmails,
@@ -76,7 +79,7 @@ const envKeys: EnvKeyConfig[] = [
   },
 ];
 
-export function createAppServer() {
+export async function createAppServer() {
   const { app, router } = createServer({ envKeys });
   const watcher = createFileWatcher(["./data", "./application-state"]);
 
@@ -159,8 +162,32 @@ export function createAppServer() {
   router.delete("/api/scheduled-jobs/:id", deleteScheduledJob);
   router.post("/api/parse-date", parseDateNl);
 
+  // File sync (multi-user collaboration)
+  const syncResult = await createFileSync({ contentRoot: "./data" });
+  if (syncResult.status === "error") {
+    console.warn(`[app] File sync failed: ${syncResult.reason}`);
+  }
+  const extraEmitters =
+    syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+
+  router.get(
+    "/api/file-sync/status",
+    defineEventHandler(() => {
+      if (syncResult.status !== "ready")
+        return { enabled: false, conflicts: 0 };
+      return {
+        enabled: true,
+        connected: true,
+        conflicts: syncResult.fileSync.conflictCount,
+      };
+    }),
+  );
+
   // SSE events (keep last)
-  router.get("/api/events", createSSEHandler(watcher));
+  router.get(
+    "/api/events",
+    createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }),
+  );
 
   // Process scheduled jobs every minute (snooze + send-later)
   setInterval(() => {
@@ -168,6 +195,31 @@ export function createAppServer() {
       console.error("[jobs] Error processing jobs:", err),
     );
   }, 60_000);
+
+  // Graceful shutdown
+  process.on("SIGTERM", async () => {
+    if (syncResult.status === "ready") await syncResult.shutdown();
+    process.exit(0);
+  });
+
+  // Conflict notification
+  if (syncResult.status === "ready") {
+    syncResult.fileSync.syncEvents.on("sync", (event) => {
+      try {
+        if (event.type === "conflict-needs-llm") {
+          fs.mkdirSync("application-state", { recursive: true });
+          fs.writeFileSync(
+            "application-state/sync-conflict.json",
+            JSON.stringify(event, null, 2),
+          );
+        } else if (event.type === "conflict-resolved") {
+          fs.rmSync("application-state/sync-conflict.json", { force: true });
+        }
+      } catch {
+        /* best-effort */
+      }
+    });
+  }
 
   return app;
 }

--- a/templates/mail/server/node-build.ts
+++ b/templates/mail/server/node-build.ts
@@ -17,7 +17,9 @@ const agentHandler = createProductionAgentHandler({
   systemPrompt,
 });
 
-createProductionServer(createAppServer(), {
-  agent: agentHandler,
-  accessToken: process.env.ACCESS_TOKEN,
-});
+createAppServer().then((app) =>
+  createProductionServer(app, {
+    agent: agentHandler,
+    accessToken: process.env.ACCESS_TOKEN,
+  }),
+);

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -69,21 +69,25 @@ File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.en
 | `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
 
 **How sync works:**
+
 - `createFileSync()` factory reads env vars and initializes sync
 - Files matching `sync-config.json` patterns are synced to/from the database
 - Sync events flow through SSE (`source: "sync"`) alongside file change events
 - Conflicts produce `.conflict` sidecar files and notify the agent
 
 **Checking sync status:**
+
 - Read `data/.sync-status.json` for current sync state
 - Read `data/.sync-failures.json` for permanently failed sync operations
 
 **Handling conflicts:**
+
 - When `application-state/sync-conflict.json` appears, resolve the conflict
 - Read the `.conflict` file alongside the original to understand both versions
 - Edit the original file to resolve, then delete the `.conflict` file
 
 **Scratch files (not synced):**
+
 - Prefix temporary files with `_tmp-` to exclude from sync
 
 ## Running Scripts

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -53,30 +53,38 @@ This means:
                    └───────────────┘
 ```
 
-## Firestore File Sync
+### File Sync (Multi-User Collaboration)
 
-Data files are bidirectionally synced with Firestore so multiple users (and the cloud-hosted Builder harness) share the same state. The sync is powered by `@agent-native/core/adapters/firestore`.
+File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.env`.
 
-**What syncs:** Configured in `data/sync-config.json`:
+**Environment variables:**
 
-- `data/decks/**/*.json` — All deck JSON files
-- `data/**/*.md` — Reference docs (e.g. `builder-positioning.md`)
+| Variable                         | Required      | Description                                          |
+| -------------------------------- | ------------- | ---------------------------------------------------- |
+| `FILE_SYNC_ENABLED`              | No            | Set to `"true"` to enable sync                       |
+| `FILE_SYNC_BACKEND`              | When enabled  | `"firestore"`, `"supabase"`, or `"convex"`           |
+| `SUPABASE_URL`                   | For Supabase  | Project URL                                          |
+| `SUPABASE_PUBLISHABLE_KEY`       | For Supabase  | Publishable key (or legacy `SUPABASE_ANON_KEY`)      |
+| `GOOGLE_APPLICATION_CREDENTIALS` | For Firestore | Path to service account JSON                         |
+| `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
 
-**What doesn't sync:** Code files, uploads, sync-config itself, conflict sidecar files.
+**How sync works:**
+- `createFileSync()` factory reads env vars and initializes sync
+- Files matching `sync-config.json` patterns are synced to/from the database
+- Sync events flow through SSE (`source: "sync"`) alongside file change events
+- Conflicts produce `.conflict` sidecar files and notify the agent
 
-**How it works:**
+**Checking sync status:**
+- Read `data/.sync-status.json` for current sync state
+- Read `data/.sync-failures.json` for permanently failed sync operations
 
-- On server start, `initFileSync()` does a startup sync (compare local vs Firestore timestamps, resolve conflicts)
-- A Firestore real-time listener pushes remote changes to disk
-- A file watcher pushes local changes to Firestore
-- Three-way merge resolves conflicts; unresolvable conflicts create `.conflict` sidecar files
+**Handling conflicts:**
+- When `application-state/sync-conflict.json` appears, resolve the conflict
+- Read the `.conflict` file alongside the original to understand both versions
+- Edit the original file to resolve, then delete the `.conflict` file
 
-**Important for agents:**
-
-- Files in `data/decks/` and `data/*.md` are **gitignored** (synced at runtime, not checked in)
-- The `.ignore` file overrides this so agents can still search/grep/read these files
-- When editing deck JSON files, the changes are automatically synced to Firestore within seconds
-- Never edit `data/sync-config.json` unless adding new sync patterns
+**Scratch files (not synced):**
+- Prefix temporary files with `_tmp-` to exclude from sync
 
 ## Running Scripts
 

--- a/templates/slides/server/index.ts
+++ b/templates/slides/server/index.ts
@@ -1,4 +1,8 @@
-import { createServer, createFileWatcher, createSSEHandler } from "@agent-native/core";
+import {
+  createServer,
+  createFileWatcher,
+  createSSEHandler,
+} from "@agent-native/core";
 import { envKeys } from "./lib/env-config.js";
 import fs from "fs";
 import path from "path";
@@ -33,13 +37,22 @@ export async function createAppServer() {
   if (syncResult.status === "error") {
     console.warn(`[app] File sync failed: ${syncResult.reason}`);
   }
-  const extraEmitters = syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+  const extraEmitters =
+    syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
 
   // File sync diagnostic endpoint
-  router.get("/api/file-sync/status", defineEventHandler(() => {
-    if (syncResult.status !== "ready") return { enabled: false, conflicts: 0 };
-    return { enabled: true, connected: true, conflicts: syncResult.fileSync.conflictCount };
-  }));
+  router.get(
+    "/api/file-sync/status",
+    defineEventHandler(() => {
+      if (syncResult.status !== "ready")
+        return { enabled: false, conflicts: 0 };
+      return {
+        enabled: true,
+        connected: true,
+        conflicts: syncResult.fileSync.conflictCount,
+      };
+    }),
+  );
 
   // Example API routes
   router.get(
@@ -150,7 +163,10 @@ export async function createAppServer() {
   );
 
   // File sync SSE (separate from deck-specific events at /api/decks/events)
-  router.get("/api/events", createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }));
+  router.get(
+    "/api/events",
+    createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }),
+  );
 
   // Graceful shutdown
   process.on("SIGTERM", async () => {
@@ -164,11 +180,16 @@ export async function createAppServer() {
       try {
         if (event.type === "conflict-needs-llm") {
           fs.mkdirSync("application-state", { recursive: true });
-          fs.writeFileSync("application-state/sync-conflict.json", JSON.stringify(event, null, 2));
+          fs.writeFileSync(
+            "application-state/sync-conflict.json",
+            JSON.stringify(event, null, 2),
+          );
         } else if (event.type === "conflict-resolved") {
           fs.rmSync("application-state/sync-conflict.json", { force: true });
         }
-      } catch { /* best-effort */ }
+      } catch {
+        /* best-effort */
+      }
     });
   }
 

--- a/templates/slides/server/index.ts
+++ b/templates/slides/server/index.ts
@@ -1,9 +1,11 @@
-import { createServer } from "@agent-native/core";
+import { createServer, createFileWatcher, createSSEHandler } from "@agent-native/core";
 import { envKeys } from "./lib/env-config.js";
+import fs from "fs";
 import path from "path";
 import { createReadStream } from "fs";
 import { stat } from "fs/promises";
 import { sendStream, defineEventHandler, setResponseStatus } from "h3";
+import { createFileSync } from "@agent-native/core/adapters/sync";
 import { handleDemo } from "./routes/demo";
 import { generateImage, getImageGenStatus } from "./routes/image-gen";
 import { generateSlides } from "./routes/generate-slides";
@@ -22,8 +24,22 @@ import { searchLogos, logoConfig } from "./routes/logo-search";
 import { uploadFiles } from "./routes/uploads";
 import { handleFeedback } from "./routes/feedback";
 
-export function createAppServer() {
+export async function createAppServer() {
   const { app, router } = createServer({ envKeys });
+
+  const watcher = createFileWatcher("./data");
+
+  const syncResult = await createFileSync({ contentRoot: "./data" });
+  if (syncResult.status === "error") {
+    console.warn(`[app] File sync failed: ${syncResult.reason}`);
+  }
+  const extraEmitters = syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+
+  // File sync diagnostic endpoint
+  router.get("/api/file-sync/status", defineEventHandler(() => {
+    if (syncResult.status !== "ready") return { enabled: false, conflicts: 0 };
+    return { enabled: true, connected: true, conflicts: syncResult.fileSync.conflictCount };
+  }));
 
   // Example API routes
   router.get(
@@ -132,6 +148,29 @@ export function createAppServer() {
       }
     }),
   );
+
+  // File sync SSE (separate from deck-specific events at /api/decks/events)
+  router.get("/api/events", createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }));
+
+  // Graceful shutdown
+  process.on("SIGTERM", async () => {
+    if (syncResult.status === "ready") await syncResult.shutdown();
+    process.exit(0);
+  });
+
+  // Conflict notification
+  if (syncResult.status === "ready") {
+    syncResult.fileSync.syncEvents.on("sync", (event) => {
+      try {
+        if (event.type === "conflict-needs-llm") {
+          fs.mkdirSync("application-state", { recursive: true });
+          fs.writeFileSync("application-state/sync-conflict.json", JSON.stringify(event, null, 2));
+        } else if (event.type === "conflict-resolved") {
+          fs.rmSync("application-state/sync-conflict.json", { force: true });
+        }
+      } catch { /* best-effort */ }
+    });
+  }
 
   return app;
 }

--- a/templates/slides/server/node-build.ts
+++ b/templates/slides/server/node-build.ts
@@ -1,5 +1,4 @@
 import { createProductionServer } from "@agent-native/core";
 import { createAppServer } from "./index.js";
 
-const app = createAppServer();
-createProductionServer(app);
+createAppServer().then((app) => createProductionServer(app));

--- a/templates/videos/AGENTS.md
+++ b/templates/videos/AGENTS.md
@@ -86,6 +86,41 @@ pnpm test       # Run Vitest tests
 
 ---
 
+### File Sync (Multi-User Collaboration)
+
+File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.env`.
+
+**Environment variables:**
+
+| Variable                         | Required      | Description                                          |
+| -------------------------------- | ------------- | ---------------------------------------------------- |
+| `FILE_SYNC_ENABLED`              | No            | Set to `"true"` to enable sync                       |
+| `FILE_SYNC_BACKEND`              | When enabled  | `"firestore"`, `"supabase"`, or `"convex"`           |
+| `SUPABASE_URL`                   | For Supabase  | Project URL                                          |
+| `SUPABASE_PUBLISHABLE_KEY`       | For Supabase  | Publishable key (or legacy `SUPABASE_ANON_KEY`)      |
+| `GOOGLE_APPLICATION_CREDENTIALS` | For Firestore | Path to service account JSON                         |
+| `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
+
+**How sync works:**
+- `createFileSync()` factory reads env vars and initializes sync
+- Files matching `sync-config.json` patterns are synced to/from the database
+- Sync events flow through SSE (`source: "sync"`) alongside file change events
+- Conflicts produce `.conflict` sidecar files and notify the agent
+
+**Checking sync status:**
+- Read `data/.sync-status.json` for current sync state
+- Read `data/.sync-failures.json` for permanently failed sync operations
+
+**Handling conflicts:**
+- When `application-state/sync-conflict.json` appears, resolve the conflict
+- Read the `.conflict` file alongside the original to understand both versions
+- Edit the original file to resolve, then delete the `.conflict` file
+
+**Scratch files (not synced):**
+- Prefix temporary files with `_tmp-` to exclude from sync
+
+---
+
 ## Animation Studio Architecture
 
 This project is a **Remotion-based animation studio** — a web UI for composing, editing, and previewing programmatic video compositions. Understanding this system thoroughly is essential before creating or modifying any animation-related code.

--- a/templates/videos/AGENTS.md
+++ b/templates/videos/AGENTS.md
@@ -102,21 +102,25 @@ File sync is **opt-in** — enabled when `FILE_SYNC_ENABLED=true` is set in `.en
 | `CONVEX_URL`                     | For Convex    | Deployment URL from `npx convex dev` (must be HTTPS) |
 
 **How sync works:**
+
 - `createFileSync()` factory reads env vars and initializes sync
 - Files matching `sync-config.json` patterns are synced to/from the database
 - Sync events flow through SSE (`source: "sync"`) alongside file change events
 - Conflicts produce `.conflict` sidecar files and notify the agent
 
 **Checking sync status:**
+
 - Read `data/.sync-status.json` for current sync state
 - Read `data/.sync-failures.json` for permanently failed sync operations
 
 **Handling conflicts:**
+
 - When `application-state/sync-conflict.json` appears, resolve the conflict
 - Read the `.conflict` file alongside the original to understand both versions
 - Edit the original file to resolve, then delete the `.conflict` file
 
 **Scratch files (not synced):**
+
 - Prefix temporary files with `_tmp-` to exclude from sync
 
 ---

--- a/templates/videos/data/sync-config.json
+++ b/templates/videos/data/sync-config.json
@@ -1,6 +1,3 @@
 {
-  "syncFilePatterns": [
-    "data/**/*.json",
-    "!data/sync-config.json"
-  ]
+  "syncFilePatterns": ["data/**/*.json", "!data/sync-config.json"]
 }

--- a/templates/videos/data/sync-config.json
+++ b/templates/videos/data/sync-config.json
@@ -1,0 +1,6 @@
+{
+  "syncFilePatterns": [
+    "data/**/*.json",
+    "!data/sync-config.json"
+  ]
+}

--- a/templates/videos/server/index.ts
+++ b/templates/videos/server/index.ts
@@ -1,6 +1,10 @@
 import "dotenv/config";
 import fs from "fs";
-import { createServer, createFileWatcher, createSSEHandler } from "@agent-native/core/server";
+import {
+  createServer,
+  createFileWatcher,
+  createSSEHandler,
+} from "@agent-native/core/server";
 import { defineEventHandler } from "h3";
 import { createFileSync } from "@agent-native/core/adapters/sync";
 import { handleDemo } from "./routes/demo";
@@ -15,13 +19,22 @@ export async function createAppServer() {
   if (syncResult.status === "error") {
     console.warn(`[app] File sync failed: ${syncResult.reason}`);
   }
-  const extraEmitters = syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+  const extraEmitters =
+    syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
 
   // File sync diagnostic endpoint
-  router.get("/api/file-sync/status", defineEventHandler(() => {
-    if (syncResult.status !== "ready") return { enabled: false, conflicts: 0 };
-    return { enabled: true, connected: true, conflicts: syncResult.fileSync.conflictCount };
-  }));
+  router.get(
+    "/api/file-sync/status",
+    defineEventHandler(() => {
+      if (syncResult.status !== "ready")
+        return { enabled: false, conflicts: 0 };
+      return {
+        enabled: true,
+        connected: true,
+        conflicts: syncResult.fileSync.conflictCount,
+      };
+    }),
+  );
 
   router.get("/api/demo", handleDemo);
 
@@ -29,7 +42,10 @@ export async function createAppServer() {
   router.post("/api/save-composition-defaults", handleSaveCompositionDefaults);
 
   // File sync SSE
-  router.get("/api/events", createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }));
+  router.get(
+    "/api/events",
+    createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }),
+  );
 
   // Graceful shutdown
   process.on("SIGTERM", async () => {
@@ -43,11 +59,16 @@ export async function createAppServer() {
       try {
         if (event.type === "conflict-needs-llm") {
           fs.mkdirSync("application-state", { recursive: true });
-          fs.writeFileSync("application-state/sync-conflict.json", JSON.stringify(event, null, 2));
+          fs.writeFileSync(
+            "application-state/sync-conflict.json",
+            JSON.stringify(event, null, 2),
+          );
         } else if (event.type === "conflict-resolved") {
           fs.rmSync("application-state/sync-conflict.json", { force: true });
         }
-      } catch { /* best-effort */ }
+      } catch {
+        /* best-effort */
+      }
     });
   }
 

--- a/templates/videos/server/index.ts
+++ b/templates/videos/server/index.ts
@@ -1,15 +1,55 @@
 import "dotenv/config";
-import { createServer } from "@agent-native/core/server";
+import fs from "fs";
+import { createServer, createFileWatcher, createSSEHandler } from "@agent-native/core/server";
+import { defineEventHandler } from "h3";
+import { createFileSync } from "@agent-native/core/adapters/sync";
 import { handleDemo } from "./routes/demo";
 import { handleSaveCompositionDefaults } from "./routes/save-composition";
 
-export function createAppServer() {
+export async function createAppServer() {
   const { app, router } = createServer();
+
+  const watcher = createFileWatcher("./data");
+
+  const syncResult = await createFileSync({ contentRoot: "./data" });
+  if (syncResult.status === "error") {
+    console.warn(`[app] File sync failed: ${syncResult.reason}`);
+  }
+  const extraEmitters = syncResult.status === "ready" ? [syncResult.sseEmitter] : [];
+
+  // File sync diagnostic endpoint
+  router.get("/api/file-sync/status", defineEventHandler(() => {
+    if (syncResult.status !== "ready") return { enabled: false, conflicts: 0 };
+    return { enabled: true, connected: true, conflicts: syncResult.fileSync.conflictCount };
+  }));
 
   router.get("/api/demo", handleDemo);
 
   // Save composition defaults to registry
   router.post("/api/save-composition-defaults", handleSaveCompositionDefaults);
+
+  // File sync SSE
+  router.get("/api/events", createSSEHandler(watcher, { extraEmitters, contentRoot: "./data" }));
+
+  // Graceful shutdown
+  process.on("SIGTERM", async () => {
+    if (syncResult.status === "ready") await syncResult.shutdown();
+    process.exit(0);
+  });
+
+  // Conflict notification
+  if (syncResult.status === "ready") {
+    syncResult.fileSync.syncEvents.on("sync", (event) => {
+      try {
+        if (event.type === "conflict-needs-llm") {
+          fs.mkdirSync("application-state", { recursive: true });
+          fs.writeFileSync("application-state/sync-conflict.json", JSON.stringify(event, null, 2));
+        } else if (event.type === "conflict-resolved") {
+          fs.rmSync("application-state/sync-conflict.json", { force: true });
+        }
+      } catch { /* best-effort */ }
+    });
+  }
 
   return app;
 }

--- a/templates/videos/server/node-build.ts
+++ b/templates/videos/server/node-build.ts
@@ -1,4 +1,4 @@
 import { createProductionServer } from "@agent-native/core/server";
 import { createAppServer } from "./index.js";
 
-createProductionServer(createAppServer());
+createAppServer().then((app) => createProductionServer(app));


### PR DESCRIPTION
## Summary

1. All 8 templates (analytics, brand, calendar, content, imagegen, mail, slides, videos) now have `createFileSync()` wiring matching the default template pattern from PR #57
2. Each template gets: async `createAppServer()`, `.then()` node-build, diagnostic endpoint (`/api/file-sync/status`), SSE extraEmitters, graceful shutdown, and conflict notification
3. Templates without SSE (analytics, calendar, slides, videos) now have `createFileWatcher` + `createSSEHandler`
4. Dead Firestore/`initFileSync()` docs in calendar and slides AGENTS.md replaced with correct `createFileSync()` documentation
5. New `sync-config.json` files created for brand, mail, and videos templates
6. Content template correctly uses `contentRoot: "./content"` (not `./data`)
7. Mail template syncs `./data` only — `./application-state` is ephemeral and excluded
8. Slides keeps existing `/api/decks/events` alongside new `/api/events` for file sync

## Testing

- `pnpm build` passes — all 13 workspace packages build successfully
- All 182 existing tests pass
- Sync remains opt-in via `FILE_SYNC_ENABLED=true` — no behavioral change without it