### PR TITLE
fix: use Linking.openURL instead of expo-web-browser for OAuth

### DIFF
--- a/packages/mobile-app/components/AppWebView.tsx
+++ b/packages/mobile-app/components/AppWebView.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useCallback } from "react";
-import { View, StyleSheet, ActivityIndicator } from "react-native";
+import { View, StyleSheet, ActivityIndicator, Linking } from "react-native";
 import { WebView, type WebViewNavigation } from "react-native-webview";
-import * as WebBrowser from "expo-web-browser";
 
 interface AppWebViewProps {
   url: string;
@@ -35,11 +34,8 @@ export default function AppWebView({
     try {
       const parsed = new URL(event.url);
       if (EXTERNAL_HOSTS.includes(parsed.hostname)) {
-        // Open in system browser instead of WebView
-        WebBrowser.openBrowserAsync(event.url).then(() => {
-          // When browser closes, reload the WebView to check for new session
-          webviewRef.current?.reload();
-        });
+        // Open in system browser via Linking (works without native module rebuild)
+        Linking.openURL(event.url);
         return false; // Block the WebView from navigating
       }
     } catch {

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -36,6 +36,7 @@ import type { Label } from "@shared/types";
 import { toast } from "sonner";
 
 import { AccountFilterContext } from "@/hooks/use-account-filter";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 /** Extract the trailing segment of a nested label name, e.g. "[Superhuman]/AI/Pitch" → "Pitch" */
 function shortLabelName(name: string): string {
@@ -58,6 +59,7 @@ const collapsibleViews = [
 ];
 
 export function AppLayout({ children }: AppLayoutProps) {
+  const isMobile = useIsMobile();
   const compose = useComposeState();
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [snoozeOpen, setSnoozeOpen] = useState(false);
@@ -905,7 +907,7 @@ export function AppLayout({ children }: AppLayoutProps) {
           {/* Show full-page takeover when no accounts connected, otherwise content */}
           <AgentSidebar
             position="left"
-            defaultOpen
+            defaultOpen={!isMobile}
             emptyStateText="Ask me anything about your emails"
             suggestions={[
               "What's in my inbox?",

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { useParams, useNavigate, useSearchParams } from "react-router";
 import { cn } from "@/lib/utils";
 import { EmailList, InboxZero } from "@/components/email/EmailList";
@@ -388,6 +389,7 @@ export function InboxPage() {
     [compose, deleteDraft],
   );
 
+  const isMobile = useIsMobile();
   const hasThread = !!threadId;
   const isInboxZero =
     !isLoading &&
@@ -420,8 +422,8 @@ export function InboxPage() {
 
   return (
     <div className="flex flex-1 overflow-hidden">
-      {/* Thin email list sidebar — shown when viewing a thread */}
-      {hasThread && (
+      {/* Thin email list sidebar — shown when viewing a thread, hidden on mobile */}
+      {hasThread && !isMobile && (
         <ThreadListSidebar
           emails={emails}
           activeThreadId={threadId!}


### PR DESCRIPTION
expo-web-browser requires a native rebuild. Linking.openURL works with the existing dev client build and opens Google OAuth in Safari. Also remove debug text from Mail tab.