### PR TITLE
feat: mobile app tab bar with app WebViews + Google OAuth fix

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -108,3 +108,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm build && npx electron-builder --linux --config --publish always
+
+  publish-release:
+    needs: [build-mac, build-windows, build-linux]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: echo "version=$(node -p "require('./packages/desktop-app/package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Publish draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "v${{ steps.version.outputs.version }}" --draft=false --latest

--- a/packages/core/src/templates/default/app/root.tsx
+++ b/packages/core/src/templates/default/app/root.tsx
@@ -23,6 +23,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#111111" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
+        <meta name="apple-mobile-web-app-title" content="App" />
+        <link rel="apple-touch-icon" href="/icon-180.svg" />
         <Meta />
         <Links />
       </head>

--- a/packages/core/src/templates/default/public/icon-180.svg
+++ b/packages/core/src/templates/default/public/icon-180.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="36" fill="#111111"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="99">⚡</text>
+</svg>

--- a/packages/core/src/templates/default/public/icon-192.svg
+++ b/packages/core/src/templates/default/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="38" fill="#111111"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="105">⚡</text>
+</svg>

--- a/packages/core/src/templates/default/public/icon-512.svg
+++ b/packages/core/src/templates/default/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="102" fill="#111111"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="281">⚡</text>
+</svg>

--- a/packages/core/src/templates/default/public/manifest.json
+++ b/packages/core/src/templates/default/public/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Agent Native App",
+  "short_name": "App",
+  "description": "Agent-native application",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111111",
+  "theme_color": "#111111",
+  "icons": [
+    { "src": "/icon-192.svg", "sizes": "192x192", "type": "image/svg+xml" },
+    { "src": "/icon-512.svg", "sizes": "512x512", "type": "image/svg+xml" }
+  ]
+}

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/desktop-app",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "main": "out/main/index.js",
   "productName": "Agent Native",

--- a/packages/docs/app/routes/download.tsx
+++ b/packages/docs/app/routes/download.tsx
@@ -19,7 +19,7 @@ const PLATFORMS: Record<Platform, PlatformInfo> = {
     icon: <AppleIcon />,
     primary: {
       label: "Download for Mac",
-      href: `${DL}/Agent%20Native.dmg`,
+      href: `${DL}/Agent-Native.dmg`,
     },
     note: "Universal binary — works on Apple Silicon and Intel.",
   },
@@ -28,11 +28,11 @@ const PLATFORMS: Record<Platform, PlatformInfo> = {
     icon: <WindowsIcon />,
     primary: {
       label: "Download for Windows",
-      href: `${DL}/Agent%20Native-x64.exe`,
+      href: `${DL}/Agent-Native-x64.exe`,
     },
     secondary: {
       label: "ARM64",
-      href: `${DL}/Agent%20Native-arm64.exe`,
+      href: `${DL}/Agent-Native-arm64.exe`,
     },
     note: "Windows 10 or later.",
   },
@@ -41,11 +41,11 @@ const PLATFORMS: Record<Platform, PlatformInfo> = {
     icon: <LinuxIcon />,
     primary: {
       label: "Download AppImage",
-      href: `${DL}/Agent%20Native-x64.AppImage`,
+      href: `${DL}/Agent-Native-x86_64.AppImage`,
     },
     secondary: {
       label: "Download .deb",
-      href: `${DL}/Agent%20Native-x64.deb`,
+      href: `${DL}/Agent-Native-amd64.deb`,
     },
     note: "x64 — ARM64 also available on GitHub.",
   },

--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -26,10 +26,7 @@
       "bundler": "metro",
       "favicon": "./assets/favicon.png"
     },
-    "plugins": [
-      "expo-router",
-      "expo-web-browser"
-    ],
+    "plugins": ["expo-router", "expo-web-browser"],
     "extra": {
       "router": {},
       "eas": {

--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -26,7 +26,10 @@
       "bundler": "metro",
       "favicon": "./assets/favicon.png"
     },
-    "plugins": ["expo-router"],
+    "plugins": [
+      "expo-router",
+      "expo-web-browser"
+    ],
     "extra": {
       "router": {},
       "eas": {

--- a/packages/mobile-app/components/AppWebView.tsx
+++ b/packages/mobile-app/components/AppWebView.tsx
@@ -1,11 +1,17 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useCallback } from "react";
 import { View, StyleSheet, ActivityIndicator } from "react-native";
-import { WebView } from "react-native-webview";
+import { WebView, type WebViewNavigation } from "react-native-webview";
+import * as WebBrowser from "expo-web-browser";
 
 interface AppWebViewProps {
   url: string;
   color?: string;
 }
+
+// Google blocks OAuth in embedded WebViews. Open Google auth URLs in the
+// system browser (Safari) instead, which completes the OAuth flow and
+// redirects back to the app's callback URL.
+const EXTERNAL_HOSTS = ["accounts.google.com", "oauth2.googleapis.com"];
 
 export default function AppWebView({
   url,
@@ -13,6 +19,34 @@ export default function AppWebView({
 }: AppWebViewProps) {
   const webviewRef = useRef<WebView>(null);
   const [loading, setLoading] = useState(true);
+
+  const handleNavigationStateChange = useCallback(
+    (navState: WebViewNavigation) => {
+      // When the WebView returns from OAuth (callback URL), reload to pick up the session
+      if (navState.url?.includes("/api/google/callback")) {
+        // The callback will set cookies — after redirect, reload the app
+        setTimeout(() => webviewRef.current?.reload(), 1000);
+      }
+    },
+    [],
+  );
+
+  const handleShouldStartLoad = useCallback((event: { url: string }) => {
+    try {
+      const parsed = new URL(event.url);
+      if (EXTERNAL_HOSTS.includes(parsed.hostname)) {
+        // Open in system browser instead of WebView
+        WebBrowser.openBrowserAsync(event.url).then(() => {
+          // When browser closes, reload the WebView to check for new session
+          webviewRef.current?.reload();
+        });
+        return false; // Block the WebView from navigating
+      }
+    } catch {
+      // Invalid URL — let WebView handle it
+    }
+    return true;
+  }, []);
 
   return (
     <View style={styles.container}>
@@ -22,8 +56,12 @@ export default function AppWebView({
         style={styles.webview}
         onLoadStart={() => setLoading(true)}
         onLoadEnd={() => setLoading(false)}
+        onNavigationStateChange={handleNavigationStateChange}
+        onShouldStartLoadWithRequest={handleShouldStartLoad}
         javaScriptEnabled
         domStorageEnabled
+        sharedCookiesEnabled
+        thirdPartyCookiesEnabled
         startInLoadingState={false}
         allowsBackForwardNavigationGestures
         pullToRefreshEnabled

--- a/packages/mobile-app/package.json
+++ b/packages/mobile-app/package.json
@@ -19,6 +19,7 @@
     "expo-linking": "^7.1.7",
     "expo-router": "^5.1.0",
     "expo-status-bar": "^2.2.3",
+    "expo-web-browser": "~14.2.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "^0.79.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -376,6 +376,9 @@ importers:
       expo-status-bar:
         specifier: ^2.2.3
         version: 2.2.3(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0)
+      expo-web-browser:
+        specifier: ~14.2.0
+        version: 14.2.0(expo@53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -8615,6 +8618,12 @@ packages:
     resolution: {integrity: sha512-DeB+fRe0hUDPZhpJ4X4bFMAItatFBUPjw/TVSbJsaf3Exeami+2qbbJhWkcTMoYHOB73nOIcaYcWXYJnCJXO0w==}
     peerDependencies:
       expo: '*'
+
+  expo-web-browser@14.2.0:
+    resolution: {integrity: sha512-6S51d8pVlDRDsgGAp8BPpwnxtyKiMWEFdezNz+5jVIyT+ctReW42uxnjRgtsdn5sXaqzhaX+Tzk/CWaKCyC0hw==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
 
   expo@53.0.27:
     resolution: {integrity: sha512-iQwe2uWLb88opUY4vBYEW1d2GUq3lsa43gsMBEdDV+6pw0Oek93l/4nDLe0ODDdrBRjIJm/rdhKqJC/ehHCUqw==}
@@ -20368,6 +20377,11 @@ snapshots:
   expo-updates-interface@1.1.0(expo@53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0)):
     dependencies:
       expo: 53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0)
+
+  expo-web-browser@14.2.0(expo@53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0)):
+    dependencies:
+      expo: 53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0)
+      react-native: 0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0)
 
   expo@53.0.27(@babel/core@7.29.0)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.29.0)(@types/react@18.3.28)(react@19.0.0))(react@19.0.0):
     dependencies:

--- a/templates/analytics/app/root.tsx
+++ b/templates/analytics/app/root.tsx
@@ -14,6 +14,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#F59E0B" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
+        <meta name="apple-mobile-web-app-title" content="Analytics" />
+        <link rel="apple-touch-icon" href="/icon-180.svg" />
         <Meta />
         <Links />
       </head>

--- a/templates/analytics/public/icon-180.svg
+++ b/templates/analytics/public/icon-180.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="36" fill="#F59E0B"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="99">📊</text>
+</svg>

--- a/templates/analytics/public/icon-192.svg
+++ b/templates/analytics/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="38" fill="#F59E0B"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="106">📊</text>
+</svg>

--- a/templates/analytics/public/icon-512.svg
+++ b/templates/analytics/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="102" fill="#F59E0B"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="282">📊</text>
+</svg>

--- a/templates/analytics/public/manifest.json
+++ b/templates/analytics/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Agent Native Analytics",
+  "short_name": "Analytics",
+  "description": "Analytics dashboard",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111111",
+  "theme_color": "#F59E0B",
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/templates/calendar/app/root.tsx
+++ b/templates/calendar/app/root.tsx
@@ -22,6 +22,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
           type="image/svg+xml"
           href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📅</text></svg>"
         />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#8B5CF6" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
+        <meta name="apple-mobile-web-app-title" content="Calendar" />
+        <link rel="apple-touch-icon" href="/icon-180.svg" />
         <Meta />
         <Links />
       </head>

--- a/templates/calendar/public/icon-180.svg
+++ b/templates/calendar/public/icon-180.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="36" fill="#8B5CF6"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="99">📅</text>
+</svg>

--- a/templates/calendar/public/icon-192.svg
+++ b/templates/calendar/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="38" fill="#8B5CF6"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="106">📅</text>
+</svg>

--- a/templates/calendar/public/icon-512.svg
+++ b/templates/calendar/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="102" fill="#8B5CF6"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="282">📅</text>
+</svg>

--- a/templates/calendar/public/manifest.json
+++ b/templates/calendar/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Agent Native Calendar",
+  "short_name": "Calendar",
+  "description": "Google Calendar integration",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111111",
+  "theme_color": "#8B5CF6",
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/templates/content/app/root.tsx
+++ b/templates/content/app/root.tsx
@@ -14,6 +14,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#10B981" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
+        <meta name="apple-mobile-web-app-title" content="Content" />
+        <link rel="apple-touch-icon" href="/icon-180.svg" />
         <Meta />
         <Links />
       </head>

--- a/templates/content/public/icon-180.svg
+++ b/templates/content/public/icon-180.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="36" fill="#10B981"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="99">📝</text>
+</svg>

--- a/templates/content/public/icon-192.svg
+++ b/templates/content/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="38" fill="#10B981"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="106">📝</text>
+</svg>

--- a/templates/content/public/icon-512.svg
+++ b/templates/content/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="102" fill="#10B981"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="282">📝</text>
+</svg>

--- a/templates/content/public/manifest.json
+++ b/templates/content/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Agent Native Content",
+  "short_name": "Content",
+  "description": "Notion-like content workspace",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111111",
+  "theme_color": "#10B981",
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/templates/forms/app/root.tsx
+++ b/templates/forms/app/root.tsx
@@ -22,6 +22,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
           type="image/svg+xml"
           href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📋</text></svg>"
         />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#06B6D4" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
+        <meta name="apple-mobile-web-app-title" content="Forms" />
+        <link rel="apple-touch-icon" href="/icon-180.svg" />
         <Meta />
         <Links />
       </head>

--- a/templates/forms/public/icon-180.svg
+++ b/templates/forms/public/icon-180.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="36" fill="#06B6D4"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="99">📋</text>
+</svg>

--- a/templates/forms/public/icon-192.svg
+++ b/templates/forms/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="38" fill="#06B6D4"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="106">📋</text>
+</svg>

--- a/templates/forms/public/icon-512.svg
+++ b/templates/forms/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="102" fill="#06B6D4"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="282">📋</text>
+</svg>

--- a/templates/forms/public/manifest.json
+++ b/templates/forms/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Agent Native Forms",
+  "short_name": "Forms",
+  "description": "Form builder",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111111",
+  "theme_color": "#06B6D4",
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -24,6 +24,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
           type="image/svg+xml"
           href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📧</text></svg>"
         />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#3B82F6" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
+        <meta name="apple-mobile-web-app-title" content="Mail" />
+        <link rel="apple-touch-icon" href="/icon-180.svg" />
         <Meta />
         <Links />
       </head>

--- a/templates/mail/public/icon-180.svg
+++ b/templates/mail/public/icon-180.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="36" fill="#3B82F6"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="99">📧</text>
+</svg>

--- a/templates/mail/public/icon-192.svg
+++ b/templates/mail/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="38" fill="#3B82F6"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="106">📧</text>
+</svg>

--- a/templates/mail/public/icon-512.svg
+++ b/templates/mail/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="102" fill="#3B82F6"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="282">📧</text>
+</svg>

--- a/templates/mail/public/manifest.json
+++ b/templates/mail/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Agent Native Mail",
+  "short_name": "Mail",
+  "description": "Email client",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111111",
+  "theme_color": "#3B82F6",
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -64,6 +64,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
           type="image/svg+xml"
           href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎴</text></svg>"
         />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#EC4899" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
+        <meta name="apple-mobile-web-app-title" content="Slides" />
+        <link rel="apple-touch-icon" href="/icon-180.svg" />
         <Meta />
         <Links />
       </head>

--- a/templates/slides/public/icon-180.svg
+++ b/templates/slides/public/icon-180.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="36" fill="#EC4899"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="99">🎴</text>
+</svg>

--- a/templates/slides/public/icon-192.svg
+++ b/templates/slides/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="38" fill="#EC4899"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="106">🎴</text>
+</svg>

--- a/templates/slides/public/icon-512.svg
+++ b/templates/slides/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="102" fill="#EC4899"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="282">🎴</text>
+</svg>

--- a/templates/slides/public/manifest.json
+++ b/templates/slides/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Agent Native Slides",
+  "short_name": "Slides",
+  "description": "AI slide deck creator",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111111",
+  "theme_color": "#EC4899",
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/templates/starter/app/root.tsx
+++ b/templates/starter/app/root.tsx
@@ -17,6 +17,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#71717A" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
+        <meta name="apple-mobile-web-app-title" content="Starter" />
+        <link rel="apple-touch-icon" href="/icon-180.svg" />
         <Meta />
         <Links />
       </head>

--- a/templates/starter/public/icon-180.svg
+++ b/templates/starter/public/icon-180.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="36" fill="#71717A"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="99">🚀</text>
+</svg>

--- a/templates/starter/public/icon-192.svg
+++ b/templates/starter/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="38" fill="#71717A"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="106">🚀</text>
+</svg>

--- a/templates/starter/public/icon-512.svg
+++ b/templates/starter/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="102" fill="#71717A"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="282">🚀</text>
+</svg>

--- a/templates/starter/public/manifest.json
+++ b/templates/starter/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Agent Native",
+  "short_name": "Starter",
+  "description": "Blank starter template",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111111",
+  "theme_color": "#71717A",
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/templates/videos/app/root.tsx
+++ b/templates/videos/app/root.tsx
@@ -10,6 +10,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#EF4444" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
+        <meta name="apple-mobile-web-app-title" content="Videos" />
+        <link rel="apple-touch-icon" href="/icon-180.svg" />
         <Meta />
         <Links />
       </head>

--- a/templates/videos/public/icon-180.svg
+++ b/templates/videos/public/icon-180.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
+  <rect width="180" height="180" rx="36" fill="#EF4444"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="99">🎬</text>
+</svg>

--- a/templates/videos/public/icon-192.svg
+++ b/templates/videos/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="38" fill="#EF4444"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="106">🎬</text>
+</svg>

--- a/templates/videos/public/icon-512.svg
+++ b/templates/videos/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="102" fill="#EF4444"/>
+  <text x="50%" y="50%" dominant-baseline="central" text-anchor="middle" font-size="282">🎬</text>
+</svg>

--- a/templates/videos/public/manifest.json
+++ b/templates/videos/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Agent Native Videos",
+  "short_name": "Videos",
+  "description": "AI video creator",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#111111",
+  "theme_color": "#EF4444",
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Replace grid-of-apps with bottom tab bar (Mail, Calendar, Content, Forms, Settings)
- Each tab loads the deployed web app directly in a WebView
- Fix Google OAuth in WebView — opens in Safari to comply with Google's policy
- Add metro.config.js for monorepo React version deduplication
- Add .gitignore for generated ios/android directories

## Test plan
- [ ] Simulator: tabs show, Mail/Calendar load deployed CF Workers apps
- [ ] Physical device: preview build installs, OAuth works via Safari redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)