### PR TITLE
Improve mobile docs UX with nav dropdown and prev/next

### DIFF
--- a/packages/docs/src/components/DocsLayout.tsx
+++ b/packages/docs/src/components/DocsLayout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import DocsSidebar from "./DocsSidebar";
 import TableOfContents from "./TableOfContents";
+import MobileDocsNav from "./MobileDocsNav";
+import DocsPrevNext from "./DocsPrevNext";
 
 interface TocItem {
   id: string;
@@ -16,12 +18,16 @@ export default function DocsLayout({
   toc?: TocItem[];
 }) {
   return (
-    <div className="mx-auto flex max-w-[1440px] px-6">
+    <div className="mx-auto flex max-w-[1440px] px-0 lg:px-6">
       <DocsSidebar />
-      <main className="min-w-0 flex-1 border-x border-[var(--border)] px-8 pb-16 pt-8 lg:px-12">
+      <main className="min-w-0 flex-1 border-0 border-[var(--border)] px-4 pb-16 pt-0 sm:px-6 lg:border-x lg:px-12 lg:pt-8">
+        <MobileDocsNav />
         <article className="docs-content mx-auto max-w-[720px]">
           {children}
         </article>
+        <div className="mx-auto max-w-[720px]">
+          <DocsPrevNext />
+        </div>
       </main>
       {toc && toc.length > 0 ? (
         <TableOfContents items={toc} />

--- a/packages/docs/src/components/DocsPrevNext.tsx
+++ b/packages/docs/src/components/DocsPrevNext.tsx
@@ -1,0 +1,83 @@
+import { Link, useMatches } from "@tanstack/react-router";
+import { NAV_ITEMS } from "./docsNavItems";
+
+function ArrowLeft() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="19" y1="12" x2="5" y2="12" />
+      <polyline points="12 19 5 12 12 5" />
+    </svg>
+  );
+}
+
+function ArrowRight() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <polyline points="12 5 19 12 12 19" />
+    </svg>
+  );
+}
+
+export default function DocsPrevNext() {
+  const matches = useMatches();
+  const currentPath = matches[matches.length - 1]?.pathname ?? "/docs";
+
+  const currentIndex = NAV_ITEMS.findIndex((item) => {
+    if (item.to === "/docs") {
+      return currentPath === "/docs" || currentPath === "/docs/";
+    }
+    return currentPath.startsWith(item.to);
+  });
+
+  const prev = currentIndex > 0 ? NAV_ITEMS[currentIndex - 1] : null;
+  const next =
+    currentIndex < NAV_ITEMS.length - 1 ? NAV_ITEMS[currentIndex + 1] : null;
+
+  if (!prev && !next) return null;
+
+  return (
+    <nav className="docs-prev-next">
+      {prev ? (
+        <Link to={prev.to} className="docs-prev-next-link docs-prev-link">
+          <ArrowLeft />
+          <div className="docs-prev-next-text">
+            <span className="docs-prev-next-label">Previous</span>
+            <span className="docs-prev-next-title">{prev.label}</span>
+          </div>
+        </Link>
+      ) : (
+        <div />
+      )}
+      {next ? (
+        <Link to={next.to} className="docs-prev-next-link docs-next-link">
+          <div className="docs-prev-next-text" style={{ textAlign: "right" }}>
+            <span className="docs-prev-next-label">Next</span>
+            <span className="docs-prev-next-title">{next.label}</span>
+          </div>
+          <ArrowRight />
+        </Link>
+      ) : (
+        <div />
+      )}
+    </nav>
+  );
+}

--- a/packages/docs/src/components/DocsSidebar.tsx
+++ b/packages/docs/src/components/DocsSidebar.tsx
@@ -1,17 +1,5 @@
 import { Link } from "@tanstack/react-router";
-
-const NAV_ITEMS = [
-  { label: "Getting Started", to: "/docs" as const },
-  { label: "Key Concepts", to: "/docs/key-concepts" as const },
-  { label: "Server", to: "/docs/server" as const },
-  { label: "Client", to: "/docs/client" as const },
-  { label: "Scripts", to: "/docs/scripts" as const },
-  { label: "File Sync", to: "/docs/file-sync" as const },
-  { label: "CLI Adapters", to: "/docs/cli-adapters" as const },
-  { label: "Deployment", to: "/docs/deployment" as const },
-  { label: "Harnesses", to: "/docs/harnesses" as const },
-  { label: "Creating Templates", to: "/docs/creating-templates" as const },
-];
+import { NAV_ITEMS } from "./docsNavItems";
 
 export default function DocsSidebar() {
   return (

--- a/packages/docs/src/components/MobileDocsNav.tsx
+++ b/packages/docs/src/components/MobileDocsNav.tsx
@@ -1,0 +1,100 @@
+import { Link, useMatches } from "@tanstack/react-router";
+import { useState, useEffect, useRef } from "react";
+import { NAV_ITEMS } from "./docsNavItems";
+
+function ChevronIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{
+        transition: "transform 200ms ease",
+        transform: open ? "rotate(180deg)" : "rotate(0deg)",
+      }}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+export default function MobileDocsNav() {
+  const [open, setOpen] = useState(false);
+  const navRef = useRef<HTMLDivElement>(null);
+  const matches = useMatches();
+
+  const currentPath = matches[matches.length - 1]?.pathname ?? "/docs";
+  const currentItem =
+    NAV_ITEMS.find((item) => {
+      if (item.to === "/docs") {
+        return currentPath === "/docs" || currentPath === "/docs/";
+      }
+      return currentPath.startsWith(item.to);
+    }) ?? NAV_ITEMS[0];
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (navRef.current && !navRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [open]);
+
+  return (
+    <div ref={navRef} className="mobile-docs-nav lg:hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        className="mobile-docs-nav-trigger"
+        aria-expanded={open}
+        aria-label="Navigate docs"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+          <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+        </svg>
+        <span>{currentItem.label}</span>
+        <ChevronIcon open={open} />
+      </button>
+
+      {open && (
+        <nav className="mobile-docs-nav-dropdown">
+          <ul className="mobile-docs-nav-list">
+            {NAV_ITEMS.map((item) => {
+              const isActive = item.to === currentItem.to;
+              return (
+                <li key={item.to}>
+                  <Link
+                    to={item.to}
+                    className={`mobile-docs-nav-link ${isActive ? "is-active" : ""}`}
+                    onClick={() => setOpen(false)}
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/packages/docs/src/components/docsNavItems.ts
+++ b/packages/docs/src/components/docsNavItems.ts
@@ -1,0 +1,12 @@
+export const NAV_ITEMS = [
+  { label: "Getting Started", to: "/docs" as const },
+  { label: "Key Concepts", to: "/docs/key-concepts" as const },
+  { label: "Server", to: "/docs/server" as const },
+  { label: "Client", to: "/docs/client" as const },
+  { label: "Scripts", to: "/docs/scripts" as const },
+  { label: "File Sync", to: "/docs/file-sync" as const },
+  { label: "CLI Adapters", to: "/docs/cli-adapters" as const },
+  { label: "Deployment", to: "/docs/deployment" as const },
+  { label: "Harnesses", to: "/docs/harnesses" as const },
+  { label: "Creating Templates", to: "/docs/creating-templates" as const },
+];

--- a/packages/docs/src/styles.css
+++ b/packages/docs/src/styles.css
@@ -532,6 +532,200 @@ html.dark .shiki span {
   opacity: 0.85;
 }
 
+/* Mobile docs nav dropdown */
+.mobile-docs-nav {
+  position: sticky;
+  top: 64px;
+  z-index: 40;
+  margin: 0 -16px;
+  padding: 0 16px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+
+@media (min-width: 640px) {
+  .mobile-docs-nav {
+    margin: 0 -24px;
+    padding: 0 24px;
+  }
+}
+
+.mobile-docs-nav-trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 0;
+  background: none;
+  border: none;
+  color: var(--fg);
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mobile-docs-nav-trigger svg:last-child {
+  margin-left: auto;
+  color: var(--fg-secondary);
+}
+
+.mobile-docs-nav-dropdown {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  max-height: 60vh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.mobile-docs-nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 8px 0;
+}
+
+.mobile-docs-nav-link {
+  display: block;
+  padding: 10px 20px;
+  font-size: 14px;
+  color: var(--fg-secondary);
+  text-decoration: none;
+  transition:
+    background-color 120ms,
+    color 120ms;
+}
+
+.mobile-docs-nav-link:hover {
+  background: var(--sidebar-hover);
+  color: var(--fg);
+  text-decoration: none;
+}
+
+.mobile-docs-nav-link.is-active {
+  color: var(--accent);
+  font-weight: 500;
+  background: var(--accent-light);
+}
+
+/* Prev / Next navigation */
+.docs-prev-next {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border);
+}
+
+.docs-prev-next-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  text-decoration: none;
+  color: var(--fg);
+  transition:
+    border-color 200ms,
+    background-color 200ms;
+  min-width: 0;
+}
+
+.docs-prev-next-link:hover {
+  border-color: var(--fg-secondary);
+  background: var(--bg-secondary);
+  text-decoration: none;
+}
+
+.docs-prev-next-link svg {
+  flex-shrink: 0;
+  color: var(--fg-secondary);
+}
+
+.docs-prev-next-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.docs-prev-next-label {
+  font-size: 12px;
+  color: var(--fg-secondary);
+}
+
+.docs-prev-next-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.docs-next-link {
+  margin-left: auto;
+}
+
+@media (max-width: 479px) {
+  .docs-prev-next {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .docs-prev-next-link {
+    width: 100%;
+  }
+  .docs-next-link {
+    flex-direction: row-reverse;
+    margin-left: 0;
+  }
+  .docs-next-link .docs-prev-next-text {
+    text-align: left;
+  }
+}
+
+/* Mobile docs content improvements */
+@media (max-width: 1023px) {
+  .docs-content h1 {
+    font-size: 28px;
+  }
+
+  .docs-content h2 {
+    font-size: 20px;
+    margin-top: 24px;
+  }
+
+  .docs-content h3 {
+    font-size: 16px;
+  }
+
+  .docs-content table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .docs-content table th,
+  .docs-content table td {
+    padding: 8px 12px;
+    font-size: 13px;
+  }
+
+  .docs-content pre,
+  .code-block pre {
+    font-size: 12px;
+    padding: 12px;
+    border-radius: 6px;
+  }
+}
+
 /* Transitions */
 button,
 a {


### PR DESCRIPTION
### Summary
Overhauls the mobile documentation experience by fixing layout issues, adding a dropdown navigation menu, and introducing previous/next page navigation — bringing the docs UX closer to the standard set by sites like Next.js.

### Problem
The mobile docs had awkward left/right borders and excess margins that made the layout feel broken on small screens. There was also no way to navigate between docs pages on mobile — the sidebar is hidden, leaving users with no navigation at all. Additionally, there were no prev/next links to move sequentially through the docs.

### Key Changes
- **`docsNavItems.ts`** — Extracted shared `NAV_ITEMS` constant into its own module so it can be reused across components
- **`MobileDocsNav.tsx`** — New sticky dropdown nav component (hidden on desktop) that shows the current doc title and expands to a full list of all docs pages; closes on outside click
- **`DocsPrevNext.tsx`** — New previous/next navigation component rendered at the bottom of every doc page, with arrow icons and labels matching the current route position in `NAV_ITEMS`
- **`DocsLayout.tsx`** — Removed the broken side borders and padding on mobile (`border-x` and `px-6` now only apply at `lg` breakpoint); integrated `MobileDocsNav` and `DocsPrevNext` into the layout
- **`styles.css`** — Added styles for the mobile nav dropdown, prev/next nav cards, and responsive typography/table/code-block adjustments for screens under 1024px

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/loaded-works-xi7mlpeh"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-loaded-works-xi7mlpeh_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 67`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>loaded-works-xi7mlpeh</branchName>-->