### PR TITLE
feat: AI resume filter for recruiting + missing wrangler configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ ralph-loop.local.md
 templates/*/wrangler.toml
 wrangler.toml
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 
 # Shell `script` command log artifacts
 db-exec

--- a/packages/docs/app/components/TemplateCard.tsx
+++ b/packages/docs/app/components/TemplateCard.tsx
@@ -66,7 +66,7 @@ export const templates = [
     slug: "video",
     replaces: "Replaces or augments video editing",
     cliCommand: "npx @agent-native/core create my-video-app",
-    demoUrl: "https://video.agent-native.com",
+    demoUrl: "https://videos.agent-native.com",
     description:
       "Build React-based video compositions with Remotion. Keyframe animation, 30+ easing curves, camera controls, and agent-assisted editing.",
     color: "#ec4899",

--- a/packages/docs/app/routes/templates.video.tsx
+++ b/packages/docs/app/routes/templates.video.tsx
@@ -130,7 +130,7 @@ export default function VideoTemplate() {
 
             <div className="mb-8 flex flex-wrap items-center gap-3">
               <a
-                href="https://video.agent-native.com"
+                href="https://videos.agent-native.com"
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={() =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,42 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    '@tabler/icons-react':
-      specifier: ^3.40.0
-      version: 3.41.1
-    '@tailwindcss/vite':
-      specifier: ^4.1.18
-      version: 4.2.2
-    '@vitejs/plugin-react':
-      specifier: ^4.5.2
-      version: 4.7.0
-    h3:
-      specifier: ^1.14.0
-      version: 1.15.11
-    listhen:
-      specifier: ^1.9.1
-      version: 1.9.1
-    react:
-      specifier: ^18.3.1
-      version: 18.3.1
-    react-dom:
-      specifier: ^18.3.1
-      version: 18.3.1
-    tailwindcss:
-      specifier: ^4.1.18
-      version: 4.2.2
-    tsx:
-      specifier: ^4.20.3
-      version: 4.21.0
-    typescript:
-      specifier: ^5.9.2
-      version: 5.9.3
-    vite:
-      specifier: ^8.0.0
-      version: 8.0.3
-
 overrides:
   '@types/react': ^18.3.23
   '@types/react-dom': ^18.3.7
@@ -103,10 +67,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
       '@tabler/icons-react':
         specifier: ^3
         version: 3.41.1(react@18.3.1)
@@ -133,7 +97,7 @@ importers:
         version: 3.22.2
       better-auth:
         specifier: ^1.6.0
-        version: 1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(postgres@3.4.8))(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))
+        version: 1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(postgres@3.4.8))(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -169,7 +133,7 @@ importers:
         version: 10.2.5
       nitro:
         specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
@@ -233,7 +197,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -272,10 +236,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
       ws:
         specifier: ^8.18.0
         version: 8.20.0
@@ -1170,10 +1134,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
       '@swc/core':
         specifier: ^1.13.3
         version: 1.15.21
@@ -1194,7 +1158,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
@@ -1266,7 +1230,7 @@ importers:
         version: 1.1.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vite:
         specifier: ^8.0.0
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
@@ -2147,6 +2111,9 @@ importers:
       '@agent-native/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@anthropic-ai/sdk':
+        specifier: '>=0.81.0'
+        version: 0.82.0(zod@3.25.76)
       '@libsql/client':
         specifier: ^0.15.0
         version: 0.15.15
@@ -2165,6 +2132,9 @@ importers:
       nanoid:
         specifier: ^4.0.2
         version: 4.0.2
+      pdf-parse:
+        specifier: ^2.4.5
+        version: 2.4.5
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -2216,10 +2186,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
       '@swc/core':
         specifier: ^1.13.3
         version: 1.15.21
@@ -2237,7 +2207,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
@@ -2303,7 +2273,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
 
   templates/slides:
     dependencies:
@@ -13608,6 +13578,12 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@anthropic-ai/sdk@0.82.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
+
   '@anthropic-ai/sdk@0.82.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -17684,7 +17660,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
+  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -17714,7 +17690,7 @@ snapshots:
       semver: 7.7.4
       tinyglobby: 0.2.15
       valibot: 1.3.1(typescript@5.9.3)
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@24.12.2)(lightningcss@1.32.0)(terser@5.46.1)
     optionalDependencies:
       typescript: 5.9.3
@@ -17778,7 +17754,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
+  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -17808,7 +17784,7 @@ snapshots:
       semver: 7.7.4
       tinyglobby: 0.2.15
       valibot: 1.3.1(typescript@5.9.3)
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@24.12.2)(lightningcss@1.32.0)(terser@5.46.1)
     optionalDependencies:
       typescript: 5.9.3
@@ -17832,9 +17808,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
+  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
     dependencies:
-      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       minimatch: 10.2.5
     optionalDependencies:
       typescript: 5.9.3
@@ -17846,9 +17822,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
+  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
     dependencies:
-      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       minimatch: 10.2.5
     optionalDependencies:
       typescript: 5.9.3
@@ -19195,19 +19171,11 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react-swc@4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))':
+  '@vitejs/plugin-react-swc@4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       '@swc/core': 1.15.21
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-
-  '@vitejs/plugin-react-swc@4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.0-rc.7
-      '@swc/core': 1.15.21
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -19246,14 +19214,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
-
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))':
     dependencies:
@@ -19645,7 +19605,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.14: {}
 
-  better-auth@1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(postgres@3.4.8))(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)):
+  better-auth@1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(postgres@3.4.8))(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(postgres@3.4.8))
@@ -19671,7 +19631,7 @@ snapshots:
       react: 18.3.1
       react-dom: 19.2.4(react@18.3.1)
       solid-js: 1.9.12
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -23247,7 +23207,7 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro@3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)):
+  nitro@3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.4(srvx@0.11.15)
@@ -23266,9 +23226,9 @@ snapshots:
     optionalDependencies:
       dotenv: 17.4.0
       giget: 3.2.0
-      jiti: 1.21.7
+      jiti: 2.6.1
       rollup: 4.60.1
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -25635,22 +25595,6 @@ snapshots:
       terser: 5.46.1
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.7
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.2
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      lightningcss: 1.32.0
-      terser: 5.46.1
-      tsx: 4.21.0
-
   vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.7
@@ -25685,7 +25629,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0):
+  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -25695,24 +25639,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.2
       esbuild: 0.19.12
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.46.1
-      tsx: 4.21.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
-  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.2
-      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.46.1
@@ -25771,50 +25697,6 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 22.19.17
-      happy-dom: 20.8.9
-      jsdom: 28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3)
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.2)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@24.12.2)(lightningcss@1.32.0)(terser@5.46.1)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.13
-      '@types/node': 24.12.2
       happy-dom: 20.8.9
       jsdom: 28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2132,9 +2132,6 @@ importers:
       nanoid:
         specifier: ^4.0.2
         version: 4.0.2
-      pdf-parse:
-        specifier: ^2.4.5
-        version: 2.4.5
       zod:
         specifier: ^3.25.76
         version: 3.25.76

--- a/templates/recruiting/AGENTS.md
+++ b/templates/recruiting/AGENTS.md
@@ -122,18 +122,19 @@ The current screen state (navigation + Greenhouse API data) is automatically inc
 
 ### Reading & Searching
 
-| Action              | Args                             | Purpose                                |
-| ------------------- | -------------------------------- | -------------------------------------- |
-| `view-screen`       |                                  | See what the user sees (with data)     |
-| `list-jobs`         | `--status <open\|closed\|draft>` | List jobs with optional filter         |
-| `get-job`           | `--id <job-id>`                  | Get job detail + pipeline summary      |
-| `list-candidates`   | `--search <term> --jobId <id>`   | Search/filter candidates               |
-| `get-candidate`     | `--id <candidate-id>`            | Get full candidate details             |
-| `get-pipeline`      | `--jobId <id> [--compact]`       | Pipeline view (candidates by stage)    |
-| `list-interviews`   | `[--compact]`                    | List upcoming interviews               |
-| `dashboard-summary` |                                  | Get dashboard statistics               |
-| `check-scorecards`  | `[--overdueHours] [--section]`   | Check overdue/pending/recent feedback  |
-| `pipeline-health`   | `[--stuckDays]`                  | Find stuck candidates, pipeline issues |
+| Action              | Args                             | Purpose                                      |
+| ------------------- | -------------------------------- | -------------------------------------------- |
+| `view-screen`       |                                  | See what the user sees (with data)           |
+| `list-jobs`         | `--status <open\|closed\|draft>` | List jobs with optional filter               |
+| `get-job`           | `--id <job-id>`                  | Get job detail + pipeline summary            |
+| `list-candidates`   | `--search <term> --jobId <id>`   | Search/filter candidates                     |
+| `get-candidate`     | `--id <candidate-id>`            | Get full candidate details                   |
+| `get-pipeline`      | `--jobId <id> [--compact]`       | Pipeline view (candidates by stage)          |
+| `list-interviews`   | `[--compact]`                    | List upcoming interviews                     |
+| `dashboard-summary` |                                  | Get dashboard statistics                     |
+| `check-scorecards`  | `[--overdueHours] [--section]`   | Check overdue/pending/recent feedback        |
+| `pipeline-health`   | `[--stuckDays]`                  | Find stuck candidates, pipeline issues       |
+| `filter-candidates` | `--prompt <criteria> [--jobId]`  | AI filter: evaluate resumes against criteria |
 
 ### Actions
 
@@ -166,6 +167,7 @@ The current screen state (navigation + Greenhouse API data) is automatically inc
 | "Move candidate to next stage"       | `advance-candidate --applicationId=<id> --fromStageId=<id>`   |
 | "Reject this candidate"              | `reject-candidate --applicationId=<id>`                       |
 | "Add a new candidate"                | `create-candidate --firstName=... --lastName=... --email=...` |
+| "Find candidates with X skills"      | `filter-candidates --prompt="X skills"`                       |
 | "What's falling through the cracks?" | `check-scorecards` + `pipeline-health`                        |
 | "Who hasn't submitted feedback?"     | `check-scorecards --section=overdue`                          |
 | "Send an update to the recruiter"    | `send-recruiter-update`                                       |

--- a/templates/recruiting/actions/filter-candidates.ts
+++ b/templates/recruiting/actions/filter-candidates.ts
@@ -1,0 +1,78 @@
+import { parseArgs, output, localFetch } from "./helpers.js";
+import type { ActionTool } from "@agent-native/core";
+import type { FilterResponse } from "@shared/types";
+
+export const tool: ActionTool = {
+  description:
+    "Filter candidates using AI. Evaluates resumes and profiles against a natural language prompt.",
+  parameters: {
+    type: "object",
+    properties: {
+      prompt: {
+        type: "string",
+        description:
+          'The filter criteria in natural language, e.g. "5+ years Python, strong ML background"',
+      },
+      jobId: {
+        type: "string",
+        description: "Optional job ID to filter candidates for a specific role",
+      },
+      limit: {
+        type: "string",
+        description: "Max candidates to evaluate (default 50, max 100)",
+      },
+    },
+    required: ["prompt"],
+  },
+};
+
+export async function run(args: Record<string, string>): Promise<string> {
+  if (!args.prompt) {
+    return "Error: --prompt is required";
+  }
+
+  const body: Record<string, any> = { prompt: args.prompt };
+  if (args.jobId) body.jobId = Number(args.jobId);
+  if (args.limit) body.limit = Number(args.limit);
+
+  const result = await localFetch<FilterResponse>("/api/candidates/filter", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  const matches = result.results.filter((r) => r.match);
+  const nonMatches = result.results.filter((r) => !r.match);
+
+  const lines: string[] = [
+    `AI Filter: "${result.prompt}"`,
+    `Evaluated: ${result.totalEvaluated} candidates`,
+    `Matches: ${matches.length}`,
+    "",
+  ];
+
+  if (matches.length > 0) {
+    lines.push("## Matches\n");
+    for (const r of matches) {
+      lines.push(
+        `- **${r.name}** (ID: ${r.candidateId}) [${r.confidence}]: ${r.reasoning}`,
+      );
+    }
+  }
+
+  if (nonMatches.length > 0) {
+    lines.push("\n## Non-matches\n");
+    for (const r of nonMatches) {
+      lines.push(
+        `- ${r.name} (ID: ${r.candidateId}) [${r.confidence}]: ${r.reasoning}`,
+      );
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export default async function main(): Promise<void> {
+  const args = parseArgs();
+  const result = await run(args);
+  console.log(result);
+}

--- a/templates/recruiting/actions/registry.ts
+++ b/templates/recruiting/actions/registry.ts
@@ -64,6 +64,10 @@ import {
   run as sendRecruiterUpdateRun,
 } from "./send-recruiter-update.js";
 import { tool as manageOrgTool, run as manageOrgRun } from "./manage-org.js";
+import {
+  tool as filterCandidatesTool,
+  run as filterCandidatesRun,
+} from "./filter-candidates.js";
 
 import type { ActionEntry } from "@agent-native/core";
 
@@ -102,4 +106,8 @@ export const actionRegistry: Record<string, ActionEntry> = {
     run: sendRecruiterUpdateRun,
   },
   "manage-org": { tool: manageOrgTool, run: manageOrgRun },
+  "filter-candidates": {
+    tool: filterCandidatesTool,
+    run: filterCandidatesRun,
+  },
 };

--- a/templates/recruiting/app/hooks/use-greenhouse.ts
+++ b/templates/recruiting/app/hooks/use-greenhouse.ts
@@ -10,6 +10,8 @@ import type {
   PipelineStage,
   AgentNote,
   ActionItemsResponse,
+  FilterResult,
+  FilterResponse,
 } from "@shared/types";
 
 function apiFetch(path: string, init?: RequestInit) {
@@ -327,6 +329,22 @@ export function useCreateNote() {
     onSuccess: (_, vars) => {
       qc.invalidateQueries({ queryKey: ["notes", vars.candidateId] });
     },
+  });
+}
+
+// --- AI Filter ---
+
+export function useFilterCandidates() {
+  return useMutation<
+    FilterResponse,
+    Error,
+    { prompt: string; jobId?: number; limit?: number }
+  >({
+    mutationFn: (data) =>
+      apiFetch("/api/candidates/filter", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
   });
 }
 

--- a/templates/recruiting/app/pages/CandidatesListPage.tsx
+++ b/templates/recruiting/app/pages/CandidatesListPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import { useCandidates } from "@/hooks/use-greenhouse";
+import { useCandidates, useFilterCandidates } from "@/hooks/use-greenhouse";
 import {
   formatRelativeDate,
   getInitials,
@@ -8,11 +8,22 @@ import {
   titleCase,
   cn,
 } from "@/lib/utils";
-import { IconSearch, IconLoader2, IconUsers } from "@tabler/icons-react";
+import {
+  IconSearch,
+  IconLoader2,
+  IconUsers,
+  IconSparkles,
+  IconX,
+  IconCheck,
+  IconMinus,
+} from "@tabler/icons-react";
+import type { FilterResult } from "@shared/types";
 
 export function CandidatesListPage() {
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [filterPrompt, setFilterPrompt] = useState("");
+  const filterMutation = useFilterCandidates();
   const {
     data: candidates = [],
     isLoading,
@@ -22,6 +33,11 @@ export function CandidatesListPage() {
   });
   const navigate = useNavigate();
 
+  const filterResults = filterMutation.data?.results;
+  const filterResultMap = new Map(
+    filterResults?.map((r) => [r.candidateId, r]),
+  );
+
   // Simple debounce
   const handleSearch = (value: string) => {
     setSearch(value);
@@ -30,6 +46,28 @@ export function CandidatesListPage() {
       setDebouncedSearch(value);
     }, 300);
   };
+
+  const handleFilter = () => {
+    const prompt = filterPrompt.trim();
+    if (!prompt) return;
+    filterMutation.mutate({ prompt, limit: 50 });
+  };
+
+  const clearFilter = () => {
+    filterMutation.reset();
+    setFilterPrompt("");
+  };
+
+  // When filter results exist, sort candidates by match status
+  const displayCandidates = filterResults
+    ? [...candidates].sort((a, b) => {
+        const aResult = filterResultMap.get(a.id);
+        const bResult = filterResultMap.get(b.id);
+        if (aResult?.match && !bResult?.match) return -1;
+        if (!aResult?.match && bResult?.match) return 1;
+        return 0;
+      })
+    : candidates;
 
   return (
     <div className="h-full flex flex-col">
@@ -48,6 +86,62 @@ export function CandidatesListPage() {
             className="h-8 w-40 rounded-md border border-border bg-background pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-ring sm:w-64 sm:placeholder:content-['Search_candidates...']"
           />
         </div>
+      </div>
+
+      {/* AI Filter bar */}
+      <div className="border-b border-border px-4 py-3 sm:px-6">
+        <div className="flex items-start gap-2">
+          <div className="relative flex-1">
+            <IconSparkles className="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-violet-500" />
+            <textarea
+              value={filterPrompt}
+              onChange={(e) => setFilterPrompt(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleFilter();
+                }
+              }}
+              placeholder='Filter by AI... e.g. "5+ years Python, strong ML background"'
+              rows={1}
+              className="w-full min-h-[36px] max-h-24 rounded-md border border-border bg-background pl-8 pr-3 py-2 text-xs text-foreground placeholder:text-muted-foreground/50 outline-none focus:border-violet-500 resize-y"
+            />
+          </div>
+          <button
+            onClick={handleFilter}
+            disabled={!filterPrompt.trim() || filterMutation.isPending}
+            className="h-9 px-3 rounded-md bg-violet-600 text-white text-xs font-medium hover:bg-violet-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5 flex-shrink-0"
+          >
+            {filterMutation.isPending ? (
+              <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <IconSparkles className="h-3.5 w-3.5" />
+            )}
+            Filter
+          </button>
+          {filterResults && (
+            <button
+              onClick={clearFilter}
+              className="h-9 px-2 rounded-md border border-border text-xs text-muted-foreground hover:text-foreground hover:bg-accent flex items-center gap-1 flex-shrink-0"
+            >
+              <IconX className="h-3.5 w-3.5" />
+              Clear
+            </button>
+          )}
+        </div>
+        {filterResults && (
+          <div className="mt-2 text-xs text-muted-foreground">
+            <span className="font-medium text-violet-600">
+              {filterResults.filter((r) => r.match).length}
+            </span>{" "}
+            matches out of {filterMutation.data?.totalEvaluated} evaluated
+          </div>
+        )}
+        {filterMutation.isError && (
+          <div className="mt-2 text-xs text-red-500">
+            {filterMutation.error?.message || "Failed to filter candidates"}
+          </div>
+        )}
       </div>
 
       {/* Table */}
@@ -72,7 +166,7 @@ export function CandidatesListPage() {
               Try again
             </button>
           </div>
-        ) : candidates.length === 0 ? (
+        ) : displayCandidates.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
             <IconUsers className="h-8 w-8 mb-2 opacity-40" />
             <p className="text-sm">
@@ -85,7 +179,7 @@ export function CandidatesListPage() {
           <>
             {/* Mobile list */}
             <div className="divide-y divide-border sm:hidden">
-              {candidates.map((candidate) => {
+              {displayCandidates.map((candidate) => {
                 const name = titleCase(
                   `${candidate.first_name} ${candidate.last_name}`,
                 );
@@ -94,6 +188,7 @@ export function CandidatesListPage() {
                 const activeApp = candidate.applications.find(
                   (a) => a.status === "active",
                 );
+                const filterResult = filterResultMap.get(candidate.id);
 
                 return (
                   <div
@@ -101,6 +196,7 @@ export function CandidatesListPage() {
                     onClick={() => navigate(`/candidates/${candidate.id}`)}
                     className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-accent/50"
                   >
+                    {filterResult && <FilterBadge result={filterResult} />}
                     <div
                       className={cn(
                         "flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white",
@@ -118,6 +214,11 @@ export function CandidatesListPage() {
                         {activeApp?.current_stage &&
                           ` · ${activeApp.current_stage.name}`}
                       </div>
+                      {filterResult && (
+                        <div className="text-[11px] text-muted-foreground mt-0.5 line-clamp-2">
+                          {filterResult.reasoning}
+                        </div>
+                      )}
                     </div>
                     <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0">
                       {formatRelativeDate(candidate.last_activity)}
@@ -132,18 +233,35 @@ export function CandidatesListPage() {
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-border text-left">
+                    {filterResults && (
+                      <th
+                        scope="col"
+                        className="px-3 py-2.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider w-16"
+                      >
+                        Match
+                      </th>
+                    )}
                     <th
                       scope="col"
                       className="px-6 py-2.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider"
                     >
                       Name
                     </th>
-                    <th
-                      scope="col"
-                      className="px-4 py-2.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider"
-                    >
-                      Email
-                    </th>
+                    {filterResults ? (
+                      <th
+                        scope="col"
+                        className="px-4 py-2.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider"
+                      >
+                        AI Assessment
+                      </th>
+                    ) : (
+                      <th
+                        scope="col"
+                        className="px-4 py-2.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider"
+                      >
+                        Email
+                      </th>
+                    )}
                     <th
                       scope="col"
                       className="px-4 py-2.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider"
@@ -171,7 +289,7 @@ export function CandidatesListPage() {
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-border">
-                  {candidates.map((candidate) => {
+                  {displayCandidates.map((candidate) => {
                     const name = titleCase(
                       `${candidate.first_name} ${candidate.last_name}`,
                     );
@@ -181,6 +299,7 @@ export function CandidatesListPage() {
                     const activeApp = candidate.applications.find(
                       (a) => a.status === "active",
                     );
+                    const filterResult = filterResultMap.get(candidate.id);
 
                     return (
                       <tr
@@ -193,8 +312,16 @@ export function CandidatesListPage() {
                           }
                         }}
                         tabIndex={0}
-                        className="list-row cursor-pointer hover:bg-accent/50"
+                        className={cn(
+                          "list-row cursor-pointer hover:bg-accent/50",
+                          filterResult && !filterResult.match && "opacity-50",
+                        )}
                       >
+                        {filterResults && (
+                          <td className="px-3 py-3">
+                            <FilterBadge result={filterResult} />
+                          </td>
+                        )}
                         <td className="px-6 py-3">
                           <div className="flex items-center gap-3">
                             <div
@@ -217,9 +344,17 @@ export function CandidatesListPage() {
                             </div>
                           </div>
                         </td>
-                        <td className="px-4 py-3 text-sm text-muted-foreground">
-                          {email || "\u2014"}
-                        </td>
+                        {filterResults ? (
+                          <td className="px-4 py-3 max-w-xs">
+                            <div className="text-xs text-muted-foreground line-clamp-2">
+                              {filterResult?.reasoning || "Not evaluated"}
+                            </div>
+                          </td>
+                        ) : (
+                          <td className="px-4 py-3 text-sm text-muted-foreground">
+                            {email || "\u2014"}
+                          </td>
+                        )}
                         <td className="px-4 py-3 text-sm text-muted-foreground">
                           {candidate.company || "\u2014"}
                         </td>
@@ -263,6 +398,36 @@ export function CandidatesListPage() {
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+function FilterBadge({ result }: { result: FilterResult | undefined }) {
+  if (!result) {
+    return (
+      <div className="flex h-6 w-6 items-center justify-center rounded-full bg-muted">
+        <IconMinus className="h-3 w-3 text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (result.match) {
+    return (
+      <div
+        className="flex h-6 w-6 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30"
+        title={result.reasoning}
+      >
+        <IconCheck className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex h-6 w-6 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30"
+      title={result.reasoning}
+    >
+      <IconX className="h-3.5 w-3.5 text-red-500 dark:text-red-400" />
     </div>
   );
 }

--- a/templates/recruiting/package.json
+++ b/templates/recruiting/package.json
@@ -15,12 +15,14 @@
   },
   "dependencies": {
     "@agent-native/core": "workspace:*",
+    "@anthropic-ai/sdk": "^0.80.0",
     "@libsql/client": "^0.15.0",
     "@tabler/icons-react": "^3.40.0",
     "drizzle-orm": "^0.44.0",
     "h3": "^1.13.0",
     "isbot": "^5",
     "nanoid": "^4.0.2",
+    "pdf-parse": "^2.4.5",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/templates/recruiting/package.json
+++ b/templates/recruiting/package.json
@@ -22,7 +22,6 @@
     "h3": "^1.13.0",
     "isbot": "^5",
     "nanoid": "^4.0.2",
-    "pdf-parse": "^2.4.5",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/templates/recruiting/server/lib/resume-filter.ts
+++ b/templates/recruiting/server/lib/resume-filter.ts
@@ -1,0 +1,229 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { PDFParse } from "pdf-parse";
+import type { GreenhouseCandidate } from "@shared/types";
+import { getApiKey } from "./greenhouse-api.js";
+
+export type FilterResult = {
+  candidateId: number;
+  name: string;
+  match: boolean;
+  reasoning: string;
+  confidence: "high" | "medium" | "low";
+};
+
+export type FilterResponse = {
+  prompt: string;
+  results: FilterResult[];
+  totalEvaluated: number;
+};
+
+/**
+ * Build a text profile for a candidate from their structured data + resume attachment.
+ */
+async function buildCandidateProfile(
+  candidate: GreenhouseCandidate,
+): Promise<string> {
+  const parts: string[] = [];
+
+  const name = [candidate.first_name, candidate.last_name]
+    .filter(Boolean)
+    .join(" ");
+  parts.push(`Name: ${name}`);
+  if (candidate.title) parts.push(`Title: ${candidate.title}`);
+  if (candidate.company) parts.push(`Company: ${candidate.company}`);
+  if (candidate.tags.length > 0)
+    parts.push(`Tags: ${candidate.tags.join(", ")}`);
+
+  // Application info
+  for (const app of candidate.applications) {
+    const jobNames = app.jobs.map((j) => j.name).join(", ");
+    if (jobNames) parts.push(`Applied to: ${jobNames}`);
+    if (app.current_stage) parts.push(`Stage: ${app.current_stage.name}`);
+    if (app.source) parts.push(`Source: ${app.source.public_name}`);
+
+    // Application answers (custom questions)
+    for (const answer of app.answers || []) {
+      if (answer.answer) {
+        parts.push(`Q: ${answer.question}\nA: ${answer.answer}`);
+      }
+    }
+
+    // Try to extract resume text from attachments
+    for (const attachment of app.attachments || []) {
+      if (!attachment.url) continue;
+      const resumeText = await extractAttachmentText(attachment);
+      if (resumeText) {
+        parts.push(`\n--- Resume (${attachment.filename}) ---\n${resumeText}`);
+      }
+    }
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Download and extract text from an attachment (PDF or plain text).
+ */
+async function extractAttachmentText(attachment: {
+  filename: string;
+  url: string;
+  type: string;
+}): Promise<string | null> {
+  try {
+    // Greenhouse attachment URLs require the same API key auth
+    const apiKey = await getApiKey();
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers["Authorization"] =
+        `Basic ${Buffer.from(`${apiKey}:`).toString("base64")}`;
+    }
+
+    const res = await fetch(attachment.url, { headers });
+    if (!res.ok) return null;
+
+    const contentType = res.headers.get("content-type") || "";
+    const filename = attachment.filename.toLowerCase();
+
+    if (filename.endsWith(".pdf") || contentType.includes("pdf")) {
+      const arrayBuffer = await res.arrayBuffer();
+      const pdf = new PDFParse({ data: new Uint8Array(arrayBuffer) });
+      const result = await pdf.getText();
+      return result.text?.trim() || null;
+    }
+
+    if (
+      filename.endsWith(".txt") ||
+      filename.endsWith(".md") ||
+      contentType.includes("text/")
+    ) {
+      return await res.text();
+    }
+
+    // For DOCX and other formats, skip (we could add mammoth later)
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Filter candidates against a natural language prompt using Claude.
+ * Processes candidates in batches for efficiency.
+ */
+export async function filterCandidates(
+  candidates: GreenhouseCandidate[],
+  prompt: string,
+): Promise<FilterResponse> {
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  if (!anthropicKey) {
+    throw new Error(
+      "ANTHROPIC_API_KEY is required for AI-powered resume filtering",
+    );
+  }
+
+  const client = new Anthropic({ apiKey: anthropicKey });
+  const BATCH_SIZE = 10;
+  const results: FilterResult[] = [];
+
+  // Build profiles for all candidates
+  const profiles = await Promise.all(
+    candidates.map(async (c) => ({
+      candidate: c,
+      profile: await buildCandidateProfile(c),
+    })),
+  );
+
+  // Process in batches
+  for (let i = 0; i < profiles.length; i += BATCH_SIZE) {
+    const batch = profiles.slice(i, i + BATCH_SIZE);
+    const batchResults = await evaluateBatch(client, batch, prompt);
+    results.push(...batchResults);
+  }
+
+  // Sort: matches first, then by confidence
+  const confidenceOrder = { high: 0, medium: 1, low: 2 };
+  results.sort((a, b) => {
+    if (a.match !== b.match) return a.match ? -1 : 1;
+    return confidenceOrder[a.confidence] - confidenceOrder[b.confidence];
+  });
+
+  return {
+    prompt,
+    results,
+    totalEvaluated: candidates.length,
+  };
+}
+
+async function evaluateBatch(
+  client: Anthropic,
+  batch: { candidate: GreenhouseCandidate; profile: string }[],
+  prompt: string,
+): Promise<FilterResult[]> {
+  const candidateBlocks = batch
+    .map(
+      ({ candidate, profile }, idx) =>
+        `<candidate id="${candidate.id}" index="${idx}">\n${profile}\n</candidate>`,
+    )
+    .join("\n\n");
+
+  const response = await client.messages.create({
+    model: "claude-sonnet-4-20250514",
+    max_tokens: 4096,
+    system: `You are an expert recruiting assistant that evaluates candidate profiles against hiring criteria. You return structured JSON assessments.
+
+Always respond with a valid JSON array. Each element must have:
+- "candidateId": number (the candidate's ID from the <candidate> tag)
+- "match": boolean (true if the candidate meets the criteria)
+- "reasoning": string (1-2 sentence explanation of why they match or don't)
+- "confidence": "high" | "medium" | "low" (how confident you are in the assessment)
+
+Base your assessment on all available information: resume content, job titles, companies, tags, application answers, etc. If a candidate has limited information, set confidence to "low".`,
+    messages: [
+      {
+        role: "user",
+        content: `Evaluate these candidates against the following criteria:
+
+"${prompt}"
+
+${candidateBlocks}
+
+Return a JSON array with one assessment per candidate.`,
+      },
+    ],
+  });
+
+  const text =
+    response.content[0].type === "text" ? response.content[0].text : "";
+
+  try {
+    // Extract JSON from the response (handle markdown code blocks)
+    const jsonMatch = text.match(/\[[\s\S]*\]/);
+    if (!jsonMatch) return [];
+
+    const parsed = JSON.parse(jsonMatch[0]) as Array<{
+      candidateId: number;
+      match: boolean;
+      reasoning: string;
+      confidence: "high" | "medium" | "low";
+    }>;
+
+    return parsed.map((r) => {
+      const candidate = batch.find((b) => b.candidate.id === r.candidateId);
+      const name = candidate
+        ? [candidate.candidate.first_name, candidate.candidate.last_name]
+            .filter(Boolean)
+            .join(" ")
+        : `Candidate ${r.candidateId}`;
+
+      return {
+        candidateId: r.candidateId,
+        name,
+        match: r.match,
+        reasoning: r.reasoning,
+        confidence: r.confidence,
+      };
+    });
+  } catch {
+    return [];
+  }
+}

--- a/templates/recruiting/server/lib/resume-filter.ts
+++ b/templates/recruiting/server/lib/resume-filter.ts
@@ -1,5 +1,4 @@
 import Anthropic from "@anthropic-ai/sdk";
-import { PDFParse } from "pdf-parse";
 import type { GreenhouseCandidate } from "@shared/types";
 import { getApiKey } from "./greenhouse-api.js";
 
@@ -84,13 +83,8 @@ async function extractAttachmentText(attachment: {
     const contentType = res.headers.get("content-type") || "";
     const filename = attachment.filename.toLowerCase();
 
-    if (filename.endsWith(".pdf") || contentType.includes("pdf")) {
-      const arrayBuffer = await res.arrayBuffer();
-      const pdf = new PDFParse({ data: new Uint8Array(arrayBuffer) });
-      const result = await pdf.getText();
-      return result.text?.trim() || null;
-    }
-
+    // Only extract plain text attachments — PDF/DOCX parsing requires
+    // native APIs (DOMMatrix, etc.) not available on Cloudflare Workers.
     if (
       filename.endsWith(".txt") ||
       filename.endsWith(".md") ||
@@ -99,7 +93,6 @@ async function extractAttachmentText(attachment: {
       return await res.text();
     }
 
-    // For DOCX and other formats, skip (we could add mammoth later)
     return null;
   } catch {
     return null;

--- a/templates/recruiting/server/routes/api/candidates/filter.post.ts
+++ b/templates/recruiting/server/routes/api/candidates/filter.post.ts
@@ -1,0 +1,47 @@
+import { readBody, createError } from "h3";
+import { defineOrgHandler } from "../../../lib/org-context.js";
+import { filterCandidates } from "../../../lib/resume-filter.js";
+import {
+  searchCandidates,
+  listRecentCandidates,
+} from "../../../lib/candidate-search.js";
+import * as gh from "../../../lib/greenhouse-api.js";
+
+export default defineOrgHandler(async (event) => {
+  const body = await readBody(event);
+  const prompt = body?.prompt?.trim();
+
+  if (!prompt) {
+    throw createError({
+      statusCode: 400,
+      message: "prompt is required",
+    });
+  }
+
+  const jobId = body.jobId ? Number(body.jobId) : undefined;
+  const limit = Math.min(Number(body.limit) || 50, 100);
+
+  // Fetch candidates to evaluate — either for a specific job or recent ones
+  let candidates;
+  if (jobId) {
+    candidates = await gh.listCandidates({
+      job_id: jobId,
+      per_page: limit,
+      page: 1,
+    });
+  } else {
+    candidates = await listRecentCandidates({ limit });
+  }
+
+  if (candidates.length === 0) {
+    return { prompt, results: [], totalEvaluated: 0 };
+  }
+
+  // For each candidate, we need full details (with attachments)
+  // The list endpoint may not include attachments, so fetch individually
+  const fullCandidates = await Promise.all(
+    candidates.map((c) => gh.getCandidate(c.id).catch(() => c)),
+  );
+
+  return filterCandidates(fullCandidates, prompt);
+});

--- a/templates/recruiting/shared/types.ts
+++ b/templates/recruiting/shared/types.ts
@@ -195,6 +195,20 @@ export type ActionItemsResponse = {
   };
 };
 
+export type FilterResult = {
+  candidateId: number;
+  name: string;
+  match: boolean;
+  reasoning: string;
+  confidence: "high" | "medium" | "low";
+};
+
+export type FilterResponse = {
+  prompt: string;
+  results: FilterResult[];
+  totalEvaluated: number;
+};
+
 export type GreenhouseView =
   | "dashboard"
   | "jobs"

--- a/wrangler-analytics.toml
+++ b/wrangler-analytics.toml
@@ -3,15 +3,8 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./templates/analytics/dist"
 
-# Smart Placement: run the Worker near the D1 database to reduce latency
 [placement]
 mode = "smart"
 
 [vars]
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
-
-
-[[d1_databases]]
-binding = "DB"
-database_name = "an-analytics"
-database_id = "a323fbbc-aad3-4f77-bc53-9f9b2673e38a"

--- a/wrangler-calendar.toml
+++ b/wrangler-calendar.toml
@@ -3,15 +3,8 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./templates/calendar/dist"
 
-# Smart Placement: run the Worker near the D1 database to reduce latency
 [placement]
 mode = "smart"
 
 [vars]
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
-
-
-[[d1_databases]]
-binding = "DB"
-database_name = "an-calendar"
-database_id = "26d5afaf-e324-40dc-b963-9417e26ee70c"

--- a/wrangler-calorie-tracker.toml
+++ b/wrangler-calorie-tracker.toml
@@ -1,0 +1,17 @@
+name = "an-calorie-tracker"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+pages_build_output_dir = "./templates/calorie-tracker/dist"
+
+# Smart Placement: run the Worker near the D1 database to reduce latency
+[placement]
+mode = "smart"
+
+[vars]
+GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
+
+
+[[d1_databases]]
+binding = "DB"
+database_name = "an-calorie-tracker"
+database_id = "af64b871-0fd7-4e48-bb0e-4dd5535d90a6"

--- a/wrangler-calorie-tracker.toml
+++ b/wrangler-calorie-tracker.toml
@@ -3,15 +3,8 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./templates/calorie-tracker/dist"
 
-# Smart Placement: run the Worker near the D1 database to reduce latency
 [placement]
 mode = "smart"
 
 [vars]
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
-
-
-[[d1_databases]]
-binding = "DB"
-database_name = "an-calorie-tracker"
-database_id = "af64b871-0fd7-4e48-bb0e-4dd5535d90a6"

--- a/wrangler-content.toml
+++ b/wrangler-content.toml
@@ -3,15 +3,8 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./templates/content/dist"
 
-# Smart Placement: run the Worker near the D1 database to reduce latency
 [placement]
 mode = "smart"
 
 [vars]
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
-
-
-[[d1_databases]]
-binding = "DB"
-database_name = "an-content"
-database_id = "e9999bd0-a254-4d46-8f86-dae15228b1e0"

--- a/wrangler-forms.toml
+++ b/wrangler-forms.toml
@@ -3,15 +3,8 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./templates/forms/dist"
 
-# Smart Placement: run the Worker near the D1 database to reduce latency
 [placement]
 mode = "smart"
 
 [vars]
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
-
-
-[[d1_databases]]
-binding = "DB"
-database_name = "an-forms"
-database_id = "ea55ebda-4c45-4f15-88c3-379199504dda"

--- a/wrangler-issues.toml
+++ b/wrangler-issues.toml
@@ -3,15 +3,8 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./templates/issues/dist"
 
-# Smart Placement: run the Worker near the D1 database to reduce latency
 [placement]
 mode = "smart"
 
 [vars]
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
-
-
-[[d1_databases]]
-binding = "DB"
-database_name = "an-issues"
-database_id = "1ee02371-bd52-46ff-a7a3-80a5960e849d"

--- a/wrangler-issues.toml
+++ b/wrangler-issues.toml
@@ -1,0 +1,17 @@
+name = "an-issues"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+pages_build_output_dir = "./templates/issues/dist"
+
+# Smart Placement: run the Worker near the D1 database to reduce latency
+[placement]
+mode = "smart"
+
+[vars]
+GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
+
+
+[[d1_databases]]
+binding = "DB"
+database_name = "an-issues"
+database_id = "1ee02371-bd52-46ff-a7a3-80a5960e849d"

--- a/wrangler-mail.toml
+++ b/wrangler-mail.toml
@@ -3,15 +3,8 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./templates/mail/dist"
 
-# Smart Placement: run the Worker near the D1 database to reduce latency
 [placement]
 mode = "smart"
 
 [vars]
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
-
-
-[[d1_databases]]
-binding = "DB"
-database_name = "an-mail"
-database_id = "5cbb9720-f664-40f7-b38c-a24bfdba4fb8"

--- a/wrangler-recruiting.toml
+++ b/wrangler-recruiting.toml
@@ -3,15 +3,8 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./templates/recruiting/dist"
 
-# Smart Placement: run the Worker near the D1 database to reduce latency
 [placement]
 mode = "smart"
 
 [vars]
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
-
-
-[[d1_databases]]
-binding = "DB"
-database_name = "an-recruiting"
-database_id = "ea331e6c-5095-4ddb-bd67-369a19dcd54a"

--- a/wrangler-recruiting.toml
+++ b/wrangler-recruiting.toml
@@ -1,0 +1,17 @@
+name = "an-recruiting"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+pages_build_output_dir = "./templates/recruiting/dist"
+
+# Smart Placement: run the Worker near the D1 database to reduce latency
+[placement]
+mode = "smart"
+
+[vars]
+GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
+
+
+[[d1_databases]]
+binding = "DB"
+database_name = "an-recruiting"
+database_id = "ea331e6c-5095-4ddb-bd67-369a19dcd54a"

--- a/wrangler-slides.toml
+++ b/wrangler-slides.toml
@@ -3,11 +3,8 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./templates/slides/dist"
 
+[placement]
+mode = "smart"
+
 [vars]
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
-
-
-[[d1_databases]]
-binding = "DB"
-database_name = "an-slides"
-database_id = "dfa8936b-2ecd-460e-a6ac-2088cf12d701"

--- a/wrangler-starter.toml
+++ b/wrangler-starter.toml
@@ -3,15 +3,8 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./templates/starter/dist"
 
-# Smart Placement: run the Worker near the D1 database to reduce latency
 [placement]
 mode = "smart"
 
 [vars]
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
-
-
-[[d1_databases]]
-binding = "DB"
-database_name = "an-starter"
-database_id = "0871e970-55cf-482c-93a3-204725da8710"

--- a/wrangler-videos.toml
+++ b/wrangler-videos.toml
@@ -3,15 +3,8 @@ compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "./templates/videos/dist"
 
-# Smart Placement: run the Worker near the D1 database to reduce latency
 [placement]
 mode = "smart"
 
 [vars]
 GA_MEASUREMENT_ID = "G-ESF7FYXGN9"
-
-
-[[d1_databases]]
-binding = "DB"
-database_name = "an-videos"
-database_id = "a13415ec-0d2e-43da-8fce-5c616646fbce"


### PR DESCRIPTION
## Summary
- Add AI-powered candidate filtering to the recruiting app, inspired by [BuilderIO/greenhouse-filter](https://github.com/BuilderIO/greenhouse-filter). Users type a natural language prompt (e.g. "5+ years Python, strong ML background") and candidates are evaluated against it using Claude, with resume text extracted from PDF attachments.
- Add missing wrangler toml files for recruiting, calorie-tracker, and issues templates.

### What's included
- **Server lib** `resume-filter.ts` — builds candidate profiles from Greenhouse data + PDF resume extraction, evaluates in batches via Claude Sonnet
- **API endpoint** `POST /api/candidates/filter` — accepts prompt, optional jobId/limit
- **UI** — AI filter bar on Candidates page with match badges, reasoning column, and clear button
- **Agent action** `filter-candidates` — registered in action registry for agent parity
- **Types** — `FilterResult` and `FilterResponse` in shared types

## Test plan
- [ ] Verify typecheck passes (`pnpm typecheck` in recruiting template)
- [ ] Test AI filter with a Greenhouse-connected instance
- [ ] Verify filter results show match/no-match badges and reasoning
- [ ] Verify `pnpm action filter-candidates --prompt="..."` works via agent
- [ ] Verify wrangler configs are valid for CF deployment