### PR TITLE
Add zero-config auth layer: dev bypass, production enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Auth is automatic and environment-driven. Templates include a `server/plugins/au
 - **Production** (no token, no `AUTH_DISABLED=true`): Server refuses to start with a clear error.
 
 **Key APIs:**
+
 - Server: `getSession(event)` from `@agent-native/core/server` — returns `AuthSession | null`
 - Client: `useSession()` from `@agent-native/core` — returns `{ session, isLoading }`
 - Routes: `GET /api/auth/session`, `POST /api/auth/login`, `POST /api/auth/logout`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,23 @@ Ephemeral UI state lives in `application-state/` as JSON files. Both the agent a
 - File existence = state is active. Deleting the file = clearing the state.
 - The SSE file watcher watches `application-state/` alongside `data/`
 
+## Authentication
+
+Auth is automatic and environment-driven. Templates include a `server/plugins/auth.ts` Nitro plugin that calls `autoMountAuth(app)` at startup.
+
+- **Dev mode** (`NODE_ENV !== "production"`): Auth is bypassed. `getSession()` returns `{ email: "local@localhost" }`. No login page.
+- **Production** (`ACCESS_TOKEN` set): Auth middleware mounts automatically. Login page for unauthenticated visitors. Cookie-based sessions stored in `data/.sessions.json`.
+- **Production** (no token, no `AUTH_DISABLED=true`): Server refuses to start with a clear error.
+
+**Key APIs:**
+- Server: `getSession(event)` from `@agent-native/core/server` — returns `AuthSession | null`
+- Client: `useSession()` from `@agent-native/core` — returns `{ session, isLoading }`
+- Routes: `GET /api/auth/session`, `POST /api/auth/login`, `POST /api/auth/logout`
+
+**Bring your own auth**: Pass a custom `getSession` function to `autoMountAuth(app, { getSession: ... })` to plug in Auth.js, Clerk, or any auth system. Templates don't change.
+
+See [docs/auth.md](docs/auth.md) for the full guide.
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -117,6 +117,33 @@ Or **[launch a template](https://agent-native.com/templates)** — no setup requ
 | **Ownership**        | Rented             | N/A                     | Yours but costly | You own the code        |
 | **Non-dev friendly** | Yes                | No                      | Rarely           | Guided UI + agent       |
 
+## Architecture
+
+Agent-native is designed to be agnostic at every layer — use the defaults or swap in your own.
+
+| Layer | Default | Swappable? |
+|---|---|---|
+| **Server** | [Nitro](https://nitro.build) (H3) | Deploy anywhere Nitro supports (Node, Cloudflare, Vercel, Netlify, Deno, Bun) |
+| **Auth** | Token-based (zero-config) | Plug in Auth.js, Clerk, Lucia, or any auth system via `getSession()` contract |
+| **Database** | Files (`data/` directory) | Add Drizzle, Prisma, or any ORM when you need a real DB |
+| **Frontend** | React + React Router + Tailwind | Modify or replace — it's your code |
+| **Agent** | Works with any CLI-based agent (Claude Code, Codex, Cursor, etc.) | Agent-agnostic by design |
+| **Hosting** | Any (Netlify, Vercel, Cloudflare, self-hosted) | Nitro's preset system handles deployment targets |
+
+### Auth: Zero to Production
+
+Auth is invisible in development and automatic in production. No code changes required.
+
+```bash
+# Development — no auth, no config
+pnpm dev
+
+# Production — set one env var, auth activates
+ACCESS_TOKEN=your-secret pnpm start
+```
+
+See [docs/auth.md](docs/auth.md) for the full auth guide, including multi-token team access and bring-your-own-auth.
+
 ## Docs
 
 Full documentation at **[agent-native.com](https://agent-native.com)**.

--- a/README.md
+++ b/README.md
@@ -121,14 +121,14 @@ Or **[launch a template](https://agent-native.com/templates)** — no setup requ
 
 Agent-native is designed to be agnostic at every layer — use the defaults or swap in your own.
 
-| Layer | Default | Swappable? |
-|---|---|---|
-| **Server** | [Nitro](https://nitro.build) (H3) | Deploy anywhere Nitro supports (Node, Cloudflare, Vercel, Netlify, Deno, Bun) |
-| **Auth** | Token-based (zero-config) | Plug in Auth.js, Clerk, Lucia, or any auth system via `getSession()` contract |
-| **Database** | Files (`data/` directory) | Add Drizzle, Prisma, or any ORM when you need a real DB |
-| **Frontend** | React + React Router + Tailwind | Modify or replace — it's your code |
-| **Agent** | Works with any CLI-based agent (Claude Code, Codex, Cursor, etc.) | Agent-agnostic by design |
-| **Hosting** | Any (Netlify, Vercel, Cloudflare, self-hosted) | Nitro's preset system handles deployment targets |
+| Layer        | Default                                                           | Swappable?                                                                    |
+| ------------ | ----------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| **Server**   | [Nitro](https://nitro.build) (H3)                                 | Deploy anywhere Nitro supports (Node, Cloudflare, Vercel, Netlify, Deno, Bun) |
+| **Auth**     | Token-based (zero-config)                                         | Plug in Auth.js, Clerk, Lucia, or any auth system via `getSession()` contract |
+| **Database** | Files (`data/` directory)                                         | Add Drizzle, Prisma, or any ORM when you need a real DB                       |
+| **Frontend** | React + React Router + Tailwind                                   | Modify or replace — it's your code                                            |
+| **Agent**    | Works with any CLI-based agent (Claude Code, Codex, Cursor, etc.) | Agent-agnostic by design                                                      |
+| **Hosting**  | Any (Netlify, Vercel, Cloudflare, self-hosted)                    | Nitro's preset system handles deployment targets                              |
 
 ### Auth: Zero to Production
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,164 @@
+# Authentication
+
+Agent-native provides a zero-config authentication system that is invisible in development and automatic in production.
+
+## How It Works
+
+```
+Development                    Production                     Custom Auth
+─────────────                  ──────────                     ───────────
+No auth middleware             Auth middleware auto-mounts     Plug in Auth.js, Clerk, etc.
+All requests pass through      Login page for visitors        Same getSession() contract
+getSession() → local@localhost One env var to enable           Templates don't change
+```
+
+### Development Mode
+
+In development (`NODE_ENV !== "production"`), auth is completely bypassed:
+
+- No login page, no middleware, no cookies
+- `getSession()` always returns `{ email: "local@localhost" }`
+- `useSession()` hook returns the same dev stub
+- Zero friction, zero config
+
+### Production Mode
+
+When you deploy, set one environment variable and auth activates automatically:
+
+```bash
+ACCESS_TOKEN=your-secret-token
+```
+
+That's it. Every route is now protected. Unauthenticated visitors see a login page. The framework handles cookies, session management, and expiry.
+
+For small teams, use comma-separated tokens:
+
+```bash
+ACCESS_TOKENS=alice-token,bob-token,charlie-token
+```
+
+### Production Without Auth
+
+If your app is behind infrastructure-level auth (Cloudflare Access, VPN, etc.), explicitly disable framework auth:
+
+```bash
+AUTH_DISABLED=true
+```
+
+Without either `ACCESS_TOKEN` or `AUTH_DISABLED`, the server **refuses to start in production** to prevent accidental exposure.
+
+## The Auth Contract
+
+All templates code against two interfaces — they never read cookies directly.
+
+### Server: `getSession(event)`
+
+```ts
+import { getSession } from "@agent-native/core/server";
+
+export default defineEventHandler(async (event) => {
+  const session = await getSession(event);
+  // session: { email, userId?, token? } or null
+});
+```
+
+### Client: `useSession()`
+
+```ts
+import { useSession } from "@agent-native/core";
+
+function MyComponent() {
+  const { session, isLoading } = useSession();
+  // session.email, session.userId, etc.
+}
+```
+
+### API Endpoint: `GET /api/auth/session`
+
+Returns the current session as JSON, or `{ error: "Not authenticated" }`.
+
+## How It's Wired
+
+Each template includes a Nitro plugin at `server/plugins/auth.ts`:
+
+```ts
+import { defineNitroPlugin, autoMountAuth } from "@agent-native/core";
+
+export default defineNitroPlugin((nitroApp: any) => {
+  autoMountAuth(nitroApp.h3App);
+});
+```
+
+This runs at server startup and configures auth based on the environment automatically.
+
+## Session Storage
+
+Sessions are stored in `data/.sessions.json` (file-backed, consistent with the files-as-database principle). This file is:
+
+- Gitignored in all templates
+- Excluded from file sync
+- Pruned on startup (expired sessions are removed)
+- Default session lifetime: 30 days
+
+## Bring Your Own Auth
+
+For apps that outgrow single-token auth (multi-user, OAuth, roles), the framework provides an upgrade path through the `AuthOptions.getSession` hook:
+
+```ts
+import { defineNitroPlugin, autoMountAuth } from "@agent-native/core";
+
+export default defineNitroPlugin((nitroApp: any) => {
+  autoMountAuth(nitroApp.h3App, {
+    getSession: async (event) => {
+      // Your custom auth logic here — Auth.js, Clerk, Lucia, etc.
+      // Return { email, userId?, token? } or null
+      const session = await myAuthLib.getSession(event);
+      return session ? { email: session.user.email } : null;
+    },
+  });
+});
+```
+
+The framework doesn't ship Auth.js, Clerk, or any specific auth library. Instead, the `getSession` contract makes any auth system pluggable without changing templates or application code.
+
+### Why Not Ship Auth.js in Core
+
+- No official Nitro/H3 adapter — maintaining a custom bridge would be a permanent burden
+- OAuth, account linking, and email verification are overkill for most agent-native apps
+- Alternatives (Clerk, Lucia, WorkOS) exist — the framework shouldn't pick winners
+- The auth contract makes any of them pluggable
+
+## Configuration Reference
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `ACCESS_TOKEN` | Single access token for production auth |
+| `ACCESS_TOKENS` | Comma-separated tokens for team access |
+| `AUTH_DISABLED` | Set to `"true"` to skip auth in production |
+
+### `AuthOptions`
+
+```ts
+autoMountAuth(app, {
+  maxAge: 60 * 60 * 24 * 30,       // Session lifetime in seconds (default: 30 days)
+  sessionsPath: "data/.sessions.json", // Path to session store (default)
+  getSession: async (event) => {},     // Custom auth (BYOA)
+});
+```
+
+### Routes
+
+| Route | Method | Description |
+|---|---|---|
+| `/api/auth/login` | POST | Validate token, set session cookie |
+| `/api/auth/logout` | POST | Clear session cookie |
+| `/api/auth/session` | GET | Get current session |
+
+## Security
+
+- **Cookies**: HttpOnly, Secure (production), SameSite=Lax
+- **Session tokens**: Cryptographically random (32 bytes)
+- **CSRF**: Baseline protection via SameSite=Lax
+- **Session file**: Gitignored, excluded from sync, pruned on startup

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -132,29 +132,29 @@ The framework doesn't ship Auth.js, Clerk, or any specific auth library. Instead
 
 ### Environment Variables
 
-| Variable | Description |
-|---|---|
-| `ACCESS_TOKEN` | Single access token for production auth |
-| `ACCESS_TOKENS` | Comma-separated tokens for team access |
+| Variable        | Description                                |
+| --------------- | ------------------------------------------ |
+| `ACCESS_TOKEN`  | Single access token for production auth    |
+| `ACCESS_TOKENS` | Comma-separated tokens for team access     |
 | `AUTH_DISABLED` | Set to `"true"` to skip auth in production |
 
 ### `AuthOptions`
 
 ```ts
 autoMountAuth(app, {
-  maxAge: 60 * 60 * 24 * 30,       // Session lifetime in seconds (default: 30 days)
+  maxAge: 60 * 60 * 24 * 30, // Session lifetime in seconds (default: 30 days)
   sessionsPath: "data/.sessions.json", // Path to session store (default)
-  getSession: async (event) => {},     // Custom auth (BYOA)
+  getSession: async (event) => {}, // Custom auth (BYOA)
 });
 ```
 
 ### Routes
 
-| Route | Method | Description |
-|---|---|---|
-| `/api/auth/login` | POST | Validate token, set session cookie |
-| `/api/auth/logout` | POST | Clear session cookie |
-| `/api/auth/session` | GET | Get current session |
+| Route               | Method | Description                        |
+| ------------------- | ------ | ---------------------------------- |
+| `/api/auth/login`   | POST   | Validate token, set session cookie |
+| `/api/auth/logout`  | POST   | Clear session cookie               |
+| `/api/auth/session` | GET    | Get current session                |
 
 ## Security
 

--- a/packages/core/src/adapters/sync/config.ts
+++ b/packages/core/src/adapters/sync/config.ts
@@ -33,6 +33,8 @@ const SYNC_DENYLIST = [
   "**/*.sqlite",
   "**/*.db",
   "**/*.tfstate*",
+  // Auth sessions (sensitive runtime state)
+  "**/.sessions.json",
   // Sync meta-files (prevents meta-sync attack)
   "**/sync-config.json",
   "**/.sync-status.json",

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -4,6 +4,7 @@ export { useFileWatcher } from "./use-file-watcher.js";
 export { useFileSyncStatus } from "./use-file-sync-status.js";
 export { cn } from "./utils.js";
 export { ApiKeySettings } from "./components/ApiKeySettings.js";
+export { useSession, type AuthSession } from "./use-session.js";
 export {
   sendToHarness,
   onHarnessMessage,

--- a/packages/core/src/client/use-session.ts
+++ b/packages/core/src/client/use-session.ts
@@ -1,0 +1,56 @@
+import { useState, useEffect } from "react";
+import type { AuthSession } from "../server/auth.js";
+
+export type { AuthSession };
+
+interface UseSessionResult {
+  session: AuthSession | null;
+  isLoading: boolean;
+}
+
+/**
+ * Client-side hook to get the current auth session.
+ *
+ * - In dev mode: immediately returns { email: "local@localhost" }
+ * - In production: fetches /api/auth/session and returns the result
+ *
+ * Templates should use this instead of building their own auth context.
+ */
+export function useSession(): UseSessionResult {
+  const [session, setSession] = useState<AuthSession | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchSession() {
+      try {
+        const res = await fetch("/api/auth/session");
+        if (!res.ok) {
+          setSession(null);
+          return;
+        }
+        const data = await res.json();
+        if (!cancelled) {
+          // The endpoint returns { error: "..." } when not authenticated
+          if (data.error) {
+            setSession(null);
+          } else {
+            setSession(data as AuthSession);
+          }
+        }
+      } catch {
+        if (!cancelled) setSession(null);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    fetchSession();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { session, isLoading };
+}

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -5,9 +5,11 @@ export {
   sendToAgentChat,
   useAgentChatGenerating,
   useFileWatcher,
+  useSession,
   cn,
   ApiKeySettings,
   type AgentChatMessage,
+  type AuthSession,
 } from "./client/index.js";
 
 // Shared (isomorphic)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,9 +18,13 @@ export {
   createFileWatcher,
   createSSEHandler,
   defineNitroPlugin,
+  autoMountAuth,
+  getSession,
   type CreateServerOptions,
   type FileWatcherOptions,
   type SSEHandlerOptions,
+  type AuthSession,
+  type AuthOptions,
 } from "./server/index.js";
 
 // Client
@@ -30,6 +34,7 @@ export {
   useFileWatcher,
   cn,
   ApiKeySettings,
+  useSession,
   useProductionAgent,
   ProductionAgentPanel,
   type AgentChatMessage,

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -140,9 +140,8 @@ function isDevMode(): boolean {
 // getSession — the auth contract
 // ---------------------------------------------------------------------------
 
-let customGetSession:
-  | ((event: H3Event) => Promise<AuthSession | null>)
-  | null = null;
+let customGetSession: ((event: H3Event) => Promise<AuthSession | null>) | null =
+  null;
 
 const DEV_SESSION: AuthSession = { email: "local@localhost" };
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -142,6 +142,7 @@ function isDevMode(): boolean {
 
 let customGetSession: ((event: H3Event) => Promise<AuthSession | null>) | null =
   null;
+let authDisabledMode = false;
 
 const DEV_SESSION: AuthSession = { email: "local@localhost" };
 
@@ -154,6 +155,7 @@ const DEV_SESSION: AuthSession = { email: "local@localhost" };
  */
 export async function getSession(event: H3Event): Promise<AuthSession | null> {
   if (isDevMode()) return DEV_SESSION;
+  if (authDisabledMode) return DEV_SESSION;
 
   if (customGetSession) return customGetSession(event);
 
@@ -162,6 +164,24 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
     return { email: "user", token: cookie };
   }
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Constant-time token comparison
+// ---------------------------------------------------------------------------
+
+function safeTokenMatch(input: string, tokens: string[]): boolean {
+  const inputBuf = Buffer.from(input);
+  for (const token of tokens) {
+    const tokenBuf = Buffer.from(token);
+    if (
+      inputBuf.length === tokenBuf.length &&
+      crypto.timingSafeEqual(inputBuf, tokenBuf)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -279,7 +299,11 @@ function mountAuthRoutes(app: H3App, accessTokens: string[]): void {
         return { error: "Method not allowed" };
       }
       const body = await readBody(event);
-      if (!body?.token || !accessTokens.includes(body.token)) {
+      if (
+        !body?.token ||
+        typeof body.token !== "string" ||
+        !safeTokenMatch(body.token, accessTokens)
+      ) {
         setResponseStatus(event, 401);
         return { error: "Invalid token" };
       }
@@ -322,7 +346,7 @@ function mountAuthRoutes(app: H3App, accessTokens: string[]): void {
 
   // Auth guard — runs before all other handlers
   app.use(
-    defineEventHandler((event) => {
+    defineEventHandler(async (event) => {
       const url = event.node.req.url ?? "/";
       const p = url.split("?")[0];
 
@@ -335,8 +359,9 @@ function mountAuthRoutes(app: H3App, accessTokens: string[]): void {
         return;
       }
 
-      const cookie = getCookie(event, COOKIE_NAME);
-      if (cookie && hasSession(cookie)) {
+      // Use getSession() so BYOA custom auth is respected
+      const session = await getSession(event);
+      if (session) {
         return; // Authenticated
       }
 
@@ -377,7 +402,9 @@ function mountAuthRoutes(app: H3App, accessTokens: string[]): void {
  * Returns true if auth was mounted, false if skipped.
  */
 export function autoMountAuth(app: H3App, options: AuthOptions = {}): boolean {
-  // Apply options
+  // Reset globals to avoid stale state from prior calls
+  customGetSession = null;
+  authDisabledMode = false;
   sessionMaxAge = options.maxAge ?? DEFAULT_MAX_AGE;
   sessionsFilePath = resolveSessionsPath(options.sessionsPath);
 
@@ -412,18 +439,71 @@ export function autoMountAuth(app: H3App, options: AuthOptions = {}): boolean {
     return false;
   }
 
+  // BYOA with custom getSession — skip token check, mount session/guard routes
+  if (customGetSession) {
+    // Mount session endpoint
+    app.use(
+      "/api/auth/session",
+      defineEventHandler(async (event) => {
+        if (getMethod(event) !== "GET") {
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
+        const session = await getSession(event);
+        return session ?? { error: "Not authenticated" };
+      }),
+    );
+    app.use(
+      "/api/auth/login",
+      defineEventHandler(() => ({ ok: true })),
+    );
+    app.use(
+      "/api/auth/logout",
+      defineEventHandler(() => ({ ok: true })),
+    );
+
+    // Mount auth guard that delegates to custom getSession
+    app.use(
+      defineEventHandler(async (event) => {
+        const url = event.node.req.url ?? "/";
+        const p = url.split("?")[0];
+        if (
+          p === "/api/auth/login" ||
+          p === "/api/auth/logout" ||
+          p === "/api/auth/session"
+        ) {
+          return;
+        }
+        const session = await getSession(event);
+        if (session) return;
+        if (p.startsWith("/api/")) {
+          setResponseStatus(event, 401);
+          setResponseHeader(event, "Content-Type", "application/json");
+          event.node.res.end(JSON.stringify({ error: "Unauthorized" }));
+          return;
+        }
+        setResponseHeader(event, "Content-Type", "text/html");
+        event.node.res.end(LOGIN_HTML);
+      }),
+    );
+
+    console.log("[agent-native] Auth enabled — custom getSession provider.");
+    return true;
+  }
+
   // Production — check for tokens
   const tokens = getAccessTokens();
 
   if (tokens.length === 0) {
     // No tokens set — check if auth is explicitly disabled
     if (process.env.AUTH_DISABLED === "true") {
+      authDisabledMode = true;
       console.warn(
         "[agent-native] AUTH_DISABLED=true — running in production without auth. " +
           "Ensure this app is behind infrastructure-level auth (Cloudflare Access, VPN, etc.).",
       );
 
-      // Still mount session endpoint returning null
+      // Mount session endpoint — getSession() will return DEV_SESSION
       app.use(
         "/api/auth/session",
         defineEventHandler(async (event) => {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1,4 +1,6 @@
 import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 import {
   defineEventHandler,
   readBody,
@@ -8,14 +10,164 @@ import {
   getCookie,
   setCookie,
   deleteCookie,
-  getRequestURL,
 } from "h3";
-import type { App as H3App } from "h3";
+import type { App as H3App, H3Event } from "h3";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AuthSession {
+  email: string;
+  userId?: string;
+  token?: string;
+}
+
+export interface AuthOptions {
+  /** Session max age in seconds. Default: 30 days */
+  maxAge?: number;
+  /** Path to the sessions file. Default: data/.sessions.json */
+  sessionsPath?: string;
+  /**
+   * Custom getSession implementation (for BYOA — Auth.js, Clerk, etc.).
+   * When provided, the built-in token auth is bypassed entirely.
+   */
+  getSession?: (event: H3Event) => Promise<AuthSession | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
 
 const COOKIE_NAME = "an_session";
+const DEFAULT_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+const DEFAULT_SESSIONS_PATH = "data/.sessions.json";
 
-// In-memory session store — maps random session tokens to their creation time
-const activeSessions = new Set<string>();
+// ---------------------------------------------------------------------------
+// Session store — file-backed
+// ---------------------------------------------------------------------------
+
+interface StoredSession {
+  token: string;
+  createdAt: number;
+}
+
+let sessions: Map<string, StoredSession> = new Map();
+let sessionsFilePath = DEFAULT_SESSIONS_PATH;
+let sessionMaxAge = DEFAULT_MAX_AGE;
+
+function resolveSessionsPath(customPath?: string): string {
+  return path.resolve(process.cwd(), customPath ?? DEFAULT_SESSIONS_PATH);
+}
+
+function loadSessions(): void {
+  try {
+    const raw = fs.readFileSync(sessionsFilePath, "utf-8");
+    const entries: StoredSession[] = JSON.parse(raw);
+    sessions = new Map(entries.map((s) => [s.token, s]));
+  } catch {
+    sessions = new Map();
+  }
+}
+
+function saveSessions(): void {
+  const dir = path.dirname(sessionsFilePath);
+  fs.mkdirSync(dir, { recursive: true });
+  const entries = Array.from(sessions.values());
+  fs.writeFileSync(sessionsFilePath, JSON.stringify(entries, null, 2));
+}
+
+function pruneExpiredSessions(): void {
+  const now = Date.now();
+  let pruned = false;
+  for (const [token, session] of sessions) {
+    if (now - session.createdAt > sessionMaxAge * 1000) {
+      sessions.delete(token);
+      pruned = true;
+    }
+  }
+  if (pruned) saveSessions();
+}
+
+function addSession(token: string): void {
+  sessions.set(token, { token, createdAt: Date.now() });
+  saveSessions();
+}
+
+function removeSession(token: string): void {
+  sessions.delete(token);
+  saveSessions();
+}
+
+function hasSession(token: string): boolean {
+  const session = sessions.get(token);
+  if (!session) return false;
+  if (Date.now() - session.createdAt > sessionMaxAge * 1000) {
+    sessions.delete(token);
+    saveSessions();
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Token resolution — supports ACCESS_TOKEN (single) or ACCESS_TOKENS (multi)
+// ---------------------------------------------------------------------------
+
+function getAccessTokens(): string[] {
+  const single = process.env.ACCESS_TOKEN;
+  const multi = process.env.ACCESS_TOKENS;
+  const tokens: string[] = [];
+  if (single) tokens.push(single);
+  if (multi) {
+    for (const t of multi.split(",")) {
+      const trimmed = t.trim();
+      if (trimmed && !tokens.includes(trimmed)) tokens.push(trimmed);
+    }
+  }
+  return tokens;
+}
+
+// ---------------------------------------------------------------------------
+// Dev mode detection
+// ---------------------------------------------------------------------------
+
+function isDevMode(): boolean {
+  return process.env.NODE_ENV !== "production";
+}
+
+// ---------------------------------------------------------------------------
+// getSession — the auth contract
+// ---------------------------------------------------------------------------
+
+let customGetSession:
+  | ((event: H3Event) => Promise<AuthSession | null>)
+  | null = null;
+
+const DEV_SESSION: AuthSession = { email: "local@localhost" };
+
+/**
+ * Get the current auth session for a request.
+ *
+ * - In dev mode: always returns { email: "local@localhost" }
+ * - In production with built-in auth: returns session if cookie is valid
+ * - With custom auth (BYOA): delegates to the custom getSession
+ */
+export async function getSession(event: H3Event): Promise<AuthSession | null> {
+  if (isDevMode()) return DEV_SESSION;
+
+  if (customGetSession) return customGetSession(event);
+
+  const cookie = getCookie(event, COOKIE_NAME);
+  if (cookie && hasSession(cookie)) {
+    return { email: "user", token: cookie };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Login page HTML
+// ---------------------------------------------------------------------------
 
 const LOGIN_HTML = `<!DOCTYPE html>
 <html lang="en">
@@ -103,15 +255,23 @@ const LOGIN_HTML = `<!DOCTYPE html>
 </body>
 </html>`;
 
+// ---------------------------------------------------------------------------
+// mountAuthMiddleware — mounts login/logout/session routes + auth guard
+// ---------------------------------------------------------------------------
+
 /**
- * Mount auth middleware + login/logout routes onto an H3 app.
+ * Mount auth middleware + login/logout/session routes onto an H3 app.
  *
- * - POST /api/auth/login  — validates token, sets HttpOnly session cookie
- * - POST /api/auth/logout — clears session cookie
- * - All other routes: redirects/blocks unauthenticated requests
+ * @deprecated Use `autoMountAuth(app, options?)` instead for automatic
+ * dev/prod behavior. This function is kept for backwards compatibility
+ * when you need explicit control over the access token.
  */
 export function mountAuthMiddleware(app: H3App, accessToken: string): void {
-  // Login route
+  mountAuthRoutes(app, [accessToken]);
+}
+
+function mountAuthRoutes(app: H3App, accessTokens: string[]): void {
+  // POST /api/auth/login
   app.use(
     "/api/auth/login",
     defineEventHandler(async (event) => {
@@ -120,52 +280,69 @@ export function mountAuthMiddleware(app: H3App, accessToken: string): void {
         return { error: "Method not allowed" };
       }
       const body = await readBody(event);
-      if (body?.token !== accessToken) {
+      if (!body?.token || !accessTokens.includes(body.token)) {
         setResponseStatus(event, 401);
         return { error: "Invalid token" };
       }
       const sessionToken = crypto.randomBytes(32).toString("hex");
-      activeSessions.add(sessionToken);
+      addSession(sessionToken);
       setCookie(event, COOKIE_NAME, sessionToken, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
+        secure: true,
         sameSite: "lax",
         path: "/",
-        maxAge: 60 * 60 * 24 * 30, // 30 days
+        maxAge: sessionMaxAge,
       });
       return { ok: true };
     }),
   );
 
-  // Logout route
+  // POST /api/auth/logout
   app.use(
     "/api/auth/logout",
     defineEventHandler((event) => {
-      const session = getCookie(event, COOKIE_NAME);
-      if (session) activeSessions.delete(session);
+      const cookie = getCookie(event, COOKIE_NAME);
+      if (cookie) removeSession(cookie);
       deleteCookie(event, COOKIE_NAME, { path: "/" });
       return { ok: true };
     }),
   );
 
-  // Auth guard middleware (runs before all other handlers)
+  // GET /api/auth/session — client session check
+  app.use(
+    "/api/auth/session",
+    defineEventHandler(async (event) => {
+      if (getMethod(event) !== "GET") {
+        setResponseStatus(event, 405);
+        return { error: "Method not allowed" };
+      }
+      const session = await getSession(event);
+      return session ?? { error: "Not authenticated" };
+    }),
+  );
+
+  // Auth guard — runs before all other handlers
   app.use(
     defineEventHandler((event) => {
       const url = event.node.req.url ?? "/";
-      const path = url.split("?")[0];
+      const p = url.split("?")[0];
 
-      // Skip auth check for login/logout routes
-      if (path === "/api/auth/login" || path === "/api/auth/logout") {
+      // Skip auth routes
+      if (
+        p === "/api/auth/login" ||
+        p === "/api/auth/logout" ||
+        p === "/api/auth/session"
+      ) {
         return;
       }
 
-      const session = getCookie(event, COOKIE_NAME);
-      if (session && activeSessions.has(session)) {
-        return; // Authenticated — continue
+      const cookie = getCookie(event, COOKIE_NAME);
+      if (cookie && hasSession(cookie)) {
+        return; // Authenticated
       }
 
-      // Unauthenticated — API routes get 401, all others get login page
-      if (path.startsWith("/api/")) {
+      // Unauthenticated
+      if (p.startsWith("/api/")) {
         setResponseStatus(event, 401);
         setResponseHeader(event, "Content-Type", "application/json");
         event.node.res.end(JSON.stringify({ error: "Unauthorized" }));
@@ -176,4 +353,122 @@ export function mountAuthMiddleware(app: H3App, accessToken: string): void {
       event.node.res.end(LOGIN_HTML);
     }),
   );
+}
+
+// ---------------------------------------------------------------------------
+// autoMountAuth — the recommended entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Automatically configure auth based on the environment:
+ *
+ * - **Dev mode** (`NODE_ENV !== "production"`): Auth is skipped entirely.
+ *   `getSession()` returns `{ email: "local@localhost" }` for all requests.
+ *
+ * - **Production with ACCESS_TOKEN/ACCESS_TOKENS set**: Auth middleware is
+ *   mounted. Unauthenticated requests see a login page. One env var is all
+ *   you need.
+ *
+ * - **Production without tokens and AUTH_DISABLED !== "true"**: Refuses to
+ *   start. Logs a clear error explaining what to do.
+ *
+ * - **Production with AUTH_DISABLED=true**: Auth is skipped (for apps behind
+ *   infrastructure-level auth like Cloudflare Access or a VPN).
+ *
+ * Returns true if auth was mounted, false if skipped.
+ */
+export function autoMountAuth(app: H3App, options: AuthOptions = {}): boolean {
+  // Apply options
+  sessionMaxAge = options.maxAge ?? DEFAULT_MAX_AGE;
+  sessionsFilePath = resolveSessionsPath(options.sessionsPath);
+
+  if (options.getSession) {
+    customGetSession = options.getSession;
+  }
+
+  // Dev mode — skip auth entirely
+  if (isDevMode()) {
+    // Mount a session endpoint that returns the dev stub
+    app.use(
+      "/api/auth/session",
+      defineEventHandler(async (event) => {
+        if (getMethod(event) !== "GET") {
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
+        return DEV_SESSION;
+      }),
+    );
+
+    // Mount no-op login/logout so client code doesn't break
+    app.use(
+      "/api/auth/login",
+      defineEventHandler(() => ({ ok: true })),
+    );
+    app.use(
+      "/api/auth/logout",
+      defineEventHandler(() => ({ ok: true })),
+    );
+
+    return false;
+  }
+
+  // Production — check for tokens
+  const tokens = getAccessTokens();
+
+  if (tokens.length === 0) {
+    // No tokens set — check if auth is explicitly disabled
+    if (process.env.AUTH_DISABLED === "true") {
+      console.warn(
+        "[agent-native] AUTH_DISABLED=true — running in production without auth. " +
+          "Ensure this app is behind infrastructure-level auth (Cloudflare Access, VPN, etc.).",
+      );
+
+      // Still mount session endpoint returning null
+      app.use(
+        "/api/auth/session",
+        defineEventHandler(async (event) => {
+          if (getMethod(event) !== "GET") {
+            setResponseStatus(event, 405);
+            return { error: "Method not allowed" };
+          }
+          return DEV_SESSION;
+        }),
+      );
+      app.use(
+        "/api/auth/login",
+        defineEventHandler(() => ({ ok: true })),
+      );
+      app.use(
+        "/api/auth/logout",
+        defineEventHandler(() => ({ ok: true })),
+      );
+
+      return false;
+    }
+
+    // Refuse to start without auth in production
+    const msg =
+      "\n" +
+      "=".repeat(70) +
+      "\n" +
+      " ERROR: Running in production without authentication.\n\n" +
+      " Set ACCESS_TOKEN=<your-secret> to enable auth, or\n" +
+      " set AUTH_DISABLED=true if this app is behind infrastructure auth.\n\n" +
+      " For multi-user access: ACCESS_TOKENS=token1,token2,token3\n" +
+      "=".repeat(70) +
+      "\n";
+    console.error(msg);
+    process.exit(1);
+  }
+
+  // Production with tokens — mount auth
+  loadSessions();
+  pruneExpiredSessions();
+  mountAuthRoutes(app, tokens);
+
+  console.log(
+    `[agent-native] Auth enabled — ${tokens.length} access token(s) configured.`,
+  );
+  return true;
 }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -9,7 +9,13 @@ export {
   type FileWatcherOptions,
   type SSEHandlerOptions,
 } from "./sse.js";
-export { mountAuthMiddleware } from "./auth.js";
+export {
+  mountAuthMiddleware,
+  autoMountAuth,
+  getSession,
+  type AuthSession,
+  type AuthOptions,
+} from "./auth.js";
 export { requireEnvKey, type MissingKeyResponse } from "./missing-key.js";
 export {
   createProductionAgentHandler,

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -12,6 +12,16 @@ This is an **@agent-native/core** application — the AI agent and UI share stat
 4. **Bidirectional SSE events** — The file watcher keeps the UI in sync when the agent modifies files.
 5. **Agent can update code** — The agent can modify this app's source code directly.
 
+### Authentication
+
+Auth is automatic and environment-driven. The `server/plugins/auth.ts` plugin calls `autoMountAuth(app)` at startup.
+
+- **Dev mode**: Auth is bypassed. `getSession()` returns `{ email: "local@localhost" }`. Zero friction.
+- **Production** (`ACCESS_TOKEN` set): Auth middleware auto-mounts. Login page for unauthenticated visitors.
+- **Production** (no token, no `AUTH_DISABLED=true`): Server refuses to start.
+
+Use `getSession(event)` server-side and `useSession()` client-side. See [docs/auth.md](docs/auth.md).
+
 ### Directory Structure
 
 ```

--- a/packages/core/src/templates/default/_gitignore
+++ b/packages/core/src/templates/default/_gitignore
@@ -31,6 +31,7 @@ dist-ssr
 # Data
 data/uploads/
 data/settings.json
+data/.sessions.json
 
 # Learnings (personal preferences and memory — use learnings.defaults.md for tracked defaults)
 learnings.md

--- a/packages/core/src/templates/default/server/plugins/auth.ts
+++ b/packages/core/src/templates/default/server/plugins/auth.ts
@@ -1,0 +1,5 @@
+import { defineNitroPlugin, autoMountAuth } from "@agent-native/core";
+
+export default defineNitroPlugin((nitroApp: any) => {
+  autoMountAuth(nitroApp.h3App);
+});

--- a/templates/analytics/.gitignore
+++ b/templates/analytics/.gitignore
@@ -28,6 +28,9 @@ dist-ssr
 .config/
 .env
 
+# Auth sessions (sensitive, never commit)
+data/.sessions.json
+
 # Generated chart images (ephemeral)
 media/*.png
 media/theme.json

--- a/templates/analytics/client/components/auth/AuthProvider.tsx
+++ b/templates/analytics/client/components/auth/AuthProvider.tsx
@@ -1,8 +1,8 @@
 import { createContext, useContext, type ReactNode } from "react";
-import { type BuilderAuth } from "@/lib/auth";
+import { useSession, type AuthSession } from "@agent-native/core";
 
 interface AuthContextValue {
-  auth: BuilderAuth | null;
+  auth: AuthSession | null;
   isLoading: boolean;
   logout: () => void;
 }
@@ -10,11 +10,15 @@ interface AuthContextValue {
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  // No authentication — always treat the user as logged in.
+  const { session, isLoading } = useSession();
+
   const value: AuthContextValue = {
-    auth: { email: "local@localhost" },
-    isLoading: false,
-    logout: () => {},
+    auth: session,
+    isLoading,
+    logout: () =>
+      fetch("/api/auth/logout", { method: "POST" }).then(() =>
+        location.reload(),
+      ),
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/templates/analytics/client/lib/auth.ts
+++ b/templates/analytics/client/lib/auth.ts
@@ -1,14 +1,15 @@
-// Stub auth module — no authentication required.
+// Stub auth module — authentication is handled by the framework middleware.
 // getIdToken returns null so existing fetch calls safely skip the Authorization header.
+// In production, auth is enforced at the middleware layer via cookies.
 
-export interface BuilderAuth {
-  email: string;
-}
+import type { AuthSession } from "@agent-native/core";
+
+export type BuilderAuth = AuthSession;
 
 export async function getIdToken(): Promise<string | null> {
   return null;
 }
 
 export async function signOutUser(): Promise<void> {
-  // no-op
+  // no-op — use the logout endpoint instead
 }

--- a/templates/analytics/server/plugins/auth.ts
+++ b/templates/analytics/server/plugins/auth.ts
@@ -1,0 +1,5 @@
+import { defineNitroPlugin, autoMountAuth } from "@agent-native/core";
+
+export default defineNitroPlugin((nitroApp: any) => {
+  autoMountAuth(nitroApp.h3App);
+});

--- a/templates/brand/.gitignore
+++ b/templates/brand/.gitignore
@@ -1,5 +1,8 @@
 # React Router generated types
 .react-router/
 
+# Auth sessions (sensitive, never commit)
+data/.sessions.json
+
 # Learnings (personal preferences and memory — use learnings.defaults.md for tracked defaults)
 learnings.md

--- a/templates/brand/server/plugins/auth.ts
+++ b/templates/brand/server/plugins/auth.ts
@@ -1,0 +1,5 @@
+import { defineNitroPlugin, autoMountAuth } from "@agent-native/core";
+
+export default defineNitroPlugin((nitroApp: any) => {
+  autoMountAuth(nitroApp.h3App);
+});

--- a/templates/calendar/.gitignore
+++ b/templates/calendar/.gitignore
@@ -28,6 +28,9 @@ dist-ssr
 .config/
 .env
 
+# Auth sessions (sensitive, never commit)
+data/.sessions.json
+
 # Google OAuth tokens (sensitive, never commit)
 data/google-auth.json
 data/google-accounts/

--- a/templates/calendar/server/plugins/auth.ts
+++ b/templates/calendar/server/plugins/auth.ts
@@ -1,0 +1,5 @@
+import { defineNitroPlugin, autoMountAuth } from "@agent-native/core";
+
+export default defineNitroPlugin((nitroApp: any) => {
+  autoMountAuth(nitroApp.h3App);
+});

--- a/templates/content/.gitignore
+++ b/templates/content/.gitignore
@@ -28,6 +28,9 @@ dist-ssr
 .config/
 .env
 
+# Auth sessions (sensitive, never commit)
+data/.sessions.json
+
 # Ephemeral editor state
 .editor-selection.json
 

--- a/templates/content/server/plugins/auth.ts
+++ b/templates/content/server/plugins/auth.ts
@@ -1,0 +1,5 @@
+import { defineNitroPlugin, autoMountAuth } from "@agent-native/core";
+
+export default defineNitroPlugin((nitroApp: any) => {
+  autoMountAuth(nitroApp.h3App);
+});

--- a/templates/imagegen/.gitignore
+++ b/templates/imagegen/.gitignore
@@ -5,5 +5,8 @@ node_modules/
 dist/
 .env
 
+# Auth sessions (sensitive, never commit)
+data/.sessions.json
+
 # Learnings (personal preferences and memory — use learnings.defaults.md for tracked defaults)
 learnings.md

--- a/templates/imagegen/server/plugins/auth.ts
+++ b/templates/imagegen/server/plugins/auth.ts
@@ -1,0 +1,5 @@
+import { defineNitroPlugin, autoMountAuth } from "@agent-native/core";
+
+export default defineNitroPlugin((nitroApp: any) => {
+  autoMountAuth(nitroApp.h3App);
+});

--- a/templates/mail/.gitignore
+++ b/templates/mail/.gitignore
@@ -28,6 +28,9 @@ dist-ssr
 .config/
 .env
 
+# Auth sessions (sensitive, never commit)
+data/.sessions.json
+
 # User data (gitignored, defaults copied on first run)
 data/settings.json
 data/emails.json

--- a/templates/mail/server/plugins/auth.ts
+++ b/templates/mail/server/plugins/auth.ts
@@ -1,0 +1,5 @@
+import { defineNitroPlugin, autoMountAuth } from "@agent-native/core";
+
+export default defineNitroPlugin((nitroApp: any) => {
+  autoMountAuth(nitroApp.h3App);
+});


### PR DESCRIPTION
### Summary
Introduces a framework-native authentication layer that is completely invisible in development and automatically enforced in production, making it trivial to go from local dev to a secured deployed app with zero code changes.

### Problem
Agent-native apps had no standard authentication story. Developers building for production had to roll their own auth, and there was no clear, safe path from "running locally" to "deployed and secured." This created friction and potential for accidental exposure of production apps.

### Solution
Implemented an environment-driven `autoMountAuth()` system in `@agent-native/core` that auto-detects the environment and configures auth accordingly. In dev mode, auth is bypassed entirely. In production, setting a single env var (`ACCESS_TOKEN`) activates cookie-based session middleware. The framework refuses to start in production without either a token or an explicit `AUTH_DISABLED=true` opt-out, preventing accidental exposure. A `getSession()` contract makes any external auth system (Auth.js, Clerk, Lucia, etc.) pluggable without changing templates.

### Key Changes
- **`autoMountAuth(app, options?)`** — new core function that mounts auth middleware based on environment; exported from `@agent-native/core/server`
- **`getSession(event)`** — server-side helper returning `AuthSession | null`; returns a dev stub (`local@localhost`) outside production
- **`useSession()` hook** — new client-side React hook (`packages/core/src/client/use-session.ts`) that fetches `/api/auth/session` in production and returns the dev stub immediately in dev
- **Auth routes** — `POST /api/auth/login`, `POST /api/auth/logout`, `GET /api/auth/session` mounted automatically
- **Session storage** — file-backed in `data/.sessions.json` (gitignored, pruned on startup, 30-day default lifetime); HttpOnly + Secure + SameSite=Lax cookies
- **Nitro plugin template** — `server/plugins/auth.ts` added to the default template and all existing templates (analytics, brand, calendar, content, imagegen, mail)
- **Bring-your-own-auth** — `AuthOptions.getSession` hook allows plugging in any auth library without changing application code or templates
- **`docs/auth.md`** — new comprehensive auth guide covering dev/prod modes, multi-token team access, BYOA, security details, and configuration reference
- **README.md + AGENTS.md** — updated with architecture table (Nitro, Auth, DB, Frontend, Agent, Hosting layers) and auth quick-start section
- **All template `.gitignore` files** — `data/.sessions.json` added to prevent accidental session file commits


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/ultra-station-t1huyefh"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-ultra-station-t1huyefh_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 65`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>ultra-station-t1huyefh</branchName>-->