### PR TITLE
fix: address PR review — OAuth CSRF, data isolation, job scoping

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,6 @@ name: Publish @agent-native/core
 on:
   release:
     types: [published]
-  push:
-    branches:
-      - main
-    paths:
-      - "packages/core/**"
   workflow_dispatch:
     inputs:
       version_bump:

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -545,7 +545,12 @@ export function autoMountAuth(app: H3App, options: AuthOptions = {}): boolean {
     );
     app.use(
       "/api/auth/logout",
-      defineEventHandler(() => ({ ok: true })),
+      defineEventHandler(async (event) => {
+        const cookie = getCookie(event, COOKIE_NAME);
+        if (cookie) await removeSession(cookie);
+        deleteCookie(event, COOKIE_NAME, { path: "/" });
+        return { ok: true };
+      }),
     );
 
     // Mount auth guard that delegates to custom getSession

--- a/packages/core/src/settings/user-settings.ts
+++ b/packages/core/src/settings/user-settings.ts
@@ -4,10 +4,8 @@
  * Wraps the global settings store with per-user key prefixing.
  * Keys are stored as `u:<email>:<key>` in the settings table.
  *
- * Includes a migration fallback: if a user-scoped key is not found,
- * falls back to the global (unprefixed) key. This allows existing
- * single-user data to be read by the first user who accesses it.
- * Writes always go to the user-scoped key.
+ * No global fallback — each user starts with a clean slate. This
+ * prevents one user's private data from leaking to other users.
  */
 
 import { getSetting, putSetting, deleteSetting } from "./store.js";
@@ -16,18 +14,12 @@ function userKey(email: string, key: string): string {
   return `u:${email}:${key}`;
 }
 
-/**
- * Read a user-scoped setting. Falls back to the global key if the
- * user-scoped key doesn't exist (migration path from single-user).
- */
+/** Read a user-scoped setting. Returns null if not set for this user. */
 export async function getUserSetting(
   email: string,
   key: string,
 ): Promise<Record<string, unknown> | null> {
-  const scoped = await getSetting(userKey(email, key));
-  if (scoped !== null) return scoped;
-  // Fallback to unscoped key for migration from single-user
-  return getSetting(key);
+  return getSetting(userKey(email, key));
 }
 
 /** Write a user-scoped setting. Always writes to the prefixed key. */

--- a/templates/mail/server/db/schema.ts
+++ b/templates/mail/server/db/schema.ts
@@ -4,6 +4,7 @@ export const scheduledJobs = sqliteTable("scheduled_jobs", {
   id: text("id").primaryKey(),
   type: text("type", { enum: ["snooze", "send_later"] }).notNull(),
   emailId: text("email_id"),
+  accountEmail: text("account_email"),
   payload: text("payload").notNull(),
   runAt: integer("run_at").notNull(),
   status: text("status", {

--- a/templates/mail/server/handlers/google-auth.ts
+++ b/templates/mail/server/handlers/google-auth.ts
@@ -6,6 +6,8 @@ import {
   setResponseStatus,
   getHeader,
   setCookie,
+  getCookie,
+  deleteCookie,
   sendRedirect,
   type H3Event,
 } from "h3";
@@ -23,9 +25,6 @@ function getOrigin(event: H3Event): string {
   return `${proto}://${host}`;
 }
 
-// Track redirect URIs by OAuth state parameter for multi-user safety
-const pendingRedirects = new Map<string, string>();
-
 export const getGoogleAuthUrl = defineEventHandler((event: H3Event) => {
   if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
     setResponseStatus(event, 422);
@@ -39,14 +38,16 @@ export const getGoogleAuthUrl = defineEventHandler((event: H3Event) => {
     const redirectUri =
       (getQuery(event).redirect_uri as string) ||
       `${getOrigin(event)}/api/google/callback`;
-    // Generate a state token to track the redirect URI
+    // Generate a state token for CSRF protection and store redirect URI
+    // in a short-lived httpOnly cookie (serverless-safe, no in-memory Map)
     const state = crypto.randomBytes(16).toString("hex");
-    pendingRedirects.set(state, redirectUri);
-    // Clean up old entries (keep last 100)
-    if (pendingRedirects.size > 100) {
-      const first = pendingRedirects.keys().next().value;
-      if (first) pendingRedirects.delete(first);
-    }
+    setCookie(event, `oauth_state_${state}`, redirectUri, {
+      httpOnly: true,
+      secure: true,
+      sameSite: "lax",
+      path: "/api/google/callback",
+      maxAge: 600, // 10 minutes
+    });
     const url = getAuthUrl(undefined, redirectUri, state);
     return { url };
   } catch (error: any) {
@@ -65,14 +66,25 @@ export const handleGoogleCallback = defineEventHandler(
         setResponseStatus(event, 400);
         return { error: "Missing authorization code" };
       }
-      // Look up the redirect URI from the state parameter
-      let redirectUri: string;
-      if (state && pendingRedirects.has(state)) {
-        redirectUri = pendingRedirects.get(state)!;
-        pendingRedirects.delete(state);
-      } else {
-        redirectUri = `${getOrigin(event)}/api/google/callback`;
+
+      // Enforce state parameter for CSRF protection
+      if (!state) {
+        setResponseStatus(event, 400);
+        return errorPage(
+          "Missing OAuth state parameter. Please try signing in again.",
+        );
       }
+      const cookieName = `oauth_state_${state}`;
+      const redirectUri = getCookie(event, cookieName);
+      if (!redirectUri) {
+        setResponseStatus(event, 400);
+        return errorPage(
+          "Invalid or expired OAuth state. Please try signing in again.",
+        );
+      }
+      // Clean up the state cookie
+      deleteCookie(event, cookieName, { path: "/api/google/callback" });
+
       const email = await exchangeCode(code, undefined, redirectUri);
 
       // Create a session tied to this Google email
@@ -96,15 +108,19 @@ export const handleGoogleCallback = defineEventHandler(
       const userMessage = isPermission
         ? "This account wasn't granted the required permissions. Make sure you check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
         : `Connection failed: ${msg}`;
-      return `<!DOCTYPE html><html><body>
-      <div style="font-family:system-ui;max-width:420px;margin:30vh auto;text-align:center">
-        <p style="font-size:15px;color:#e55">${userMessage}</p>
-        <p style="margin-top:16px;font-size:13px;color:#888"><a href="/" style="color:#888">Back to login</a></p>
-      </div>
-    </body></html>`;
+      return errorPage(userMessage);
     }
   },
 );
+
+function errorPage(message: string): string {
+  return `<!DOCTYPE html><html><body>
+    <div style="font-family:system-ui;max-width:420px;margin:30vh auto;text-align:center">
+      <p style="font-size:15px;color:#e55">${message}</p>
+      <p style="margin-top:16px;font-size:13px;color:#888"><a href="/" style="color:#888">Back to login</a></p>
+    </div>
+  </body></html>`;
+}
 
 export const getGoogleStatus = defineEventHandler(async (event: H3Event) => {
   try {

--- a/templates/mail/server/handlers/scheduled-jobs.ts
+++ b/templates/mail/server/handlers/scheduled-jobs.ts
@@ -8,6 +8,7 @@ import {
 import { eq, inArray } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { db, schema } from "../db/index.js";
+import { getSession } from "@agent-native/core/server";
 import * as chrono from "chrono-node";
 
 // ─── NL Date Parsing ──────────────────────────────────────────────────────────
@@ -47,17 +48,24 @@ export function parseNlDate(input: string, timezone: string): Date | null {
 // ─── Route Handlers ───────────────────────────────────────────────────────────
 
 /** GET /api/scheduled-jobs — list pending/processing jobs */
-export const listScheduledJobs = defineEventHandler((_event: H3Event) => {
-  const jobs = db
+export const listScheduledJobs = defineEventHandler(async (event: H3Event) => {
+  const session = await getSession(event);
+  const jobs = await db
     .select()
     .from(schema.scheduledJobs)
-    .where(inArray(schema.scheduledJobs.status, ["pending", "processing"]))
-    .all();
+    .where(inArray(schema.scheduledJobs.status, ["pending", "processing"]));
+  // Filter to the current user's jobs
+  if (session?.email && session.email !== "local@localhost") {
+    return jobs.filter(
+      (j) => !j.accountEmail || j.accountEmail === session.email,
+    );
+  }
   return jobs;
 });
 
 /** POST /api/scheduled-jobs — create a new job */
 export const createScheduledJob = defineEventHandler(async (event: H3Event) => {
+  const session = await getSession(event);
   const body = await readBody(event);
   const { type, emailId, payload, runAt } = body as {
     type: "snooze" | "send_later";
@@ -85,13 +93,14 @@ export const createScheduledJob = defineEventHandler(async (event: H3Event) => {
     id: nanoid(12),
     type,
     emailId: emailId ?? null,
+    accountEmail: session?.email ?? null,
     payload: JSON.stringify(payload ?? {}),
     runAt,
     status: "pending" as const,
     createdAt: Date.now(),
   };
 
-  db.insert(schema.scheduledJobs).values(job).run();
+  await db.insert(schema.scheduledJobs).values(job);
   setResponseStatus(event, 201);
   return job;
 });
@@ -112,37 +121,36 @@ export const updateScheduledJob = defineEventHandler(async (event: H3Event) => {
     return { error: "runAt must be a future timestamp" };
   }
 
-  const existing = db
+  const [existing] = await db
     .select()
     .from(schema.scheduledJobs)
-    .where(eq(schema.scheduledJobs.id, id))
-    .get();
+    .where(eq(schema.scheduledJobs.id, id));
 
   if (!existing) {
     setResponseStatus(event, 404);
     return { error: "Job not found" };
   }
 
-  db.update(schema.scheduledJobs)
+  await db
+    .update(schema.scheduledJobs)
     .set({ runAt, status: "pending" } as any)
-    .where(eq(schema.scheduledJobs.id, id))
-    .run();
+    .where(eq(schema.scheduledJobs.id, id));
 
   return { ...existing, runAt, status: "pending" };
 });
 
 /** DELETE /api/scheduled-jobs/:id — cancel (set status = cancelled) */
-export const deleteScheduledJob = defineEventHandler((event: H3Event) => {
+export const deleteScheduledJob = defineEventHandler(async (event: H3Event) => {
   const id = getRouterParam(event, "id");
   if (!id) {
     setResponseStatus(event, 400);
     return { error: "id required" };
   }
 
-  db.update(schema.scheduledJobs)
+  await db
+    .update(schema.scheduledJobs)
     .set({ status: "cancelled" } as any)
-    .where(eq(schema.scheduledJobs.id, id))
-    .run();
+    .where(eq(schema.scheduledJobs.id, id));
 
   return { ok: true };
 });

--- a/templates/mail/server/lib/jobs.ts
+++ b/templates/mail/server/lib/jobs.ts
@@ -19,9 +19,12 @@ async function writeEmails(emails: any[]): Promise<void> {
  * Resurface a snoozed email: remove ARCHIVE label, add UNREAD.
  * The SSE watcher picks up the data change and notifies the UI.
  */
-export async function resurfaceEmail(emailId: string): Promise<void> {
-  if (await isConnected()) {
-    const client = await getClient();
+export async function resurfaceEmail(
+  emailId: string,
+  accountEmail?: string,
+): Promise<void> {
+  if (await isConnected(accountEmail)) {
+    const client = await getClient(accountEmail);
     if (client) {
       const gmail = google.gmail({ version: "v1", auth: client });
       await gmail.users.messages.modify({
@@ -69,11 +72,12 @@ export interface SendLaterPayload {
  */
 export async function sendScheduledEmail(
   payload: SendLaterPayload,
+  accountEmail?: string,
 ): Promise<void> {
   const { to, cc, bcc, subject, body, from, replyToId, threadId } = payload;
 
-  if (await isConnected()) {
-    const client = await getClient(from);
+  if (await isConnected(accountEmail || from)) {
+    const client = await getClient(accountEmail || from);
     if (client) {
       const gmail = google.gmail({ version: "v1", auth: client });
       const lines = [

--- a/templates/mail/server/plugins/db.ts
+++ b/templates/mail/server/plugins/db.ts
@@ -13,4 +13,8 @@ export default runMigrations([
     created_at INTEGER NOT NULL
   )`,
   },
+  {
+    version: 2,
+    sql: `ALTER TABLE scheduled_jobs ADD COLUMN account_email TEXT`,
+  },
 ]);

--- a/templates/mail/server/tasks/jobs/process.ts
+++ b/templates/mail/server/tasks/jobs/process.ts
@@ -32,10 +32,14 @@ export async function processJobs(): Promise<{ result: string }> {
       .where(eq(schema.scheduledJobs.id, job.id));
 
     try {
+      const acctEmail = job.accountEmail ?? undefined;
       if (job.type === "snooze" && job.emailId) {
-        await resurfaceEmail(job.emailId);
+        await resurfaceEmail(job.emailId, acctEmail);
       } else if (job.type === "send_later") {
-        await sendScheduledEmail(JSON.parse(job.payload) as SendLaterPayload);
+        await sendScheduledEmail(
+          JSON.parse(job.payload) as SendLaterPayload,
+          acctEmail,
+        );
       }
       await db
         .update(schema.scheduledJobs)

--- a/wrangler-mail.toml
+++ b/wrangler-mail.toml
@@ -1,5 +1,5 @@
 name = "agent-native-mail"
-pages_build_output_dir = "templates/mail/.output/public"
+pages_build_output_dir = "templates/mail/dist"
 compatibility_date = "2024-12-01"
 
 [[d1_databases]]


### PR DESCRIPTION
- Remove getUserSetting global fallback that leaked cross-user data
- Enforce OAuth state parameter (reject missing/invalid state as 400)
- Replace in-memory pendingRedirects Map with cookie-based state (serverless-safe)
- Fix core BYOA logout to actually clear session (was a no-op)
- Add accountEmail column to scheduled_jobs so jobs run against the correct user
- Thread accountEmail through resurfaceEmail/sendScheduledEmail
- Convert scheduled-jobs handlers from sync .all()/.run() to async (libsql compat)