### PR TITLE
chore: release @agent-native/core v0.4.6

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bumps `@agent-native/core` from `0.4.5` → `0.4.6`

## Release steps

After merging, trigger the [publish workflow](https://github.com/BuilderIO/agent-native/actions/workflows/publish.yml) via `workflow_dispatch` with `patch` selected — or it will fire automatically on the next GitHub release publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)