### PR TITLE
fix(core): move @assistant-ui packages from peerDeps to deps

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,6 +77,8 @@
     "minimatch": "^10.0.0",
     "nitro": "3.0.260311-beta",
     "p-limit": "^7.3.0",
+    "@assistant-ui/react": "^0.12.19",
+    "@assistant-ui/react-markdown": "^0.12.6",
     "react-markdown": "^10.1.0",
     "react-router": "^7.13.1",
     "remark-gfm": "^4.0.1",
@@ -84,8 +86,6 @@
     "tiptap-markdown": "^0.8.10"
   },
   "peerDependencies": {
-    "@assistant-ui/react": ">=0.12",
-    "@assistant-ui/react-markdown": ">=0.12",
     "@supabase/supabase-js": ">=2",
     "@tabler/icons-react": ">=3",
     "@tanstack/react-query": ">=5",
@@ -161,8 +161,6 @@
     }
   },
   "devDependencies": {
-    "@assistant-ui/react": "^0.12.19",
-    "@assistant-ui/react-markdown": "^0.12.6",
     "@radix-ui/react-popover": "^1.1.15",
     "@react-router/dev": "^7.13.1",
     "@react-router/fs-routes": "^7.13.1",


### PR DESCRIPTION
## Problem

When a user creates a new project with the `agent-native` CLI and runs `pnpm dev`, the dev server fails immediately with:

```
Error when evaluating SSR module virtual:react-router/server-build:
Cannot find package '@assistant-ui/react' imported from
.../node_modules/@agent-native/core/dist/client/AssistantChat.js
```

## Root Cause

`@assistant-ui/react` and `@assistant-ui/react-markdown` were declared as **peer dependencies** of `@agent-native/core`. With pnpm's strict module isolation, a package can only resolve imports from packages listed in its own `dependencies` — not from peer dependencies that happen to be installed in the consumer project.

During SSR, Node's ESM resolver walks the module graph starting from `@agent-native/core`'s location inside pnpm's isolated `node_modules`. When `AssistantChat.js` imports `@assistant-ui/react`, the resolver looks for it relative to core's own package boundary and fails — even though the consumer project has it installed — because pnpm doesn't hoist it into core's closure.

The consumer's `package.json` does list `@assistant-ui/react` as a direct dependency, but that only places it in the consumer's own module scope, not in core's.

## Fix

Move `@assistant-ui/react` and `@assistant-ui/react-markdown` from `peerDependencies` to `dependencies`. This ensures pnpm places them inside core's own node_modules closure, making them resolvable from `AssistantChat.js` during SSR evaluation regardless of what the consumer project declares.

**Why this is safe:** `@assistant-ui/react` itself declares `react` and `react-dom` as peer dependencies, so it will always use the React instance from the consuming project — there is no risk of duplicate React or context mismatch.

## Changes

- `packages/core/package.json`
  - Added `@assistant-ui/react` and `@assistant-ui/react-markdown` to `dependencies`
  - Removed them from `peerDependencies`
  - Removed them from `devDependencies` (redundant once in `dependencies`)

## Testing

```bash
# Build and pack locally
cd packages/core
pnpm build && pnpm pack

# Scaffold a fresh project
node dist/cli/index.js create /tmp/test-app

# Swap in the local tarball
cd /tmp/test-app
pnpm remove @agent-native/core
pnpm add ~/code/agent-native/packages/core/agent-native-core-0.5.1.tgz

# Verify dev server starts without the @assistant-ui/react error
pnpm dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)