### PR TITLE
fix: shared Neon DB compat, Postgres BIGINT, mail label aliases

### DIFF
--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -105,7 +105,9 @@ async function initClient(): Promise<void> {
   // Postgres — dynamically import to avoid bundling in non-Postgres runtimes
   if (dialect === "postgres") {
     const { default: postgres } = await import("postgres");
-    _pgPool = postgres(url);
+    _pgPool = postgres(url, {
+      onnotice: () => {}, // Suppress CREATE TABLE IF NOT EXISTS notices
+    });
     const pool = _pgPool;
 
     _exec = {

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -97,9 +97,11 @@ async function getAccessToken(accountEmail: string): Promise<string | null> {
 async function getAccountTokens(
   forEmail?: string,
 ): Promise<Array<{ email: string; accessToken: string }>> {
-  const accounts = forEmail
-    ? await listOAuthAccountsByOwner("google", forEmail)
-    : await listOAuthAccounts("google");
+  // In dev mode (local@localhost), show all accounts regardless of owner
+  const accounts =
+    forEmail && forEmail !== "local@localhost"
+      ? await listOAuthAccountsByOwner("google", forEmail)
+      : await listOAuthAccounts("google");
 
   const results: Array<{ email: string; accessToken: string }> = [];
 

--- a/templates/mail/server/handlers/google-auth.ts
+++ b/templates/mail/server/handlers/google-auth.ts
@@ -215,11 +215,7 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
 export const getGoogleStatus = defineEventHandler(async (event: H3Event) => {
   try {
     const session = await getSession(event);
-    // In dev mode (local@localhost), show all connected accounts regardless of owner
-    // so tokens created in prod are visible locally and vice versa
-    const forEmail =
-      session?.email === "local@localhost" ? undefined : session?.email;
-    const status = await getAuthStatus(forEmail);
+    const status = await getAuthStatus(session?.email);
     return status;
   } catch (error: any) {
     setResponseStatus(event, 500);

--- a/templates/mail/server/handlers/google-auth.ts
+++ b/templates/mail/server/handlers/google-auth.ts
@@ -215,7 +215,11 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
 export const getGoogleStatus = defineEventHandler(async (event: H3Event) => {
   try {
     const session = await getSession(event);
-    const status = await getAuthStatus(session?.email);
+    // In dev mode (local@localhost), show all connected accounts regardless of owner
+    // so tokens created in prod are visible locally and vice versa
+    const forEmail =
+      session?.email === "local@localhost" ? undefined : session?.email;
+    const status = await getAuthStatus(forEmail);
     return status;
   } catch (error: any) {
     setResponseStatus(event, 500);

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -235,7 +235,8 @@ export async function getClients(
  * checks only that specific account.
  */
 export async function isConnected(forEmail?: string): Promise<boolean> {
-  if (forEmail) {
+  // In dev mode, check all accounts regardless of owner
+  if (forEmail && forEmail !== "local@localhost") {
     const accounts = await listOAuthAccountsByOwner("google", forEmail);
     return accounts.length > 0;
   }
@@ -263,7 +264,8 @@ export async function getAuthStatus(
     accountId: string;
     tokens: Record<string, unknown>;
   }>;
-  if (forEmail) {
+  // In dev mode (local@localhost), show all accounts regardless of owner
+  if (forEmail && forEmail !== "local@localhost") {
     oauthAccounts = await listOAuthAccountsByOwner("google", forEmail);
   } else {
     oauthAccounts = await listOAuthAccounts("google");


### PR DESCRIPTION
## Summary
- Fix dev/prod data sharing when using same Neon Postgres DB
- Dev mode Google status shows all accounts regardless of owner
- INTEGER → BIGINT for timestamp columns on Postgres (Date.now() overflow)
- Mail label alias system for renaming tab labels
- Mail db/index.ts switched to core's createGetDb for Postgres support
- SSE → polling migration for serverless compatibility
- Calendar stacking layout, past/declined event styling, attendee photos
- Various fixes from parallel agents

## Test plan
- [ ] Mail app connects to Neon Postgres locally and in production
- [ ] Same Google account visible in both environments
- [ ] Same pinned labels/settings sync across local and prod
- [ ] Calendar event layout renders correctly with overlapping events

🤖 Generated with [Claude Code](https://claude.com/claude-code)