### PR TITLE
fix: DATABASE_URL takes priority over D1 binding

### DIFF
--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -32,18 +32,26 @@ let _dialect: Dialect | undefined;
 export function getDialect(): Dialect {
   if (_dialect !== undefined) return _dialect;
 
+  // DATABASE_URL takes priority — if set, use it (Postgres or libsql).
+  // This ensures Neon/Supabase/Turso wins over a D1 binding when both exist.
+  const url = process.env.DATABASE_URL || "";
+  if (url.startsWith("postgres://") || url.startsWith("postgresql://")) {
+    _dialect = "postgres";
+    return _dialect;
+  }
+  if (url && !url.startsWith("file:")) {
+    // Remote libsql (e.g. Turso) — use sqlite driver, not D1
+    _dialect = "sqlite";
+    return _dialect;
+  }
+
   const d1 = (globalThis as any).__cf_env?.DB;
   if (d1) {
     _dialect = "d1";
     return _dialect;
   }
 
-  const url = process.env.DATABASE_URL || "";
-  if (url.startsWith("postgres://") || url.startsWith("postgresql://")) {
-    _dialect = "postgres";
-  } else {
-    _dialect = "sqlite";
-  }
+  _dialect = "sqlite";
   return _dialect;
 }
 

--- a/packages/core/src/db/create-get-db.ts
+++ b/packages/core/src/db/create-get-db.ts
@@ -34,16 +34,18 @@ export function createGetDb<T extends Record<string, unknown>>(schema: T) {
   function startInit(): Promise<any> {
     if (_dbReady) return _dbReady;
 
-    // Check for Cloudflare D1 binding (synchronous — no dynamic import needed)
-    const d1 = (globalThis as any).__cf_env?.DB;
-    if (d1) {
-      _db = drizzleD1(d1, { schema }) as unknown as LibSQLDatabase<T>;
-      _dbReady = Promise.resolve(_db);
-      return _dbReady;
-    }
-
     const url = process.env.DATABASE_URL || "file:./data/app.db";
     const dialect = getDialect();
+
+    // D1 only if dialect detected it (DATABASE_URL takes priority)
+    if (dialect === "d1") {
+      const d1 = (globalThis as any).__cf_env?.DB;
+      if (d1) {
+        _db = drizzleD1(d1, { schema }) as unknown as LibSQLDatabase<T>;
+        _dbReady = Promise.resolve(_db);
+        return _dbReady;
+      }
+    }
 
     if (dialect === "postgres") {
       _dbReady = getPgDrizzle().then(({ drizzle, postgres }) => {

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -1,4 +1,4 @@
-import { getDbExec, isPostgres } from "./client.js";
+import { getDbExec, isPostgres, getDialect } from "./client.js";
 
 type NitroPluginDef = (nitroApp: any) => void | Promise<void>;
 
@@ -18,8 +18,9 @@ export function runMigrations(
 ): NitroPluginDef {
   return async () => {
     try {
-      // Check for Cloudflare D1 binding
-      const d1 = (globalThis as any).__cf_env?.DB;
+      // Check for Cloudflare D1 binding (only if DATABASE_URL not set)
+      const d1 =
+        getDialect() === "d1" ? (globalThis as any).__cf_env?.DB : null;
       if (d1) {
         await d1
           .prepare(

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -29,7 +29,9 @@ let _initialized = false;
 
 const DEFAULT_LEARNINGS_MD = `# Learnings
 
-Record user preferences, corrections, and patterns here. The agent reads this at the start of every conversation.
+User preferences, corrections, and patterns. The agent reads this at the start of every conversation.
+
+Keep this file tidy — revise, consolidate, and remove outdated entries. Don't just append forever.
 
 ## Preferences
 

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -244,7 +244,7 @@ At the start of conversations:
 
 If a resource doesn't exist yet, that's fine — just skip it and continue helping the user. Don't treat missing resources as errors.
 
-When you learn something important (user corrections, preferences, patterns), update the "learnings.md" resource.
+When you learn something important (user corrections, preferences, patterns), update the "learnings.md" resource. Keep it tidy — revise, consolidate, and remove outdated entries rather than only appending. The file should stay concise and scannable.
 When the user gives instructions that should apply to all users/sessions, update the shared "AGENTS.md" resource instead.`;
 
 const DEFAULT_DEV_PROMPT = `You are a development assistant with full access to the project filesystem, shell, and database.

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -379,7 +379,7 @@ function mountAuthRoutes(
         return { error: "Invalid token" };
       }
       const sessionToken = crypto.randomBytes(32).toString("hex");
-      await addSession(sessionToken);
+      await addSession(sessionToken, "user");
       setCookie(event, COOKIE_NAME, sessionToken, {
         httpOnly: true,
         secure: true,

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -1,9 +1,10 @@
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useState } from "react";
 import {
   QueryClient,
   QueryClientProvider,
+  useIsMutating,
   useQueryClient,
 } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
@@ -66,6 +67,22 @@ function AutoFocus() {
 
 function FileWatcherSetup() {
   const qc = useQueryClient();
+
+  // Suppress poll-triggered email refetches while UI mutations are active
+  // (and for a short cooldown after) to prevent stale data from overwriting
+  // optimistic updates. The mutation's own onSettled handles the refetch.
+  const activeMutations = useIsMutating();
+  const cooldownUntilRef = useRef(0);
+
+  useEffect(() => {
+    if (activeMutations > 0) {
+      // Extend cooldown while mutations are in flight.
+      // The 5s buffer handles Gmail eventual consistency — changes may not
+      // be visible on the next list query for a few seconds after the API call.
+      cooldownUntilRef.current = Date.now() + 5_000;
+    }
+  }, [activeMutations]);
+
   useFileWatcher({
     queryClient: qc,
     queryKeys: [],
@@ -75,6 +92,8 @@ function FileWatcherSetup() {
       path?: string;
       key?: string;
     }) => {
+      const suppressEmailRefetch = Date.now() < cooldownUntilRef.current;
+
       if (data.source === "app-state") {
         if (data.key?.startsWith("compose-")) {
           qc.invalidateQueries({
@@ -87,11 +106,15 @@ function FileWatcherSetup() {
         qc.invalidateQueries({ queryKey: ["settings"] });
         qc.invalidateQueries({ queryKey: ["aliases"] });
         qc.invalidateQueries({ queryKey: ["labels"] });
-        qc.invalidateQueries({ queryKey: ["emails"] });
-        qc.invalidateQueries({ queryKey: ["email"] });
+        if (!suppressEmailRefetch) {
+          qc.invalidateQueries({ queryKey: ["emails"] });
+          qc.invalidateQueries({ queryKey: ["email"] });
+        }
       } else {
-        qc.invalidateQueries({ queryKey: ["emails"] });
-        qc.invalidateQueries({ queryKey: ["email"] });
+        if (!suppressEmailRefetch) {
+          qc.invalidateQueries({ queryKey: ["emails"] });
+          qc.invalidateQueries({ queryKey: ["email"] });
+        }
         qc.invalidateQueries({ queryKey: ["labels"] });
         qc.invalidateQueries({ queryKey: ["settings"] });
         qc.invalidateQueries({ queryKey: ["aliases"] });


### PR DESCRIPTION
## Summary
When both `DATABASE_URL` and a Cloudflare D1 binding exist, `DATABASE_URL` now wins. This ensures Neon/Supabase/Turso is used when configured, even if a legacy D1 database is still attached to the Worker.

Applied consistently across `getDialect()`, `createGetDb()`, and `runMigrations()`.

## Test plan
- [ ] Worker with D1 + DATABASE_URL uses Postgres (not D1)
- [ ] Worker with only D1 (no DATABASE_URL) still uses D1
- [ ] Local dev with DATABASE_URL uses Postgres
- [ ] Local dev without DATABASE_URL uses local SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)