### PR TITLE
Fix hero section horizontal overflow on mobile

### DIFF
--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -348,7 +348,7 @@ html.dark .shiki span {
 /* Home hero */
 .hero-section {
   text-align: center;
-  padding: 80px 0 64px;
+  padding: 80px 24px 64px;
   border-bottom: 1px solid var(--border);
 }
 
@@ -363,7 +363,7 @@ html.dark .shiki span {
 @media (max-width: 767px) {
   .hero-section {
     text-align: left;
-    padding: 48px 0 48px;
+    padding: 48px 24px;
   }
 
   .hero-section .flex {

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -260,7 +260,7 @@ export default function Home() {
               Every Agent-Native app is both.
             </p>
 
-            <div className="flex items-center justify-center gap-4">
+            <div className="flex flex-wrap items-center justify-center gap-4">
               <a
                 href="#templates"
                 className="primary-button"

--- a/templates/starter/.react-router/types/app/+types/root.ts
+++ b/templates/starter/.react-router/types/app/+types/root.ts
@@ -14,7 +14,7 @@ type Matches = [{
   module: typeof import("../root.js");
 }];
 
-type Annotations = GetAnnotations<Info & { module: Module, matches: Matches }, false>;
+type Annotations = GetAnnotations<Info & { module: Module, matches: Matches }>;
 
 export namespace Route {
   // links
@@ -51,9 +51,18 @@ export namespace Route {
   // HydrateFallback
   export type HydrateFallbackProps = Annotations["HydrateFallbackProps"];
 
+  // ServerHydrateFallback
+  export type ServerHydrateFallbackProps = Annotations["ServerHydrateFallbackProps"];
+
   // Component
   export type ComponentProps = Annotations["ComponentProps"];
 
+  // ServerComponent
+  export type ServerComponentProps = Annotations["ServerComponentProps"];
+
   // ErrorBoundary
   export type ErrorBoundaryProps = Annotations["ErrorBoundaryProps"];
+
+  // ServerErrorBoundary
+  export type ServerErrorBoundaryProps = Annotations["ServerErrorBoundaryProps"];
 }

--- a/templates/starter/.react-router/types/app/routes/+types/_index.ts
+++ b/templates/starter/.react-router/types/app/routes/+types/_index.ts
@@ -17,7 +17,7 @@ type Matches = [{
   module: typeof import("../_index.js");
 }];
 
-type Annotations = GetAnnotations<Info & { module: Module, matches: Matches }, false>;
+type Annotations = GetAnnotations<Info & { module: Module, matches: Matches }>;
 
 export namespace Route {
   // links
@@ -54,9 +54,18 @@ export namespace Route {
   // HydrateFallback
   export type HydrateFallbackProps = Annotations["HydrateFallbackProps"];
 
+  // ServerHydrateFallback
+  export type ServerHydrateFallbackProps = Annotations["ServerHydrateFallbackProps"];
+
   // Component
   export type ComponentProps = Annotations["ComponentProps"];
 
+  // ServerComponent
+  export type ServerComponentProps = Annotations["ServerComponentProps"];
+
   // ErrorBoundary
   export type ErrorBoundaryProps = Annotations["ErrorBoundaryProps"];
+
+  // ServerErrorBoundary
+  export type ServerErrorBoundaryProps = Annotations["ServerErrorBoundaryProps"];
 }


### PR DESCRIPTION
### Summary
Fixes the docs homepage hero overflowing horizontally on mobile viewports, as reported via mobile Safari on agent-native.com. The hero content now stays within the viewport with appropriate padding on all screen sizes.

### Problem
The homepage hero section had no horizontal padding, causing the heading, body text, CTA buttons, and code snippet to extend past the screen edges on small mobile screens. Additionally, the CTA button row did not wrap on narrow viewports, compounding the overflow issue.

### Key Changes
- Added `24px` horizontal padding to `.hero-section` for both desktop and mobile breakpoints in `global.css`
- Added `flex-wrap` to the CTA button container in `_index.tsx` so buttons wrap gracefully on narrow screens
- Updated generated React Router type annotations in the starter template to include new server-side component/error boundary prop types (`ServerHydrateFallbackProps`, `ServerComponentProps`, `ServerErrorBoundaryProps`) and removed the now-unnecessary `false` generic argument from `GetAnnotations`

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/tundra-record-kxs7yckw"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-tundra-record-kxs7yckw_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<h3>Preview</h3>
<img src="https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F9d7aef01a75f4d7698948481aaf458ef?alt=media&token=4201f7dd-2fde-4479-b20b-06c4a88eee0c&apiKey=YJIGb4i01jvw0SRdL5Bt" alt="Changes preview" style="max-width: 100%; height: auto;">
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 148`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>tundra-record-kxs7yckw</branchName>-->