### PR TITLE
fix(mail): eliminate read/unread flicker and improve UI responsiveness

### DIFF
--- a/templates/mail/app/components/email/EmailListItem.tsx
+++ b/templates/mail/app/components/email/EmailListItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { cn, formatEmailDate, truncate } from "@/lib/utils";
 import { IconStarFilled } from "@tabler/icons-react";
 import type { EmailMessage } from "@shared/types";
@@ -80,7 +81,7 @@ function getLabelStyle(labelId: string): { bg: string; text: string } {
   return options[Math.abs(hash) % options.length];
 }
 
-export function EmailListItem({
+export const EmailListItem = memo(function EmailListItem({
   email,
   thread,
   isSelected,
@@ -238,4 +239,4 @@ export function EmailListItem({
       </div>
     </div>
   );
-}
+});

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -916,11 +916,10 @@ export function AppLayout({ children }: AppLayoutProps) {
             )}
 
             {/* Show full-page takeover when no accounts connected (except on settings page) */}
-            {view !== "settings" && googleStatus.isLoading ? (
-              <div className="flex flex-1 items-center justify-center" />
-            ) : !googleStatus.isLoading &&
-              !hasAccounts &&
-              view !== "settings" ? (
+            {!googleStatus.isLoading &&
+            !googleStatus.isError &&
+            !hasAccounts &&
+            view !== "settings" ? (
               <GoogleConnectBanner variant="hero" />
             ) : (
               <main className="flex flex-1 overflow-hidden">{children}</main>

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -152,6 +152,51 @@ function filterSuppressed(
   return emails.filter((e) => !isSuppressedInView(e.threadId || e.id, view));
 }
 
+// ─── Optimistic property overrides ──────────────────────────────────────────
+// Gmail's eventual consistency means refetches can return stale read/star state,
+// overwriting optimistic updates. We track local overrides here and apply them
+// in the `select` transform so the UI never flickers back to stale state.
+
+const optimisticOverrides = new Map<
+  string,
+  { props: Partial<EmailMessage>; timestamp: number }
+>();
+const OVERRIDE_DURATION = 60_000; // 60s — covers Gmail's consistency window
+
+/** Set optimistic property overrides for an email (read, star, etc.) */
+export function setOptimisticOverride(
+  emailId: string,
+  props: Partial<EmailMessage>,
+) {
+  const existing = optimisticOverrides.get(emailId);
+  optimisticOverrides.set(emailId, {
+    props: { ...(existing?.props ?? {}), ...props },
+    timestamp: Date.now(),
+  });
+}
+
+/** Clear optimistic overrides — used on mutation error rollback. */
+export function clearOptimisticOverride(emailId: string) {
+  optimisticOverrides.delete(emailId);
+}
+
+function applyOverrides(emails: EmailMessage[]): EmailMessage[] {
+  if (optimisticOverrides.size === 0) return emails;
+  const now = Date.now();
+  let changed = false;
+  const result = emails.map((e) => {
+    const entry = optimisticOverrides.get(e.id);
+    if (!entry) return e;
+    if (now - entry.timestamp > OVERRIDE_DURATION) {
+      optimisticOverrides.delete(e.id);
+      return e;
+    }
+    changed = true;
+    return { ...e, ...entry.props };
+  });
+  return changed ? result : emails;
+}
+
 // ─── Emails ──────────────────────────────────────────────────────────────────
 
 export function useEmails(view: string = "inbox", search?: string) {
@@ -162,7 +207,7 @@ export function useEmails(view: string = "inbox", search?: string) {
       if (search) params.set("q", search);
       return apiFetch(`/api/emails?${params}`);
     },
-    select: (data) => filterSuppressed(data, view),
+    select: (data) => applyOverrides(filterSuppressed(data, view)),
     staleTime: 15_000,
     // Only poll when the last fetch succeeded — avoids retry loops when
     // Google is disconnected or credentials are missing.
@@ -203,12 +248,14 @@ export function useMarkRead() {
       const previous = qc.getQueriesData<EmailMessage[]>({
         queryKey: ["emails"],
       });
+      setOptimisticOverride(id, { isRead });
       qc.setQueriesData<EmailMessage[]>({ queryKey: ["emails"] }, (old) =>
         old?.map((e) => (e.id === id ? { ...e, isRead } : e)),
       );
       return { previous };
     },
-    onError: (_err, _vars, context) => {
+    onError: (_err, { id }, context) => {
+      clearOptimisticOverride(id);
       context?.previous.forEach(([key, data]) => qc.setQueryData(key, data));
     },
     onSettled: () => delayedInvalidate(qc, [["emails"], ["labels"]]),
@@ -217,14 +264,16 @@ export function useMarkRead() {
 
 export function useMarkThreadRead() {
   const qc = useQueryClient();
-  // Stash unread IDs between onMutate (which computes them before the
-  // optimistic update) and mutationFn (which sends the actual API calls).
-  let pendingUnreadIds: string[] = [];
+  // Per-thread pending IDs — using a Map so concurrent mutations for different
+  // threads don't overwrite each other's pending IDs.
+  const pendingByThread = new Map<string, string[]>();
   return useMutation({
-    mutationFn: async (_threadId: string) => {
-      if (pendingUnreadIds.length > 0) {
+    mutationFn: async (threadId: string) => {
+      const ids = pendingByThread.get(threadId) ?? [];
+      pendingByThread.delete(threadId);
+      if (ids.length > 0) {
         await Promise.all(
-          pendingUnreadIds.map((id) =>
+          ids.map((id) =>
             apiFetch(`/api/emails/${id}/read`, {
               method: "PATCH",
               body: JSON.stringify({ isRead: true }),
@@ -240,18 +289,26 @@ export function useMarkThreadRead() {
       });
       // Capture unread IDs BEFORE optimistic update
       const allEmails = previous.flatMap(([, data]) => data ?? []) ?? [];
-      pendingUnreadIds = allEmails
+      const unreadIds = allEmails
         .filter((e) => (e.threadId || e.id) === threadId && !e.isRead)
         .map((e) => e.id);
+      pendingByThread.set(threadId, unreadIds);
+      // Set overrides so refetches don't revert read state
+      for (const id of unreadIds) {
+        setOptimisticOverride(id, { isRead: true });
+      }
       // Optimistic update
       qc.setQueriesData<EmailMessage[]>({ queryKey: ["emails"] }, (old) =>
         old?.map((e) =>
           (e.threadId || e.id) === threadId ? { ...e, isRead: true } : e,
         ),
       );
-      return { previous };
+      return { previous, overrideIds: [...unreadIds] };
     },
     onError: (_err, _vars, context) => {
+      for (const id of context?.overrideIds ?? []) {
+        clearOptimisticOverride(id);
+      }
       context?.previous.forEach(([key, data]) => qc.setQueryData(key, data));
     },
     onSettled: () => delayedInvalidate(qc, [["emails"], ["labels"]]),
@@ -266,7 +323,22 @@ export function useToggleStar() {
         method: "PATCH",
         body: JSON.stringify({ isStarred }),
       }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["emails"] }),
+    onMutate: async ({ id, isStarred }) => {
+      await qc.cancelQueries({ queryKey: ["emails"] });
+      const previous = qc.getQueriesData<EmailMessage[]>({
+        queryKey: ["emails"],
+      });
+      setOptimisticOverride(id, { isStarred });
+      qc.setQueriesData<EmailMessage[]>({ queryKey: ["emails"] }, (old) =>
+        old?.map((e) => (e.id === id ? { ...e, isStarred } : e)),
+      );
+      return { previous };
+    },
+    onError: (_err, { id }, context) => {
+      clearOptimisticOverride(id);
+      context?.previous.forEach(([key, data]) => qc.setQueryData(key, data));
+    },
+    onSettled: () => delayedInvalidate(qc, [["emails"], ["labels"]]),
   });
 }
 
@@ -536,7 +608,7 @@ export function useReportSpam() {
       if (context?.threadId) unsuppressThread(context.threadId);
       context?.previous.forEach(([key, data]) => qc.setQueryData(key, data));
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: ["emails"] }),
+    onSettled: () => delayedInvalidate(qc, [["emails"], ["labels"]]),
   });
 }
 
@@ -572,7 +644,7 @@ export function useBlockSender() {
       if (context?.threadId) unsuppressThread(context.threadId);
       context?.previous.forEach(([key, data]) => qc.setQueryData(key, data));
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: ["emails"] }),
+    onSettled: () => delayedInvalidate(qc, [["emails"], ["labels"]]),
   });
 }
 
@@ -596,7 +668,7 @@ export function useMuteThread() {
       if (context?.threadId) unsuppressThread(context.threadId);
       context?.previous.forEach(([key, data]) => qc.setQueryData(key, data));
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: ["emails"] }),
+    onSettled: () => delayedInvalidate(qc, [["emails"], ["labels"]]),
   });
 }
 

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -38,6 +38,9 @@ function ContactPanel({
     () => emails.find((e) => e.id === emailId),
     [emails, emailId],
   );
+  // Always use inbox emails for "recent from contact" — shares React Query cache,
+  // no extra fetch. The `emails` prop may be a different view (sent, starred, etc.)
+  const { data: inboxEmails = [] } = useEmails("inbox");
 
   const displayEmail = contactEmail || email?.from.email;
   const displayName = contactEmail
@@ -52,7 +55,7 @@ function ContactPanel({
     );
   }
 
-  const recentFromContact = emails
+  const recentFromContact = inboxEmails
     .filter((e) => e.from.email === displayEmail && e.id !== emailId)
     .slice(0, 4)
     .map((e) => ({ id: e.id, subject: e.subject }));

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -11,7 +11,6 @@ import {
   type NavigationState,
 } from "@/hooks/use-navigation-state";
 import {
-  useEmail,
   useEmails,
   useMarkRead,
   useDeleteDraft,
@@ -28,12 +27,17 @@ import type { EmailMessage } from "@shared/types";
 function ContactPanel({
   emailId,
   contactEmail,
+  emails,
 }: {
   emailId: string | undefined;
   contactEmail?: string;
+  emails: EmailMessage[];
 }) {
-  const { data: email } = useEmail(emailId);
-  const { data: allEmails = [] } = useEmails("inbox");
+  // Look up from already-cached list data instead of making a separate API call
+  const email = useMemo(
+    () => emails.find((e) => e.id === emailId),
+    [emails, emailId],
+  );
 
   const displayEmail = contactEmail || email?.from.email;
   const displayName = contactEmail
@@ -48,7 +52,7 @@ function ContactPanel({
     );
   }
 
-  const recentFromContact = allEmails
+  const recentFromContact = emails
     .filter((e) => e.from.email === displayEmail && e.id !== emailId)
     .slice(0, 4)
     .map((e) => ({ id: e.id, subject: e.subject }));
@@ -345,7 +349,7 @@ export function InboxPage() {
     if (!googleStatus.isLoading && googleStatus.data?.connected === false) {
       return <GoogleConnectBanner variant="hero" />;
     }
-    if (!googleStatus.isLoading && googleStatus.data?.connected) {
+    if (!googleStatus.isLoading) {
       return (
         <div className="flex flex-1 items-center justify-center text-center">
           <div>
@@ -411,6 +415,7 @@ export function InboxPage() {
           <ContactPanel
             emailId={contactEmailId}
             contactEmail={sidebarContactEmail}
+            emails={emails}
           />
         </div>
       )}

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -41,6 +41,47 @@ import {
 import { getSyntheticEmailsForView } from "../lib/jobs.js";
 
 // ---------------------------------------------------------------------------
+// Label map cache — avoids re-fetching label names from Gmail on every request
+// ---------------------------------------------------------------------------
+
+const labelMapCache = new Map<
+  string,
+  { map: Map<string, string>; expiresAt: number }
+>();
+const LABEL_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+async function getCachedLabelMap(
+  accountTokens: Array<{ email: string; accessToken: string }>,
+): Promise<Map<string, string>> {
+  // Build a cache key from sorted account emails
+  const cacheKey = accountTokens
+    .map((a) => a.email)
+    .sort()
+    .join(",");
+  const cached = labelMapCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.map;
+
+  const labelMap = new Map<string, string>();
+  await Promise.all(
+    accountTokens.map(async ({ accessToken }) => {
+      try {
+        const res = await gmailListLabels(accessToken);
+        for (const label of res.labels || []) {
+          if (label.id && label.name) {
+            labelMap.set(label.id, label.name);
+          }
+        }
+      } catch {}
+    }),
+  );
+  labelMapCache.set(cacheKey, {
+    map: labelMap,
+    expiresAt: Date.now() + LABEL_CACHE_TTL,
+  });
+  return labelMap;
+}
+
+// ---------------------------------------------------------------------------
 // Token helper — get a valid access token, refreshing if needed
 // ---------------------------------------------------------------------------
 
@@ -241,26 +282,9 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
         searchQuery = gmailQuery[view] ?? `label:${view}`;
       }
 
-      // Fetch label name mapping from all accounts
+      // Fetch label name mapping from all accounts (cached)
       const accountTokens = await getAccountTokens(email);
-      const labelMap = new Map<string, string>();
-      await Promise.all(
-        accountTokens.map(async ({ accessToken }) => {
-          try {
-            const res = await gmailListLabels(accessToken);
-            for (const label of res.labels || []) {
-              if (label.id && label.name) {
-                labelMap.set(label.id, label.name);
-              }
-            }
-          } catch (err: any) {
-            console.error(
-              "[listEmails] Failed to fetch label map:",
-              err?.message,
-            );
-          }
-        }),
-      );
+      const labelMap = await getCachedLabelMap(accountTokens);
       const { messages, errors } = await listGmailMessages(
         searchQuery,
         undefined,
@@ -364,19 +388,7 @@ export const getThreadMessages = defineEventHandler(async (event: H3Event) => {
   if (await isConnected(email)) {
     try {
       const accountTokens = await getAccountTokens(email);
-      const labelMap = new Map<string, string>();
-      await Promise.all(
-        accountTokens.map(async ({ accessToken }) => {
-          try {
-            const res = await gmailListLabels(accessToken);
-            for (const label of res.labels || []) {
-              if (label.id && label.name) {
-                labelMap.set(label.id, label.name);
-              }
-            }
-          } catch {}
-        }),
-      );
+      const labelMap = await getCachedLabelMap(accountTokens);
 
       // Search across all accounts for messages in this thread
       for (const { email: acctEmail, accessToken } of accountTokens) {
@@ -434,15 +446,9 @@ export const getEmail = defineEventHandler(async (event: H3Event) => {
   const email = await userEmail(event);
   if (await isConnected(email)) {
     const accountTokens = await getAccountTokens(email);
+    const labelMap = await getCachedLabelMap(accountTokens);
     for (const { email: acctEmail, accessToken } of accountTokens) {
       try {
-        const labelRes = await gmailListLabels(accessToken);
-        const labelMap = new Map<string, string>();
-        for (const label of labelRes.labels || []) {
-          if (label.id && label.name) {
-            labelMap.set(label.id, label.name);
-          }
-        }
         const msg = await gmailGetMessage(
           accessToken,
           getRouterParam(event, "id") as string,


### PR DESCRIPTION
## Summary

- **Fix read/unread flicker**: Shared mutable variable in `useMarkThreadRead` caused rapid j/k navigation to only mark the last thread as read on Gmail. When Gmail refetched, earlier threads reverted to unread. Fixed with per-thread Map + optimistic property overrides that persist through refetch cycles (60s).
- **Fix blank inbox**: `googleStatus.isLoading` blocked all content rendering when the status endpoint was missing/erroring. Content now renders immediately.
- **Perf improvements**: Memoize `EmailListItem`, cache Gmail label map server-side (5min), remove per-email API calls from `ContactPanel`, add optimistic updates to star toggle, use `delayedInvalidate` consistently.

## Test plan

- [ ] Open inbox with 10+ emails, rapidly navigate threads with j/k, go back to list — read states should not flicker back to unread after 30+ seconds
- [ ] Press `e` to archive from both list and thread view — next email selected instantly, archived email never reappears
- [ ] Toggle star with `s` — should update instantly without waiting for server
- [ ] Mark read email as unread with `u` — should not revert on refetch
- [ ] Verify inbox loads correctly (not blank) on fresh page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)