### PR TITLE
fix: OAuth session reload + sidebar mobile flash

### DIFF
--- a/packages/mobile-app/components/AppWebView.tsx
+++ b/packages/mobile-app/components/AppWebView.tsx
@@ -1,6 +1,12 @@
-import { useState, useRef, useCallback } from "react";
-import { View, StyleSheet, ActivityIndicator, Linking } from "react-native";
-import { WebView, type WebViewNavigation } from "react-native-webview";
+import { useState, useRef, useCallback, useEffect } from "react";
+import {
+  View,
+  StyleSheet,
+  ActivityIndicator,
+  Linking,
+  AppState,
+} from "react-native";
+import { WebView } from "react-native-webview";
 
 interface AppWebViewProps {
   url: string;
@@ -8,8 +14,7 @@ interface AppWebViewProps {
 }
 
 // Google blocks OAuth in embedded WebViews. Open Google auth URLs in the
-// system browser (Safari) instead, which completes the OAuth flow and
-// redirects back to the app's callback URL.
+// system browser (Safari) instead.
 const EXTERNAL_HOSTS = ["accounts.google.com", "oauth2.googleapis.com"];
 
 export default function AppWebView({
@@ -18,25 +23,27 @@ export default function AppWebView({
 }: AppWebViewProps) {
   const webviewRef = useRef<WebView>(null);
   const [loading, setLoading] = useState(true);
+  const openedExternal = useRef(false);
 
-  const handleNavigationStateChange = useCallback(
-    (navState: WebViewNavigation) => {
-      // When the WebView returns from OAuth (callback URL), reload to pick up the session
-      if (navState.url?.includes("/api/google/callback")) {
-        // The callback will set cookies — after redirect, reload the app
-        setTimeout(() => webviewRef.current?.reload(), 1000);
+  // When the app returns to foreground after external OAuth, reload the WebView
+  // to pick up the new session cookie.
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "active" && openedExternal.current) {
+        openedExternal.current = false;
+        webviewRef.current?.reload();
       }
-    },
-    [],
-  );
+    });
+    return () => sub.remove();
+  }, []);
 
   const handleShouldStartLoad = useCallback((event: { url: string }) => {
     try {
       const parsed = new URL(event.url);
       if (EXTERNAL_HOSTS.includes(parsed.hostname)) {
-        // Open in system browser via Linking (works without native module rebuild)
+        openedExternal.current = true;
         Linking.openURL(event.url);
-        return false; // Block the WebView from navigating
+        return false;
       }
     } catch {
       // Invalid URL — let WebView handle it
@@ -52,7 +59,6 @@ export default function AppWebView({
         style={styles.webview}
         onLoadStart={() => setLoading(true)}
         onLoadEnd={() => setLoading(false)}
-        onNavigationStateChange={handleNavigationStateChange}
         onShouldStartLoadWithRequest={handleShouldStartLoad}
         javaScriptEnabled
         domStorageEnabled

--- a/templates/mail/app/hooks/use-mobile.tsx
+++ b/templates/mail/app/hooks/use-mobile.tsx
@@ -3,9 +3,12 @@ import * as React from "react";
 const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined,
-  );
+  // Initialize with the actual value (not undefined) to avoid hydration mismatch
+  // where !isMobile briefly evaluates to true on mobile before useEffect fires.
+  const [isMobile, setIsMobile] = React.useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth < MOBILE_BREAKPOINT;
+  });
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
@@ -17,5 +20,5 @@ export function useIsMobile() {
     return () => mql.removeEventListener("change", onChange);
   }, []);
 
-  return !!isMobile;
+  return isMobile;
 }


### PR DESCRIPTION
## Summary

- WebView reloads after returning from external OAuth (AppState listener)
- Fix useIsMobile() initializing as undefined causing sidebar to flash open on mobile

## Test plan
- [ ] OAuth: tap Sign in with Google → complete in Safari → return to app → WebView reloads with session
- [ ] Mobile: sidebar doesn't flash open on first render

🤖 Generated with [Claude Code](https://claude.com/claude-code)