### PR TITLE
feat: streaming @mentions, TipTap slides editor, inline reply, BYOA auth

### DIFF
--- a/packages/core/src/a2a/server.ts
+++ b/packages/core/src/a2a/server.ts
@@ -120,7 +120,7 @@ export function mountA2A(
       // Store verified caller email on the event context so the handler
       // can set AGENT_USER_EMAIL from a trusted source instead of metadata
       if (verifiedCallerEmail) {
-        (event.context as any).__a2aVerifiedEmail = verifiedCallerEmail;
+        event.context.__a2aVerifiedEmail = verifiedCallerEmail;
       }
 
       const body = await readBody(event);

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -320,7 +320,9 @@ export function createProductionAgentHandler(
     ([name, entry]) => ({
       name,
       description: entry.tool.description,
-      input_schema: entry.tool.parameters as Anthropic.Tool["input_schema"],
+      input_schema: (entry.tool.parameters ?? {
+        type: "object",
+      }) as Anthropic.Tool["input_schema"],
     }),
   );
 
@@ -544,7 +546,12 @@ export function createProductionAgentHandler(
                   for await (const task of client.stream(
                     {
                       role: "user",
-                      parts: [{ type: "text", text: message }],
+                      parts: [
+                        {
+                          type: "text",
+                          text: enrichedMessage + screenContext,
+                        },
+                      ],
                     },
                     Object.keys(a2aMetadata).length > 0
                       ? { metadata: a2aMetadata }
@@ -572,7 +579,10 @@ export function createProductionAgentHandler(
                 } catch {
                   // Streaming failed — fall back to blocking call
                   if (!responseText) {
-                    responseText = await callAgent(ref.path, message);
+                    responseText = await callAgent(
+                      ref.path,
+                      enrichedMessage + screenContext,
+                    );
                   }
                 }
 

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -184,7 +184,7 @@ export function startRun(
 
   // On Cloudflare Workers, keep the isolate alive for this run
   try {
-    const cfCtx = (globalThis as any).__cf_ctx;
+    const cfCtx = globalThis.__cf_ctx;
     if (cfCtx?.waitUntil) {
       cfCtx.waitUntil(runPromise);
     }

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -70,7 +70,9 @@ export async function isRunAborted(runId: string): Promise<boolean> {
     sql: `SELECT status FROM agent_runs WHERE id = ?`,
     args: [runId],
   });
-  return rows.length > 0 && (rows[0] as any).status === "aborted";
+  return (
+    rows.length > 0 && (rows[0] as { status: string }).status === "aborted"
+  );
 }
 
 export async function insertRunEvent(
@@ -96,10 +98,10 @@ export async function getRunEventsSince(
     sql: `SELECT seq, event_data FROM agent_run_events WHERE run_id = ? AND seq >= ? ORDER BY seq ASC`,
     args: [runId, fromSeq],
   });
-  return rows.map((r: any) => ({
-    seq: Number(r.seq),
-    eventData: r.event_data as string,
-  }));
+  return rows.map((r) => {
+    const row = r as { seq: number | string; event_data: string };
+    return { seq: Number(row.seq), eventData: row.event_data };
+  });
 }
 
 export async function getRunById(runId: string): Promise<{
@@ -115,7 +117,12 @@ export async function getRunById(runId: string): Promise<{
     args: [runId],
   });
   if (rows.length === 0) return null;
-  const r = rows[0] as any;
+  const r = rows[0] as {
+    id: string;
+    thread_id: string;
+    status: string;
+    started_at: number | string;
+  };
   return {
     id: r.id,
     threadId: r.thread_id,
@@ -137,7 +144,12 @@ export async function getRunByThread(threadId: string): Promise<{
     args: [threadId],
   });
   if (rows.length === 0) return null;
-  const r = rows[0] as any;
+  const r = rows[0] as {
+    id: string;
+    thread_id: string;
+    status: string;
+    started_at: number | string;
+  };
   return {
     id: r.id,
     threadId: r.thread_id,

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -120,18 +120,19 @@ function useAvailableClis() {
   return clis;
 }
 
-function useCliSelection() {
+function useCliSelection(keyPrefix: string) {
+  const cliKey = `${CLI_STORAGE_KEY}${keyPrefix}`;
   const [selected, setSelected] = useState(CLI_DEFAULT);
   useEffect(() => {
     try {
-      const saved = localStorage.getItem(CLI_STORAGE_KEY);
+      const saved = localStorage.getItem(cliKey);
       if (saved) setSelected(saved);
     } catch {}
-  }, []);
+  }, [cliKey]);
   const select = (cmd: string) => {
     setSelected(cmd);
     try {
-      localStorage.setItem(CLI_STORAGE_KEY, cmd);
+      localStorage.setItem(cliKey, cmd);
     } catch {}
   };
   return [selected, select] as const;
@@ -734,29 +735,36 @@ export function AgentPanel({
   storageKey,
 }: AgentPanelProps) {
   const mounted = useClientOnly();
+  const keyPrefix = storageKey ? `:${storageKey}` : "";
+  const execModeKey = `${EXEC_MODE_KEY}${keyPrefix}`;
+  const panelModeKey = `agent-native-panel-mode${keyPrefix}`;
+
   const [execMode, setExecMode] = useState<ExecMode>(() => {
     try {
-      const saved = localStorage.getItem(EXEC_MODE_KEY);
+      const saved = localStorage.getItem(execModeKey);
       if (saved === "build" || saved === "plan") return saved;
     } catch {}
     return "build";
   });
 
-  const switchExecMode = useCallback((next: ExecMode) => {
-    setExecMode(next);
-    try {
-      localStorage.setItem(EXEC_MODE_KEY, next);
-    } catch {}
-    window.dispatchEvent(
-      new CustomEvent("agent-panel:exec-mode-change", {
-        detail: { mode: next },
-      }),
-    );
-  }, []);
+  const switchExecMode = useCallback(
+    (next: ExecMode) => {
+      setExecMode(next);
+      try {
+        localStorage.setItem(execModeKey, next);
+      } catch {}
+      window.dispatchEvent(
+        new CustomEvent("agent-panel:exec-mode-change", {
+          detail: { mode: next },
+        }),
+      );
+    },
+    [execModeKey],
+  );
 
   const [mode, setMode] = useState<"chat" | "cli" | "resources">(() => {
     try {
-      const saved = localStorage.getItem("agent-native-panel-mode");
+      const saved = localStorage.getItem(panelModeKey);
       if (saved === "chat" || saved === "cli" || saved === "resources")
         return saved;
     } catch {}
@@ -764,9 +772,9 @@ export function AgentPanel({
   });
   useEffect(() => {
     try {
-      localStorage.setItem("agent-native-panel-mode", mode);
+      localStorage.setItem(panelModeKey, mode);
     } catch {}
-  }, [mode]);
+  }, [mode, panelModeKey]);
   const switchMode = useCallback((m: "chat" | "cli" | "resources") => {
     startTransition(() => setMode(m));
   }, []);
@@ -824,7 +832,7 @@ export function AgentPanel({
   }, []);
 
   const availableClis = useAvailableClis();
-  const [selectedCli, selectCli] = useCliSelection();
+  const [selectedCli, selectCli] = useCliSelection(keyPrefix);
   const selectedLabel =
     availableClis.find((c) => c.command === selectedCli)?.label || selectedCli;
   const { isDevMode, canToggle, setDevMode } = useDevMode(apiUrl);

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -138,10 +138,7 @@ function useCliSelection() {
 }
 
 // Detect dev mode at build time (Vite replaces this)
-const IS_DEV: boolean =
-  typeof import.meta !== "undefined" &&
-  typeof (import.meta as any).env !== "undefined" &&
-  (import.meta as any).env.DEV === true;
+const IS_DEV: boolean = import.meta.env?.DEV === true;
 
 interface SettingsSelectOption {
   value: string;

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -715,6 +715,8 @@ export interface AgentPanelProps extends Omit<
   onCollapse?: () => void;
   /** URL of the app being developed (shown as "Open app in new tab" in settings). Set by frame. */
   devAppUrl?: string;
+  /** Namespace for localStorage keys — used to isolate chat state per app in the frame. */
+  storageKey?: string;
 }
 
 function useClientOnly() {
@@ -732,6 +734,7 @@ export function AgentPanel({
   showHeader = true,
   onCollapse,
   devAppUrl,
+  storageKey,
 }: AgentPanelProps) {
   const mounted = useClientOnly();
   const [execMode, setExecMode] = useState<ExecMode>(() => {
@@ -1449,6 +1452,7 @@ export function AgentPanel({
             onSwitchToCli={() => switchMode("cli")}
             execMode={execMode}
             onExecModeChange={switchExecMode}
+            storageKey={storageKey}
           />
         )}
       </div>

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -269,6 +269,8 @@ export type MultiTabAssistantChatProps = Omit<
   renderOverlay?: (props: MultiTabAssistantChatHeaderProps) => React.ReactNode;
   /** Hide the chat content while keeping the header visible. Used when CLI/resources mode is active. */
   contentHidden?: boolean;
+  /** Namespace for localStorage keys — used to isolate chat state per app in the frame. */
+  storageKey?: string;
 };
 
 export function MultiTabAssistantChat({
@@ -277,6 +279,7 @@ export function MultiTabAssistantChat({
   renderOverlay,
   contentHidden = false,
   apiUrl = "/_agent-native/agent-chat",
+  storageKey,
   ...props
 }: MultiTabAssistantChatProps) {
   const {
@@ -290,7 +293,10 @@ export function MultiTabAssistantChat({
     generateTitle,
     searchThreads,
     refreshThreads,
-  } = useChatThreads(apiUrl);
+  } = useChatThreads(apiUrl, storageKey);
+
+  // Namespace all localStorage keys by storageKey when provided (for per-app isolation in frame)
+  const keyPrefix = storageKey ? `:${storageKey}` : "";
 
   // Track which tabs have been focused at least once (lazy mount for sub-agent tabs)
   const mountedTabsRef = useRef<Set<string>>(new Set());
@@ -306,7 +312,7 @@ export function MultiTabAssistantChat({
 
   // Parent-child thread mapping — persisted to localStorage.
   // Maps childThreadId → parentThreadId for sub-agent tabs.
-  const PARENT_MAP_KEY = "agent-chat-parent-map";
+  const PARENT_MAP_KEY = `agent-chat-parent-map${keyPrefix}`;
   const [parentMap, setParentMap] = useState<Record<string, string>>(() => {
     try {
       const saved = localStorage.getItem(PARENT_MAP_KEY);
@@ -320,11 +326,11 @@ export function MultiTabAssistantChat({
     try {
       localStorage.setItem(PARENT_MAP_KEY, JSON.stringify(parentMap));
     } catch {}
-  }, [parentMap]);
+  }, [parentMap, PARENT_MAP_KEY]);
 
   // Sub-agent display names — persisted to localStorage.
   // Maps childThreadId → short name (e.g. "Research", "Draft email").
-  const SUB_AGENT_NAMES_KEY = "agent-chat-sub-agent-names";
+  const SUB_AGENT_NAMES_KEY = `agent-chat-sub-agent-names${keyPrefix}`;
   const [subAgentNames, setSubAgentNames] = useState<Record<string, string>>(
     () => {
       try {
@@ -339,10 +345,10 @@ export function MultiTabAssistantChat({
     try {
       localStorage.setItem(SUB_AGENT_NAMES_KEY, JSON.stringify(subAgentNames));
     } catch {}
-  }, [subAgentNames]);
+  }, [subAgentNames, SUB_AGENT_NAMES_KEY]);
 
   // Open tabs — persisted to localStorage so they survive refresh.
-  const OPEN_TABS_KEY = "agent-chat-open-tabs";
+  const OPEN_TABS_KEY = `agent-chat-open-tabs${keyPrefix}`;
   const [openTabIds, setOpenTabIds] = useState<string[]>(() => {
     try {
       const saved = localStorage.getItem(OPEN_TABS_KEY);
@@ -367,7 +373,7 @@ export function MultiTabAssistantChat({
         localStorage.setItem(OPEN_TABS_KEY, JSON.stringify(mainTabs));
       } catch {}
     }
-  }, [openTabIds, parentMap]);
+  }, [openTabIds, parentMap, OPEN_TABS_KEY]);
 
   // Initialize open tabs once threads load — validate saved tabs still exist
   useEffect(() => {

--- a/packages/core/src/client/PoweredByBadge.tsx
+++ b/packages/core/src/client/PoweredByBadge.tsx
@@ -48,8 +48,8 @@ export function PoweredByBadge({
 }: PoweredByBadgeProps) {
   // Allow hiding via env var
   const hidden =
-    typeof import.meta !== "undefined" &&
-    (import.meta as any).env?.VITE_HIDE_BRANDING === "true";
+    (import.meta.env as Record<string, string | undefined>)
+      ?.VITE_HIDE_BRANDING === "true";
 
   if (hidden) return null;
 

--- a/packages/core/src/client/Turnstile.tsx
+++ b/packages/core/src/client/Turnstile.tsx
@@ -73,9 +73,8 @@ export function Turnstile({
 }: TurnstileProps) {
   const resolvedKey =
     siteKey ||
-    (typeof import.meta !== "undefined"
-      ? (import.meta as any).env?.VITE_TURNSTILE_SITE_KEY
-      : undefined);
+    (import.meta.env as Record<string, string | undefined>)
+      ?.VITE_TURNSTILE_SITE_KEY;
 
   const containerRef = useRef<HTMLDivElement>(null);
   const widgetIdRef = useRef<string | null>(null);

--- a/packages/core/src/client/composer/use-mention-search.ts
+++ b/packages/core/src/client/composer/use-mention-search.ts
@@ -4,6 +4,7 @@ import type { MentionItem } from "./types.js";
 export function useMentionSearch(query: string, enabled: boolean) {
   const [items, setItems] = useState<MentionItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
   const requestIdRef = useRef(0);
 
   useEffect(() => {
@@ -13,34 +14,66 @@ export function useMentionSearch(query: string, enabled: boolean) {
       return;
     }
 
-    setIsLoading(true);
+    // Cancel any in-flight stream
+    abortRef.current?.abort();
+    const abort = new AbortController();
+    abortRef.current = abort;
     const id = ++requestIdRef.current;
 
-    const timer = setTimeout(
-      async () => {
-        try {
-          const res = await fetch(
-            `/_agent-native/agent-chat/mentions?q=${encodeURIComponent(query)}`,
-          );
-          if (!res.ok) throw new Error();
-          const data = await res.json();
-          if (id === requestIdRef.current) {
-            setItems(data.items || []);
-          }
-        } catch {
-          if (id === requestIdRef.current) {
-            setItems([]);
-          }
-        } finally {
-          if (id === requestIdRef.current) {
-            setIsLoading(false);
+    setItems([]);
+    setIsLoading(true);
+
+    const debounceMs = query.length === 0 ? 0 : 150;
+
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/_agent-native/agent-chat/mentions?q=${encodeURIComponent(query)}`,
+          { signal: abort.signal },
+        );
+        if (!res.ok || !res.body) throw new Error();
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buf = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buf += decoder.decode(value, { stream: true });
+          const lines = buf.split("\n");
+          buf = lines.pop()!; // last line may be incomplete
+
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+              const { items: batch } = JSON.parse(line) as {
+                items: MentionItem[];
+              };
+              if (id === requestIdRef.current && batch?.length) {
+                setItems((prev) => {
+                  // Deduplicate by id
+                  const seen = new Set(prev.map((x) => x.id));
+                  const fresh = batch.filter((x) => !seen.has(x.id));
+                  return fresh.length ? [...prev, ...fresh] : prev;
+                });
+              }
+            } catch {}
           }
         }
-      },
-      query.length === 0 ? 0 : 200,
-    );
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name === "AbortError") return;
+        if (id === requestIdRef.current) setItems([]);
+      } finally {
+        if (id === requestIdRef.current) setIsLoading(false);
+      }
+    }, debounceMs);
 
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      abort.abort();
+    };
   }, [query, enabled]);
 
   return { items, isLoading };

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -22,11 +22,17 @@ export interface ChatThreadData {
 
 const ACTIVE_THREAD_KEY = "agent-chat-active-thread";
 
-export function useChatThreads(apiUrl = "/_agent-native/agent-chat") {
+export function useChatThreads(
+  apiUrl = "/_agent-native/agent-chat",
+  storageKey?: string,
+) {
+  const activeThreadKey = storageKey
+    ? `${ACTIVE_THREAD_KEY}:${storageKey}`
+    : ACTIVE_THREAD_KEY;
   const [threads, setThreads] = useState<ChatThreadSummary[]>([]);
   const [activeThreadId, setActiveThreadId] = useState<string | null>(() => {
     try {
-      return localStorage.getItem(ACTIVE_THREAD_KEY);
+      return localStorage.getItem(activeThreadKey);
     } catch {
       return null;
     }
@@ -38,10 +44,10 @@ export function useChatThreads(apiUrl = "/_agent-native/agent-chat") {
   useEffect(() => {
     try {
       if (activeThreadId) {
-        localStorage.setItem(ACTIVE_THREAD_KEY, activeThreadId);
+        localStorage.setItem(activeThreadKey, activeThreadId);
       }
     } catch {}
-  }, [activeThreadId]);
+  }, [activeThreadId, activeThreadKey]);
 
   const fetchThreads = useCallback(async () => {
     try {

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -76,7 +76,7 @@ export function getDialect(): Dialect {
     return _dialect;
   }
 
-  const d1 = (globalThis as any).__cf_env?.DB;
+  const d1 = globalThis.__cf_env?.DB;
   if (d1) {
     _dialect = "d1";
     return _dialect;
@@ -121,7 +121,7 @@ async function initClient(): Promise<void> {
 
   // Cloudflare D1
   if (dialect === "d1") {
-    const d1 = (globalThis as any).__cf_env?.DB;
+    const d1 = globalThis.__cf_env?.DB;
     _exec = {
       async execute(sql) {
         if (typeof sql === "string") {
@@ -151,7 +151,7 @@ async function initClient(): Promise<void> {
   if (dialect === "postgres") {
     const { default: postgres } = await import("postgres");
     const isWorkers =
-      typeof (globalThis as any).__cf_env !== "undefined" ||
+      "__cf_env" in globalThis ||
       (typeof navigator !== "undefined" &&
         navigator.userAgent === "Cloudflare-Workers");
 

--- a/packages/core/src/db/create-get-db.ts
+++ b/packages/core/src/db/create-get-db.ts
@@ -39,7 +39,7 @@ export function createGetDb<T extends Record<string, unknown>>(schema: T) {
 
     // D1 only if dialect detected it (DATABASE_URL takes priority)
     if (dialect === "d1") {
-      const d1 = (globalThis as any).__cf_env?.DB;
+      const d1 = globalThis.__cf_env?.DB;
       if (d1) {
         _db = drizzleD1(d1, { schema }) as unknown as LibSQLDatabase<T>;
         _dbReady = Promise.resolve(_db);

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -27,18 +27,17 @@ export function runMigrations(
   return async () => {
     try {
       // Check for Cloudflare D1 binding (only if DATABASE_URL not set)
-      const d1 =
-        getDialect() === "d1" ? (globalThis as any).__cf_env?.DB : null;
+      const d1 = getDialect() === "d1" ? globalThis.__cf_env?.DB : null;
       if (d1) {
         await d1
           .prepare(
             `CREATE TABLE IF NOT EXISTS _migrations (version INTEGER PRIMARY KEY)`,
           )
           .run();
-        const { results } = await d1
+        const firstRow = await d1
           .prepare(`SELECT MAX(version) as v FROM _migrations`)
-          .first();
-        const current = (results?.v as number) ?? 0;
+          .first<{ v?: number }>();
+        const current = (firstRow?.v as number) ?? 0;
 
         for (const m of migrations.filter((m) => m.version > current)) {
           try {

--- a/packages/core/src/integrations/adapters/slack.ts
+++ b/packages/core/src/integrations/adapters/slack.ts
@@ -52,7 +52,7 @@ export function slackAdapter(): PlatformAdapter {
         }
       } catch {}
       // Store raw body for later use
-      (event as any).__rawBody = body;
+      event.context.__rawBody = body;
       return { handled: false };
     },
 
@@ -68,7 +68,9 @@ export function slackAdapter(): PlatformAdapter {
       const ts = parseInt(timestamp, 10);
       if (Math.abs(Date.now() / 1000 - ts) > 300) return false;
 
-      const body = (event as any).__rawBody ?? (await readRawBody(event));
+      const body =
+        (event.context.__rawBody as string | undefined) ??
+        (await readRawBody(event));
       const crypto = await import("node:crypto");
       const basestring = `v0:${timestamp}:${body}`;
       const expectedSignature =
@@ -92,7 +94,9 @@ export function slackAdapter(): PlatformAdapter {
     async parseIncomingMessage(
       event: H3Event,
     ): Promise<IncomingMessage | null> {
-      const raw = (event as any).__rawBody ?? (await readRawBody(event));
+      const raw =
+        (event.context.__rawBody as string | undefined) ??
+        (await readRawBody(event));
       let payload: any;
       try {
         payload = JSON.parse(raw);
@@ -213,10 +217,10 @@ export function slackAdapter(): PlatformAdapter {
 
 /** Read the raw body as a string (H3 may have already parsed it) */
 async function readRawBody(event: H3Event): Promise<string> {
-  if ((event as any).__rawBody) return (event as any).__rawBody;
+  if (event.context.__rawBody) return event.context.__rawBody as string;
   const body = await readBody(event);
   const raw = typeof body === "string" ? body : JSON.stringify(body);
-  (event as any).__rawBody = raw;
+  event.context.__rawBody = raw;
   return raw;
 }
 

--- a/packages/core/src/integrations/adapters/whatsapp.ts
+++ b/packages/core/src/integrations/adapters/whatsapp.ts
@@ -214,10 +214,10 @@ export function whatsappAdapter(): PlatformAdapter {
 }
 
 async function readRawBody(event: H3Event): Promise<string> {
-  if ((event as any).__rawBody) return (event as any).__rawBody;
+  if (event.context.__rawBody) return event.context.__rawBody as string;
   const body = await readBody(event);
   const raw = typeof body === "string" ? body : JSON.stringify(body);
-  (event as any).__rawBody = raw;
+  event.context.__rawBody = raw;
   return raw;
 }
 

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -231,9 +231,10 @@ export function createIntegrationsPlugin(
       }),
     );
 
-    console.log(
-      `[integrations] Mounted integration routes for: ${adapters.map((a) => a.platform).join(", ")}`,
-    );
+    if (process.env.DEBUG)
+      console.log(
+        `[integrations] Mounted integration routes for: ${adapters.map((a) => a.platform).join(", ")}`,
+      );
   };
 }
 

--- a/packages/core/src/mcp/server.ts
+++ b/packages/core/src/mcp/server.ts
@@ -239,7 +239,8 @@ export function mountMCP(
     }),
   );
 
-  console.log(
-    `[mcp] Mounted MCP server at ${routePrefix}/mcp (${Object.keys(config.actions).length} tools${config.askAgent ? " + ask-agent" : ""})`,
-  );
+  if (process.env.DEBUG)
+    console.log(
+      `[mcp] Mounted MCP server at ${routePrefix}/mcp (${Object.keys(config.actions).length} tools${config.askAgent ? " + ask-agent" : ""})`,
+    );
 }

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -122,9 +122,8 @@ export function mountActionRoutes(
     mounted.push(`${method} ${routePath}`);
   }
 
-  if (mounted.length > 0) {
+  if (mounted.length > 0 && process.env.DEBUG)
     console.log(
       `[action-routes] Mounted ${mounted.length} action route(s): ${mounted.join(", ")}`,
     );
-  }
 }

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1740,111 +1740,146 @@ export function createAgentChatPlugin(
           section?: string;
         }
 
-        const items: MentionItemResponse[] = [];
+        const matchesQuery = (item: MentionItemResponse) =>
+          !q ||
+          item.label.toLowerCase().includes(q) ||
+          (item.description?.toLowerCase().includes(q) ?? false);
 
-        // 1. Built-in: files from codebase (dev mode only)
-        if (currentDevMode) {
-          const codebaseFiles: Array<{
-            path: string;
-            name: string;
-            type: "file" | "folder";
-          }> = [];
-          try {
-            await collectFiles(process.cwd(), "", 0, codebaseFiles);
-          } catch {}
-          for (const f of codebaseFiles) {
-            items.push({
-              id: `codebase:${f.path}`,
-              label: f.name,
-              description: f.path !== f.name ? f.path : undefined,
-              icon: f.type,
-              source: "codebase",
-              refType: "file",
-              refPath: f.path,
-              section: "Files",
-            });
-          }
-        }
+        const enc = new TextEncoder();
 
-        // 2. Built-in: resources from SQL
-        try {
-          const resources = currentDevMode
-            ? await resourceListAccessible("local@localhost")
-            : await resourceList(SHARED_OWNER);
-          for (const r of resources) {
-            const isShared = r.owner === SHARED_OWNER;
-            items.push({
-              id: `resource:${r.path}`,
-              label: r.path.split("/").pop() || r.path,
-              description: r.path,
-              icon: "file",
-              source: isShared ? "resource:shared" : "resource:private",
-              refType: "file",
-              refPath: r.path,
-              section: "Files",
-            });
-          }
-        } catch {}
+        // Stream NDJSON — each source flushes its batch as soon as it's ready.
+        setResponseHeader(event, "Content-Type", "application/x-ndjson");
+        setResponseHeader(event, "Cache-Control", "no-cache");
 
-        // 3. Custom mention providers
-        const providerResults = await Promise.all(
-          Object.entries(mentionProviders).map(async ([key, provider]) => {
-            try {
-              const providerItems = await provider.search(q, event);
-              return providerItems.map((item) => ({
-                id: item.id,
-                label: item.label,
-                description: item.description,
-                icon: item.icon || provider.icon || "file",
-                source: key,
-                refType: item.refType,
-                refPath: item.refPath,
-                refId: item.refId,
-                section: provider.label,
-              }));
-            } catch (e) {
-              console.error(
-                `[agent-native] Mention provider "${key}" failed:`,
-                e,
+        const stream = new ReadableStream({
+          async start(controller) {
+            const flush = (batch: MentionItemResponse[]) => {
+              const filtered = batch.filter(matchesQuery);
+              if (filtered.length > 0) {
+                controller.enqueue(
+                  enc.encode(JSON.stringify({ items: filtered }) + "\n"),
+                );
+              }
+            };
+
+            // All sources run in parallel; each flushes independently.
+            const sources: Promise<void>[] = [];
+
+            // 1. Resources from SQL (fast — flush first)
+            sources.push(
+              (async () => {
+                try {
+                  const resources = currentDevMode
+                    ? await resourceListAccessible("local@localhost")
+                    : await resourceList(SHARED_OWNER);
+                  flush(
+                    resources.map((r) => {
+                      const isShared = r.owner === SHARED_OWNER;
+                      return {
+                        id: `resource:${r.path}`,
+                        label: r.path.split("/").pop() || r.path,
+                        description: r.path,
+                        icon: "file",
+                        source: isShared
+                          ? "resource:shared"
+                          : "resource:private",
+                        refType: "file",
+                        refPath: r.path,
+                        section: "Files",
+                      };
+                    }),
+                  );
+                } catch {}
+              })(),
+            );
+
+            // 2. Codebase files (dev mode only — can be slow on large repos)
+            if (currentDevMode) {
+              sources.push(
+                (async () => {
+                  const codebaseFiles: Array<{
+                    path: string;
+                    name: string;
+                    type: "file" | "folder";
+                  }> = [];
+                  try {
+                    await collectFiles(process.cwd(), "", 0, codebaseFiles);
+                  } catch {}
+                  flush(
+                    codebaseFiles.map((f) => ({
+                      id: `codebase:${f.path}`,
+                      label: f.name,
+                      description: f.path !== f.name ? f.path : undefined,
+                      icon: f.type,
+                      source: "codebase",
+                      refType: "file",
+                      refPath: f.path,
+                      section: "Files",
+                    })),
+                  );
+                })(),
               );
-              return [];
             }
-          }),
-        );
-        for (const batch of providerResults) {
-          items.push(...batch);
-        }
 
-        // 4. Discovered peer agents
-        try {
-          const agents = await discoverAgents(options?.appId);
-          for (const agent of agents) {
-            items.push({
-              id: `agent:${agent.id}`,
-              label: agent.name,
-              description: agent.description,
-              icon: "agent",
-              source: "agent",
-              refType: "agent",
-              refPath: agent.url,
-              refId: agent.id,
-              section: "Agents",
-            });
-          }
-        } catch (e) {
-          console.error("[agent-native] Agent discovery failed:", e);
-        }
+            // 3. Custom mention providers (each flushes independently)
+            for (const [key, provider] of Object.entries(mentionProviders)) {
+              sources.push(
+                (async () => {
+                  try {
+                    const providerItems = await provider.search(q, event);
+                    flush(
+                      providerItems.map((item) => ({
+                        id: item.id,
+                        label: item.label,
+                        description: item.description,
+                        icon: item.icon || provider.icon || "file",
+                        source: key,
+                        refType: item.refType,
+                        refPath: item.refPath,
+                        refId: item.refId,
+                        section: provider.label,
+                      })),
+                    );
+                  } catch (e) {
+                    console.error(
+                      `[agent-native] Mention provider "${key}" failed:`,
+                      e,
+                    );
+                  }
+                })(),
+              );
+            }
 
-        // Filter by query and limit
-        const filtered = q
-          ? items.filter(
-              (item) =>
-                item.label.toLowerCase().includes(q) ||
-                (item.description?.toLowerCase().includes(q) ?? false),
-            )
-          : items;
+            // 4. Peer agent discovery (network call — often slowest)
+            sources.push(
+              (async () => {
+                try {
+                  const agents = await discoverAgents(options?.appId);
+                  flush(
+                    agents.map((agent) => ({
+                      id: `agent:${agent.id}`,
+                      label: agent.name,
+                      description: agent.description,
+                      icon: "agent",
+                      source: "agent",
+                      refType: "agent",
+                      refPath: agent.url,
+                      refId: agent.id,
+                      section: "Agents",
+                    })),
+                  );
+                } catch (e) {
+                  console.error("[agent-native] Agent discovery failed:", e);
+                }
+              })(),
+            );
 
-        return { items: filtered.slice(0, 30) };
+            await Promise.all(sources);
+            controller.close();
+          },
+        });
+
+        return stream;
       }),
     );
 
@@ -1863,10 +1898,12 @@ export function createAgentChatPlugin(
           setResponseStatus(event, 400);
           return { error: "message is required" };
         }
+        // Strip mention markup: @[Name|type] → @Name
+        const cleanMessage = message.replace(/@\[([^\]|]+)\|[^\]]*\]/g, "@$1");
         const apiKey = process.env.ANTHROPIC_API_KEY;
         if (!apiKey) {
           // Fallback: truncate the message
-          return { title: message.trim().slice(0, 60) };
+          return { title: cleanMessage.trim().slice(0, 60) };
         }
         try {
           const res = await fetch("https://api.anthropic.com/v1/messages", {
@@ -1882,21 +1919,21 @@ export function createAgentChatPlugin(
               messages: [
                 {
                   role: "user",
-                  content: `Generate a very short title (3-6 words, no quotes) for a chat that starts with this message:\n\n${message.slice(0, 500)}`,
+                  content: `Generate a very short title (3-6 words, no quotes) for a chat that starts with this message:\n\n${cleanMessage.slice(0, 500)}`,
                 },
               ],
             }),
           });
           if (!res.ok) {
-            return { title: message.trim().slice(0, 60) };
+            return { title: cleanMessage.trim().slice(0, 60) };
           }
           const data = (await res.json()) as {
             content?: Array<{ type: string; text?: string }>;
           };
           const text = data.content?.[0]?.text?.trim();
-          return { title: text || message.trim().slice(0, 60) };
+          return { title: text || cleanMessage.trim().slice(0, 60) };
         } catch {
-          return { title: message.trim().slice(0, 60) };
+          return { title: cleanMessage.trim().slice(0, 60) };
         }
       }),
     );

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -960,11 +960,10 @@ export function createAgentChatPlugin(
             };
           }
         }
-        if (Object.keys(discoveredActions).length > 0) {
+        if (Object.keys(discoveredActions).length > 0 && process.env.DEBUG)
           console.log(
             `[agent-chat] Auto-discovered ${Object.keys(discoveredActions).length} action(s): ${Object.keys(discoveredActions).join(", ")}`,
           );
-        }
       } catch {}
     }
     const allScripts = {
@@ -2193,7 +2192,8 @@ export function createAgentChatPlugin(
               console.error("[recurring-jobs] Scheduler error:", err?.message);
             });
           }, 60_000);
-          console.log("[recurring-jobs] Scheduler started (60s interval)");
+          if (process.env.DEBUG)
+            console.log("[recurring-jobs] Scheduler started (60s interval)");
         }, 10_000);
       } catch (err) {
         // Jobs module not available — skip silently

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1752,12 +1752,26 @@ export function createAgentChatPlugin(
 
         const stream = new ReadableStream({
           async start(controller) {
+            const MAX_RESULTS = 50;
+            let totalSent = 0;
+            let cancelled = false;
+
             const flush = (batch: MentionItemResponse[]) => {
+              if (cancelled) return;
               const filtered = batch.filter(matchesQuery);
-              if (filtered.length > 0) {
-                controller.enqueue(
-                  enc.encode(JSON.stringify({ items: filtered }) + "\n"),
-                );
+              if (filtered.length === 0) return;
+              const remaining = MAX_RESULTS - totalSent;
+              const toSend = filtered.slice(0, remaining);
+              if (toSend.length > 0) {
+                totalSent += toSend.length;
+                try {
+                  controller.enqueue(
+                    enc.encode(JSON.stringify({ items: toSend }) + "\n"),
+                  );
+                } catch {
+                  // Stream was closed by client
+                  cancelled = true;
+                }
               }
             };
 
@@ -1874,7 +1888,10 @@ export function createAgentChatPlugin(
             );
 
             await Promise.all(sources);
-            controller.close();
+            if (!cancelled) controller.close();
+          },
+          cancel() {
+            // Client disconnected — stop enqueuing
           },
         });
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -98,21 +98,26 @@ const DEFAULT_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
  *
  * Returns true when:
  * - AUTH_MODE=local is explicitly set (escape hatch)
- * - In dev environment (NODE_ENV=development) with no explicit auth configured
- *   (no ACCESS_TOKEN, no GOOGLE_CLIENT_ID, no BYOA). This makes dev "just work"
+ * - In dev environment (NODE_ENV=development) with no explicit auth token
+ *   configured (no ACCESS_TOKEN, no BYOA). This makes dev "just work"
  *   without requiring auth setup, while still respecting auth when configured.
+ *
+ * NOTE: GOOGLE_CLIENT_ID is intentionally NOT checked here — it is used for
+ * Google Calendar / Gmail API access as well as Google Sign-In, and its
+ * presence alone should not force authentication. Only ACCESS_TOKEN/ACCESS_TOKENS
+ * (explicit token-based auth) or a custom getSession (BYOA) signal that the
+ * developer has explicitly opted into requiring authentication.
  *
  * BYOA (customGetSession) opts out of dev auto-local — templates that provide
  * their own auth (e.g. Supabase) shouldn't be silently bypassed in dev.
  */
 function isLocalMode(): boolean {
   if (process.env.AUTH_MODE === "local") return true;
-  // Default to local mode in dev when no auth is explicitly configured
+  // Default to local mode in dev when no explicit auth is configured
   if (
     isDevEnvironment() &&
     !process.env.ACCESS_TOKEN &&
     !process.env.ACCESS_TOKENS &&
-    !process.env.GOOGLE_CLIENT_ID &&
     !customGetSession
   ) {
     return true;

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -247,6 +247,19 @@ let customGetSession: ((event: H3Event) => Promise<AuthSession | null>) | null =
 let authDisabledMode = false;
 
 /**
+ * Mutable config for the auth guard. Stored separately from the guard function
+ * so that a custom auth plugin can update the login HTML / public paths even
+ * after the default plugin has already installed the middleware (a race that
+ * occurs in production serverless environments where the default plugin is
+ * auto-mounted before the template's custom auth plugin runs).
+ */
+interface AuthGuardConfig {
+  loginHtml: string;
+  publicPaths: string[];
+}
+let _authGuardConfig: AuthGuardConfig | null = null;
+
+/**
  * Module-level auth guard function. Set by autoMountAuth() when auth is active.
  * Called by the server middleware to enforce auth on ALL requests (not just
  * /_agent-native/* routes).
@@ -279,12 +292,19 @@ const LOCAL_SESSION: AuthSession = { email: "local@localhost" };
  * Create an auth guard function that checks session and blocks
  * unauthenticated requests. Returns the login HTML for page routes
  * or a 401 JSON response for API routes.
+ *
+ * Reads loginHtml and publicPaths from _authGuardConfig on every request
+ * so that a custom plugin can update them after the default has already
+ * installed this middleware (the production race condition fix).
  */
-function createAuthGuardFn(
-  loginHtml: string,
-  publicPaths: string[],
-): (event: H3Event) => Promise<Response | object | string | void> {
+function createAuthGuardFn(): (
+  event: H3Event,
+) => Promise<Response | object | string | void> {
   return async (event: H3Event) => {
+    const config = _authGuardConfig;
+    if (!config) return;
+    const { loginHtml, publicPaths } = config;
+
     const url = event.node?.req?.url ?? event.path ?? "/";
     const p = url.split("?")[0];
 
@@ -809,7 +829,8 @@ async function mountBetterAuthRoutes(
   // _authGuardFn so the server middleware can enforce it on ALL routes.
   const loginHtml =
     options.loginHtml ?? getOnboardingHtml({ googleOnly: options.googleOnly });
-  const guardFn = createAuthGuardFn(loginHtml, publicPaths);
+  _authGuardConfig = { loginHtml, publicPaths };
+  const guardFn = createAuthGuardFn();
   _authGuardFn = guardFn;
   app.use(defineEventHandler(guardFn));
 }
@@ -875,7 +896,8 @@ function mountTokenOnlyRoutes(
     }),
   );
 
-  const guardFn = createAuthGuardFn(TOKEN_LOGIN_HTML, publicPaths);
+  _authGuardConfig = { loginHtml: TOKEN_LOGIN_HTML, publicPaths };
+  const guardFn = createAuthGuardFn();
   _authGuardFn = guardFn;
   app.use(defineEventHandler(guardFn));
 }
@@ -942,12 +964,18 @@ export async function autoMountAuth(
   app: H3App,
   options: AuthOptions = {},
 ): Promise<boolean> {
-  // If auth is already mounted (e.g., custom plugin ran first), skip.
-  // On serverless runtimes (Netlify, CF Workers), the framework can't read
-  // the filesystem to detect custom plugins, so it auto-mounts defaults
-  // that may duplicate a custom plugin. This guard prevents the default
-  // from overriding the custom plugin's configuration.
+  // If auth is already mounted (e.g., default plugin ran before custom plugin),
+  // don't re-mount routes — but DO update the live config if custom options
+  // like googleOnly or loginHtml were provided. This fixes the production race
+  // where the default plugin (no googleOnly) mounts first, and the template's
+  // custom auth plugin runs later. Because createAuthGuardFn() reads from
+  // _authGuardConfig on every request, updating it here takes effect immediately.
   if (_authGuardFn) {
+    if ((options.googleOnly || options.loginHtml) && _authGuardConfig) {
+      _authGuardConfig.loginHtml =
+        options.loginHtml ??
+        getOnboardingHtml({ googleOnly: options.googleOnly });
+    }
     return true;
   }
 
@@ -1009,7 +1037,8 @@ export async function autoMountAuth(
     );
 
     const byoaLoginHtml = options.loginHtml ?? TOKEN_LOGIN_HTML;
-    const guardFn = createAuthGuardFn(byoaLoginHtml, publicPaths);
+    _authGuardConfig = { loginHtml: byoaLoginHtml, publicPaths };
+    const guardFn = createAuthGuardFn();
     _authGuardFn = guardFn;
     app.use(defineEventHandler(guardFn));
 
@@ -1052,7 +1081,8 @@ export async function autoMountAuth(
     const loginHtml =
       options.loginHtml ??
       getOnboardingHtml({ googleOnly: options.googleOnly });
-    const guardFn = createAuthGuardFn(loginHtml, publicPaths);
+    _authGuardConfig = { loginHtml, publicPaths };
+    const guardFn = createAuthGuardFn();
     _authGuardFn = guardFn;
     app.use(defineEventHandler(guardFn));
     console.log(

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -99,8 +99,11 @@ const DEFAULT_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
  * Returns true when:
  * - AUTH_MODE=local is explicitly set (escape hatch)
  * - In dev environment (NODE_ENV=development) with no explicit auth configured
- *   (no ACCESS_TOKEN, no GOOGLE_CLIENT_ID). This makes dev "just work" without
- *   requiring auth setup, while still respecting auth when configured.
+ *   (no ACCESS_TOKEN, no GOOGLE_CLIENT_ID, no BYOA). This makes dev "just work"
+ *   without requiring auth setup, while still respecting auth when configured.
+ *
+ * BYOA (customGetSession) opts out of dev auto-local — templates that provide
+ * their own auth (e.g. Supabase) shouldn't be silently bypassed in dev.
  */
 function isLocalMode(): boolean {
   if (process.env.AUTH_MODE === "local") return true;
@@ -109,7 +112,8 @@ function isLocalMode(): boolean {
     isDevEnvironment() &&
     !process.env.ACCESS_TOKEN &&
     !process.env.ACCESS_TOKENS &&
-    !process.env.GOOGLE_CLIENT_ID
+    !process.env.GOOGLE_CLIENT_ID &&
+    !customGetSession
   ) {
     return true;
   }

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -976,10 +976,18 @@ export async function autoMountAuth(
   // custom auth plugin runs later. Because createAuthGuardFn() reads from
   // _authGuardConfig on every request, updating it here takes effect immediately.
   if (_authGuardFn) {
-    if ((options.googleOnly || options.loginHtml) && _authGuardConfig) {
-      _authGuardConfig.loginHtml =
-        options.loginHtml ??
-        getOnboardingHtml({ googleOnly: options.googleOnly });
+    if (_authGuardConfig) {
+      if (options.googleOnly || options.loginHtml) {
+        _authGuardConfig.loginHtml =
+          options.loginHtml ??
+          getOnboardingHtml({ googleOnly: options.googleOnly });
+      }
+      if (options.publicPaths) {
+        _authGuardConfig.publicPaths = [
+          ...(_authGuardConfig.publicPaths ?? []),
+          ...options.publicPaths,
+        ];
+      }
     }
     return true;
   }

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -137,9 +137,10 @@ export function createServer(
   const app = createApp({
     onError(error, event) {
       // Suppress connection-reset errors — client disconnected mid-request (tab close, reload)
-      const code = (error as any)?.code || (error as any)?.cause?.code;
+      const err = error as NodeJS.ErrnoException;
+      const code = err?.code || (err?.cause as NodeJS.ErrnoException)?.code;
       if (code === "ECONNRESET" || code === "ECONNABORTED") return;
-      if ((error as any)?.message === "aborted") return;
+      if (err?.message === "aborted") return;
       console.error("[agent-native] Server error:", error);
     },
   });

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -188,9 +188,10 @@ async function bootstrapDefaultPlugins(nitroApp: any): Promise<void> {
       terminal: (terminalModule as any).defaultTerminalPlugin,
     };
 
-    console.log(
-      `[agent-native] Auto-mounting ${missing.length} default plugin(s): ${missing.join(", ")}`,
-    );
+    if (process.env.DEBUG)
+      console.log(
+        `[agent-native] Auto-mounting ${missing.length} default plugin(s): ${missing.join(", ")}`,
+      );
 
     for (const stem of missing) {
       const impl = impls[stem];

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -20,6 +20,7 @@ export const ssrHandler = defineEventHandler(async (event) => {
   const p = event.url.pathname;
   if (
     p.startsWith("/.well-known/") ||
+    p.startsWith("/_agent-native/") ||
     p === "/favicon.ico" ||
     p === "/favicon.png"
   ) {

--- a/packages/core/src/shared/cloudflare-globals.d.ts
+++ b/packages/core/src/shared/cloudflare-globals.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Cloudflare Workers runtime globals.
+ *
+ * These are injected by the Workers runtime at request time.
+ * They don't exist in Node.js or other runtimes.
+ */
+
+/** Minimal D1 Database binding interface (Cloudflare Workers) */
+interface CfD1Database {
+  prepare(query: string): CfD1PreparedStatement;
+  batch(
+    statements: CfD1PreparedStatement[],
+  ): Promise<
+    { results: Record<string, unknown>[]; meta?: { changes?: number } }[]
+  >;
+}
+
+interface CfD1PreparedStatement {
+  bind(...values: unknown[]): CfD1PreparedStatement;
+  all(): Promise<{
+    results: Record<string, unknown>[];
+    meta?: { changes?: number };
+  }>;
+  first<T = Record<string, unknown>>(): Promise<T | null>;
+  run(): Promise<{ meta?: { changes?: number } }>;
+}
+
+interface CfEnv {
+  DB?: CfD1Database;
+  [key: string]: unknown;
+}
+
+declare var __cf_env: CfEnv | undefined;
+declare var __cf_ctx: { waitUntil(p: Promise<unknown>): void } | undefined;

--- a/packages/core/src/shared/runtime.ts
+++ b/packages/core/src/shared/runtime.ts
@@ -11,15 +11,15 @@ export function isNodeRuntime(): boolean {
   return (
     typeof process !== "undefined" &&
     typeof process.versions?.node === "string" &&
-    typeof (globalThis as any).__cf_env === "undefined" &&
-    typeof (globalThis as any).Deno === "undefined"
+    !("__cf_env" in globalThis) &&
+    !("Deno" in globalThis)
   );
 }
 
 /** True when running in Cloudflare Workers/Pages. */
 export function isCloudflareRuntime(): boolean {
   return (
-    typeof (globalThis as any).__cf_env !== "undefined" ||
+    "__cf_env" in globalThis ||
     (typeof navigator !== "undefined" &&
       navigator.userAgent === "Cloudflare-Workers")
   );

--- a/packages/core/src/terminal/pty-server.ts
+++ b/packages/core/src/terminal/pty-server.ts
@@ -394,9 +394,10 @@ export async function createPtyWebSocketServer(
     server.listen(port, "127.0.0.1", () => {
       const addr = server.address();
       const actualPort = typeof addr === "object" && addr ? addr.port : port;
-      console.log(
-        `${logPrefix} PTY WebSocket server on ws://localhost:${actualPort}/ws`,
-      );
+      if (process.env.DEBUG)
+        console.log(
+          `${logPrefix} PTY WebSocket server on ws://localhost:${actualPort}/ws`,
+        );
 
       resolve({
         server,

--- a/packages/core/src/terminal/terminal-plugin.ts
+++ b/packages/core/src/terminal/terminal-plugin.ts
@@ -191,9 +191,10 @@ export function createTerminalPlugin(options: TerminalPluginOptions = {}) {
       process.once("SIGINT", cleanup);
       process.once("exit", cleanup);
 
-      console.log(
-        `[terminal] Agent terminal ready (command: ${command}, port: ${result.port})`,
-      );
+      if (process.env.DEBUG)
+        console.log(
+          `[terminal] Agent terminal ready (command: ${command}, port: ${result.port})`,
+        );
     } catch (err) {
       // Clear the running flag so a retry can spawn a fresh server
       delete process.env.__AGENT_TERMINAL_RUNNING;

--- a/packages/core/src/usage/store.ts
+++ b/packages/core/src/usage/store.ts
@@ -102,7 +102,7 @@ export async function getUserUsageCents(ownerEmail: string): Promise<number> {
     sql: `SELECT COALESCE(SUM(cost_cents_x100), 0) as total FROM token_usage WHERE owner_email = ?`,
     args: [ownerEmail],
   });
-  const total = Number((rows[0] as any)?.total ?? 0);
+  const total = Number((rows[0] as { total?: number })?.total ?? 0);
   // Convert from centicents to cents
   return total / 100;
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -16,7 +16,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "types": ["node"]
+    "types": ["node", "vite/client"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "src/templates", "src/**/*.spec.ts"]

--- a/packages/frame/client/App.tsx
+++ b/packages/frame/client/App.tsx
@@ -293,6 +293,7 @@ export function App() {
                 ]}
                 onCollapse={() => setSidebarOpen(false)}
                 devAppUrl={appUrl}
+                storageKey={appId}
               />
             </Suspense>
           </div>

--- a/packages/frame/vite.config.ts
+++ b/packages/frame/vite.config.ts
@@ -1,8 +1,23 @@
-import { defineConfig } from "vite";
+import { defineConfig, createLogger } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 import type { IncomingMessage } from "http";
+
+// Custom logger that suppresses proxy ECONNREFUSED noise during startup.
+// When dev:all starts, template backends aren't ready yet — the frame polls
+// and gets ECONNREFUSED until they come up. These are harmless (the frontend
+// retries), but flood the terminal with hundreds of identical lines.
+const logger = createLogger();
+const _loggerError = logger.error.bind(logger);
+logger.error = (msg, opts) => {
+  if (
+    opts?.error?.code === "ECONNREFUSED" ||
+    (typeof msg === "string" && msg.includes("ECONNREFUSED"))
+  )
+    return;
+  _loggerError(msg, opts);
+};
 
 // Import app registry to resolve ports by app ID
 const configPath = path.resolve(__dirname, "../shared-app-config/index.ts");
@@ -31,6 +46,7 @@ function getAppPort(req: IncomingMessage): number {
 
 export default defineConfig({
   root: ".",
+  customLogger: logger,
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
@@ -50,30 +66,12 @@ export default defineConfig({
         target: "http://localhost:8085",
         changeOrigin: true,
         router: (req: IncomingMessage) => `http://localhost:${getAppPort(req)}`,
-        configure: (proxy) => {
-          proxy.on("error", (_err, _req, res) => {
-            // Backend not ready yet (ECONNREFUSED during startup) — return 503
-            // silently so the frontend retries. Avoids log spam during dev:all.
-            if ("writeHead" in res) {
-              (res as any).writeHead(503);
-              res.end("Backend not ready");
-            }
-          });
-        },
       },
       // Proxy app API routes
       "/api": {
         target: "http://localhost:8085",
         changeOrigin: true,
         router: (req: IncomingMessage) => `http://localhost:${getAppPort(req)}`,
-        configure: (proxy) => {
-          proxy.on("error", (_err, _req, res) => {
-            if ("writeHead" in res) {
-              (res as any).writeHead(503);
-              res.end("Backend not ready");
-            }
-          });
-        },
       },
     },
   },

--- a/packages/frame/vite.config.ts
+++ b/packages/frame/vite.config.ts
@@ -50,12 +50,30 @@ export default defineConfig({
         target: "http://localhost:8085",
         changeOrigin: true,
         router: (req: IncomingMessage) => `http://localhost:${getAppPort(req)}`,
+        configure: (proxy) => {
+          proxy.on("error", (_err, _req, res) => {
+            // Backend not ready yet (ECONNREFUSED during startup) — return 503
+            // silently so the frontend retries. Avoids log spam during dev:all.
+            if ("writeHead" in res) {
+              (res as any).writeHead(503);
+              res.end("Backend not ready");
+            }
+          });
+        },
       },
       // Proxy app API routes
       "/api": {
         target: "http://localhost:8085",
         changeOrigin: true,
         router: (req: IncomingMessage) => `http://localhost:${getAppPort(req)}`,
+        configure: (proxy) => {
+          proxy.on("error", (_err, _req, res) => {
+            if ("writeHead" in res) {
+              (res as any).writeHead(503);
+              res.end("Backend not ready");
+            }
+          });
+        },
       },
     },
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,10 +106,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
@@ -139,7 +139,7 @@ importers:
         version: 3.22.2
       better-auth:
         specifier: ^1.6.0
-        version: 1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))
+        version: 1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -175,7 +175,7 @@ importers:
         version: 10.2.5
       nitro:
         specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
@@ -239,7 +239,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -278,10 +278,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
       ws:
         specifier: ^8.18.0
         version: 8.20.0
@@ -2349,6 +2349,24 @@ importers:
       '@tabler/icons-react':
         specifier: ^3.40.0
         version: 3.41.1(react@18.3.1)
+      '@tiptap/core':
+        specifier: ^3.22.2
+        version: 3.22.2(@tiptap/pm@3.22.2)
+      '@tiptap/extension-link':
+        specifier: ^3.22.2
+        version: 3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)
+      '@tiptap/extension-placeholder':
+        specifier: ^3.22.2
+        version: 3.22.2(@tiptap/extensions@3.22.2(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2))
+      '@tiptap/pm':
+        specifier: ^3.22.2
+        version: 3.22.2
+      '@tiptap/react':
+        specifier: ^3.22.2
+        version: 3.22.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))(@tiptap/pm@3.22.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tiptap/starter-kit':
+        specifier: ^3.22.2
+        version: 3.22.2
       dotenv:
         specifier: ^17.2.1
         version: 17.4.0
@@ -2466,10 +2484,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
       '@react-three/drei':
         specifier: ^9.122.0
         version: 9.122.0(@react-three/fiber@8.18.0(a4f87a1c9cd5afeda248b1850f15afe1))(@types/react@18.3.28)(@types/three@0.176.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.176.0)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -2499,7 +2517,7 @@ importers:
         version: 0.176.0
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
@@ -2586,10 +2604,10 @@ importers:
         version: 1.1.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vite:
         specifier: ^8.0.0
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
 
   templates/starter:
     dependencies:
@@ -19129,6 +19147,53 @@ snapshots:
       - supports-color
       - terser
 
+  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@react-router/node': 7.14.0(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      '@remix-run/node-fetch-server': 0.13.0
+      arg: 5.0.2
+      babel-dead-code-elimination: 1.0.12
+      chokidar: 4.0.3
+      dedent: 1.7.2
+      es-module-lexer: 1.7.0
+      exit-hook: 2.2.1
+      isbot: 5.1.37
+      jsesc: 3.0.2
+      lodash: 4.18.1
+      p-map: 7.0.4
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      pkg-types: 2.3.0
+      prettier: 3.8.1
+      react-refresh: 0.14.2
+      react-router: 7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      valibot: 1.3.1(typescript@5.9.3)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@24.12.2)(lightningcss@1.32.0)(terser@5.46.1)
+    optionalDependencies:
+      typescript: 5.9.3
+      wrangler: 4.81.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -19176,7 +19241,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
+  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -19206,7 +19271,7 @@ snapshots:
       semver: 7.7.4
       tinyglobby: 0.2.15
       valibot: 1.3.1(typescript@5.9.3)
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@24.12.2)(lightningcss@1.32.0)(terser@5.46.1)
     optionalDependencies:
       typescript: 5.9.3
@@ -19237,6 +19302,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
+    dependencies:
+      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+      minimatch: 10.2.5
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
     dependencies:
       '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
@@ -19244,9 +19316,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
+  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
     dependencies:
-      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       minimatch: 10.2.5
     optionalDependencies:
       typescript: 5.9.3
@@ -21142,7 +21214,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.14: {}
 
-  better-auth@1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)):
+  better-auth@1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))
@@ -21169,7 +21241,7 @@ snapshots:
       react: 18.3.1
       react-dom: 19.2.4(react@18.3.1)
       solid-js: 1.9.12
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -25231,7 +25303,7 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro@3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)):
+  nitro@3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.4(srvx@0.11.15)
@@ -25250,9 +25322,9 @@ snapshots:
     optionalDependencies:
       dotenv: 17.4.0
       giget: 3.2.0
-      jiti: 1.21.7
+      jiti: 2.6.1
       rollup: 4.60.1
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'

--- a/scripts/dev-all.ts
+++ b/scripts/dev-all.ts
@@ -77,14 +77,22 @@ console.log(`\x1b[36m[dev-all]\x1b[0m Docs: http://localhost:${DOCS_PORT}`);
 const names: string[] = [];
 const commands: string[] = [];
 
-templatePorts.forEach(({ name, port }) => {
+// Stagger template starts by 1.5s each to prevent CPU saturation.
+// When all 11+ apps start simultaneously, Nitro's ViteEnvRunner hits its
+// 3-second initialization timeout, producing "Vite environment unavailable" 503s.
+const STAGGER_DELAY_S = 1.5;
+
+templatePorts.forEach(({ name, port }, i) => {
   console.log(`\x1b[36m[dev-all]\x1b[0m ${name}: http://localhost:${port}`);
+
+  const delay = i * STAGGER_DELAY_S;
+  const prefix = delay > 0 ? `sleep ${delay} && ` : "";
 
   names.push(name);
   // Pass APP_NAME so each app can resolve its own DATABASE_URL
   // (e.g. MAIL_DATABASE_URL when APP_NAME=mail)
   commands.push(
-    `APP_NAME=${name} pnpm --filter ${name} exec vite --port ${port}`,
+    `${prefix}APP_NAME=${name} pnpm --filter ${name} exec vite --port ${port}`,
   );
 });
 

--- a/templates/analytics/actions/bigquery.ts
+++ b/templates/analytics/actions/bigquery.ts
@@ -5,12 +5,10 @@ import { runQuery } from "../server/lib/bigquery";
 export default defineAction({
   description: "Run an arbitrary SQL query against BigQuery.",
   schema: z.object({
-    sql: z.string().optional().describe("SQL query to execute"),
+    sql: z.string().describe("SQL query to execute"),
   }),
   http: false,
   run: async (args) => {
-    if (!args.sql)
-      return { error: '--sql is required. Example: --sql="SELECT 1"' };
     return await runQuery(args.sql);
   },
 });

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -18,6 +18,7 @@ import {
   IconTrash,
   IconStar,
   IconSettings,
+  IconHammer,
   IconGripVertical,
   IconHome,
   IconChartBar,
@@ -715,7 +716,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
                 : "text-muted-foreground hover:bg-sidebar-accent/50",
             )}
           >
-            <IconSettings className="h-4 w-4" />
+            <IconHammer className="h-4 w-4" />
             <span className="flex-1">Tools</span>
             <IconChevronDown
               className={cn(

--- a/templates/analytics/app/hooks/use-navigation-state.ts
+++ b/templates/analytics/app/hooks/use-navigation-state.ts
@@ -22,7 +22,10 @@ export function useNavigationState() {
     } else if (path.startsWith("/adhoc/")) {
       state.view = "adhoc";
       const match = path.match(/\/adhoc\/(.+)/);
-      if (match) state.dashboardId = match[1];
+      if (match) {
+        state.dashboardId = match[1];
+        localStorage.setItem("last-dashboard-id", match[1]);
+      }
     } else if (path === "/query") {
       state.view = "query";
     } else if (path === "/data-sources") {

--- a/templates/analytics/app/pages/Index.tsx
+++ b/templates/analytics/app/pages/Index.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { Layout } from "@/components/layout/Layout";
 import {
   Card,
@@ -9,23 +9,13 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import {
-  IconChartBar,
-  IconDatabase,
-  IconPlus,
-  IconArrowRight,
-  IconCheck,
-  IconCircle,
-} from "@tabler/icons-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { IconChartBar, IconPlus, IconArrowRight } from "@tabler/icons-react";
 import { getIdToken } from "@/lib/auth";
-import {
-  dataSources,
-  categoryLabels,
-  type DataSource,
-} from "@/lib/data-sources";
+import { dataSources, type DataSource } from "@/lib/data-sources";
 import { dashboards } from "@/pages/adhoc/registry";
 import { useSendToAgentChat } from "@agent-native/core/client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 interface EnvKeyStatus {
   key: string;
@@ -135,7 +125,16 @@ async function fetchSqlDashboards(): Promise<
 }
 
 export default function Index() {
-  const { data: envStatus = [] } = useQuery({
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const lastId = localStorage.getItem("last-dashboard-id");
+    if (lastId) {
+      navigate(`/adhoc/${lastId}`, { replace: true });
+    }
+  }, [navigate]);
+
+  const { data: envStatus, isLoading: envLoading } = useQuery({
     queryKey: ["env-status"],
     queryFn: fetchEnvStatus,
     staleTime: 10_000,
@@ -148,9 +147,15 @@ export default function Index() {
   });
 
   const connectedSources = dataSources.filter((s) =>
-    isSourceConnected(s, envStatus),
+    isSourceConnected(s, envStatus ?? []),
   );
   const hasConnections = connectedSources.length > 0;
+
+  const lastDashboardId =
+    typeof window !== "undefined"
+      ? localStorage.getItem("last-dashboard-id")
+      : null;
+  if (lastDashboardId) return null;
 
   return (
     <Layout>
@@ -163,8 +168,21 @@ export default function Index() {
           </p>
         </div>
 
-        {/* Connected sources summary */}
-        {hasConnections && (
+        {/* Connected sources summary / skeleton / get started */}
+        {envLoading ? (
+          <Card className="bg-card border-border/50">
+            <CardHeader className="pb-3">
+              <Skeleton className="h-4 w-36" />
+            </CardHeader>
+            <CardContent className="pt-0">
+              <div className="flex flex-wrap gap-2">
+                <Skeleton className="h-6 w-24 rounded-full" />
+                <Skeleton className="h-6 w-20 rounded-full" />
+                <Skeleton className="h-6 w-28 rounded-full" />
+              </div>
+            </CardContent>
+          </Card>
+        ) : hasConnections ? (
           <Card className="bg-card border-border/50">
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">
@@ -196,10 +214,7 @@ export default function Index() {
               </div>
             </CardContent>
           </Card>
-        )}
-
-        {/* Quick start when no sources connected */}
-        {!hasConnections && (
+        ) : (
           <Card className="bg-card border-border/50">
             <CardHeader>
               <CardTitle className="text-base">Get Started</CardTitle>
@@ -299,7 +314,7 @@ export default function Index() {
         )}
 
         {/* Suggested dashboards based on connected sources */}
-        {hasConnections && (
+        {!envLoading && hasConnections && (
           <div className="space-y-3">
             <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
               Suggested Dashboards

--- a/templates/calendar/actions/create-event.ts
+++ b/templates/calendar/actions/create-event.ts
@@ -6,9 +6,9 @@ import * as googleCalendar from "../server/lib/google-calendar.js";
 export default defineAction({
   description: "Create a calendar event on Google Calendar",
   schema: z.object({
-    title: z.string().optional().describe("Event title (required)"),
-    start: z.string().optional().describe("Start time, ISO format (required)"),
-    end: z.string().optional().describe("End time, ISO format (required)"),
+    title: z.string().describe("Event title"),
+    start: z.string().describe("Start time, ISO format"),
+    end: z.string().describe("End time, ISO format"),
     description: z.string().optional().describe("Event description"),
     location: z.string().optional().describe("Event location"),
     accountEmail: z
@@ -17,10 +17,6 @@ export default defineAction({
       .describe("Account email to create the event on"),
   }),
   run: async (args) => {
-    if (!args.title) throw new Error("title is required");
-    if (!args.start) throw new Error("start is required (ISO date format)");
-    if (!args.end) throw new Error("end is required (ISO date format)");
-
     const email = process.env.AGENT_USER_EMAIL || "local@localhost";
 
     if (!(await googleCalendar.isConnected(email))) {

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -10,6 +10,7 @@ import {
   addMinutes,
 } from "date-fns";
 import { cn } from "@/lib/utils";
+import { shouldSuppressAfterPopoverClose } from "@/lib/popover-click-guard";
 import { getEventAutoColor, allOtherDeclined } from "@/lib/event-colors";
 import { IconAlertTriangleFilled } from "@tabler/icons-react";
 import { EventDetailPopover } from "./EventDetailPopover";
@@ -274,7 +275,13 @@ export function DayView({
           className="absolute inset-0 ml-[40px] mr-2 sm:ml-[56px] sm:mr-4"
           onClick={(e) => {
             if ((e.target as HTMLElement).closest("button")) return;
-            if (!onClickTimeSlot || isDragging || shouldSuppressClick()) return;
+            if (
+              !onClickTimeSlot ||
+              isDragging ||
+              shouldSuppressClick() ||
+              shouldSuppressAfterPopoverClose()
+            )
+              return;
             const rect = e.currentTarget.getBoundingClientRect();
             const y = e.clientY - rect.top;
             const totalMinutes =

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { markPopoverInteractOutside } from "@/lib/popover-click-guard";
 import { format, parseISO, differenceInMinutes } from "date-fns";
 import {
   IconX,
@@ -489,7 +490,10 @@ export function EventDetailPopover({
           const target = e.target as HTMLElement;
           if (target.closest("[data-apollo-popover]")) {
             e.preventDefault();
+            return;
           }
+          // Mark that a popover was dismissed so the grid suppresses time-slot creation
+          markPopoverInteractOutside();
         }}
       >
         <TooltipProvider>

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -15,6 +15,7 @@ import {
   addMinutes,
 } from "date-fns";
 import { cn } from "@/lib/utils";
+import { shouldSuppressAfterPopoverClose } from "@/lib/popover-click-guard";
 import { getEventAutoColor, allOtherDeclined } from "@/lib/event-colors";
 import { IconAlertTriangleFilled } from "@tabler/icons-react";
 import { EventDetailPopover } from "./EventDetailPopover";
@@ -528,7 +529,12 @@ export function WeekView({
                 onClick={(e) => {
                   // Only fire on empty space (not on event buttons or after drags)
                   if ((e.target as HTMLElement).closest("button")) return;
-                  if (!onClickTimeSlot || isDragging || shouldSuppressClick())
+                  if (
+                    !onClickTimeSlot ||
+                    isDragging ||
+                    shouldSuppressClick() ||
+                    shouldSuppressAfterPopoverClose()
+                  )
                     return;
                   const rect = e.currentTarget.getBoundingClientRect();
                   const y = e.clientY - rect.top;

--- a/templates/calendar/app/lib/popover-click-guard.ts
+++ b/templates/calendar/app/lib/popover-click-guard.ts
@@ -1,0 +1,13 @@
+/**
+ * Tracks when an event detail popover was dismissed by clicking outside.
+ * WeekView/DayView read this to suppress time-slot creation on the same click.
+ */
+let popoverInteractOutsideAt = 0;
+
+export function markPopoverInteractOutside() {
+  popoverInteractOutsideAt = Date.now();
+}
+
+export function shouldSuppressAfterPopoverClose() {
+  return Date.now() - popoverInteractOutsideAt < 200;
+}

--- a/templates/content/actions/create-document.ts
+++ b/templates/content/actions/create-document.ts
@@ -17,14 +17,17 @@ function nanoid(size = 12): string {
 export default defineAction({
   description: "Create a new document.",
   schema: z.object({
-    title: z.string().optional().describe("Document title (required)"),
+    id: z
+      .string()
+      .optional()
+      .describe("Pre-generated document ID (for optimistic UI)"),
+    title: z.string().describe("Document title"),
     content: z.string().optional().describe("Markdown content"),
-    parentId: z.string().optional().describe("Parent document ID for nesting"),
+    parentId: z.string().nullish().describe("Parent document ID for nesting"),
     icon: z.string().optional().describe("Emoji icon"),
   }),
   run: async (args) => {
     const title = args.title;
-    if (!title) throw new Error("--title is required");
 
     let content = args.content || "";
     // Strip leading H1 that duplicates the title
@@ -54,7 +57,7 @@ export default defineAction({
 
     const position = (maxPos[0]?.max ?? -1) + 1;
     const now = new Date().toISOString();
-    const id = nanoid();
+    const id = args.id || nanoid();
 
     await db.insert(schema.documents).values({
       id,

--- a/templates/content/actions/list-comments.ts
+++ b/templates/content/actions/list-comments.ts
@@ -18,19 +18,6 @@ export default defineAction({
       args: [documentId],
     });
 
-    if (rows.length === 0) {
-      console.log("No comments on this document.");
-    } else {
-      // Group by thread for agent output
-      const threads = new Map<string, any[]>();
-      for (const row of rows) {
-        const tid = (row as any).thread_id;
-        if (!threads.has(tid)) threads.set(tid, []);
-        threads.get(tid)!.push(row);
-      }
-      console.log(`${threads.size} comment thread(s)`);
-    }
-
     return { comments: rows };
   },
 });

--- a/templates/content/actions/list-documents.ts
+++ b/templates/content/actions/list-documents.ts
@@ -6,14 +6,9 @@ import { z } from "zod";
 
 export default defineAction({
   description: "List all documents ordered by position.",
-  schema: z.object({
-    format: z
-      .enum(["json", "tree"])
-      .optional()
-      .describe('Output format: "json" or "tree"'),
-  }),
+  schema: z.object({}),
   http: { method: "GET" },
-  run: async (args) => {
+  run: async () => {
     const db = getDb();
     const documents = await db
       .select()
@@ -31,44 +26,6 @@ export default defineAction({
       createdAt: d.createdAt,
       updatedAt: d.updatedAt,
     }));
-
-    // For agent CLI usage, print a tree
-    if (args.format === "tree") {
-      interface DocRow {
-        id: string;
-        parentId: string | null;
-        title: string;
-        icon: string | null;
-        isFavorite: boolean;
-      }
-      const byParent = new Map<string, DocRow[]>();
-      for (const doc of mapped) {
-        const key = doc.parentId ?? "__root__";
-        if (!byParent.has(key)) byParent.set(key, []);
-        byParent.get(key)!.push(doc);
-      }
-
-      function printTree(parentId: string | null, indent: string) {
-        const key = parentId ?? "__root__";
-        const children = byParent.get(key) || [];
-        for (let i = 0; i < children.length; i++) {
-          const doc = children[i];
-          const isLast = i === children.length - 1;
-          const prefix = isLast ? "└── " : "├── ";
-          const icon = doc.icon ? `${doc.icon} ` : "";
-          const fav = doc.isFavorite ? " ★" : "";
-          console.log(
-            `${indent}${prefix}${icon}${doc.title || "Untitled"}${fav} (${doc.id})`,
-          );
-          const childIndent = indent + (isLast ? "    " : "│   ");
-          printTree(doc.id, childIndent);
-        }
-      }
-
-      console.log("Documents:");
-      printTree(null, "");
-      return { documents: mapped };
-    }
 
     return { documents: mapped };
   },

--- a/templates/content/actions/search-documents.ts
+++ b/templates/content/actions/search-documents.ts
@@ -6,12 +6,11 @@ import { z } from "zod";
 export default defineAction({
   description: "Search documents by title and content.",
   schema: z.object({
-    query: z.string().optional().describe("Search text (required)"),
+    query: z.string().describe("Search text"),
   }),
   http: { method: "GET" },
   run: async (args) => {
     const query = args.query;
-    if (!query) throw new Error("--query is required");
 
     const db = getDb();
     const pattern = `%${query}%`;

--- a/templates/content/app/components/EmptyState.tsx
+++ b/templates/content/app/components/EmptyState.tsx
@@ -10,7 +10,7 @@ export function EmptyState() {
 
   const handleCreate = async () => {
     try {
-      const doc = await createDocument.mutateAsync({});
+      const doc = await createDocument.mutateAsync({ title: "Untitled" });
       navigate(`/page/${doc.id}`);
     } catch (err) {
       toast.error("Failed to create page", {

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -43,6 +43,8 @@ export function DocumentEditor({ documentId }: DocumentEditorProps) {
   const localContentRef = useRef(localContent);
   localContentRef.current = localContent;
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const shouldFocusTitleRef = useRef(false);
 
   // Current user info for cursor labels
   const { session } = useSession();
@@ -86,6 +88,9 @@ export function DocumentEditor({ documentId }: DocumentEditorProps) {
         content: document.content,
       };
       isInitializedRef.current = true;
+      if (!document.title) {
+        shouldFocusTitleRef.current = true;
+      }
     }
   }, [document, documentId]);
 
@@ -158,6 +163,14 @@ export function DocumentEditor({ documentId }: DocumentEditorProps) {
   const handleComment = useCallback((quotedText: string, offsetTop: number) => {
     setPendingComment({ quotedText, offsetTop });
   }, []);
+
+  // Auto-focus title on new empty documents once loading is done
+  useEffect(() => {
+    if (!isLoading && !collabLoading && shouldFocusTitleRef.current) {
+      shouldFocusTitleRef.current = false;
+      requestAnimationFrame(() => titleInputRef.current?.focus());
+    }
+  });
 
   if (isLoading || collabLoading) {
     return (
@@ -252,6 +265,7 @@ export function DocumentEditor({ documentId }: DocumentEditorProps) {
               />
             </div>
             <input
+              ref={titleInputRef}
               value={localTitle}
               onChange={(e) => handleTitleChange(e.target.value)}
               onKeyDown={(e) => {
@@ -263,7 +277,7 @@ export function DocumentEditor({ documentId }: DocumentEditorProps) {
                   pm?.focus();
                 }
               }}
-              placeholder="Untitled"
+              placeholder="Title"
               className="w-full text-3xl font-bold bg-transparent border-none outline-none text-foreground placeholder:text-muted-foreground/40 md:text-4xl"
             />
           </div>

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -75,6 +75,7 @@ export function DocumentToolbar({ documentId }: DocumentToolbarProps) {
   const [resolvingDirection, setResolvingDirection] = useState<
     "pull" | "push" | null
   >(null);
+  const [linkingPageId, setLinkingPageId] = useState<string | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
 
@@ -124,12 +125,15 @@ export function DocumentToolbar({ documentId }: DocumentToolbarProps) {
 
   const handleLink = useCallback(
     async (pageId: string) => {
+      setLinkingPageId(pageId);
       try {
         await linkDocument.mutateAsync({ pageIdOrUrl: pageId });
         toast.success("Linked to Notion page.");
         setSearchQuery("");
       } catch (error) {
         toast.error(error instanceof Error ? error.message : "Failed to link.");
+      } finally {
+        setLinkingPageId(null);
       }
     },
     [linkDocument],
@@ -513,25 +517,36 @@ export function DocumentToolbar({ documentId }: DocumentToolbarProps) {
                         className="w-full flex items-center gap-2.5 px-2.5 py-2 text-left rounded-md hover:bg-accent disabled:opacity-40"
                       >
                         <span className="flex h-5 w-5 shrink-0 items-center justify-center text-sm">
-                          {page.icon || (
-                            <IconFileText
+                          {linkingPageId === page.id ? (
+                            <IconLoader2
                               size={14}
-                              className="text-muted-foreground"
+                              className="animate-spin text-muted-foreground"
                             />
+                          ) : (
+                            page.icon || (
+                              <IconFileText
+                                size={14}
+                                className="text-muted-foreground"
+                              />
+                            )
                           )}
                         </span>
                         <div className="min-w-0 flex-1">
                           <p className="text-xs font-medium truncate">
                             {page.title}
                           </p>
-                          {page.lastEditedTime && (
+                          {linkingPageId === page.id ? (
+                            <p className="text-[10px] text-muted-foreground">
+                              Importing from Notion…
+                            </p>
+                          ) : page.lastEditedTime ? (
                             <p className="text-[10px] text-muted-foreground">
                               Edited{" "}
                               {new Date(
                                 page.lastEditedTime,
                               ).toLocaleDateString()}
                             </p>
-                          )}
+                          ) : null}
                         </div>
                       </button>
                     ))}

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
+import type { Document } from "@shared/api";
 import {
   IconPlus,
   IconSearch,
@@ -22,6 +24,13 @@ import {
 } from "@/hooks/use-documents";
 import { cn } from "@/lib/utils";
 
+function nanoid(size = 12): string {
+  const chars =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  const bytes = crypto.getRandomValues(new Uint8Array(size));
+  return Array.from(bytes, (b) => chars[b % chars.length]).join("");
+}
+
 interface DocumentSidebarProps {
   activeDocumentId: string | null;
   collapsed: boolean;
@@ -40,6 +49,7 @@ export function DocumentSidebar({
   onResize,
 }: DocumentSidebarProps) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { data: documents = [], isLoading } = useDocuments();
   const createDocument = useCreateDocument();
   const deleteDocument = useDeleteDocument();
@@ -100,20 +110,56 @@ export function DocumentSidebar({
 
   const handleCreatePage = useCallback(
     async (parentId?: string) => {
+      const id = nanoid();
+      const now = new Date().toISOString();
+      const tempDoc: Document = {
+        id,
+        parentId: parentId ?? null,
+        title: "",
+        content: "",
+        icon: null,
+        position: 9999,
+        isFavorite: false,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      // Optimistically inject into caches so UI updates immediately
+      queryClient.setQueryData(
+        ["action", "list-documents", undefined],
+        (old: any) => {
+          const docs: Document[] =
+            old?.documents ?? (Array.isArray(old) ? old : []);
+          return { documents: [...docs, tempDoc] };
+        },
+      );
+      queryClient.setQueryData(["action", "get-document", { id }], tempDoc);
+
+      navigate(`/page/${id}`);
+      onNavigate?.();
+
       try {
-        const doc = await createDocument.mutateAsync({
-          parentId: parentId ?? null,
+        await createDocument.mutateAsync({
+          id,
+          title: "",
+          parentId: parentId ?? undefined,
         });
-        navigate(`/page/${doc.id}`);
-        onNavigate?.();
       } catch (err) {
+        // Revert optimistic updates
+        queryClient.invalidateQueries({
+          queryKey: ["action", "list-documents"],
+        });
+        queryClient.removeQueries({
+          queryKey: ["action", "get-document", { id }],
+        });
+        navigate("/");
         toast.error("Failed to create page", {
           description:
             err instanceof Error ? err.message : "Something went wrong",
         });
       }
     },
-    [createDocument, navigate, onNavigate],
+    [createDocument, navigate, onNavigate, queryClient],
   );
 
   const handleDelete = useCallback(

--- a/templates/content/shared/api.ts
+++ b/templates/content/shared/api.ts
@@ -47,6 +47,7 @@ export interface ResolveDocumentSyncConflictRequest {
 }
 
 export interface DocumentCreateRequest {
+  id?: string;
   title?: string;
   parentId?: string | null;
   content?: string;

--- a/templates/forms/actions/create-form.ts
+++ b/templates/forms/actions/create-form.ts
@@ -81,11 +81,11 @@ export default defineAction({
       updatedAt: now,
     });
 
-    const row = await db
+    const [row] = await db
       .select()
       .from(schema.forms)
       .where(eq(schema.forms.id, id))
-      .get();
+      .limit(1);
 
     return {
       id: row!.id,

--- a/templates/forms/actions/delete-form.ts
+++ b/templates/forms/actions/delete-form.ts
@@ -10,11 +10,11 @@ export default defineAction({
   }),
   run: async (args) => {
     const db = getDb();
-    const existing = await db
+    const [existing] = await db
       .select()
       .from(schema.forms)
       .where(eq(schema.forms.id, args.id))
-      .get();
+      .limit(1);
 
     if (!existing) {
       throw new Error(`Form ${args.id} not found`);

--- a/templates/forms/actions/export-responses.ts
+++ b/templates/forms/actions/export-responses.ts
@@ -14,10 +14,6 @@ export default defineAction({
   http: false,
   run: async (args) => {
     const formId = args.form;
-    if (!formId) {
-      throw new Error("--form is required");
-    }
-
     const db = getDb();
     const form = await db
       .select()

--- a/templates/forms/actions/export-responses.ts
+++ b/templates/forms/actions/export-responses.ts
@@ -15,11 +15,11 @@ export default defineAction({
   run: async (args) => {
     const formId = args.form;
     const db = getDb();
-    const form = await db
+    const [form] = await db
       .select()
       .from(schema.forms)
       .where(eq(schema.forms.id, formId))
-      .get();
+      .limit(1);
     if (!form) {
       throw new Error(`Form ${formId} not found`);
     }
@@ -28,8 +28,7 @@ export default defineAction({
       .select()
       .from(schema.responses)
       .where(eq(schema.responses.formId, formId))
-      .orderBy(desc(schema.responses.submittedAt))
-      .all();
+      .orderBy(desc(schema.responses.submittedAt));
 
     const fields = JSON.parse(form.fields);
     const fmt =

--- a/templates/forms/actions/get-form.ts
+++ b/templates/forms/actions/get-form.ts
@@ -12,21 +12,20 @@ export default defineAction({
   http: { method: "GET" },
   run: async (args) => {
     const db = getDb();
-    const row = await db
+    const [row] = await db
       .select()
       .from(schema.forms)
       .where(eq(schema.forms.id, args.id))
-      .get();
+      .limit(1);
 
     if (!row) {
       throw new Error(`Form ${args.id} not found`);
     }
 
-    const count = await db
+    const [count] = await db
       .select({ count: sql<number>`count(*)` })
       .from(schema.responses)
-      .where(eq(schema.responses.formId, args.id))
-      .get();
+      .where(eq(schema.responses.formId, args.id));
 
     return {
       id: row.id,

--- a/templates/forms/actions/list-forms.ts
+++ b/templates/forms/actions/list-forms.ts
@@ -18,8 +18,7 @@ export default defineAction({
     const rows = await db
       .select()
       .from(schema.forms)
-      .orderBy(schema.forms.updatedAt)
-      .all();
+      .orderBy(schema.forms.updatedAt);
 
     const counts = await db
       .select({
@@ -27,8 +26,7 @@ export default defineAction({
         count: sql<number>`count(*)`,
       })
       .from(schema.responses)
-      .groupBy(schema.responses.formId)
-      .all();
+      .groupBy(schema.responses.formId);
     const countMap = new Map(counts.map((c) => [c.formId, c.count]));
 
     let forms = rows.map((r) => ({

--- a/templates/forms/actions/list-responses.ts
+++ b/templates/forms/actions/list-responses.ts
@@ -17,10 +17,6 @@ export default defineAction({
   http: { method: "GET" },
   run: async (args) => {
     const formId = args.formId;
-    if (!formId) {
-      throw new Error("--formId is required");
-    }
-
     const db = getDb();
     const form = await db
       .select()

--- a/templates/forms/actions/list-responses.ts
+++ b/templates/forms/actions/list-responses.ts
@@ -18,11 +18,11 @@ export default defineAction({
   run: async (args) => {
     const formId = args.formId;
     const db = getDb();
-    const form = await db
+    const [form] = await db
       .select()
       .from(schema.forms)
       .where(eq(schema.forms.id, formId))
-      .get();
+      .limit(1);
 
     if (!form) {
       throw new Error(`Form ${formId} not found`);
@@ -34,14 +34,12 @@ export default defineAction({
       .from(schema.responses)
       .where(eq(schema.responses.formId, formId))
       .orderBy(desc(schema.responses.submittedAt))
-      .limit(limit)
-      .all();
+      .limit(limit);
 
-    const total = await db
+    const [total] = await db
       .select({ count: sql<number>`count(*)` })
       .from(schema.responses)
-      .where(eq(schema.responses.formId, formId))
-      .get();
+      .where(eq(schema.responses.formId, formId));
 
     return {
       responses: rows.map((r) => ({
@@ -50,7 +48,7 @@ export default defineAction({
         data: JSON.parse(r.data),
         submittedAt: r.submittedAt,
       })) as FormResponse[],
-      total: total?.count ?? 0,
+      total: (total as any)?.count ?? 0,
       fields: JSON.parse(form.fields),
     };
   },

--- a/templates/forms/actions/update-form.ts
+++ b/templates/forms/actions/update-form.ts
@@ -28,11 +28,11 @@ export default defineAction({
   }),
   run: async (args) => {
     const db = getDb();
-    const existing = await db
+    const [existing] = await db
       .select()
       .from(schema.forms)
       .where(eq(schema.forms.id, args.id))
-      .get();
+      .limit(1);
 
     if (!existing) {
       throw new Error(`Form ${args.id} not found`);
@@ -81,11 +81,11 @@ export default defineAction({
       .set(updates)
       .where(eq(schema.forms.id, args.id));
 
-    const row = await db
+    const [row] = await db
       .select()
       .from(schema.forms)
       .where(eq(schema.forms.id, args.id))
-      .get();
+      .limit(1);
 
     return {
       id: row!.id,

--- a/templates/forms/actions/view-screen.ts
+++ b/templates/forms/actions/view-screen.ts
@@ -17,17 +17,16 @@ export default defineAction({
     if (nav?.formId) {
       const db = getDb();
       try {
-        const form = await db
+        const [form] = await db
           .select()
           .from(schema.forms)
           .where(eq(schema.forms.id, nav.formId))
-          .get();
+          .limit(1);
         if (form) {
-          const responseCount = await db
+          const [responseCount] = await db
             .select({ count: sql<number>`count(*)` })
             .from(schema.responses)
-            .where(eq(schema.responses.formId, nav.formId))
-            .get();
+            .where(eq(schema.responses.formId, nav.formId));
 
           screen.form = {
             id: form.id,
@@ -50,15 +49,14 @@ export default defineAction({
     if (nav?.view === "forms" || nav?.view === "forms-list" || !nav?.formId) {
       try {
         const db = getDb();
-        const rows = await db.select().from(schema.forms).all();
+        const rows = await db.select().from(schema.forms);
         const counts = await db
           .select({
             formId: schema.responses.formId,
             count: sql<number>`count(*)`,
           })
           .from(schema.responses)
-          .groupBy(schema.responses.formId)
-          .all();
+          .groupBy(schema.responses.formId);
         const countMap = new Map(counts.map((c) => [c.formId, c.count]));
 
         screen.formsList = {
@@ -85,14 +83,12 @@ export default defineAction({
           .select()
           .from(schema.responses)
           .where(eq(schema.responses.formId, nav.formId))
-          .limit(20)
-          .all();
+          .limit(20);
 
-        const total = await db
+        const [total] = await db
           .select({ count: sql<number>`count(*)` })
           .from(schema.responses)
-          .where(eq(schema.responses.formId, nav.formId))
-          .get();
+          .where(eq(schema.responses.formId, nav.formId));
 
         screen.responses = {
           formId: nav.formId,

--- a/templates/issues/actions/create-issue.ts
+++ b/templates/issues/actions/create-issue.ts
@@ -30,7 +30,7 @@ export default defineAction({
     // Otherwise build from flat params (agent path)
     const { project, type, summary, description, priority, assignee } = args;
 
-    if (!project) throw new Error("project is required (project key)");
+    if (!project) throw new Error("project key is required");
     if (!summary) throw new Error("summary is required");
 
     const fields: Record<string, unknown> = {

--- a/templates/issues/server/plugins/auth.ts
+++ b/templates/issues/server/plugins/auth.ts
@@ -49,7 +49,7 @@ const ATLASSIAN_LOGIN_HTML = `<!DOCTYPE html>
   button:disabled { opacity: 0.5; cursor: wait; }
   .error { margin-top: 0.75rem; font-size: 0.8125rem; color: #f87171; display: none; }
   .error.show { display: block; }
-  svg { width: 18px; height: 18px; }
+  svg { width: 20px; height: 20px; }
 </style>
 </head>
 <body>
@@ -57,7 +57,7 @@ const ATLASSIAN_LOGIN_HTML = `<!DOCTYPE html>
   <h1>Sign in</h1>
   <p class="subtitle">Continue with your Atlassian account</p>
   <button id="btn" onclick="signIn()">
-    <svg viewBox="0 0 24 24" fill="none"><path d="M7.36 20.93c-.27 0-.54-.1-.73-.33a1 1 0 0 1-.1-1.07c1.1-2.23.85-3.4-1.6-7.64C3.3 8.96 2 6.86 2 4.64A1 1 0 0 1 3.05 3.7h5.38c.38 0 .72.21.89.55 2.3 4.53 3.06 6.66 3.06 10.56 0 3.29-1.65 5.47-4.1 6.03-.3.07-.6.1-.92.1ZM16.64 20.93c2.44-.56 4.1-2.74 4.1-6.03 0-3.9-.76-6.03-3.06-10.56a1 1 0 0 0-.89-.55h-5.38a1 1 0 0 0-.95 1.33c.32.9.73 1.79 1.24 2.78 1.84 3.56 2.7 5.44 2.7 8 0 1.85-.5 3.32-1.45 4.43a1 1 0 0 0 .1 1.07c.2.23.46.33.73.33.32 0 .62-.03.92-.1l1.94-.7Z" fill="#2684FF"/></svg>
+    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="atl-grad" x1="0.993" y1="0.404" x2="0.123" y2="0.971" gradientUnits="objectBoundingBox"><stop offset="0" stop-color="#0052cc"/><stop offset="1" stop-color="#2684ff"/></linearGradient></defs><path d="M3.84 23.16 14.1 3.84a1.47 1.47 0 0 0-2.57-1.41L.35 21.75A1.47 1.47 0 0 0 1.63 24h3.5a1.47 1.47 0 0 0 1.32-.84z" fill="url(#atl-grad)" transform="translate(0.5 0.5)"/><path d="M17.9 3.84 7.64 23.16a1.47 1.47 0 0 1-1.32.84h15.1A1.47 1.47 0 0 0 22.7 21.75L11.47 2.43a1.47 1.47 0 0 0-2.57 0z" fill="#2684ff" transform="translate(8.5 0.5)"/></svg>
     Sign in with Atlassian
   </button>
   <p class="error" id="err"></p>

--- a/templates/issues/server/plugins/auth.ts
+++ b/templates/issues/server/plugins/auth.ts
@@ -57,7 +57,7 @@ const ATLASSIAN_LOGIN_HTML = `<!DOCTYPE html>
   <h1>Sign in</h1>
   <p class="subtitle">Continue with your Atlassian account</p>
   <button id="btn" onclick="signIn()">
-    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="atl-grad" x1="0.993" y1="0.404" x2="0.123" y2="0.971" gradientUnits="objectBoundingBox"><stop offset="0" stop-color="#0052cc"/><stop offset="1" stop-color="#2684ff"/></linearGradient></defs><path d="M3.84 23.16 14.1 3.84a1.47 1.47 0 0 0-2.57-1.41L.35 21.75A1.47 1.47 0 0 0 1.63 24h3.5a1.47 1.47 0 0 0 1.32-.84z" fill="url(#atl-grad)" transform="translate(0.5 0.5)"/><path d="M17.9 3.84 7.64 23.16a1.47 1.47 0 0 1-1.32.84h15.1A1.47 1.47 0 0 0 22.7 21.75L11.47 2.43a1.47 1.47 0 0 0-2.57 0z" fill="#2684ff" transform="translate(8.5 0.5)"/></svg>
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="atl-g" x1="1" y1="0" x2="0.3" y2="1"><stop offset="0" stop-color="#0052cc"/><stop offset="1" stop-color="#2684ff"/></linearGradient></defs><path d="M7.12 11.084a.683.683 0 00-1.16.126L.075 22.974a.703.703 0 00.63 1.018h8.19a.678.678 0 00.63-.39c1.767-3.65.696-9.203-2.406-12.52z" fill="url(#atl-g)"/><path d="M11.434.386a15.515 15.515 0 00-.906 15.317l3.95 7.9a.703.703 0 00.628.388h8.19a.703.703 0 00.63-1.017L12.63.38a.664.664 0 00-1.196.006z" fill="#2684ff"/></svg>
     Sign in with Atlassian
   </button>
   <p class="error" id="err"></p>

--- a/templates/macros/server/plugins/auth.ts
+++ b/templates/macros/server/plugins/auth.ts
@@ -7,10 +7,11 @@
 import {
   createAuthPlugin,
   addSession,
+  getSessionEmail,
   getH3App,
   readBody,
 } from "@agent-native/core/server";
-import { defineEventHandler } from "h3";
+import { defineEventHandler, getCookie } from "h3";
 import { createClient } from "@supabase/supabase-js";
 
 let _supabase: ReturnType<typeof createClient> | null = null;
@@ -117,5 +118,18 @@ export default (nitroApp: any) => {
     }),
   );
 
-  return createAuthPlugin({ loginHtml: LOGIN_HTML })(nitroApp);
+  return createAuthPlugin({
+    loginHtml: LOGIN_HTML,
+    // Resolve sessions from the framework's legacy session table, where
+    // supabase-login stores them via addSession(). Providing a custom
+    // getSession marks this template as BYOA — the framework will not
+    // silently bypass auth in dev mode.
+    getSession: async (event) => {
+      const cookie = getCookie(event, "an_session");
+      if (!cookie) return null;
+      const email = await getSessionEmail(cookie);
+      if (!email) return null;
+      return { email, token: cookie };
+    },
+  })(nitroApp);
 };

--- a/templates/mail/actions/send-email.ts
+++ b/templates/mail/actions/send-email.ts
@@ -181,11 +181,10 @@ async function readSettings(): Promise<{ name: string; email: string }> {
 export default defineAction({
   description: "Send an email via Gmail.",
   schema: z.object({
-    to: z.string().optional().describe("Recipient email(s), comma-separated"),
-    subject: z.string().optional().describe("Email subject"),
+    to: z.string().describe("Recipient email(s), comma-separated"),
+    subject: z.string().describe("Email subject"),
     body: z
       .string()
-      .optional()
       .describe(
         "Email body in markdown. Use [text](url) for links, **bold**, *italic*, - lists, etc.",
       ),
@@ -201,10 +200,6 @@ export default defineAction({
       .describe("Specific account email to send from"),
   }),
   run: async (args) => {
-    if (!args.to) return "Error: --to is required";
-    if (!args.subject) return "Error: --subject is required";
-    if (!args.body) return "Error: --body is required";
-
     const settings = await readSettings();
     const accounts = await getAccessTokens();
     if (accounts.length === 0) return "Error: No Google account connected.";

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useMemo,
   forwardRef,
+  Fragment,
 } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
 import { cn, formatEmailDate, formatFileSize } from "@/lib/utils";
@@ -1027,46 +1028,100 @@ export function EmailThread({
             const isExpanded = expandedIds.has(msg.id);
             const isFocused = idx === focusedIndex;
             const isLast = idx === messages.length - 1;
-            return isExpanded ? (
-              <ExpandedMessageCard
-                key={msg.id}
-                ref={(el) => {
-                  if (isFocused)
-                    (
-                      focusedRef as React.MutableRefObject<HTMLDivElement | null>
-                    ).current = el;
-                  if (isLast) lastMessageRef.current = el;
-                }}
-                email={msg}
-                isFocused={isFocused}
-                onCollapse={() => {
-                  setUserToggles((prev) => ({ ...prev, [msg.id]: false }));
-                }}
-                onReply={() => handleReply(msg)}
-                onReplyAll={() => handleReplyAll(msg)}
-                onForward={() => handleForwardMsg(msg)}
-                onFocus={() => setFocusedIndex(idx)}
-                onContactSelect={onContactSelect}
-                searchTerm={searchQuery.trim() || undefined}
-                activeLocalIdx={getActiveLocalIdx(msg.id)}
-              />
-            ) : (
-              <CollapsedMessageRow
-                key={msg.id}
-                ref={(el) => {
-                  if (isFocused)
-                    (
-                      focusedRef as React.MutableRefObject<HTMLDivElement | null>
-                    ).current = el;
-                  if (isLast) lastMessageRef.current = el;
-                }}
-                email={msg}
-                isFocused={isFocused}
-                onClick={() => {
-                  setFocusedIndex(idx);
-                  setUserToggles((prev) => ({ ...prev, [msg.id]: true }));
-                }}
-              />
+            const showComposerAfter = inlineDraft?.replyToId === msg.id;
+            return (
+              <Fragment key={msg.id}>
+                {isExpanded ? (
+                  <ExpandedMessageCard
+                    ref={(el) => {
+                      if (isFocused)
+                        (
+                          focusedRef as React.MutableRefObject<HTMLDivElement | null>
+                        ).current = el;
+                      if (isLast) lastMessageRef.current = el;
+                    }}
+                    email={msg}
+                    isFocused={isFocused}
+                    onCollapse={() => {
+                      setUserToggles((prev) => ({ ...prev, [msg.id]: false }));
+                    }}
+                    onReply={() => handleReply(msg)}
+                    onReplyAll={() => handleReplyAll(msg)}
+                    onForward={() => handleForwardMsg(msg)}
+                    onFocus={() => setFocusedIndex(idx)}
+                    onContactSelect={onContactSelect}
+                    searchTerm={searchQuery.trim() || undefined}
+                    activeLocalIdx={getActiveLocalIdx(msg.id)}
+                  />
+                ) : (
+                  <CollapsedMessageRow
+                    ref={(el) => {
+                      if (isFocused)
+                        (
+                          focusedRef as React.MutableRefObject<HTMLDivElement | null>
+                        ).current = el;
+                      if (isLast) lastMessageRef.current = el;
+                    }}
+                    email={msg}
+                    isFocused={isFocused}
+                    onClick={() => {
+                      setFocusedIndex(idx);
+                      setUserToggles((prev) => ({ ...prev, [msg.id]: true }));
+                    }}
+                  />
+                )}
+                {showComposerAfter && (
+                  <div className="mt-3">
+                    <InlineReplyComposer
+                      ref={inlineReplyRef}
+                      draft={inlineDraft}
+                      messages={messages}
+                      onUpdate={compose.update}
+                      onDiscard={compose.discard}
+                      onClose={(id) => {
+                        const drafts = compose.drafts ?? [];
+                        const draft = drafts.find((d: any) => d.id === id);
+                        const hasContent = !!(
+                          draft?.to?.trim() ||
+                          draft?.subject?.trim() ||
+                          draft?.body?.trim()
+                        );
+                        const snapshot = draft ? { ...draft } : null;
+                        compose.close(id);
+                        if (hasContent && snapshot) {
+                          toast("Draft saved.", {
+                            action: {
+                              label: "REOPEN",
+                              onClick: () => {
+                                const { id: _id, ...reopenData } = snapshot;
+                                compose.open({ ...reopenData, inline: true });
+                              },
+                            },
+                            cancel: {
+                              label: "DELETE DRAFT",
+                              onClick: () => {
+                                if (snapshot.savedDraftId) {
+                                  fetch(
+                                    `/api/emails/${snapshot.savedDraftId}`,
+                                    {
+                                      method: "DELETE",
+                                    },
+                                  );
+                                }
+                              },
+                            },
+                          });
+                        }
+                      }}
+                      onPopOut={(id) => compose.update(id, { inline: false })}
+                      onFlush={compose.flush}
+                      onReopen={(state) =>
+                        compose.open({ ...state, inline: true })
+                      }
+                    />
+                  </div>
+                )}
+              </Fragment>
             );
           })}
 
@@ -1077,53 +1132,57 @@ export function EmailThread({
             </>
           )}
 
-          {/* Inline reply composer */}
-          {inlineDraft ? (
-            <div className="mt-3">
-              <InlineReplyComposer
-                ref={inlineReplyRef}
-                draft={inlineDraft}
-                messages={messages}
-                onUpdate={compose.update}
-                onDiscard={compose.discard}
-                onClose={(id) => {
-                  const drafts = compose.drafts ?? [];
-                  const draft = drafts.find((d: any) => d.id === id);
-                  const hasContent = !!(
-                    draft?.to?.trim() ||
-                    draft?.subject?.trim() ||
-                    draft?.body?.trim()
-                  );
-                  const snapshot = draft ? { ...draft } : null;
-                  compose.close(id);
-                  if (hasContent && snapshot) {
-                    toast("Draft saved.", {
-                      action: {
-                        label: "REOPEN",
-                        onClick: () => {
-                          const { id: _id, ...reopenData } = snapshot;
-                          compose.open({ ...reopenData, inline: true });
+          {/* Inline reply composer fallback (replyToId not matched) */}
+          {inlineDraft &&
+            !messages.some((m) => m.id === inlineDraft.replyToId) && (
+              <div className="mt-3">
+                <InlineReplyComposer
+                  ref={inlineReplyRef}
+                  draft={inlineDraft}
+                  messages={messages}
+                  onUpdate={compose.update}
+                  onDiscard={compose.discard}
+                  onClose={(id) => {
+                    const drafts = compose.drafts ?? [];
+                    const draft = drafts.find((d: any) => d.id === id);
+                    const hasContent = !!(
+                      draft?.to?.trim() ||
+                      draft?.subject?.trim() ||
+                      draft?.body?.trim()
+                    );
+                    const snapshot = draft ? { ...draft } : null;
+                    compose.close(id);
+                    if (hasContent && snapshot) {
+                      toast("Draft saved.", {
+                        action: {
+                          label: "REOPEN",
+                          onClick: () => {
+                            const { id: _id, ...reopenData } = snapshot;
+                            compose.open({ ...reopenData, inline: true });
+                          },
                         },
-                      },
-                      cancel: {
-                        label: "DELETE DRAFT",
-                        onClick: () => {
-                          if (snapshot.savedDraftId) {
-                            fetch(`/api/emails/${snapshot.savedDraftId}`, {
-                              method: "DELETE",
-                            });
-                          }
+                        cancel: {
+                          label: "DELETE DRAFT",
+                          onClick: () => {
+                            if (snapshot.savedDraftId) {
+                              fetch(`/api/emails/${snapshot.savedDraftId}`, {
+                                method: "DELETE",
+                              });
+                            }
+                          },
                         },
-                      },
-                    });
-                  }
-                }}
-                onPopOut={(id) => compose.update(id, { inline: false })}
-                onFlush={compose.flush}
-                onReopen={(state) => compose.open({ ...state, inline: true })}
-              />
-            </div>
-          ) : (
+                      });
+                    }
+                  }}
+                  onPopOut={(id) => compose.update(id, { inline: false })}
+                  onFlush={compose.flush}
+                  onReopen={(state) => compose.open({ ...state, inline: true })}
+                />
+              </div>
+            )}
+
+          {/* Reply prompt when no draft open */}
+          {!inlineDraft && (
             <div
               className="flex items-center rounded-lg bg-accent/40 px-4 py-3 sm:py-2.5 cursor-text hover:bg-accent/60 transition-colors mt-3"
               onClick={() => handleReply()}

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -57,10 +57,7 @@ function AutoFocus() {
     document.addEventListener("visibilitychange", handleVisibility);
     document.addEventListener("click", handleFocusRestore, true);
     // Restore focus when cursor re-enters the app (e.g. after using the agent chat panel)
-    document.documentElement.addEventListener(
-      "mouseenter",
-      handleFocusRestore,
-    );
+    document.documentElement.addEventListener("mouseenter", handleFocusRestore);
     return () => {
       document.removeEventListener("visibilitychange", handleVisibility);
       document.removeEventListener("click", handleFocusRestore, true);

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -53,12 +53,21 @@ function AutoFocus() {
     const handleVisibility = () => {
       if (document.visibilityState === "visible") window.focus();
     };
+    const handleFocusRestore = () => window.focus();
     document.addEventListener("visibilitychange", handleVisibility);
-    const handleClick = () => window.focus();
-    document.addEventListener("click", handleClick, true);
+    document.addEventListener("click", handleFocusRestore, true);
+    // Restore focus when cursor re-enters the app (e.g. after using the agent chat panel)
+    document.documentElement.addEventListener(
+      "mouseenter",
+      handleFocusRestore,
+    );
     return () => {
       document.removeEventListener("visibilitychange", handleVisibility);
-      document.removeEventListener("click", handleClick, true);
+      document.removeEventListener("click", handleFocusRestore, true);
+      document.documentElement.removeEventListener(
+        "mouseenter",
+        handleFocusRestore,
+      );
     };
   }, []);
   return null;

--- a/templates/slides/actions/generate-slides-ai.ts
+++ b/templates/slides/actions/generate-slides-ai.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 export default defineAction({
   description: "Generate slide deck content using Gemini AI.",
   schema: z.object({
-    topic: z.string().optional().describe("Presentation topic (required)"),
+    topic: z.string().describe("Presentation topic"),
     slideCount: z.coerce
       .number()
       .optional()
@@ -27,10 +27,6 @@ export default defineAction({
     }
 
     const topic = args.topic;
-    if (!topic?.trim()) {
-      throw new Error("Topic is required");
-    }
-
     const slideCount = args.slideCount ?? 8;
     const style = args.style;
     const includeImages = args.includeImages !== false;

--- a/templates/slides/app/components/editor/SlideBubbleMenu.tsx
+++ b/templates/slides/app/components/editor/SlideBubbleMenu.tsx
@@ -1,0 +1,197 @@
+import { BubbleMenu } from "@tiptap/react/menus";
+import type { Editor } from "@tiptap/react";
+import {
+  IconBold,
+  IconItalic,
+  IconStrikethrough,
+  IconCode,
+  IconLink,
+  IconH1,
+  IconH2,
+  IconH3,
+  IconList,
+  IconListNumbers,
+} from "@tabler/icons-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyIcon = React.ComponentType<any>;
+
+interface ButtonItem {
+  type?: never;
+  icon: AnyIcon;
+  title: string;
+  action: () => void;
+  isActive: () => boolean;
+}
+
+interface DividerItem {
+  type: "divider";
+  icon?: never;
+}
+
+interface SlideBubbleMenuProps {
+  editor: Editor;
+}
+
+export function SlideBubbleMenu({ editor }: SlideBubbleMenuProps) {
+  const [showLinkInput, setShowLinkInput] = useState(false);
+  const [linkUrl, setLinkUrl] = useState("");
+
+  const handleSetLink = () => {
+    if (linkUrl.trim()) {
+      editor
+        .chain()
+        .focus()
+        .extendMarkRange("link")
+        .setLink({ href: linkUrl.trim() })
+        .run();
+    } else {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+    }
+    setShowLinkInput(false);
+    setLinkUrl("");
+  };
+
+  const toggleLink = () => {
+    if (editor.isActive("link")) {
+      editor.chain().focus().unsetLink().run();
+      return;
+    }
+    const previousUrl = editor.getAttributes("link").href || "";
+    setLinkUrl(previousUrl);
+    setShowLinkInput(true);
+  };
+
+  const buttons: (ButtonItem | DividerItem)[] = [
+    {
+      icon: IconBold,
+      title: "Bold",
+      action: () => editor.chain().focus().toggleBold().run(),
+      isActive: () => editor.isActive("bold"),
+    },
+    {
+      icon: IconItalic,
+      title: "Italic",
+      action: () => editor.chain().focus().toggleItalic().run(),
+      isActive: () => editor.isActive("italic"),
+    },
+    {
+      icon: IconStrikethrough,
+      title: "Strikethrough",
+      action: () => editor.chain().focus().toggleStrike().run(),
+      isActive: () => editor.isActive("strike"),
+    },
+    {
+      icon: IconCode,
+      title: "Code",
+      action: () => editor.chain().focus().toggleCode().run(),
+      isActive: () => editor.isActive("code"),
+    },
+    { type: "divider" },
+    {
+      icon: IconH1,
+      title: "Heading 1",
+      action: () => editor.chain().focus().toggleHeading({ level: 1 }).run(),
+      isActive: () => editor.isActive("heading", { level: 1 }),
+    },
+    {
+      icon: IconH2,
+      title: "Heading 2",
+      action: () => editor.chain().focus().toggleHeading({ level: 2 }).run(),
+      isActive: () => editor.isActive("heading", { level: 2 }),
+    },
+    {
+      icon: IconH3,
+      title: "Heading 3",
+      action: () => editor.chain().focus().toggleHeading({ level: 3 }).run(),
+      isActive: () => editor.isActive("heading", { level: 3 }),
+    },
+    { type: "divider" },
+    {
+      icon: IconList,
+      title: "Bullet List",
+      action: () => editor.chain().focus().toggleBulletList().run(),
+      isActive: () => editor.isActive("bulletList"),
+    },
+    {
+      icon: IconListNumbers,
+      title: "Ordered List",
+      action: () => editor.chain().focus().toggleOrderedList().run(),
+      isActive: () => editor.isActive("orderedList"),
+    },
+    { type: "divider" },
+    {
+      icon: IconLink,
+      title: "Link",
+      action: toggleLink,
+      isActive: () => editor.isActive("link"),
+    },
+  ];
+
+  return (
+    <BubbleMenu editor={editor}>
+      <div className="flex items-center gap-0.5 px-1.5 py-1 rounded-lg bg-[#1c1c1c] border border-white/10 shadow-xl">
+        {showLinkInput ? (
+          <div className="flex items-center gap-1.5 px-1">
+            <input
+              type="url"
+              value={linkUrl}
+              onChange={(e) => setLinkUrl(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSetLink();
+                if (e.key === "Escape") {
+                  setShowLinkInput(false);
+                  setLinkUrl("");
+                }
+              }}
+              placeholder="Paste URL..."
+              className="w-48 bg-transparent text-white text-sm outline-none placeholder-white/30 border-b border-white/20 pb-0.5"
+              autoFocus
+            />
+            <button
+              onClick={handleSetLink}
+              className="text-xs text-[#609FF8] hover:text-[#7AB2FA] font-medium"
+            >
+              Apply
+            </button>
+            <button
+              onClick={() => {
+                setShowLinkInput(false);
+                setLinkUrl("");
+              }}
+              className="text-xs text-white/50 hover:text-white/80"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          buttons.map((item, i) => {
+            if (item.type === "divider") {
+              return <div key={i} className="w-px h-4 bg-white/15 mx-0.5" />;
+            }
+            const btn = item as ButtonItem;
+            const Icon = btn.icon;
+            const active = btn.isActive() ?? false;
+            return (
+              <button
+                key={i}
+                title={btn.title}
+                onClick={btn.action}
+                className={cn(
+                  "p-1.5 rounded",
+                  active
+                    ? "bg-white/20 text-white"
+                    : "text-white/70 hover:text-white hover:bg-white/10",
+                )}
+              >
+                <Icon size={14} stroke={2} />
+              </button>
+            );
+          })
+        )}
+      </div>
+    </BubbleMenu>
+  );
+}

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -13,6 +13,7 @@ import SlideRenderer from "@/components/deck/SlideRenderer";
 import CodeEditor from "./CodeEditor";
 import ImageOverlay from "./ImageOverlay";
 import { ExcalidrawSlide } from "@/components/deck/ExcalidrawSlide";
+import { SlideInlineEditor } from "./SlideInlineEditor";
 
 let builderIdCounter = 0;
 
@@ -77,6 +78,7 @@ export default function SlideEditor({
   onLogoSearch,
   onToggleObjectFit,
 }: SlideEditorProps) {
+  const [isEditing, setIsEditing] = useState(false);
   const [imageOverlay, setImageOverlay] = useState<{
     rect: DOMRect;
     src: string;
@@ -85,6 +87,21 @@ export default function SlideEditor({
   const [selectedImg, setSelectedImg] = useState<HTMLImageElement | null>(null);
   const [selectionRect, setSelectionRect] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  // Exit edit mode when switching slides
+  useEffect(() => {
+    setIsEditing(false);
+  }, [slide.id]);
+
+  // Exit edit mode on Escape key
+  useEffect(() => {
+    if (!isEditing) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsEditing(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isEditing]);
 
   // Keep selection rect in sync with the element (scroll, resize)
   useEffect(() => {
@@ -220,16 +237,8 @@ export default function SlideEditor({
         return;
       }
 
-      // For text elements, enter text editing mode
-      const selector = getBuilderSelector(target);
-      if (selector) {
-        console.log(
-          "[SlideEditor] dblclick text selector:",
-          selector,
-          document.querySelector(selector),
-        );
-        enterSelectionMode("builder.enterTextEditing", { selector });
-      }
+      // Enter inline text editing mode
+      setIsEditing(true);
     },
     [showImageOverlay],
   );
@@ -246,18 +255,43 @@ export default function SlideEditor({
               />
             </div>
           ) : (
-            <div className="h-full flex items-center justify-center p-2 sm:p-4 md:p-8 bg-[hsl(240,5%,5%)]">
-              <div
-                ref={containerRef}
-                className="w-full max-w-4xl slide-image-clickable"
-                onClick={handleSlideClick}
-                onContextMenu={handleSlideContextMenu}
-                onDoubleClick={handleSlideDoubleClick}
-              >
-                <SlideRenderer
-                  slide={slide}
-                  className="shadow-2xl shadow-black/40"
-                />
+            <div
+              className="h-full flex items-center justify-center p-2 sm:p-4 md:p-8 bg-[hsl(240,5%,5%)]"
+              onMouseDown={(e) => {
+                // Click outside the slide canvas → exit edit mode
+                if (
+                  isEditing &&
+                  containerRef.current &&
+                  !containerRef.current.contains(e.target as Node)
+                ) {
+                  setIsEditing(false);
+                }
+              }}
+            >
+              <div ref={containerRef} className="w-full max-w-4xl">
+                {isEditing ? (
+                  <SlideInlineEditor
+                    slide={slide}
+                    onContentChange={(html) => onUpdateSlide({ content: html })}
+                    onExitEdit={() => setIsEditing(false)}
+                  />
+                ) : (
+                  <div
+                    className="slide-image-clickable"
+                    onClick={handleSlideClick}
+                    onContextMenu={handleSlideContextMenu}
+                    onDoubleClick={handleSlideDoubleClick}
+                  >
+                    <SlideRenderer
+                      slide={slide}
+                      className="shadow-2xl shadow-black/40"
+                    />
+                    {/* Double-click hint */}
+                    <div className="absolute bottom-2 left-1/2 -translate-x-1/2 text-xs text-white/20 pointer-events-none select-none opacity-0 group-hover:opacity-100">
+                      Double-click to edit text
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
           )

--- a/templates/slides/app/components/editor/SlideInlineEditor.tsx
+++ b/templates/slides/app/components/editor/SlideInlineEditor.tsx
@@ -1,0 +1,245 @@
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
+import Link from "@tiptap/extension-link";
+import { useEffect, useRef, useCallback } from "react";
+import type { Slide } from "@/context/DeckContext";
+import { SlideBubbleMenu } from "./SlideBubbleMenu";
+import {
+  SlashCommandExtension,
+  SlashMenuUI,
+  useSlashMenu,
+} from "./SlideSlashMenu";
+
+interface SlideInlineEditorProps {
+  slide: Slide;
+  onContentChange: (html: string) => void;
+  onExitEdit: () => void;
+}
+
+/** Resolve bg class / style from slide.background */
+function resolveBackground(bg?: string): {
+  bgClass: string;
+  bgStyle?: React.CSSProperties;
+} {
+  if (!bg) return { bgClass: "bg-[#000000]" };
+  if (bg.startsWith("bg-")) return { bgClass: bg };
+  return { bgClass: "", bgStyle: { background: bg } };
+}
+
+/**
+ * Strip fmd-slide wrapper and extract inner HTML for TipTap.
+ * TipTap can parse the inner HTML and preserve text / basic structure.
+ */
+function extractEditableContent(content: string): string {
+  if (!content) return "";
+
+  // If it's fmd-slide HTML, extract inner content
+  if (content.includes('class="fmd-slide"')) {
+    // Parse with DOMParser to get the inner HTML
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(content, "text/html");
+    const fmdSlide = doc.querySelector(".fmd-slide");
+    if (fmdSlide) {
+      // Convert divs with text to paragraphs so TipTap parses them correctly
+      const result = convertDivsToBlocks(fmdSlide);
+      return result;
+    }
+  }
+
+  return content;
+}
+
+/** Recursively convert div structure to TipTap-friendly HTML */
+function convertDivsToBlocks(el: Element): string {
+  const children = Array.from(el.children);
+  if (children.length === 0) {
+    // Leaf text node — wrap in <p>
+    const text = el.textContent?.trim();
+    if (!text) return "";
+
+    // Detect heading-like elements by font-size
+    const style = (el as HTMLElement).style;
+    const fontSize = parseFloat(style.fontSize || "0");
+    if (fontSize >= 40) return `<h1>${text}</h1>`;
+    if (fontSize >= 28) return `<h2>${text}</h2>`;
+    if (fontSize >= 20) return `<h3>${text}</h3>`;
+    return `<p>${text}</p>`;
+  }
+
+  // Container div — check if it looks like a list
+  const isListContainer = children.every(
+    (c) =>
+      c.tagName === "DIV" &&
+      (c as HTMLElement).style.display === "flex" &&
+      c.textContent?.includes("●"),
+  );
+
+  if (isListContainer) {
+    const items = children
+      .map((c) => {
+        // Strip the bullet span, keep the text span
+        const spans = Array.from(c.querySelectorAll("span"));
+        const textSpan = spans.find((s) => !s.textContent?.includes("●"));
+        return textSpan ? `<li>${textSpan.textContent?.trim()}</li>` : "";
+      })
+      .filter(Boolean)
+      .join("");
+    return `<ul>${items}</ul>`;
+  }
+
+  // Recurse into children
+  return children.map((c) => convertDivsToBlocks(c)).join("");
+}
+
+export function SlideInlineEditor({
+  slide,
+  onContentChange,
+  onExitEdit,
+}: SlideInlineEditorProps) {
+  const { bgClass, bgStyle } = resolveBackground(slide.background);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const initialContent = extractEditableContent(slide.content);
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Placeholder.configure({
+        placeholder: "Start typing… or press / for commands",
+      }),
+      Link.configure({
+        openOnClick: false,
+        HTMLAttributes: {
+          class: "text-[#00E5FF] underline",
+        },
+      }),
+      SlashCommandExtension,
+    ],
+    content: initialContent || "<p></p>",
+    autofocus: "end",
+    onUpdate: ({ editor }) => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => {
+        onContentChange(editor.getHTML());
+      }, 300);
+    },
+  });
+
+  const { menuPosition, query, menuRef, closeMenu, executeCommand } =
+    useSlashMenu(editor);
+
+  // Flush any pending save on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        if (editor && !editor.isDestroyed) {
+          onContentChange(editor.getHTML());
+        }
+      }
+    };
+  }, [editor, onContentChange]);
+
+  // Escape key → exit
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onExitEdit();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onExitEdit]);
+
+  return (
+    <div
+      className={`w-full aspect-video rounded-lg overflow-hidden relative shadow-2xl shadow-black/40 ring-2 ring-[#609FF8] ${bgClass}`}
+      style={bgStyle}
+    >
+      {/* Scale the editor canvas to 960x540 just like SlideRenderer */}
+      <div
+        className="absolute top-0 left-0 origin-top-left"
+        style={{
+          width: 960,
+          height: 540,
+          transform: "scale(var(--slide-scale, 0.25))",
+        }}
+      >
+        <SlideEditorCanvas editor={editor} slide={slide} />
+      </div>
+      {/* ScaleHelper mirrors SlideRenderer's ScaleHelper */}
+      <ScaleHelper targetWidth={960} />
+
+      {/* Bubble menu & slash menu live outside the scaled canvas so they render at screen scale */}
+      {editor && <SlideBubbleMenu editor={editor} />}
+      <SlashMenuUI
+        ref={menuRef}
+        editor={editor!}
+        position={menuPosition}
+        query={query}
+        onClose={closeMenu}
+        onCommand={executeCommand}
+      />
+    </div>
+  );
+}
+
+/** The 960x540 TipTap editor canvas, styled like a slide */
+function SlideEditorCanvas({
+  editor,
+  slide,
+}: {
+  editor: ReturnType<typeof useEditor>;
+  slide: Slide;
+}) {
+  const layoutPadding: Record<string, string> = {
+    title: "px-[110px] py-[80px]",
+    content: "px-[110px] py-[80px]",
+    "two-column": "px-[70px] py-[50px]",
+    section: "px-[110px] py-[80px]",
+    statement: "px-[110px] py-[60px]",
+    image: "px-[80px] py-[60px]",
+    "full-image": "p-0",
+    blank: "p-8",
+  };
+
+  const padding = layoutPadding[slide.layout] ?? "px-[110px] py-[80px]";
+
+  return (
+    <div
+      className={`w-[960px] h-[540px] relative flex flex-col justify-center ${padding}`}
+      style={{ fontFamily: "'Poppins', sans-serif" }}
+    >
+      <EditorContent
+        editor={editor}
+        className="slide-tiptap-editor w-full h-full overflow-hidden focus:outline-none"
+      />
+    </div>
+  );
+}
+
+/** Mirrors SlideRenderer's ScaleHelper */
+function ScaleHelper({ targetWidth = 960 }: { targetWidth?: number }) {
+  return (
+    <div
+      className="absolute inset-0 pointer-events-none"
+      ref={(el) => {
+        if (!el) return;
+        const parent = el.parentElement;
+        if (!parent) return;
+
+        const updateScale = () => {
+          const w = parent.offsetWidth;
+          parent.style.setProperty("--slide-scale", String(w / targetWidth));
+        };
+        updateScale();
+
+        const observer = new ResizeObserver(updateScale);
+        observer.observe(parent);
+        (el as any).__cleanup = () => observer.disconnect();
+      }}
+    />
+  );
+}

--- a/templates/slides/app/components/editor/SlideSlashMenu.tsx
+++ b/templates/slides/app/components/editor/SlideSlashMenu.tsx
@@ -1,0 +1,346 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { createPortal } from "react-dom";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
+import type { Editor } from "@tiptap/react";
+import {
+  IconH1,
+  IconH2,
+  IconH3,
+  IconList,
+  IconListNumbers,
+  IconBlockquote,
+  IconLetterT,
+} from "@tabler/icons-react";
+import { cn } from "@/lib/utils";
+
+const SLASH_MENU_KEY = new PluginKey("slideSlashMenu");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyIcon = React.ComponentType<any>;
+
+interface SlashCommand {
+  title: string;
+  description: string;
+  icon: AnyIcon;
+  command: (editor: Editor) => void;
+}
+
+const SLASH_COMMANDS: SlashCommand[] = [
+  {
+    title: "Text",
+    description: "Plain paragraph",
+    icon: IconLetterT,
+    command: (editor) => editor.chain().focus().setParagraph().run(),
+  },
+  {
+    title: "Heading 1",
+    description: "Large slide heading",
+    icon: IconH1,
+    command: (editor) =>
+      editor.chain().focus().toggleHeading({ level: 1 }).run(),
+  },
+  {
+    title: "Heading 2",
+    description: "Medium heading",
+    icon: IconH2,
+    command: (editor) =>
+      editor.chain().focus().toggleHeading({ level: 2 }).run(),
+  },
+  {
+    title: "Heading 3",
+    description: "Small heading",
+    icon: IconH3,
+    command: (editor) =>
+      editor.chain().focus().toggleHeading({ level: 3 }).run(),
+  },
+  {
+    title: "Bullet List",
+    description: "Unordered list",
+    icon: IconList,
+    command: (editor) => editor.chain().focus().toggleBulletList().run(),
+  },
+  {
+    title: "Numbered List",
+    description: "Ordered list",
+    icon: IconListNumbers,
+    command: (editor) => editor.chain().focus().toggleOrderedList().run(),
+  },
+  {
+    title: "Quote",
+    description: "Blockquote",
+    icon: IconBlockquote,
+    command: (editor) => editor.chain().focus().toggleBlockquote().run(),
+  },
+];
+
+interface SlashMenuUIProps {
+  editor: Editor;
+  position: { x: number; y: number } | null;
+  query: string;
+  onClose: () => void;
+  onCommand: (cmd: SlashCommand) => void;
+}
+
+export const SlashMenuUI = forwardRef<
+  { moveUp: () => void; moveDown: () => void; select: () => void },
+  SlashMenuUIProps
+>(({ editor, position, query, onClose, onCommand }, ref) => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const filtered = SLASH_COMMANDS.filter(
+    (cmd) =>
+      !query ||
+      cmd.title.toLowerCase().includes(query.toLowerCase()) ||
+      cmd.description.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  useImperativeHandle(ref, () => ({
+    moveUp: () =>
+      setSelectedIndex((i) => (i <= 0 ? filtered.length - 1 : i - 1)),
+    moveDown: () =>
+      setSelectedIndex((i) => (i >= filtered.length - 1 ? 0 : i + 1)),
+    select: () => {
+      const cmd = filtered[selectedIndex];
+      if (cmd) onCommand(cmd);
+    },
+  }));
+
+  // Reset selection when filter changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  if (!position || filtered.length === 0) return null;
+
+  return createPortal(
+    <div
+      className="fixed z-[9999] w-60 rounded-lg bg-[#1c1c1c] border border-white/10 shadow-2xl overflow-hidden py-1"
+      style={{ top: position.y, left: position.x }}
+    >
+      <div className="px-2 py-1 text-[10px] font-semibold text-white/30 uppercase tracking-widest">
+        Blocks
+      </div>
+      {filtered.map((cmd, i) => {
+        const Icon = cmd.icon;
+        return (
+          <button
+            key={cmd.title}
+            className={cn(
+              "w-full flex items-center gap-3 px-3 py-2 text-left",
+              i === selectedIndex
+                ? "bg-white/10 text-white"
+                : "text-white/70 hover:bg-white/5 hover:text-white",
+            )}
+            onMouseEnter={() => setSelectedIndex(i)}
+            onClick={() => onCommand(cmd)}
+          >
+            <div className="w-7 h-7 rounded flex items-center justify-center bg-white/5 shrink-0">
+              <Icon size={14} stroke={2} />
+            </div>
+            <div>
+              <div className="text-sm font-medium leading-tight">
+                {cmd.title}
+              </div>
+              <div className="text-xs text-white/40 leading-tight">
+                {cmd.description}
+              </div>
+            </div>
+          </button>
+        );
+      })}
+    </div>,
+    document.body,
+  );
+});
+
+SlashMenuUI.displayName = "SlashMenuUI";
+
+/**
+ * TipTap extension that fires a custom event when the user types / at the
+ * start of a block so the host component can show a slash command menu.
+ */
+export const SlashCommandExtension = Extension.create({
+  name: "slideSlashCommand",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: SLASH_MENU_KEY,
+        props: {
+          handleKeyDown: (view, event) => {
+            // Let the host component's keydown listener handle navigation
+            if (
+              event.key === "ArrowUp" ||
+              event.key === "ArrowDown" ||
+              event.key === "Enter" ||
+              event.key === "Escape"
+            ) {
+              // Dispatch so the React component can intercept
+              const customEvent = new CustomEvent("slide-slash-nav", {
+                detail: { key: event.key },
+                bubbles: true,
+              });
+              view.dom.dispatchEvent(customEvent);
+
+              // If the menu is open, swallow Arrow/Enter/Escape
+              const isOpen = (view.dom as any).__slashMenuOpen;
+              if (isOpen) return true;
+            }
+            return false;
+          },
+        },
+      }),
+    ];
+  },
+});
+
+/** Hook that manages slash command state for a TipTap editor */
+export function useSlashMenu(editor: Editor | null) {
+  const [menuPosition, setMenuPosition] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+  const [query, setQuery] = useState("");
+  const menuRef = useRef<{
+    moveUp: () => void;
+    moveDown: () => void;
+    select: () => void;
+  }>(null);
+  const slashPosRef = useRef<number | null>(null);
+
+  const closeMenu = useCallback(() => {
+    setMenuPosition(null);
+    setQuery("");
+    slashPosRef.current = null;
+    if (editor?.view?.dom) {
+      (editor.view.dom as any).__slashMenuOpen = false;
+    }
+  }, [editor]);
+
+  const executeCommand = useCallback(
+    (cmd: SlashCommand) => {
+      if (!editor) return;
+      closeMenu();
+
+      // Delete the slash + any query text typed
+      const { from } = editor.state.selection;
+      const slashPos = slashPosRef.current;
+      if (slashPos !== null) {
+        editor.chain().focus().deleteRange({ from: slashPos, to: from }).run();
+      }
+
+      cmd.command(editor);
+    },
+    [editor, closeMenu],
+  );
+
+  useEffect(() => {
+    if (!editor) return;
+
+    const onUpdate = () => {
+      const { state } = editor;
+      const { selection } = state;
+      const { $from } = selection;
+
+      // Get text from start of block to cursor
+      const textBefore = $from.parent.textBetween(0, $from.parentOffset, "\n");
+
+      // Find slash position
+      const slashIndex = textBefore.lastIndexOf("/");
+      if (slashIndex === -1) {
+        if (menuPosition) closeMenu();
+        return;
+      }
+
+      // Only trigger if slash is recent (within 20 chars of end) and nothing before it except whitespace
+      const beforeSlash = textBefore.slice(0, slashIndex);
+      if (beforeSlash.trim().length > 0) {
+        if (menuPosition) closeMenu();
+        return;
+      }
+
+      const q = textBefore.slice(slashIndex + 1);
+      // Don't show menu if query has spaces
+      if (q.includes(" ")) {
+        if (menuPosition) closeMenu();
+        return;
+      }
+
+      setQuery(q);
+
+      // Calculate menu position from the slash character position
+      const slashAbsPos = $from.pos - $from.parentOffset + slashIndex;
+      slashPosRef.current = slashAbsPos;
+
+      // Get DOM position of the slash character
+      try {
+        const coords = editor.view.coordsAtPos(slashAbsPos + 1);
+        const editorRect = editor.view.dom.getBoundingClientRect();
+
+        // Position below the line
+        setMenuPosition({
+          x: Math.min(coords.left, window.innerWidth - 260),
+          y: Math.min(coords.bottom + 4, window.innerHeight - 300),
+        });
+        (editor.view.dom as any).__slashMenuOpen = true;
+      } catch {
+        // coordsAtPos can fail if position is out of range
+      }
+    };
+
+    editor.on("update", onUpdate);
+    return () => {
+      editor.off("update", onUpdate);
+    };
+  }, [editor, menuPosition, closeMenu]);
+
+  // Handle keyboard navigation when menu is open
+  useEffect(() => {
+    if (!editor?.view?.dom) return;
+    const dom = editor.view.dom;
+
+    const onNav = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (!menuPosition) return;
+
+      if (detail.key === "ArrowUp") {
+        e.preventDefault();
+        menuRef.current?.moveUp();
+      } else if (detail.key === "ArrowDown") {
+        e.preventDefault();
+        menuRef.current?.moveDown();
+      } else if (detail.key === "Enter") {
+        e.preventDefault();
+        menuRef.current?.select();
+      } else if (detail.key === "Escape") {
+        closeMenu();
+      }
+    };
+
+    dom.addEventListener("slide-slash-nav", onNav);
+    return () => dom.removeEventListener("slide-slash-nav", onNav);
+  }, [editor, menuPosition, closeMenu]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!menuPosition) return;
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as Element;
+      if (!target.closest('[data-slash-menu="true"]')) {
+        closeMenu();
+      }
+    };
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [menuPosition, closeMenu]);
+
+  return { menuPosition, query, menuRef, closeMenu, executeCommand };
+}

--- a/templates/slides/app/components/editor/SlideSlashMenu.tsx
+++ b/templates/slides/app/components/editor/SlideSlashMenu.tsx
@@ -122,6 +122,7 @@ export const SlashMenuUI = forwardRef<
 
   return createPortal(
     <div
+      data-slash-menu="true"
       className="fixed z-[9999] w-60 rounded-lg bg-[#1c1c1c] border border-white/10 shadow-2xl overflow-hidden py-1"
       style={{ top: position.y, left: position.x }}
     >
@@ -228,11 +229,12 @@ export function useSlashMenu(editor: Editor | null) {
   const executeCommand = useCallback(
     (cmd: SlashCommand) => {
       if (!editor) return;
+      // Capture position BEFORE closeMenu() nulls slashPosRef
+      const slashPos = slashPosRef.current;
+      const { from } = editor.state.selection;
       closeMenu();
 
       // Delete the slash + any query text typed
-      const { from } = editor.state.selection;
-      const slashPos = slashPosRef.current;
       if (slashPos !== null) {
         editor.chain().focus().deleteRange({ from: slashPos, to: from }).run();
       }

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -801,3 +801,163 @@ button[title="Open agent sidebar"] {
   background: rgba(255, 255, 255, 0.06);
   color: #fff;
 }
+
+/* ─── Inline Slide Editor (TipTap) ─── */
+
+.slide-tiptap-editor {
+  font-family: "Poppins", sans-serif;
+  color: rgba(255, 255, 255, 0.9);
+  caret-color: #609ff8;
+  outline: none;
+  cursor: text;
+}
+
+.slide-tiptap-editor .tiptap {
+  outline: none;
+  min-height: 100%;
+  height: 100%;
+}
+
+/* Placeholder */
+.slide-tiptap-editor .tiptap p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  color: rgba(255, 255, 255, 0.2);
+  pointer-events: none;
+  float: left;
+  height: 0;
+}
+
+/* Headings */
+.slide-tiptap-editor .tiptap h1 {
+  font-size: 54px;
+  font-weight: 900;
+  color: #ffffff;
+  line-height: 1.1;
+  letter-spacing: -1px;
+  margin-bottom: 32px;
+}
+
+.slide-tiptap-editor .tiptap h2 {
+  font-size: 40px;
+  font-weight: 900;
+  color: #ffffff;
+  line-height: 1.15;
+  letter-spacing: -0.5px;
+  margin-bottom: 24px;
+}
+
+.slide-tiptap-editor .tiptap h3 {
+  font-size: 28px;
+  font-weight: 700;
+  color: #ffffff;
+  line-height: 1.2;
+  margin-bottom: 16px;
+}
+
+/* Paragraph */
+.slide-tiptap-editor .tiptap p {
+  font-size: 22px;
+  color: rgba(255, 255, 255, 0.85);
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+
+/* Lists */
+.slide-tiptap-editor .tiptap ul {
+  padding-left: 0;
+  margin-bottom: 16px;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.slide-tiptap-editor .tiptap ul li {
+  display: flex;
+  align-items: baseline;
+  gap: 18px;
+  font-size: 22px;
+  color: rgba(255, 255, 255, 0.85);
+  line-height: 1.4;
+}
+
+.slide-tiptap-editor .tiptap ul li::before {
+  content: "●";
+  color: #ffffff;
+  font-size: 8px;
+  position: relative;
+  top: -4px;
+  flex-shrink: 0;
+}
+
+/* TipTap wraps li content in <p> — remove its margin */
+.slide-tiptap-editor .tiptap ul li p {
+  margin: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+.slide-tiptap-editor .tiptap ol {
+  padding-left: 28px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.slide-tiptap-editor .tiptap ol li {
+  font-size: 22px;
+  color: rgba(255, 255, 255, 0.85);
+  line-height: 1.4;
+  list-style-type: decimal;
+}
+
+.slide-tiptap-editor .tiptap ol li p {
+  margin: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+/* Blockquote */
+.slide-tiptap-editor .tiptap blockquote {
+  border-left: 4px solid #00e5ff;
+  padding-left: 24px;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 24px;
+  font-style: italic;
+  margin-bottom: 16px;
+}
+
+/* Inline formatting */
+.slide-tiptap-editor .tiptap strong {
+  color: #ffffff;
+  font-weight: 700;
+}
+
+.slide-tiptap-editor .tiptap em {
+  color: rgba(255, 255, 255, 0.9);
+  font-style: italic;
+}
+
+.slide-tiptap-editor .tiptap s {
+  opacity: 0.6;
+}
+
+.slide-tiptap-editor .tiptap code {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 2px 8px;
+  border-radius: 4px;
+  color: #00e5ff;
+  font-family: monospace;
+  font-size: 0.85em;
+}
+
+.slide-tiptap-editor .tiptap a {
+  color: #00e5ff;
+  text-decoration: underline;
+}
+
+/* Selection highlight */
+.slide-tiptap-editor .tiptap ::selection {
+  background: rgba(96, 159, 248, 0.35);
+}

--- a/templates/slides/package.json
+++ b/templates/slides/package.json
@@ -22,6 +22,12 @@
   },
   "dependencies": {
     "@agent-native/core": "workspace:*",
+    "@tiptap/core": "^3.22.2",
+    "@tiptap/extension-link": "^3.22.2",
+    "@tiptap/extension-placeholder": "^3.22.2",
+    "@tiptap/pm": "^3.22.2",
+    "@tiptap/react": "^3.22.2",
+    "@tiptap/starter-kit": "^3.22.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/templates/slides/vite.config.ts
+++ b/templates/slides/vite.config.ts
@@ -3,4 +3,7 @@ import { defineConfig } from "@agent-native/core/vite";
 
 export default defineConfig({
   plugins: [reactRouter()],
+  optimizeDeps: {
+    include: ["@tiptap/core", "@tiptap/react", "@tiptap/starter-kit"],
+  },
 });


### PR DESCRIPTION
## Summary

- **Streaming @-mention search** — sources flush in parallel (NDJSON) so resources/agents appear instantly without waiting for codebase file scan; client uses AbortController to cancel stale streams
- **TipTap slides editor** — rich-text inline editing with BubbleMenu (bold/italic/link/headings), SlashMenu (/ commands), and InlineEditor components
- **Inline reply in mail thread** — reply composer renders inline directly after the message it replies to
- **BYOA auth fix** — `customGetSession` now opts out of dev auto-local mode so templates with their own auth (macros/issues Supabase) aren't silently bypassed
- **send-email required fields** — `to`/`subject`/`body` are now required, preventing silent agent failures
- Various template improvements: analytics BigQuery, content sidebar/toolbar, forms cleanup, calendar fixes

## Test plan

- [ ] Type `@` in agent chat — resources and agent mentions should appear immediately, codebase files populate afterwards
- [ ] Open slides template, click a text block, verify bubble menu appears on selection and slash menu on `/`
- [ ] Reply to an email in mail template — composer should appear inline below the message
- [ ] In macros template (Supabase auth), verify login is required in dev (not bypassed)
- [ ] Try sending email without `to` — agent should get a validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)