### PR TITLE
fix: dialect cache poisoning on CF Workers breaks all D1 apps

### DIFF
--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -83,8 +83,10 @@ export function getDialect(): Dialect {
     return _dialect;
   }
 
-  _dialect = "sqlite";
-  return _dialect;
+  // Don't cache the fallthrough — on CF Workers, env bindings (__cf_env) aren't
+  // available at import time. If we cache "sqlite" here, D1 will never be
+  // detected once the bindings are set in the fetch handler.
+  return "sqlite";
 }
 
 export function isPostgres(): boolean {

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -30,11 +30,11 @@ import {
 } from "drizzle-orm/pg-core";
 import { getDialect } from "./client.js";
 
-// Cache the dialect check so we only read the env once.
-let _pg: boolean | undefined;
+// No caching — getDialect() handles its own caching once env is available.
+// On CF Workers, this runs at import time before env bindings are set, so
+// caching here would lock in the wrong dialect.
 function pg(): boolean {
-  if (_pg === undefined) _pg = getDialect() === "postgres";
-  return _pg;
+  return getDialect() === "postgres";
 }
 
 /**

--- a/packages/core/src/server/auth-plugin.ts
+++ b/packages/core/src/server/auth-plugin.ts
@@ -1,5 +1,6 @@
 import { autoMountAuth } from "./auth.js";
 import type { AuthOptions } from "./auth.js";
+import { createGoogleAuthPlugin } from "./google-auth-plugin.js";
 
 type NitroPluginDef = (nitroApp: any) => void | Promise<void>;
 
@@ -9,4 +10,14 @@ export function createAuthPlugin(options?: AuthOptions): NitroPluginDef {
   };
 }
 
-export const defaultAuthPlugin: NitroPluginDef = createAuthPlugin();
+/**
+ * Default auth plugin — auto-detects the auth strategy:
+ * - If GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are set → Google OAuth
+ * - Otherwise → email/password or ACCESS_TOKEN auth
+ */
+export const defaultAuthPlugin: NitroPluginDef = (nitroApp: any) => {
+  if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+    return createGoogleAuthPlugin()(nitroApp);
+  }
+  return createAuthPlugin()(nitroApp);
+};


### PR DESCRIPTION
## Summary

- **Root cause**: The new `@agent-native/core/db/schema` module (from #125) calls `getDialect()` at import time when schema tables are defined at module level. On CF Workers, env bindings (`__cf_env`) aren't available at import time, so `getDialect()` cached `"sqlite"` instead of `"d1"`. All subsequent DB operations used the wrong dialect, causing 500 errors on every request.
- **Fix**: Don't cache the fallthrough default in `getDialect()` — only cache when a dialect is positively detected (postgres, remote libsql, or D1). This way early calls return "sqlite" (correct for schema definitions) without poisoning the cache for later D1/postgres detection.
- **Auth fix**: Make `defaultAuthPlugin` auto-detect Google OAuth credentials (`GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET`) so templates don't need explicit `auth.ts` files. Previously, deleting these files in #125 caused production apps to show email/password login instead of Google sign-in.

## Test plan

- [x] `pnpm run prep` passes (types, lint, format, tests)
- [x] `NITRO_PRESET=cloudflare_pages` build succeeds for mail and calendar templates
- [ ] Deploy to CF Workers and verify apps no longer 500
- [ ] Verify Google OAuth login works on mail.agent-native.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)