### PR TITLE
feat: integrations panel, build/plan mode, agent detail view, dialog cleanup

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -169,6 +169,7 @@
   "devDependencies": {
     "@assistant-ui/react": "^0.12.19",
     "@assistant-ui/react-markdown": "^0.12.6",
+    "@radix-ui/react-popover": "^1.1.15",
     "@react-router/dev": "^7.13.1",
     "@react-router/fs-routes": "^7.13.1",
     "@supabase/supabase-js": "^2.49.0",

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -43,12 +43,13 @@ import {
   IconPlus,
   IconFolder,
   IconX,
-  IconPencil,
   IconClockHour3,
   IconDotsVertical,
   IconHistory,
   IconTrash,
   IconPlugConnected,
+  IconChevronLeft,
+  IconCopy,
 } from "@tabler/icons-react";
 import {
   MultiTabAssistantChat,
@@ -358,23 +359,98 @@ function AgentSettingsPopover({
 
 // ─── Agents Management Section ───────────────────────────────────────────────
 
+interface AgentInfo {
+  id: string;
+  path: string;
+  name: string;
+  url: string;
+  description?: string;
+}
+
+function AgentDetail({
+  agent,
+  onBack,
+  onDelete,
+}: {
+  agent: AgentInfo;
+  onBack: () => void;
+  onDelete: (id: string) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(agent.url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [agent.url]);
+
+  return (
+    <div>
+      <button
+        onClick={onBack}
+        className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground mb-2"
+      >
+        <IconChevronLeft size={12} />
+        Back
+      </button>
+
+      <div className="flex items-center gap-2 mb-3">
+        <IconPlugConnected size={16} className="text-foreground shrink-0" />
+        <div className="min-w-0">
+          <div className="text-xs font-medium text-foreground truncate">
+            {agent.name}
+          </div>
+          {agent.description && (
+            <div className="text-[10px] text-muted-foreground">
+              {agent.description}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="mb-3">
+        <div className="text-[10px] font-medium text-muted-foreground mb-1">
+          A2A Endpoint
+        </div>
+        <div className="flex items-center gap-1">
+          <code className="flex-1 truncate rounded bg-muted px-1.5 py-0.5 text-[10px] text-foreground">
+            {agent.url}
+          </code>
+          <button
+            onClick={handleCopy}
+            className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50"
+            title="Copy URL"
+          >
+            {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+          </button>
+        </div>
+      </div>
+
+      <div className="rounded-md border border-border bg-muted/30 px-2.5 py-2 text-[10px] text-muted-foreground mb-3">
+        @-mention this agent in chat to send it tasks via the A2A protocol. It
+        will use its own tools and skills to respond.
+      </div>
+
+      <button
+        onClick={() => onDelete(agent.id)}
+        className="w-full rounded-md border border-red-800/50 px-2 py-1.5 text-[11px] font-medium text-red-400 hover:bg-red-900/20"
+      >
+        Remove agent
+      </button>
+    </div>
+  );
+}
+
 function AgentsSection() {
+  const [expanded, setExpanded] = useState(false);
   const [showAdd, setShowAdd] = useState(false);
+  const [selectedAgent, setSelectedAgent] = useState<AgentInfo | null>(null);
   const [name, setName] = useState("");
   const [url, setUrl] = useState("");
   const [description, setDescription] = useState("");
   const nameRef = useRef<HTMLInputElement>(null);
 
   // Fetch agents from resources
-  const [agents, setAgents] = useState<
-    {
-      id: string;
-      path: string;
-      name: string;
-      url: string;
-      description?: string;
-    }[]
-  >([]);
+  const [agents, setAgents] = useState<AgentInfo[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchAgents = useCallback(async () => {
@@ -465,105 +541,137 @@ function AgentsSection() {
       const res = await fetch(`/_agent-native/resources/${agentId}`, {
         method: "DELETE",
       });
-      if (res.ok) fetchAgents();
+      if (res.ok) {
+        setSelectedAgent(null);
+        fetchAgents();
+      }
     } catch {}
   };
 
+  if (selectedAgent) {
+    return (
+      <AgentDetail
+        agent={selectedAgent}
+        onBack={() => setSelectedAgent(null)}
+        onDelete={handleDelete}
+      />
+    );
+  }
+
   return (
     <div>
-      <div className="flex items-center justify-between mb-2">
-        <label className="text-[11px] font-medium text-muted-foreground">
-          Agents
-        </label>
+      <div className="flex items-center justify-between mb-1.5">
+        <div>
+          <div className="text-xs font-medium text-foreground">Agents</div>
+          <div className="text-[10px] text-muted-foreground">
+            {loading
+              ? "Loading..."
+              : agents.length > 0
+                ? `${agents.length} connected via A2A`
+                : "Connect agents via A2A protocol"}
+          </div>
+        </div>
         <button
-          onClick={() => setShowAdd(!showAdd)}
+          onClick={() => {
+            if (expanded || showAdd) {
+              setExpanded(false);
+              setShowAdd(false);
+            } else {
+              setExpanded(true);
+            }
+          }}
           className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
-          title="Add agent"
+          title={expanded ? "Collapse" : "Manage agents"}
         >
-          {showAdd ? <IconX size={12} /> : <IconPlus size={12} />}
+          {expanded || showAdd ? <IconX size={12} /> : <IconPlus size={12} />}
         </button>
       </div>
 
-      {showAdd && (
-        <div className="mb-2 flex flex-col gap-1.5 rounded-md border border-border bg-background p-2">
-          <input
-            ref={nameRef}
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleAdd();
-              if (e.key === "Escape") setShowAdd(false);
-            }}
-            className="w-full rounded border border-border bg-background px-2 py-1 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-            placeholder="Name"
-          />
-          <input
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleAdd();
-              if (e.key === "Escape") setShowAdd(false);
-            }}
-            className="w-full rounded border border-border bg-background px-2 py-1 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-            placeholder="URL"
-          />
-          <input
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleAdd();
-              if (e.key === "Escape") setShowAdd(false);
-            }}
-            className="w-full rounded border border-border bg-background px-2 py-1 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-            placeholder="Description (optional)"
-          />
-          <div className="flex justify-end">
-            <button
-              onClick={handleAdd}
-              disabled={!name.trim() || !url.trim()}
-              className="rounded bg-accent px-2.5 py-1 text-[11px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
-            >
-              Add
-            </button>
-          </div>
-        </div>
-      )}
-
-      {loading ? (
-        <p className="text-[11px] text-muted-foreground/50">Loading...</p>
-      ) : agents.length === 0 && !showAdd ? (
-        <p className="text-[11px] text-muted-foreground/50">
-          No agents configured. Add one to @-mention and communicate via A2A.
-        </p>
-      ) : (
-        <div className="flex flex-col gap-1">
-          {agents.map((agent) => (
-            <div
-              key={agent.id}
-              className="group flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-accent/30"
-            >
-              <IconPlugConnected
-                size={13}
-                className="shrink-0 text-muted-foreground"
-              />
-              <div className="flex-1 min-w-0">
-                <div className="text-[12px] font-medium text-foreground truncate">
-                  {agent.name}
-                </div>
-                <div className="text-[10px] text-muted-foreground/60 truncate">
-                  {agent.url}
-                </div>
-              </div>
+      {(expanded || showAdd) && (
+        <>
+          {!showAdd && (
+            <div className="flex flex-col gap-0.5 mb-1.5">
+              {agents.map((agent) => (
+                <button
+                  key={agent.id}
+                  onClick={() => setSelectedAgent(agent)}
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent/30"
+                >
+                  <IconPlugConnected
+                    size={13}
+                    className="shrink-0 text-muted-foreground"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="text-[11px] font-medium text-foreground truncate">
+                      {agent.name}
+                    </div>
+                    <div className="text-[10px] text-muted-foreground/60 truncate">
+                      {agent.url}
+                    </div>
+                  </div>
+                </button>
+              ))}
               <button
-                onClick={() => handleDelete(agent.id)}
-                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/40 hover:text-red-400 opacity-0 group-hover:opacity-100"
-                title="Remove agent"
+                onClick={() => setShowAdd(true)}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[11px] text-muted-foreground hover:text-foreground hover:bg-accent/30"
               >
-                <IconTrash size={12} />
+                <IconPlus size={12} className="shrink-0" />
+                Add agent
               </button>
             </div>
-          ))}
-        </div>
+          )}
+
+          {showAdd && (
+            <div className="mb-1.5 flex flex-col gap-1.5 rounded-md border border-border bg-background p-2">
+              <input
+                ref={nameRef}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleAdd();
+                  if (e.key === "Escape") setShowAdd(false);
+                }}
+                className="w-full rounded border border-border bg-background px-2 py-1 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                placeholder="Name"
+              />
+              <input
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleAdd();
+                  if (e.key === "Escape") setShowAdd(false);
+                }}
+                className="w-full rounded border border-border bg-background px-2 py-1 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                placeholder="URL (e.g. http://localhost:8085)"
+              />
+              <input
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleAdd();
+                  if (e.key === "Escape") setShowAdd(false);
+                }}
+                className="w-full rounded border border-border bg-background px-2 py-1 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                placeholder="Description (optional)"
+              />
+              <div className="flex justify-end gap-1.5">
+                <button
+                  onClick={() => setShowAdd(false)}
+                  className="rounded px-2.5 py-1 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleAdd}
+                  disabled={!name.trim() || !url.trim()}
+                  className="rounded bg-accent px-2.5 py-1 text-[11px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );
@@ -1264,49 +1372,8 @@ export function AgentPanel({
             emptyStateText={emptyStateText}
             suggestions={suggestions}
             onSwitchToCli={isDevMode ? () => switchMode("cli") : undefined}
-            composerSlot={
-              <div className="shrink-0 px-3 pt-1.5 pb-0 flex items-center justify-between gap-2">
-                {execMode === "plan" ? (
-                  <div className="flex items-center gap-1.5 text-[11px] text-amber-700 dark:text-amber-400 min-w-0 truncate">
-                    <IconPencil size={12} className="shrink-0" />
-                    <span className="truncate">
-                      Plan mode — will plan before executing
-                    </span>
-                  </div>
-                ) : (
-                  <div />
-                )}
-                <div
-                  className="flex shrink-0 items-center rounded-md border border-border overflow-hidden"
-                  style={AGENT_PANEL_CONTROL_STYLE}
-                >
-                  <button
-                    onClick={() => switchExecMode("build")}
-                    className={cn(
-                      "px-2 py-1 text-[11px] leading-none",
-                      execMode === "build"
-                        ? "bg-accent text-foreground"
-                        : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                    )}
-                    title="Build mode — agent executes immediately"
-                  >
-                    Build
-                  </button>
-                  <button
-                    onClick={() => switchExecMode("plan")}
-                    className={cn(
-                      "px-2 py-1 text-[11px] leading-none",
-                      execMode === "plan"
-                        ? "bg-amber-500/20 text-amber-700 dark:text-amber-400"
-                        : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                    )}
-                    title="Plan mode — agent plans before executing"
-                  >
-                    Plan
-                  </button>
-                </div>
-              </div>
-            }
+            execMode={execMode}
+            onExecModeChange={switchExecMode}
           />
         )}
       </div>

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -941,6 +941,10 @@ export interface AssistantChatProps {
   isNewThread?: boolean;
   /** Called when a slash command (e.g. /clear, /help) is executed */
   onSlashCommand?: (command: string) => void;
+  /** Current execution mode (build/plan) */
+  execMode?: "build" | "plan";
+  /** Callback to change execution mode */
+  onExecModeChange?: (mode: "build" | "plan") => void;
 }
 
 export const CHAT_STORAGE_PREFIX = "agent-chat:";
@@ -992,6 +996,8 @@ const AssistantChatInner = forwardRef<
     composerSlot,
     isNewThread,
     onSlashCommand,
+    execMode,
+    onExecModeChange,
   },
   ref,
 ) {
@@ -1008,6 +1014,7 @@ const AssistantChatInner = forwardRef<
   const [isReconnecting, setIsReconnecting] = useState(false);
   const [reconnectContent, setReconnectContent] = useState<ContentPart[]>([]);
   const reconnectRunIdRef = useRef<string | null>(null);
+  const reconnectAbortRef = useRef<AbortController | null>(null);
   // Treat reconnecting to an active run the same as running for UI purposes
   const isRunning = isRuntimeRunning || isReconnecting;
   const wasRunningRef = useRef(false);
@@ -1093,9 +1100,12 @@ const AssistantChatInner = forwardRef<
                 );
 
                 const streamReconnect = async () => {
+                  const abortCtrl = new AbortController();
+                  reconnectAbortRef.current = abortCtrl;
                   try {
                     const sseRes = await fetch(
                       `${apiUrl}/runs/${encodeURIComponent(runInfo.runId)}/events?after=0`,
+                      { signal: abortCtrl.signal },
                     );
                     if (sseRes.ok && sseRes.body) {
                       const content: ContentPart[] = [];
@@ -1127,11 +1137,10 @@ const AssistantChatInner = forwardRef<
                       setReconnectContent([...content]);
                     }
                   } catch {
-                    // Stream error — fall through to re-fetch
+                    // Stream error or abort — fall through to re-fetch
                   }
 
-                  // Run finished — re-fetch thread data from server
-                  // (server now persists assistant response on completion)
+                  // Re-fetch thread data from server to load final state
                   try {
                     const refreshRes = await fetch(
                       `${apiUrl}/threads/${encodeURIComponent(threadId)}`,
@@ -1149,15 +1158,18 @@ const AssistantChatInner = forwardRef<
                       }
                     }
                   } catch {}
-                  setReconnectContent([]);
-                  setIsReconnecting(false);
-                  reconnectRunIdRef.current = null;
-                  // Signal tab stopped
-                  window.dispatchEvent(
-                    new CustomEvent("builder.chatRunning", {
-                      detail: { isRunning: false, tabId: tabId || threadId },
-                    }),
-                  );
+                  // Only clean up if the stop button hasn't already done it
+                  if (reconnectRunIdRef.current) {
+                    reconnectAbortRef.current = null;
+                    setReconnectContent([]);
+                    setIsReconnecting(false);
+                    reconnectRunIdRef.current = null;
+                    window.dispatchEvent(
+                      new CustomEvent("builder.chatRunning", {
+                        detail: { isRunning: false, tabId: tabId || threadId },
+                      }),
+                    );
+                  }
                 };
                 streamReconnect();
               } // end else (running)
@@ -1589,15 +1601,31 @@ const AssistantChatInner = forwardRef<
                 : undefined
             }
             onSlashCommand={onSlashCommand}
+            execMode={execMode}
+            onExecModeChange={onExecModeChange}
             actionButton={
               isRunning ? (
                 <button
                   onClick={() => {
                     if (isReconnecting && reconnectRunIdRef.current) {
-                      // Abort the server-side run directly
+                      // Abort the server-side run
                       fetch(
                         `${apiUrl}/runs/${encodeURIComponent(reconnectRunIdRef.current)}/abort`,
                         { method: "POST" },
+                      );
+                      // Abort the client-side SSE stream so we don't hang
+                      reconnectAbortRef.current?.abort();
+                      reconnectAbortRef.current = null;
+                      reconnectRunIdRef.current = null;
+                      setIsReconnecting(false);
+                      setReconnectContent([]);
+                      window.dispatchEvent(
+                        new CustomEvent("builder.chatRunning", {
+                          detail: {
+                            isRunning: false,
+                            tabId: tabId || threadId,
+                          },
+                        }),
                       );
                     } else {
                       threadRuntime.cancelRun();

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -20,7 +20,14 @@ import { MentionReference } from "./extensions/MentionReference.js";
 import { MentionPopover, type MentionPopoverRef } from "./MentionPopover.js";
 import { useMentionSearch } from "./use-mention-search.js";
 import { useSkills } from "./use-skills.js";
-import { IconArrowUp, IconPaperclip } from "@tabler/icons-react";
+import {
+  IconArrowUp,
+  IconPlus,
+  IconBolt,
+  IconBulb,
+  IconCheck,
+  IconChevronDown,
+} from "@tabler/icons-react";
 import type {
   MentionItem,
   SkillResult,
@@ -39,6 +46,8 @@ const BUILT_IN_COMMANDS: SlashCommand[] = [
   { name: "help", description: "Show available commands", icon: "help" },
 ];
 
+type ExecMode = "build" | "plan";
+
 interface TiptapComposerProps {
   placeholder?: string;
   disabled?: boolean;
@@ -51,6 +60,103 @@ interface TiptapComposerProps {
   attachButton?: React.ReactNode;
   /** Called when a slash command (e.g. /clear, /help) is executed */
   onSlashCommand?: (command: string) => void;
+  /** Current execution mode (build/plan) */
+  execMode?: ExecMode;
+  /** Callback to change execution mode */
+  onExecModeChange?: (mode: ExecMode) => void;
+}
+
+function ModeSelector({
+  mode,
+  onChange,
+}: {
+  mode: ExecMode;
+  onChange: (mode: ExecMode) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="shrink-0 flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-muted-foreground hover:text-foreground hover:bg-accent/50"
+      >
+        {mode === "build" ? (
+          <IconBolt className="h-3.5 w-3.5" />
+        ) : (
+          <IconBulb className="h-3.5 w-3.5" />
+        )}
+        {mode === "build" ? "Build" : "Plan"}
+        <IconChevronDown className="h-3 w-3 opacity-60" />
+      </button>
+      {open && (
+        <div
+          className="absolute bottom-full right-0 mb-1.5 w-64 rounded-lg border border-border bg-popover shadow-lg z-50 py-1"
+          style={{ fontSize: 13 }}
+        >
+          <button
+            type="button"
+            onClick={() => {
+              onChange("build");
+              setOpen(false);
+            }}
+            className="flex w-full items-start gap-3 px-3 py-2 hover:bg-accent/50 text-left"
+          >
+            <IconBolt className="h-5 w-5 mt-0.5 shrink-0 text-muted-foreground" />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-foreground text-[13px]">
+                  Build
+                </span>
+                {mode === "build" && (
+                  <IconCheck className="h-3.5 w-3.5 text-blue-500" />
+                )}
+              </div>
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                Generate and make edits directly
+              </p>
+            </div>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              onChange("plan");
+              setOpen(false);
+            }}
+            className="flex w-full items-start gap-3 px-3 py-2 hover:bg-accent/50 text-left"
+          >
+            <IconBulb className="h-5 w-5 mt-0.5 shrink-0 text-muted-foreground" />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-foreground text-[13px]">
+                  Plan
+                </span>
+                {mode === "plan" && (
+                  <IconCheck className="h-3.5 w-3.5 text-blue-500" />
+                )}
+              </div>
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                Collaborate on an approach before taking action
+              </p>
+            </div>
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 type PopoverState = {
@@ -68,6 +174,8 @@ export function TiptapComposer({
   actionButton,
   attachButton,
   onSlashCommand,
+  execMode,
+  onExecModeChange,
 }: TiptapComposerProps) {
   const [popover, setPopover] = useState<PopoverState>(null);
   const popoverRef = useRef<MentionPopoverRef>(null);
@@ -80,6 +188,10 @@ export function TiptapComposer({
 
   // Refs for values accessed in handleKeyDown (ProseMirror doesn't re-bind)
   const popoverStateRef = useRef<PopoverState>(null);
+  const execModeRef = useRef(execMode);
+  execModeRef.current = execMode;
+  const onExecModeChangeRef = useRef(onExecModeChange);
+  onExecModeChangeRef.current = onExecModeChange;
 
   const { items: mentionItems, isLoading: mentionsLoading } = useMentionSearch(
     popover?.type === "@" ? popover.query : "",
@@ -187,7 +299,7 @@ export function TiptapComposer({
     editorProps: {
       attributes: {
         class:
-          "flex-1 resize-none bg-transparent text-sm text-foreground outline-none leading-[1.625rem] min-h-[1.625rem] max-h-[10rem] overflow-y-auto",
+          "flex-1 resize-none bg-transparent text-sm text-foreground outline-none leading-[1.625rem] min-h-[3.25rem] max-h-[10rem] overflow-y-auto",
       },
       handlePaste: (_view, event) => {
         const files = Array.from(event.clipboardData?.files ?? []).filter(
@@ -250,6 +362,17 @@ export function TiptapComposer({
             setPopover(null);
             return false;
           }
+        }
+
+        // Shift+Tab toggles build/plan mode
+        if (event.key === "Tab" && event.shiftKey) {
+          event.preventDefault();
+          const current = execModeRef.current;
+          const cb = onExecModeChangeRef.current;
+          if (current && cb) {
+            cb(current === "build" ? "plan" : "build");
+          }
+          return true;
         }
 
         // Submit on Enter (Shift+Enter for newline)
@@ -625,6 +748,22 @@ export function TiptapComposer({
 
   return (
     <>
+      <style>{`
+        .aui-composer .ProseMirror p.is-editor-empty:first-child::before {
+          content: attr(data-placeholder);
+          color: var(--color-muted-foreground);
+          opacity: 0.5;
+          float: left;
+          height: 0;
+          pointer-events: none;
+        }
+      `}</style>
+      <div className="px-2 pt-2 pb-1">
+        <EditorContent
+          editor={editor}
+          className="aui-composer flex-1 min-w-0 [&_.ProseMirror]:outline-none [&_.ProseMirror_p]:m-0 px-0.5"
+        />
+      </div>
       <div className="flex items-center gap-1 px-2 py-1.5">
         {attachButton ?? (
           <ComposerPrimitive.AddAttachment asChild>
@@ -633,30 +772,15 @@ export function TiptapComposer({
               className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 disabled:opacity-30 disabled:cursor-not-allowed"
               title="Attach files"
             >
-              <IconPaperclip className="h-4 w-4" />
+              <IconPlus className="h-4 w-4" />
             </button>
           </ComposerPrimitive.AddAttachment>
         )}
-        <style>{`
-          .aui-composer .ProseMirror p.is-editor-empty:first-child::before {
-            content: attr(data-placeholder);
-            color: var(--color-muted-foreground);
-            opacity: 0.5;
-            float: left;
-            height: 0;
-            pointer-events: none;
-          }
-        `}</style>
-        <EditorContent
-          editor={editor}
-          className="aui-composer flex-1 min-w-0 [&_.ProseMirror]:outline-none [&_.ProseMirror_p]:m-0"
-        />
+        <div className="flex-1" />
         {actionButton ?? (
           <>
-            {!canSend && (
-              <kbd className="shrink-0 text-[11px] text-muted-foreground/40 font-medium border border-border/50 rounded px-1.5 py-0.5 leading-none pointer-events-none">
-                {isMac ? "⌘I" : "Ctrl+I"}
-              </kbd>
+            {execMode && onExecModeChange && (
+              <ModeSelector mode={execMode} onChange={onExecModeChange} />
             )}
             <button
               type="button"

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -23,11 +23,10 @@ import { useSkills } from "./use-skills.js";
 import {
   IconArrowUp,
   IconPlus,
-  IconBolt,
-  IconBulb,
   IconCheck,
   IconChevronDown,
 } from "@tabler/icons-react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 import type {
   MentionItem,
   SkillResult,
@@ -74,37 +73,24 @@ function ModeSelector({
   onChange: (mode: ExecMode) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const handleClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
 
   return (
-    <div ref={ref} className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        className="shrink-0 flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-muted-foreground hover:text-foreground hover:bg-accent/50"
-      >
-        {mode === "build" ? (
-          <IconBolt className="h-3.5 w-3.5" />
-        ) : (
-          <IconBulb className="h-3.5 w-3.5" />
-        )}
-        {mode === "build" ? "Build" : "Plan"}
-        <IconChevronDown className="h-3 w-3 opacity-60" />
-      </button>
-      {open && (
-        <div
-          className="absolute bottom-full right-0 mb-1.5 w-64 rounded-lg border border-border bg-popover shadow-lg z-50 py-1"
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Trigger asChild>
+        <button
+          type="button"
+          className="shrink-0 flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-muted-foreground hover:text-foreground hover:bg-accent/50"
+        >
+          {mode === "build" ? "Act" : "Plan"}
+          <IconChevronDown className="h-3 w-3 opacity-60" />
+        </button>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          side="top"
+          align="end"
+          sideOffset={6}
+          className="w-60 rounded-lg border border-border bg-popover shadow-lg z-50 py-1 animate-in fade-in-0 zoom-in-95"
           style={{ fontSize: 13 }}
         >
           <button
@@ -113,22 +99,19 @@ function ModeSelector({
               onChange("build");
               setOpen(false);
             }}
-            className="flex w-full items-start gap-3 px-3 py-2 hover:bg-accent/50 text-left"
+            className="flex w-full items-center gap-3 px-3 py-2 hover:bg-accent/50 text-left"
           >
-            <IconBolt className="h-5 w-5 mt-0.5 shrink-0 text-muted-foreground" />
             <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="font-medium text-foreground text-[13px]">
-                  Build
-                </span>
-                {mode === "build" && (
-                  <IconCheck className="h-3.5 w-3.5 text-blue-500" />
-                )}
-              </div>
+              <span className="font-medium text-foreground text-[13px]">
+                Act
+              </span>
               <p className="text-[11px] text-muted-foreground mt-0.5">
                 Generate and make edits directly
               </p>
             </div>
+            {mode === "build" && (
+              <IconCheck className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+            )}
           </button>
           <button
             type="button"
@@ -136,26 +119,23 @@ function ModeSelector({
               onChange("plan");
               setOpen(false);
             }}
-            className="flex w-full items-start gap-3 px-3 py-2 hover:bg-accent/50 text-left"
+            className="flex w-full items-center gap-3 px-3 py-2 hover:bg-accent/50 text-left"
           >
-            <IconBulb className="h-5 w-5 mt-0.5 shrink-0 text-muted-foreground" />
             <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="font-medium text-foreground text-[13px]">
-                  Plan
-                </span>
-                {mode === "plan" && (
-                  <IconCheck className="h-3.5 w-3.5 text-blue-500" />
-                )}
-              </div>
+              <span className="font-medium text-foreground text-[13px]">
+                Plan
+              </span>
               <p className="text-[11px] text-muted-foreground mt-0.5">
                 Collaborate on an approach before taking action
               </p>
             </div>
+            {mode === "plan" && (
+              <IconCheck className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+            )}
           </button>
-        </div>
-      )}
-    </div>
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
   );
 }
 

--- a/packages/core/src/client/integrations/IntegrationsPanel.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.tsx
@@ -1,42 +1,445 @@
-import React from "react";
-import { useIntegrationStatus } from "./useIntegrationStatus.js";
-import { IntegrationCard } from "./IntegrationCard.js";
+import React, { useState, useCallback } from "react";
+import {
+  IconPlus,
+  IconBrandSlack,
+  IconBrandTelegram,
+  IconBrandWhatsapp,
+  IconTerminal2,
+  IconBuildingSkyscraper,
+  IconMessageCircle,
+  IconCopy,
+  IconCheck,
+  IconChevronLeft,
+  IconExternalLink,
+  IconCircleCheck,
+} from "@tabler/icons-react";
+import {
+  useIntegrationStatus,
+  type IntegrationStatus,
+} from "./useIntegrationStatus.js";
 
-function LoadingSkeleton() {
+// ─── Platform config ─────────────────────────────────────────────────────────
+
+interface PlatformInfo {
+  id: string;
+  label: string;
+  icon: React.ComponentType<any>;
+  description: string;
+  envVars: string[];
+  setupSteps: string[];
+  docsUrl?: string;
+  /** If true, this is a "client" integration (user connects TO the agent) rather than a webhook */
+  isClient?: boolean;
+}
+
+const PLATFORMS: PlatformInfo[] = [
+  {
+    id: "slack",
+    label: "Slack",
+    icon: IconBrandSlack,
+    description: "Message your agent from any Slack channel or DM.",
+    envVars: ["SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET"],
+    setupSteps: [
+      "Create a Slack app at api.slack.com/apps",
+      'Enable "Event Subscriptions" and point to your webhook URL',
+      "Subscribe to message.im and app_mention events",
+      "Install the app to your workspace",
+      "Copy the Bot Token and Signing Secret into your environment",
+    ],
+    docsUrl: "https://api.slack.com/apps",
+  },
+  {
+    id: "telegram",
+    label: "Telegram",
+    icon: IconBrandTelegram,
+    description: "Chat with your agent via a Telegram bot.",
+    envVars: ["TELEGRAM_BOT_TOKEN"],
+    setupSteps: [
+      "Message @BotFather on Telegram to create a new bot",
+      "Copy the bot token into your environment",
+      'Click "Setup webhook" below to register automatically',
+    ],
+  },
+  {
+    id: "whatsapp",
+    label: "WhatsApp",
+    icon: IconBrandWhatsapp,
+    description: "Connect your agent to WhatsApp Business.",
+    envVars: ["WHATSAPP_TOKEN", "WHATSAPP_VERIFY_TOKEN"],
+    setupSteps: [
+      "Create a Meta Business app at developers.facebook.com",
+      "Set up WhatsApp Business API",
+      "Configure the webhook URL and verify token",
+      "Copy the access token into your environment",
+    ],
+    docsUrl: "https://developers.facebook.com/docs/whatsapp",
+  },
+  {
+    id: "openclaw",
+    label: "OpenClaw",
+    icon: IconTerminal2,
+    description: "Access this agent from OpenClaw's unified agent interface.",
+    envVars: [],
+    isClient: true,
+    setupSteps: [
+      "Install OpenClaw: npm install -g openclaw",
+      "Add this agent's URL as a provider in your OpenClaw config",
+      "OpenClaw discovers your agent's capabilities via the A2A protocol",
+    ],
+  },
+  {
+    id: "claude-code",
+    label: "Claude Code",
+    icon: IconTerminal2,
+    description:
+      "Let Claude Code call this agent via A2A for data and actions.",
+    envVars: [],
+    isClient: true,
+    setupSteps: [
+      "Your agent exposes an A2A endpoint at /.well-known/agent-card.json",
+      "In Claude Code, reference your agent's URL when asking for data",
+      "Claude Code will discover and call your agent's skills automatically",
+    ],
+  },
+  {
+    id: "builder",
+    label: "Builder.io",
+    icon: IconBuildingSkyscraper,
+    description:
+      "One chat interface that orchestrates all your agents together.",
+    envVars: [],
+    isClient: true,
+    setupSteps: [
+      "Connect your agent-native apps in your Builder.io workspace",
+      "Builder.io discovers each agent's skills via A2A",
+      "Chat with one agent that can trigger actions across all your apps",
+    ],
+    docsUrl: "https://www.builder.io",
+  },
+];
+
+// ─── Integration detail view ─────────────────────────────────────────────────
+
+function IntegrationDetail({
+  platform,
+  serverStatus,
+  onBack,
+  onRefresh,
+}: {
+  platform: PlatformInfo;
+  serverStatus?: IntegrationStatus;
+  onBack: () => void;
+  onRefresh: () => void;
+}) {
+  const [toggling, setToggling] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const handleToggle = useCallback(async () => {
+    setToggling(true);
+    try {
+      const action = serverStatus?.enabled ? "disable" : "enable";
+      const res = await fetch(
+        `/_agent-native/integrations/${platform.id}/${action}`,
+        { method: "POST" },
+      );
+      if (res.ok) onRefresh();
+    } finally {
+      setToggling(false);
+    }
+  }, [platform.id, serverStatus?.enabled, onRefresh]);
+
+  const handleCopy = useCallback(async (text: string) => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, []);
+
+  const isConfigured = serverStatus?.configured ?? false;
+  const isEnabled = serverStatus?.enabled ?? false;
+
   return (
-    <div className="space-y-2">
-      {[0, 1, 2].map((i) => (
-        <div
-          key={i}
-          className="h-9 rounded-md border border-border bg-muted/50 animate-pulse"
-        />
+    <div>
+      <button
+        onClick={onBack}
+        className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground mb-2"
+      >
+        <IconChevronLeft size={12} />
+        Back
+      </button>
+
+      <div className="flex items-center gap-2 mb-2">
+        <platform.icon size={18} className="text-foreground shrink-0" />
+        <div>
+          <div className="text-xs font-medium text-foreground">
+            {platform.label}
+          </div>
+          <div className="text-[10px] text-muted-foreground">
+            {platform.description}
+          </div>
+        </div>
+      </div>
+
+      {/* Setup steps */}
+      <div className="mb-3">
+        <div className="text-[10px] font-medium text-muted-foreground mb-1.5">
+          Setup
+        </div>
+        <ol className="space-y-1">
+          {platform.setupSteps.map((step, i) => (
+            <li
+              key={i}
+              className="flex gap-1.5 text-[10px] text-muted-foreground leading-relaxed"
+            >
+              <span className="shrink-0 text-muted-foreground/50">
+                {i + 1}.
+              </span>
+              {step}
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      {/* Environment variables needed */}
+      {platform.envVars.length > 0 && (
+        <div className="mb-3">
+          <div className="text-[10px] font-medium text-muted-foreground mb-1">
+            Required environment variables
+          </div>
+          <div className="space-y-0.5">
+            {platform.envVars.map((v) => (
+              <div key={v} className="flex items-center gap-1">
+                <code className="text-[10px] text-foreground bg-muted px-1 py-0.5 rounded">
+                  {v}
+                </code>
+                {isConfigured && (
+                  <IconCircleCheck
+                    size={11}
+                    className="text-green-500 shrink-0"
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+          {!isConfigured && (
+            <p className="text-[10px] text-amber-500 mt-1">
+              Set these in your .env file or environment to connect.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Webhook URL */}
+      {serverStatus?.webhookUrl && !platform.isClient && (
+        <div className="mb-3">
+          <div className="text-[10px] font-medium text-muted-foreground mb-1">
+            Webhook URL
+          </div>
+          <div className="flex items-center gap-1">
+            <code className="flex-1 truncate rounded bg-muted px-1.5 py-0.5 text-[10px] text-foreground">
+              {serverStatus.webhookUrl}
+            </code>
+            <button
+              onClick={() => handleCopy(serverStatus.webhookUrl!)}
+              className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50"
+              title="Copy"
+            >
+              {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Docs link */}
+      {platform.docsUrl && (
+        <a
+          href={platform.docsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-[10px] text-blue-400 hover:text-blue-300 mb-3"
+        >
+          Documentation
+          <IconExternalLink size={10} />
+        </a>
+      )}
+
+      {/* Enable/disable for server integrations */}
+      {serverStatus && !platform.isClient && isConfigured && (
+        <button
+          onClick={handleToggle}
+          disabled={toggling}
+          className={`w-full rounded-md border px-2 py-1.5 text-[11px] font-medium disabled:opacity-50 ${
+            isEnabled
+              ? "border-border text-foreground hover:bg-accent/50"
+              : "border-green-600/50 text-green-400 hover:bg-green-900/20"
+          }`}
+        >
+          {toggling ? "..." : isEnabled ? "Disable" : "Enable"}
+        </button>
+      )}
+
+      {/* Status for client integrations */}
+      {platform.isClient && (
+        <div className="rounded-md border border-border bg-muted/30 px-2.5 py-2 text-[10px] text-muted-foreground">
+          This agent's A2A endpoint is automatically available. No configuration
+          needed.
+        </div>
+      )}
+
+      {serverStatus?.error && (
+        <p className="text-[10px] text-destructive mt-2">
+          {serverStatus.error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ─── Add integration picker ──────────────────────────────────────────────────
+
+function AddIntegrationPicker({
+  connectedIds,
+  onSelect,
+}: {
+  connectedIds: Set<string>;
+  onSelect: (platform: PlatformInfo) => void;
+}) {
+  return (
+    <div className="space-y-1">
+      {PLATFORMS.filter((p) => !connectedIds.has(p.id)).map((platform) => (
+        <button
+          key={platform.id}
+          onClick={() => onSelect(platform)}
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent/50"
+        >
+          <platform.icon size={14} className="shrink-0 text-muted-foreground" />
+          <div className="flex-1 min-w-0">
+            <div className="text-[11px] font-medium text-foreground">
+              {platform.label}
+            </div>
+            <div className="text-[10px] text-muted-foreground truncate">
+              {platform.description}
+            </div>
+          </div>
+        </button>
       ))}
     </div>
   );
 }
 
+// ─── Main panel ──────────────────────────────────────────────────────────────
+
 export function IntegrationsPanel() {
   const { statuses, loading, refetch } = useIntegrationStatus();
+  const [selectedPlatform, setSelectedPlatform] = useState<PlatformInfo | null>(
+    null,
+  );
+  const [showPicker, setShowPicker] = useState(false);
+
+  const statusMap = new Map(statuses.map((s) => [s.platform, s]));
+
+  // Show connected (enabled or configured) integrations
+  const connectedPlatforms = PLATFORMS.filter((p) => {
+    const s = statusMap.get(p.id);
+    return s?.configured || s?.enabled;
+  });
+
+  const connectedIds = new Set(connectedPlatforms.map((p) => p.id));
+
+  if (selectedPlatform) {
+    return (
+      <IntegrationDetail
+        platform={selectedPlatform}
+        serverStatus={statusMap.get(selectedPlatform.id)}
+        onBack={() => setSelectedPlatform(null)}
+        onRefresh={refetch}
+      />
+    );
+  }
+
+  if (showPicker) {
+    return (
+      <div>
+        <button
+          onClick={() => setShowPicker(false)}
+          className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground mb-2"
+        >
+          <IconChevronLeft size={12} />
+          Back
+        </button>
+        <div className="text-[10px] font-medium text-muted-foreground mb-1.5">
+          Add a chat integration
+        </div>
+        <AddIntegrationPicker
+          connectedIds={connectedIds}
+          onSelect={(p) => {
+            setSelectedPlatform(p);
+            setShowPicker(false);
+          }}
+        />
+      </div>
+    );
+  }
 
   return (
     <div>
-      <div className="mb-1.5">
-        <div className="text-xs font-medium text-foreground">Integrations</div>
-        <div className="text-[10px] text-muted-foreground">
-          Connect your agent to messaging platforms
+      <div className="flex items-center justify-between mb-1.5">
+        <div>
+          <div className="text-xs font-medium text-foreground">
+            Chat Integrations
+          </div>
+          <div className="text-[10px] text-muted-foreground">
+            Talk to this agent from other platforms
+          </div>
         </div>
+        <button
+          onClick={() => setShowPicker(true)}
+          className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
+          title="Add integration"
+        >
+          <IconPlus size={12} />
+        </button>
       </div>
+
       {loading ? (
-        <LoadingSkeleton />
-      ) : statuses.length === 0 ? (
-        <p className="text-[10px] text-muted-foreground">
-          No integrations available.
-        </p>
+        <div className="h-4 w-24 rounded bg-muted/50 animate-pulse" />
+      ) : connectedPlatforms.length === 0 ? (
+        <button
+          onClick={() => setShowPicker(true)}
+          className="text-[10px] text-muted-foreground hover:text-foreground"
+        >
+          Add an integration...
+        </button>
       ) : (
-        <div className="space-y-1.5">
-          {statuses.map((s) => (
-            <IntegrationCard key={s.platform} status={s} onRefresh={refetch} />
-          ))}
+        <div className="space-y-1">
+          {connectedPlatforms.map((platform) => {
+            const s = statusMap.get(platform.id);
+            return (
+              <button
+                key={platform.id}
+                onClick={() => setSelectedPlatform(platform)}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent/50"
+              >
+                <platform.icon
+                  size={14}
+                  className="shrink-0 text-muted-foreground"
+                />
+                <span className="flex-1 text-[11px] font-medium text-foreground truncate">
+                  {platform.label}
+                </span>
+                {s && (
+                  <span
+                    className={`inline-block h-1.5 w-1.5 rounded-full shrink-0 ${
+                      s.enabled && s.configured
+                        ? "bg-green-500"
+                        : s.configured
+                          ? "bg-yellow-500"
+                          : "bg-gray-400"
+                    }`}
+                  />
+                )}
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -98,7 +98,19 @@ function buildTree(resources: ResourceMeta[]): TreeNode[] {
     }
   }
 
+  sortTree(root);
   return root;
+}
+
+/** Sort tree nodes: folders first, then files, alphabetically within each group */
+function sortTree(nodes: TreeNode[]): void {
+  nodes.sort((a, b) => {
+    if (a.type !== b.type) return a.type === "folder" ? -1 : 1;
+    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  });
+  for (const node of nodes) {
+    if (node.children) sortTree(node.children);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       '@assistant-ui/react-markdown':
         specifier: ^0.12.6
         version: 0.12.8(@assistant-ui/react@0.12.22(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
       '@supabase/supabase-js':
         specifier: ^2.49.0
         version: 2.101.1
@@ -1045,10 +1048,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)))(typescript@5.9.3)
       '@swc/core':
         specifier: ^1.13.3
         version: 1.15.21
@@ -1069,7 +1072,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
@@ -1141,7 +1144,7 @@ importers:
         version: 1.1.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vite:
         specifier: ^8.0.0
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
@@ -1660,10 +1663,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)))(typescript@5.9.3)
       '@tanstack/react-query':
         specifier: ^5.84.2
         version: 5.96.2(react@18.3.1)
@@ -1735,7 +1738,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
@@ -17767,6 +17770,14 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       '@swc/core': 1.15.21
       vite: 5.4.21(@types/node@24.12.2)(lightningcss@1.32.0)(terser@5.46.1)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
+  '@vitejs/plugin-react-swc@4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      '@swc/core': 1.15.21
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 

--- a/templates/analytics/app/components/ui/alert-dialog.tsx
+++ b/templates/analytics/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/analytics/app/components/ui/dialog.tsx
+++ b/templates/analytics/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/calendar/app/components/ui/alert-dialog.tsx
+++ b/templates/calendar/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/calendar/app/components/ui/dialog.tsx
+++ b/templates/calendar/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/calorie-tracker/app/components/ui/alert-dialog.tsx
+++ b/templates/calorie-tracker/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/calorie-tracker/app/components/ui/dialog.tsx
+++ b/templates/calorie-tracker/app/components/ui/dialog.tsx
@@ -37,11 +37,9 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         // Mobile: positioned at top with padding, scrollable
-        "fixed left-[50%] top-4 z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 max-h-[calc(100vh-2rem)] overflow-y-auto rounded-lg",
+        "fixed left-[50%] top-4 z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] gap-4 border bg-background p-6 shadow-lg max-h-[calc(100vh-2rem)] overflow-y-auto rounded-lg",
         // Desktop: centered vertically
         "sm:top-[50%] sm:translate-y-[-50%] sm:max-h-[85vh]",
-        // Animations
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}

--- a/templates/calorie-tracker/server/routes/api/exercises/[id].delete.ts
+++ b/templates/calorie-tracker/server/routes/api/exercises/[id].delete.ts
@@ -1,4 +1,4 @@
-import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
+import { defineEventHandler, getRouterParam } from "h3";
 import { db } from "../../../db/index.js";
 import { schema } from "../../../db/index.js";
 import { eq } from "drizzle-orm";
@@ -6,6 +6,5 @@ import { eq } from "drizzle-orm";
 export default defineEventHandler(async (event) => {
   const id = Number(getRouterParam(event, "id"));
   await db().delete(schema.exercises).where(eq(schema.exercises.id, id));
-  setResponseStatus(event, 204);
-  return null;
+  return { success: true };
 });

--- a/templates/calorie-tracker/server/routes/api/meals/[id].delete.ts
+++ b/templates/calorie-tracker/server/routes/api/meals/[id].delete.ts
@@ -1,4 +1,4 @@
-import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
+import { defineEventHandler, getRouterParam } from "h3";
 import { db } from "../../../db/index.js";
 import { schema } from "../../../db/index.js";
 import { eq } from "drizzle-orm";
@@ -6,6 +6,5 @@ import { eq } from "drizzle-orm";
 export default defineEventHandler(async (event) => {
   const id = Number(getRouterParam(event, "id"));
   await db().delete(schema.meals).where(eq(schema.meals.id, id));
-  setResponseStatus(event, 204);
-  return null;
+  return { success: true };
 });

--- a/templates/calorie-tracker/server/routes/api/weights/[id].delete.ts
+++ b/templates/calorie-tracker/server/routes/api/weights/[id].delete.ts
@@ -1,4 +1,4 @@
-import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
+import { defineEventHandler, getRouterParam } from "h3";
 import { db } from "../../../db/index.js";
 import { schema } from "../../../db/index.js";
 import { eq } from "drizzle-orm";
@@ -6,6 +6,5 @@ import { eq } from "drizzle-orm";
 export default defineEventHandler(async (event) => {
   const id = Number(getRouterParam(event, "id"));
   await db().delete(schema.weights).where(eq(schema.weights.id, id));
-  setResponseStatus(event, 204);
-  return null;
+  return { success: true };
 });

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -54,7 +54,10 @@ interface DocumentToolbarProps {
 
 export function DocumentToolbar({ documentId }: DocumentToolbarProps) {
   const queryClient = useQueryClient();
-  const [autoSync, setAutoSync] = useLocalStorage("notion-auto-sync", false);
+  const [autoSync, setAutoSync] = useLocalStorage(
+    `notion-auto-sync:${documentId}`,
+    false,
+  );
   const { data: connection } = useNotionConnection();
   const { data: syncStatus } = useDocumentSyncStatus(documentId, { autoSync });
   const linkDocument = useLinkDocumentToNotion(documentId);

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -10,6 +10,7 @@ import {
   IconFileText,
   IconPlus,
   IconHistory,
+  IconRefresh,
 } from "@tabler/icons-react";
 import { VersionHistoryPanel } from "./VersionHistoryPanel";
 import {
@@ -33,6 +34,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { useLocalStorage } from "@/hooks/use-local-storage";
 
 function NotionIcon({ className }: { className?: string }) {
   return (
@@ -52,8 +54,9 @@ interface DocumentToolbarProps {
 
 export function DocumentToolbar({ documentId }: DocumentToolbarProps) {
   const queryClient = useQueryClient();
+  const [autoSync, setAutoSync] = useLocalStorage("notion-auto-sync", false);
   const { data: connection } = useNotionConnection();
-  const { data: syncStatus } = useDocumentSyncStatus(documentId);
+  const { data: syncStatus } = useDocumentSyncStatus(documentId, { autoSync });
   const linkDocument = useLinkDocumentToNotion(documentId);
   const unlinkDocument = useUnlinkDocumentFromNotion(documentId);
   const pullDocument = usePullDocumentFromNotion(documentId);
@@ -250,6 +253,11 @@ export function DocumentToolbar({ documentId }: DocumentToolbarProps) {
                   className="absolute -right-1 -top-1 text-amber-500"
                 />
               </div>
+            ) : isLinked && autoSync ? (
+              <div className="relative">
+                <NotionIcon className="h-4 w-4" />
+                <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-emerald-500" />
+              </div>
             ) : (
               <NotionIcon className="h-4 w-4" />
             )}
@@ -286,6 +294,12 @@ export function DocumentToolbar({ documentId }: DocumentToolbarProps) {
                   <span className="text-xs font-medium truncate">
                     Linked to Notion
                   </span>
+                  {autoSync && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-300">
+                      <IconRefresh size={9} />
+                      Auto
+                    </span>
+                  )}
                 </div>
                 {syncStatus?.lastSyncedAt && (
                   <p className="mt-1 text-[10px] text-muted-foreground">
@@ -354,6 +368,39 @@ export function DocumentToolbar({ documentId }: DocumentToolbarProps) {
               )}
 
               <div className="p-1.5">
+                <button
+                  onClick={() => setAutoSync(!autoSync)}
+                  className="w-full flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-accent rounded-md"
+                >
+                  <IconRefresh
+                    size={12}
+                    className={
+                      autoSync ? "text-emerald-500" : "text-muted-foreground"
+                    }
+                  />
+                  <span
+                    className={
+                      autoSync
+                        ? "text-foreground font-medium"
+                        : "text-muted-foreground"
+                    }
+                  >
+                    Auto-sync
+                  </span>
+                  <span
+                    className={cn(
+                      "ml-auto h-4 w-7 rounded-full relative",
+                      autoSync ? "bg-emerald-500" : "bg-muted-foreground/30",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "absolute top-0.5 h-3 w-3 rounded-full bg-white",
+                        autoSync ? "right-0.5" : "left-0.5",
+                      )}
+                    />
+                  </span>
+                </button>
                 <button
                   onClick={handlePull}
                   disabled={isWorking}

--- a/templates/content/app/components/ui/dialog.tsx
+++ b/templates/content/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/content/app/hooks/use-notion.ts
+++ b/templates/content/app/hooks/use-notion.ts
@@ -46,6 +46,8 @@ export function useDocumentSyncStatus(
         `/api/documents/${documentId}/notion/refresh`,
         {
           method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ autoSync: !!options?.autoSync }),
         },
       ),
     enabled: !!documentId,

--- a/templates/content/app/hooks/use-notion.ts
+++ b/templates/content/app/hooks/use-notion.ts
@@ -35,7 +35,10 @@ export function useNotionConnection() {
   });
 }
 
-export function useDocumentSyncStatus(documentId: string | null) {
+export function useDocumentSyncStatus(
+  documentId: string | null,
+  options?: { autoSync?: boolean },
+) {
   return useQuery({
     queryKey: ["document-sync", documentId],
     queryFn: () =>
@@ -46,7 +49,7 @@ export function useDocumentSyncStatus(documentId: string | null) {
         },
       ),
     enabled: !!documentId,
-    refetchInterval: 15_000,
+    refetchInterval: options?.autoSync ? 10_000 : 30_000,
   });
 }
 

--- a/templates/content/server/lib/notion-sync.ts
+++ b/templates/content/server/lib/notion-sync.ts
@@ -370,19 +370,38 @@ export async function pushDocumentToNotion(
   });
 }
 
+const lastRefreshAt = new Map<string, number>();
+const REFRESH_THROTTLE_MS = 10_000;
+
 export async function refreshDocumentSyncStatus(
   owner: string,
   documentId: string,
 ): Promise<DocumentSyncStatus> {
+  // Throttle Notion API calls per document (prevents excessive requests from
+  // multiple tabs or rapid polling).
+  const now = Date.now();
+  const lastCall = lastRefreshAt.get(documentId) ?? 0;
+  if (now - lastCall < REFRESH_THROTTLE_MS) {
+    const document = await getDocument(documentId);
+    const link = await getSyncLink(documentId);
+    const connection = await getNotionConnectionForOwner(owner);
+    return buildStatus({
+      connected: Boolean(connection),
+      documentId,
+      link,
+      documentUpdatedAt: document.updatedAt,
+    });
+  }
+  lastRefreshAt.set(documentId, now);
+
   const status = await getDocumentSyncStatus(owner, documentId);
-  if (
-    status.connected &&
-    status.pageId &&
-    status.remoteChanged &&
-    !status.localChanged &&
-    !status.hasConflict
-  ) {
-    return pullDocumentFromNotion(owner, documentId, true);
+  if (status.connected && status.pageId && !status.hasConflict) {
+    if (status.remoteChanged && !status.localChanged) {
+      return pullDocumentFromNotion(owner, documentId, true);
+    }
+    if (status.localChanged && !status.remoteChanged) {
+      return pushDocumentToNotion(owner, documentId, true);
+    }
   }
   return status;
 }

--- a/templates/content/server/lib/notion-sync.ts
+++ b/templates/content/server/lib/notion-sync.ts
@@ -376,9 +376,10 @@ const REFRESH_THROTTLE_MS = 10_000;
 export async function refreshDocumentSyncStatus(
   owner: string,
   documentId: string,
+  options?: { autoSync?: boolean },
 ): Promise<DocumentSyncStatus> {
   // Throttle Notion API calls per document (prevents excessive requests from
-  // multiple tabs or rapid polling).
+  // multiple tabs or rapid polling). Best-effort in serverless environments.
   const now = Date.now();
   const lastCall = lastRefreshAt.get(documentId) ?? 0;
   if (now - lastCall < REFRESH_THROTTLE_MS) {
@@ -399,7 +400,8 @@ export async function refreshDocumentSyncStatus(
     if (status.remoteChanged && !status.localChanged) {
       return pullDocumentFromNotion(owner, documentId, true);
     }
-    if (status.localChanged && !status.remoteChanged) {
+    // Only auto-push when the user has explicitly enabled auto-sync
+    if (options?.autoSync && status.localChanged && !status.remoteChanged) {
       return pushDocumentToNotion(owner, documentId, true);
     }
   }

--- a/templates/content/server/lib/notion.ts
+++ b/templates/content/server/lib/notion.ts
@@ -271,25 +271,33 @@ export async function notionFetch<T>(
   accessToken: string,
   init?: RequestInit,
 ): Promise<T> {
-  const response = await fetch(`${NOTION_API_BASE}${path}`, {
-    ...init,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      "Notion-Version": NOTION_API_VERSION,
-      "Content-Type": "application/json",
-      ...(init?.headers || {}),
-    },
-  });
-  const body = await response.json().catch(() => null);
-  if (!response.ok) {
-    throw new NotionApiError(
-      body?.message || `Notion request failed (${response.status})`,
-      response.status,
-      body?.code || null,
-      body,
-    );
+  const MAX_RETRIES = 2;
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetch(`${NOTION_API_BASE}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Notion-Version": NOTION_API_VERSION,
+        "Content-Type": "application/json",
+        ...(init?.headers || {}),
+      },
+    });
+    if (response.status === 429 && attempt < MAX_RETRIES) {
+      const retryAfter = Number(response.headers.get("retry-after")) || 1;
+      await new Promise((r) => setTimeout(r, Math.max(retryAfter, 1) * 1000));
+      continue;
+    }
+    const body = await response.json().catch(() => null);
+    if (!response.ok) {
+      throw new NotionApiError(
+        body?.message || `Notion request failed (${response.status})`,
+        response.status,
+        body?.code || null,
+        body,
+      );
+    }
+    return body as T;
   }
-  return body as T;
 }
 
 export async function fetchNotionPage(

--- a/templates/content/server/routes/api/documents/[id]/notion/refresh.post.ts
+++ b/templates/content/server/routes/api/documents/[id]/notion/refresh.post.ts
@@ -1,8 +1,11 @@
-import { defineEventHandler } from "h3";
+import { defineEventHandler, readBody } from "h3";
 import { getDocumentOwnerEmail } from "../../../../../lib/notion.js";
 import { refreshDocumentSyncStatus } from "../../../../../lib/notion-sync.js";
 
 export default defineEventHandler(async (event) => {
   const owner = await getDocumentOwnerEmail(event);
-  return refreshDocumentSyncStatus(owner, event.context.params!.id);
+  const body = await readBody(event).catch(() => ({}));
+  return refreshDocumentSyncStatus(owner, event.context.params!.id, {
+    autoSync: !!body?.autoSync,
+  });
 });

--- a/templates/forms/app/components/ui/alert-dialog.tsx
+++ b/templates/forms/app/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/forms/app/components/ui/dialog.tsx
+++ b/templates/forms/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/issues/app/components/ui/alert-dialog.tsx
+++ b/templates/issues/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/issues/app/components/ui/dialog.tsx
+++ b/templates/issues/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -410,22 +410,40 @@ export function EmailList({
     for (const id of ids) {
       const thread = threads.find((t) => t.latestMessage.id === id);
       if (!thread) continue;
-      markRead.mutate({ id, isRead: !thread.latestMessage.isRead });
+      markRead.mutate({
+        id,
+        isRead: !thread.latestMessage.isRead,
+        accountEmail: thread.latestMessage.accountEmail,
+      });
     }
     setSelectedIds(new Set());
   }, [threads, markRead, getActionIds, setSelectedIds]);
 
   const markFocusedRead = useCallback(() => {
     const ids = getActionIds();
-    for (const id of ids) markRead.mutate({ id, isRead: true });
+    for (const id of ids) {
+      const thread = threads.find((t) => t.latestMessage.id === id);
+      markRead.mutate({
+        id,
+        isRead: true,
+        accountEmail: thread?.latestMessage.accountEmail,
+      });
+    }
     setSelectedIds(new Set());
-  }, [markRead, getActionIds, setSelectedIds]);
+  }, [threads, markRead, getActionIds, setSelectedIds]);
 
   const markFocusedUnread = useCallback(() => {
     const ids = getActionIds();
-    for (const id of ids) markRead.mutate({ id, isRead: false });
+    for (const id of ids) {
+      const thread = threads.find((t) => t.latestMessage.id === id);
+      markRead.mutate({
+        id,
+        isRead: false,
+        accountEmail: thread?.latestMessage.accountEmail,
+      });
+    }
     setSelectedIds(new Set());
-  }, [markRead, getActionIds, setSelectedIds]);
+  }, [threads, markRead, getActionIds, setSelectedIds]);
 
   const starFocused = useCallback(() => {
     const ids = getActionIds();

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -651,7 +651,11 @@ export function EmailThread({
         key: "u",
         handler: () => {
           if (!email) return;
-          markRead.mutate({ id: email.id, isRead: !email.isRead });
+          markRead.mutate({
+            id: email.id,
+            isRead: !email.isRead,
+            accountEmail: email.accountEmail,
+          });
         },
       },
       {
@@ -659,7 +663,11 @@ export function EmailThread({
         shift: true,
         handler: () => {
           if (!email) return;
-          markRead.mutate({ id: email.id, isRead: true });
+          markRead.mutate({
+            id: email.id,
+            isRead: true,
+            accountEmail: email.accountEmail,
+          });
         },
       },
       {
@@ -667,7 +675,11 @@ export function EmailThread({
         shift: true,
         handler: () => {
           if (!email) return;
-          markRead.mutate({ id: email.id, isRead: false });
+          markRead.mutate({
+            id: email.id,
+            isRead: false,
+            accountEmail: email.accountEmail,
+          });
         },
       },
     ],
@@ -699,7 +711,12 @@ export function EmailThread({
           handleForward();
           break;
         case "markUnread":
-          if (email) markRead.mutate({ id: email.id, isRead: false });
+          if (email)
+            markRead.mutate({
+              id: email.id,
+              isRead: false,
+              accountEmail: email.accountEmail,
+            });
           break;
         case "prev":
           goToSibling(-1);

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -191,12 +191,21 @@ export function AppLayout({ children }: AppLayoutProps) {
       (e) => !e.labelIds.some((lid) => pinnedShorts.includes(lid)),
     ).length;
     // Count threads per pinned label: latest message must have that label
+    // For "important", exclude threads that belong to any other pinned tab
     for (let i = 0; i < pinnedLabels.length; i++) {
       const short = pinnedShorts[i];
       const full = pinnedLabels[i];
-      counts[full] = latestMessages.filter((e) =>
-        e.labelIds.some((lid) => lid === short || lid === full),
-      ).length;
+      const hasLabel = (e: (typeof filtered)[0]) =>
+        e.labelIds.some((lid) => lid === short || lid === full);
+      if (full === "important") {
+        const otherShorts = pinnedShorts.filter((_, j) => j !== i);
+        counts[full] = latestMessages.filter(
+          (e) =>
+            hasLabel(e) && !e.labelIds.some((lid) => otherShorts.includes(lid)),
+        ).length;
+      } else {
+        counts[full] = latestMessages.filter((e) => hasLabel(e)).length;
+      }
     }
     return counts;
   }, [inboxEmails, pinnedLabels, activeAccounts]);

--- a/templates/mail/app/components/ui/alert-dialog.tsx
+++ b/templates/mail/app/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/mail/app/components/ui/dialog.tsx
+++ b/templates/mail/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -292,10 +292,18 @@ export function useThreadMessages(threadId: string | undefined) {
 export function useMarkRead() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ id, isRead }: { id: string; isRead: boolean }) =>
+    mutationFn: ({
+      id,
+      isRead,
+      accountEmail,
+    }: {
+      id: string;
+      isRead: boolean;
+      accountEmail?: string;
+    }) =>
       apiFetch(`/api/emails/${id}/read`, {
         method: "PATCH",
-        body: JSON.stringify({ isRead }),
+        body: JSON.stringify({ isRead, accountEmail }),
       }),
     onMutate: async ({ id, isRead }) => {
       await qc.cancelQueries({ queryKey: ["emails"] });
@@ -320,19 +328,22 @@ export function useMarkRead() {
 
 export function useMarkThreadRead() {
   const qc = useQueryClient();
-  // Per-thread pending IDs — using a Map so concurrent mutations for different
-  // threads don't overwrite each other's pending IDs.
-  const pendingByThread = new Map<string, string[]>();
+  // Per-thread pending entries — using a Map so concurrent mutations for different
+  // threads don't overwrite each other's pending entries.
+  const pendingByThread = new Map<
+    string,
+    { id: string; accountEmail?: string }[]
+  >();
   return useMutation({
     mutationFn: async (threadId: string) => {
-      const ids = pendingByThread.get(threadId) ?? [];
+      const entries = pendingByThread.get(threadId) ?? [];
       pendingByThread.delete(threadId);
-      if (ids.length > 0) {
+      if (entries.length > 0) {
         await Promise.all(
-          ids.map((id) =>
+          entries.map(({ id, accountEmail }) =>
             apiFetch(`/api/emails/${id}/read`, {
               method: "PATCH",
-              body: JSON.stringify({ isRead: true }),
+              body: JSON.stringify({ isRead: true, accountEmail }),
             }),
           ),
         );
@@ -343,13 +354,14 @@ export function useMarkThreadRead() {
       const previous = qc.getQueriesData<InfiniteEmails>({
         queryKey: ["emails"],
       });
-      // Capture unread IDs BEFORE optimistic update
+      // Capture unread entries BEFORE optimistic update
       const allEmails =
         previous.flatMap(([, data]) => flattenInfiniteEmails(data)) ?? [];
-      const unreadIds = allEmails
+      const unreadEntries = allEmails
         .filter((e) => (e.threadId || e.id) === threadId && !e.isRead)
-        .map((e) => e.id);
-      pendingByThread.set(threadId, unreadIds);
+        .map((e) => ({ id: e.id, accountEmail: e.accountEmail }));
+      pendingByThread.set(threadId, unreadEntries);
+      const unreadIds = unreadEntries.map((e) => e.id);
       // Set overrides so refetches don't revert read state
       for (const id of unreadIds) {
         setOptimisticOverride(id, { isRead: true });

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -95,7 +95,11 @@ function ThreadListSidebar({
               key={email.id}
               onClick={() => {
                 if (!email.isRead)
-                  markRead.mutate({ id: email.id, isRead: true });
+                  markRead.mutate({
+                    id: email.id,
+                    isRead: true,
+                    accountEmail: email.accountEmail,
+                  });
                 navigate(
                   `/${view}/${email.threadId || email.id}${labelSuffix}`,
                 );
@@ -224,9 +228,32 @@ export function InboxPage() {
         }
       }
       // Keep threads whose latest message has the label
+      // For "important", exclude threads that belong to any other pinned tab
+      const otherPinnedShorts =
+        activeLabel === "important"
+          ? pinnedUserLabels
+              .filter((l) => l !== "important")
+              .map((l) =>
+                l.includes("/")
+                  ? l
+                      .slice(l.lastIndexOf("/") + 1)
+                      .replace(/_/g, " ")
+                      .toLowerCase()
+                  : l.toLowerCase(),
+              )
+          : [];
       const qualifiedThreadIds = new Set(
         [...latestByThread.entries()]
-          .filter(([, latest]) => hasLabel(latest))
+          .filter(([, latest]) => {
+            if (!hasLabel(latest)) return false;
+            // If viewing "important", skip threads that match another pinned tab
+            if (
+              otherPinnedShorts.length > 0 &&
+              latest.labelIds.some((lid) => otherPinnedShorts.includes(lid))
+            )
+              return false;
+            return true;
+          })
           .map(([threadId]) => threadId),
       );
       return filtered.filter((e) => qualifiedThreadIds.has(e.threadId || e.id));

--- a/templates/slides/app/components/ui/alert-dialog.tsx
+++ b/templates/slides/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/slides/app/components/ui/dialog.tsx
+++ b/templates/slides/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/starter/app/components/ui/alert-dialog.tsx
+++ b/templates/starter/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/starter/app/components/ui/dialog.tsx
+++ b/templates/starter/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/videos/app/components/ui/alert-dialog.tsx
+++ b/templates/videos/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/videos/app/components/ui/dialog.tsx
+++ b/templates/videos/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- **Integrations Panel rewrite** — full platform setup guides for Slack, Telegram, WhatsApp, OpenClaw, and Claude Code with env var status, setup steps, and webhook URLs
- **Build/Plan mode selector** — new execution mode toggle in TiptapComposer letting users switch between Build (execute immediately) and Plan (think first) modes
- **Agent detail view** — expanded agent panel with A2A endpoint display, copy-to-clipboard, and remove action
- **Dialog animation cleanup** — removed CSS transition animations from alert-dialog and dialog components across all templates for snappier UI
- **Content template** — Notion auto-sync toggle with visual status indicator and improved sync polling
- **Mail template** — pass `accountEmail` through all `markRead` mutations for proper multi-account Gmail support

## Test plan
- [ ] Verify integrations panel renders all platforms with correct env status
- [ ] Test Build/Plan mode toggle in composer
- [ ] Test agent detail view navigation and URL copy
- [ ] Confirm dialogs open/close without animation lag
- [ ] Test Notion auto-sync toggle in content template
- [ ] Verify mail mark-read works across multiple connected accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)