### PR TITLE
fix: calendar HTML descriptions, mail improvements, desktop updates

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: babysit-pr
+description: Monitor a PR, fix feedback and CI failures until fully green for 30 min. Run with /babysit-pr <number>
+user_invocable: true
+---
+
+Monitor PR #$ARGUMENTS in the current repo. Fix CI failures and review feedback until everything is green and no new feedback arrives for 30 minutes.
+
+**If no PR number is given**, auto-detect it: get the current branch (`git branch --show-current`), find the open PR for it (`gh pr list --head <branch> --state open --json number --limit 1`). If no open PR exists, check recent merged/closed PRs. Only ask the user if no PR can be found.
+
+## Setup
+
+1. Start a `/loop 1m` that checks for new feedback and CI status every minute
+2. Track when the last actionable item (new feedback or CI fix) occurred
+3. After 30 minutes of no new actionable items with GitHub Actions CI green, cancel the loop and report "All clear"
+
+## Each tick
+
+1. Check for new review comments from bots:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments --jq '.[] | select(.user.type == "Bot") | select(.created_at > "<30min_ago>") | {id, path: .path, body: .body[0:300]}'
+   ```
+
+2. Check CI status:
+   ```bash
+   gh pr checks $ARGUMENTS
+   ```
+
+3. **If new bot comments with real bugs** (confidence >= 75):
+   - Read the relevant files
+   - Fix the issues
+   - Run `pnpm run prep` to verify locally
+   - Commit and push
+   - Reset the 30-min timer
+
+4. **If GitHub Actions CI is failing** (lint, test, typecheck, build):
+   - Investigate the failure logs
+   - Fix the root cause
+   - Run `pnpm run prep` locally
+   - Commit and push
+   - Reset the 30-min timer
+
+5. **If only external CI fails** (Cloudflare Workers, Netlify, etc.) and GitHub Actions passes:
+   - Note the failure but don't block on it — these may need dashboard config changes
+   - Do NOT reset the 30-min timer for external-only failures
+
+6. **If everything green + no new feedback for 30 min**: cancel the loop, report done
+
+## Responding to feedback
+
+**Every comment must get a response** — either a fix or a reply explaining why you're skipping it.
+
+- If you fix it: commit, push, and the fix speaks for itself
+- If you skip it: reply to the comment via `gh api repos/{owner}/{repo}/pulls/comments/{id}/replies -f body="..."` explaining why (pre-existing, false positive, not practical, etc.)
+- Never silently ignore a comment
+
+## Evaluating feedback — be skeptical
+
+Skip (with a reply explaining why) issues that are:
+- Pre-existing (not introduced by this PR)
+- False positives / don't hold up to scrutiny
+- Nitpicks a senior engineer wouldn't flag
+- Things linter/typechecker catches (CI handles those)
+- Style/formatting issues
+- Already addressed in a previous commit
+
+Fix issues that are:
+- Real runtime bugs introduced by this PR
+- Security issues
+- CLAUDE.md violations
+- Data loss risks
+
+## Stop conditions
+
+- No new actionable feedback AND GitHub Actions green for 30 consecutive minutes
+- PR is merged or closed

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -375,6 +375,7 @@ export default function App() {
           />
           <button
             type="button"
+            tabIndex={-1}
             className="find-button"
             onClick={() =>
               runFind(findQuery, { findNext: true, forward: false })
@@ -384,6 +385,7 @@ export default function App() {
           </button>
           <button
             type="button"
+            tabIndex={-1}
             className="find-button"
             onClick={() =>
               runFind(findQuery, { findNext: true, forward: true })
@@ -393,6 +395,7 @@ export default function App() {
           </button>
           <button
             type="button"
+            tabIndex={-1}
             className="find-button find-button--close"
             onClick={closeFind}
           >

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -173,6 +173,19 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isActive]);
 
+    // Auto-focus the webview when it becomes active so keyboard events
+    // (e.g. Tab to cycle mail filters) go to the app, not the shell.
+    useEffect(() => {
+      if (isActive && !app.placeholder && !error) {
+        const wv = webviewRef.current;
+        if (wv) {
+          // Small delay to ensure the webview is ready to accept focus
+          const timer = setTimeout(() => wv.focus(), 50);
+          return () => clearTimeout(timer);
+        }
+      }
+    }, [isActive, app.placeholder, error]);
+
     useEffect(() => {
       reportActiveWebview();
     }, [isActive, url]);
@@ -186,7 +199,16 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
     }
 
     return (
-      <div className={`webview-slot${isActive ? "" : " webview-slot--hidden"}`}>
+      <div
+        className={`webview-slot${isActive ? "" : " webview-slot--hidden"}`}
+        onClick={() => {
+          // Re-focus the webview when clicking the content area so
+          // keyboard shortcuts (Tab, etc.) route into the app.
+          if (isActive && !app.placeholder && !error) {
+            webviewRef.current?.focus();
+          }
+        }}
+      >
         {app.placeholder && <PlaceholderScreen app={app} />}
 
         {!app.placeholder && error && (

--- a/packages/desktop-app/src/renderer/components/Sidebar.tsx
+++ b/packages/desktop-app/src/renderer/components/Sidebar.tsx
@@ -47,16 +47,19 @@ export default function Sidebar({
       <div className="win-controls">
         <button
           className="win-btn win-btn--close"
+          tabIndex={-1}
           onClick={() => window.electronAPI?.windowControls.close()}
           title="Close"
         />
         <button
           className="win-btn win-btn--minimize"
+          tabIndex={-1}
           onClick={() => window.electronAPI?.windowControls.minimize()}
           title="Minimize"
         />
         <button
           className="win-btn win-btn--maximize"
+          tabIndex={-1}
           onClick={() => window.electronAPI?.windowControls.maximize()}
           title="Maximize"
         />
@@ -79,6 +82,7 @@ export default function Sidebar({
         <div className="sidebar-footer">
           <button
             className="sidebar-item"
+            tabIndex={-1}
             onClick={onSettingsClick}
             title="App Settings"
             aria-label="Settings"
@@ -108,6 +112,7 @@ function SidebarItem({ app, isActive, onClick }: SidebarItemProps) {
   return (
     <button
       className={`sidebar-item${isActive ? " sidebar-item--active" : ""}`}
+      tabIndex={-1}
       onClick={onClick}
       title={app.description}
       aria-label={app.name}

--- a/packages/desktop-app/src/renderer/components/TabBar.tsx
+++ b/packages/desktop-app/src/renderer/components/TabBar.tsx
@@ -53,6 +53,7 @@ export default function TabBar({
           <button
             key={tab.id}
             className={`tab${isActive ? " tab--active" : ""}`}
+            tabIndex={-1}
             onClick={() => onTabSelect(tab.id)}
             onMouseDown={(e) => {
               // Middle-click to close
@@ -78,7 +79,12 @@ export default function TabBar({
           </button>
         );
       })}
-      <button className="tab-new" onClick={onNewTab} title="New tab">
+      <button
+        className="tab-new"
+        tabIndex={-1}
+        onClick={onNewTab}
+        title="New tab"
+      >
         <IconPlus size={14} strokeWidth={1.75} />
       </button>
     </div>

--- a/templates/analytics/app/lib/data-sources.ts
+++ b/templates/analytics/app/lib/data-sources.ts
@@ -40,6 +40,8 @@ export interface WalkthroughStep {
   inputLabel?: string;
   inputPlaceholder?: string;
   inputType?: "text" | "password" | "textarea";
+  /** Allow file upload for this input (e.g. ".json") */
+  inputAcceptFile?: string;
 }
 
 export interface DataSource {
@@ -103,25 +105,26 @@ export const dataSources: DataSource[] = [
       {
         title: "Create a service account",
         description:
-          "Go to IAM & Admin > Service Accounts, create a new service account, and download the JSON key file.",
+          "Go to IAM & Admin > Service Accounts, create a new service account (no IAM roles needed on the project), then click the account → Keys → Add Key → Create new key → JSON. This downloads a .json file.",
         url: "https://console.cloud.google.com/iam-admin/serviceaccounts",
         linkText: "Service Accounts",
       },
       {
         title: "Add the service account to GA4",
         description:
-          "In Google Analytics, go to Admin > Property Access Management and add the service account email as a Viewer.",
+          'In Google Analytics, go to Admin > Property Access Management and add the service account email (from the JSON file\'s "client_email" field) with the Viewer role. This is what grants access — not IAM roles.',
         url: "https://analytics.google.com/analytics/web/#/a-p/admin",
         linkText: "GA4 Admin",
       },
       {
-        title: "Enter your service account credentials",
+        title: "Upload your service account credentials",
         description:
-          "Paste the contents of your service account JSON key file.",
+          "Upload the JSON key file you downloaded, or paste its contents.",
         inputKey: "GOOGLE_APPLICATION_CREDENTIALS_JSON",
         inputLabel: "Service Account JSON",
         inputPlaceholder: '{"type": "service_account", ...}',
         inputType: "textarea",
+        inputAcceptFile: ".json",
       },
       {
         title: "Enter your GA4 Property ID",
@@ -159,18 +162,19 @@ export const dataSources: DataSource[] = [
       {
         title: "Create a service account",
         description:
-          'Create a service account with "BigQuery Data Viewer" and "BigQuery Job User" roles, then download the JSON key.',
+          'Create a service account with "BigQuery Data Viewer" and "BigQuery Job User" IAM roles, then go to Keys → Add Key → Create new key → JSON to download the credentials file.',
         url: "https://console.cloud.google.com/iam-admin/serviceaccounts",
         linkText: "Service Accounts",
       },
       {
-        title: "Enter your service account credentials",
+        title: "Upload your service account credentials",
         description:
-          "Paste the contents of your service account JSON key file.",
+          "Upload the JSON key file you downloaded, or paste its contents.",
         inputKey: "GOOGLE_APPLICATION_CREDENTIALS_JSON",
         inputLabel: "Service Account JSON",
         inputPlaceholder: '{"type": "service_account", ...}',
         inputType: "textarea",
+        inputAcceptFile: ".json",
       },
       {
         title: "Enter your BigQuery Project ID",
@@ -579,13 +583,14 @@ export const dataSources: DataSource[] = [
         linkText: "Service Accounts",
       },
       {
-        title: "Enter your service account credentials",
+        title: "Upload your service account credentials",
         description:
-          "Paste the contents of your service account JSON key file.",
+          "Upload the JSON key file you downloaded, or paste its contents.",
         inputKey: "GOOGLE_APPLICATION_CREDENTIALS_JSON",
         inputLabel: "Service Account JSON",
         inputPlaceholder: '{"type": "service_account", ...}',
         inputType: "textarea",
+        inputAcceptFile: ".json",
       },
     ],
   },

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -18,6 +18,7 @@ import {
   IconCircle,
   IconCopy,
   IconAlertCircle,
+  IconUpload,
 } from "@tabler/icons-react";
 import { getIdToken } from "@/lib/auth";
 import {
@@ -103,6 +104,20 @@ function StepItem({
 }) {
   const [copied, setCopied] = useState(false);
 
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !step.inputKey) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        onInputChange(step.inputKey!, reader.result);
+      }
+    };
+    reader.readAsText(file);
+    // Reset so the same file can be re-selected
+    e.target.value = "";
+  };
+
   return (
     <div className="flex gap-3 py-3">
       <div className="flex flex-col items-center">
@@ -139,9 +154,23 @@ function StepItem({
         )}
         {step.inputKey && (
           <div className="space-y-1.5 pt-1">
-            <label className="text-xs font-medium text-muted-foreground">
-              {step.inputLabel || step.inputKey}
-            </label>
+            <div className="flex items-center justify-between">
+              <label className="text-xs font-medium text-muted-foreground">
+                {step.inputLabel || step.inputKey}
+              </label>
+              {step.inputAcceptFile && (
+                <label className="inline-flex items-center gap-1.5 text-xs text-primary hover:text-primary/80 cursor-pointer">
+                  <IconUpload className="h-3 w-3" />
+                  Upload file
+                  <input
+                    type="file"
+                    accept={step.inputAcceptFile}
+                    onChange={handleFileUpload}
+                    className="hidden"
+                  />
+                </label>
+              )}
+            </div>
             {step.inputType === "textarea" ? (
               <textarea
                 value={inputValues[step.inputKey] || ""}

--- a/templates/calendar/app/components/calendar/EventAttendeesSection.tsx
+++ b/templates/calendar/app/components/calendar/EventAttendeesSection.tsx
@@ -7,9 +7,20 @@ import {
 } from "@tabler/icons-react";
 import type { CalendarEvent } from "@shared/api";
 import { AttendeeApolloPopover } from "@/components/calendar/ApolloPanel";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { useAttendeePhotos } from "@/hooks/use-attendee-photos";
 import { useRsvpEvent } from "@/hooks/use-events";
 import { cn } from "@/lib/utils";
+
+type RecurringScope = "single" | "all" | "thisAndFollowing";
 
 type Attendee = NonNullable<CalendarEvent["attendees"]>[number];
 type RsvpStatus = "accepted" | "declined" | "tentative" | "needsAction";
@@ -80,13 +91,20 @@ function RsvpControls({
   accountEmail,
   value,
   onChange,
+  isRecurring,
 }: {
   eventId: string;
   accountEmail?: string;
   value: RsvpStatus;
   onChange: (status: RsvpStatus) => void;
+  isRecurring?: boolean;
 }) {
   const mutation = useRsvpEvent();
+  const [pendingStatus, setPendingStatus] = useState<Exclude<
+    RsvpStatus,
+    "needsAction"
+  > | null>(null);
+
   const options: Array<{
     value: Exclude<RsvpStatus, "needsAction">;
     label: string;
@@ -96,50 +114,105 @@ function RsvpControls({
     { value: "tentative", label: "Maybe" },
   ];
 
-  const handleRsvp = (status: Exclude<RsvpStatus, "needsAction">) => {
-    if (mutation.isPending || value === status) return;
+  const doRsvp = (
+    status: Exclude<RsvpStatus, "needsAction">,
+    scope?: RecurringScope,
+  ) => {
     const previous = value;
     onChange(status);
     mutation.mutate(
-      {
-        id: eventId,
-        status,
-        accountEmail,
-      },
-      {
-        onError: () => {
-          onChange(previous);
-        },
-      },
+      { id: eventId, status, accountEmail, scope },
+      { onError: () => onChange(previous) },
     );
   };
 
+  const handleRsvp = (status: Exclude<RsvpStatus, "needsAction">) => {
+    if (mutation.isPending || value === status) return;
+    if (isRecurring) {
+      setPendingStatus(status);
+    } else {
+      doRsvp(status);
+    }
+  };
+
   return (
-    <div className="mt-2 flex items-center gap-1 rounded-2xl bg-muted/60 p-1">
-      {options.map((option) => {
-        const active = value === option.value;
-        return (
-          <button
-            key={option.value}
-            type="button"
-            disabled={mutation.isPending}
-            onClick={(e) => {
-              e.stopPropagation();
-              handleRsvp(option.value);
-            }}
-            className={cn(
-              "min-w-0 flex-1 rounded-xl px-3 py-2 text-sm font-medium transition-colors",
-              active
-                ? "bg-background text-foreground shadow-sm ring-1 ring-border"
-                : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
-              mutation.isPending && "opacity-60",
-            )}
-          >
-            {option.label}
-          </button>
-        );
-      })}
-    </div>
+    <>
+      <div className="mt-2 flex items-center gap-1 rounded-2xl bg-muted/60 p-1">
+        {options.map((option) => {
+          const active = value === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              disabled={mutation.isPending}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleRsvp(option.value);
+              }}
+              className={cn(
+                "min-w-0 flex-1 rounded-xl px-3 py-2 text-sm font-medium transition-colors",
+                active
+                  ? "bg-background text-foreground shadow-sm ring-1 ring-border"
+                  : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
+                mutation.isPending && "opacity-60",
+              )}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <AlertDialog
+        open={!!pendingStatus}
+        onOpenChange={(open) => !open && setPendingStatus(null)}
+      >
+        <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>This is a recurring event</AlertDialogTitle>
+            <AlertDialogDescription>
+              Would you like to change your response for just this event, this
+              and all following events, or all events in the series?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col gap-2 sm:flex-col">
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={(e) => {
+                e.stopPropagation();
+                doRsvp(pendingStatus!, "single");
+                setPendingStatus(null);
+              }}
+            >
+              This event
+            </Button>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={(e) => {
+                e.stopPropagation();
+                doRsvp(pendingStatus!, "thisAndFollowing");
+                setPendingStatus(null);
+              }}
+            >
+              This and following events
+            </Button>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={(e) => {
+                e.stopPropagation();
+                doRsvp(pendingStatus!, "all");
+                setPendingStatus(null);
+              }}
+            >
+              All events
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
 
@@ -150,6 +223,7 @@ function AttendeeRow({
   inlineRsvp,
   currentStatus,
   onStatusChange,
+  isRecurring,
 }: {
   attendee: Attendee;
   event: Pick<CalendarEvent, "id" | "accountEmail">;
@@ -157,6 +231,7 @@ function AttendeeRow({
   inlineRsvp?: boolean;
   currentStatus?: RsvpStatus;
   onStatusChange?: (status: Exclude<RsvpStatus, "needsAction">) => void;
+  isRecurring?: boolean;
 }) {
   return (
     <AttendeeApolloPopover attendee={attendee}>
@@ -194,6 +269,7 @@ function AttendeeRow({
             accountEmail={event.accountEmail}
             value={currentStatus}
             onChange={onStatusChange}
+            isRecurring={isRecurring}
           />
         )}
       </div>
@@ -216,7 +292,12 @@ export function EventAttendeesSection({
 }: {
   event: Pick<
     CalendarEvent,
-    "id" | "accountEmail" | "attendees" | "responseStatus" | "source"
+    | "id"
+    | "accountEmail"
+    | "attendees"
+    | "responseStatus"
+    | "source"
+    | "recurringEventId"
   >;
 }) {
   const attendees = event.attendees ?? [];
@@ -306,6 +387,7 @@ export function EventAttendeesSection({
                   inlineRsvp={event.source === "google"}
                   currentStatus={selfStatus}
                   onStatusChange={setSelfStatus}
+                  isRecurring={!!event.recurringEventId}
                 />
               </>
             )}

--- a/templates/calendar/app/components/calendar/EventDetailPanel.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPanel.tsx
@@ -26,6 +26,7 @@ import type { CalendarEvent } from "@shared/api";
 import { ResearchMeetingButton } from "@/components/calendar/ApolloPanel";
 import { EventAttendeesSection } from "@/components/calendar/EventAttendeesSection";
 import { useCalendarContext } from "@/components/layout/AppLayout";
+import { sanitizeHtml, stripGcalInviteHtml } from "@/lib/sanitize-description";
 
 interface EventDetailPanelProps {
   event: CalendarEvent | null;
@@ -142,33 +143,22 @@ export function EventDetailPanel({
                   </div>
                 )}
 
-                {/* Description — strip HTML and gcal invitation cruft */}
+                {/* Description — sanitize HTML and strip gcal invitation cruft */}
                 {event.description &&
                   (() => {
                     const hasHtml = /<[a-z][\s\S]*>/i.test(event.description);
                     if (hasHtml) {
-                      // Strip gcal invitation HTML and extract text
-                      const text = event.description
-                        .replace(/<style[\s\S]*?<\/style>/gi, "")
-                        .replace(/<[^>]+>/g, " ")
-                        .replace(/&nbsp;/g, " ")
-                        .replace(/&amp;/g, "&")
-                        .replace(/&lt;/g, "<")
-                        .replace(/&gt;/g, ">")
-                        .replace(/\s+/g, " ")
-                        .trim();
-                      // Skip if it's just Google Calendar boilerplate
-                      if (
-                        !text ||
-                        /^(Invitation from Google Calendar|Reply for|View all guest info)/i.test(
-                          text,
-                        )
-                      )
-                        return null;
+                      const cleanedHtml = stripGcalInviteHtml(
+                        sanitizeHtml(event.description),
+                      );
+                      const hasContent =
+                        cleanedHtml.replace(/<[^>]*>/g, "").trim().length > 0;
+                      if (!hasContent) return null;
                       return (
-                        <p className="rounded-md bg-muted/50 px-3 py-2.5 text-sm leading-relaxed text-foreground whitespace-pre-wrap">
-                          {text}
-                        </p>
+                        <div
+                          className="rounded-md bg-muted/50 px-3 py-2.5 text-sm leading-relaxed text-foreground prose prose-sm dark:prose-invert prose-p:my-1 prose-a:text-primary"
+                          dangerouslySetInnerHTML={{ __html: cleanedHtml }}
+                        />
                       );
                     }
                     return (

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -28,6 +28,11 @@ import type { CalendarEvent } from "@shared/api";
 import { ResearchMeetingButton } from "@/components/calendar/ApolloPanel";
 import { EventAttendeesSection } from "@/components/calendar/EventAttendeesSection";
 import { useCalendarContext } from "@/components/layout/AppLayout";
+import {
+  sanitizeHtml,
+  stripGcalInviteHtml,
+  isHtml,
+} from "@/lib/sanitize-description";
 
 function formatDuration(start: string, end: string): string {
   const totalMinutes = differenceInMinutes(parseISO(end), parseISO(start));
@@ -46,95 +51,6 @@ function formatTimeShort(dateStr: string): string {
   const hour12 = h % 12 || 12;
   if (m === 0) return `${hour12} ${period}`;
   return `${hour12}:${m.toString().padStart(2, "0")} ${period}`;
-}
-
-/** Sanitize HTML: strip script tags and on* event handlers */
-function sanitizeHtml(html: string): string {
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<script[\s\S]*?>/gi, "")
-    .replace(/\bon\w+\s*=\s*"[^"]*"/gi, "")
-    .replace(/\bon\w+\s*=\s*'[^']*'/gi, "")
-    .replace(/\bon\w+\s*=\s*[^\s>]*/gi, "");
-}
-
-/**
- * Strip Google Calendar invitation boilerplate from event descriptions.
- * GCal embeds the full invitation HTML (guest list, RSVP buttons, "More options",
- * meeting details, "Invitation from Google Calendar" footer) into the description.
- * We render all of that natively, so strip it out to avoid ugly duplication.
- */
-function stripGcalInviteHtml(html: string): string {
-  let cleaned = html;
-
-  // Remove "Reply for <email>" section with Yes/No/Maybe buttons
-  // This covers the RSVP table/block that Google Calendar injects
-  cleaned = cleaned.replace(
-    /<(table|div)[^>]*>[\s\S]*?Reply\s+for[\s\S]*?<\/(table|div)>/gi,
-    "",
-  );
-
-  // Remove standalone Yes/No/Maybe buttons (various Google formats)
-  cleaned = cleaned.replace(
-    /<(table|div)[^>]*>[\s\S]*?(?:>Yes<|>No<|>Maybe<)[\s\S]*?<\/(table|div)>/gi,
-    "",
-  );
-
-  // Remove "More options" link/button
-  cleaned = cleaned.replace(/<a[^>]*>[\s]*More\s+options[\s]*<\/a>/gi, "");
-  cleaned = cleaned.replace(
-    /<(table|div)[^>]*>[\s\S]*?More\s+options[\s\S]*?<\/(table|div)>/gi,
-    "",
-  );
-
-  // Remove "Invitation from Google Calendar" footer
-  cleaned = cleaned.replace(
-    /Invitation\s+from\s+<a[^>]*>Google\s+Calendar<\/a>/gi,
-    "",
-  );
-  cleaned = cleaned.replace(/Invitation\s+from\s+Google\s+Calendar/gi, "");
-
-  // Remove "You are receiving this email" disclaimer
-  cleaned = cleaned.replace(/You\s+are\s+receiving\s+this[\s\S]*?$/gi, "");
-
-  // Remove "View all guest info" links
-  cleaned = cleaned.replace(
-    /<a[^>]*>[\s]*View\s+all\s+guest\s+info[\s]*<\/a>/gi,
-    "",
-  );
-
-  // Remove the "When" / "Guests" sections that duplicate our native UI
-  cleaned = cleaned.replace(
-    /<b>When<\/b>[\s\S]*?(?=<b>|<hr|<br\s*\/?>[\s]*<br\s*\/?>|$)/gi,
-    "",
-  );
-
-  // Remove "Join Zoom Meeting" / "Join by phone" blocks that duplicate our meeting link
-  cleaned = cleaned.replace(
-    /<b>Join\s+Zoom\s+Meeting<\/b>[\s\S]*?(?=<b>Joining\s+notes|<hr|<br\s*\/?>[\s]*<br\s*\/?>[\s]*<br|$)/gi,
-    "",
-  );
-  cleaned = cleaned.replace(
-    /<b>Join\s+by\s+phone<\/b>[\s\S]*?(?=<b>|<hr|$)/gi,
-    "",
-  );
-
-  // Remove "Joining instructions" links
-  cleaned = cleaned.replace(
-    /<a[^>]*>[\s]*Joining\s+instructions[\s]*<\/a>/gi,
-    "",
-  );
-
-  // Clean up leftover separators and whitespace
-  cleaned = cleaned.replace(/(<hr\s*\/?>[\s]*){2,}/gi, "<hr/>");
-  cleaned = cleaned.replace(/(<br\s*\/?>[\s]*){4,}/gi, "<br/><br/>");
-  cleaned = cleaned.replace(/([-─]{5,}[\s]*){2,}/g, "");
-
-  // Trim leading/trailing whitespace and empty elements
-  cleaned = cleaned.replace(/^[\s<br\/>]*(<hr\s*\/?>)?[\s<br\/>]*/i, "");
-  cleaned = cleaned.replace(/[\s<br\/>]*(<hr\s*\/?>)?[\s<br\/>]*$/i, "");
-
-  return cleaned.trim();
 }
 
 /** Extract a Zoom/Meet/Teams link from location or description */
@@ -248,11 +164,6 @@ function formatRecurrence(recurrence?: string[]): string | null {
 /** Check if a string looks like a URL */
 function isUrl(str: string): boolean {
   return /^https?:\/\//i.test(str.trim());
-}
-
-/** IconCheck if description contains HTML */
-function isHtml(str: string): boolean {
-  return /<[a-z][\s\S]*>/i.test(str);
 }
 
 interface EventDetailPopoverProps {

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -383,7 +383,7 @@ export function EventDetailPopover({
                     href={meetingLink.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center justify-center w-full rounded-xl bg-[#4965E0] hover:bg-[#5A75F0] text-white font-semibold py-3 px-4 text-[15px] relative"
+                    className="flex items-center justify-center w-full rounded-xl bg-[#4965E0] hover:bg-[#5A75F0] text-white font-semibold py-2 px-4 text-[15px] relative"
                   >
                     <IconVideo className="h-5 w-5 mr-2 opacity-80" />
                     <span>{getMeetingLabel(meetingLink.type)}</span>

--- a/templates/calendar/app/components/calendar/EventDialog.tsx
+++ b/templates/calendar/app/components/calendar/EventDialog.tsx
@@ -8,6 +8,11 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import {
+  sanitizeHtml,
+  stripGcalInviteHtml,
+  isHtml,
+} from "@/lib/sanitize-description";
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -237,11 +242,26 @@ export function EventDialog({ event, open, onClose }: EventDialogProps) {
             )}
 
             {/* Description */}
-            {event.description && (
-              <p className="rounded-md bg-muted/50 px-3 py-2.5 text-sm leading-relaxed text-foreground">
-                {event.description}
-              </p>
-            )}
+            {event.description &&
+              (() => {
+                if (isHtml(event.description)) {
+                  const cleanedHtml = stripGcalInviteHtml(
+                    sanitizeHtml(event.description),
+                  );
+                  if (!cleanedHtml.replace(/<[^>]*>/g, "").trim()) return null;
+                  return (
+                    <div
+                      className="rounded-md bg-muted/50 px-3 py-2.5 text-sm leading-relaxed text-foreground prose prose-sm dark:prose-invert prose-p:my-1 prose-a:text-primary"
+                      dangerouslySetInnerHTML={{ __html: cleanedHtml }}
+                    />
+                  );
+                }
+                return (
+                  <p className="rounded-md bg-muted/50 px-3 py-2.5 text-sm leading-relaxed text-foreground whitespace-pre-wrap">
+                    {event.description}
+                  </p>
+                );
+              })()}
 
             {/* Keyboard hint */}
             {!isGoogle && (

--- a/templates/calendar/app/hooks/use-events.ts
+++ b/templates/calendar/app/hooks/use-events.ts
@@ -102,15 +102,17 @@ export function useRsvpEvent() {
       id,
       status,
       accountEmail,
+      scope,
     }: {
       id: string;
       status: "accepted" | "declined" | "tentative";
       accountEmail?: string;
+      scope?: "single" | "all" | "thisAndFollowing";
     }) => {
       const res = await fetch(`/api/events/${id}/rsvp`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status, accountEmail }),
+        body: JSON.stringify({ status, accountEmail, scope }),
       });
       if (!res.ok) throw new Error("Failed to update RSVP");
       return res.json();

--- a/templates/calendar/app/lib/sanitize-description.ts
+++ b/templates/calendar/app/lib/sanitize-description.ts
@@ -1,0 +1,92 @@
+/** Sanitize HTML: strip script tags and on* event handlers */
+export function sanitizeHtml(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<script[\s\S]*?>/gi, "")
+    .replace(/\bon\w+\s*=\s*"[^"]*"/gi, "")
+    .replace(/\bon\w+\s*=\s*'[^']*'/gi, "")
+    .replace(/\bon\w+\s*=\s*[^\s>]*/gi, "");
+}
+
+/**
+ * Strip Google Calendar invitation boilerplate from event descriptions.
+ * GCal embeds the full invitation HTML (guest list, RSVP buttons, "More options",
+ * meeting details, "Invitation from Google Calendar" footer) into the description.
+ * We render all of that natively, so strip it out to avoid ugly duplication.
+ */
+export function stripGcalInviteHtml(html: string): string {
+  let cleaned = html;
+
+  // Remove "Reply for <email>" section with Yes/No/Maybe buttons
+  cleaned = cleaned.replace(
+    /<(table|div)[^>]*>[\s\S]*?Reply\s+for[\s\S]*?<\/(table|div)>/gi,
+    "",
+  );
+
+  // Remove standalone Yes/No/Maybe buttons (various Google formats)
+  cleaned = cleaned.replace(
+    /<(table|div)[^>]*>[\s\S]*?(?:>Yes<|>No<|>Maybe<)[\s\S]*?<\/(table|div)>/gi,
+    "",
+  );
+
+  // Remove "More options" link/button
+  cleaned = cleaned.replace(/<a[^>]*>[\s]*More\s+options[\s]*<\/a>/gi, "");
+  cleaned = cleaned.replace(
+    /<(table|div)[^>]*>[\s\S]*?More\s+options[\s\S]*?<\/(table|div)>/gi,
+    "",
+  );
+
+  // Remove "Invitation from Google Calendar" footer
+  cleaned = cleaned.replace(
+    /Invitation\s+from\s+<a[^>]*>Google\s+Calendar<\/a>/gi,
+    "",
+  );
+  cleaned = cleaned.replace(/Invitation\s+from\s+Google\s+Calendar/gi, "");
+
+  // Remove "You are receiving this email" disclaimer
+  cleaned = cleaned.replace(/You\s+are\s+receiving\s+this[\s\S]*?$/gi, "");
+
+  // Remove "View all guest info" links
+  cleaned = cleaned.replace(
+    /<a[^>]*>[\s]*View\s+all\s+guest\s+info[\s]*<\/a>/gi,
+    "",
+  );
+
+  // Remove the "When" / "Guests" sections that duplicate our native UI
+  cleaned = cleaned.replace(
+    /<b>When<\/b>[\s\S]*?(?=<b>|<hr|<br\s*\/?>[\s]*<br\s*\/?>|$)/gi,
+    "",
+  );
+
+  // Remove "Join Zoom Meeting" / "Join by phone" blocks that duplicate our meeting link
+  cleaned = cleaned.replace(
+    /<b>Join\s+Zoom\s+Meeting<\/b>[\s\S]*?(?=<b>Joining\s+notes|<hr|<br\s*\/?>[\s]*<br\s*\/?>[\s]*<br|$)/gi,
+    "",
+  );
+  cleaned = cleaned.replace(
+    /<b>Join\s+by\s+phone<\/b>[\s\S]*?(?=<b>|<hr|$)/gi,
+    "",
+  );
+
+  // Remove "Joining instructions" links
+  cleaned = cleaned.replace(
+    /<a[^>]*>[\s]*Joining\s+instructions[\s]*<\/a>/gi,
+    "",
+  );
+
+  // Clean up leftover separators and whitespace
+  cleaned = cleaned.replace(/(<hr\s*\/?>[\s]*){2,}/gi, "<hr/>");
+  cleaned = cleaned.replace(/(<br\s*\/?>[\s]*){4,}/gi, "<br/><br/>");
+  cleaned = cleaned.replace(/([-─]{5,}[\s]*){2,}/g, "");
+
+  // Trim leading/trailing whitespace and empty elements
+  cleaned = cleaned.replace(/^[\s<br\/>]*(<hr\s*\/?>)?[\s<br\/>]*/i, "");
+  cleaned = cleaned.replace(/[\s<br\/>]*(<hr\s*\/?>)?[\s<br\/>]*$/i, "");
+
+  return cleaned.trim();
+}
+
+/** Check if a string looks like HTML */
+export function isHtml(str: string): boolean {
+  return /<[a-z][\s\S]*>/i.test(str);
+}

--- a/templates/calendar/server/handlers/events.ts
+++ b/templates/calendar/server/handlers/events.ts
@@ -310,8 +310,10 @@ export const rsvpEvent = defineEventHandler(async (event: H3Event) => {
 
     const acctEmail = await resolveAccountEmail(body.accountEmail, email);
 
+    const scope = body?.scope || "single";
+
     try {
-      await googleCalendar.rsvpEvent(googleEventId, status, acctEmail);
+      await googleCalendar.rsvpEvent(googleEventId, status, acctEmail, scope);
     } catch (error: any) {
       setResponseStatus(event, 500);
       return { error: `Failed to update RSVP: ${error.message}` };

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -461,33 +461,96 @@ export async function deleteEvent(
 }
 
 /**
- * Update the current user's RSVP status for an event.
- * Fetches the full attendees list first to avoid overwriting other guests.
+ * RSVP a single event instance — fetches attendees first to avoid overwriting.
  */
-export async function rsvpEvent(
-  googleEventId: string,
-  responseStatus: "accepted" | "declined" | "tentative",
+async function rsvpSingleEvent(
+  accessToken: string,
+  eventId: string,
+  responseStatus: string,
   accountEmail: string,
 ): Promise<void> {
-  const client = await getClient(accountEmail);
-  if (!client) return;
-
-  // GET the current event to preserve the full attendees list — PATCH with a
-  // single-entry array would silently remove every other guest.
-  const existing = await calendarGetEvent(
-    client.accessToken,
-    "primary",
-    googleEventId,
-  );
+  const existing = await calendarGetEvent(accessToken, "primary", eventId);
   const attendees = (existing.attendees ?? []).map(
     (a: { email: string; responseStatus?: string }) =>
       a.email === accountEmail ? { ...a, responseStatus } : a,
   );
   await calendarPatchEvent(
+    accessToken,
+    "primary",
+    eventId,
+    { attendees },
+    "none",
+  );
+}
+
+/**
+ * Update the current user's RSVP status for an event.
+ * Supports recurring event scopes: "single", "all", or "thisAndFollowing".
+ */
+export async function rsvpEvent(
+  googleEventId: string,
+  responseStatus: "accepted" | "declined" | "tentative",
+  accountEmail: string,
+  scope: "single" | "all" | "thisAndFollowing" = "single",
+): Promise<void> {
+  const client = await getClient(accountEmail);
+  if (!client) return;
+
+  if (scope === "single") {
+    await rsvpSingleEvent(
+      client.accessToken,
+      googleEventId,
+      responseStatus,
+      accountEmail,
+    );
+    return;
+  }
+
+  // For "all" or "thisAndFollowing", we need the base recurring event ID.
+  const instance = await calendarGetEvent(
     client.accessToken,
     "primary",
     googleEventId,
-    { attendees },
-    "none",
+  );
+  const recurringEventId = instance.recurringEventId || googleEventId;
+
+  if (scope === "all") {
+    // RSVP the base recurring event — Google propagates to all instances
+    // that don't have individual overrides.
+    await rsvpSingleEvent(
+      client.accessToken,
+      recurringEventId,
+      responseStatus,
+      accountEmail,
+    );
+    return;
+  }
+
+  // "thisAndFollowing": RSVP this instance and all future instances.
+  // Get the start time of the current instance to use as the cutoff.
+  const instanceStart =
+    instance.start?.dateTime ||
+    instance.start?.date ||
+    new Date().toISOString();
+
+  // Fetch all future instances of this recurring event
+  const futureEvents = await calendarListEvents(client.accessToken, "primary", {
+    timeMin: instanceStart,
+    singleEvents: true,
+    orderBy: "startTime",
+    maxResults: 250,
+  });
+
+  // Filter to only instances of the same recurring series
+  const futureInstances = (futureEvents.items || []).filter(
+    (e: any) =>
+      e.recurringEventId === recurringEventId || e.id === recurringEventId,
+  );
+
+  // RSVP each instance (including the current one)
+  await Promise.all(
+    futureInstances.map((e: any) =>
+      rsvpSingleEvent(client.accessToken, e.id, responseStatus, accountEmail),
+    ),
   );
 }

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -42,13 +42,13 @@ const INBOX_ZERO_PHOTOS = [
   "photo-1441974231531-c6227db76b6e", // Forest sunlight
   "photo-1469474968028-56623f02e42e", // Golden sunset coast
   "photo-1472214103451-9374bd1c798e", // Green rolling hills
-  "photo-1500534314263-0869cef46947", // Aurora borealis
+  "photo-1483347756197-71ef80e95f73", // Aurora borealis
   "photo-1507525428034-b723cf961d3e", // Tropical beach
   "photo-1505765050516-f72dcac9c60e", // Mountain reflection lake
   "photo-1464822759023-fed622ff2c3b", // Snow-capped mountain
   "photo-1433086966358-54859d0ed716", // Waterfall in forest
   "photo-1501854140801-50d01698950b", // Aerial forest
-  "photo-1518173946687-a24f76e138a6", // Pink sky desert
+  "photo-1643840154819-6831d22f7621", // Pink sky desert
   "photo-1502082553048-f009c37129b9", // Sun through trees
   "photo-1536431311719-398b6704d4cc", // Dramatic clouds
   "photo-1475924156734-496f6cac6ec1", // Northern lights

--- a/templates/mail/app/components/email/EmailListItem.tsx
+++ b/templates/mail/app/components/email/EmailListItem.tsx
@@ -1,6 +1,7 @@
 import { cn, formatEmailDate, truncate } from "@/lib/utils";
 import type { EmailMessage } from "@shared/types";
 import type { ThreadSummary } from "@/lib/threads";
+import { useAccountFilter } from "@/hooks/use-account-filter";
 
 interface EmailListItemProps {
   email: EmailMessage;
@@ -46,6 +47,26 @@ const labelColors: Record<string, { bg: string; text: string }> = {
   travel: { bg: "bg-cyan-500/20", text: "text-cyan-700 dark:text-cyan-300" },
 };
 
+/** Stable dot colors for distinguishing accounts */
+const accountDotColors = [
+  "bg-blue-400",
+  "bg-emerald-400",
+  "bg-amber-400",
+  "bg-rose-400",
+  "bg-violet-400",
+  "bg-cyan-400",
+  "bg-orange-400",
+  "bg-pink-400",
+];
+
+function getAccountColor(
+  email: string,
+  allAccounts: Array<{ email: string }>,
+): string {
+  const idx = allAccounts.findIndex((a) => a.email === email);
+  return accountDotColors[(idx >= 0 ? idx : 0) % accountDotColors.length];
+}
+
 function getLabelStyle(labelId: string): { bg: string; text: string } {
   const normalized = labelId.toLowerCase().replace(/^label:/, "");
   if (labelColors[normalized]) return labelColors[normalized];
@@ -68,6 +89,9 @@ export function EmailListItem({
   onStar,
   onHover,
 }: EmailListItemProps) {
+  const { allAccounts } = useAccountFilter();
+  const isMultiAccount = allAccounts.length > 1;
+
   const isThread = thread && thread.messageCount > 1;
   const senderName = isThread
     ? formatParticipants(thread.participants)
@@ -122,11 +146,18 @@ export function EmailListItem({
         <div className="absolute left-0 top-0 bottom-0 w-[3px] bg-primary rounded-r" />
       )}
 
-      {/* Unread dot */}
+      {/* Unread / account dot */}
       <div className="w-5 shrink-0 flex items-center justify-center">
-        {isUnread && (
+        {isUnread ? (
           <div className="h-[7px] w-[7px] rounded-full bg-primary" />
-        )}
+        ) : isMultiAccount && email.accountEmail ? (
+          <div
+            className={cn(
+              "h-[5px] w-[5px] rounded-full opacity-50",
+              getAccountColor(email.accountEmail, allAccounts),
+            )}
+          />
+        ) : null}
       </div>
 
       {/* Sender name — fixed width column */}
@@ -137,6 +168,11 @@ export function EmailListItem({
             ? "font-semibold text-foreground"
             : "font-normal text-foreground/90",
         )}
+        title={
+          isMultiAccount && email.accountEmail
+            ? `Account: ${email.accountEmail}`
+            : undefined
+        }
       >
         {senderName}
       </span>

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -28,12 +28,14 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { setUndoAction } from "@/hooks/use-undo";
 import { toast } from "sonner";
-import type { EmailMessage } from "@shared/types";
+import type { EmailMessage, MobileActionId } from "@shared/types";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   InlineReplyComposer,
   type InlineReplyHandle,
 } from "./InlineReplyComposer";
+import { MobileActionBar, DEFAULT_MOBILE_ACTIONS } from "./MobileActionBar";
+import { useIsMobile } from "@/hooks/use-mobile";
 
 export function EmailThread({
   onArchived,
@@ -450,6 +452,7 @@ export function EmailThread({
   }, [email, toggleStar]);
 
   const { data: settings } = useSettings();
+  const updateSettings = useUpdateSettings();
   const { allAccounts } = useAccountFilter();
   const myEmails = useMemo(() => {
     const emails = new Set(allAccounts.map((a) => a.email.toLowerCase()));
@@ -655,6 +658,54 @@ export function EmailThread({
       },
     ],
     !!threadId,
+  );
+
+  // Mobile action bar
+  const isMobile = useIsMobile();
+  const mobileActions = settings?.mobileActions ?? DEFAULT_MOBILE_ACTIONS;
+  const handleMobileAction = useCallback(
+    (action: MobileActionId) => {
+      switch (action) {
+        case "archive":
+          handleArchive();
+          break;
+        case "trash":
+          handleTrash();
+          break;
+        case "star":
+          handleStar();
+          break;
+        case "reply":
+          handleReply();
+          break;
+        case "replyAll":
+          handleReplyAll();
+          break;
+        case "forward":
+          handleForward();
+          break;
+        case "markUnread":
+          if (email) markRead.mutate({ id: email.id, isRead: false });
+          break;
+        case "prev":
+          goToSibling(-1);
+          break;
+        case "next":
+          goToSibling(1);
+          break;
+      }
+    },
+    [
+      handleArchive,
+      handleTrash,
+      handleStar,
+      handleReply,
+      handleReplyAll,
+      handleForward,
+      email,
+      markRead,
+      goToSibling,
+    ],
   );
 
   // Extract GitHub PR URL from any message in the thread
@@ -979,6 +1030,18 @@ export function EmailThread({
           )}
         </div>
       </div>
+
+      {/* Mobile bottom action bar */}
+      {isMobile && (
+        <MobileActionBar
+          actions={mobileActions}
+          isStarred={email.isStarred}
+          onAction={handleMobileAction}
+          onUpdateActions={(actions) =>
+            updateSettings.mutate({ mobileActions: actions })
+          }
+        />
+      )}
     </div>
   );
 }

--- a/templates/mail/app/components/email/MobileActionBar.tsx
+++ b/templates/mail/app/components/email/MobileActionBar.tsx
@@ -1,0 +1,278 @@
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import type { MobileActionId } from "@shared/types";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerClose,
+} from "@/components/ui/drawer";
+import { Switch } from "@/components/ui/switch";
+
+export const ALL_MOBILE_ACTIONS: MobileActionId[] = [
+  "archive",
+  "trash",
+  "star",
+  "reply",
+  "replyAll",
+  "forward",
+  "markUnread",
+  "prev",
+  "next",
+];
+
+export const DEFAULT_MOBILE_ACTIONS: MobileActionId[] = [
+  "archive",
+  "trash",
+  "star",
+  "reply",
+  "replyAll",
+  "forward",
+  "markUnread",
+  "prev",
+  "next",
+];
+
+/** Metadata for each action: icon SVG, label */
+const ACTION_META: Record<
+  MobileActionId,
+  {
+    label: string;
+    icon: (active?: boolean) => React.ReactNode;
+  }
+> = {
+  archive: {
+    label: "Done",
+    icon: () => (
+      <svg viewBox="0 0 16 16" fill="currentColor" className="h-5 w-5">
+        <path
+          fillRule="evenodd"
+          d="M12.416 3.376a.75.75 0 0 1 .208 1.04l-5 7.5a.75.75 0 0 1-1.154.114l-3-3a.75.75 0 0 1 1.06-1.06l2.353 2.353 4.493-6.74a.75.75 0 0 1 1.04-.207z"
+          clipRule="evenodd"
+        />
+      </svg>
+    ),
+  },
+  trash: {
+    label: "Trash",
+    icon: () => (
+      <svg viewBox="0 0 16 16" fill="currentColor" className="h-5 w-5">
+        <path
+          fillRule="evenodd"
+          d="M5 3.25V4H2.75a.75.75 0 0 0 0 1.5h.3l.815 8.15A1.5 1.5 0 0 0 5.357 15h5.285a1.5 1.5 0 0 0 1.493-1.35l.815-8.15h.3a.75.75 0 0 0 0-1.5H11v-.75A2.25 2.25 0 0 0 8.75 1h-1.5A2.25 2.25 0 0 0 5 3.25zm2.25-.75a.75.75 0 0 0-.75.75V4h3v-.75a.75.75 0 0 0-.75-.75h-1.5zM6.05 6a.75.75 0 0 1 .787.713l.275 5.5a.75.75 0 0 1-1.498.075l-.275-5.5A.75.75 0 0 1 6.05 6zm3.9 0a.75.75 0 0 1 .712.787l-.275 5.5a.75.75 0 0 1-1.498-.075l.275-5.5A.75.75 0 0 1 9.95 6z"
+          clipRule="evenodd"
+        />
+      </svg>
+    ),
+  },
+  star: {
+    label: "Star",
+    icon: (active) =>
+      active ? (
+        <svg
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          className="h-5 w-5 text-yellow-500"
+        >
+          <path
+            fillRule="evenodd"
+            d="M8 1.75a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 13.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 7.874a.75.75 0 0 1 .416-1.28l4.21-.611L7.327 2.17A.75.75 0 0 1 8 1.75z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ) : (
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.2"
+          className="h-5 w-5"
+        >
+          <path d="M8 1.75l1.882 3.815 4.21.612-3.046 2.97.719 4.192L8 11.36l-3.766 1.98.72-4.194L1.907 6.177l4.21-.611z" />
+        </svg>
+      ),
+  },
+  reply: {
+    label: "Reply",
+    icon: () => (
+      <svg viewBox="0 0 16 16" fill="currentColor" className="h-5 w-5">
+        <path
+          fillRule="evenodd"
+          d="M7.28 1.22a.75.75 0 0 1 0 1.06L4.56 5H8.5a5.5 5.5 0 0 1 0 11H6a.75.75 0 0 1 0-1.5h2.5a4 4 0 0 0 0-8H4.56l2.72 2.72a.75.75 0 1 1-1.06 1.06l-4-4a.75.75 0 0 1 0-1.06l4-4a.75.75 0 0 1 1.06 0z"
+          clipRule="evenodd"
+        />
+      </svg>
+    ),
+  },
+  replyAll: {
+    label: "Reply All",
+    icon: () => (
+      <svg viewBox="0 0 16 16" fill="currentColor" className="h-5 w-5">
+        <path d="M3.28 1.22a.75.75 0 0 0-1.06 0l-2 2a.75.75 0 0 0 0 1.06l2 2a.75.75 0 0 0 1.06-1.06L2.06 4l1.22-1.22a.75.75 0 0 0 0-1.06z" />
+        <path
+          fillRule="evenodd"
+          d="M9.28 1.22a.75.75 0 0 1 0 1.06L6.56 5H10.5a5.5 5.5 0 0 1 0 11H8a.75.75 0 0 1 0-1.5h2.5a4 4 0 0 0 0-8H6.56l2.72 2.72a.75.75 0 1 1-1.06 1.06l-4-4a.75.75 0 0 1 0-1.06l4-4a.75.75 0 0 1 1.06 0z"
+          clipRule="evenodd"
+        />
+      </svg>
+    ),
+  },
+  forward: {
+    label: "Forward",
+    icon: () => (
+      <svg
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        className="h-5 w-5 scale-x-[-1]"
+      >
+        <path
+          fillRule="evenodd"
+          d="M7.28 1.22a.75.75 0 0 1 0 1.06L4.56 5H8.5a5.5 5.5 0 0 1 0 11H6a.75.75 0 0 1 0-1.5h2.5a4 4 0 0 0 0-8H4.56l2.72 2.72a.75.75 0 1 1-1.06 1.06l-4-4a.75.75 0 0 1 0-1.06l4-4a.75.75 0 0 1 1.06 0z"
+          clipRule="evenodd"
+        />
+      </svg>
+    ),
+  },
+  markUnread: {
+    label: "Unread",
+    icon: () => (
+      <svg viewBox="0 0 16 16" fill="currentColor" className="h-5 w-5">
+        <path d="M2.5 3A1.5 1.5 0 0 0 1 4.5v.793c.026.009.051.02.076.032L7.674 8.51c.206.1.446.1.652 0l6.598-3.185A.755.755 0 0 1 15 5.293V4.5A1.5 1.5 0 0 0 13.5 3h-11z" />
+        <path d="M15 6.954 8.978 9.86a2.25 2.25 0 0 1-1.956 0L1 6.954V11.5A1.5 1.5 0 0 0 2.5 13h11a1.5 1.5 0 0 0 1.5-1.5V6.954z" />
+      </svg>
+    ),
+  },
+  prev: {
+    label: "Prev",
+    icon: () => (
+      <svg viewBox="0 0 16 16" fill="currentColor" className="h-5 w-5">
+        <path
+          fillRule="evenodd"
+          d="M11.78 9.78a.75.75 0 0 1-1.06 0L8 7.06 5.28 9.78a.75.75 0 0 1-1.06-1.06l3.25-3.25a.75.75 0 0 1 1.06 0l3.25 3.25a.75.75 0 0 1 0 1.06z"
+          clipRule="evenodd"
+        />
+      </svg>
+    ),
+  },
+  next: {
+    label: "Next",
+    icon: () => (
+      <svg viewBox="0 0 16 16" fill="currentColor" className="h-5 w-5">
+        <path
+          fillRule="evenodd"
+          d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06z"
+          clipRule="evenodd"
+        />
+      </svg>
+    ),
+  },
+};
+
+export type MobileActionBarProps = {
+  actions: MobileActionId[];
+  isStarred?: boolean;
+  onAction: (action: MobileActionId) => void;
+  onUpdateActions?: (actions: MobileActionId[]) => void;
+};
+
+export function MobileActionBar({
+  actions,
+  isStarred,
+  onAction,
+  onUpdateActions,
+}: MobileActionBarProps) {
+  const [customizeOpen, setCustomizeOpen] = useState(false);
+
+  return (
+    <>
+      <div className="shrink-0 border-t border-border bg-background px-1 pb-[env(safe-area-inset-bottom)]">
+        <div className="flex items-center justify-around">
+          {actions.map((id) => {
+            const meta = ACTION_META[id];
+            if (!meta) return null;
+            return (
+              <button
+                key={id}
+                onClick={() => onAction(id)}
+                className={cn(
+                  "flex flex-col items-center justify-center gap-0.5 py-2 px-3 min-w-[44px] min-h-[44px]",
+                  "text-muted-foreground active:text-foreground active:bg-accent/50 rounded-lg",
+                )}
+                title={meta.label}
+              >
+                {meta.icon(id === "star" ? isStarred : false)}
+                <span className="text-[10px] leading-tight">{meta.label}</span>
+              </button>
+            );
+          })}
+          {onUpdateActions && (
+            <button
+              onClick={() => setCustomizeOpen(true)}
+              className={cn(
+                "flex flex-col items-center justify-center gap-0.5 py-2 px-3 min-w-[44px] min-h-[44px]",
+                "text-muted-foreground active:text-foreground active:bg-accent/50 rounded-lg",
+              )}
+              title="Customize"
+            >
+              <svg viewBox="0 0 16 16" fill="currentColor" className="h-5 w-5">
+                <path d="M6.5 2.25a.75.75 0 0 0-1.5 0v3a.75.75 0 0 0 1.5 0V4.5h7.75a.75.75 0 0 0 0-1.5H6.5V2.25zM1.75 3a.75.75 0 0 0 0 1.5h1.5a.75.75 0 0 0 0-1.5h-1.5zM4.75 7.25a.75.75 0 0 0-.75.75v.5H1.75a.75.75 0 0 0 0 1.5H4v.5a.75.75 0 0 0 1.5 0v-3a.75.75 0 0 0-.75-.75zm2.5 1.5a.75.75 0 0 0 0 1.5h7a.75.75 0 0 0 0-1.5h-7zm-5.5 4a.75.75 0 0 0 0 1.5h7.5a.75.75 0 0 0 0-1.5h-7.5zm10.25-.75a.75.75 0 0 0-.75.75v3a.75.75 0 0 0 1.5 0v-.5h1.5a.75.75 0 0 0 0-1.5h-1.5V12a.75.75 0 0 0-.75-.75z" />
+              </svg>
+              <span className="text-[10px] leading-tight">More</span>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {onUpdateActions && (
+        <Drawer open={customizeOpen} onOpenChange={setCustomizeOpen}>
+          <DrawerContent>
+            <DrawerHeader>
+              <DrawerTitle>Customize Actions</DrawerTitle>
+            </DrawerHeader>
+            <div className="px-4 pb-6 space-y-1">
+              {ALL_MOBILE_ACTIONS.map((id) => {
+                const meta = ACTION_META[id];
+                if (!meta) return null;
+                const enabled = actions.includes(id);
+                return (
+                  <label
+                    key={id}
+                    className="flex items-center justify-between py-3 px-2 rounded-lg active:bg-accent/50"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-muted-foreground">
+                        {meta.icon(false)}
+                      </span>
+                      <span className="text-sm font-medium">{meta.label}</span>
+                    </div>
+                    <Switch
+                      checked={enabled}
+                      onCheckedChange={(checked) => {
+                        const next = checked
+                          ? [...actions, id]
+                          : actions.filter((a) => a !== id);
+                        // Maintain canonical order
+                        const ordered = ALL_MOBILE_ACTIONS.filter((a) =>
+                          next.includes(a),
+                        );
+                        onUpdateActions(ordered);
+                      }}
+                    />
+                  </label>
+                );
+              })}
+            </div>
+            <div className="px-4 pb-6">
+              <DrawerClose asChild>
+                <button className="w-full rounded-lg bg-accent py-2.5 text-sm font-medium">
+                  Done
+                </button>
+              </DrawerClose>
+            </div>
+          </DrawerContent>
+        </Drawer>
+      )}
+    </>
+  );
+}

--- a/templates/mail/shared/types.ts
+++ b/templates/mail/shared/types.ts
@@ -114,7 +114,21 @@ export type UserSettings = {
   imagePolicy?: "show" | "block-trackers" | "block-all";
   /** Senders whose images are always loaded even when imagePolicy is "block-all" */
   trustedSenders?: string[];
+  /** Actions shown in the mobile bottom action bar (detail view). Order matters. */
+  mobileActions?: MobileActionId[];
 };
+
+/** Identifiers for actions available in the mobile bottom bar */
+export type MobileActionId =
+  | "archive"
+  | "trash"
+  | "star"
+  | "reply"
+  | "replyAll"
+  | "forward"
+  | "markUnread"
+  | "prev"
+  | "next";
 
 export type Alias = {
   id: string;


### PR DESCRIPTION
## Summary

- **Calendar**: Fix HTML description rendering — properly sanitize and render rich HTML (clickable links, formatting) instead of stripping tags and showing raw attribute text. Extract shared sanitization utils. Improved attendees section and Google Calendar API.
- **Mail**: Replace 2 dead Unsplash inbox-zero backdrop images. Add mobile action bar, email list/thread improvements.
- **Desktop**: Webview, sidebar, and tab bar updates.
- **Analytics**: Data sources improvements.
- **Skills**: Add `babysit-pr` skill to repo for Codex/Claude agents.

## Test plan

- [ ] Open calendar event with HTML description (e.g. Google Docs link) — should render as clickable link, not raw HTML text
- [ ] Check calendar event detail panel, popover, and dialog all render HTML descriptions correctly
- [ ] Verify mail inbox-zero backdrops load (no broken images)
- [ ] Verify desktop app loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)