### PR TITLE
Fix missing bash code fence in llms docs

### DIFF
--- a/packages/docs/public/llms-full.txt
+++ b/packages/docs/public/llms-full.txt
@@ -12,7 +12,7 @@ Agent-Native is an open source framework for building full-featured applications
 
 Create a new project:
 
-
+```bash
 npx @agent-native/core create my-app
 ```
 

--- a/packages/docs/public/llms.txt
+++ b/packages/docs/public/llms.txt
@@ -15,7 +15,7 @@ Agent-Native is an open source framework for building full-featured applications
 
 ## Quick Start
 
-
+```bash
 npx @agent-native/core create my-app
 cd my-app
 pnpm install


### PR DESCRIPTION
### Summary
Fixes two documentation files where the opening `bash` code fence tag was missing from the Quick Start command block.

### Problem
In both `llms-full.txt` and `llms.txt`, the `npx` command snippet was missing its opening ` ```bash ` tag, leaving the code block improperly formatted and potentially confusing for readers or LLM consumers of the docs.

### Solution
Added the missing ` ```bash ` opening tag to the code block in both affected files.

### Key Changes
- Added ` ```bash ` opening fence to the `npx @agent-native/core create my-app` snippet in `packages/docs/public/llms-full.txt`
- Added ` ```bash ` opening fence to the `npx @agent-native/core create my-app` snippet in `packages/docs/public/llms.txt`


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/blazing-circuit-i4wdvk6z"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-blazing-circuit-i4wdvk6z_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 105`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>blazing-circuit-i4wdvk6z</branchName>-->