### PR TITLE
fix(ci): remove broken npm install -g npm@latest step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,9 +50,6 @@ jobs:
           node-version: "22"
           cache: "pnpm"
 
-      - name: Install latest npm
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- Removes the `npm install -g npm@latest` step from `publish.yml` that was failing with `MODULE_NOT_FOUND: promise-retry` on the GitHub runner
- Node 22 ships with a modern enough npm — this step isn't needed

## Why it broke

The pre-installed npm on the runner has a corrupted module tree, so trying to self-upgrade fails before anything else runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)