### PR TITLE
fix(content): overhaul Notion import rendering

### DIFF
--- a/templates/content/app/components/editor/extensions/NotionExtensions.tsx
+++ b/templates/content/app/components/editor/extensions/NotionExtensions.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Mark,
   Node,
@@ -7,6 +8,7 @@ import {
   mergeAttributes,
   type NodeViewProps,
 } from "@tiptap/react";
+import { IconChevronRight, IconChevronDown } from "@tabler/icons-react";
 import {
   escapeHtml,
   indentMarkdown,
@@ -72,6 +74,9 @@ function parseAttrsJson(
 }
 
 function serializeInnerMarkdown(editor: any, node: any): string {
+  if (!editor?.storage?.markdown?.serializer) {
+    return node.textContent || "";
+  }
   return editor.storage.markdown.serializer.serialize(node).trimEnd();
 }
 
@@ -104,30 +109,41 @@ function humanizeTag(tagName: string): string {
 }
 
 function ToggleView({ node, updateAttributes }: NodeViewProps) {
+  const [open, setOpen] = useState(false);
   const summary = (node.attrs.summary || "") as string;
 
   return (
     <NodeViewWrapper
-      className="notion-toggle"
+      className={`notion-toggle ${open ? "notion-toggle--open" : ""}`}
       data-color={node.attrs.color || undefined}
       data-heading-level={node.attrs.headingLevel || undefined}
     >
-      <div className="notion-toggle__summary-row">
+      <div
+        className="notion-toggle__summary-row"
+        onClick={() => setOpen(!open)}
+      >
         <span className="notion-toggle__chevron" contentEditable={false}>
-          ▾
+          {open ? (
+            <IconChevronDown size={18} stroke={2} />
+          ) : (
+            <IconChevronRight size={18} stroke={2} />
+          )}
         </span>
         <input
           value={summary}
           onChange={(event) =>
             updateAttributes({ summary: event.currentTarget.value })
           }
+          onClick={(e) => e.stopPropagation()}
           placeholder="Toggle"
           className="notion-toggle__summary"
         />
       </div>
-      <div className="notion-toggle__body">
-        <NodeViewContent className="notion-toggle__content" />
-      </div>
+      {open && (
+        <div className="notion-toggle__body">
+          <NodeViewContent className="notion-toggle__content" />
+        </div>
+      )}
     </NodeViewWrapper>
   );
 }

--- a/templates/content/app/global.css
+++ b/templates/content/app/global.css
@@ -297,8 +297,8 @@
 
 /* Paragraphs */
 .notion-editor p {
-  margin: 0.5em 0;
-  min-height: 1.7em;
+  margin: 0.15em 0;
+  min-height: 1.5em;
 }
 
 /* Placeholders */
@@ -320,10 +320,22 @@
   padding-left: 1.5em;
   margin: 0.2em 0;
 }
+.notion-editor ul ul {
+  list-style-type: circle;
+}
+.notion-editor ul ul ul {
+  list-style-type: square;
+}
 .notion-editor ol {
   list-style-type: decimal;
   padding-left: 1.5em;
   margin: 0.2em 0;
+}
+.notion-editor ol ol {
+  list-style-type: lower-alpha;
+}
+.notion-editor ol ol ol {
+  list-style-type: lower-roman;
 }
 .notion-editor li {
   margin: 0.1em 0;
@@ -359,11 +371,11 @@
   color: hsl(var(--muted-foreground));
 }
 
-/* Blockquote */
+/* Blockquote — styled as Notion-like indent (no border) */
 .notion-editor blockquote {
-  border-left: 3px solid hsl(var(--foreground));
-  padding-left: 1em;
-  margin: 0.4em 0;
+  border-left: none;
+  padding-left: 1.5em;
+  margin: 0.15em 0;
 }
 
 /* Code block */
@@ -536,23 +548,30 @@
 
 /* Enhanced Notion-flavored markdown blocks */
 .notion-toggle {
-  margin: 0.75em 0;
-  border: 1px solid hsl(var(--border));
-  border-radius: 10px;
-  background: hsl(var(--background));
+  margin: 0.3em 0;
 }
 
 .notion-toggle__summary-row {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.65rem 0.8rem 0.35rem;
+  gap: 0.25rem;
+  cursor: pointer;
 }
 
 .notion-toggle__chevron {
   color: hsl(var(--muted-foreground));
-  font-size: 0.9rem;
-  line-height: 1;
+  flex-shrink: 0;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 3px;
+  transition: background 120ms ease-in;
+}
+.notion-toggle__chevron:hover {
+  background: hsl(var(--muted));
 }
 
 .notion-toggle__summary {
@@ -563,7 +582,7 @@
   background: transparent;
   color: hsl(var(--foreground));
   font: inherit;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .notion-toggle__summary::placeholder {
@@ -571,7 +590,7 @@
 }
 
 .notion-toggle__body {
-  padding: 0 0.8rem 0.75rem 1.75rem;
+  padding: 0 0 0 1.5em;
 }
 
 .notion-toggle__content > :first-child {

--- a/templates/content/shared/notion-markdown.spec.ts
+++ b/templates/content/shared/notion-markdown.spec.ts
@@ -178,11 +178,13 @@ describe("parseNfmForEditor", () => {
     });
   });
 
-  describe("HTML containers are left untouched in pass 2", () => {
-    it("does not rewrite content inside callout", () => {
-      const input = "<callout>\n\tindented\n</callout>";
+  describe("callout content conversion", () => {
+    it("converts callout inner content to HTML with inline markdown", () => {
+      const input =
+        '<callout icon="💡">\n\tThis is **bold** and [a link](https://example.com)\n</callout>';
       const result = parseNfmForEditor(input);
-      expect(result).toContain("\tindented");
+      expect(result).toContain("<strong>bold</strong>");
+      expect(result).toContain('<a href="https://example.com">a link</a>');
     });
   });
 

--- a/templates/content/shared/notion-markdown.spec.ts
+++ b/templates/content/shared/notion-markdown.spec.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+import { parseNfmForEditor, normalizeNfmForStorage } from "./notion-markdown";
+
+describe("parseNfmForEditor", () => {
+  describe("empty-block handling", () => {
+    it("converts <empty-block/> to visible &nbsp; paragraph", () => {
+      const result = parseNfmForEditor(
+        "text above\n<empty-block/>\ntext below",
+      );
+      expect(result).toContain("&nbsp;");
+      expect(result).not.toContain("<empty-block/>");
+    });
+
+    it("handles multiple consecutive empty blocks", () => {
+      const result = parseNfmForEditor(
+        "above\n<empty-block/>\n<empty-block/>\nbelow",
+      );
+      const nbspCount = (result.match(/&nbsp;/g) || []).length;
+      expect(nbspCount).toBe(2);
+    });
+
+    it("handles leading empty block", () => {
+      const result = parseNfmForEditor("<empty-block/>\nfirst content");
+      expect(result).toContain("&nbsp;");
+    });
+
+    it("handles empty-block with attributes", () => {
+      const result = parseNfmForEditor('<empty-block id="x"/>');
+      expect(result).not.toContain("<empty-block");
+    });
+  });
+
+  describe("tab-indented plain text → blockquote", () => {
+    it("converts single-tab indent to blockquote", () => {
+      const result = parseNfmForEditor("parent\n\tchild");
+      expect(result).toContain("> child");
+      expect(result).not.toContain("\tchild");
+    });
+
+    it("converts double-tab indent to nested blockquote", () => {
+      const result = parseNfmForEditor("parent\n\t\tgrandchild");
+      expect(result).toContain("> > grandchild");
+    });
+
+    it("converts triple-tab indent to triply-nested blockquote", () => {
+      const result = parseNfmForEditor("parent\n\t\t\tdeep");
+      expect(result).toContain("> > > deep");
+    });
+
+    it("does NOT convert list items to blockquotes", () => {
+      const result = parseNfmForEditor("\t- list item");
+      expect(result).toContain("- list item");
+      expect(result).not.toContain("> - list item");
+    });
+
+    it("does NOT convert numbered list items to blockquotes", () => {
+      const result = parseNfmForEditor("\t1. numbered");
+      expect(result).toContain("1. numbered");
+      expect(result).not.toContain("> 1. numbered");
+    });
+
+    it("does NOT convert task items to blockquotes", () => {
+      const result = parseNfmForEditor("\t- [ ] task");
+      expect(result).toContain("- [ ] task");
+    });
+  });
+
+  describe("tab-indented list items → space-indented", () => {
+    it("uses 4-space indentation for nested bullet lists", () => {
+      const result = parseNfmForEditor("- parent\n\t- child");
+      expect(result).toContain("    - child");
+    });
+
+    it("uses 4-space indentation for nested numbered lists", () => {
+      const result = parseNfmForEditor("1. parent\n\t1. child");
+      expect(result).toContain("    1. child");
+    });
+
+    it("handles double-nested list items", () => {
+      const result = parseNfmForEditor("- a\n\t- b\n\t\t- c");
+      expect(result).toContain("        - c");
+    });
+  });
+
+  describe("toggle (details) content conversion", () => {
+    it("converts toggle content from NFM to HTML", () => {
+      const input = [
+        "<details>",
+        "<summary>My Toggle</summary>",
+        "\tSome content here",
+        "</details>",
+      ].join("\n");
+      const result = parseNfmForEditor(input);
+      expect(result).toContain("<details>");
+      expect(result).toContain("<summary>My Toggle</summary>");
+      // Base-level content inside toggle becomes <p>
+      expect(result).toContain("<p>Some content here</p>");
+      expect(result).toContain("</details>");
+    });
+
+    it("converts list items inside toggle to HTML lists", () => {
+      const input = [
+        "<details>",
+        "<summary>Toggle</summary>",
+        "\t- item 1",
+        "\t- item 2",
+        "</details>",
+      ].join("\n");
+      const result = parseNfmForEditor(input);
+      expect(result).toContain("<ul>");
+      expect(result).toContain("<li>");
+    });
+
+    it("handles nested indentation inside toggle", () => {
+      const input = [
+        "<details>",
+        "<summary>Toggle</summary>",
+        "\tparent text",
+        "\t\tchild text",
+        "</details>",
+      ].join("\n");
+      const result = parseNfmForEditor(input);
+      expect(result).toContain("<blockquote>");
+    });
+
+    it("does not modify content outside toggle", () => {
+      const input =
+        "plain text\n<details>\n<summary>T</summary>\n\tcontent\n</details>\nmore text";
+      const result = parseNfmForEditor(input);
+      expect(result).toContain("plain text");
+      expect(result).toContain("more text");
+    });
+  });
+
+  describe("paragraph separation", () => {
+    it("inserts blank line between consecutive plain text lines", () => {
+      const result = parseNfmForEditor("line one\nline two");
+      const lines = result.split("\n");
+      const idx = lines.indexOf("line one");
+      expect(lines[idx + 1]).toBe("");
+    });
+
+    it("does NOT insert blank line between list items", () => {
+      const result = parseNfmForEditor("- a\n- b");
+      expect(result).toBe("- a\n- b");
+    });
+
+    it("inserts blank line after blockquote before non-blockquote", () => {
+      const result = parseNfmForEditor("parent\n\tchild\nnext paragraph");
+      // blockquote (> child) should be followed by blank line before "next paragraph"
+      expect(result).toMatch(/> child\n\nnext paragraph/);
+    });
+
+    it("inserts blank line before --- to prevent setext heading", () => {
+      const result = parseNfmForEditor("text\n---\nmore");
+      expect(result).toMatch(/text\n\n---/);
+    });
+
+    it("inserts blank line after </details>", () => {
+      const input = "<details>\n<summary>T</summary>\n\tx\n</details>\nnext";
+      const result = parseNfmForEditor(input);
+      expect(result).toMatch(/<\/details>\n\nnext/);
+    });
+  });
+
+  describe("code blocks are left untouched", () => {
+    it("preserves indentation inside code fences", () => {
+      const input = "```\n\tindented code\n\t\tmore\n```";
+      const result = parseNfmForEditor(input);
+      expect(result).toContain("\tindented code");
+      expect(result).toContain("\t\tmore");
+    });
+
+    it("does not convert empty-blocks inside code", () => {
+      const input = "```\n<empty-block/>\n```";
+      const result = parseNfmForEditor(input);
+      expect(result).toContain("<empty-block/>");
+    });
+  });
+
+  describe("HTML containers are left untouched in pass 2", () => {
+    it("does not rewrite content inside callout", () => {
+      const input = "<callout>\n\tindented\n</callout>";
+      const result = parseNfmForEditor(input);
+      expect(result).toContain("\tindented");
+    });
+  });
+
+  describe("mixed content", () => {
+    it("handles heading followed by list followed by indented text", () => {
+      const input = "## Heading\n- item\nplain\n\tindented";
+      const result = parseNfmForEditor(input);
+      expect(result).toContain("## Heading");
+      expect(result).toContain("- item");
+      expect(result).toContain("> indented");
+    });
+
+    it("handles empty input", () => {
+      expect(parseNfmForEditor("")).toBe("");
+    });
+
+    it("handles input with only empty blocks", () => {
+      const result = parseNfmForEditor(
+        "<empty-block/>\n<empty-block/>\n<empty-block/>",
+      );
+      expect(result).not.toContain("<empty-block");
+    });
+
+    it("preserves markdown links in indented text", () => {
+      const result = parseNfmForEditor("\t[link text](https://example.com)");
+      // Link text should be in a blockquote, preserving the markdown
+      expect(result).toContain("> [link text](https://example.com)");
+    });
+  });
+
+  describe("round-trip stability", () => {
+    it("preserves all content through conversion", () => {
+      const nfm =
+        "heading\n<empty-block/>\nparent\n\tchild\n- bullet\n\t- nested";
+      const result = parseNfmForEditor(nfm);
+      expect(result).toContain("heading");
+      expect(result).toContain("parent");
+      expect(result).toContain("child");
+      expect(result).toContain("bullet");
+      expect(result).toContain("nested");
+      expect(result).not.toContain("<empty-block");
+      expect(result).not.toMatch(/^\t/m);
+    });
+
+    it("preserves content structure through parse", () => {
+      const nfm =
+        "heading\n<empty-block/>\nparent\n\tchild\n- bullet\n\t- nested";
+      const result = parseNfmForEditor(nfm);
+      // All content should be present
+      expect(result).toContain("heading");
+      expect(result).toContain("parent");
+      expect(result).toContain("child");
+      expect(result).toContain("bullet");
+      expect(result).toContain("nested");
+      // NFM constructs should be gone
+      expect(result).not.toContain("<empty-block");
+      expect(result).not.toMatch(/^\t/m);
+    });
+  });
+});

--- a/templates/content/shared/notion-markdown.ts
+++ b/templates/content/shared/notion-markdown.ts
@@ -260,6 +260,7 @@ function inlineMarkdownToHtml(text: string): string {
 function nfmLinesToHtml(lines: string[]): string {
   const html: string[] = [];
   let openLevels = 0;
+  let inCodeFence = false;
 
   let baseIndent = Infinity;
   for (const line of lines) {
@@ -279,6 +280,33 @@ function nfmLinesToHtml(lines: string[]): string {
   for (const line of lines) {
     const trimmed = line.trim();
 
+    // Code fences — pass through as a <pre><code> block
+    if (CODE_FENCE_RE.test(trimmed)) {
+      if (!inCodeFence) {
+        closeLists();
+        const lang = trimmed.slice(3).trim();
+        html.push(
+          lang
+            ? `<pre><code class="language-${escapeHtml(lang)}">`
+            : "<pre><code>",
+        );
+      } else {
+        html.push("</code></pre>");
+      }
+      inCodeFence = !inCodeFence;
+      continue;
+    }
+    if (inCodeFence) {
+      html.push(
+        escapeHtml(
+          line.startsWith("\t".repeat(baseIndent))
+            ? line.slice(baseIndent)
+            : line,
+        ),
+      );
+      continue;
+    }
+
     if (!trimmed || /^<empty-block\b[^>]*\/>$/.test(trimmed)) {
       closeLists();
       continue;
@@ -288,8 +316,9 @@ function nfmLinesToHtml(lines: string[]): string {
     const depth = (indentMatch ? indentMatch[1].length : 0) - baseIndent;
     const content = (indentMatch ? indentMatch[2] : line).trim();
 
-    // HTML tags (nested <details>, <summary>, <callout>, etc.) → pass through
-    if (/^<\/?[\w]/.test(content)) {
+    // HTML element tags (nested <details>, <summary>, <callout>, etc.)
+    // Use [a-zA-Z] to avoid matching text like "<3"
+    if (/^<\/?[a-zA-Z]/.test(content)) {
       closeLists();
       html.push(content);
       continue;
@@ -444,8 +473,8 @@ function ensureParagraphSeparation(text: string): string {
       (/^>/.test(cur) && !/^>/.test(next)) ||
       // Before `---`/`***`/`___` (prevent setext H2 interpretation)
       (cur !== "" && !/^</.test(cur) && /^(---+|\*\*\*+|___+)$/.test(next)) ||
-      // After any HTML close tag (</details>, </callout>, </table>, etc.)
-      /^<\/\w+>/.test(cur);
+      // After block-level HTML close tags (not </li>, </ul>, etc.)
+      /^<\/(details|callout|table|columns|column)>/.test(cur);
 
     if (needsBlank) {
       result.push("");

--- a/templates/content/shared/notion-markdown.ts
+++ b/templates/content/shared/notion-markdown.ts
@@ -158,20 +158,23 @@ export function parseNfmForEditor(markdown: string): string {
  *   Pass 3 – Insert blank lines between consecutive plain-text paragraphs.
  */
 function convertNfmToEditorMarkdown(nfm: string): string {
-  let result = convertDetailsContentToHtml(nfm);
+  let result = convertHtmlContainerContent(nfm);
   result = convertNfmBlocks(result);
   result = ensureParagraphSeparation(result);
   return result;
 }
 
-// ── Pass 1: Convert <details> inner content to HTML ─────────────────
-// markdown-it doesn't parse markdown inside HTML blocks, so toggle body
-// content must be actual HTML elements for TipTap to render them.
-function convertDetailsContentToHtml(nfm: string): string {
+// ── Pass 1: Convert HTML container inner content to HTML ─────────────
+// markdown-it doesn't parse markdown inside HTML blocks, so content
+// inside <details> and <callout> must be actual HTML elements.
+const HTML_CONTENT_CONTAINERS = /^<(details|callout)\b/;
+const HTML_CONTENT_CLOSE = /^<\/(details|callout)>/;
+
+function convertHtmlContainerContent(nfm: string): string {
   const lines = nfm.split("\n");
   const output: string[] = [];
   let inCodeFence = false;
-  let detailsDepth = 0;
+  let containerDepth = 0;
   let capturedContent: string[] = [];
   let capturedOpen = "";
   let capturedSummary = "";
@@ -179,7 +182,7 @@ function convertDetailsContentToHtml(nfm: string): string {
   for (const line of lines) {
     const trimmed = line.trim();
 
-    if (CODE_FENCE_RE.test(trimmed) && detailsDepth === 0) {
+    if (CODE_FENCE_RE.test(trimmed) && containerDepth === 0) {
       inCodeFence = !inCodeFence;
       output.push(line);
       continue;
@@ -189,9 +192,10 @@ function convertDetailsContentToHtml(nfm: string): string {
       continue;
     }
 
-    if (/^<details\b/.test(trimmed) && !trimmed.endsWith("/>")) {
-      detailsDepth++;
-      if (detailsDepth === 1) {
+    // Opening tag for containers whose content needs HTML conversion
+    if (HTML_CONTENT_CONTAINERS.test(trimmed) && !trimmed.endsWith("/>")) {
+      containerDepth++;
+      if (containerDepth === 1) {
         capturedOpen = line;
         capturedSummary = "";
         capturedContent = [];
@@ -199,26 +203,32 @@ function convertDetailsContentToHtml(nfm: string): string {
       }
     }
 
-    if (detailsDepth === 1 && /^<summary>/.test(trimmed) && !capturedSummary) {
+    // <summary> only relevant for <details>
+    if (
+      containerDepth === 1 &&
+      /^<summary>/.test(trimmed) &&
+      !capturedSummary
+    ) {
       capturedSummary = line;
       continue;
     }
 
-    if (/^<\/details>/.test(trimmed)) {
-      if (detailsDepth === 1) {
+    // Closing tag
+    if (HTML_CONTENT_CLOSE.test(trimmed)) {
+      if (containerDepth === 1) {
         output.push(capturedOpen);
         if (capturedSummary) output.push(capturedSummary);
         const htmlContent = nfmLinesToHtml(capturedContent);
         if (htmlContent) output.push(htmlContent);
         output.push(line);
-      } else if (detailsDepth > 1) {
+      } else if (containerDepth > 1) {
         capturedContent.push(line);
       }
-      detailsDepth = Math.max(0, detailsDepth - 1);
+      containerDepth = Math.max(0, containerDepth - 1);
       continue;
     }
 
-    if (detailsDepth > 0) {
+    if (containerDepth > 0) {
       capturedContent.push(line);
       continue;
     }
@@ -426,8 +436,8 @@ function ensureParagraphSeparation(text: string): string {
       (/^>/.test(cur) && !/^>/.test(next)) ||
       // Before `---`/`***`/`___` (prevent setext H2 interpretation)
       (cur !== "" && !/^</.test(cur) && /^(---+|\*\*\*+|___+)$/.test(next)) ||
-      // After HTML close tags like </details>
-      /^<\/(details|callout|columns|column)>/.test(cur);
+      // After any HTML close tag (</details>, </callout>, </table>, etc.)
+      /^<\/\w+>/.test(cur);
 
     if (needsBlank) {
       result.push("");

--- a/templates/content/shared/notion-markdown.ts
+++ b/templates/content/shared/notion-markdown.ts
@@ -287,6 +287,14 @@ function nfmLinesToHtml(lines: string[]): string {
     const indentMatch = line.match(/^(\t*)(.*)/);
     const depth = (indentMatch ? indentMatch[1].length : 0) - baseIndent;
     const content = (indentMatch ? indentMatch[2] : line).trim();
+
+    // HTML tags (nested <details>, <summary>, <callout>, etc.) → pass through
+    if (/^<\/?[\w]/.test(content)) {
+      closeLists();
+      html.push(content);
+      continue;
+    }
+
     const listMatch = content.match(/^[-*+]\s+(.*)/);
 
     if (listMatch) {

--- a/templates/content/shared/notion-markdown.ts
+++ b/templates/content/shared/notion-markdown.ts
@@ -135,7 +135,319 @@ export function normalizeNfmForStorage(markdown: string): string {
 }
 
 export function parseNfmForEditor(markdown: string): string {
-  return normalizeNfmForStorage(markdown);
+  const normalized = normalizeNfmForStorage(markdown);
+  return convertNfmToEditorMarkdown(normalized);
+}
+
+/**
+ * Convert Notion-flavored markdown (NFM) to standard markdown that
+ * TipTap/markdown-it can parse.
+ *
+ * Three issues with raw NFM in a standard markdown parser:
+ *
+ * 1. `<empty-block/>` has no TipTap extension → adjacent blocks merge.
+ * 2. A leading tab triggers an indented code block, not visual nesting.
+ * 3. Content inside `<details>` is treated as raw HTML by markdown-it,
+ *    so tab-indented markdown inside toggles is never parsed.
+ * 4. Notion treats every line as a separate block, but consecutive lines
+ *    without blank-line separation are one paragraph in standard markdown.
+ *
+ * The conversion runs in three passes:
+ *   Pass 1 – Convert `<details>` inner content from NFM to HTML.
+ *   Pass 2 – Rewrite `<empty-block/>` → blank lines, tabs → list items.
+ *   Pass 3 – Insert blank lines between consecutive plain-text paragraphs.
+ */
+function convertNfmToEditorMarkdown(nfm: string): string {
+  let result = convertDetailsContentToHtml(nfm);
+  result = convertNfmBlocks(result);
+  result = ensureParagraphSeparation(result);
+  return result;
+}
+
+// ── Pass 1: Convert <details> inner content to HTML ─────────────────
+// markdown-it doesn't parse markdown inside HTML blocks, so toggle body
+// content must be actual HTML elements for TipTap to render them.
+function convertDetailsContentToHtml(nfm: string): string {
+  const lines = nfm.split("\n");
+  const output: string[] = [];
+  let inCodeFence = false;
+  let detailsDepth = 0;
+  let capturedContent: string[] = [];
+  let capturedOpen = "";
+  let capturedSummary = "";
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (CODE_FENCE_RE.test(trimmed) && detailsDepth === 0) {
+      inCodeFence = !inCodeFence;
+      output.push(line);
+      continue;
+    }
+    if (inCodeFence) {
+      output.push(line);
+      continue;
+    }
+
+    if (/^<details\b/.test(trimmed) && !trimmed.endsWith("/>")) {
+      detailsDepth++;
+      if (detailsDepth === 1) {
+        capturedOpen = line;
+        capturedSummary = "";
+        capturedContent = [];
+        continue;
+      }
+    }
+
+    if (detailsDepth === 1 && /^<summary>/.test(trimmed) && !capturedSummary) {
+      capturedSummary = line;
+      continue;
+    }
+
+    if (/^<\/details>/.test(trimmed)) {
+      if (detailsDepth === 1) {
+        output.push(capturedOpen);
+        if (capturedSummary) output.push(capturedSummary);
+        const htmlContent = nfmLinesToHtml(capturedContent);
+        if (htmlContent) output.push(htmlContent);
+        output.push(line);
+      } else if (detailsDepth > 1) {
+        capturedContent.push(line);
+      }
+      detailsDepth = Math.max(0, detailsDepth - 1);
+      continue;
+    }
+
+    if (detailsDepth > 0) {
+      capturedContent.push(line);
+      continue;
+    }
+
+    output.push(line);
+  }
+
+  return output.join("\n");
+}
+
+/** Convert common inline markdown (bold, italic, code, links) to HTML. */
+function inlineMarkdownToHtml(text: string): string {
+  let result = escapeHtml(text);
+  // Order matters: bold before italic to handle **bold *nested*** correctly
+  result = result.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  result = result.replace(/\*(.+?)\*/g, "<em>$1</em>");
+  result = result.replace(/~~(.+?)~~/g, "<s>$1</s>");
+  result = result.replace(/`([^`]+)`/g, "<code>$1</code>");
+  // Links: [text](url) — need to unescape the HTML entities in href
+  result = result.replace(
+    /\[([^\]]+)\]\(([^)]+)\)/g,
+    (_m, label, href) =>
+      `<a href="${href.replace(/&amp;/g, "&")}">${label}</a>`,
+  );
+  return result;
+}
+
+/** Convert NFM lines (tab-indented, with optional list markers) to HTML. */
+function nfmLinesToHtml(lines: string[]): string {
+  const html: string[] = [];
+  let openLevels = 0;
+
+  let baseIndent = Infinity;
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const m = line.match(/^(\t*)/);
+    if (m) baseIndent = Math.min(baseIndent, m[1].length);
+  }
+  if (!isFinite(baseIndent)) baseIndent = 0;
+
+  const closeLists = () => {
+    while (openLevels > 0) {
+      html.push("</li></ul>");
+      openLevels--;
+    }
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!trimmed || /^<empty-block\b[^>]*\/>$/.test(trimmed)) {
+      closeLists();
+      continue;
+    }
+
+    const indentMatch = line.match(/^(\t*)(.*)/);
+    const depth = (indentMatch ? indentMatch[1].length : 0) - baseIndent;
+    const content = (indentMatch ? indentMatch[2] : line).trim();
+    const listMatch = content.match(/^[-*+]\s+(.*)/);
+
+    if (listMatch) {
+      const text = listMatch[1].trim();
+      const target = depth + 1;
+
+      while (openLevels > target) {
+        html.push("</li></ul>");
+        openLevels--;
+      }
+      if (openLevels === target) {
+        html.push("</li>");
+      }
+      while (openLevels < target) {
+        html.push("<ul>");
+        openLevels++;
+      }
+
+      html.push(`<li>${inlineMarkdownToHtml(text)}`);
+    } else {
+      closeLists();
+      // Plain text — use nested <blockquote> for indentation
+      let tag = `<p>${inlineMarkdownToHtml(content)}</p>`;
+      for (let i = 0; i < depth; i++) {
+        tag = `<blockquote>${tag}</blockquote>`;
+      }
+      html.push(tag);
+    }
+  }
+
+  closeLists();
+  return html.join("\n");
+}
+
+// ── Pass 2: Rewrite remaining NFM constructs ────────────────────────
+function convertNfmBlocks(text: string): string {
+  const lines = text.split("\n");
+  const result: string[] = [];
+  let inCodeFence = false;
+  let htmlDepth = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (CODE_FENCE_RE.test(trimmed) && htmlDepth === 0) {
+      inCodeFence = !inCodeFence;
+      result.push(line);
+      continue;
+    }
+    if (inCodeFence) {
+      result.push(line);
+      continue;
+    }
+
+    // Track HTML containers so we don't rewrite their content
+    if (
+      /^<(details|callout|columns|column)\b/.test(trimmed) &&
+      !trimmed.endsWith("/>")
+    ) {
+      htmlDepth++;
+      result.push(line);
+      continue;
+    }
+    if (/^<\/(details|callout|columns|column)>/.test(trimmed)) {
+      htmlDepth = Math.max(0, htmlDepth - 1);
+      result.push(line);
+      continue;
+    }
+    if (htmlDepth > 0) {
+      result.push(line);
+      continue;
+    }
+
+    // <empty-block/> → visible empty paragraph (preserves Notion's vertical spacing)
+    if (/^<empty-block\b[^>]*\/>$/.test(trimmed)) {
+      result.push("");
+      result.push("&nbsp;");
+      result.push("");
+      continue;
+    }
+
+    // Tab-indented lines → standard markdown
+    const indentMatch = line.match(/^(\t+)(.*)/);
+    if (indentMatch) {
+      const depth = indentMatch[1].length;
+      const content = (indentMatch[2] ?? "").trim();
+
+      if (!content) {
+        result.push("");
+        continue;
+      }
+
+      // Already a list/task item → re-indent with spaces
+      // Use 4 spaces per level so numbered list nesting works in CommonMark
+      if (
+        /^[-*+]\s/.test(content) ||
+        /^\d+\.\s/.test(content) ||
+        /^\[[ x]]\s/i.test(content)
+      ) {
+        result.push("    ".repeat(depth) + content);
+        continue;
+      }
+
+      // HTML tag → keep as space-indented HTML
+      if (/^</.test(content)) {
+        result.push("  ".repeat(depth) + content);
+        continue;
+      }
+
+      // Plain indented text → blockquote (Notion-style indent, no bullet)
+      // Separate from previous non-blank line so each becomes its own block
+      if (result.length > 0 && result[result.length - 1].trim() !== "") {
+        result.push("");
+      }
+      result.push("> ".repeat(depth) + content);
+      continue;
+    }
+
+    result.push(line);
+  }
+
+  return result.join("\n");
+}
+
+// ── Pass 3: Paragraph separation ────────────────────────────────────
+// Ensures every Notion block becomes its own element in the editor.
+// Without this, consecutive text lines merge into one paragraph,
+// blockquote content leaks via lazy continuation, and `---` after
+// text becomes a setext H2 heading.
+function ensureParagraphSeparation(text: string): string {
+  const lines = text.split("\n");
+  const result: string[] = [];
+  let inCodeFence = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const cur = lines[i].trim();
+    const next = i < lines.length - 1 ? lines[i + 1].trim() : "";
+
+    if (CODE_FENCE_RE.test(cur)) inCodeFence = !inCodeFence;
+    result.push(lines[i]);
+    if (inCodeFence || !next) continue;
+
+    const needsBlank =
+      // Two consecutive plain-text lines → separate paragraphs
+      (isPlainTextLine(cur) && isPlainTextLine(next)) ||
+      // Blockquote → non-blockquote (prevent lazy continuation)
+      (/^>/.test(cur) && !/^>/.test(next)) ||
+      // Before `---`/`***`/`___` (prevent setext H2 interpretation)
+      (cur !== "" && !/^</.test(cur) && /^(---+|\*\*\*+|___+)$/.test(next)) ||
+      // After HTML close tags like </details>
+      /^<\/(details|callout|columns|column)>/.test(cur);
+
+    if (needsBlank) {
+      result.push("");
+    }
+  }
+
+  return result.join("\n");
+}
+
+function isPlainTextLine(trimmed: string): boolean {
+  if (!trimmed) return false;
+  if (/^#{1,6}\s/.test(trimmed)) return false;
+  if (/^[-*+]\s/.test(trimmed)) return false;
+  if (/^\d+\.\s/.test(trimmed)) return false;
+  if (/^>/.test(trimmed)) return false;
+  if (/^\|/.test(trimmed)) return false;
+  if (/^```/.test(trimmed)) return false;
+  if (/^</.test(trimmed)) return false;
+  if (/^(---+|\*\*\*+|___+)$/.test(trimmed)) return false;
+  return true;
 }
 
 export function serializeEditorToNfm(markdown: string): string {


### PR DESCRIPTION
## Summary

- **Rewrites `parseNfmForEditor()`** with a 3-pass NFM→markdown conversion that faithfully reproduces Notion's visual structure in the TipTap editor
- **Fixes toggle lists**: collapsed by default with Tabler chevron icons, click to expand/collapse, no box border
- **Fixes crash**: `serializeInnerMarkdown` null-safe when editor not yet attached
- **Fixes list nesting CSS**: bullet disc→circle→square, numbered decimal→lower-alpha→lower-roman
- **Adds 31 unit tests** for `parseNfmForEditor` edge cases

## What was broken

The Notion import rendered all content as a single blob of text — `<empty-block/>` tags, tab indentation, toggle content, and consecutive text blocks all collapsed together. Toggle lists showed expanded with a big box border. Nested list bullets all used the same style.

## Test plan

- [x] Kitchen sink Notion page with all block types (headings, bullets, numbered, tasks, toggles, indented text, code blocks, dividers, mixed content, inline formatting)
- [x] Builder Todo live page import comparison
- [x] Toggle expand/collapse interactions
- [x] DB content preserved in NFM format after page load (no round-trip corruption)
- [x] 35 unit tests passing (31 new + 4 existing)
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)