### PR TITLE
feat: per-user token usage tracking and Builder.io CTAs for hosted apps

### DIFF
--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -59,6 +59,12 @@ export interface ProductionAgentOptions {
     send: (event: AgentChatEvent) => void,
     threadId: string,
   ) => void;
+  /** Resolve the owner email from the H3 event (for usage tracking) */
+  resolveOwnerEmail?: (event: any) => string | Promise<string>;
+  /** Enable per-user usage limit checking and token tracking */
+  trackUsage?: boolean;
+  /** Usage limit in cents (default: 100 = $1.00) */
+  usageLimitCents?: number;
 }
 
 const MAX_ITERATIONS = 40;
@@ -147,9 +153,17 @@ function enrichMessage(
   return `${parts.join("\n\n")}\n\n${message}`;
 }
 
+/** Accumulated token usage from an agent loop run */
+export interface AgentLoopUsage {
+  inputTokens: number;
+  outputTokens: number;
+  model: string;
+}
+
 /**
  * The core agent loop — calls Claude iteratively until no more tool calls.
  * Decoupled from HTTP transport so it can run in the background.
+ * Returns accumulated token usage for cost tracking.
  */
 export async function runAgentLoop(opts: {
   client: Anthropic;
@@ -160,7 +174,7 @@ export async function runAgentLoop(opts: {
   actions: Record<string, ActionEntry>;
   send: (event: AgentChatEvent) => void;
   signal: AbortSignal;
-}): Promise<void> {
+}): Promise<AgentLoopUsage> {
   const {
     client,
     model,
@@ -171,6 +185,8 @@ export async function runAgentLoop(opts: {
     send,
     signal,
   } = opts;
+
+  const usage: AgentLoopUsage = { inputTokens: 0, outputTokens: 0, model };
 
   let iterations = 0;
   while (true) {
@@ -205,6 +221,11 @@ export async function runAgentLoop(opts: {
 
         const finalMessage = await apiStream.finalMessage();
         assistantContent = finalMessage.content;
+        // Accumulate token usage
+        if (finalMessage.usage) {
+          usage.inputTokens += finalMessage.usage.input_tokens ?? 0;
+          usage.outputTokens += finalMessage.usage.output_tokens ?? 0;
+        }
         break;
       } catch (err: unknown) {
         if (signal.aborted) throw err;
@@ -280,6 +301,7 @@ export async function runAgentLoop(opts: {
   }
 
   send({ type: "done" });
+  return usage;
 }
 
 export function createProductionAgentHandler(
@@ -342,6 +364,38 @@ export function createProductionAgentHandler(
           controller.close();
         },
       });
+    }
+
+    // Check usage limit before starting a run (production hosted mode)
+    if (options.trackUsage && options.resolveOwnerEmail) {
+      try {
+        const ownerEmail = await options.resolveOwnerEmail(event);
+        if (ownerEmail && ownerEmail !== "local@localhost") {
+          const { checkUsageLimit } = await import("../usage/store.js");
+          const result = await checkUsageLimit(
+            ownerEmail,
+            options.usageLimitCents,
+          );
+          if (!result.allowed) {
+            setResponseHeader(event, "Content-Type", "text/event-stream");
+            setResponseHeader(event, "Cache-Control", "no-cache");
+            setResponseHeader(event, "Connection", "keep-alive");
+            const encoder = new TextEncoder();
+            return new ReadableStream({
+              start(controller) {
+                controller.enqueue(
+                  encoder.encode(
+                    `data: ${JSON.stringify({ type: "usage_limit_reached", usageCents: result.usageCents, limitCents: result.limitCents })}\n\n`,
+                  ),
+                );
+                controller.close();
+              },
+            });
+          }
+        }
+      } catch {
+        // Usage check failed — allow the request to proceed
+      }
     }
 
     // Resolve system prompt before starting the run
@@ -558,7 +612,7 @@ export function createProductionAgentHandler(
           }
         }
 
-        return runAgentLoop({
+        const loopUsage = await runAgentLoop({
           client,
           model,
           systemPrompt,
@@ -568,6 +622,28 @@ export function createProductionAgentHandler(
           send,
           signal,
         });
+
+        // Record token usage for cost tracking (production hosted mode)
+        if (options.trackUsage && options.resolveOwnerEmail) {
+          try {
+            const ownerEmail = await options.resolveOwnerEmail(event);
+            if (
+              ownerEmail &&
+              ownerEmail !== "local@localhost" &&
+              (loopUsage.inputTokens > 0 || loopUsage.outputTokens > 0)
+            ) {
+              const { recordUsage } = await import("../usage/store.js");
+              await recordUsage(
+                ownerEmail,
+                loopUsage.inputTokens,
+                loopUsage.outputTokens,
+                loopUsage.model,
+              );
+            }
+          } catch {
+            // Usage recording failed — don't break the run
+          }
+        }
       },
       options.onRunComplete
         ? (run) => options.onRunComplete!(run, threadId)

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -130,6 +130,7 @@ export function startRun(
           (last.event.type !== "done" &&
             last.event.type !== "error" &&
             last.event.type !== "missing_api_key" &&
+            last.event.type !== "usage_limit_reached" &&
             last.event.type !== "loop_limit")
         ) {
           run.events.push(terminal);
@@ -256,6 +257,7 @@ function subscribeInMemory(
             event.event.type === "done" ||
             event.event.type === "error" ||
             event.event.type === "missing_api_key" ||
+            event.event.type === "usage_limit_reached" ||
             event.event.type === "loop_limit"
           ) {
             run.subscribers.delete(subscriberRef!);
@@ -317,6 +319,7 @@ function subscribeFromSQL(
               parsed.type === "done" ||
               parsed.type === "error" ||
               parsed.type === "missing_api_key" ||
+              parsed.type === "usage_limit_reached" ||
               parsed.type === "loop_limit"
             ) {
               controller.close();

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -98,6 +98,7 @@ export type AgentChatEvent =
   | { type: "done" }
   | { type: "error"; error: string }
   | { type: "missing_api_key" }
+  | { type: "usage_limit_reached"; usageCents: number; limitCents: number }
   | { type: "loop_limit" }
   | { type: "clear" };
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -890,7 +890,80 @@ function ApiKeySetupCard({ apiUrl }: { apiUrl: string }) {
   );
 }
 
-// ─── Main Component ─────────────────────────────────────────────────────────
+// ─── Builder.io CTA Card (usage limit / code changes / CLI) ─────────────────
+
+export function BuilderCtaCard({
+  reason,
+  usageCents,
+  limitCents,
+}: {
+  reason: "usage_limit" | "code_changes" | "cli_tab";
+  usageCents?: number;
+  limitCents?: number;
+}) {
+  const appName =
+    typeof window !== "undefined"
+      ? window.location.hostname.split(".")[0]
+      : "app";
+  const cloneCommand = `npx agent-native create ${appName}`;
+
+  const title =
+    reason === "usage_limit"
+      ? "Free usage limit reached"
+      : reason === "code_changes"
+        ? "Code changes require a local setup"
+        : "Get full access";
+
+  const description =
+    reason === "usage_limit"
+      ? `You've used $${((usageCents ?? 0) / 100).toFixed(2)} of your $${((limitCents ?? 100) / 100).toFixed(2)} free tier. Connect to Builder.io for unlimited usage, or clone this app to run it locally with your own API key.`
+      : reason === "code_changes"
+        ? "This app is running in hosted mode. To make code changes, connect to Builder.io or clone and run locally."
+        : "This hosted app has limited AI features. Connect to Builder.io for the full experience, or clone and run locally with your own API key.";
+
+  return (
+    <div className="mx-4 my-6 rounded-lg border border-border bg-card p-5">
+      <div className="flex items-center gap-3 mb-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted">
+          <IconSparkles className="h-4.5 w-4.5 text-muted-foreground" />
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-foreground">{title}</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+        </div>
+      </div>
+
+      <div className="space-y-2.5">
+        <a
+          href="https://www.builder.io/m/agent-native"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex w-full items-center justify-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+        >
+          Connect to Builder.io
+        </a>
+
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full border-t border-border" />
+          </div>
+          <div className="relative flex justify-center text-xs">
+            <span className="bg-card px-2 text-muted-foreground">or</span>
+          </div>
+        </div>
+
+        <div className="rounded-md bg-muted/50 px-3 py-2.5">
+          <p className="text-xs text-muted-foreground mb-1.5">
+            Clone and run locally:
+          </p>
+          <code className="block text-xs text-foreground/80 font-mono break-all select-all">
+            {cloneCommand}
+          </code>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 // ─── Main Component ─────────────────────────────────────────────────────────
 
@@ -1009,6 +1082,10 @@ const AssistantChatInner = forwardRef<
   const messages = thread.messages;
   const [missingApiKey, setMissingApiKey] = useState(false);
   const [authError, setAuthError] = useState(false);
+  const [usageLimitReached, setUsageLimitReached] = useState<{
+    usageCents: number;
+    limitCents: number;
+  } | null>(null);
   const [queuedMessages, setQueuedMessages] = useState<
     Array<{ text: string; images?: string[]; references?: Reference[] }>
   >([]);
@@ -1304,6 +1381,20 @@ const AssistantChatInner = forwardRef<
     return () => window.removeEventListener("agent-chat:auth-error", handler);
   }, []);
 
+  // Listen for usage limit reached events from the adapter
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      setUsageLimitReached({
+        usageCents: detail?.usageCents ?? 0,
+        limitCents: detail?.limitCents ?? 100,
+      });
+    };
+    window.addEventListener("agent-chat:usage-limit-reached", handler);
+    return () =>
+      window.removeEventListener("agent-chat:usage-limit-reached", handler);
+  }, []);
+
   // Listen for loop-limit events from the adapter
   useEffect(() => {
     const handler = (e: Event) => {
@@ -1509,6 +1600,14 @@ const AssistantChatInner = forwardRef<
         ) : missingApiKey ? (
           <div className="flex flex-col items-center justify-center h-full px-2">
             <ApiKeySetupCard apiUrl={apiUrl} />
+          </div>
+        ) : usageLimitReached ? (
+          <div className="flex flex-col items-center justify-center h-full px-2">
+            <BuilderCtaCard
+              reason="usage_limit"
+              usageCents={usageLimitReached.usageCents}
+              limitCents={usageLimitReached.limitCents}
+            />
           </div>
         ) : isRestoring ? (
           <div className="flex flex-col gap-3 p-4">

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -32,6 +32,7 @@ export {
 } from "./frame.js";
 export {
   AssistantChat,
+  BuilderCtaCard,
   clearChatStorage,
   type AssistantChatProps,
   type AssistantChatHandle,

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -28,6 +28,9 @@ export interface SSEEvent {
   preview?: string;
   currentStep?: string;
   summary?: string;
+  // Usage limit fields
+  usageCents?: number;
+  limitCents?: number;
 }
 
 /**
@@ -40,7 +43,13 @@ export function processEvent(
   toolCallCounter: { value: number },
   tabId: string | undefined,
 ): {
-  action: "continue" | "done" | "yield" | "error" | "missing_api_key";
+  action:
+    | "continue"
+    | "done"
+    | "yield"
+    | "error"
+    | "missing_api_key"
+    | "usage_limit_reached";
   result?: ChatModelRunResult;
 } {
   if (ev.type === "clear") {
@@ -175,6 +184,27 @@ export function processEvent(
     };
   }
 
+  if (ev.type === "usage_limit_reached") {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("agent-chat:usage-limit-reached", {
+          detail: {
+            usageCents: ev.usageCents,
+            limitCents: ev.limitCents,
+          },
+        }),
+      );
+    }
+    content.push({ type: "text", text: "" });
+    return {
+      action: "usage_limit_reached",
+      result: {
+        content: [...content],
+        status: { type: "incomplete" as const, reason: "error" as const },
+      } as ChatModelRunResult,
+    };
+  }
+
   if (ev.type === "loop_limit") {
     content.push({
       type: "text",
@@ -283,7 +313,8 @@ export async function* readSSEStream(
         if (
           action === "done" ||
           action === "error" ||
-          action === "missing_api_key"
+          action === "missing_api_key" ||
+          action === "usage_limit_reached"
         ) {
           return;
         }
@@ -344,14 +375,16 @@ export async function readSSEStreamRaw(
           action === "yield" ||
           action === "done" ||
           action === "error" ||
-          action === "missing_api_key"
+          action === "missing_api_key" ||
+          action === "usage_limit_reached"
         ) {
           updated = true;
         }
         if (
           action === "done" ||
           action === "error" ||
-          action === "missing_api_key"
+          action === "missing_api_key" ||
+          action === "usage_limit_reached"
         ) {
           onUpdate([...content]);
           return;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -643,6 +643,21 @@ You are an AI agent in an agent-native application, running in **production mode
 The agent and the UI are equal partners — everything the UI can do, you can do via your tools, and vice versa. They share the same SQL database and stay in sync automatically.
 
 **In production mode, you operate through registered actions exposed as tools.** These are your capabilities — use them to read data, take actions, and help the user. You cannot edit source code or access the filesystem directly. Your tools are the app's API.
+
+### Code Changes Not Available
+
+When the user asks you to change the UI, modify code, add features, fix bugs in the app itself, change styles, or do anything that requires editing source files — you MUST respond with this exact message (replacing APP_NAME with the current app name from the URL hostname):
+
+> This app is running in hosted mode and I can't make code changes here. To customize this app:
+>
+> **Option 1:** Connect to [Builder.io](https://www.builder.io/m/agent-native) for a full development environment
+>
+> **Option 2:** Clone and run locally:
+> \`\`\`
+> npx agent-native create APP_NAME
+> \`\`\`
+
+Do NOT attempt to work around this limitation. Do NOT say "I can't do that" without providing the options above. Always include both the Builder.io link and the CLI command.
 ${FRAMEWORK_CORE}`;
 
 const DEV_FRAMEWORK_PROMPT = `## Agent-Native Framework — Development Mode
@@ -1027,7 +1042,9 @@ export function createAgentChatPlugin(
           : basePrompt + resources;
 
         const a2aClient = new Anthropic({ apiKey });
-        const model = options?.model ?? "claude-sonnet-4-6";
+        const model =
+          options?.model ??
+          (canToggle ? "claude-sonnet-4-6" : "claude-haiku-4-5-20251001");
 
         // Build tools — same as interactive handler but WITHOUT call-agent
         // to prevent infinite recursive A2A loops (agent calling itself).
@@ -1213,7 +1230,10 @@ export function createAgentChatPlugin(
     let _currentRunOwner = "local@localhost";
     let _currentRunThreadId = "";
     let _currentRunSystemPrompt = basePrompt;
-    const resolvedModel = options?.model ?? "claude-sonnet-4-6";
+    // Default to Haiku in production mode to manage costs for hosted apps
+    const resolvedModel =
+      options?.model ??
+      (canToggle ? "claude-sonnet-4-6" : "claude-haiku-4-5-20251001");
 
     const teamTools = createTeamTools({
       getOwner: () => _currentRunOwner,
@@ -1251,6 +1271,8 @@ export function createAgentChatPlugin(
     };
 
     // Always build the production handler (includes resource tools + call-agent + team tools)
+    // In production mode (!canToggle), enable usage tracking and limits
+    const isHostedProd = !canToggle;
     const prodHandler = createProductionAgentHandler({
       actions: prodActions,
       systemPrompt: async (event: any) => {
@@ -1260,7 +1282,9 @@ export function createAgentChatPlugin(
         _currentRunSystemPrompt = basePrompt + resources;
         return _currentRunSystemPrompt;
       },
-      model: options?.model,
+      model:
+        options?.model ??
+        (isHostedProd ? "claude-haiku-4-5-20251001" : undefined),
       apiKey: options?.apiKey,
       onRunStart: (
         send: (event: import("../agent/types.js").AgentChatEvent) => void,
@@ -1273,6 +1297,9 @@ export function createAgentChatPlugin(
         if (threadId) _runSendByThread.delete(threadId);
         await onRunComplete(run, threadId);
       },
+      // Usage tracking for hosted production deployments
+      trackUsage: isHostedProd,
+      resolveOwnerEmail: isHostedProd ? getOwnerFromEvent : undefined,
     });
 
     // Build the dev handler (with filesystem/shell/db tools) if environment allows toggling

--- a/packages/core/src/usage/store.ts
+++ b/packages/core/src/usage/store.ts
@@ -1,0 +1,128 @@
+/**
+ * Token usage tracking and cost limits.
+ * Tracks per-user API token consumption and enforces spending limits
+ * for hosted production deployments.
+ */
+import { getDbExec, intType } from "../db/client.js";
+
+/** Default usage limit per user in cents ($1.00) */
+export const DEFAULT_USAGE_LIMIT_CENTS = 100;
+
+/** Cost per million tokens in cents — Haiku 4.5 pricing */
+const HAIKU_INPUT_COST_PER_MTOK = 80; // $0.80
+const HAIKU_OUTPUT_COST_PER_MTOK = 400; // $4.00
+
+/** Cost per million tokens in cents — Sonnet pricing */
+const SONNET_INPUT_COST_PER_MTOK = 300; // $3.00
+const SONNET_OUTPUT_COST_PER_MTOK = 1500; // $15.00
+
+let _initPromise: Promise<void> | undefined;
+
+async function ensureUsageTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const client = getDbExec();
+      await client.execute(`
+        CREATE TABLE IF NOT EXISTS token_usage (
+          id ${intType()} PRIMARY KEY,
+          owner_email TEXT NOT NULL,
+          input_tokens ${intType()} NOT NULL DEFAULT 0,
+          output_tokens ${intType()} NOT NULL DEFAULT 0,
+          cost_cents_x100 ${intType()} NOT NULL DEFAULT 0,
+          model TEXT NOT NULL DEFAULT '',
+          created_at ${intType()} NOT NULL
+        )
+      `);
+      // For id generation on SQLite we rely on rowid; on Postgres use a sequence.
+      // Using timestamp-based IDs to avoid needing AUTOINCREMENT.
+    })();
+  }
+  return _initPromise;
+}
+
+/**
+ * Calculate cost in cents * 100 (for integer precision) given token counts and model.
+ * Returns cost in "centicents" (1/100th of a cent) so we can store as integer.
+ */
+export function calculateCost(
+  inputTokens: number,
+  outputTokens: number,
+  model: string,
+): number {
+  const isHaiku = model.includes("haiku");
+  const inputCost = isHaiku
+    ? HAIKU_INPUT_COST_PER_MTOK
+    : SONNET_INPUT_COST_PER_MTOK;
+  const outputCost = isHaiku
+    ? HAIKU_OUTPUT_COST_PER_MTOK
+    : SONNET_OUTPUT_COST_PER_MTOK;
+
+  // cost_cents_x100 = (tokens / 1_000_000) * cost_per_mtok * 100
+  const inputCostX100 = Math.round((inputTokens / 1_000_000) * inputCost * 100);
+  const outputCostX100 = Math.round(
+    (outputTokens / 1_000_000) * outputCost * 100,
+  );
+  return inputCostX100 + outputCostX100;
+}
+
+/**
+ * Record token usage for a user after an agent run.
+ */
+export async function recordUsage(
+  ownerEmail: string,
+  inputTokens: number,
+  outputTokens: number,
+  model: string,
+): Promise<void> {
+  await ensureUsageTable();
+  const client = getDbExec();
+  const costX100 = calculateCost(inputTokens, outputTokens, model);
+  const id = Date.now() * 1000 + Math.floor(Math.random() * 1000);
+  await client.execute({
+    sql: `INSERT INTO token_usage (id, owner_email, input_tokens, output_tokens, cost_cents_x100, model, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      id,
+      ownerEmail,
+      inputTokens,
+      outputTokens,
+      costX100,
+      model,
+      Date.now(),
+    ],
+  });
+}
+
+/**
+ * Get total usage cost for a user in cents.
+ */
+export async function getUserUsageCents(ownerEmail: string): Promise<number> {
+  await ensureUsageTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT COALESCE(SUM(cost_cents_x100), 0) as total FROM token_usage WHERE owner_email = ?`,
+    args: [ownerEmail],
+  });
+  const total = Number((rows[0] as any)?.total ?? 0);
+  // Convert from centicents to cents
+  return total / 100;
+}
+
+/**
+ * Check if a user has exceeded their usage limit.
+ * Returns { allowed: true } or { allowed: false, usageCents, limitCents }.
+ */
+export async function checkUsageLimit(
+  ownerEmail: string,
+  limitCents?: number,
+): Promise<
+  | { allowed: true; usageCents: number; limitCents: number }
+  | { allowed: false; usageCents: number; limitCents: number }
+> {
+  const limit = limitCents ?? DEFAULT_USAGE_LIMIT_CENTS;
+  const usageCents = await getUserUsageCents(ownerEmail);
+  return {
+    allowed: usageCents < limit,
+    usageCents,
+    limitCents: limit,
+  };
+}


### PR DESCRIPTION
## Summary

- **Token usage tracking**: New `token_usage` SQL table tracks per-user input/output tokens and cost (stored as integer centicents for precision). Supports both Haiku and Sonnet pricing.
- **$1/user spending limit**: Pre-run check in production mode returns `usage_limit_reached` SSE event when exceeded, with a Builder.io connect / clone-locally CTA card.
- **Default to Haiku in production**: Hosted apps use `claude-haiku-4-5-20251001` instead of Sonnet to manage costs. Dev mode keeps Sonnet.
- **Code changes CTA**: Production system prompt instructs the agent to show Builder.io / CLI options when users ask for code changes (which aren't possible in hosted mode).
- **Exported `BuilderCtaCard`** component for template reuse.

## Test plan

- [ ] Verify production mode defaults to Haiku model
- [ ] Verify dev mode still defaults to Sonnet
- [ ] Test usage tracking records tokens after agent runs
- [ ] Test usage limit check blocks requests when exceeded
- [ ] Verify `usage_limit_reached` SSE event renders the CTA card
- [ ] Verify code change requests in production show the Builder.io CTA
- [ ] Confirm all existing tests pass (`pnpm run prep`)