### PR TITLE
fix: correct .claude/skills symlink path in templates

### DIFF
--- a/templates/analytics/.claude/skills
+++ b/templates/analytics/.claude/skills
@@ -1,1 +1,1 @@
-../../.agents/skills
+../.agents/skills

--- a/templates/calendar/.claude/skills
+++ b/templates/calendar/.claude/skills
@@ -1,1 +1,1 @@
-../../.agents/skills
+../.agents/skills

--- a/templates/content/.claude/skills
+++ b/templates/content/.claude/skills
@@ -1,1 +1,1 @@
-../../.agents/skills
+../.agents/skills

--- a/templates/mail/.claude/skills
+++ b/templates/mail/.claude/skills
@@ -1,1 +1,1 @@
-../../.agents/skills
+../.agents/skills

--- a/templates/slides/.claude/skills
+++ b/templates/slides/.claude/skills
@@ -1,1 +1,1 @@
-../../.agents/skills
+../.agents/skills

--- a/templates/videos/.claude/skills
+++ b/templates/videos/.claude/skills
@@ -1,1 +1,1 @@
-../../.agents/skills
+../.agents/skills


### PR DESCRIPTION
## Summary

- Six templates had `.claude/skills` pointing to `../../.agents/skills` (two levels up), which resolves outside the template directory and creates a broken symlink when a user scaffolds a new app from one of these templates.
- Corrected to `../.agents/skills` (one level up), which correctly points from `.claude/` to the app root's `.agents/skills/` directory.

Affected templates: analytics, calendar, content, mail, slides, videos

## How it was found

Discovered while wiring up `--template` flag support for `agent-native create`. When fetching a template from GitHub and copying it into a new app directory, `copyDir` would crash attempting to `stat` the broken symlink target.

The `default` template (the only one previously used) had the correct `../.agents/skills` path all along — the other templates were never exercised by the scaffolding CLI until now.

## Test plan

- [ ] Run `agent-native create my-app --template calendar` and confirm `.claude/skills` in the scaffolded app resolves correctly to `.agents/skills/`
- [ ] Confirm Claude Code picks up the skills from the symlink in each template

🤖 Generated with [Claude Code](https://claude.com/claude-code)