### PR TITLE
feat(mail): restore sender name in list view and unify row height

### DIFF
--- a/packages/docs/src/routeTree.gen.ts
+++ b/packages/docs/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as DocsServerRouteImport } from './routes/docs/server'
 import { Route as DocsScriptsRouteImport } from './routes/docs/scripts'
 import { Route as DocsKeyConceptsRouteImport } from './routes/docs/key-concepts'
 import { Route as DocsHarnessesRouteImport } from './routes/docs/harnesses'
+import { Route as DocsFileSyncRouteImport } from './routes/docs/file-sync'
 import { Route as DocsDatabaseAdaptersRouteImport } from './routes/docs/database-adapters'
 import { Route as DocsCreatingTemplatesRouteImport } from './routes/docs/creating-templates'
 import { Route as DocsClientRouteImport } from './routes/docs/client'
@@ -104,6 +105,11 @@ const DocsHarnessesRoute = DocsHarnessesRouteImport.update({
   path: '/docs/harnesses',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DocsFileSyncRoute = DocsFileSyncRouteImport.update({
+  id: '/docs/file-sync',
+  path: '/docs/file-sync',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DocsDatabaseAdaptersRoute = DocsDatabaseAdaptersRouteImport.update({
   id: '/docs/database-adapters',
   path: '/docs/database-adapters',
@@ -132,6 +138,7 @@ export interface FileRoutesByFullPath {
   '/docs/client': typeof DocsClientRoute
   '/docs/creating-templates': typeof DocsCreatingTemplatesRoute
   '/docs/database-adapters': typeof DocsDatabaseAdaptersRoute
+  '/docs/file-sync': typeof DocsFileSyncRoute
   '/docs/harnesses': typeof DocsHarnessesRoute
   '/docs/key-concepts': typeof DocsKeyConceptsRoute
   '/docs/scripts': typeof DocsScriptsRoute
@@ -152,6 +159,7 @@ export interface FileRoutesByTo {
   '/docs/client': typeof DocsClientRoute
   '/docs/creating-templates': typeof DocsCreatingTemplatesRoute
   '/docs/database-adapters': typeof DocsDatabaseAdaptersRoute
+  '/docs/file-sync': typeof DocsFileSyncRoute
   '/docs/harnesses': typeof DocsHarnessesRoute
   '/docs/key-concepts': typeof DocsKeyConceptsRoute
   '/docs/scripts': typeof DocsScriptsRoute
@@ -174,6 +182,7 @@ export interface FileRoutesById {
   '/docs/client': typeof DocsClientRoute
   '/docs/creating-templates': typeof DocsCreatingTemplatesRoute
   '/docs/database-adapters': typeof DocsDatabaseAdaptersRoute
+  '/docs/file-sync': typeof DocsFileSyncRoute
   '/docs/harnesses': typeof DocsHarnessesRoute
   '/docs/key-concepts': typeof DocsKeyConceptsRoute
   '/docs/scripts': typeof DocsScriptsRoute
@@ -197,6 +206,7 @@ export interface FileRouteTypes {
     | '/docs/client'
     | '/docs/creating-templates'
     | '/docs/database-adapters'
+    | '/docs/file-sync'
     | '/docs/harnesses'
     | '/docs/key-concepts'
     | '/docs/scripts'
@@ -217,6 +227,7 @@ export interface FileRouteTypes {
     | '/docs/client'
     | '/docs/creating-templates'
     | '/docs/database-adapters'
+    | '/docs/file-sync'
     | '/docs/harnesses'
     | '/docs/key-concepts'
     | '/docs/scripts'
@@ -238,6 +249,7 @@ export interface FileRouteTypes {
     | '/docs/client'
     | '/docs/creating-templates'
     | '/docs/database-adapters'
+    | '/docs/file-sync'
     | '/docs/harnesses'
     | '/docs/key-concepts'
     | '/docs/scripts'
@@ -260,6 +272,7 @@ export interface RootRouteChildren {
   DocsClientRoute: typeof DocsClientRoute
   DocsCreatingTemplatesRoute: typeof DocsCreatingTemplatesRoute
   DocsDatabaseAdaptersRoute: typeof DocsDatabaseAdaptersRoute
+  DocsFileSyncRoute: typeof DocsFileSyncRoute
   DocsHarnessesRoute: typeof DocsHarnessesRoute
   DocsKeyConceptsRoute: typeof DocsKeyConceptsRoute
   DocsScriptsRoute: typeof DocsScriptsRoute
@@ -374,6 +387,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsHarnessesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/docs/file-sync': {
+      id: '/docs/file-sync'
+      path: '/docs/file-sync'
+      fullPath: '/docs/file-sync'
+      preLoaderRoute: typeof DocsFileSyncRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/docs/database-adapters': {
       id: '/docs/database-adapters'
       path: '/docs/database-adapters'
@@ -438,6 +458,7 @@ const rootRouteChildren: RootRouteChildren = {
   DocsClientRoute: DocsClientRoute,
   DocsCreatingTemplatesRoute: DocsCreatingTemplatesRoute,
   DocsDatabaseAdaptersRoute: DocsDatabaseAdaptersRoute,
+  DocsFileSyncRoute: DocsFileSyncRoute,
   DocsHarnessesRoute: DocsHarnessesRoute,
   DocsKeyConceptsRoute: DocsKeyConceptsRoute,
   DocsScriptsRoute: DocsScriptsRoute,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 2.1.1
       convex:
         specifier: '>=1'
-        version: 1.33.1(react@18.3.1)
+        version: 1.34.0(react@18.3.1)
       dotenv:
         specifier: ^17.2.1
         version: 17.3.1
@@ -7007,8 +7007,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  convex@1.33.1:
-    resolution: {integrity: sha512-mRhR1XqZPLhgJsUepecM/kOgQVRCWKJtHHtyEX/XYY4zmzfItG0D1GNh5fjNEkuO5+72X4PCkzbEFA6327rxog==}
+  convex@1.34.0:
+    resolution: {integrity: sha512-TbC509Z4urZMChZR2aLPgalQ8gMhAYSz2VMxaYsCvba8YqB0Uxma7zWnXwRn7aEGXuA8ro5/uHgD1IJ0HhYYPg==}
     engines: {node: '>=18.0.0', npm: '>=7.0.0'}
     hasBin: true
     peerDependencies:
@@ -16789,7 +16789,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convex@1.33.1(react@18.3.1):
+  convex@1.34.0(react@18.3.1):
     dependencies:
       esbuild: 0.27.0
       prettier: 3.8.1

--- a/templates/mail/client/components/email/EmailListItem.tsx
+++ b/templates/mail/client/components/email/EmailListItem.tsx
@@ -107,6 +107,18 @@ export function EmailListItem({
         )}
       </div>
 
+      {/* Sender name — fixed width column */}
+      <span
+        className={cn(
+          "w-[160px] shrink-0 text-[13px] truncate mr-3",
+          isUnread
+            ? "font-semibold text-foreground"
+            : "font-normal text-foreground/70",
+        )}
+      >
+        {senderName}
+      </span>
+
       {/* Label badges */}
       {displayLabels.length > 0 && (
         <div className="flex items-center gap-1 shrink-0 mr-2">

--- a/templates/mail/client/components/email/EmailThread.tsx
+++ b/templates/mail/client/components/email/EmailThread.tsx
@@ -1313,20 +1313,29 @@ function emailHasCustomStyling(html: string): boolean {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, "text/html");
 
-  // bgcolor attribute on any element (classic HTML email tables)
-  if (doc.querySelector("[bgcolor]")) return true;
+  // bgcolor on <body> or top-level table (classic HTML email)
+  const body = doc.body;
+  if (body?.getAttribute("bgcolor")) return true;
 
-  // background-color or background in any inline style attribute
-  const styledEls = doc.querySelectorAll("[style]");
-  for (const el of styledEls) {
-    const style = el.getAttribute("style") || "";
-    if (/background(-color)?:/i.test(style)) return true;
+  // background-color on <body> inline style
+  const bodyStyle = body?.getAttribute("style") || "";
+  if (/background(-color)?:/i.test(bodyStyle)) return true;
+
+  // Check top-level direct children of <body> only (not deep descendants)
+  // A full-email wrapper table/div with background = designed for light bg
+  for (const child of Array.from(body?.children ?? [])) {
+    const style = child.getAttribute("style") || "";
+    const bgcolor = child.getAttribute("bgcolor");
+    if (bgcolor || /background(-color)?:/i.test(style)) return true;
   }
 
-  // background-color in <style> blocks
+  // background-color on <body> or <html> in <style> blocks
+  // (only flag if it targets html/body selectors, not arbitrary elements)
   const styleTags = doc.querySelectorAll("style");
   for (const tag of styleTags) {
-    if (/background(-color)?:/i.test(tag.textContent || "")) return true;
+    const text = tag.textContent || "";
+    if (/(?:^|[,\s}])(?:html|body)\s*\{[^}]*background(-color)?:/im.test(text))
+      return true;
   }
 
   return false;

--- a/templates/mail/client/components/email/EmailThread.tsx
+++ b/templates/mail/client/components/email/EmailThread.tsx
@@ -1313,28 +1313,36 @@ function emailHasCustomStyling(html: string): boolean {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, "text/html");
 
-  // bgcolor on <body> or top-level table (classic HTML email)
-  const body = doc.body;
-  if (body?.getAttribute("bgcolor")) return true;
+  // bgcolor on ANY element — this attribute is exclusively used in HTML emails
+  // to set structural background colors; it's never set by accident
+  if (doc.querySelector("[bgcolor]")) return true;
 
   // background-color on <body> inline style
+  const body = doc.body;
   const bodyStyle = body?.getAttribute("style") || "";
   if (/background(-color)?:/i.test(bodyStyle)) return true;
 
-  // Check top-level direct children of <body> only (not deep descendants)
-  // A full-email wrapper table/div with background = designed for light bg
+  // background-color on direct children of <body> (outer wrapper divs/tables)
   for (const child of Array.from(body?.children ?? [])) {
     const style = child.getAttribute("style") || "";
-    const bgcolor = child.getAttribute("bgcolor");
-    if (bgcolor || /background(-color)?:/i.test(style)) return true;
+    if (/background(-color)?:/i.test(style)) return true;
   }
 
-  // background-color on <body> or <html> in <style> blocks
-  // (only flag if it targets html/body selectors, not arbitrary elements)
+  // background-color in <style> blocks targeting structural email selectors
   const styleTags = doc.querySelectorAll("style");
   for (const tag of styleTags) {
     const text = tag.textContent || "";
-    if (/(?:^|[,\s}])(?:html|body)\s*\{[^}]*background(-color)?:/im.test(text))
+    // html/body/table/td/div element selectors
+    if (
+      /(?:html|body|table|td|th|div)\s*\{[^}]*background(-color)?:/im.test(text)
+    )
+      return true;
+    // common email wrapper class names
+    if (
+      /\.(?:wrapper|container|email|body|content|main|outer)\s*\{[^}]*background(-color)?:/im.test(
+        text,
+      )
+    )
       return true;
   }
 

--- a/templates/mail/client/components/layout/AppLayout.tsx
+++ b/templates/mail/client/components/layout/AppLayout.tsx
@@ -13,13 +13,6 @@ import {
   useLocation,
   useSearchParams,
 } from "react-router-dom";
-import {
-  IconChevronRight,
-  IconChevronLeft,
-  IconSettings,
-  IconAlarm,
-  IconClockHour4,
-} from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { CommandPalette } from "./CommandPalette";
 import { ComposeModal } from "@/components/email/ComposeModal";
@@ -710,35 +703,77 @@ export function AppLayout({ children }: AppLayoutProps) {
           {sidebarOpen && (
             <>
               <div
-                className="fixed inset-0 z-30 bg-black/40"
+                className="fixed inset-0 z-30 bg-black/20"
                 onClick={() => setSidebarOpen(false)}
               />
-              <div className="fixed left-0 top-0 bottom-0 z-40 w-64 bg-card border-r border-border/50 shadow-xl overflow-y-auto">
+              <div className="fixed left-0 top-0 bottom-0 z-40 w-64 bg-background/70 backdrop-blur-2xl border-r border-white/8 shadow-2xl overflow-y-auto">
+                {/* Accounts */}
+                {hasAccounts && (
+                  <div className="px-4 pt-5 pb-4 border-b border-white/8">
+                    <div className="space-y-2">
+                      {accounts.map((account) => {
+                        const isActive =
+                          activeAccounts.size === 0 ||
+                          activeAccounts.has(account.email);
+                        return (
+                          <button
+                            key={account.email}
+                            onClick={() => {
+                              setActiveAccounts((prev) => {
+                                const next = new Set(prev);
+                                if (next.size === 0) {
+                                  for (const a of accounts) {
+                                    if (a.email !== account.email)
+                                      next.add(a.email);
+                                  }
+                                } else if (next.has(account.email)) {
+                                  next.delete(account.email);
+                                  if (next.size === 0) return new Set();
+                                } else {
+                                  next.add(account.email);
+                                  if (next.size === accounts.length)
+                                    return new Set();
+                                }
+                                return next;
+                              });
+                            }}
+                            className={cn(
+                              "flex w-full items-center gap-3 rounded-lg px-2 py-1.5 text-left transition-all",
+                              isActive
+                                ? "opacity-100"
+                                : "opacity-30",
+                            )}
+                          >
+                            {account.photoUrl ? (
+                              <img
+                                src={account.photoUrl}
+                                alt=""
+                                className="h-8 w-8 rounded-full object-cover shrink-0"
+                                referrerPolicy="no-referrer"
+                              />
+                            ) : (
+                              <div className="h-8 w-8 rounded-full bg-primary/20 flex items-center justify-center text-[12px] font-semibold text-primary shrink-0">
+                                {account.email[0]?.toUpperCase()}
+                              </div>
+                            )}
+                            <span className="text-[13px] text-foreground truncate">
+                              {account.email}
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+
                 <div className="p-4">
-                  <h2 className="text-[11px] font-medium text-muted-foreground/50 uppercase tracking-wider mb-3">
-                    Mailbox
-                  </h2>
                   <div className="space-y-0.5">
                     {[
                       { id: "inbox", label: "Inbox", href: "/inbox" },
                       { id: "starred", label: "Starred", href: "/starred" },
-                      {
-                        id: "snoozed",
-                        label: "Snoozed",
-                        href: "/snoozed",
-                        icon: (
-                          <IconAlarm className="h-4 w-4 shrink-0 text-muted-foreground/60" />
-                        ),
-                      },
+                      { id: "snoozed", label: "Snoozed", href: "/snoozed" },
                       { id: "sent", label: "Sent", href: "/sent" },
-                      {
-                        id: "scheduled",
-                        label: "Scheduled",
-                        href: "/scheduled",
-                        icon: (
-                          <IconClockHour4 className="h-4 w-4 shrink-0 text-muted-foreground/60" />
-                        ),
-                      },
+                      { id: "scheduled", label: "Scheduled", href: "/scheduled" },
                       { id: "drafts", label: "Drafts", href: "/drafts" },
                       { id: "archive", label: "Done", href: "/archive" },
                       { id: "trash", label: "Trash", href: "/trash" },
@@ -750,14 +785,11 @@ export function AppLayout({ children }: AppLayoutProps) {
                         className={cn(
                           "flex items-center justify-between rounded-md px-3 py-2 text-[14px] transition-colors",
                           view === item.id
-                            ? "bg-accent text-foreground font-medium"
-                            : "text-foreground/70 hover:bg-accent/50",
+                            ? "bg-accent/60 text-foreground font-medium"
+                            : "text-foreground/70 hover:bg-accent/30",
                         )}
                       >
-                        <span className="flex items-center gap-2">
-                          {"icon" in item && item.icon}
-                          {item.label}
-                        </span>
+                        <span>{item.label}</span>
                         {item.id === "inbox" && labelCounts["inbox"] > 0 && (
                           <span className="text-[12px] text-muted-foreground/50 tabular-nums">
                             {labelCounts["inbox"]}
@@ -765,19 +797,18 @@ export function AppLayout({ children }: AppLayoutProps) {
                         )}
                       </Link>
                     ))}
-                    <div className="mt-2 pt-2 border-t border-border/30">
+                    <div className="mt-2 pt-2 border-t border-white/8">
                       <Link
                         to="/settings"
                         onClick={() => setSidebarOpen(false)}
                         className={cn(
-                          "flex items-center gap-2.5 rounded-md px-3 py-2 text-[14px] transition-colors",
+                          "flex items-center rounded-md px-3 py-2 text-[14px] transition-colors",
                           location.pathname === "/settings"
-                            ? "bg-accent text-foreground font-medium"
-                            : "text-foreground/70 hover:bg-accent/50",
+                            ? "bg-accent/60 text-foreground font-medium"
+                            : "text-foreground/70 hover:bg-accent/30",
                         )}
                       >
-                        <IconSettings className="h-4 w-4 shrink-0" />
-                        <span>Settings</span>
+                        Settings
                       </Link>
                     </div>
                   </div>
@@ -807,8 +838,8 @@ export function AppLayout({ children }: AppLayoutProps) {
                                 className={cn(
                                   "flex items-center justify-between rounded-md px-3 py-2 text-[14px] transition-colors",
                                   tab.isActive
-                                    ? "bg-accent text-foreground font-medium"
-                                    : "text-foreground/70 hover:bg-accent/50",
+                                    ? "bg-accent/60 text-foreground font-medium"
+                                    : "text-foreground/70 hover:bg-accent/30",
                                 )}
                               >
                                 <span className="flex items-center gap-2">

--- a/templates/mail/client/components/layout/AppLayout.tsx
+++ b/templates/mail/client/components/layout/AppLayout.tsx
@@ -739,9 +739,7 @@ export function AppLayout({ children }: AppLayoutProps) {
                             }}
                             className={cn(
                               "flex w-full items-center gap-3 rounded-lg px-2 py-1.5 text-left transition-all",
-                              isActive
-                                ? "opacity-100"
-                                : "opacity-30",
+                              isActive ? "opacity-100" : "opacity-30",
                             )}
                           >
                             {account.photoUrl ? (
@@ -773,7 +771,11 @@ export function AppLayout({ children }: AppLayoutProps) {
                       { id: "starred", label: "Starred", href: "/starred" },
                       { id: "snoozed", label: "Snoozed", href: "/snoozed" },
                       { id: "sent", label: "Sent", href: "/sent" },
-                      { id: "scheduled", label: "Scheduled", href: "/scheduled" },
+                      {
+                        id: "scheduled",
+                        label: "Scheduled",
+                        href: "/scheduled",
+                      },
                       { id: "drafts", label: "Drafts", href: "/drafts" },
                       { id: "archive", label: "Done", href: "/archive" },
                       { id: "trash", label: "Trash", href: "/trash" },

--- a/templates/mail/client/global.css
+++ b/templates/mail/client/global.css
@@ -615,3 +615,15 @@
   background: transparent !important;
   border-color: transparent !important;
 }
+
+/* Inbox Zero — tab text: active white, inactive white/60, icons white/40 */
+.inbox-zero .inbox-zero-header a,
+.inbox-zero .inbox-zero-header button,
+.inbox-zero .inbox-zero-header span {
+  color: rgba(255, 255, 255, 0.6) !important;
+}
+
+.inbox-zero .inbox-zero-header a[aria-current],
+.inbox-zero .inbox-zero-header a.font-semibold {
+  color: rgba(255, 255, 255, 1) !important;
+}

--- a/templates/mail/client/hooks/use-emails.ts
+++ b/templates/mail/client/hooks/use-emails.ts
@@ -202,7 +202,10 @@ export function useSendEmail() {
         method: "POST",
         body: JSON.stringify(data),
       }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["emails"] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["emails"] });
+      qc.invalidateQueries({ queryKey: ["thread-messages"] });
+    },
   });
 }
 

--- a/templates/mail/client/pages/InboxPage.tsx
+++ b/templates/mail/client/pages/InboxPage.tsx
@@ -86,10 +86,6 @@ function ThreadListSidebar({
         {threads.map((thread) => {
           const email = thread.latestMessage;
           const isActive = (email.threadId || email.id) === activeThreadId;
-          const senderName =
-            thread.messageCount > 1
-              ? thread.participants.map((p) => p.split(" ")[0]).join(", ")
-              : email.from.name || email.from.email;
           return (
             <button
               key={email.id}

--- a/templates/mail/client/pages/InboxPage.tsx
+++ b/templates/mail/client/pages/InboxPage.tsx
@@ -101,11 +101,11 @@ function ThreadListSidebar({
                 );
               }}
               className={cn(
-                "w-full text-left px-3 py-2 border-b border-border/10 transition-colors",
+                "w-full text-left px-3 h-[38px] flex items-center border-b border-border/10 transition-colors",
                 isActive ? "bg-primary/10" : "hover:bg-[hsl(220,5%,13%)]",
               )}
             >
-              <div className="flex items-center gap-2 min-w-0">
+              <div className="flex items-center gap-2 min-w-0 w-full">
                 {thread.hasUnread && (
                   <div className="h-[5px] w-[5px] rounded-full bg-primary shrink-0" />
                 )}
@@ -125,9 +125,6 @@ function ThreadListSidebar({
                   </span>
                 )}
               </div>
-              <p className="text-[11px] text-muted-foreground truncate mt-0.5 pl-0">
-                {senderName}
-              </p>
             </button>
           );
         })}

--- a/templates/mail/client/pages/InboxPage.tsx
+++ b/templates/mail/client/pages/InboxPage.tsx
@@ -107,11 +107,11 @@ function ThreadListSidebar({
             >
               <div className="flex items-center gap-2 min-w-0 w-full">
                 {thread.hasUnread && (
-                  <div className="h-[5px] w-[5px] rounded-full bg-primary shrink-0" />
+                  <div className="h-[7px] w-[7px] rounded-full bg-primary shrink-0" />
                 )}
                 <span
                   className={cn(
-                    "text-[12px] truncate",
+                    "text-[13px] truncate",
                     thread.hasUnread
                       ? "font-semibold text-foreground"
                       : "text-foreground/80",


### PR DESCRIPTION
- Add sender name as fixed-width column in EmailListItem (like Superhuman)
- Sidebar (ThreadListSidebar) rows now use h-[38px] to match main list height