### PR TITLE
fix: add missing Nitro 3 catch-all route to docs package

### DIFF
--- a/packages/docs/server/routes/_agent-native/[...path].ts
+++ b/packages/docs/server/routes/_agent-native/[...path].ts
@@ -1,0 +1,12 @@
+import { defineEventHandler } from "h3";
+import { handleFrameworkRequest } from "@agent-native/core/server";
+
+/**
+ * Catch-all route for all /_agent-native/* framework endpoints.
+ * Nitro discovers this file automatically. The actual routing and
+ * handler dispatch is done by the framework's request handler,
+ * which loads plugins and registers routes on first request.
+ */
+export default defineEventHandler(async (event) => {
+  return handleFrameworkRequest(event);
+});


### PR DESCRIPTION
## Summary
- The Vite 8 + Nitro 3 migration added `server/routes/_agent-native/[...path].ts` to every template but missed `packages/docs/`
- Adds the same standard framework request handler catch-all that all other packages already have

## Test plan
- [ ] Verify docs package handles `/_agent-native/*` routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)