### PR TITLE
fix(ci): switch to NPM_TOKEN for publish auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,7 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
-
-      - name: Install npm with OIDC provenance support
-        run: npm install -g npm@10
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -88,9 +86,13 @@ jobs:
       - name: Publish to npm
         if: github.event.inputs.version_bump != 'dev'
         working-directory: packages/core
-        run: npm publish --access public --provenance
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish dev version to npm
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.version_bump == 'dev'
         working-directory: packages/core
-        run: npm publish --access public --provenance --tag dev
+        run: npm publish --access public --tag dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

OIDC trusted publishing (`--provenance` without a token) has been failing with `ENEEDAUTH` across multiple runs. The March 24 run that worked was using the same approach but something in the npm OIDC trusted publishing config has drifted since then.

Switching to a classic npm Automation token which is simpler and more reliable:

- Adds `registry-url` to `actions/setup-node` so it writes the `.npmrc`
- Passes `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` on publish steps
- Removes the `npm install -g npm@10` step (no longer needed without OIDC)
- Removes `--provenance` flag (tied to OIDC; can be re-added later if needed)

## Required: add NPM_TOKEN secret

Before merging, add an npm **Automation** token as `NPM_TOKEN` in the `npm-publish` environment:

GitHub → Settings → Environments → `npm-publish` → Add secret → `NPM_TOKEN`

Generate the token at npmjs.com → your avatar → Access Tokens → Generate New Token → Automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)