### PR TITLE
fix(content): convert columns/column inner content in Notion import

### DIFF
--- a/templates/content/shared/notion-markdown.ts
+++ b/templates/content/shared/notion-markdown.ts
@@ -166,9 +166,9 @@ function convertNfmToEditorMarkdown(nfm: string): string {
 
 // ── Pass 1: Convert HTML container inner content to HTML ─────────────
 // markdown-it doesn't parse markdown inside HTML blocks, so content
-// inside <details> and <callout> must be actual HTML elements.
-const HTML_CONTENT_CONTAINERS = /^<(details|callout)\b/;
-const HTML_CONTENT_CLOSE = /^<\/(details|callout)>/;
+// inside <details>, <callout>, <columns>, and <column> must be actual HTML elements.
+const HTML_CONTENT_CONTAINERS = /^<(details|callout|columns|column)\b/;
+const HTML_CONTENT_CLOSE = /^<\/(details|callout|columns|column)>/;
 
 function convertHtmlContainerContent(nfm: string): string {
   const lines = nfm.split("\n");


### PR DESCRIPTION
## Summary

- Extends Pass 1's `HTML_CONTENT_CONTAINERS` regex to include `<columns>` and `<column>` so their tab-indented NFM content is converted to HTML

## Context

PR #119 review feedback identified that `<columns>`/`<column>` containers were tracked in Pass 2 (skipping rewriting) but never processed in Pass 1 — so tab-indented NFM inside columns (bullet lists, empty blocks, indented paragraphs) was left unconverted and wouldn't render as editor blocks. This is the same class of bug that was already fixed for `<details>` and `<callout>`.

## Test plan

- [x] 35 unit tests passing
- [x] No regressions on existing kitchen sink or Builder Todo pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)