### PR TITLE
Fix mobile overflow in docs homepage hero npm command

### DIFF
--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -375,9 +375,19 @@ html.dark .shiki span {
     margin-right: 0;
   }
 
+  /* Constrain the hero content flex item so it can't exceed viewport width.
+     Without this, min-width: auto on the flex item lets the nowrap command
+     text push the item wider than the mobile viewport (the root overflow cause). */
+  .hero-content {
+    width: 100%;
+    min-width: 0;
+  }
+
   .hero-section button {
     margin-left: 0;
     margin-right: auto;
+    /* size to content but never wider than parent */
+    width: max-content;
     max-width: 100%;
     overflow: hidden;
   }

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -31,7 +31,7 @@ function TerminalCommand() {
       className="group mx-auto mt-8 flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
     >
       <span className="text-[var(--fg-secondary)]">$</span>
-      <span className="terminal-command-text text-[var(--fg)]">{command}</span>
+      <span className="terminal-command-text min-w-0 flex-1 text-[var(--fg)]">{command}</span>
       <span className="ml-2 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
         {copied ? (
           <svg
@@ -244,7 +244,7 @@ export default function Home() {
               opacity: 0.5,
             }}
           />
-          <div className="relative z-10">
+          <div className="relative z-10 hero-content">
             <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--bg-secondary)] px-4 py-1.5 text-sm text-[var(--fg-secondary)]">
               <span className="inline-block h-2 w-2 rounded-full bg-[var(--accent)]" />
               Open source framework

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -31,7 +31,9 @@ function TerminalCommand() {
       className="group mx-auto mt-8 flex items-center gap-3 rounded-lg border border-[var(--code-border)] bg-[var(--code-bg)] px-5 py-3 font-mono text-sm transition hover:border-[var(--fg-secondary)]"
     >
       <span className="text-[var(--fg-secondary)]">$</span>
-      <span className="terminal-command-text min-w-0 flex-1 text-[var(--fg)]">{command}</span>
+      <span className="terminal-command-text min-w-0 flex-1 text-[var(--fg)]">
+        {command}
+      </span>
       <span className="ml-2 text-[var(--fg-secondary)] opacity-0 transition group-hover:opacity-100">
         {copied ? (
           <svg


### PR DESCRIPTION
### Summary
Fixes the remaining horizontal overflow on the docs homepage hero on mobile viewports, specifically caused by the npm command/code snippet row forcing the hero content wider than the screen.

### Problem
After a prior fix attempt, the docs homepage hero still exhibited left/right horizontal overflow on mobile (e.g. Safari-sized widths). The root cause was that the hero content flex item had `min-width: auto` (the default), which allowed the non-wrapping terminal command text inside it to push the item — and the entire page — wider than the mobile viewport.

### Solution
Constrain the hero content flex item so it cannot exceed the viewport width, and ensure the terminal command text span participates correctly in flex shrinking. This prevents the nowrap command text from dictating a minimum width larger than the screen.

### Key Changes
- Added `.hero-content` CSS rule in `global.css` with `width: 100%` and `min-width: 0` to override the default `min-width: auto` on the flex item, eliminating the root overflow cause.
- Added `width: max-content` to the `.hero-section button` rule so the button sizes to its content but never exceeds its parent.
- Added `min-w-0 flex-1` Tailwind classes to the `terminal-command-text` span so it can shrink properly within the flex row instead of forcing the container to expand.
- Applied the `hero-content` class to the main hero content `<div>` in `_index.tsx`.

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/sage-spring-q3lxaorr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-sage-spring-q3lxaorr_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 149`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>sage-spring-q3lxaorr</branchName>-->