### PR TITLE
fix(ci): configure npm auth for publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,9 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
+
+      - name: Install npm with OIDC provenance support
+        run: npm install -g npm@10
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -87,12 +89,8 @@ jobs:
         if: github.event.inputs.version_bump != 'dev'
         working-directory: packages/core
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish dev version to npm
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version_bump == 'dev'
         working-directory: packages/core
         run: npm publish --access public --provenance --tag dev
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -86,8 +87,12 @@ jobs:
         if: github.event.inputs.version_bump != 'dev'
         working-directory: packages/core
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish dev version to npm
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version_bump == 'dev'
         working-directory: packages/core
         run: npm publish --access public --provenance --tag dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `registry-url` to `actions/setup-node` so it writes the `.npmrc` that maps `NODE_AUTH_TOKEN` to the npm registry
- Passes `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to both publish steps

Without `registry-url`, `setup-node` never configures `.npmrc` and npm has no credentials, causing `ENEEDAUTH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)