### PR TITLE
feat: multi-user Google OAuth, Cloudflare deployment, and core v0.4.3 fixes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/application-state/handlers.ts
+++ b/packages/core/src/application-state/handlers.ts
@@ -12,8 +12,21 @@ import {
   appStateList,
   appStateDeleteByPrefix,
 } from "./store.js";
+import { getSession } from "../server/auth.js";
 
-const SESSION_ID = "local";
+/**
+ * Resolve the session ID for app state scoping.
+ * - Dev mode: returns "local" (backward-compatible with existing dev databases)
+ * - Production with Google OAuth: returns the user's email
+ * - Production with token auth: returns "user" (single-user, same as before)
+ */
+async function getSessionId(event: H3Event): Promise<string> {
+  const session = await getSession(event);
+  if (!session) return "local";
+  // Dev mode returns "local@localhost" — keep using "local" for compat
+  if (session.email === "local@localhost") return "local";
+  return session.email;
+}
 
 function safeKey(key: string): string {
   return key.replace(/[^a-zA-Z0-9_-]/g, "");
@@ -22,8 +35,9 @@ function safeKey(key: string): string {
 // --- Generic state handlers ---
 
 export const getState = defineEventHandler(async (event: H3Event) => {
+  const sessionId = await getSessionId(event);
   const key = safeKey(String(getRouterParam(event, "key")));
-  const value = await appStateGet(SESSION_ID, key);
+  const value = await appStateGet(sessionId, key);
   if (!value) {
     setResponseStatus(event, 404);
     return { error: `No state for ${key}` };
@@ -32,15 +46,17 @@ export const getState = defineEventHandler(async (event: H3Event) => {
 });
 
 export const putState = defineEventHandler(async (event: H3Event) => {
+  const sessionId = await getSessionId(event);
   const key = safeKey(String(getRouterParam(event, "key")));
   const body = await readBody(event);
-  await appStatePut(SESSION_ID, key, body);
+  await appStatePut(sessionId, key, body);
   return body;
 });
 
 export const deleteState = defineEventHandler(async (event: H3Event) => {
+  const sessionId = await getSessionId(event);
   const key = safeKey(String(getRouterParam(event, "key")));
-  await appStateDelete(SESSION_ID, key);
+  await appStateDelete(sessionId, key);
   return { ok: true };
 });
 
@@ -51,15 +67,17 @@ function composeDraftKey(id: string): string {
 }
 
 /** List all compose drafts */
-export const listComposeDrafts = defineEventHandler(async () => {
-  const items = await appStateList(SESSION_ID, "compose-");
+export const listComposeDrafts = defineEventHandler(async (event: H3Event) => {
+  const sessionId = await getSessionId(event);
+  const items = await appStateList(sessionId, "compose-");
   return items.map((item) => item.value);
 });
 
 /** Get a single compose draft */
 export const getComposeDraft = defineEventHandler(async (event: H3Event) => {
+  const sessionId = await getSessionId(event);
   const id = getRouterParam(event, "id") as string;
-  const value = await appStateGet(SESSION_ID, composeDraftKey(id));
+  const value = await appStateGet(sessionId, composeDraftKey(id));
   if (!value) {
     setResponseStatus(event, 404);
     return { error: "Draft not found" };
@@ -69,6 +87,7 @@ export const getComposeDraft = defineEventHandler(async (event: H3Event) => {
 
 /** Create or update a compose draft */
 export const putComposeDraft = defineEventHandler(async (event: H3Event) => {
+  const sessionId = await getSessionId(event);
   const id = getRouterParam(event, "id") as string;
   const body = await readBody(event);
   const { subject, body: bodyText } = body;
@@ -79,19 +98,23 @@ export const putComposeDraft = defineEventHandler(async (event: H3Event) => {
   }
 
   const state = { ...body, id };
-  await appStatePut(SESSION_ID, composeDraftKey(id), state);
+  await appStatePut(sessionId, composeDraftKey(id), state);
   return state;
 });
 
 /** Delete a single compose draft */
 export const deleteComposeDraft = defineEventHandler(async (event: H3Event) => {
+  const sessionId = await getSessionId(event);
   const id = getRouterParam(event, "id") as string;
-  await appStateDelete(SESSION_ID, composeDraftKey(id));
+  await appStateDelete(sessionId, composeDraftKey(id));
   return { ok: true };
 });
 
 /** Delete all compose drafts */
-export const deleteAllComposeDrafts = defineEventHandler(async () => {
-  await appStateDeleteByPrefix(SESSION_ID, "compose-");
-  return { ok: true };
-});
+export const deleteAllComposeDrafts = defineEventHandler(
+  async (event: H3Event) => {
+    const sessionId = await getSessionId(event);
+    await appStateDeleteByPrefix(sessionId, "compose-");
+    return { ok: true };
+  },
+);

--- a/packages/core/src/application-state/script-helpers.ts
+++ b/packages/core/src/application-state/script-helpers.ts
@@ -1,8 +1,10 @@
 /**
  * Application state helpers for use in scripts.
  *
- * Scripts run as standalone processes without HTTP context,
- * so these use a fixed session ID ("local" for now).
+ * Scripts run as standalone processes without HTTP context.
+ * The session ID is resolved from the AGENT_USER_EMAIL env var
+ * (set by the agent runtime for multi-user apps), defaulting to
+ * "local" for backward compatibility in dev mode.
  */
 
 import {
@@ -13,31 +15,33 @@ import {
   appStateDeleteByPrefix,
 } from "./store.js";
 
-const SESSION_ID = "local";
+function getScriptSessionId(): string {
+  return process.env.AGENT_USER_EMAIL ?? "local";
+}
 
 export async function readAppState(
   key: string,
 ): Promise<Record<string, unknown> | null> {
-  return appStateGet(SESSION_ID, key);
+  return appStateGet(getScriptSessionId(), key);
 }
 
 export async function writeAppState(
   key: string,
   value: Record<string, unknown>,
 ): Promise<void> {
-  return appStatePut(SESSION_ID, key, value);
+  return appStatePut(getScriptSessionId(), key, value);
 }
 
 export async function deleteAppState(key: string): Promise<boolean> {
-  return appStateDelete(SESSION_ID, key);
+  return appStateDelete(getScriptSessionId(), key);
 }
 
 export async function listAppState(
   prefix: string,
 ): Promise<Array<{ key: string; value: Record<string, unknown> }>> {
-  return appStateList(SESSION_ID, prefix);
+  return appStateList(getScriptSessionId(), prefix);
 }
 
 export async function deleteAppStateByPrefix(prefix: string): Promise<number> {
-  return appStateDeleteByPrefix(SESSION_ID, prefix);
+  return appStateDeleteByPrefix(getScriptSessionId(), prefix);
 }

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -38,6 +38,12 @@ export interface AuthOptions {
    * Both page routes and API routes can be made public.
    */
   publicPaths?: string[];
+  /**
+   * Custom login page HTML. When provided, this HTML is served to
+   * unauthenticated page requests instead of the built-in token login form.
+   * Use this for custom login flows (e.g., "Sign in with Google" button).
+   */
+  loginHtml?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,9 +81,16 @@ async function ensureSessionTable(): Promise<void> {
   await client.execute(`
     CREATE TABLE IF NOT EXISTS sessions (
       token TEXT PRIMARY KEY,
+      email TEXT,
       created_at INTEGER NOT NULL
     )
   `);
+  // Migration: add email column to existing tables that lack it
+  try {
+    await client.execute(`ALTER TABLE sessions ADD COLUMN email TEXT`);
+  } catch {
+    // Column already exists — ignore
+  }
   _sessionTableReady = true;
 }
 
@@ -91,22 +104,50 @@ async function pruneExpiredSessions(): Promise<void> {
   });
 }
 
-async function addSession(token: string): Promise<void> {
+/**
+ * Create a new session. Optionally associate it with an email address
+ * (used by Google OAuth and other identity-aware auth providers).
+ */
+export async function addSession(token: string, email?: string): Promise<void> {
   await ensureSessionTable();
   const client = getSessionClient();
   await client.execute({
-    sql: `INSERT OR REPLACE INTO sessions (token, created_at) VALUES (?, ?)`,
-    args: [token, Date.now()],
+    sql: `INSERT OR REPLACE INTO sessions (token, email, created_at) VALUES (?, ?, ?)`,
+    args: [token, email ?? null, Date.now()],
   });
 }
 
-async function removeSession(token: string): Promise<void> {
+/** Remove a session by token. */
+export async function removeSession(token: string): Promise<void> {
   await ensureSessionTable();
   const client = getSessionClient();
   await client.execute({
     sql: `DELETE FROM sessions WHERE token = ?`,
     args: [token],
   });
+}
+
+/**
+ * Look up the email associated with a session token.
+ * Returns null if the session doesn't exist, is expired, or has no email.
+ */
+export async function getSessionEmail(token: string): Promise<string | null> {
+  await ensureSessionTable();
+  const client = getSessionClient();
+  const { rows } = await client.execute({
+    sql: `SELECT email, created_at FROM sessions WHERE token = ?`,
+    args: [token],
+  });
+  if (rows.length === 0) return null;
+  const createdAt = rows[0].created_at as number;
+  if (Date.now() - createdAt > sessionMaxAge * 1000) {
+    await client.execute({
+      sql: `DELETE FROM sessions WHERE token = ?`,
+      args: [token],
+    });
+    return null;
+  }
+  return (rows[0].email as string) ?? null;
 }
 
 async function hasSession(token: string): Promise<boolean> {
@@ -508,6 +549,7 @@ export function autoMountAuth(app: H3App, options: AuthOptions = {}): boolean {
     );
 
     // Mount auth guard that delegates to custom getSession
+    const byoaLoginHtml = options.loginHtml ?? LOGIN_HTML;
     app.use(
       defineEventHandler(async (event) => {
         const url = event.node.req.url ?? "/";
@@ -532,7 +574,7 @@ export function autoMountAuth(app: H3App, options: AuthOptions = {}): boolean {
           return;
         }
         setResponseHeader(event, "Content-Type", "text/html");
-        event.node.res.end(LOGIN_HTML);
+        event.node.res.end(byoaLoginHtml);
       }),
     );
 

--- a/packages/core/src/server/google-auth-plugin.ts
+++ b/packages/core/src/server/google-auth-plugin.ts
@@ -1,0 +1,130 @@
+import { getCookie } from "h3";
+import { createAuthPlugin } from "./auth-plugin.js";
+import { getSessionEmail } from "./auth.js";
+
+type NitroPluginDef = (nitroApp: any) => void | Promise<void>;
+
+export interface GoogleAuthPluginOptions {
+  /** Additional paths accessible without authentication */
+  publicPaths?: string[];
+}
+
+const GOOGLE_LOGIN_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sign in</title>
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: #0a0a0a;
+    color: #e5e5e5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+  }
+  .card {
+    width: 100%;
+    max-width: 360px;
+    padding: 2rem;
+    background: #141414;
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 12px;
+    text-align: center;
+  }
+  h1 { font-size: 1.125rem; font-weight: 600; margin-bottom: 0.5rem; color: #fff; }
+  .subtitle { font-size: 0.8125rem; color: #888; margin-bottom: 1.5rem; }
+  button {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+    padding: 0.625rem;
+    background: #fff;
+    color: #000;
+    border: none;
+    border-radius: 8px;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    cursor: pointer;
+  }
+  button:hover { opacity: 0.85; }
+  button:disabled { opacity: 0.5; cursor: wait; }
+  .error { margin-top: 0.75rem; font-size: 0.8125rem; color: #f87171; display: none; }
+  .error.show { display: block; }
+  svg { width: 18px; height: 18px; }
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>Sign in</h1>
+  <p class="subtitle">Continue with your Google account</p>
+  <button id="btn" onclick="signIn()">
+    <svg viewBox="0 0 24 24"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
+    Sign in with Google
+  </button>
+  <p class="error" id="err"></p>
+</div>
+<script>
+  async function signIn() {
+    var btn = document.getElementById('btn');
+    var err = document.getElementById('err');
+    btn.disabled = true;
+    err.classList.remove('show');
+    try {
+      var res = await fetch('/api/google/auth-url');
+      var data = await res.json();
+      if (data.url) {
+        window.location.href = data.url;
+      } else {
+        err.textContent = data.message || 'Google OAuth is not configured. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.';
+        err.classList.add('show');
+        btn.disabled = false;
+      }
+    } catch (e) {
+      err.textContent = 'Failed to connect. Please try again.';
+      err.classList.add('show');
+      btn.disabled = false;
+    }
+  }
+</script>
+</body>
+</html>`;
+
+/**
+ * Create an auth plugin that uses Google OAuth for authentication.
+ *
+ * When a user visits the app unauthenticated, they see a "Sign in with Google"
+ * page. The Google OAuth callback (handled by the template) creates a session
+ * tied to the user's Google email. `getSession()` then returns `{ email }` for
+ * all subsequent requests.
+ *
+ * Usage in a template's `server/plugins/auth.ts`:
+ * ```ts
+ * import { createGoogleAuthPlugin } from "@agent-native/core/server";
+ * export default createGoogleAuthPlugin();
+ * ```
+ */
+export function createGoogleAuthPlugin(
+  options?: GoogleAuthPluginOptions,
+): NitroPluginDef {
+  return createAuthPlugin({
+    getSession: async (event) => {
+      const cookie = getCookie(event, "an_session");
+      if (!cookie) return null;
+      const email = await getSessionEmail(cookie);
+      if (!email) return null;
+      return { email, token: cookie };
+    },
+    publicPaths: [
+      "/api/google/callback",
+      "/api/google/auth-url",
+      ...(options?.publicPaths ?? []),
+    ],
+    loginHtml: GOOGLE_LOGIN_HTML,
+  });
+}

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -14,6 +14,9 @@ export {
   mountAuthMiddleware,
   autoMountAuth,
   getSession,
+  addSession,
+  removeSession,
+  getSessionEmail,
   type AuthSession,
   type AuthOptions,
 } from "./auth.js";
@@ -37,6 +40,10 @@ export {
   defaultSyncStatusHandler,
 } from "./default-watcher.js";
 export { createAuthPlugin, defaultAuthPlugin } from "./auth-plugin.js";
+export {
+  createGoogleAuthPlugin,
+  type GoogleAuthPluginOptions,
+} from "./google-auth-plugin.js";
 export {
   createAgentChatPlugin,
   defaultAgentChatPlugin,

--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -16,3 +16,10 @@ export {
 
 // Script helpers
 export { readSetting, writeSetting, removeSetting } from "./script-helpers.js";
+
+// User-scoped helpers
+export {
+  getUserSetting,
+  putUserSetting,
+  deleteUserSetting,
+} from "./user-settings.js";

--- a/packages/core/src/settings/user-settings.ts
+++ b/packages/core/src/settings/user-settings.ts
@@ -1,0 +1,48 @@
+/**
+ * User-scoped settings helpers.
+ *
+ * Wraps the global settings store with per-user key prefixing.
+ * Keys are stored as `u:<email>:<key>` in the settings table.
+ *
+ * Includes a migration fallback: if a user-scoped key is not found,
+ * falls back to the global (unprefixed) key. This allows existing
+ * single-user data to be read by the first user who accesses it.
+ * Writes always go to the user-scoped key.
+ */
+
+import { getSetting, putSetting, deleteSetting } from "./store.js";
+
+function userKey(email: string, key: string): string {
+  return `u:${email}:${key}`;
+}
+
+/**
+ * Read a user-scoped setting. Falls back to the global key if the
+ * user-scoped key doesn't exist (migration path from single-user).
+ */
+export async function getUserSetting(
+  email: string,
+  key: string,
+): Promise<Record<string, unknown> | null> {
+  const scoped = await getSetting(userKey(email, key));
+  if (scoped !== null) return scoped;
+  // Fallback to unscoped key for migration from single-user
+  return getSetting(key);
+}
+
+/** Write a user-scoped setting. Always writes to the prefixed key. */
+export async function putUserSetting(
+  email: string,
+  key: string,
+  value: Record<string, unknown>,
+): Promise<void> {
+  return putSetting(userKey(email, key), value);
+}
+
+/** Delete a user-scoped setting. */
+export async function deleteUserSetting(
+  email: string,
+  key: string,
+): Promise<boolean> {
+  return deleteSetting(userKey(email, key));
+}

--- a/packages/core/src/templates/default/app/routes/_index.tsx
+++ b/packages/core/src/templates/default/app/routes/_index.tsx
@@ -25,7 +25,7 @@ export default function IndexPage() {
           <p className="text-[14px] text-muted-foreground leading-relaxed">
             Start building by editing{" "}
             <code className="text-[13px] bg-muted px-1.5 py-0.5 rounded font-mono">
-              client/routes/_index.tsx
+              app/routes/_index.tsx
             </code>
           </p>
         </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,10 +29,10 @@ importers:
         version: 0.15.15
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.13.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+        version: 7.13.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.13.1(@react-router/dev@7.13.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)
+        version: 7.13.1(@react-router/dev@7.13.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -65,7 +65,7 @@ importers:
         version: 10.2.4
       nitro:
         specifier: ^3.0.0
-        version: 3.0.0(@electric-sql/pglite@0.3.16)(@libsql/client@0.15.15)(@netlify/blobs@10.7.2)(better-sqlite3@12.8.0)(chokidar@4.0.3)(drizzle-orm@0.44.7(@electric-sql/pglite@0.3.16)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0))(lru-cache@11.2.6)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.0.0(@electric-sql/pglite@0.3.16)(@libsql/client@0.15.15)(@netlify/blobs@10.7.2)(better-sqlite3@12.8.0)(chokidar@4.0.3)(drizzle-orm@0.44.7(@electric-sql/pglite@0.3.16)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0))(lru-cache@11.2.6)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
@@ -114,7 +114,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.3.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -153,10 +153,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(canvas@3.2.1))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@1.21.7)(jsdom@28.1.0(canvas@3.2.1))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
       ws:
         specifier: ^8.18.0
         version: 8.19.0
@@ -1341,12 +1341,12 @@ importers:
       '@agent-native/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@libsql/client':
+        specifier: ^0.15.0
+        version: 0.15.15
       '@tabler/icons-react':
         specifier: ^3.40.0
         version: 3.40.0(react@18.3.1)
-      better-sqlite3:
-        specifier: ^12.8.0
-        version: 12.8.0
       chrono-node:
         specifier: ^2.7.6
         version: 2.9.0
@@ -1467,10 +1467,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.13.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+        version: 7.13.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.13.1(@react-router/dev@7.13.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)
+        version: 7.13.1(@react-router/dev@7.13.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)
       '@swc/core':
         specifier: ^1.13.3
         version: 1.15.18
@@ -1501,9 +1501,6 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.19.0
         version: 3.20.1
-      '@types/better-sqlite3':
-        specifier: ^7.6.8
-        version: 7.6.13
       '@types/node':
         specifier: ^24.2.1
         version: 24.12.0
@@ -1515,7 +1512,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.3.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
@@ -1599,10 +1596,10 @@ importers:
         version: 1.1.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vite:
         specifier: ^7.1.2
-        version: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@1.21.7)(jsdom@28.1.0(canvas@3.2.1))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(canvas@3.2.1))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
 
   templates/slides:
     dependencies:
@@ -18719,7 +18716,7 @@ snapshots:
     dependencies:
       nanoid: 3.3.11
 
-  '@react-router/dev@7.13.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)':
+  '@react-router/dev@7.13.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -18728,7 +18725,7 @@ snapshots:
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      '@react-router/node': 7.13.1(react-router@7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@react-router/node': 7.13.1(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@remix-run/node-fetch-server': 0.13.0
       arg: 5.0.2
       babel-dead-code-elimination: 1.0.12
@@ -18745,11 +18742,11 @@ snapshots:
       pkg-types: 2.3.0
       prettier: 3.8.1
       react-refresh: 0.14.2
-      react-router: 7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-router: 7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
       semver: 7.7.4
       tinyglobby: 0.2.15
       valibot: 1.3.1(typescript@5.9.3)
-      vite: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
       vite-node: 3.2.4(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.9.3
@@ -18817,58 +18814,9 @@ snapshots:
       - tsx
       - yaml
 
-  '@react-router/dev@7.13.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)':
+  '@react-router/fs-routes@7.13.1(@react-router/dev@7.13.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@react-router/node': 7.13.1(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
-      '@remix-run/node-fetch-server': 0.13.0
-      arg: 5.0.2
-      babel-dead-code-elimination: 1.0.12
-      chokidar: 4.0.3
-      dedent: 1.7.2
-      es-module-lexer: 1.7.0
-      exit-hook: 2.2.1
-      isbot: 5.1.36
-      jsesc: 3.0.2
-      lodash: 4.17.23
-      p-map: 7.0.4
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      pkg-types: 2.3.0
-      prettier: 3.8.1
-      react-refresh: 0.14.2
-      react-router: 7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      valibot: 1.3.1(typescript@5.9.3)
-      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  '@react-router/fs-routes@7.13.1(@react-router/dev@7.13.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)':
-    dependencies:
-      '@react-router/dev': 7.13.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+      '@react-router/dev': 7.13.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
       minimatch: 9.0.9
     optionalDependencies:
       typescript: 5.9.3
@@ -18876,13 +18824,6 @@ snapshots:
   '@react-router/fs-routes@7.13.1(@react-router/dev@7.13.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)':
     dependencies:
       '@react-router/dev': 7.13.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
-      minimatch: 9.0.9
-    optionalDependencies:
-      typescript: 5.9.3
-
-  '@react-router/fs-routes@7.13.1(@react-router/dev@7.13.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2))(typescript@5.9.3)':
-    dependencies:
-      '@react-router/dev': 7.13.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.13.1(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
       minimatch: 9.0.9
     optionalDependencies:
       typescript: 5.9.3
@@ -20354,14 +20295,6 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react-swc@4.3.0(vite@7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.7
-      '@swc/core': 1.15.18
-      vite: 7.3.1(@types/node@24.12.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-
   '@vitejs/plugin-react-swc@4.3.0(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -20370,11 +20303,11 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react-swc@4.3.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react-swc@4.3.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       '@swc/core': 1.15.18
-      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -25138,7 +25071,7 @@ snapshots:
 
   nf3@0.1.12: {}
 
-  nitro@3.0.0(@electric-sql/pglite@0.3.16)(@libsql/client@0.15.15)(@netlify/blobs@10.7.2)(better-sqlite3@12.8.0)(chokidar@4.0.3)(drizzle-orm@0.44.7(@electric-sql/pglite@0.3.16)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0))(lru-cache@11.2.6)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
+  nitro@3.0.0(@electric-sql/pglite@0.3.16)(@libsql/client@0.15.15)(@netlify/blobs@10.7.2)(better-sqlite3@12.8.0)(chokidar@4.0.3)(drizzle-orm@0.44.7(@electric-sql/pglite@0.3.16)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0))(lru-cache@11.2.6)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       consola: 3.4.2
       cookie-es: 2.0.0
@@ -25158,7 +25091,7 @@ snapshots:
       unenv: 2.0.0-rc.21
       unstorage: 2.0.0-alpha.3(@netlify/blobs@10.7.2)(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.3.16)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@electric-sql/pglite@0.3.16)(@libsql/client@0.15.15)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)))(lru-cache@11.2.6)(ofetch@1.5.1)
     optionalDependencies:
-      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -28021,6 +27954,23 @@ snapshots:
       esbuild: 0.27.4
       fsevents: 2.3.3
       jiti: 2.6.1
+      terser: 5.46.1
+      tsx: 4.21.0
+      yaml: 2.8.2
+
+  vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@oxc-project/runtime': 0.115.0
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.9
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.12.0
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 1.21.7
       terser: 5.46.1
       tsx: 4.21.0
       yaml: 2.8.2

--- a/templates/forms/app/hooks/use-db-status.ts
+++ b/templates/forms/app/hooks/use-db-status.ts
@@ -12,7 +12,7 @@ export function useDbStatus() {
     queryKey: ["env-status"],
     queryFn: async () => {
       const res = await fetch("/api/env-status");
-      if (!res.ok) throw new Error("Failed to fetch env status");
+      if (!res.ok) return [];
       return res.json();
     },
     staleTime: 30_000,

--- a/templates/mail/package.json
+++ b/templates/mail/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@agent-native/core": "workspace:*",
+    "@libsql/client": "^0.15.0",
     "@tabler/icons-react": "^3.40.0",
-    "better-sqlite3": "^12.8.0",
     "chrono-node": "^2.7.6",
     "drizzle-orm": "^0.36.4",
     "embla-carousel-react": "^8.6.0",
@@ -70,7 +70,6 @@
     "@tiptap/pm": "^3.19.0",
     "@tiptap/react": "^3.19.0",
     "@tiptap/starter-kit": "^3.19.0",
-    "@types/better-sqlite3": "^7.6.8",
     "@types/node": "^24.2.1",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",

--- a/templates/mail/server/db/index.ts
+++ b/templates/mail/server/db/index.ts
@@ -1,27 +1,13 @@
-import { drizzle } from "drizzle-orm/better-sqlite3";
-import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/libsql";
+import { createClient } from "@libsql/client";
 import * as schema from "./schema.js";
-import path from "path";
-import fs from "fs";
 
-const DATA_DIR = path.join(process.cwd(), "data");
-fs.mkdirSync(DATA_DIR, { recursive: true });
+const url = process.env.DATABASE_URL || "file:./data/app.db";
 
-const sqlite = new Database(path.join(DATA_DIR, "app.db"));
-sqlite.pragma("journal_mode = WAL");
+const client = createClient({
+  url,
+  authToken: process.env.DATABASE_AUTH_TOKEN,
+});
 
-// Run migrations inline: create the table if it doesn't exist
-sqlite.exec(`
-  CREATE TABLE IF NOT EXISTS scheduled_jobs (
-    id TEXT PRIMARY KEY,
-    type TEXT NOT NULL CHECK(type IN ('snooze', 'send_later')),
-    email_id TEXT,
-    payload TEXT NOT NULL,
-    run_at INTEGER NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'processing', 'done', 'cancelled')),
-    created_at INTEGER NOT NULL
-  )
-`);
-
-export const db = drizzle(sqlite, { schema });
+export const db = drizzle(client, { schema });
 export { schema };

--- a/templates/mail/server/handlers/aliases.ts
+++ b/templates/mail/server/handlers/aliases.ts
@@ -7,25 +7,33 @@ import {
 } from "h3";
 import { nanoid } from "nanoid";
 import type { Alias } from "@shared/types.js";
-import { getSetting, putSetting } from "@agent-native/core/settings";
+import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
+import { getSession } from "@agent-native/core/server";
 
-async function readAliases(): Promise<Alias[]> {
-  const data = await getSetting("aliases");
+async function uEmail(event: H3Event): Promise<string> {
+  const session = await getSession(event);
+  return session?.email ?? "local@localhost";
+}
+
+async function readAliases(email: string): Promise<Alias[]> {
+  const data = await getUserSetting(email, "aliases");
   if (data && Array.isArray((data as any).aliases)) {
     return (data as any).aliases;
   }
   return [];
 }
 
-async function writeAliases(aliases: Alias[]): Promise<void> {
-  await putSetting("aliases", { aliases });
+async function writeAliases(email: string, aliases: Alias[]): Promise<void> {
+  await putUserSetting(email, "aliases", { aliases });
 }
 
-export const listAliases = defineEventHandler(async (_event: H3Event) => {
-  return readAliases();
+export const listAliases = defineEventHandler(async (event: H3Event) => {
+  const email = await uEmail(event);
+  return readAliases(email);
 });
 
 export const createAlias = defineEventHandler(async (event: H3Event) => {
+  const email = await uEmail(event);
   const { name, emails } = (await readBody(event)) as {
     name: string;
     emails: string[];
@@ -34,7 +42,7 @@ export const createAlias = defineEventHandler(async (event: H3Event) => {
     setResponseStatus(event, 400);
     return { error: "name and emails are required" };
   }
-  const aliases = await readAliases();
+  const aliases = await readAliases(email);
   const now = new Date().toISOString();
   const alias: Alias = {
     id: nanoid(10),
@@ -44,18 +52,19 @@ export const createAlias = defineEventHandler(async (event: H3Event) => {
     updatedAt: now,
   };
   aliases.push(alias);
-  await writeAliases(aliases);
+  await writeAliases(email, aliases);
   setResponseStatus(event, 201);
   return alias;
 });
 
 export const updateAlias = defineEventHandler(async (event: H3Event) => {
+  const email = await uEmail(event);
   const id = getRouterParam(event, "id");
   const { name, emails } = (await readBody(event)) as {
     name?: string;
     emails?: string[];
   };
-  const aliases = await readAliases();
+  const aliases = await readAliases(email);
   const idx = aliases.findIndex((a) => a.id === id);
   if (idx === -1) {
     setResponseStatus(event, 404);
@@ -67,19 +76,20 @@ export const updateAlias = defineEventHandler(async (event: H3Event) => {
     ...(emails !== undefined ? { emails } : {}),
     updatedAt: new Date().toISOString(),
   };
-  await writeAliases(aliases);
+  await writeAliases(email, aliases);
   return aliases[idx];
 });
 
 export const deleteAlias = defineEventHandler(async (event: H3Event) => {
+  const email = await uEmail(event);
   const id = getRouterParam(event, "id");
-  const aliases = await readAliases();
+  const aliases = await readAliases(email);
   const filtered = aliases.filter((a) => a.id !== id);
   if (filtered.length === aliases.length) {
     setResponseStatus(event, 404);
     return { error: "Alias not found" };
   }
-  await writeAliases(filtered);
+  await writeAliases(email, filtered);
   setResponseStatus(event, 204);
   return null;
 });

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -10,7 +10,8 @@ import {
 import { nanoid } from "nanoid";
 import type { EmailMessage, Label, UserSettings } from "@shared/types.js";
 import { google } from "googleapis";
-import { getSetting, putSetting } from "@agent-native/core/settings";
+import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
+import { getSession } from "@agent-native/core/server";
 import {
   isConnected,
   getClient,
@@ -19,6 +20,12 @@ import {
   gmailToEmailMessage,
   fetchGmailLabelMap,
 } from "../lib/google-auth.js";
+
+/** Extract the logged-in user's email from the request session. */
+async function userEmail(event: H3Event): Promise<string> {
+  const session = await getSession(event);
+  return session?.email ?? "local@localhost";
+}
 
 // ─── Settings defaults ──────────────────────────────────────────────────────
 
@@ -34,32 +41,35 @@ const DEFAULT_SETTINGS: UserSettings = {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-async function readEmails(): Promise<EmailMessage[]> {
-  const data = await getSetting("local-emails");
+async function readEmails(email: string): Promise<EmailMessage[]> {
+  const data = await getUserSetting(email, "local-emails");
   if (data && Array.isArray((data as any).emails)) {
     return (data as any).emails;
   }
   return [];
 }
 
-async function writeEmails(emails: EmailMessage[]): Promise<void> {
-  await putSetting("local-emails", { emails });
+async function writeEmails(
+  email: string,
+  emails: EmailMessage[],
+): Promise<void> {
+  await putUserSetting(email, "local-emails", { emails });
 }
 
-async function readLabels(): Promise<Label[]> {
-  const data = await getSetting("labels");
+async function readLabels(email: string): Promise<Label[]> {
+  const data = await getUserSetting(email, "labels");
   if (data && Array.isArray((data as any).labels)) {
     return (data as any).labels;
   }
   return [];
 }
 
-async function writeLabels(labels: Label[]): Promise<void> {
-  await putSetting("labels", { labels });
+async function writeLabels(email: string, labels: Label[]): Promise<void> {
+  await putUserSetting(email, "labels", { labels });
 }
 
-async function readSettings(): Promise<UserSettings> {
-  const data = await getSetting("mail-settings");
+async function readSettings(email: string): Promise<UserSettings> {
+  const data = await getUserSetting(email, "mail-settings");
   if (data) {
     return { ...DEFAULT_SETTINGS, ...(data as any) } as UserSettings;
   }
@@ -82,13 +92,14 @@ function recomputeUnreadCounts(
 // ─── Email list ───────────────────────────────────────────────────────────────
 
 export const listEmails = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const { view = "inbox", q } = getQuery(event) as {
     view?: string;
     q?: string;
   };
 
   // If Google is connected, fetch from Gmail directly (skip demo data)
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
       // Map view to Gmail search query
       const gmailQuery: Record<string, string> = {
@@ -105,7 +116,7 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
       if (q) searchQuery += ` ${q}`;
 
       // Fetch label name mapping from all accounts
-      const clients = await getClients();
+      const clients = await getClients(email);
       const labelMap = new Map<string, string>();
       await Promise.all(
         clients.map(async ({ client }) => {
@@ -120,7 +131,11 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
           }
         }),
       );
-      const { messages, errors } = await listGmailMessages(searchQuery);
+      const { messages, errors } = await listGmailMessages(
+        searchQuery,
+        undefined,
+        email,
+      );
       if (messages.length === 0 && errors.length > 0) {
         // All accounts failed — surface as error
         setResponseStatus(event, 502);
@@ -147,7 +162,7 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
     }
   }
 
-  let emails = await readEmails();
+  let emails = await readEmails(email);
 
   // Filter by view
   switch (view) {
@@ -213,11 +228,12 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
 // ─── Thread messages ─────────────────────────────────────────────────────────
 
 export const getThreadMessages = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const threadId = getRouterParam(event, "threadId") as string;
 
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
-      const clients = await getClients();
+      const clients = await getClients(email);
       const labelMap = new Map<string, string>();
       await Promise.all(
         clients.map(async ({ client }) => {
@@ -271,7 +287,7 @@ export const getThreadMessages = defineEventHandler(async (event: H3Event) => {
   }
 
   // Demo data: find all emails with matching threadId
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   const threadMessages = emails
     .filter((e) => e.threadId === threadId)
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
@@ -287,9 +303,10 @@ export const getThreadMessages = defineEventHandler(async (event: H3Event) => {
 // ─── Single email ─────────────────────────────────────────────────────────────
 
 export const getEmail = defineEventHandler(async (event: H3Event) => {
-  if (await isConnected()) {
-    const clients = await getClients();
-    for (const { email, client } of clients) {
+  const email = await userEmail(event);
+  if (await isConnected(email)) {
+    const clients = await getClients(email);
+    for (const { email: acctEmail, client } of clients) {
       try {
         const gmail = google.gmail({ version: "v1", auth: client });
         const labelMap = await fetchGmailLabelMap(client);
@@ -298,7 +315,7 @@ export const getEmail = defineEventHandler(async (event: H3Event) => {
           id: getRouterParam(event, "id") as string,
           format: "full",
         });
-        return gmailToEmailMessage((msg as any).data, email, labelMap);
+        return gmailToEmailMessage((msg as any).data, acctEmail, labelMap);
       } catch (error: any) {
         const status =
           typeof error?.response?.status === "number"
@@ -316,21 +333,22 @@ export const getEmail = defineEventHandler(async (event: H3Event) => {
     }
   }
 
-  const emails = await readEmails();
-  const email = emails.find((e) => e.id === getRouterParam(event, "id"));
-  if (!email) {
+  const emails = await readEmails(email);
+  const found = emails.find((e) => e.id === getRouterParam(event, "id"));
+  if (!found) {
     setResponseStatus(event, 404);
     return { error: "Email not found" };
   }
-  return email;
+  return found;
 });
 
 // ─── Mark read ────────────────────────────────────────────────────────────────
 
 export const markRead = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const { isRead, accountEmail } = await readBody(event);
 
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
       // Route to specific account if provided, otherwise try first client
       const client = await getClient(accountEmail);
@@ -353,7 +371,7 @@ export const markRead = defineEventHandler(async (event: H3Event) => {
     }
   }
 
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   const idx = emails.findIndex((e) => e.id === getRouterParam(event, "id"));
   if (idx === -1) {
     setResponseStatus(event, 404);
@@ -361,10 +379,10 @@ export const markRead = defineEventHandler(async (event: H3Event) => {
   }
 
   emails[idx] = { ...emails[idx], isRead };
-  await writeEmails(emails);
+  await writeEmails(email, emails);
 
-  const labels = recomputeUnreadCounts(emails, await readLabels());
-  await writeLabels(labels);
+  const labels = recomputeUnreadCounts(emails, await readLabels(email));
+  await writeLabels(email, labels);
 
   return emails[idx];
 });
@@ -372,8 +390,9 @@ export const markRead = defineEventHandler(async (event: H3Event) => {
 // ─── Toggle star ──────────────────────────────────────────────────────────────
 
 export const toggleStar = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const { isStarred } = await readBody(event);
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   const idx = emails.findIndex((e) => e.id === getRouterParam(event, "id"));
   if (idx === -1) {
     setResponseStatus(event, 404);
@@ -381,15 +400,16 @@ export const toggleStar = defineEventHandler(async (event: H3Event) => {
   }
 
   emails[idx] = { ...emails[idx], isStarred };
-  await writeEmails(emails);
+  await writeEmails(email, emails);
   return emails[idx];
 });
 
 // ─── Archive ──────────────────────────────────────────────────────────────────
 
 export const archiveEmail = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const body = await readBody(event);
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
       const client = await getClient(body?.accountEmail);
       if (client) {
@@ -409,7 +429,7 @@ export const archiveEmail = defineEventHandler(async (event: H3Event) => {
     }
   }
 
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   const target = emails.find((e) => e.id === getRouterParam(event, "id"));
   if (!target) {
     setResponseStatus(event, 404);
@@ -428,10 +448,10 @@ export const archiveEmail = defineEventHandler(async (event: H3Event) => {
       };
     }
   }
-  await writeEmails(emails);
+  await writeEmails(email, emails);
 
-  const labels = recomputeUnreadCounts(emails, await readLabels());
-  await writeLabels(labels);
+  const labels = recomputeUnreadCounts(emails, await readLabels(email));
+  await writeLabels(email, labels);
 
   return { id: getRouterParam(event, "id"), threadId, isArchived: true };
 });
@@ -439,8 +459,9 @@ export const archiveEmail = defineEventHandler(async (event: H3Event) => {
 // ─── Unarchive ───────────────────────────────────────────────────────────────
 
 export const unarchiveEmail = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const body = await readBody(event);
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
       const client = await getClient(body?.accountEmail);
       if (client) {
@@ -460,7 +481,7 @@ export const unarchiveEmail = defineEventHandler(async (event: H3Event) => {
     }
   }
 
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   const target = emails.find((e) => e.id === getRouterParam(event, "id"));
   if (!target) {
     setResponseStatus(event, 404);
@@ -481,10 +502,10 @@ export const unarchiveEmail = defineEventHandler(async (event: H3Event) => {
       };
     }
   }
-  await writeEmails(emails);
+  await writeEmails(email, emails);
 
-  const labels = recomputeUnreadCounts(emails, await readLabels());
-  await writeLabels(labels);
+  const labels = recomputeUnreadCounts(emails, await readLabels(email));
+  await writeLabels(email, labels);
 
   return { id: getRouterParam(event, "id"), threadId, isArchived: false };
 });
@@ -492,8 +513,9 @@ export const unarchiveEmail = defineEventHandler(async (event: H3Event) => {
 // ─── Trash ────────────────────────────────────────────────────────────────────
 
 export const trashEmail = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const body = await readBody(event);
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
       const client = await getClient(body?.accountEmail);
       if (client) {
@@ -512,7 +534,7 @@ export const trashEmail = defineEventHandler(async (event: H3Event) => {
     }
   }
 
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   const target = emails.find((e) => e.id === getRouterParam(event, "id"));
   if (!target) {
     setResponseStatus(event, 404);
@@ -527,10 +549,10 @@ export const trashEmail = defineEventHandler(async (event: H3Event) => {
       emails[i] = { ...emails[i], isTrashed: true, isArchived: false };
     }
   }
-  await writeEmails(emails);
+  await writeEmails(email, emails);
 
-  const labels = recomputeUnreadCounts(emails, await readLabels());
-  await writeLabels(labels);
+  const labels = recomputeUnreadCounts(emails, await readLabels(email));
+  await writeLabels(email, labels);
 
   return { id: getRouterParam(event, "id"), threadId, isTrashed: true };
 });
@@ -538,9 +560,10 @@ export const trashEmail = defineEventHandler(async (event: H3Event) => {
 // ─── Report spam ──────────────────────────────────────────────────────────────
 
 export const reportSpam = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const { accountEmail } = await readBody(event);
 
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
       const client = await getClient(accountEmail);
       if (client) {
@@ -564,7 +587,7 @@ export const reportSpam = defineEventHandler(async (event: H3Event) => {
   }
 
   // Local fallback: move to trash with a spam label
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   const target = emails.find((e) => e.id === getRouterParam(event, "id"));
   if (!target) {
     setResponseStatus(event, 404);
@@ -581,27 +604,31 @@ export const reportSpam = defineEventHandler(async (event: H3Event) => {
       };
     }
   }
-  await writeEmails(emails);
-  const labels = recomputeUnreadCounts(emails, await readLabels());
-  await writeLabels(labels);
+  await writeEmails(email, emails);
+  const labels = recomputeUnreadCounts(emails, await readLabels(email));
+  await writeLabels(email, labels);
   return { id: getRouterParam(event, "id"), threadId, spam: true };
 });
 
 // ─── Block sender ─────────────────────────────────────────────────────────────
 
-async function readBlockedSenders(): Promise<string[]> {
-  const data = await getSetting("blocked-senders");
+async function readBlockedSenders(email: string): Promise<string[]> {
+  const data = await getUserSetting(email, "blocked-senders");
   if (data && Array.isArray((data as any).senders)) {
     return (data as any).senders;
   }
   return [];
 }
 
-async function writeBlockedSenders(senders: string[]): Promise<void> {
-  await putSetting("blocked-senders", { senders });
+async function writeBlockedSenders(
+  email: string,
+  senders: string[],
+): Promise<void> {
+  await putUserSetting(email, "blocked-senders", { senders });
 }
 
 export const blockSender = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const { senderEmail, accountEmail } = await readBody(event);
 
   if (!senderEmail) {
@@ -610,7 +637,7 @@ export const blockSender = defineEventHandler(async (event: H3Event) => {
   }
 
   // If Gmail is connected, create a filter to auto-delete + report spam
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
       const client = await getClient(accountEmail);
       if (client) {
@@ -654,13 +681,13 @@ export const blockSender = defineEventHandler(async (event: H3Event) => {
   }
 
   // Local fallback: add to blocked list + trash the thread
-  const blocked = await readBlockedSenders();
+  const blocked = await readBlockedSenders(email);
   if (!blocked.includes(senderEmail.toLowerCase())) {
     blocked.push(senderEmail.toLowerCase());
-    await writeBlockedSenders(blocked);
+    await writeBlockedSenders(email, blocked);
   }
 
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   const target = emails.find((e) => e.id === getRouterParam(event, "id"));
   if (!target) {
     setResponseStatus(event, 404);
@@ -677,30 +704,34 @@ export const blockSender = defineEventHandler(async (event: H3Event) => {
       };
     }
   }
-  await writeEmails(emails);
-  const labels = recomputeUnreadCounts(emails, await readLabels());
-  await writeLabels(labels);
+  await writeEmails(email, emails);
+  const labels = recomputeUnreadCounts(emails, await readLabels(email));
+  await writeLabels(email, labels);
   return { id: getRouterParam(event, "id"), threadId, blocked: senderEmail };
 });
 
 // ─── Mute thread ──────────────────────────────────────────────────────────────
 
-async function readMutedThreads(): Promise<string[]> {
-  const data = await getSetting("muted-threads");
+async function readMutedThreads(email: string): Promise<string[]> {
+  const data = await getUserSetting(email, "muted-threads");
   if (data && Array.isArray((data as any).threads)) {
     return (data as any).threads;
   }
   return [];
 }
 
-async function writeMutedThreads(threads: string[]): Promise<void> {
-  await putSetting("muted-threads", { threads });
+async function writeMutedThreads(
+  email: string,
+  threads: string[],
+): Promise<void> {
+  await putUserSetting(email, "muted-threads", { threads });
 }
 
 export const muteThread = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const { accountEmail } = await readBody(event);
 
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
       const client = await getClient(accountEmail);
       if (client) {
@@ -725,13 +756,13 @@ export const muteThread = defineEventHandler(async (event: H3Event) => {
 
   // Local fallback: archive all messages in thread + record as muted
   const threadId = getRouterParam(event, "threadId") as string;
-  const muted = await readMutedThreads();
+  const muted = await readMutedThreads(email);
   if (!muted.includes(threadId)) {
     muted.push(threadId);
-    await writeMutedThreads(muted);
+    await writeMutedThreads(email, muted);
   }
 
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   for (let i = 0; i < emails.length; i++) {
     const eid = emails[i].threadId || emails[i].id;
     if (eid === threadId) {
@@ -742,29 +773,31 @@ export const muteThread = defineEventHandler(async (event: H3Event) => {
       };
     }
   }
-  await writeEmails(emails);
-  const labels = recomputeUnreadCounts(emails, await readLabels());
-  await writeLabels(labels);
+  await writeEmails(email, emails);
+  const labels = recomputeUnreadCounts(emails, await readLabels(email));
+  await writeLabels(email, labels);
   return { threadId, muted: true };
 });
 
 // ─── Delete permanently ───────────────────────────────────────────────────────
 
 export const deleteEmail = defineEventHandler(async (event: H3Event) => {
-  const emails = await readEmails();
+  const email = await userEmail(event);
+  const emails = await readEmails(email);
   const filtered = emails.filter((e) => e.id !== getRouterParam(event, "id"));
   if (filtered.length === emails.length) {
     setResponseStatus(event, 404);
     return { error: "Email not found" };
   }
-  await writeEmails(filtered);
+  await writeEmails(email, filtered);
   return { ok: true };
 });
 
 // ─── Send / compose ───────────────────────────────────────────────────────────
 
 export const sendEmail = defineEventHandler(async (event: H3Event) => {
-  const settings = await readSettings();
+  const email = await userEmail(event);
+  const settings = await readSettings(email);
   const { to, cc, bcc, subject, body, replyToId, accountEmail } =
     await readBody(event);
 
@@ -774,9 +807,9 @@ export const sendEmail = defineEventHandler(async (event: H3Event) => {
   }
 
   // If Gmail is connected, send via Gmail API
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
-      const clients = await getClients();
+      const clients = await getClients(email);
       let selectedClient = clients[0]?.client;
       let selectedEmail = accountEmail || clients[0]?.email || "me";
 
@@ -857,7 +890,7 @@ export const sendEmail = defineEventHandler(async (event: H3Event) => {
   }
 
   // Local fallback: store as sent email
-  const emails = await readEmails();
+  const emails = await readEmails(email);
 
   const newEmail: EmailMessage = {
     id: `msg-${nanoid(8)}`,
@@ -897,7 +930,7 @@ export const sendEmail = defineEventHandler(async (event: H3Event) => {
   };
 
   emails.push(newEmail);
-  await writeEmails(emails);
+  await writeEmails(email, emails);
 
   setResponseStatus(event, 201);
   return newEmail;
@@ -906,13 +939,14 @@ export const sendEmail = defineEventHandler(async (event: H3Event) => {
 // ─── Save draft (persistent, Gmail-style) ─────────────────────────────────────
 
 export const saveDraft = defineEventHandler(async (event: H3Event) => {
-  const settings = await readSettings();
+  const email = await userEmail(event);
+  const settings = await readSettings(email);
   const reqBody = await readBody(event);
   const { to, cc, bcc, subject, body, draftId, replyToId, replyToThreadId } =
     reqBody;
 
   // If Gmail is connected, create/update a Gmail draft
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
       const client = await getClient(reqBody?.accountEmail);
       if (client) {
@@ -954,7 +988,7 @@ export const saveDraft = defineEventHandler(async (event: H3Event) => {
   }
 
   // Local fallback: save as EmailMessage with isDraft=true
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   const existingIdx = draftId
     ? emails.findIndex((e) => e.id === draftId && e.isDraft)
     : -1;
@@ -1010,7 +1044,7 @@ export const saveDraft = defineEventHandler(async (event: H3Event) => {
   } else {
     emails.push(draftEmail);
   }
-  await writeEmails(emails);
+  await writeEmails(email, emails);
 
   return {
     draftId: draftEmail.id,
@@ -1052,9 +1086,10 @@ function buildRawEmail(opts: {
 // ─── Delete draft ─────────────────────────────────────────────────────────────
 
 export const deleteDraft = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const id = getRouterParam(event, "id") as string;
 
-  if (await isConnected()) {
+  if (await isConnected(email)) {
     try {
       const body = await readBody(event).catch(() => ({}));
       const client = await getClient(body?.accountEmail);
@@ -1076,10 +1111,10 @@ export const deleteDraft = defineEventHandler(async (event: H3Event) => {
   }
 
   // Local fallback
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   const filtered = emails.filter((e) => !(e.id === id && e.isDraft));
   if (filtered.length !== emails.length) {
-    await writeEmails(filtered);
+    await writeEmails(email, filtered);
   }
   return { ok: true };
 });
@@ -1087,9 +1122,10 @@ export const deleteDraft = defineEventHandler(async (event: H3Event) => {
 // ─── Contacts (extracted from email history) ─────────────────────────────────
 
 export const listContacts = defineEventHandler(async (event: H3Event) => {
-  if (await isConnected()) {
+  const email = await userEmail(event);
+  if (await isConnected(email)) {
     try {
-      const clients = await getClients();
+      const clients = await getClients(email);
       const contactMap = new Map<
         string,
         { name: string; email: string; count: number }
@@ -1175,7 +1211,7 @@ export const listContacts = defineEventHandler(async (event: H3Event) => {
       // If People API returned nothing (e.g. missing scopes), extract from Gmail
       if (contactMap.size === 0) {
         try {
-          const { messages } = await listGmailMessages("", 100);
+          const { messages } = await listGmailMessages("", 100, email);
           for (const msg of messages) {
             const headers = msg.payload?.headers || [];
             for (const field of ["From", "To", "Cc", "Bcc"]) {
@@ -1229,18 +1265,18 @@ export const listContacts = defineEventHandler(async (event: H3Event) => {
     }
   }
 
-  const emails = await readEmails();
+  const emails = await readEmails(email);
   const contactMap = new Map<
     string,
     { name: string; email: string; count: number }
   >();
 
-  for (const email of emails) {
+  for (const msg of emails) {
     const addresses = [
-      email.from,
-      ...(email.to || []),
-      ...(email.cc || []),
-      ...(email.bcc || []),
+      msg.from,
+      ...(msg.to || []),
+      ...(msg.cc || []),
+      ...(msg.bcc || []),
     ];
     for (const addr of addresses) {
       if (!addr?.email) continue;
@@ -1274,9 +1310,10 @@ export const listContacts = defineEventHandler(async (event: H3Event) => {
 // ─── Labels ───────────────────────────────────────────────────────────────────
 
 export const listLabels = defineEventHandler(async (_event: H3Event) => {
-  if (await isConnected()) {
+  const email = await userEmail(_event);
+  if (await isConnected(email)) {
     try {
-      const clients = await getClients();
+      const clients = await getClients(email);
       // Deduplicate by derived short-name id (not Gmail label ID)
       const labelMap = new Map<
         string,
@@ -1312,26 +1349,33 @@ export const listLabels = defineEventHandler(async (_event: H3Event) => {
       return labels;
     } catch {}
   }
-  return readLabels();
+  return readLabels(email);
 });
 
 // ─── Settings ─────────────────────────────────────────────────────────────────
 
-export const getSettings = defineEventHandler(async (_event: H3Event) => {
-  return readSettings();
+export const getSettings = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
+  return readSettings(email);
 });
 
 export const updateSettings = defineEventHandler(async (event: H3Event) => {
-  const current = await readSettings();
+  const email = await userEmail(event);
+  const current = await readSettings(email);
   const body = await readBody(event);
   const updated = { ...current, ...body };
-  await putSetting("mail-settings", updated as Record<string, unknown>);
+  await putUserSetting(
+    email,
+    "mail-settings",
+    updated as Record<string, unknown>,
+  );
   return updated;
 });
 
 // ─── Calendar RSVP ───────────────────────────────────────────────────────────
 
 export const calendarRsvp = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
   const { eventId, calendarId, response, accountEmail } = (await readBody(
     event,
   )) as {
@@ -1346,7 +1390,7 @@ export const calendarRsvp = defineEventHandler(async (event: H3Event) => {
     return { error: "eventId and response are required" };
   }
 
-  if (!(await isConnected())) {
+  if (!(await isConnected(email))) {
     setResponseStatus(event, 401);
     return { error: "No Google account connected" };
   }
@@ -1374,7 +1418,7 @@ export const calendarRsvp = defineEventHandler(async (event: H3Event) => {
     }
 
     // Find the current user's attendee entry and update their response
-    const settings = await readSettings();
+    const settings = await readSettings(email);
     const myEmail = settings.email?.toLowerCase();
     const attendees = calEvent.attendees || [];
     let found = false;

--- a/templates/mail/server/handlers/google-auth.ts
+++ b/templates/mail/server/handlers/google-auth.ts
@@ -1,11 +1,15 @@
+import crypto from "node:crypto";
 import {
   defineEventHandler,
   getQuery,
   readBody,
   setResponseStatus,
   getHeader,
+  setCookie,
+  sendRedirect,
   type H3Event,
 } from "h3";
+import { addSession, getSession } from "@agent-native/core/server";
 import {
   getAuthUrl,
   exchangeCode,
@@ -19,8 +23,8 @@ function getOrigin(event: H3Event): string {
   return `${proto}://${host}`;
 }
 
-// Track the redirect URI used for auth so the callback can match it
-let lastRedirectUri: string | undefined;
+// Track redirect URIs by OAuth state parameter for multi-user safety
+const pendingRedirects = new Map<string, string>();
 
 export const getGoogleAuthUrl = defineEventHandler((event: H3Event) => {
   if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
@@ -28,15 +32,22 @@ export const getGoogleAuthUrl = defineEventHandler((event: H3Event) => {
     return {
       error: "missing_credentials",
       message:
-        "Google OAuth credentials are not configured. Add your Client ID and Secret in Settings.",
+        "Google OAuth credentials are not configured. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.",
     };
   }
   try {
     const redirectUri =
       (getQuery(event).redirect_uri as string) ||
       `${getOrigin(event)}/api/google/callback`;
-    lastRedirectUri = redirectUri;
-    const url = getAuthUrl(undefined, redirectUri);
+    // Generate a state token to track the redirect URI
+    const state = crypto.randomBytes(16).toString("hex");
+    pendingRedirects.set(state, redirectUri);
+    // Clean up old entries (keep last 100)
+    if (pendingRedirects.size > 100) {
+      const first = pendingRedirects.keys().next().value;
+      if (first) pendingRedirects.delete(first);
+    }
+    const url = getAuthUrl(undefined, redirectUri, state);
     return { url };
   } catch (error: any) {
     setResponseStatus(event, 500);
@@ -47,23 +58,36 @@ export const getGoogleAuthUrl = defineEventHandler((event: H3Event) => {
 export const handleGoogleCallback = defineEventHandler(
   async (event: H3Event) => {
     try {
-      const code = getQuery(event).code as string;
+      const query = getQuery(event);
+      const code = query.code as string;
+      const state = query.state as string | undefined;
       if (!code) {
         setResponseStatus(event, 400);
         return { error: "Missing authorization code" };
       }
-      // Use the same redirect URI that was used to generate the auth URL
-      const redirectUri =
-        lastRedirectUri || `${getOrigin(event)}/api/google/callback`;
+      // Look up the redirect URI from the state parameter
+      let redirectUri: string;
+      if (state && pendingRedirects.has(state)) {
+        redirectUri = pendingRedirects.get(state)!;
+        pendingRedirects.delete(state);
+      } else {
+        redirectUri = `${getOrigin(event)}/api/google/callback`;
+      }
       const email = await exchangeCode(code, undefined, redirectUri);
-      const safeEmail = JSON.stringify(email);
-      return `<!DOCTYPE html><html><body><script>
-      window.close();
-      var p = document.createElement('p');
-      p.style.cssText = 'font-family:system-ui;text-align:center;margin-top:40vh';
-      p.textContent = 'Connected ' + ${safeEmail} + '! You can close this tab.';
-      document.body.appendChild(p);
-    </script></body></html>`;
+
+      // Create a session tied to this Google email
+      const sessionToken = crypto.randomBytes(32).toString("hex");
+      await addSession(sessionToken, email);
+      setCookie(event, "an_session", sessionToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        path: "/",
+        maxAge: 60 * 60 * 24 * 30, // 30 days
+      });
+
+      // Redirect to app home
+      return sendRedirect(event, "/");
     } catch (error: any) {
       const msg = error.message || "Unknown error";
       const isPermission =
@@ -75,7 +99,7 @@ export const handleGoogleCallback = defineEventHandler(
       return `<!DOCTYPE html><html><body>
       <div style="font-family:system-ui;max-width:420px;margin:30vh auto;text-align:center">
         <p style="font-size:15px;color:#e55">${userMessage}</p>
-        <p style="margin-top:16px;font-size:13px;color:#888">You can close this tab and try again.</p>
+        <p style="margin-top:16px;font-size:13px;color:#888"><a href="/" style="color:#888">Back to login</a></p>
       </div>
     </body></html>`;
     }
@@ -84,7 +108,8 @@ export const handleGoogleCallback = defineEventHandler(
 
 export const getGoogleStatus = defineEventHandler(async (event: H3Event) => {
   try {
-    const status = await getAuthStatus();
+    const session = await getSession(event);
+    const status = await getAuthStatus(session?.email);
     return status;
   } catch (error: any) {
     setResponseStatus(event, 500);
@@ -94,9 +119,15 @@ export const getGoogleStatus = defineEventHandler(async (event: H3Event) => {
 
 export const disconnectGoogle = defineEventHandler(async (event: H3Event) => {
   try {
+    const session = await getSession(event);
     const body = await readBody(event);
+    // Only allow disconnecting the logged-in user's own account
     const email = body?.email as string | undefined;
-    await disconnect(email);
+    if (email && session?.email && email !== session.email) {
+      setResponseStatus(event, 403);
+      return { error: "Cannot disconnect another user's account" };
+    }
+    await disconnect(email || session?.email);
     return { success: true };
   } catch (error: any) {
     setResponseStatus(event, 500);

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -40,7 +40,11 @@ function createOAuth2Client(redirectUri?: string) {
   );
 }
 
-export function getAuthUrl(origin?: string, redirectUri?: string): string {
+export function getAuthUrl(
+  origin?: string,
+  redirectUri?: string,
+  state?: string,
+): string {
   const uri =
     redirectUri || (origin ? `${origin}/api/google/callback` : undefined);
   const client = createOAuth2Client(uri);
@@ -48,6 +52,7 @@ export function getAuthUrl(origin?: string, redirectUri?: string): string {
     access_type: "offline",
     scope: SCOPES,
     prompt: "consent",
+    state,
   });
 }
 
@@ -112,9 +117,20 @@ export async function getClient(
   return client;
 }
 
-export async function getClients(): Promise<
-  Array<{ email: string; client: Auth.OAuth2Client }>
-> {
+/**
+ * Get OAuth clients. When `forEmail` is provided, returns only that
+ * user's client (multi-user mode). Otherwise returns all (legacy).
+ */
+export async function getClients(
+  forEmail?: string,
+): Promise<Array<{ email: string; client: Auth.OAuth2Client }>> {
+  if (forEmail) {
+    // Multi-user: return only this user's account
+    const client = await getClient(forEmail);
+    if (!client) return [];
+    return [{ email: forEmail, client }];
+  }
+
   const accounts = await listOAuthAccounts("google");
   const results: Array<{ email: string; client: Auth.OAuth2Client }> = [];
 
@@ -143,7 +159,15 @@ export async function getClients(): Promise<
   return results;
 }
 
-export async function isConnected(): Promise<boolean> {
+/**
+ * Check if a Google account is connected. When `forEmail` is provided,
+ * checks only that specific account.
+ */
+export async function isConnected(forEmail?: string): Promise<boolean> {
+  if (forEmail) {
+    const tokens = await getOAuthTokens("google", forEmail);
+    return tokens !== null;
+  }
   return hasOAuthTokens("google");
 }
 
@@ -157,8 +181,24 @@ export interface GoogleAuthStatus {
   accounts: Array<{ email: string; expiresAt?: string; photoUrl?: string }>;
 }
 
-export async function getAuthStatus(): Promise<GoogleAuthStatus> {
-  const oauthAccounts = await listOAuthAccounts("google");
+/**
+ * Get the OAuth status. When `forEmail` is provided, only returns
+ * status for that specific account (multi-user mode).
+ */
+export async function getAuthStatus(
+  forEmail?: string,
+): Promise<GoogleAuthStatus> {
+  let oauthAccounts: Array<{
+    accountId: string;
+    tokens: Record<string, unknown>;
+  }>;
+  if (forEmail) {
+    const tokens = await getOAuthTokens("google", forEmail);
+    oauthAccounts = tokens ? [{ accountId: forEmail, tokens }] : [];
+  } else {
+    oauthAccounts = await listOAuthAccounts("google");
+  }
+
   if (oauthAccounts.length === 0) {
     return { connected: false, accounts: [] };
   }
@@ -209,11 +249,12 @@ export async function disconnect(email?: string): Promise<void> {
 export async function listGmailMessages(
   query?: string,
   maxResults = 50,
+  forEmail?: string,
 ): Promise<{
   messages: any[];
   errors: Array<{ email: string; error: string }>;
 }> {
-  const clients = await getClients();
+  const clients = await getClients(forEmail);
   if (clients.length === 0) return { messages: [], errors: [] };
 
   const errors: Array<{ email: string; error: string }> = [];

--- a/templates/mail/server/plugins/auth.ts
+++ b/templates/mail/server/plugins/auth.ts
@@ -1,1 +1,3 @@
-export { defaultAuthPlugin as default } from "@agent-native/core/server";
+import { createGoogleAuthPlugin } from "@agent-native/core/server";
+
+export default createGoogleAuthPlugin();

--- a/templates/mail/server/plugins/db.ts
+++ b/templates/mail/server/plugins/db.ts
@@ -1,0 +1,16 @@
+import { runMigrations } from "@agent-native/core/db";
+
+export default runMigrations([
+  {
+    version: 1,
+    sql: `CREATE TABLE IF NOT EXISTS scheduled_jobs (
+    id TEXT PRIMARY KEY,
+    type TEXT NOT NULL CHECK(type IN ('snooze', 'send_later')),
+    email_id TEXT,
+    payload TEXT NOT NULL,
+    run_at INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending', 'processing', 'done', 'cancelled')),
+    created_at INTEGER NOT NULL
+  )`,
+  },
+]);

--- a/templates/mail/server/routes/api/auth/logout.post.ts
+++ b/templates/mail/server/routes/api/auth/logout.post.ts
@@ -1,0 +1,9 @@
+import { defineEventHandler, getCookie, deleteCookie } from "h3";
+import { removeSession } from "@agent-native/core/server";
+
+export default defineEventHandler(async (event) => {
+  const cookie = getCookie(event, "an_session");
+  if (cookie) await removeSession(cookie);
+  deleteCookie(event, "an_session", { path: "/" });
+  return { ok: true };
+});

--- a/templates/mail/server/tasks/jobs/process.ts
+++ b/templates/mail/server/tasks/jobs/process.ts
@@ -14,7 +14,7 @@ export async function processJobs(): Promise<{ result: string }> {
   const now = Date.now();
 
   // Fetch all pending due jobs
-  const due = db
+  const due = await db
     .select()
     .from(schema.scheduledJobs)
     .where(
@@ -22,15 +22,14 @@ export async function processJobs(): Promise<{ result: string }> {
         eq(schema.scheduledJobs.status, "pending"),
         lte(schema.scheduledJobs.runAt, now),
       ),
-    )
-    .all();
+    );
 
   for (const job of due) {
-    // Mark as processing immediately (synchronous SQLite — no race risk in single process)
-    db.update(schema.scheduledJobs)
+    // Mark as processing immediately
+    await db
+      .update(schema.scheduledJobs)
       .set({ status: "processing" } as any)
-      .where(eq(schema.scheduledJobs.id, job.id))
-      .run();
+      .where(eq(schema.scheduledJobs.id, job.id));
 
     try {
       if (job.type === "snooze" && job.emailId) {
@@ -38,16 +37,16 @@ export async function processJobs(): Promise<{ result: string }> {
       } else if (job.type === "send_later") {
         await sendScheduledEmail(JSON.parse(job.payload) as SendLaterPayload);
       }
-      db.update(schema.scheduledJobs)
+      await db
+        .update(schema.scheduledJobs)
         .set({ status: "done" } as any)
-        .where(eq(schema.scheduledJobs.id, job.id))
-        .run();
+        .where(eq(schema.scheduledJobs.id, job.id));
     } catch (err) {
       console.error(`[jobs:process] Job ${job.id} failed:`, err);
-      db.update(schema.scheduledJobs)
+      await db
+        .update(schema.scheduledJobs)
         .set({ status: "cancelled" } as any)
-        .where(eq(schema.scheduledJobs.id, job.id))
-        .run();
+        .where(eq(schema.scheduledJobs.id, job.id));
     }
   }
 

--- a/templates/starter/app/routes/_index.tsx
+++ b/templates/starter/app/routes/_index.tsx
@@ -29,7 +29,7 @@ export default function IndexPage() {
             <p className="text-[14px] text-muted-foreground leading-relaxed">
               Start building by editing{" "}
               <code className="text-[13px] bg-muted px-1.5 py-0.5 rounded font-mono">
-                client/routes/_index.tsx
+                app/routes/_index.tsx
               </code>
             </p>
           </div>

--- a/templates/videos/app/hooks/use-db-status.ts
+++ b/templates/videos/app/hooks/use-db-status.ts
@@ -12,7 +12,7 @@ export function useDbStatus() {
     queryKey: ["env-status"],
     queryFn: async () => {
       const res = await fetch("/api/env-status");
-      if (!res.ok) throw new Error("Failed to fetch env status");
+      if (!res.ok) return [];
       return res.json();
     },
     staleTime: 30_000,

--- a/wrangler-calendar.toml
+++ b/wrangler-calendar.toml
@@ -1,0 +1,8 @@
+name = "agent-native-calendar"
+pages_build_output_dir = "templates/calendar/.output/public"
+compatibility_date = "2024-12-01"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "agent-native-calendar"
+database_id = "26d5afaf-e324-40dc-b963-9417e26ee70c"

--- a/wrangler-mail.toml
+++ b/wrangler-mail.toml
@@ -1,0 +1,8 @@
+name = "agent-native-mail"
+pages_build_output_dir = "templates/mail/.output/public"
+compatibility_date = "2024-12-01"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "agent-native-mail"
+database_id = "5cbb9720-f664-40f7-b38c-a24bfdba4fb8"


### PR DESCRIPTION
## Summary

### Multi-user Google OAuth auth (core + mail template)
- **`createGoogleAuthPlugin()`** — new reusable core plugin. Any template can opt into Google OAuth login with one line: `export default createGoogleAuthPlugin()`
- **Session identity** — sessions table now stores email, so `getSession()` returns the user's Google email instead of generic `"user"`
- **Per-user data isolation** — application state scoped by user email, new `getUserSetting`/`putUserSetting` helpers for per-user settings with migration fallback
- **Mail template** — switched to Google OAuth login, all settings/emails/labels scoped per user, Gmail API calls filtered to logged-in user's account only

### Cloudflare deployment support (mail template)
- **Switched DB from `better-sqlite3` to `@libsql/client`** — works on Cloudflare Workers (and still works locally with SQLite)
- **Moved scheduled_jobs migration** to a proper server plugin (matches pattern used by other templates)
- Deploy with `NITRO_PRESET=cloudflare_pages` env var — no code changes needed

### Core v0.4.3 bump + fixes
- Bump `@agent-native/core` to v0.4.3 — published v0.4.2 was missing 5 server modules (`default-watcher`, `auth-plugin`, `agent-chat-plugin`, `file-sync-plugin`, `terminal-plugin`)
- Fix path hint: `client/routes/_index.tsx` → `app/routes/_index.tsx`
- Graceful 404 handling for `/api/env-status` in forms/videos templates

## Test plan

- [ ] `pnpm prep` passes (format, typecheck, tests)
- [ ] Dev mode: `pnpm dev` in mail template works as before (no login, single-user)
- [ ] Production: deployed app shows "Sign in with Google" page
- [ ] User isolation: two users log in with different Google accounts, see separate inboxes/settings
- [ ] Cross-device: settings persist across devices for the same Google account
- [ ] Other templates (`starter`, `calendar`, etc.) still work unchanged with `defaultAuthPlugin`