### PR TITLE
fix: remove ssr-handler from server barrel to fix CF Pages build

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     },
     "./vite": "./dist/vite/index.js",
     "./server": "./dist/server/index.js",
+    "./server/ssr-handler": "./dist/server/ssr-handler.js",
     "./db": "./dist/db/index.js",
     "./db/schema": "./dist/db/schema.js",
     "./client": "./dist/client/index.js",

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -129,7 +129,10 @@ export {
   type OAuthSessionResult,
 } from "./google-oauth.js";
 
-export { ssrHandler, createSSRRequestHandler } from "./ssr-handler.js";
+// SSR handler is NOT re-exported here — it uses a virtual module
+// (virtual:react-router/server-build) that only exists at Vite dev/build time.
+// Including it in this barrel would break the esbuild CF Pages bundler.
+// Templates import directly: import { ssrHandler } from "@agent-native/core/server/ssr-handler"
 
 // Nitro plugin helper — re-exported so templates don't need nitro as a direct dependency.
 // defineNitroPlugin is an identity function; this typed wrapper lets templates use it

--- a/packages/core/src/templates/default/server/routes/[...page].get.ts
+++ b/packages/core/src/templates/default/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";

--- a/packages/docs/server/routes/[...page].get.ts
+++ b/packages/docs/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";

--- a/packages/docs/server/routes/docs/[...slug].get.ts
+++ b/packages/docs/server/routes/docs/[...slug].get.ts
@@ -1,4 +1,11 @@
-import { createSSRRequestHandler } from "@agent-native/core/server";
+/**
+ * Catch-all route for /docs/* requests.
+ * Serves raw markdown for .md requests, SSR for everything else.
+ *
+ * Example: GET /docs/actions.md → raw markdown for the Actions page
+ *          GET /docs/actions    → SSR rendered page
+ */
+import { createSSRRequestHandler } from "@agent-native/core/server/ssr-handler";
 import { defineEventHandler, getRouterParam, setResponseHeader } from "h3";
 import fs from "node:fs";
 import path from "node:path";

--- a/templates/analytics/server/routes/[...page].get.ts
+++ b/templates/analytics/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";

--- a/templates/calendar/server/routes/[...page].get.ts
+++ b/templates/calendar/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";

--- a/templates/calorie-tracker/server/routes/[...page].get.ts
+++ b/templates/calorie-tracker/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";

--- a/templates/content/server/routes/[...page].get.ts
+++ b/templates/content/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";

--- a/templates/forms/server/routes/[...page].get.ts
+++ b/templates/forms/server/routes/[...page].get.ts
@@ -1,4 +1,4 @@
-import { createSSRRequestHandler } from "@agent-native/core/server";
+import { createSSRRequestHandler } from "@agent-native/core/server/ssr-handler";
 import { defineEventHandler, getRequestURL } from "h3";
 import { renderPublicForm } from "../lib/public-form-ssr.js";
 

--- a/templates/issues/server/routes/[...page].get.ts
+++ b/templates/issues/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";

--- a/templates/mail/server/routes/[...page].get.ts
+++ b/templates/mail/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";

--- a/templates/recruiting/server/routes/[...page].get.ts
+++ b/templates/recruiting/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";

--- a/templates/slides/server/routes/[...page].get.ts
+++ b/templates/slides/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";

--- a/templates/starter/server/routes/[...page].get.ts
+++ b/templates/starter/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";

--- a/templates/videos/server/routes/[...page].get.ts
+++ b/templates/videos/server/routes/[...page].get.ts
@@ -1,1 +1,1 @@
-export { ssrHandler as default } from "@agent-native/core/server";
+export { ssrHandler as default } from "@agent-native/core/server/ssr-handler";


### PR DESCRIPTION
## Summary
- The `ssr-handler` module imports `virtual:react-router/server-build` which only exists at Vite build time
- Including it in the `@agent-native/core/server` barrel export caused esbuild to fail when bundling for Cloudflare Pages, **breaking all production deployments**
- Move to a dedicated export path: `@agent-native/core/server/ssr-handler`
- Update all templates and docs to import from the new path

## Test plan
- [x] `pnpm run prep` passes (fmt, typecheck, tests)
- [x] `NITRO_PRESET=cloudflare_pages pnpm --filter calendar build` succeeds
- [x] Built worker returns 200 via miniflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)