### PR TITLE
fix: accept cloudflare-pages (hyphen) as NITRO_PRESET value

### DIFF
--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -1034,6 +1034,7 @@ console.log(`[deploy] Building for ${preset}...`);
 
 switch (preset) {
   case "cloudflare_pages":
+  case "cloudflare-pages":
     // Cloudflare Workers require a single-file bundle that wrangler can deploy.
     // Nitro's native presets produce split chunks that wrangler can't upload
     // as multi-module Workers. Use the custom esbuild-based bundler.


### PR DESCRIPTION
## Summary
- CF dashboard build commands use `NITRO_PRESET=cloudflare-pages` (hyphen)
- The switch statement only matched `cloudflare_pages` (underscore)
- This caused builds to fall through to the Nitro native path, producing incompatible worker output that crashes at runtime
- **This is the root cause of all production CF apps being broken**

One-line fix: add `case "cloudflare-pages":` to the switch.

## Test plan
- [x] `NITRO_PRESET=cloudflare-pages pnpm --filter calendar build` now uses the correct custom bundler
- [x] Worker returns 200 via miniflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)