### PR TITLE
fix: note delete guard, contact_frequency migration, calendar & chat improvements

### DIFF
--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -41,7 +41,7 @@ export function startRun(
     send: (event: AgentChatEvent) => void,
     signal: AbortSignal,
   ) => Promise<void>,
-  onComplete?: (run: ActiveRun) => void,
+  onComplete?: (run: ActiveRun) => void | Promise<void>,
 ): ActiveRun {
   // If there's already a run for this thread, abort it
   const existingRunId = threadToRun.get(threadId);
@@ -157,13 +157,18 @@ export function startRun(
         runId,
         run.status === "errored" ? "errored" : "completed",
       ).catch(() => {});
-      // Call completion callback (e.g. to save thread data)
+      // Call completion callback (e.g. to save thread data).
+      // onComplete may be async — handle the returned Promise so rejections
+      // don't go unobserved and the callback reliably runs to completion.
       if (onComplete) {
-        try {
-          onComplete(run);
-        } catch {
-          // Don't let callback errors break cleanup
-        }
+        Promise.resolve()
+          .then(() => onComplete(run))
+          .catch((err) => {
+            console.error(
+              "[run-manager] onComplete callback error:",
+              err instanceof Error ? err.message : err,
+            );
+          });
       }
       // Schedule in-memory cleanup
       setTimeout(() => {

--- a/packages/core/src/client/AgentTaskCard.tsx
+++ b/packages/core/src/client/AgentTaskCard.tsx
@@ -64,10 +64,12 @@ export function AgentTaskCard({
   useEffect(() => {
     if (status !== "running") return;
     let stopped = false;
+    let pollCount = 0;
     const poll = async () => {
       while (!stopped) {
         await new Promise((r) => setTimeout(r, 3000));
         if (stopped) break;
+        pollCount++;
         try {
           const res = await fetch(
             `/_agent-native/application-state/agent-task:${taskId}`,
@@ -93,6 +95,37 @@ export function AgentTaskCard({
             if (task.preview) setPreview(task.preview);
             if (task.currentStep) setCurrentStep(task.currentStep);
           }
+
+          // Fallback: every 5th poll, check if the sub-agent's run is still
+          // active. If it's gone (completed without updating app-state), mark
+          // the task as completed so the card doesn't spin forever.
+          if (pollCount % 5 === 0) {
+            try {
+              const runRes = await fetch(
+                `/_agent-native/agent-chat/runs/active?threadId=${encodeURIComponent(threadId)}`,
+              );
+              if (runRes.ok) {
+                const runData = await runRes.json();
+                // null or non-running status means the run finished
+                if (
+                  !runData ||
+                  runData.status === "completed" ||
+                  runData.status === "errored"
+                ) {
+                  const finalStatus =
+                    runData?.status === "errored" ? "errored" : "completed";
+                  setStatus(finalStatus);
+                  setCurrentStep("");
+                  setSummary(
+                    (prev) => prev || task?.preview || "Task completed.",
+                  );
+                  break;
+                }
+              }
+            } catch {
+              // Fallback check failed — continue normal polling
+            }
+          }
         } catch {
           // Polling error — continue
         }
@@ -102,7 +135,7 @@ export function AgentTaskCard({
     return () => {
       stopped = true;
     };
-  }, [status, taskId]);
+  }, [status, taskId, threadId]);
 
   // Auto-scroll preview to bottom
   useEffect(() => {

--- a/packages/core/src/client/AgentTaskCard.tsx
+++ b/packages/core/src/client/AgentTaskCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import {
   IconLoader2,
   IconCheck,
@@ -182,7 +183,7 @@ export function AgentTaskCard({
             ref={previewRef}
             className="rounded-md bg-muted/30 px-3 py-2 text-xs text-muted-foreground break-words max-h-48 overflow-y-auto agent-markdown prose prose-sm prose-invert max-w-none"
           >
-            <ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
               {displayText.length > 800
                 ? "..." + displayText.slice(-800)
                 : displayText}

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -995,7 +995,7 @@ const AssistantChatInner = forwardRef<
   const scrollRef = useRef<HTMLDivElement>(null);
   const thread = useThread();
   const threadRuntime = useThreadRuntime();
-  const isRunning = thread.isRunning;
+  const isRuntimeRunning = thread.isRunning;
   const messages = thread.messages;
   const [missingApiKey, setMissingApiKey] = useState(false);
   const [queuedMessages, setQueuedMessages] = useState<
@@ -1005,6 +1005,8 @@ const AssistantChatInner = forwardRef<
   const [isReconnecting, setIsReconnecting] = useState(false);
   const [reconnectContent, setReconnectContent] = useState<ContentPart[]>([]);
   const reconnectRunIdRef = useRef<string | null>(null);
+  // Treat reconnecting to an active run the same as running for UI purposes
+  const isRunning = isRuntimeRunning || isReconnecting;
   const wasRunningRef = useRef(false);
   const tiptapRef = useRef<TiptapComposerHandle>(null);
 
@@ -1488,11 +1490,10 @@ const AssistantChatInner = forwardRef<
                 </button>
               </div>
             )}
-            {isRunning && <ThinkingIndicator />}
-            {isReconnecting && !isRunning && reconnectContent.length > 0 && (
+            {isReconnecting && reconnectContent.length > 0 && (
               <ReconnectStreamMessage content={reconnectContent} />
             )}
-            {isReconnecting && !isRunning && reconnectContent.length === 0 && (
+            {isRunning && !(isReconnecting && reconnectContent.length > 0) && (
               <ThinkingIndicator />
             )}
             {queuedMessages.map((msg, i) => (
@@ -1563,7 +1564,17 @@ const AssistantChatInner = forwardRef<
             actionButton={
               isRunning ? (
                 <button
-                  onClick={() => threadRuntime.cancelRun()}
+                  onClick={() => {
+                    if (isReconnecting && reconnectRunIdRef.current) {
+                      // Abort the server-side run directly
+                      fetch(
+                        `${apiUrl}/runs/${encodeURIComponent(reconnectRunIdRef.current)}/abort`,
+                        { method: "POST" },
+                      );
+                    } else {
+                      threadRuntime.cancelRun();
+                    }
+                  }}
                   className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-primary text-primary-foreground hover:opacity-90"
                   title="Stop generating"
                 >

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -27,6 +27,7 @@ import {
 } from "@assistant-ui/react";
 import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { createAgentChatAdapter } from "./agent-chat-adapter.js";
 import { type ContentPart, readSSEStreamRaw } from "./sse-event-processor.js";
 import { cn } from "./utils.js";
@@ -98,7 +99,11 @@ function MarkdownText() {
     injectMarkdownStyles();
   }, []);
   return (
-    <MarkdownTextPrimitive smooth className="agent-markdown break-words" />
+    <MarkdownTextPrimitive
+      smooth
+      className="agent-markdown break-words"
+      remarkPlugins={[remarkGfm]}
+    />
   );
 }
 
@@ -342,7 +347,9 @@ function ToolCallFallback({
           ref={streamRef}
           className="mt-1 rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground break-words max-h-48 overflow-y-auto agent-markdown prose prose-sm prose-invert max-w-none"
         >
-          <ReactMarkdown>{agentStreamText}</ReactMarkdown>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {agentStreamText}
+          </ReactMarkdown>
         </div>
       )}
       {isExpanded && !isAgentCall && result !== undefined && (
@@ -472,7 +479,9 @@ function ReconnectStreamToolCall({
           ref={streamRef}
           className="mt-1 rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground break-words max-h-48 overflow-y-auto agent-markdown prose prose-sm prose-invert max-w-none"
         >
-          <ReactMarkdown>{agentStreamText}</ReactMarkdown>
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {agentStreamText}
+          </ReactMarkdown>
         </div>
       )}
       {isExpanded && !isAgentCall && result !== undefined && (
@@ -763,10 +772,10 @@ function AssistantMessage() {
 // ─── Thinking Indicator ─────────────────────────────────────────────────────
 
 function ThinkingIndicator() {
-  const [dots, setDots] = useState(1);
+  const [dots, setDots] = useState(0);
   useEffect(() => {
     const interval = setInterval(() => {
-      setDots((d) => (d % 3) + 1);
+      setDots((d) => (d + 1) % 4);
     }, 400);
     return () => clearInterval(interval);
   }, []);
@@ -995,6 +1004,7 @@ const AssistantChatInner = forwardRef<
   const [showContinue, setShowContinue] = useState(false);
   const [isReconnecting, setIsReconnecting] = useState(false);
   const [reconnectContent, setReconnectContent] = useState<ContentPart[]>([]);
+  const reconnectRunIdRef = useRef<string | null>(null);
   const wasRunningRef = useRef(false);
   const tiptapRef = useRef<TiptapComposerHandle>(null);
 
@@ -1044,8 +1054,15 @@ const AssistantChatInner = forwardRef<
             if (runRes.ok) {
               const runInfo = await runRes.json();
               // Agent is still running — subscribe to live SSE stream
+              reconnectRunIdRef.current = runInfo.runId;
               setIsReconnecting(true);
               setReconnectContent([]);
+              // Signal tab running indicator
+              window.dispatchEvent(
+                new CustomEvent("builder.chatRunning", {
+                  detail: { isRunning: true, tabId: tabId || threadId },
+                }),
+              );
 
               const streamReconnect = async () => {
                 try {
@@ -1106,6 +1123,13 @@ const AssistantChatInner = forwardRef<
                 } catch {}
                 setReconnectContent([]);
                 setIsReconnecting(false);
+                reconnectRunIdRef.current = null;
+                // Signal tab stopped
+                window.dispatchEvent(
+                  new CustomEvent("builder.chatRunning", {
+                    detail: { isRunning: false, tabId: tabId || threadId },
+                  }),
+                );
               };
               streamReconnect();
             }

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -305,14 +305,15 @@ export function MultiTabAssistantChat({
   });
   const initializedRef = useRef(false);
 
-  // Persist open tab IDs to localStorage
+  // Persist open tab IDs to localStorage (exclude sub-agent tabs — they're session-only)
   useEffect(() => {
-    if (openTabIds.length > 0) {
+    const mainTabs = openTabIds.filter((id) => !parentMap[id]);
+    if (mainTabs.length > 0) {
       try {
-        localStorage.setItem(OPEN_TABS_KEY, JSON.stringify(openTabIds));
+        localStorage.setItem(OPEN_TABS_KEY, JSON.stringify(mainTabs));
       } catch {}
     }
-  }, [openTabIds]);
+  }, [openTabIds, parentMap]);
 
   // Initialize open tabs once threads load — validate saved tabs still exist
   useEffect(() => {
@@ -320,16 +321,29 @@ export function MultiTabAssistantChat({
       return;
     initializedRef.current = true;
     const threadIds = new Set(threads.map((t) => t.id));
+
+    // If the active thread is a sub-agent, switch to its parent or the most recent main thread
+    if (parentMap[activeThreadId]) {
+      const parent = parentMap[activeThreadId];
+      if (parent && threadIds.has(parent)) {
+        switchThread(parent);
+      } else {
+        // Fall back to most recent main thread
+        const mainThread = threads.find((t) => !parentMap[t.id]);
+        if (mainThread) switchThread(mainThread.id);
+      }
+    }
+
     setOpenTabIds((prev) => {
-      // Filter out any saved tabs that no longer exist
-      const valid = prev.filter((id) => threadIds.has(id));
-      // Ensure active thread is included
-      if (!valid.includes(activeThreadId)) {
+      // Filter out any saved tabs that no longer exist, and any sub-agent tabs
+      const valid = prev.filter((id) => threadIds.has(id) && !parentMap[id]);
+      // Ensure active thread is included (only if it's not a sub-agent)
+      if (!parentMap[activeThreadId] && !valid.includes(activeThreadId)) {
         valid.push(activeThreadId);
       }
       return valid.length > 0 ? valid : [activeThreadId];
     });
-  }, [activeThreadId, threads]);
+  }, [activeThreadId, threads, parentMap, switchThread]);
 
   // Ensure active thread is always in open tabs.
   // Use functional update to check inside the setter — avoids race with the

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -99,6 +99,10 @@ export function TiptapComposer({
     popoverStateRef.current = null;
   }, []);
 
+  // Persist draft to localStorage so hot-reloads don't lose the prompt
+  const DRAFT_KEY = "an-composer-draft";
+  const draftTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
   const editor = useEditor({
     extensions: [
       StarterKit.configure({
@@ -124,6 +128,32 @@ export function TiptapComposer({
       MentionReference,
     ],
     editable: !disabled,
+    onCreate: ({ editor: ed }) => {
+      // Restore draft on mount
+      try {
+        const saved = localStorage.getItem(DRAFT_KEY);
+        if (saved) {
+          ed.commands.setContent(saved);
+          // Move cursor to end
+          ed.commands.focus("end");
+        }
+      } catch {}
+    },
+    onUpdate: ({ editor: ed }) => {
+      // Debounce-save draft to localStorage
+      clearTimeout(draftTimerRef.current);
+      draftTimerRef.current = setTimeout(() => {
+        try {
+          const html = ed.getHTML();
+          const isEmpty = !ed.state.doc.textContent.trim();
+          if (isEmpty) {
+            localStorage.removeItem(DRAFT_KEY);
+          } else {
+            localStorage.setItem(DRAFT_KEY, html);
+          }
+        } catch {}
+      }, 300);
+    },
     editorProps: {
       attributes: {
         class:
@@ -345,6 +375,9 @@ export function TiptapComposer({
       composerRuntime.send();
     }
     ed.commands.clearContent();
+    try {
+      localStorage.removeItem(DRAFT_KEY);
+    } catch {}
     closePopover();
   }, [closePopover, composerRuntime, editor, onSubmit, syncComposerState]);
 

--- a/packages/core/src/client/resources/use-resources.ts
+++ b/packages/core/src/client/resources/use-resources.ts
@@ -55,7 +55,7 @@ export function useResources(scope: ResourceScope = "personal") {
       const data = await fetchJson<{ resources: ResourceMeta[] }>(
         `/_agent-native/resources?scope=${scope}`,
       );
-      return data.resources;
+      return data.resources ?? [];
     },
   });
 }
@@ -67,7 +67,7 @@ export function useResourceTree(scope: ResourceScope = "personal") {
       const data = await fetchJson<{ tree: TreeNode[] }>(
         `/_agent-native/resources/tree?scope=${scope}`,
       );
-      return data.tree;
+      return data.tree ?? [];
     },
   });
 }

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -150,7 +150,9 @@ export function useChatThreads(apiUrl = "/_agent-native/agent-chat") {
                   ...t,
                   title: data.title,
                   preview: data.preview,
-                  messageCount: data.messageCount,
+                  ...(data.messageCount != null && {
+                    messageCount: data.messageCount,
+                  }),
                   updatedAt: Date.now(),
                 }
               : t,

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -33,6 +33,7 @@ export {
   getDbExec,
   getDialect,
   isPostgres,
+  intType,
   closeDbExec,
   type DbExec,
   type Dialect,

--- a/packages/core/src/deploy/route-discovery.ts
+++ b/packages/core/src/deploy/route-discovery.ts
@@ -116,6 +116,7 @@ export const DEFAULT_PLUGIN_REGISTRY: Record<string, string> = {
   auth: "defaultAuthPlugin",
   "core-routes": "defaultCoreRoutesPlugin",
   "file-sync": "defaultFileSyncPlugin",
+  integrations: "defaultIntegrationsPlugin",
   resources: "defaultResourcesPlugin",
   terminal: "defaultTerminalPlugin",
 };

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -19,3 +19,6 @@ export {
 
 // Shared (isomorphic)
 export { agentChat } from "./shared/index.js";
+
+// Pure utilities (no Node.js deps — safe for browser and SSR)
+export { parseArgs, camelCaseArgs } from "./scripts/parse-args.js";

--- a/packages/core/src/scripts/parse-args.ts
+++ b/packages/core/src/scripts/parse-args.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure script utilities — no Node.js dependencies.
+ * Safe to import from browser bundles and Vite SSR.
+ */
+
+/**
+ * Parse CLI args in --key value format.
+ * Supports: --key value, --key=value, --flag (boolean true)
+ */
+export function parseArgs(args: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith("--")) continue;
+
+    const eqIndex = arg.indexOf("=");
+    if (eqIndex !== -1) {
+      const key = arg.slice(2, eqIndex);
+      result[key] = arg.slice(eqIndex + 1);
+    } else {
+      const key = arg.slice(2);
+      const next = args[i + 1];
+      if (next && !next.startsWith("--")) {
+        result[key] = next;
+        i++;
+      } else {
+        result[key] = "true";
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Convert kebab-case keys to camelCase.
+ */
+export function camelCaseArgs(
+  args: Record<string, string>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(args)) {
+    const camel = key.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+    result[camel] = value;
+  }
+  return result;
+}

--- a/packages/core/src/scripts/utils.ts
+++ b/packages/core/src/scripts/utils.ts
@@ -2,53 +2,14 @@ import fs from "fs";
 import path from "path";
 import dotenv from "dotenv";
 
+// Re-export pure arg-parsing utilities (no Node.js deps, browser-safe)
+export { parseArgs, camelCaseArgs } from "./parse-args.js";
+
 /**
  * Load .env from project root (cwd).
  */
 export function loadEnv(envPath?: string): void {
   dotenv.config({ path: envPath ?? path.join(process.cwd(), ".env") });
-}
-
-/**
- * Parse CLI args in --key value format.
- * Supports: --key value, --key=value, --flag (boolean true)
- */
-export function parseArgs(args: string[]): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (!arg.startsWith("--")) continue;
-
-    const eqIndex = arg.indexOf("=");
-    if (eqIndex !== -1) {
-      const key = arg.slice(2, eqIndex);
-      result[key] = arg.slice(eqIndex + 1);
-    } else {
-      const key = arg.slice(2);
-      const next = args[i + 1];
-      if (next && !next.startsWith("--")) {
-        result[key] = next;
-        i++;
-      } else {
-        result[key] = "true";
-      }
-    }
-  }
-  return result;
-}
-
-/**
- * Convert kebab-case keys to camelCase.
- */
-export function camelCaseArgs(
-  args: Record<string, string>,
-): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const [key, value] of Object.entries(args)) {
-    const camel = key.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-    result[camel] = value;
-  }
-  return result;
 }
 
 /**

--- a/packages/core/src/server/agent-teams.ts
+++ b/packages/core/src/server/agent-teams.ts
@@ -175,12 +175,15 @@ export async function spawnTask(opts: SpawnTaskOptions): Promise<AgentTask> {
   let accumulatedText = "";
   let lastPreviewSent = 0;
   const PREVIEW_INTERVAL_MS = 300; // Throttle preview updates to every 300ms
+  // Gate to prevent sendPreviewUpdate from overwriting terminal status
+  let runFinished = false;
 
   startRun(
     runId,
     thread.id,
     async (send, signal) => {
       const sendPreviewUpdate = async (force = false) => {
+        if (runFinished) return; // Don't overwrite completed/errored status
         const now = Date.now();
         if (!force && now - lastPreviewSent < PREVIEW_INTERVAL_MS) return;
         lastPreviewSent = now;
@@ -224,6 +227,9 @@ export async function spawnTask(opts: SpawnTaskOptions): Promise<AgentTask> {
     },
     // onComplete callback — called when the run finishes (success or error)
     async (run) => {
+      // Prevent any in-flight sendPreviewUpdate from overwriting terminal status
+      runFinished = true;
+
       if (run.status === "errored") {
         task.status = "errored";
         task.summary = accumulatedText.slice(-500) || "Task failed.";

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -131,9 +131,11 @@ async function ensureInitialized() {
  * Match a request path against the registered routes.
  * Uses prefix matching (like H3 v1's app.use behavior).
  */
-function matchRoute(
-  requestPath: string,
-): { handler: EventHandler; params: Record<string, string> } | null {
+function matchRoute(requestPath: string): {
+  handler: EventHandler;
+  params: Record<string, string>;
+  path: string;
+} | null {
   // Sort routes by specificity (longest path first)
   const sorted = [...routes].sort((a, b) => b.path.length - a.path.length);
 
@@ -158,7 +160,7 @@ function matchRoute(
     }
 
     if (matches) {
-      return { handler: route.handler, params };
+      return { handler: route.handler, params, path: route.path };
     }
   }
 
@@ -192,7 +194,25 @@ export async function handleFrameworkRequest(event: any): Promise<any> {
     if (event.context) {
       event.context.params = { ...event.context.params, ...match.params };
     }
-    return match.handler(event);
+    // Emulate H3 v1's app.use() behavior: strip the matched base path from
+    // event.path so handlers see a path relative to their mount point.
+    // Without this, handlers that inspect event.path (e.g. routers, thread
+    // handlers) would see the full URL and fail to route correctly.
+    // In H3 >=1.15, event.path is a getter-only property on the prototype,
+    // so we shadow it with an instance-level value property, then delete
+    // the shadow to restore the prototype getter.
+    const remainder = path.slice(match.path.length) || "/";
+    Object.defineProperty(event, "path", {
+      value: remainder,
+      configurable: true,
+      writable: true,
+    });
+    try {
+      return await match.handler(event);
+    } finally {
+      // Remove instance shadow to restore prototype getter
+      delete (event as any).path;
+    }
   }
 
   // No match — return 404

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -28,6 +28,7 @@ import {
   defaultAgentChatPlugin,
 } from "./index.js";
 import { defaultTerminalPlugin } from "../terminal/terminal-plugin.js";
+import { defaultIntegrationsPlugin } from "../integrations/plugin.js";
 
 const DEFAULT_PLUGIN_IMPLEMENTATIONS: Record<
   string,
@@ -37,6 +38,7 @@ const DEFAULT_PLUGIN_IMPLEMENTATIONS: Record<
   auth: defaultAuthPlugin,
   "core-routes": defaultCoreRoutesPlugin,
   "file-sync": defaultFileSyncPlugin,
+  integrations: defaultIntegrationsPlugin,
   resources: defaultResourcesPlugin,
   terminal: defaultTerminalPlugin,
 };

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -167,6 +167,14 @@ pnpm action hubspot-deals --grep="enterprise" --fields=dealname,amount,stageLabe
 3. **Update skills directly** when you discover new gotchas or patterns.
 4. **Learn from corrections** — capture in the relevant skill or LEARNINGS.md resource.
 
+## UI Components
+
+**Always use shadcn/ui components** from `app/components/ui/` for all standard UI patterns (dialogs, popovers, dropdowns, tooltips, buttons, etc). Never build custom modals or dropdowns with absolute/fixed positioning — use the shadcn primitives instead.
+
+**Always use Tabler Icons** (`@tabler/icons-react`) for all icons. Never use other icon libraries.
+
+**Never use browser dialogs** (`window.confirm`, `window.alert`, `window.prompt`) — use shadcn AlertDialog instead.
+
 ## TypeScript Everywhere
 
 All code must be TypeScript (`.ts`). Never create `.js`, `.cjs`, or `.mjs` files. Use ESM imports.

--- a/templates/calendar/AGENTS.md
+++ b/templates/calendar/AGENTS.md
@@ -161,3 +161,11 @@ The `--to` bound is exclusive, so use tomorrow's date for today's events.
 2. **Actions for backend logic** — anything the agent needs to execute goes through `pnpm action`.
 3. **Context-first** — always run `view-screen` before acting. Know what the user sees.
 4. **Always query Google Calendar** — use `list-events` or `search-events` for schedule questions. Never return empty results without running a script first.
+
+### UI Components
+
+**Always use shadcn/ui components** from `app/components/ui/` for all standard UI patterns (dialogs, popovers, dropdowns, tooltips, buttons, etc). Never build custom modals or dropdowns with absolute/fixed positioning — use the shadcn primitives instead.
+
+**Always use Tabler Icons** (`@tabler/icons-react`) for all icons. Never use other icon libraries.
+
+**Never use browser dialogs** (`window.confirm`, `window.alert`, `window.prompt`) — use shadcn AlertDialog instead.

--- a/templates/calendar/actions/helpers.ts
+++ b/templates/calendar/actions/helpers.ts
@@ -1,6 +1,27 @@
-import { parseArgs as coreParseArgs } from "@agent-native/core";
-
-export { coreParseArgs as parseArgs };
+/**
+ * Parse CLI-style arguments (--key value or --flag).
+ * Replaces the broken @agent-native/core parseArgs import.
+ */
+export function parseArgs(argv: string[]): Record<string, string | boolean> {
+  const values: Record<string, string | boolean> = {};
+  // Skip the first two entries if they look like node + script path
+  const args =
+    argv[0]?.startsWith("/") || argv[0] === "node" ? argv.slice(2) : argv;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const next = args[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        values[key] = next;
+        i++;
+      } else {
+        values[key] = true;
+      }
+    }
+  }
+  return values;
+}
 
 /**
  * Format an ISO date string to a human-readable date.

--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -18,12 +18,16 @@ interface CreateEventPopoverProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   defaultDate?: Date;
+  defaultStartTime?: string;
+  defaultEndTime?: string;
 }
 
 export function CreateEventPopover({
   open,
   onOpenChange,
   defaultDate,
+  defaultStartTime: defaultStart,
+  defaultEndTime: defaultEnd,
 }: CreateEventPopoverProps) {
   const today = defaultDate || new Date();
   const defaultDateStr = format(today, "yyyy-MM-dd");
@@ -31,8 +35,8 @@ export function CreateEventPopover({
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [date, setDate] = useState(defaultDateStr);
-  const [startTime, setStartTime] = useState("09:00");
-  const [endTime, setEndTime] = useState("10:00");
+  const [startTime, setStartTime] = useState(defaultStart || "09:00");
+  const [endTime, setEndTime] = useState(defaultEnd || "10:00");
   const [location, setLocation] = useState("");
   const [allDay, setAllDay] = useState(false);
 
@@ -45,12 +49,12 @@ export function CreateEventPopover({
       setTitle("");
       setDescription("");
       setDate(format(defaultDate || new Date(), "yyyy-MM-dd"));
-      setStartTime("09:00");
-      setEndTime("10:00");
+      setStartTime(defaultStart || "09:00");
+      setEndTime(defaultEnd || "10:00");
       setLocation("");
       setAllDay(false);
     }
-  }, [open, defaultDate]);
+  }, [open, defaultDate, defaultStart, defaultEnd]);
 
   // ⌘+Enter to submit
   useEffect(() => {

--- a/templates/calendar/app/components/calendar/CreateEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/CreateEventDialog.tsx
@@ -10,7 +10,8 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { useCreateEvent } from "@/hooks/use-events";
+import { useCreateEvent, useDeleteEvent } from "@/hooks/use-events";
+import { setUndoAction } from "@/hooks/use-undo";
 import { toast } from "sonner";
 import { IconPlus } from "@tabler/icons-react";
 
@@ -41,6 +42,7 @@ export function CreateEventPopover({
   const [allDay, setAllDay] = useState(false);
 
   const createEvent = useCreateEvent();
+  const delEvent = useDeleteEvent();
   const formRef = useRef<HTMLFormElement>(null);
 
   // Reset form when popover opens
@@ -94,9 +96,22 @@ export function CreateEventPopover({
         color: undefined,
       },
       {
-        onSuccess: () => {
-          toast.success("Event created");
+        onSuccess: (result) => {
           onOpenChange(false);
+          const eventId = result?.id;
+          const undo = eventId
+            ? () => {
+                delEvent.mutate({
+                  id: eventId,
+                  scope: "single",
+                  sendUpdates: "none",
+                });
+              }
+            : undefined;
+          if (undo) setUndoAction(undo);
+          toast("Event created", {
+            action: undo ? { label: "Undo", onClick: undo } : undefined,
+          });
         },
         onError: () => toast.error("Failed to create event"),
       },

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -21,7 +21,49 @@ interface DayViewProps {
   onEditEvent: (event: CalendarEvent) => void;
   onDeleteEvent: (eventId: string) => void;
   onEventTimeChange?: (eventId: string, newStart: Date, newEnd: Date) => void;
+  onClickTimeSlot?: (date: Date, startTime: string, endTime: string) => void;
+  quickEditEventId?: string | null;
+  onQuickEditSave?: (eventId: string, title: string) => void;
+  onQuickEditCancel?: (eventId: string) => void;
   isLoading?: boolean;
+}
+
+function QuickEditInput({
+  eventId,
+  onSave,
+  onCancel,
+}: {
+  eventId: string;
+  onSave: (eventId: string, title: string) => void;
+  onCancel: (eventId: string) => void;
+}) {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  return (
+    <input
+      ref={inputRef}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          onSave(eventId, value);
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          onCancel(eventId);
+        }
+        e.stopPropagation();
+      }}
+      onBlur={() => onSave(eventId, value)}
+      placeholder="(No title)"
+      className="w-full bg-transparent text-[11px] font-semibold text-foreground placeholder:text-foreground/40 outline-none leading-tight"
+    />
+  );
 }
 
 // [startHour, startMin, durationMin, widthPct]
@@ -94,6 +136,10 @@ export function DayView({
   onEditEvent,
   onDeleteEvent,
   onEventTimeChange,
+  onClickTimeSlot,
+  quickEditEventId,
+  onQuickEditSave,
+  onQuickEditCancel,
   isLoading = false,
 }: DayViewProps) {
   const [now, setNow] = useState(new Date());
@@ -255,7 +301,28 @@ export function DayView({
         </div>
 
         {/* Positioned events overlay */}
-        <div className="absolute inset-0 ml-[56px] mr-4">
+        <div
+          className="absolute inset-0 ml-[56px] mr-4"
+          onClick={(e) => {
+            if ((e.target as HTMLElement).closest("button")) return;
+            if (!onClickTimeSlot || isDragging || shouldSuppressClick()) return;
+            const rect = e.currentTarget.getBoundingClientRect();
+            const y = e.clientY - rect.top;
+            const totalMinutes =
+              Math.floor(((y / HOUR_HEIGHT) * 60) / 15) * 15 + START_HOUR * 60;
+            const startH = Math.floor(totalMinutes / 60);
+            const startM = totalMinutes % 60;
+            const endMinutes = totalMinutes + 60;
+            const endH = Math.min(Math.floor(endMinutes / 60), 23);
+            const endM = endMinutes % 60;
+            const pad = (n: number) => String(n).padStart(2, "0");
+            onClickTimeSlot(
+              date,
+              `${pad(startH)}:${pad(startM)}`,
+              `${pad(endH)}:${pad(endM)}`,
+            );
+          }}
+        >
           {/* Current time indicator */}
           {showNowIndicator && (
             <div
@@ -380,7 +447,21 @@ export function DayView({
                     opacity: isBeingDragged && isDragging ? 0.9 : undefined,
                   }}
                 >
-                  {durationMin <= 30 ? (
+                  {quickEditEventId === event.id &&
+                  onQuickEditSave &&
+                  onQuickEditCancel ? (
+                    <div className="flex flex-col justify-center flex-1 min-w-0 mt-0.5">
+                      <QuickEditInput
+                        eventId={event.id}
+                        onSave={onQuickEditSave}
+                        onCancel={onQuickEditCancel}
+                      />
+                      <div className="mt-0.5 truncate text-[10px] leading-tight text-foreground/60">
+                        {format(displayStart, "h:mm a")} –{" "}
+                        {format(displayEnd, "h:mm a")}
+                      </div>
+                    </div>
+                  ) : durationMin <= 30 ? (
                     <div className="flex items-baseline gap-1.5 truncate">
                       <span
                         className={cn(
@@ -471,8 +552,11 @@ export function DayView({
                 </button>
               );
 
-              // Don't wrap in popover while dragging
-              if (isBeingDragged && isDragging) {
+              // Don't wrap in popover while dragging or quick-editing
+              if (
+                (isBeingDragged && isDragging) ||
+                quickEditEventId === event.id
+              ) {
                 return (
                   <div key={event.id} className="contents">
                     {eventButton}

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -38,6 +38,7 @@ function QuickEditInput({
   onCancel: (eventId: string) => void;
 }) {
   const [value, setValue] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -48,19 +49,41 @@ function QuickEditInput({
     <input
       ref={inputRef}
       value={value}
-      onChange={(e) => setValue(e.target.value)}
+      onChange={(e) => {
+        setValue(e.target.value);
+        setConfirmDelete(false);
+      }}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
           e.preventDefault();
-          onSave(eventId, value);
+          if (confirmDelete) {
+            onCancel(eventId);
+          } else {
+            onSave(eventId, value);
+          }
         } else if (e.key === "Escape") {
           e.preventDefault();
           onCancel(eventId);
+        } else if (
+          (e.key === "Delete" || e.key === "Backspace") &&
+          value === ""
+        ) {
+          e.preventDefault();
+          onCancel(eventId);
+        } else if (e.key === "Delete" && value.trim()) {
+          e.preventDefault();
+          if (confirmDelete) {
+            onCancel(eventId);
+          } else {
+            setConfirmDelete(true);
+          }
         }
         e.stopPropagation();
       }}
       onBlur={() => (value.trim() ? onSave(eventId, value) : onCancel(eventId))}
-      placeholder="(No title)"
+      placeholder={
+        confirmDelete ? "Press Delete or Enter to discard" : "(No title)"
+      }
       className="w-full bg-transparent text-[11px] font-semibold text-foreground placeholder:text-foreground/40 outline-none leading-tight"
     />
   );

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -59,7 +59,7 @@ function QuickEditInput({
         }
         e.stopPropagation();
       }}
-      onBlur={() => onSave(eventId, value)}
+      onBlur={() => (value.trim() ? onSave(eventId, value) : onCancel(eventId))}
       placeholder="(No title)"
       className="w-full bg-transparent text-[11px] font-semibold text-foreground placeholder:text-foreground/40 outline-none leading-tight"
     />

--- a/templates/calendar/app/components/calendar/DeleteEventDialog.tsx
+++ b/templates/calendar/app/components/calendar/DeleteEventDialog.tsx
@@ -1,5 +1,13 @@
-import { useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog";
 import type { CalendarEvent, DeleteEventScope } from "@shared/api";
 
 interface DeleteEventDialogProps {
@@ -21,25 +29,6 @@ export function DeleteEventDialog({
   onConfirm,
   isPending,
 }: DeleteEventDialogProps) {
-  // Close on Escape
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        e.stopPropagation();
-        onClose();
-      }
-    },
-    [onClose],
-  );
-
-  useEffect(() => {
-    if (open) {
-      window.addEventListener("keydown", handleKeyDown, true);
-      return () => window.removeEventListener("keydown", handleKeyDown, true);
-    }
-  }, [open, handleKeyDown]);
-
   if (!event || !open) return null;
 
   const isOrganizer = getIsOrganizer(event);
@@ -56,19 +45,17 @@ export function DeleteEventDialog({
   }
 
   return (
-    <>
-      {/* Transparent backdrop — click to dismiss */}
-      <div className="fixed inset-0 z-50" onClick={onClose} />
-
-      {/* Popover card */}
-      <div className="fixed left-1/2 top-1/2 z-50 w-[340px] -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border bg-popover p-5 shadow-xl animate-in fade-in-0 zoom-in-95">
-        <p className="mb-1 text-sm font-semibold text-foreground">
-          This is a recurring event
-        </p>
-        <p className="mb-4 text-sm text-muted-foreground">
-          Would you like to {isRemoveOnly ? "remove" : "delete"} just this
-          event, this and all following events, or all events in the series?
-        </p>
+    <AlertDialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <AlertDialogContent className="max-w-[340px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-sm">
+            This is a recurring event
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            Would you like to {isRemoveOnly ? "remove" : "delete"} just this
+            event, this and all following events, or all events in the series?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
 
         <div className="space-y-1.5">
           <Button
@@ -96,8 +83,12 @@ export function DeleteEventDialog({
             All events
           </Button>
         </div>
-      </div>
-    </>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 

--- a/templates/calendar/app/components/calendar/IntegrationsSidebar.tsx
+++ b/templates/calendar/app/components/calendar/IntegrationsSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
 import {
   IconPlus,
   IconCheck,
@@ -16,6 +16,17 @@ import {
 } from "@/hooks/use-integrations";
 import { useApolloPerson } from "@/hooks/use-apollo";
 import type { ApolloPersonResult } from "@shared/api";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
 
 // ─── Integration definitions ────────────────────────────────────────────────
 
@@ -284,18 +295,7 @@ function IntegrationSetup() {
 function AddIntegrationButton() {
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState("");
-  const ref = useRef<HTMLDivElement>(null);
   const { send, codeRequiredDialog } = useSendToAgentChat();
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node))
-        setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
 
   const handleSubmit = () => {
     const name = value.trim();
@@ -313,45 +313,47 @@ function AddIntegrationButton() {
   return (
     <>
       {codeRequiredDialog}
-      <div className="relative" ref={ref}>
-        <button
-          onClick={() => setOpen(!open)}
-          className="flex items-center gap-2 w-full py-1.5 text-[11px] text-muted-foreground/40 hover:text-muted-foreground transition-colors"
-        >
-          <div className="h-7 w-7 rounded-md border border-dashed border-border/40 flex items-center justify-center shrink-0">
-            <IconPlus className="h-3 w-3" />
-          </div>
-          <span>Add integration</span>
-        </button>
-
-        {open && (
-          <div className="absolute left-0 right-0 top-full mt-1 z-50 rounded-lg border border-border/50 bg-card shadow-xl p-2.5">
-            <p className="text-[11px] text-muted-foreground/60 mb-1.5">
-              What do you want to integrate?
-            </p>
-            <div className="flex gap-1.5">
-              <input
-                autoFocus
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleSubmit();
-                  if (e.key === "Escape") setOpen(false);
-                }}
-                placeholder="e.g. Salesforce, Intercom..."
-                className="flex-1 min-w-0 rounded-md border border-border bg-background px-2 py-1 text-[12px] outline-none focus:border-primary/50 placeholder:text-muted-foreground/40"
-              />
-              <button
-                onClick={handleSubmit}
-                disabled={!value.trim()}
-                className="shrink-0 rounded-md bg-primary px-2 py-1 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
-              >
-                Go
-              </button>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button className="flex items-center gap-2 w-full py-1.5 text-[11px] text-muted-foreground/40 hover:text-muted-foreground">
+            <div className="h-7 w-7 rounded-md border border-dashed border-border/40 flex items-center justify-center shrink-0">
+              <IconPlus className="h-3 w-3" />
             </div>
+            <span>Add integration</span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          side="left"
+          align="end"
+          sideOffset={8}
+          collisionPadding={12}
+          className="w-auto rounded-lg border-border/50 bg-card p-2.5 shadow-xl"
+        >
+          <p className="text-[11px] text-muted-foreground/60 mb-1.5">
+            What do you want to integrate?
+          </p>
+          <div className="flex gap-1.5">
+            <input
+              autoFocus
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSubmit();
+                if (e.key === "Escape") setOpen(false);
+              }}
+              placeholder="e.g. Salesforce, Intercom..."
+              className="flex-1 min-w-0 rounded-md border border-border bg-background px-2 py-1 text-[12px] outline-none focus:border-primary/50 placeholder:text-muted-foreground/40"
+            />
+            <button
+              onClick={handleSubmit}
+              disabled={!value.trim()}
+              className="shrink-0 rounded-md bg-primary px-2 py-1 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              Go
+            </button>
           </div>
-        )}
-      </div>
+        </PopoverContent>
+      </Popover>
     </>
   );
 }
@@ -366,21 +368,9 @@ function IntegrationRow({
   onConfigure: () => void;
 }) {
   const { disconnect } = useIntegration(def.id);
-  const [showDisconnect, setShowDisconnect] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!showDisconnect) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node))
-        setShowDisconnect(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [showDisconnect]);
 
   return (
-    <div ref={ref} className="flex items-center gap-2.5 py-1.5 group relative">
+    <div className="flex items-center gap-2.5 py-1.5 group">
       <div className="h-7 w-7 rounded-md overflow-hidden shrink-0 bg-accent/30 p-0.5">
         {def.logo}
       </div>
@@ -395,44 +385,44 @@ function IntegrationRow({
           <div className="h-5 w-5 rounded-full bg-emerald-500/20 flex items-center justify-center">
             <IconCheck className="h-3 w-3 text-emerald-400" />
           </div>
-          <button
-            onClick={() => setShowDisconnect(!showDisconnect)}
-            className="h-5 w-5 flex items-center justify-center rounded text-muted-foreground/30 hover:text-muted-foreground transition-colors"
-            title="Settings"
-          >
-            <IconSettings className="h-3.5 w-3.5" />
-          </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                className="h-5 w-5 flex items-center justify-center rounded text-muted-foreground/30 hover:text-muted-foreground"
+                title="Settings"
+              >
+                <IconSettings className="h-3.5 w-3.5" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              side="left"
+              align="start"
+              sideOffset={8}
+              collisionPadding={12}
+              className="w-36"
+            >
+              <DropdownMenuItem
+                onClick={onConfigure}
+                className="text-[12px] text-foreground/70"
+              >
+                Update key
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => disconnect.mutate()}
+                className="text-[12px] text-red-400/80"
+              >
+                Disconnect
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       ) : (
         <button
           onClick={onConfigure}
-          className="shrink-0 text-[11px] text-primary/70 hover:text-primary font-medium transition-colors"
+          className="shrink-0 text-[11px] text-primary/70 hover:text-primary font-medium"
         >
           Connect
         </button>
-      )}
-
-      {showDisconnect && (
-        <div className="absolute right-0 top-full mt-1 z-50 w-36 rounded-lg border border-border/50 bg-card shadow-lg py-1">
-          <button
-            onClick={() => {
-              setShowDisconnect(false);
-              onConfigure();
-            }}
-            className="w-full text-left px-3 py-1.5 text-[12px] text-foreground/70 hover:bg-accent/50"
-          >
-            Update key
-          </button>
-          <button
-            onClick={() => {
-              disconnect.mutate();
-              setShowDisconnect(false);
-            }}
-            className="w-full text-left px-3 py-1.5 text-[12px] text-red-400/80 hover:bg-accent/50"
-          >
-            Disconnect
-          </button>
-        </div>
       )}
     </div>
   );

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -27,7 +27,50 @@ interface WeekViewProps {
   onEditEvent: (event: CalendarEvent) => void;
   onDeleteEvent: (eventId: string) => void;
   onEventTimeChange?: (eventId: string, newStart: Date, newEnd: Date) => void;
+  onClickTimeSlot?: (date: Date, startTime: string, endTime: string) => void;
+  quickEditEventId?: string | null;
+  onQuickEditSave?: (eventId: string, title: string) => void;
+  onQuickEditCancel?: (eventId: string) => void;
   isLoading?: boolean;
+}
+
+function QuickEditInput({
+  eventId,
+  onSave,
+  onCancel,
+}: {
+  eventId: string;
+  onSave: (eventId: string, title: string) => void;
+  onCancel: (eventId: string) => void;
+}) {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    // Focus after a frame so the element is painted
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  return (
+    <input
+      ref={inputRef}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          onSave(eventId, value);
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          onCancel(eventId);
+        }
+        e.stopPropagation();
+      }}
+      onBlur={() => onSave(eventId, value)}
+      placeholder="(No title)"
+      className="w-full bg-transparent text-[11px] font-semibold text-foreground placeholder:text-foreground/40 outline-none leading-tight"
+    />
+  );
 }
 
 // [startHour, startMin, durationMin, widthPct] per day column (Sun–Sat)
@@ -169,6 +212,10 @@ export function WeekView({
   onEditEvent,
   onDeleteEvent,
   onEventTimeChange,
+  onClickTimeSlot,
+  quickEditEventId,
+  onQuickEditSave,
+  onQuickEditCancel,
   isLoading = false,
 }: WeekViewProps) {
   const [now, setNow] = useState(new Date());
@@ -504,6 +551,28 @@ export function WeekView({
                   "relative flex-1 border-r border-border last:border-r-0",
                   isCurrentDay && "bg-primary/[0.02]",
                 )}
+                onClick={(e) => {
+                  // Only fire on empty space (not on event buttons or after drags)
+                  if ((e.target as HTMLElement).closest("button")) return;
+                  if (!onClickTimeSlot || isDragging || shouldSuppressClick())
+                    return;
+                  const rect = e.currentTarget.getBoundingClientRect();
+                  const y = e.clientY - rect.top;
+                  const totalMinutes =
+                    Math.floor(((y / HOUR_HEIGHT) * 60) / 15) * 15 +
+                    START_HOUR * 60;
+                  const startH = Math.floor(totalMinutes / 60);
+                  const startM = totalMinutes % 60;
+                  const endMinutes = totalMinutes + 60;
+                  const endH = Math.min(Math.floor(endMinutes / 60), 23);
+                  const endM = endMinutes % 60;
+                  const pad = (n: number) => String(n).padStart(2, "0");
+                  onClickTimeSlot(
+                    day,
+                    `${pad(startH)}:${pad(startM)}`,
+                    `${pad(endH)}:${pad(endM)}`,
+                  );
+                }}
               >
                 {/* Hour grid lines */}
                 {hours.map((hour) => (
@@ -656,7 +725,20 @@ export function WeekView({
                             isBeingDragged && isDragging ? 0.9 : undefined,
                         }}
                       >
-                        {durationMin <= 30 ? (
+                        {quickEditEventId === event.id &&
+                        onQuickEditSave &&
+                        onQuickEditCancel ? (
+                          <div className="flex flex-col justify-center flex-1 min-w-0 mt-0.5">
+                            <QuickEditInput
+                              eventId={event.id}
+                              onSave={onQuickEditSave}
+                              onCancel={onQuickEditCancel}
+                            />
+                            <div className="mt-0.5 truncate text-[9px] leading-tight text-foreground/60">
+                              {formatEventTime(displayStart, displayEnd)}
+                            </div>
+                          </div>
+                        ) : durationMin <= 30 ? (
                           <div className="flex items-baseline gap-1 truncate">
                             <span
                               className={cn(
@@ -743,8 +825,11 @@ export function WeekView({
                       </button>
                     );
 
-                    // Don't wrap in popover while dragging
-                    if (isBeingDragged && isDragging) {
+                    // Don't wrap in popover while dragging or quick-editing
+                    if (
+                      (isBeingDragged && isDragging) ||
+                      quickEditEventId === event.id
+                    ) {
                       return (
                         <div key={event.id} className="contents">
                           {eventButton}

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -44,6 +44,7 @@ function QuickEditInput({
   onCancel: (eventId: string) => void;
 }) {
   const [value, setValue] = useState("");
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -55,19 +56,41 @@ function QuickEditInput({
     <input
       ref={inputRef}
       value={value}
-      onChange={(e) => setValue(e.target.value)}
+      onChange={(e) => {
+        setValue(e.target.value);
+        setConfirmDelete(false);
+      }}
       onKeyDown={(e) => {
         if (e.key === "Enter") {
           e.preventDefault();
-          onSave(eventId, value);
+          if (confirmDelete) {
+            onCancel(eventId);
+          } else {
+            onSave(eventId, value);
+          }
         } else if (e.key === "Escape") {
           e.preventDefault();
           onCancel(eventId);
+        } else if (
+          (e.key === "Delete" || e.key === "Backspace") &&
+          value === ""
+        ) {
+          e.preventDefault();
+          onCancel(eventId);
+        } else if (e.key === "Delete" && value.trim()) {
+          e.preventDefault();
+          if (confirmDelete) {
+            onCancel(eventId);
+          } else {
+            setConfirmDelete(true);
+          }
         }
         e.stopPropagation();
       }}
       onBlur={() => (value.trim() ? onSave(eventId, value) : onCancel(eventId))}
-      placeholder="(No title)"
+      placeholder={
+        confirmDelete ? "Press Delete or Enter to discard" : "(No title)"
+      }
       className="w-full bg-transparent text-[11px] font-semibold text-foreground placeholder:text-foreground/40 outline-none leading-tight"
     />
   );

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -66,7 +66,7 @@ function QuickEditInput({
         }
         e.stopPropagation();
       }}
-      onBlur={() => onSave(eventId, value)}
+      onBlur={() => (value.trim() ? onSave(eventId, value) : onCancel(eventId))}
       placeholder="(No title)"
       className="w-full bg-transparent text-[11px] font-semibold text-foreground placeholder:text-foreground/40 outline-none leading-tight"
     />

--- a/templates/calendar/app/components/ui/sonner.tsx
+++ b/templates/calendar/app/components/ui/sonner.tsx
@@ -16,7 +16,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
             "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
           description: "group-[.toast]:text-muted-foreground",
           actionButton:
-            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+            "group-[.toast]:!bg-transparent group-[.toast]:!text-[hsl(210,80%,65%)] group-[.toast]:!text-[13px] group-[.toast]:!font-bold group-[.toast]:!tracking-wide group-[.toast]:!px-0 group-[.toast]:!ml-4 group-[.toast]:hover:!text-[hsl(210,80%,75%)]",
           cancelButton:
             "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
         },

--- a/templates/calendar/app/hooks/use-events.ts
+++ b/templates/calendar/app/hooks/use-events.ts
@@ -47,17 +47,55 @@ export function useCreateEvent() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (
-      data: Omit<CalendarEvent, "id" | "createdAt" | "updatedAt" | "source">,
+      data: Omit<CalendarEvent, "id" | "createdAt" | "updatedAt" | "source"> & {
+        /** Temporary client-side ID used for optimistic rendering */
+        _tempId?: string;
+      },
     ) => {
+      const { _tempId, ...eventData } = data;
       const res = await fetch("/api/events", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(data),
+        body: JSON.stringify(eventData),
       });
       if (!res.ok) throw new Error("Failed to create event");
-      return res.json();
+      const result = await res.json();
+      // Return tempId so onSuccess can map it
+      return { ...result, _tempId };
     },
-    onSuccess: () => {
+    onMutate: async (newData) => {
+      if (!newData._tempId) return;
+      await queryClient.cancelQueries({ queryKey: ["events"] });
+      const previous = queryClient.getQueriesData<CalendarEvent[]>({
+        queryKey: ["events"],
+      });
+      // Optimistically add the event to all matching queries
+      const optimisticEvent: CalendarEvent = {
+        id: newData._tempId,
+        title: newData.title,
+        start: newData.start,
+        end: newData.end,
+        allDay: newData.allDay ?? false,
+        description: newData.description,
+        location: newData.location,
+        source: "local",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      queryClient.setQueriesData<CalendarEvent[]>(
+        { queryKey: ["events"] },
+        (old) => (old ? [...old, optimisticEvent] : [optimisticEvent]),
+      );
+      return { previous };
+    },
+    onError: (_err, _newData, context) => {
+      if (context?.previous) {
+        for (const [key, data] of context.previous) {
+          queryClient.setQueryData(key, data);
+        }
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["events"] });
     },
   });

--- a/templates/calendar/app/hooks/use-events.ts
+++ b/templates/calendar/app/hooks/use-events.ts
@@ -163,7 +163,25 @@ export function useDeleteEvent() {
       if (!res.ok) throw new Error("Failed to delete event");
       return res.json();
     },
-    onSuccess: () => {
+    onMutate: async ({ id }) => {
+      await queryClient.cancelQueries({ queryKey: ["events"] });
+      const previous = queryClient.getQueriesData<CalendarEvent[]>({
+        queryKey: ["events"],
+      });
+      queryClient.setQueriesData<CalendarEvent[]>(
+        { queryKey: ["events"] },
+        (old) => old?.filter((e) => e.id !== id),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        for (const [key, data] of context.previous) {
+          queryClient.setQueryData(key, data);
+        }
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["events"] });
     },
   });

--- a/templates/calendar/app/hooks/use-undo.ts
+++ b/templates/calendar/app/hooks/use-undo.ts
@@ -1,0 +1,47 @@
+import { useSyncExternalStore } from "react";
+import { toast } from "sonner";
+
+type UndoEntry = () => void;
+
+const undoStack: UndoEntry[] = [];
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const l of listeners) l();
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): number {
+  return undoStack.length;
+}
+
+/** Push an undo action onto the stack. */
+export function setUndoAction(action: UndoEntry) {
+  undoStack.push(action);
+  notify();
+}
+
+/** Clear the entire undo stack. */
+export function clearUndoAction() {
+  undoStack.length = 0;
+  notify();
+}
+
+/** Pop and run the most recent undo action. */
+export function runUndo() {
+  const action = undoStack.pop();
+  if (action) {
+    action();
+    toast.dismiss();
+    notify();
+  }
+}
+
+/** React hook — returns true if any undo actions are available. */
+export function useHasUndo(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot) > 0;
+}

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -44,7 +44,12 @@ import { PeopleSearchDialog } from "@/components/calendar/PeopleSearchDialog";
 import { EventDetailPanel } from "@/components/calendar/EventDetailPanel";
 import { DeleteEventDialog } from "@/components/calendar/DeleteEventDialog";
 import { useCalendarContext } from "@/components/layout/AppLayout";
-import { useEvents, useUpdateEvent, useDeleteEvent } from "@/hooks/use-events";
+import {
+  useEvents,
+  useCreateEvent,
+  useUpdateEvent,
+  useDeleteEvent,
+} from "@/hooks/use-events";
 import { useOverlayPeople } from "@/hooks/use-overlay-people";
 import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
 import { AgentToggleButton } from "@agent-native/core/client";
@@ -73,6 +78,9 @@ export default function CalendarView() {
     focusedEvent,
   } = useCalendarContext();
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [createDefaultStart, setCreateDefaultStart] = useState<string>();
+  const [createDefaultEnd, setCreateDefaultEnd] = useState<string>();
+  const [quickEditEventId, setQuickEditEventId] = useState<string | null>(null);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [shortcutsHelpOpen, setShortcutsHelpOpen] = useState(false);
   const [deleteDialogEvent, setDeleteDialogEvent] =
@@ -85,6 +93,7 @@ export default function CalendarView() {
     [overlayPeople],
   );
   const isGoogleConnected = googleStatus.data?.connected ?? false;
+  const createEvent = useCreateEvent();
   const updateEvent = useUpdateEvent();
   const deleteEvent = useDeleteEvent();
 
@@ -273,6 +282,58 @@ export default function CalendarView() {
     );
   }
 
+  function handleClickTimeSlot(
+    clickedDate: Date,
+    startTime: string,
+    endTime: string,
+  ) {
+    const dateStr = format(clickedDate, "yyyy-MM-dd");
+    const startISO = new Date(`${dateStr}T${startTime}:00`).toISOString();
+    const endISO = new Date(`${dateStr}T${endTime}:00`).toISOString();
+    const tempId = `temp-${Date.now()}`;
+
+    createEvent.mutate(
+      {
+        title: "(No title)",
+        description: "",
+        location: "",
+        start: startISO,
+        end: endISO,
+        allDay: false,
+        _tempId: tempId,
+      },
+      {
+        onSuccess: (result) => {
+          // Replace temp ID with real ID for quick-edit
+          setQuickEditEventId(result.id);
+        },
+        onError: () => {
+          setQuickEditEventId(null);
+          toast.error("Failed to create event");
+        },
+      },
+    );
+
+    // Immediately show inline editor on the optimistic event
+    setQuickEditEventId(tempId);
+  }
+
+  function handleQuickEditSave(eventId: string, title: string) {
+    setQuickEditEventId(null);
+    if (title.trim() && title.trim() !== "(No title)") {
+      updateEvent.mutate({ id: eventId, title: title.trim() });
+    }
+  }
+
+  function handleQuickEditCancel(eventId: string) {
+    setQuickEditEventId(null);
+    // Delete the event if title was never set
+    const ev = events.find((e) => e.id === eventId);
+    if (!ev || ev.title === "(No title)") {
+      deleteEvent.mutate({ id: eventId, scope: "single", sendUpdates: "none" });
+    }
+  }
+
   // IconKeyboard shortcuts — don't fire when user is typing in an input
   const isTypingInInput = useCallback((e: KeyboardEvent) => {
     const target = e.target as HTMLElement;
@@ -343,6 +404,8 @@ export default function CalendarView() {
           break;
         case "c":
           e.preventDefault();
+          setCreateDefaultStart(undefined);
+          setCreateDefaultEnd(undefined);
           setCreateDialogOpen(true);
           break;
         case "/":
@@ -535,8 +598,16 @@ export default function CalendarView() {
 
               <CreateEventPopover
                 open={createDialogOpen}
-                onOpenChange={setCreateDialogOpen}
+                onOpenChange={(open) => {
+                  setCreateDialogOpen(open);
+                  if (!open) {
+                    setCreateDefaultStart(undefined);
+                    setCreateDefaultEnd(undefined);
+                  }
+                }}
                 defaultDate={selectedDate}
+                defaultStartTime={createDefaultStart}
+                defaultEndTime={createDefaultEnd}
               />
               <AgentToggleButton />
             </div>
@@ -563,6 +634,10 @@ export default function CalendarView() {
                 onEditEvent={handleEditEvent}
                 onDeleteEvent={handleDeleteEvent}
                 onEventTimeChange={handleEventTimeChange}
+                onClickTimeSlot={handleClickTimeSlot}
+                quickEditEventId={quickEditEventId}
+                onQuickEditSave={handleQuickEditSave}
+                onQuickEditCancel={handleQuickEditCancel}
                 isLoading={eventsLoading}
               />
             )}
@@ -573,6 +648,10 @@ export default function CalendarView() {
                 onEditEvent={handleEditEvent}
                 onDeleteEvent={handleDeleteEvent}
                 onEventTimeChange={handleEventTimeChange}
+                onClickTimeSlot={handleClickTimeSlot}
+                quickEditEventId={quickEditEventId}
+                onQuickEditSave={handleQuickEditSave}
+                onQuickEditCancel={handleQuickEditCancel}
                 isLoading={eventsLoading}
               />
             )}

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -55,6 +55,7 @@ import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
 import { useQueryClient } from "@tanstack/react-query";
 import { AgentToggleButton } from "@agent-native/core/client";
 import { toast } from "sonner";
+import { setUndoAction, runUndo } from "@/hooks/use-undo";
 import type { CalendarEvent } from "@shared/api";
 
 import type { ViewMode } from "@/components/layout/AppLayout";
@@ -193,6 +194,20 @@ export default function CalendarView() {
       ev.attendees && ev.attendees.filter((a) => !a.self).length > 0;
     const removeOnly = !isOrganizer && !!hasOtherAttendees;
 
+    // Snapshot for undo
+    const snapshot = { ...ev };
+    const undo = () => {
+      createEvent.mutate({
+        title: snapshot.title,
+        description: snapshot.description ?? "",
+        location: snapshot.location ?? "",
+        start: snapshot.start,
+        end: snapshot.end,
+        allDay: snapshot.allDay ?? false,
+        color: snapshot.color,
+      });
+    };
+
     deleteEvent.mutate(
       {
         id: ev.id,
@@ -202,8 +217,11 @@ export default function CalendarView() {
       },
       {
         onSuccess: () => {
-          toast.success(`Event ${removeOnly ? "removed" : "deleted"}`);
           if (sidebarEvent?.id === ev.id) setSidebarEvent(null);
+          setUndoAction(undo);
+          toast(`Event ${removeOnly ? "removed" : "deleted"}`, {
+            action: { label: "Undo", onClick: undo },
+          });
         },
         onError: () => toast.error("Failed to delete event"),
       },
@@ -226,6 +244,8 @@ export default function CalendarView() {
     const event = events.find((e) => e.id === eventId);
     if (!event) return;
 
+    const oldStartISO = event.start;
+    const oldEndISO = event.end;
     const originalStart = parseISO(event.start);
     const originalEnd = parseISO(event.end);
     const newStart = new Date(originalStart);
@@ -242,6 +262,10 @@ export default function CalendarView() {
       newDate.getDate(),
     );
 
+    const undo = () => {
+      updateEvent.mutate({ id: eventId, start: oldStartISO, end: oldEndISO });
+    };
+
     updateEvent.mutate(
       {
         id: eventId,
@@ -249,7 +273,12 @@ export default function CalendarView() {
         end: newEnd.toISOString(),
       },
       {
-        onSuccess: () => toast.success("Event moved"),
+        onSuccess: () => {
+          setUndoAction(undo);
+          toast("Event moved", {
+            action: { label: "Undo", onClick: undo },
+          });
+        },
         onError: () => toast.error("Failed to move event"),
       },
     );
@@ -263,13 +292,18 @@ export default function CalendarView() {
   ) {
     // Skip no-op drags (dropped back in same spot)
     const event = events.find((e) => e.id === eventId);
-    if (event) {
-      const oldStart = parseISO(event.start).getTime();
-      const oldEnd = parseISO(event.end).getTime();
-      if (oldStart === newStart.getTime() && oldEnd === newEnd.getTime()) {
-        return;
-      }
+    if (!event) return;
+    const oldStart = parseISO(event.start).getTime();
+    const oldEnd = parseISO(event.end).getTime();
+    if (oldStart === newStart.getTime() && oldEnd === newEnd.getTime()) {
+      return;
     }
+
+    const oldStartISO = event.start;
+    const oldEndISO = event.end;
+    const undo = () => {
+      updateEvent.mutate({ id: eventId, start: oldStartISO, end: oldEndISO });
+    };
 
     updateEvent.mutate(
       {
@@ -278,7 +312,12 @@ export default function CalendarView() {
         end: newEnd.toISOString(),
       },
       {
-        onSuccess: () => toast.success("Event updated"),
+        onSuccess: () => {
+          setUndoAction(undo);
+          toast("Event updated", {
+            action: { label: "Undo", onClick: undo },
+          });
+        },
         onError: () => toast.error("Failed to update event"),
       },
     );
@@ -387,6 +426,10 @@ export default function CalendarView() {
       if (e.metaKey || e.ctrlKey || e.altKey) return;
 
       switch (e.key) {
+        case "z":
+          e.preventDefault();
+          runUndo();
+          break;
         case "j":
         case "n":
           e.preventDefault();
@@ -709,16 +752,31 @@ export default function CalendarView() {
           onClose={() => setDeleteDialogEvent(null)}
           onConfirm={(options) => {
             if (!deleteDialogEvent) return;
+            const snapshot = { ...deleteDialogEvent };
+            const undo = () => {
+              createEvent.mutate({
+                title: snapshot.title,
+                description: snapshot.description ?? "",
+                location: snapshot.location ?? "",
+                start: snapshot.start,
+                end: snapshot.end,
+                allDay: snapshot.allDay ?? false,
+                color: snapshot.color,
+              });
+            };
             deleteEvent.mutate(
               { id: deleteDialogEvent.id, ...options },
               {
                 onSuccess: () => {
                   const label = options.removeOnly ? "removed" : "deleted";
-                  toast.success(`Event ${label}`);
                   setDeleteDialogEvent(null);
                   if (sidebarEvent?.id === deleteDialogEvent.id) {
                     setSidebarEvent(null);
                   }
+                  setUndoAction(undo);
+                  toast(`Event ${label}`, {
+                    action: { label: "Undo", onClick: undo },
+                  });
                 },
                 onError: () => toast.error("Failed to delete event"),
               },

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/hooks/use-events";
 import { useOverlayPeople } from "@/hooks/use-overlay-people";
 import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
+import { useQueryClient } from "@tanstack/react-query";
 import { AgentToggleButton } from "@agent-native/core/client";
 import { toast } from "sonner";
 import type { CalendarEvent } from "@shared/api";
@@ -86,6 +87,7 @@ export default function CalendarView() {
   const [deleteDialogEvent, setDeleteDialogEvent] =
     useState<CalendarEvent | null>(null);
 
+  const queryClient = useQueryClient();
   const googleStatus = useGoogleAuthStatus();
   const { data: overlayPeople = [] } = useOverlayPeople();
   const overlayEmails = useMemo(
@@ -304,8 +306,16 @@ export default function CalendarView() {
       },
       {
         onSuccess: (result) => {
-          // Replace temp ID with real ID for quick-edit
-          setQuickEditEventId(result.id);
+          // Synchronously swap the optimistic temp event for the real one
+          // in the cache so the inline input stays mounted when we update
+          // quickEditEventId to the real ID.
+          const { _tempId, ...realEvent } = result;
+          queryClient.setQueriesData<CalendarEvent[]>(
+            { queryKey: ["events"] },
+            (old) =>
+              old?.map((e) => (e.id === _tempId ? { ...e, ...realEvent } : e)),
+          );
+          setQuickEditEventId(realEvent.id);
         },
         onError: () => {
           setQuickEditEventId(null);

--- a/templates/calorie-tracker/AGENTS.md
+++ b/templates/calorie-tracker/AGENTS.md
@@ -91,6 +91,14 @@ When users speak via the microphone button, their transcribed text is sent to th
 
 Handle multiple items in one command. For weight entries, require explicit weight-related keywords.
 
+## UI Components
+
+**Always use shadcn/ui components** from `app/components/ui/` for all standard UI patterns (dialogs, popovers, dropdowns, tooltips, buttons, etc). Never build custom modals or dropdowns with absolute/fixed positioning — use the shadcn primitives instead.
+
+**Always use Tabler Icons** (`@tabler/icons-react`) for all icons. Never use other icon libraries.
+
+**Never use browser dialogs** (`window.confirm`, `window.alert`, `window.prompt`) — use shadcn AlertDialog instead.
+
 ## API Routes
 
 | Method | Route                        | Description          |

--- a/templates/calorie-tracker/CLAUDE.md
+++ b/templates/calorie-tracker/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/templates/content/AGENTS.md
+++ b/templates/content/AGENTS.md
@@ -133,6 +133,14 @@ Documents are stored in the SQL `documents` table via Drizzle ORM:
 
 Documents form a tree via `parent_id`. Content is stored as markdown.
 
+## UI Components
+
+**Always use shadcn/ui components** from `app/components/ui/` for all standard UI patterns (dialogs, popovers, dropdowns, tooltips, buttons, etc). Never build custom modals or dropdowns with absolute/fixed positioning — use the shadcn primitives instead.
+
+**Always use Tabler Icons** (`@tabler/icons-react`) for all icons. Never use other icon libraries.
+
+**Never use browser dialogs** (`window.confirm`, `window.alert`, `window.prompt`) — use shadcn AlertDialog instead.
+
 ## Rules
 
 1. **Use scripts for document operations** — never use raw `db-exec` SQL for documents

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -10,7 +10,12 @@ import { TableCell } from "@tiptap/extension-table-cell";
 import { TableHeader } from "@tiptap/extension-table-header";
 import { Markdown } from "tiptap-markdown";
 import { defaultMarkdownSerializer } from "@tiptap/pm/markdown";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
+import {
+  Plugin,
+  PluginKey,
+  TextSelection,
+  AllSelection,
+} from "@tiptap/pm/state";
 import { useEffect, useRef } from "react";
 import { BubbleToolbar } from "./BubbleToolbar";
 import { SlashCommandMenu } from "./SlashCommandMenu";
@@ -233,6 +238,62 @@ const TypographyReplacements = Extension.create({
   },
 });
 
+/**
+ * Two-stage Cmd+A: first press selects the current block,
+ * second press (when block is already fully selected) selects the whole document.
+ */
+const SelectAllBlock = Extension.create({
+  name: "selectAllBlock",
+  addKeyboardShortcuts() {
+    return {
+      "Mod-a": ({ editor }) => {
+        const { state } = editor;
+        const { selection, doc } = state;
+
+        // Find the nearest top-level block node containing the cursor
+        const $from = selection.$from;
+        let blockStart: number | null = null;
+        let blockEnd: number | null = null;
+
+        // Walk up to find the top-level (depth 1) block
+        for (let depth = $from.depth; depth >= 1; depth--) {
+          if (depth === 1) {
+            blockStart = $from.before(depth);
+            blockEnd = $from.after(depth);
+            break;
+          }
+        }
+
+        if (blockStart == null || blockEnd == null) {
+          // Fallback: select all
+          editor.commands.setTextSelection({ from: 0, to: doc.content.size });
+          return true;
+        }
+
+        // Check if the current block is already fully selected
+        const blockContentStart = blockStart + 1;
+        const blockContentEnd = blockEnd - 1;
+        const isBlockSelected =
+          selection.from <= blockContentStart &&
+          selection.to >= blockContentEnd;
+
+        if (isBlockSelected) {
+          // Second Cmd+A: select entire document
+          editor.commands.setTextSelection({ from: 0, to: doc.content.size });
+        } else {
+          // First Cmd+A: select current block content
+          editor.commands.setTextSelection({
+            from: blockContentStart,
+            to: blockContentEnd,
+          });
+        }
+
+        return true;
+      },
+    };
+  },
+});
+
 const CustomTable = BaseTable.extend({
   addStorage() {
     return {
@@ -361,6 +422,7 @@ export function VisualEditor({
       DragHandle,
       TypographyReplacements,
       MarkdownPasteDetection,
+      SelectAllBlock,
       Markdown.configure({
         html: true,
         transformPastedText: true,

--- a/templates/content/app/components/editor/extensions/NotionExtensions.tsx
+++ b/templates/content/app/components/editor/extensions/NotionExtensions.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
   Mark,
   Node,
@@ -109,7 +108,8 @@ function humanizeTag(tagName: string): string {
 }
 
 function ToggleView({ node, updateAttributes, editor, getPos }: NodeViewProps) {
-  const [open, setOpen] = useState(false);
+  const open = !!node.attrs.open;
+  const setOpen = (value: boolean) => updateAttributes({ open: value });
   const summary = (node.attrs.summary || "") as string;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -310,6 +310,7 @@ export const NotionToggle = Node.create({
       summary: { default: "" },
       color: { default: null },
       headingLevel: { default: null },
+      open: { default: false },
     };
   },
 
@@ -323,6 +324,7 @@ export const NotionToggle = Node.create({
             summary: node.querySelector("summary")?.textContent?.trim() || "",
             color: node.getAttribute("color"),
             headingLevel: node.getAttribute("data-heading-level"),
+            open: node.hasAttribute("open"),
           };
         },
         contentElement: (element) => {
@@ -347,6 +349,7 @@ export const NotionToggle = Node.create({
             summary: node.getAttribute("data-summary") || "",
             color: node.getAttribute("data-color"),
             headingLevel: node.getAttribute("data-heading-level"),
+            open: node.getAttribute("data-open") === "true",
           };
         },
         contentElement: (element) =>
@@ -365,6 +368,7 @@ export const NotionToggle = Node.create({
         "data-summary": HTMLAttributes.summary || "",
         "data-color": HTMLAttributes.color || undefined,
         "data-heading-level": HTMLAttributes.headingLevel || undefined,
+        "data-open": HTMLAttributes.open ? "true" : undefined,
       }),
       [
         "div",
@@ -387,6 +391,7 @@ export const NotionToggle = Node.create({
           if (node.attrs.headingLevel) {
             attrs["data-heading-level"] = String(node.attrs.headingLevel);
           }
+          if (node.attrs.open) attrs.open = "";
           const inner = serializeInnerMarkdown((this as any).editor, node);
           const openTag = `<details${serializeTagAttributes(attrs)}>`;
           _state.write(openTag);

--- a/templates/issues/AGENTS.md
+++ b/templates/issues/AGENTS.md
@@ -170,6 +170,14 @@ After any write operation, run `pnpm action refresh-list`.
 | GET    | `/api/boards`                  | List boards        |
 | GET    | `/api/boards/:id/sprints`      | List sprints       |
 
+## UI Components
+
+**Always use shadcn/ui components** from `app/components/ui/` for all standard UI patterns (dialogs, popovers, dropdowns, tooltips, buttons, etc). Never build custom modals or dropdowns with absolute/fixed positioning — use the shadcn primitives instead.
+
+**Always use Tabler Icons** (`@tabler/icons-react`) for all icons. Never use other icon libraries.
+
+**Never use browser dialogs** (`window.confirm`, `window.alert`, `window.prompt`) — use shadcn AlertDialog instead.
+
 ## Development
 
 For code editing and development guidance, read `DEVELOPING.md`.

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -369,6 +369,14 @@ Scripts use `readAppState()` / `writeAppState()` from `@agent-native/core/applic
 | `G then A` | Go to Archive                |
 | `Esc`      | Close thread / clear search  |
 
+## UI Components
+
+**Always use shadcn/ui components** from `app/components/ui/` for all standard UI patterns (dialogs, popovers, dropdowns, tooltips, buttons, etc). Never build custom modals or dropdowns with absolute/fixed positioning — use the shadcn primitives instead.
+
+**Always use Tabler Icons** (`@tabler/icons-react`) for all icons. Never use other icon libraries.
+
+**Never use browser dialogs** (`window.confirm`, `window.alert`, `window.prompt`) — use shadcn AlertDialog instead.
+
 ## Development
 
 For code editing and development guidance, read `DEVELOPING.md`.

--- a/templates/mail/app/components/email/ComposeEditor.tsx
+++ b/templates/mail/app/components/email/ComposeEditor.tsx
@@ -6,10 +6,26 @@ import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
 import { ComposeImageNode } from "./extensions/ComposeImageNode";
 import { common, createLowlight } from "lowlight";
 import { Markdown } from "tiptap-markdown";
-import { useEffect, useRef, useImperativeHandle, forwardRef } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  useImperativeHandle,
+  forwardRef,
+} from "react";
 import { ComposeSlashMenu } from "./ComposeSlashMenu";
 import { ComposeBubbleToolbar } from "./ComposeBubbleToolbar";
 import { CodeBlockLangPicker } from "./CodeBlockLangPicker";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 const lowlight = createLowlight(common);
 
@@ -129,6 +145,21 @@ export const ComposeEditor = forwardRef<
     }
   }, [content, editor]);
 
+  const [showLinkDialog, setShowLinkDialog] = useState(false);
+  const [linkUrl, setLinkUrl] = useState("");
+
+  const applyLink = () => {
+    if (!editor || !linkUrl.trim()) return;
+    editor
+      .chain()
+      .focus()
+      .extendMarkRange("link")
+      .setLink({ href: linkUrl.trim() })
+      .run();
+    setLinkUrl("");
+    setShowLinkDialog(false);
+  };
+
   useImperativeHandle(ref, () => ({
     toggleBold: () => {
       editor?.chain().focus().toggleBold().run();
@@ -142,15 +173,8 @@ export const ComposeEditor = forwardRef<
         editor.chain().focus().unsetLink().run();
         return;
       }
-      const url = window.prompt("Enter URL:");
-      if (url) {
-        editor
-          .chain()
-          .focus()
-          .extendMarkRange("link")
-          .setLink({ href: url })
-          .run();
-      }
+      setLinkUrl("");
+      setShowLinkDialog(true);
     },
     isActive: (name: string) => editor?.isActive(name) ?? false,
     getEditor: () => editor,
@@ -169,6 +193,35 @@ export const ComposeEditor = forwardRef<
       <ComposeSlashMenu editor={editor} onGenerate={onGenerate} />
       <CodeBlockLangPicker editor={editor} />
       <EditorContent editor={editor} />
+
+      <Dialog open={showLinkDialog} onOpenChange={setShowLinkDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Insert link</DialogTitle>
+            <DialogDescription>Enter the URL for the link.</DialogDescription>
+          </DialogHeader>
+          <Input
+            autoFocus
+            value={linkUrl}
+            onChange={(e) => setLinkUrl(e.target.value)}
+            placeholder="https://example.com"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                applyLink();
+              }
+            }}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowLinkDialog(false)}>
+              Cancel
+            </Button>
+            <Button onClick={applyLink} disabled={!linkUrl.trim()}>
+              Apply
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 });

--- a/templates/mail/app/components/email/IntegrationsSidebar.tsx
+++ b/templates/mail/app/components/email/IntegrationsSidebar.tsx
@@ -4,8 +4,14 @@ import {
   IconCheck,
   IconSettings,
   IconChevronLeft,
+  IconArrowUp,
 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
 import { useSendToAgentChat } from "@agent-native/core/client";
 import {
   useIntegration,
@@ -285,25 +291,23 @@ function IntegrationSetup() {
 function AddIntegrationButton() {
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState("");
-  const ref = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { send, codeRequiredDialog } = useSendToAgentChat();
 
   useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node))
-        setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
+    if (open) {
+      setTimeout(() => textareaRef.current?.focus(), 50);
+    } else {
+      setValue("");
+    }
   }, [open]);
 
   const handleSubmit = () => {
-    const name = value.trim();
-    if (!name) return;
+    const prompt = value.trim();
+    if (!prompt) return;
     send({
-      message: `Add a ${name} integration to the sidebar`,
-      context: `The user wants to add a new integration for "${name}" to the contact sidebar. Look at the existing integrations in client/components/email/IntegrationsSidebar.tsx and the pattern in server/routes/ and client/hooks/use-integrations.ts. Add the new provider following the same pattern: server route, hook, sidebar section, and logo. Use the real brand logo SVG if possible.`,
+      message: `Add a new integration to the sidebar: ${prompt}`,
+      context: `The user wants to add a new integration to the contact sidebar. Their request: "${prompt}". Look at the existing integrations in client/components/email/IntegrationsSidebar.tsx and the pattern in server/routes/ and client/hooks/use-integrations.ts. Add the new provider following the same pattern: server route, hook, sidebar section, and logo. Use the real brand logo SVG if possible.`,
       submit: true,
       requiresCode: true,
     });
@@ -314,45 +318,69 @@ function AddIntegrationButton() {
   return (
     <>
       {codeRequiredDialog}
-      <div className="relative" ref={ref}>
-        <button
-          onClick={() => setOpen(!open)}
-          className="flex items-center gap-2 w-full py-1.5 text-[11px] text-muted-foreground/70 hover:text-muted-foreground transition-colors"
-        >
-          <div className="h-7 w-7 rounded-md border border-dashed border-border/40 flex items-center justify-center shrink-0">
-            <IconPlus className="h-3 w-3" />
-          </div>
-          <span>Add integration</span>
-        </button>
-
-        {open && (
-          <div className="absolute left-0 right-0 top-full mt-1 z-50 rounded-lg border border-border/50 bg-card shadow-xl p-2.5">
-            <p className="text-[11px] text-muted-foreground/60 mb-1.5">
-              What do you want to integrate?
-            </p>
-            <div className="flex gap-1.5">
-              <input
-                autoFocus
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleSubmit();
-                  if (e.key === "Escape") setOpen(false);
-                }}
-                placeholder="e.g. Salesforce, Intercom..."
-                className="flex-1 min-w-0 rounded-md border border-border bg-background px-2 py-1 text-[12px] outline-none focus:border-primary/50 placeholder:text-muted-foreground/40"
-              />
-              <button
-                onClick={handleSubmit}
-                disabled={!value.trim()}
-                className="shrink-0 rounded-md bg-primary px-2 py-1 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
-              >
-                Go
-              </button>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button className="flex items-center gap-2 w-full py-1.5 text-[11px] text-muted-foreground/70 hover:text-muted-foreground transition-colors">
+            <div className="h-7 w-7 rounded-md border border-dashed border-border/40 flex items-center justify-center shrink-0">
+              <IconPlus className="h-3 w-3" />
             </div>
+            <span>Add integration</span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          side="left"
+          align="end"
+          sideOffset={8}
+          className="w-80 p-0 rounded-xl border-border/50 shadow-2xl shadow-black/40 overflow-hidden"
+          collisionPadding={12}
+        >
+          <div className="px-3.5 pt-3 pb-1.5">
+            <span className="text-[12px] font-medium text-foreground/80">
+              What do you want to integrate?
+            </span>
           </div>
-        )}
-      </div>
+
+          <div className="px-3.5 pb-2">
+            <textarea
+              ref={textareaRef}
+              value={value}
+              onChange={(e) => {
+                setValue(e.target.value);
+                const el = e.target;
+                el.style.height = "auto";
+                el.style.height = Math.min(el.scrollHeight, 200) + "px";
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  handleSubmit();
+                }
+              }}
+              placeholder="e.g. Salesforce CRM — show deal stage and recent activity for the contact"
+              className="w-full bg-transparent text-[12px] text-foreground/90 placeholder:text-muted-foreground/30 outline-none resize-none"
+              rows={3}
+              style={{ maxHeight: "200px" }}
+            />
+          </div>
+
+          <div className="px-3.5 py-2 flex items-center justify-end border-t border-border/30">
+            <button
+              onClick={handleSubmit}
+              disabled={!value.trim()}
+              className={cn(
+                "p-1.5 rounded-lg",
+                value.trim()
+                  ? "bg-primary hover:bg-primary/90 text-primary-foreground"
+                  : "bg-muted/50 text-muted-foreground/30 cursor-not-allowed",
+              )}
+              title="Submit (⌘↵)"
+              aria-label="Submit"
+            >
+              <IconArrowUp className="w-4 h-4" />
+            </button>
+          </div>
+        </PopoverContent>
+      </Popover>
     </>
   );
 }

--- a/templates/mail/app/pages/SettingsPage.tsx
+++ b/templates/mail/app/pages/SettingsPage.tsx
@@ -13,6 +13,16 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -119,6 +129,7 @@ function AliasRow({
   const updateAlias = useUpdateAlias();
   const deleteAlias = useDeleteAlias();
   const rowRef = useRef<HTMLDivElement>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   useEffect(() => {
     if (isEditing && rowRef.current) {
@@ -134,11 +145,12 @@ function AliasRow({
   };
 
   const handleDelete = () => {
-    if (
-      window.confirm(`Delete alias "${alias.name}"? This cannot be undone.`)
-    ) {
-      deleteAlias.mutate(alias.id);
-    }
+    setShowDeleteConfirm(true);
+  };
+
+  const confirmDelete = () => {
+    deleteAlias.mutate(alias.id);
+    setShowDeleteConfirm(false);
   };
 
   if (isEditing) {
@@ -155,50 +167,69 @@ function AliasRow({
   }
 
   return (
-    <div
-      ref={rowRef}
-      className="flex items-start gap-3 rounded-lg border border-border/30 bg-card px-4 py-3 group hover:border-border/60 transition-colors"
-    >
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 mb-0.5">
-          <span className="text-[13px] font-semibold text-foreground">
-            {alias.name}
-          </span>
-          <span className="rounded-full bg-indigo-500/15 px-2 py-0.5 text-[11px] font-medium text-indigo-300">
-            {alias.emails.length}{" "}
-            {alias.emails.length === 1 ? "person" : "people"}
-          </span>
+    <>
+      <div
+        ref={rowRef}
+        className="flex items-start gap-3 rounded-lg border border-border/30 bg-card px-4 py-3 group hover:border-border/60"
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-0.5">
+            <span className="text-[13px] font-semibold text-foreground">
+              {alias.name}
+            </span>
+            <span className="rounded-full bg-indigo-500/15 px-2 py-0.5 text-[11px] font-medium text-indigo-300">
+              {alias.emails.length}{" "}
+              {alias.emails.length === 1 ? "person" : "people"}
+            </span>
+          </div>
+          <p className="text-[12px] text-muted-foreground truncate">
+            {alias.emails.join(", ")}
+          </p>
         </div>
-        <p className="text-[12px] text-muted-foreground truncate">
-          {alias.emails.join(", ")}
-        </p>
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 shrink-0">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onEdit}
+            className="h-7 w-7 p-0"
+            title="Edit alias"
+          >
+            <IconPencil className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={handleDelete}
+            disabled={deleteAlias.isPending}
+            className="h-7 w-7 p-0"
+            title="Delete alias"
+          >
+            {deleteAlias.isPending ? (
+              <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <IconTrash className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        </div>
       </div>
-      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onEdit}
-          className="h-7 w-7 p-0"
-          title="Edit alias"
-        >
-          <IconPencil className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="destructive"
-          size="sm"
-          onClick={handleDelete}
-          disabled={deleteAlias.isPending}
-          className="h-7 w-7 p-0"
-          title="Delete alias"
-        >
-          {deleteAlias.isPending ? (
-            <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <IconTrash className="h-3.5 w-3.5" />
-          )}
-        </Button>
-      </div>
-    </div>
+
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete alias</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete alias "{alias.name}"? This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDelete}>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
 

--- a/templates/mail/server/plugins/db.ts
+++ b/templates/mail/server/plugins/db.ts
@@ -1,4 +1,4 @@
-import { runMigrations } from "@agent-native/core/db";
+import { runMigrations, intType } from "@agent-native/core/db";
 
 export default runMigrations([
   {
@@ -46,9 +46,9 @@ export default runMigrations([
     owner_email TEXT NOT NULL,
     contact_email TEXT NOT NULL,
     contact_name TEXT NOT NULL DEFAULT '',
-    send_count INTEGER NOT NULL DEFAULT 0,
-    receive_count INTEGER NOT NULL DEFAULT 0,
-    last_contacted_at INTEGER NOT NULL
+    send_count ${intType()} NOT NULL DEFAULT 0,
+    receive_count ${intType()} NOT NULL DEFAULT 0,
+    last_contacted_at ${intType()} NOT NULL
   )`,
   },
 ]);

--- a/templates/mail/server/plugins/db.ts
+++ b/templates/mail/server/plugins/db.ts
@@ -39,4 +39,16 @@ export default runMigrations([
     updated_at INTEGER NOT NULL
   )`,
   },
+  {
+    version: 6,
+    sql: `CREATE TABLE IF NOT EXISTS contact_frequency (
+    id TEXT PRIMARY KEY,
+    owner_email TEXT NOT NULL,
+    contact_email TEXT NOT NULL,
+    contact_name TEXT NOT NULL DEFAULT '',
+    send_count INTEGER NOT NULL DEFAULT 0,
+    receive_count INTEGER NOT NULL DEFAULT 0,
+    last_contacted_at INTEGER NOT NULL
+  )`,
+  },
 ]);

--- a/templates/mail/server/tasks/automations/nitro-task.ts
+++ b/templates/mail/server/tasks/automations/nitro-task.ts
@@ -1,5 +1,6 @@
+// @ts-expect-error — nitro/runtime is a virtual module resolved by Nitro at build time
 import { defineTask } from "nitro/runtime";
-import { processAutomationRules } from "../server/tasks/automations/process.js";
+import { processAutomationRules } from "./process.js";
 
 export default defineTask({
   meta: {

--- a/templates/mail/server/tasks/jobs/nitro-task.ts
+++ b/templates/mail/server/tasks/jobs/nitro-task.ts
@@ -1,5 +1,6 @@
+// @ts-expect-error — nitro/runtime is a virtual module resolved by Nitro at build time
 import { defineTask } from "nitro/runtime";
-import { processJobs } from "../server/tasks/jobs/process.js";
+import { processJobs } from "./process.js";
 
 export default defineTask({
   meta: {

--- a/templates/mail/vite.config.ts
+++ b/templates/mail/vite.config.ts
@@ -8,11 +8,11 @@ export default defineConfig({
     },
     tasks: {
       "mail-jobs:process": {
-        handler: "./tasks/process-mail-jobs.ts",
+        handler: "./server/tasks/jobs/nitro-task.ts",
         description: "Process due mail snooze and scheduled-send jobs",
       },
       "automations:process": {
-        handler: "./tasks/process-automations.ts",
+        handler: "./server/tasks/automations/nitro-task.ts",
         description: "Process automation rules against new inbox emails",
       },
     },

--- a/templates/recruiting/AGENTS.md
+++ b/templates/recruiting/AGENTS.md
@@ -213,6 +213,14 @@ Note types: `resume_analysis`, `comparison`, `interview_prep`, `general`
 | POST   | `/api/notes`                    | Create note                      |
 | DELETE | `/api/notes/:id`                | Delete note                      |
 
+## UI Components
+
+**Always use shadcn/ui components** from `app/components/ui/` for all standard UI patterns (dialogs, popovers, dropdowns, tooltips, buttons, etc). Never build custom modals or dropdowns with absolute/fixed positioning — use the shadcn primitives instead.
+
+**Always use Tabler Icons** (`@tabler/icons-react`) for all icons. Never use other icon libraries.
+
+**Never use browser dialogs** (`window.confirm`, `window.alert`, `window.prompt`) — use shadcn AlertDialog instead.
+
 ## Keyboard Shortcuts
 
 | Key        | Action               |

--- a/templates/recruiting/server/handlers/notes.ts
+++ b/templates/recruiting/server/handlers/notes.ts
@@ -93,6 +93,7 @@ export const deleteNoteHandler = defineEventHandler(async (event) => {
     : and(
         eq(schema.agentNotes.id, id),
         eq(schema.agentNotes.ownerEmail, ctx.email),
+        isNull(schema.agentNotes.orgId),
       );
 
   await db.delete(schema.agentNotes).where(condition);

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -156,6 +156,14 @@ When generating outbound content (deck slides, marketing copy), consult **`data/
 | PUT    | `/api/decks/:id` | Update a deck     |
 | DELETE | `/api/decks/:id` | Delete a deck     |
 
+## UI Components
+
+**Always use shadcn/ui components** from `app/components/ui/` for all standard UI patterns (dialogs, popovers, dropdowns, tooltips, buttons, etc). Never build custom modals or dropdowns with absolute/fixed positioning — use the shadcn primitives instead.
+
+**Always use Tabler Icons** (`@tabler/icons-react`) for all icons. Never use other icon libraries.
+
+**Never use browser dialogs** (`window.confirm`, `window.alert`, `window.prompt`) — use shadcn AlertDialog instead.
+
 ## Development
 
 For code editing and development guidance, read `DEVELOPING.md`.

--- a/templates/starter/AGENTS.md
+++ b/templates/starter/AGENTS.md
@@ -77,6 +77,14 @@ Auth is automatic and environment-driven:
 
 Use `getSession(event)` server-side and `useSession()` client-side.
 
+### UI Components
+
+**Always use shadcn/ui components** from `app/components/ui/` for all standard UI patterns (dialogs, popovers, dropdowns, tooltips, buttons, etc). Never build custom modals or dropdowns with absolute/fixed positioning — use the shadcn primitives instead.
+
+**Always use Tabler Icons** (`@tabler/icons-react`) for all icons. Never use other icon libraries.
+
+**Never use browser dialogs** (`window.confirm`, `window.alert`, `window.prompt`) — use shadcn AlertDialog instead.
+
 ---
 
 For code editing and development guidance, read `DEVELOPING.md`.

--- a/templates/videos/actions/generate-animated-component.ts
+++ b/templates/videos/actions/generate-animated-component.ts
@@ -1,7 +1,5 @@
-#!/usr/bin/env ts-node
-
 /**
- * Component Generator CLI
+ * Component Generator
  *
  * Generates a new Remotion composition with animated elements and boilerplate
  *
@@ -413,40 +411,36 @@ function generateComponent(options: GeneratorOptions): void {
   console.log(`   3. Open in Video Studio UI to configure animations\n`);
 }
 
-// Parse CLI arguments
-function parseArgs(): GeneratorOptions {
-  const args = process.argv.slice(2);
-
+export default async function (args: string[]) {
   if (args.length === 0 || args[0] === "--help") {
     console.log(`
 📦 Animated Component Generator
 
 Usage:
-  npm run generate:component <ComponentName> [options]
+  pnpm action generate-animated-component <ComponentName> [options]
 
 Options:
   --elements <Element1,Element2>   Comma-separated list of element types (default: Button,Card)
   --output <dir>                   Output directory (default: app/remotion/compositions)
 
 Examples:
-  npm run generate:component MyDashboard
-  npm run generate:component MyDashboard --elements Button,Card,Panel,Toggle
-  npm run generate:component MyApp --elements Hero,Feature,CTA --output src/components
+  pnpm action generate-animated-component MyDashboard
+  pnpm action generate-animated-component MyDashboard --elements Button,Card,Panel,Toggle
     `);
     return;
   }
 
   const name = args[0];
-  const elementsArg = args.find((arg, i) => args[i - 1] === "--elements");
-  const outputArg = args.find((arg, i) => args[i - 1] === "--output");
+  const elementsIdx = args.indexOf("--elements");
+  const elementsArg = elementsIdx >= 0 ? args[elementsIdx + 1] : undefined;
+  const outputIdx = args.indexOf("--output");
+  const outputArg = outputIdx >= 0 ? args[outputIdx + 1] : undefined;
 
-  return {
+  const options: GeneratorOptions = {
     name,
     elements: elementsArg ? elementsArg.split(",") : ["Button", "Card"],
     outputDir: outputArg || "app/remotion/compositions",
   };
-}
 
-// Run generator
-const options = parseArgs();
-generateComponent(options);
+  generateComponent(options);
+}

--- a/templates/videos/actions/validate-compositions.ts
+++ b/templates/videos/actions/validate-compositions.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env ts-node
-
 /**
  * Composition Validation Agent
  *
@@ -490,10 +488,13 @@ class CompositionValidator {
   }
 }
 
-// Run validator
-const validator = new CompositionValidator();
-const compositionsDir = path.join(process.cwd(), "app/remotion/compositions");
-const result = validator.validate(compositionsDir);
-validator.printResults(result);
+export default async function () {
+  const validator = new CompositionValidator();
+  const compositionsDir = path.join(process.cwd(), "app/remotion/compositions");
+  const result = validator.validate(compositionsDir);
+  validator.printResults(result);
 
-process.exit(result.passed ? 0 : 1);
+  if (!result.passed) {
+    throw new Error("Validation failed");
+  }
+}

--- a/templates/videos/app/components/LocalStorageIndicator.tsx
+++ b/templates/videos/app/components/LocalStorageIndicator.tsx
@@ -2,6 +2,16 @@ import { useState, useEffect } from "react";
 import { IconAlertCircle, IconRefresh } from "@tabler/icons-react";
 import { useComposition } from "@/contexts/CompositionContext";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 /**
  * Visual indicator that appears when localStorage has user overrides.
@@ -38,47 +48,65 @@ export function LocalStorageIndicator() {
     setOverrideTypes(types);
   }, [compositionId]);
 
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+
   if (!hasOverrides) return null;
 
   const handleReset = () => {
+    setShowResetConfirm(true);
+  };
+
+  const confirmReset = () => {
     if (!compositionId) return;
-
-    const confirmed = window.confirm(
-      `Reset "${selected?.title}" to registry defaults?\n\n` +
-        `This will clear your local changes to: ${overrideTypes.join(", ")}\n\n` +
-        `The page will reload automatically.`,
-    );
-
-    if (!confirmed) return;
 
     localStorage.removeItem(`videos-tracks:${compositionId}`);
     localStorage.removeItem(`videos-props:${compositionId}`);
     localStorage.removeItem(`videos-comp-settings:${compositionId}`);
     localStorage.removeItem(`videos-tracks-version:${compositionId}`);
 
+    setShowResetConfirm(false);
     window.location.reload();
   };
 
   return (
-    <div className="flex items-center gap-2 px-3 py-1.5 bg-amber-500/10 border border-amber-500/30 rounded-lg">
-      <IconAlertCircle className="w-3.5 h-3.5 text-amber-500 flex-shrink-0" />
-      <div className="flex-1 min-w-0">
-        <p className="text-xs text-amber-200/90 font-medium">
-          Using local overrides
-        </p>
-        <p className="text-[10px] text-amber-200/60">
-          {overrideTypes.join(", ")} modified
-        </p>
+    <>
+      <div className="flex items-center gap-2 px-3 py-1.5 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+        <IconAlertCircle className="w-3.5 h-3.5 text-amber-500 flex-shrink-0" />
+        <div className="flex-1 min-w-0">
+          <p className="text-xs text-amber-200/90 font-medium">
+            Using local overrides
+          </p>
+          <p className="text-[10px] text-amber-200/60">
+            {overrideTypes.join(", ")} modified
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={handleReset}
+          className="h-6 px-2 text-xs text-amber-200 hover:text-amber-100 hover:bg-amber-500/20"
+        >
+          <IconRefresh className="w-3 h-3 mr-1" />
+          Reset
+        </Button>
       </div>
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={handleReset}
-        className="h-6 px-2 text-xs text-amber-200 hover:text-amber-100 hover:bg-amber-500/20"
-      >
-        <IconRefresh className="w-3 h-3 mr-1" />
-        Reset
-      </Button>
-    </div>
+
+      <AlertDialog open={showResetConfirm} onOpenChange={setShowResetConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reset to defaults</AlertDialogTitle>
+            <AlertDialogDescription>
+              Reset "{selected?.title}" to registry defaults? This will clear
+              your local changes to: {overrideTypes.join(", ")}. The page will
+              reload automatically.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmReset}>Reset</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/templates/videos/app/pages/CompositionView.tsx
+++ b/templates/videos/app/pages/CompositionView.tsx
@@ -12,6 +12,16 @@ import { usePlayback } from "@/contexts/PlaybackContext";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { cn } from "@/lib/utils";
 import NewComposition from "@/pages/NewComposition";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 type CompositionViewProps = {
   onCameraKeyframeClick?: (trackType: "camera" | "cursor") => void;
@@ -61,6 +71,12 @@ export default function CompositionView({
 
   // Detect if there are unsaved changes in localStorage
   const hasUnsavedChanges = useUnsavedChanges();
+
+  // Dialog states for save confirmation and status alerts
+  const [showSaveConfirm, setShowSaveConfirm] = useState(false);
+  const [showSaveSuccess, setShowSaveSuccess] = useState(false);
+  const [showSaveError, setShowSaveError] = useState(false);
+  const [saveErrorMessage, setSaveErrorMessage] = useState("");
 
   // All hooks must be called before any early returns (React rules of hooks)
   const playerRef = useRef<VideoPlayerHandle>(null);
@@ -209,26 +225,19 @@ export default function CompositionView({
           console.log(`[Save] Saved "${composition.title}" to registry`);
 
           if (!silent) {
-            alert(
-              `Saved "${composition.title}" to registry!\n\nThe page will reload to pick up the changes.`,
-            );
+            setShowSaveSuccess(true);
+          } else {
+            // Reload to pick up fresh registry data
+            window.location.reload();
           }
-
-          // Reload to pick up fresh registry data
-          window.location.reload();
         } else if (lastError) {
           // Network error or server not available after all retries
           const errorMessage = lastError.message;
           console.error("[Save] Failed to save after retries:", errorMessage);
 
           if (!silent) {
-            alert(
-              `Failed to save to registry:\n\n${errorMessage}\n\n` +
-                `This usually means:\n` +
-                `- The dev server needs to be restarted\n` +
-                `- The API endpoint is not available\n\n` +
-                `Your changes are still saved in browser storage and will persist until you reload the page.`,
-            );
+            setSaveErrorMessage(errorMessage);
+            setShowSaveError(true);
           }
 
           throw lastError; // Re-throw to be caught by outer catch
@@ -242,17 +251,15 @@ export default function CompositionView({
   );
 
   // Manual save handler (shows confirmation)
-  const handleSaveAsDefault = useCallback(async () => {
+  const handleSaveAsDefault = useCallback(() => {
     if (!composition) return;
+    setShowSaveConfirm(true);
+  }, [composition]);
 
-    const confirmed = window.confirm(
-      `Save current settings as default for "${composition.title}"?\n\nThis will update the registry file with:\n- Current tracks and animations\n- Current properties\n- Current composition settings`,
-    );
-
-    if (!confirmed) return;
-
-    await performSave(false); // Not silent - show alerts
-  }, [composition, performSave]);
+  const confirmSave = useCallback(async () => {
+    setShowSaveConfirm(false);
+    await performSave(false); // Not silent - show dialogs
+  }, [performSave]);
 
   // Listen for auto-save events from AI generation
   useEffect(() => {
@@ -425,6 +432,66 @@ export default function CompositionView({
           isPlaying={isPlaying}
         />
       </div>
+
+      {/* Save confirmation dialog */}
+      <AlertDialog open={showSaveConfirm} onOpenChange={setShowSaveConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Save to registry</AlertDialogTitle>
+            <AlertDialogDescription>
+              Save current settings as default for "{composition.title}"? This
+              will update the registry file with current tracks, animations,
+              properties, and composition settings.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmSave}>Save</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Save success dialog */}
+      <AlertDialog
+        open={showSaveSuccess}
+        onOpenChange={(open) => {
+          setShowSaveSuccess(open);
+          if (!open) window.location.reload();
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Saved</AlertDialogTitle>
+            <AlertDialogDescription>
+              Saved "{composition.title}" to registry. The page will reload to
+              pick up the changes.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => window.location.reload()}>
+              OK
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Save error dialog */}
+      <AlertDialog open={showSaveError} onOpenChange={setShowSaveError}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Save failed</AlertDialogTitle>
+            <AlertDialogDescription>
+              Failed to save to registry: {saveErrorMessage}
+              {"\n\n"}This usually means the dev server needs to be restarted or
+              the API endpoint is not available. Your changes are still saved in
+              browser storage and will persist until you reload.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction>OK</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Note delete guard** — solo-mode delete now checks `isNull(orgId)` to prevent ex-members from deleting org-scoped notes
- **contact_frequency migration** — added version 6 DB migration for the `contact_frequency` table (was missing from PR #153)
- **Calendar improvements** — event creation dialog, day/week view enhancements (concurrent agent)
- **Agent chat** — task card and assistant chat updates (concurrent agent)
- **AGENTS.md updates** — refreshed across all templates

## Test plan
- [ ] Verify solo-mode note deletion still works for personal notes
- [ ] Verify org-scoped notes can't be deleted without org membership
- [ ] Verify contact_frequency table is created on fresh DB init
- [ ] Verify calendar create event dialog works

🤖 Generated with [Claude Code](https://claude.com/claude-code)