### PR TITLE
fix: add docs SSR server routes for Netlify deployment

### DIFF
--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -5,7 +5,7 @@
  * Cloudflare Workers, etc.) by avoiding H3 helpers that depend on event.node.
  */
 import { createRequestHandler } from "react-router";
-import { defineEventHandler, toWebRequest, getRequestURL } from "h3";
+import { defineEventHandler } from "h3";
 
 const handler = createRequestHandler(
   // @ts-expect-error — virtual module provided by React Router Vite plugin at build time
@@ -16,24 +16,19 @@ const handler = createRequestHandler(
  * Convert an H3 event to a web Request, compatible with both Node and web runtimes.
  */
 function toRequest(event: any): Request {
-  try {
-    return toWebRequest(event);
-  } catch {
-    // Fallback for non-Node runtimes where toWebRequest may fail
-    return new Request(getRequestURL(event).href, {
-      method: event.method,
-      headers: event.headers,
-    });
-  }
+  if (event.req instanceof Request) return event.req;
+  return new Request(event.url.href, {
+    method: event.method,
+    headers: event.headers,
+  });
 }
 
 /**
  * Default SSR catch-all handler. Ignores /.well-known/ probes and renders
  * all other routes through React Router.
  */
-export const ssrHandler = defineEventHandler(async (event) => {
-  const url = getRequestURL(event);
-  if (url.pathname.startsWith("/.well-known/")) {
+export const ssrHandler = defineEventHandler(async (event: any) => {
+  if (event.url.pathname.startsWith("/.well-known/")) {
     return new Response(null, { status: 404 });
   }
 

--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -8,7 +8,8 @@ dist-ssr
 .tanstack
 .wrangler
 .output
-server/
+server/*
+!server/routes/
 .vinxi
 __unconfig*
 todos.json

--- a/packages/docs/server/routes/[...page].get.ts
+++ b/packages/docs/server/routes/[...page].get.ts
@@ -1,0 +1,1 @@
+export { ssrHandler as default } from "@agent-native/core/server";

--- a/packages/docs/server/routes/docs/[...slug].get.ts
+++ b/packages/docs/server/routes/docs/[...slug].get.ts
@@ -1,0 +1,26 @@
+import { createSSRRequestHandler } from "@agent-native/core/server";
+import { defineEventHandler, getRouterParam, setResponseHeader } from "h3";
+import fs from "node:fs";
+import path from "node:path";
+
+const renderSSR = createSSRRequestHandler();
+
+export default defineEventHandler(async (event) => {
+  const slug = getRouterParam(event, "slug");
+  if (!slug || !slug.endsWith(".md")) {
+    return renderSSR(event);
+  }
+
+  const docSlug = slug.replace(/\.md$/, "");
+  const contentDir = path.resolve(import.meta.dirname, "../../../content");
+  const filePath = path.join(contentDir, `${docSlug}.md`);
+
+  if (!filePath.startsWith(contentDir) || !fs.existsSync(filePath)) {
+    return renderSSR(event);
+  }
+
+  const content = fs.readFileSync(filePath, "utf-8");
+  setResponseHeader(event, "Content-Type", "text/markdown; charset=utf-8");
+  setResponseHeader(event, "Access-Control-Allow-Origin", "*");
+  return content;
+});


### PR DESCRIPTION
## Summary
- Adds `server/routes/[...page].get.ts` and `server/routes/docs/[...slug].get.ts` to the docs site so Nitro can discover SSR routes during the Netlify build
- Fixes `ssr-handler.ts` to avoid H3's `getRequestURL`/`toWebRequest` which access `event.node` (undefined in Netlify Functions v2 web-standard runtime)
- Uses `event.url` and `event.req instanceof Request` checks that work in both Node and web runtimes

## Context
After merging PR #161, Netlify deploys 404 with "Cannot find any route matching" because:
1. The docs site had no `server/routes/` directory, so Nitro's route discovery found zero routes
2. The existing `ssr-entry.ts` at root was not used by Nitro (it looks in `serverDir: "./server"`)

## Test plan
- [ ] Netlify branch preview should render all pages (/, /docs/getting-started, /templates, /download)
- [ ] No 404 or 500 errors on any route