### PR TITLE
fix: consolidate template imports to @agent-native/core/client

### DIFF
--- a/packages/core/src/templates/default/app/root.tsx
+++ b/packages/core/src/templates/default/app/root.tsx
@@ -13,8 +13,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
-import { useDbSync } from "@agent-native/core";
-import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
+import { useDbSync, ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { Toaster } from "sonner";
 import "./global.css";
 

--- a/templates/issues/app/root.tsx
+++ b/templates/issues/app/root.tsx
@@ -9,8 +9,7 @@ import { ThemeProvider } from "next-themes";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppLayout } from "@/components/layout/AppLayout";
-import { useDbSync } from "@agent-native/core";
-import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
+import { useDbSync, ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { TAB_ID } from "@/lib/tab-id";
 import "./global.css";
 

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -9,8 +9,7 @@ import { ThemeProvider } from "next-themes";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppLayout } from "@/components/layout/AppLayout";
-import { useDbSync } from "@agent-native/core";
-import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
+import { useDbSync, ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { TAB_ID } from "@/lib/tab-id";
 import "./global.css";
 

--- a/templates/mail/package.json
+++ b/templates/mail/package.json
@@ -63,6 +63,7 @@
     "@swc/core": "^1.13.3",
     "@tailwindcss/typography": "^0.5.16",
     "@tanstack/react-query": "^5.84.2",
+    "@tiptap/core": "^3.19.0",
     "@tiptap/extension-code-block-lowlight": "^3.19.0",
     "@tiptap/extension-image": "^3.19.0",
     "@tiptap/extension-link": "^3.19.0",

--- a/templates/recruiting/app/root.tsx
+++ b/templates/recruiting/app/root.tsx
@@ -9,8 +9,7 @@ import {
 import { ThemeProvider } from "next-themes";
 import { Toaster } from "sonner";
 import { AppLayout } from "@/components/layout/AppLayout";
-import { useDbSync } from "@agent-native/core";
-import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
+import { useDbSync, ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { TAB_ID } from "@/lib/tab-id";
 import "./global.css";
 

--- a/templates/starter/app/root.tsx
+++ b/templates/starter/app/root.tsx
@@ -7,8 +7,8 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
-import { useDbSync } from "@agent-native/core";
 import {
+  useDbSync,
   ClientOnly,
   CommandMenu,
   DefaultSpinner,


### PR DESCRIPTION
## Summary

- Moves `useDbSync`, `ClientOnly`, and `DefaultSpinner` imports from `@agent-native/core` (root) to `@agent-native/core/client` across all affected templates (`default`, `mail`, `issues`, `recruiting`, `starter`). These exports live in `/client` and aren't available at the root in the current published build, causing runtime errors.
- Adds `@tiptap/core: ^3.19.0` as an explicit dep in the mail template so pnpm doesn't hoist the v2 copy from `@agent-native/core`'s internal deps over the v3 the template requires.

## Test plan

- [ ] `npx @agent-native/core@dev create my-app --template mail && cd my-app && pnpm install && pnpm dev` — no `useDbSync` or `DefaultSpinner` export errors
- [ ] Same for `--template issues`, `--template recruiting`, `--template starter`
- [ ] Default template (`agent-native create my-app`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)