### PR TITLE
fix: mobile Google OAuth connect flow + email swipe gestures

### DIFF
--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1657,6 +1657,14 @@ export function AgentSidebar({
   defaultOpen = false,
 }: AgentSidebarProps) {
   const [open, setOpen] = useState(() => {
+    // On mobile viewports the sidebar would cover most of the screen, so
+    // always start closed regardless of any persisted desktop preference.
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(max-width: 767px)").matches
+    ) {
+      return false;
+    }
     try {
       const saved = localStorage.getItem(SIDEBAR_OPEN_KEY);
       if (saved !== null) return saved === "true";

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1019,7 +1019,9 @@ const AssistantChatInner = forwardRef<
   const isRuntimeRunning = thread.isRunning;
   const messages = thread.messages;
   const [missingApiKey, setMissingApiKey] = useState(false);
-  const [authError, setAuthError] = useState(false);
+  const [authError, setAuthError] = useState<{
+    sessionExpired?: boolean;
+  } | null>(null);
   const [usageLimitReached, setUsageLimitReached] = useState<{
     usageCents: number;
     limitCents: number;
@@ -1336,7 +1338,10 @@ const AssistantChatInner = forwardRef<
 
   // Listen for auth error events from the adapter
   useEffect(() => {
-    const handler = () => setAuthError(true);
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      setAuthError({ sessionExpired: detail?.reason === "session-expired" });
+    };
     window.addEventListener("agent-chat:auth-error", handler);
     return () => window.removeEventListener("agent-chat:auth-error", handler);
   }, []);
@@ -1541,30 +1546,55 @@ const AssistantChatInner = forwardRef<
             </div>
             <div className="text-center max-w-[280px]">
               <p className="text-sm font-medium text-foreground mb-1">
-                Authentication required
+                {authError.sessionExpired
+                  ? "Session expired"
+                  : "Authentication required"}
               </p>
               <p className="text-xs text-muted-foreground leading-relaxed">
-                You need to log in to use the agent. If you're running locally,
-                add{" "}
-                <code className="bg-muted px-1 py-0.5 rounded text-[10px]">
-                  AUTH_MODE=local
-                </code>{" "}
-                to your{" "}
-                <code className="bg-muted px-1 py-0.5 rounded text-[10px]">
-                  .env
-                </code>{" "}
-                file and restart the dev server.
+                {authError.sessionExpired ? (
+                  "Your session may have expired. Log out and log back in to reconnect."
+                ) : (
+                  <>
+                    You need to log in to use the agent. If you&apos;re running
+                    locally, add{" "}
+                    <code className="bg-muted px-1 py-0.5 rounded text-[10px]">
+                      AUTH_MODE=local
+                    </code>{" "}
+                    to your{" "}
+                    <code className="bg-muted px-1 py-0.5 rounded text-[10px]">
+                      .env
+                    </code>{" "}
+                    file and restart the dev server.
+                  </>
+                )}
               </p>
             </div>
-            <button
-              onClick={() => {
-                setAuthError(false);
-                window.location.reload();
-              }}
-              className="text-xs text-muted-foreground hover:text-foreground px-3 py-1.5 rounded-md border border-border hover:bg-accent"
-            >
-              Retry
-            </button>
+            <div className="flex gap-2">
+              {authError.sessionExpired && (
+                <button
+                  onClick={async () => {
+                    try {
+                      await fetch("/_agent-native/auth/logout", {
+                        method: "POST",
+                      });
+                    } catch {}
+                    window.location.reload();
+                  }}
+                  className="text-xs text-destructive hover:text-destructive/80 px-3 py-1.5 rounded-md border border-destructive/30 hover:bg-destructive/10"
+                >
+                  Log out
+                </button>
+              )}
+              <button
+                onClick={() => {
+                  setAuthError(null);
+                  window.location.reload();
+                }}
+                className="text-xs text-muted-foreground hover:text-foreground px-3 py-1.5 rounded-md border border-border hover:bg-accent"
+              >
+                Retry
+              </button>
+            </div>
           </div>
         ) : missingApiKey ? (
           <div className="flex flex-col items-center justify-center h-full px-2">

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -133,6 +133,27 @@ export function createAgentChatAdapter(options?: {
         }
 
         if (!res.ok) {
+          // 405 Method Not Allowed usually means the session is broken/expired
+          // (e.g. a redirect to a login page that only accepts GET).
+          if (res.status === 405) {
+            if (typeof window !== "undefined") {
+              window.dispatchEvent(
+                new CustomEvent("agent-chat:auth-error", {
+                  detail: { reason: "session-expired" },
+                }),
+              );
+            }
+            content.push({ type: "text", text: "" });
+            yield {
+              content: [...content],
+              status: {
+                type: "incomplete" as const,
+                reason: "error" as const,
+              },
+            } as ChatModelRunResult;
+            return;
+          }
+
           let errorText = `Server error: ${res.status}`;
           try {
             const body = await res.text();
@@ -201,7 +222,8 @@ export function createAgentChatAdapter(options?: {
           errMsg.includes("Unauthorized") ||
           errMsg.includes("Not authenticated") ||
           errMsg.includes("401") ||
-          errMsg.includes("403");
+          errMsg.includes("403") ||
+          errMsg.includes("405");
 
         // Don't try to reconnect for auth/client errors — show error directly
         if (isAuthError) {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -197,8 +197,12 @@ export default {
       }
     }
 
-    // Try serving static assets first (CF Pages advanced mode)
-    if (env?.ASSETS) {
+    // Try serving static assets first (CF Pages advanced mode).
+    // Only attempt this for GET/HEAD — the ASSETS binding is a static file
+    // server and returns 405 for any other method, which would short-circuit
+    // API calls (PUT/POST/DELETE to /_agent-native/*) before they reach our
+    // h3 middleware.
+    if (env?.ASSETS && (request.method === "GET" || request.method === "HEAD")) {
       try {
         const assetResponse = await env.ASSETS.fetch(request);
         if (assetResponse.status !== 404) {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -15,6 +15,7 @@ import type {
   MentionProviderItem,
 } from "../agent/types.js";
 import { discoverAgents } from "./agent-discovery.js";
+import { loadSchemaPromptBlock } from "./schema-prompt.js";
 import {
   buildAssistantMessage,
   extractThreadMeta,
@@ -769,6 +770,26 @@ async function loadResourcesForPrompt(owner: string): Promise<string> {
   );
 }
 
+/**
+ * Build the per-request SQL-schema context block. Reads AGENT_ORG_ID live
+ * from the environment so scheduler/A2A/HTTP call sites all see whatever
+ * org was just resolved for this request.
+ */
+async function buildSchemaBlock(
+  owner: string,
+  hasRawDbTools: boolean,
+): Promise<string> {
+  try {
+    return await loadSchemaPromptBlock({
+      owner,
+      orgId: process.env.AGENT_ORG_ID ?? null,
+      hasRawDbTools,
+    });
+  } catch {
+    return "";
+  }
+}
+
 /** @deprecated Kept for backward compat — dev prompt is now part of DEV_FRAMEWORK_PROMPT */
 const DEFAULT_DEV_PROMPT = "";
 
@@ -1201,9 +1222,10 @@ export function createAgentChatPlugin(
         // Build the same system prompt the interactive agent uses
         const owner = userEmail || "local@localhost";
         const resources = await loadResourcesForPrompt(owner);
+        const schemaBlock = await buildSchemaBlock(owner, canToggle);
         const systemPrompt = canToggle
-          ? devPrompt + resources
-          : basePrompt + resources;
+          ? devPrompt + resources + schemaBlock
+          : basePrompt + resources + schemaBlock;
 
         const a2aClient = new Anthropic({ apiKey });
         const model =
@@ -1358,9 +1380,13 @@ export function createAgentChatPlugin(
         );
 
         const resources = await loadResourcesForPrompt("local@localhost");
+        const schemaBlock = await buildSchemaBlock(
+          "local@localhost",
+          canToggle,
+        );
         const systemPrompt = canToggle
-          ? devPrompt + resources
-          : basePrompt + resources;
+          ? devPrompt + resources + schemaBlock
+          : basePrompt + resources + schemaBlock;
 
         let accumulatedText = "";
         const controller = new AbortController();
@@ -1545,7 +1571,8 @@ export function createAgentChatPlugin(
         const owner = await getOwnerFromEvent(event);
         _currentRunOwner = owner;
         const resources = await loadResourcesForPrompt(owner);
-        _currentRunSystemPrompt = basePrompt + resources;
+        const schemaBlock = await buildSchemaBlock(owner, false);
+        _currentRunSystemPrompt = basePrompt + resources + schemaBlock;
         return _currentRunSystemPrompt;
       },
       model:
@@ -1594,7 +1621,8 @@ export function createAgentChatPlugin(
           const owner = await getOwnerFromEvent(event);
           _currentRunOwner = owner;
           const resources = await loadResourcesForPrompt(owner);
-          _currentRunSystemPrompt = devPrompt + resources;
+          const schemaBlock = await buildSchemaBlock(owner, true);
+          _currentRunSystemPrompt = devPrompt + resources + schemaBlock;
           return _currentRunSystemPrompt;
         },
         model: options?.model,
@@ -2350,7 +2378,8 @@ export function createAgentChatPlugin(
           }),
           getSystemPrompt: async (owner: string) => {
             const resources = await loadResourcesForPrompt(owner);
-            return basePrompt + resources;
+            const schemaBlock = await buildSchemaBlock(owner, false);
+            return basePrompt + resources + schemaBlock;
           },
           getTools: (actions: Record<string, ActionEntry>) =>
             Object.entries(actions).map(([name, entry]) => ({

--- a/packages/core/src/server/schema-prompt.ts
+++ b/packages/core/src/server/schema-prompt.ts
@@ -1,0 +1,361 @@
+/**
+ * Auto-introspected SQL schema context block for the agent's system prompt.
+ *
+ * On every chat turn, the framework appends a compact, always-fresh summary
+ * of the app's SQL database — every table, every column, every foreign key —
+ * so the agent knows exactly what data model it's working with. The schema
+ * is pulled live from `information_schema` (Postgres) or `PRAGMA table_info`
+ * (SQLite), cached briefly to keep latency down but never hard-coded.
+ *
+ * The block also:
+ *   - points at the db-query / db-exec / db-schema tools for runtime access
+ *   - lists Postgres column descriptions (`COMMENT ON COLUMN ...`) if present
+ *   - explains the current user/org data scoping so the agent doesn't re-filter
+ *     by hand (which would be redundant and easy to get wrong)
+ */
+import {
+  getDbExec,
+  getDatabaseUrl,
+  isPostgres,
+  type DbExec,
+} from "../db/client.js";
+
+interface ColumnSchema {
+  name: string;
+  type: string;
+  notnull: boolean;
+  pk: boolean;
+  comment: string | null;
+}
+
+interface ForeignKey {
+  from: string;
+  table: string;
+  to: string;
+}
+
+interface TableSchema {
+  name: string;
+  columns: ColumnSchema[];
+  foreignKeys: ForeignKey[];
+  comment: string | null;
+}
+
+// Short-lived in-memory cache — schema rarely changes between messages, but
+// we want new tables to show up within a few seconds during active dev.
+const CACHE_TTL_MS = 15_000;
+let _cache: {
+  key: string;
+  expires: number;
+  tables: TableSchema[];
+  dialect: "postgres" | "sqlite";
+} | null = null;
+
+function cacheKey(): string {
+  return (isPostgres() ? "pg:" : "lite:") + (getDatabaseUrl() || "");
+}
+
+// ─── Postgres introspection ─────────────────────────────────────────────────
+
+async function introspectPostgres(db: DbExec): Promise<TableSchema[]> {
+  const tablesRes = await db.execute({
+    sql: `SELECT table_name AS name,
+                 obj_description((quote_ident(table_schema) || '.' || quote_ident(table_name))::regclass, 'pg_class') AS comment
+          FROM information_schema.tables
+          WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+          ORDER BY table_name`,
+    args: [],
+  });
+
+  const tables: TableSchema[] = [];
+
+  for (const t of tablesRes.rows as any[]) {
+    const name = t.name as string;
+
+    const colsRes = await db.execute({
+      sql: `SELECT c.column_name AS name,
+                   c.data_type AS type,
+                   CASE WHEN c.is_nullable = 'NO' THEN 1 ELSE 0 END AS notnull,
+                   col_description((quote_ident(c.table_schema) || '.' || quote_ident(c.table_name))::regclass, c.ordinal_position) AS comment
+            FROM information_schema.columns c
+            WHERE c.table_name = ? AND c.table_schema = 'public'
+            ORDER BY c.ordinal_position`,
+      args: [name],
+    });
+
+    const pksRes = await db.execute({
+      sql: `SELECT kcu.column_name AS name
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name
+             AND tc.table_schema = kcu.table_schema
+            WHERE tc.table_name = ? AND tc.constraint_type = 'PRIMARY KEY'`,
+      args: [name],
+    });
+    const pkSet = new Set((pksRes.rows as any[]).map((r) => r.name as string));
+
+    const fksRes = await db.execute({
+      sql: `SELECT kcu.column_name AS col_from,
+                   ccu.table_name  AS ref_table,
+                   ccu.column_name AS ref_col
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name
+            JOIN information_schema.constraint_column_usage ccu
+              ON tc.constraint_name = ccu.constraint_name
+            WHERE tc.table_name = ? AND tc.constraint_type = 'FOREIGN KEY'`,
+      args: [name],
+    });
+
+    tables.push({
+      name,
+      comment: (t.comment as string | null) ?? null,
+      columns: (colsRes.rows as any[]).map((c) => ({
+        name: c.name as string,
+        type: (c.type as string) || "any",
+        notnull: Number(c.notnull) === 1,
+        pk: pkSet.has(c.name as string),
+        comment: (c.comment as string | null) ?? null,
+      })),
+      foreignKeys: (fksRes.rows as any[]).map((f) => ({
+        from: f.col_from as string,
+        table: f.ref_table as string,
+        to: f.ref_col as string,
+      })),
+    });
+  }
+
+  return tables;
+}
+
+// ─── SQLite / libSQL / D1 introspection ────────────────────────────────────
+
+async function introspectSqlite(db: DbExec): Promise<TableSchema[]> {
+  const tablesRes = await db.execute(
+    `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
+  );
+
+  const tables: TableSchema[] = [];
+
+  for (const row of tablesRes.rows as any[]) {
+    const name = row.name as string;
+    if (!name) continue;
+    // Quote the identifier for PRAGMA calls; SQLite requires doubling embedded quotes.
+    const escaped = name.replace(/"/g, '""');
+
+    const colsRes = await db.execute(`PRAGMA table_info("${escaped}")`);
+    const fksRes = await db.execute(`PRAGMA foreign_key_list("${escaped}")`);
+
+    tables.push({
+      name,
+      comment: null, // SQLite has no column/table comments
+      columns: (colsRes.rows as any[]).map((c) => ({
+        name: c.name as string,
+        type: ((c.type as string) || "").toLowerCase() || "any",
+        notnull: Number(c.notnull) === 1,
+        pk: Number(c.pk) === 1,
+        comment: null,
+      })),
+      foreignKeys: (fksRes.rows as any[]).map((f) => ({
+        from: f.from as string,
+        table: f.table as string,
+        to: f.to as string,
+      })),
+    });
+  }
+
+  return tables;
+}
+
+// ─── Cached entry point ─────────────────────────────────────────────────────
+
+async function getSchema(): Promise<{
+  tables: TableSchema[];
+  dialect: "postgres" | "sqlite";
+}> {
+  const key = cacheKey();
+  const now = Date.now();
+  if (_cache && _cache.key === key && _cache.expires > now) {
+    return { tables: _cache.tables, dialect: _cache.dialect };
+  }
+
+  const db = getDbExec();
+  const dialect: "postgres" | "sqlite" = isPostgres() ? "postgres" : "sqlite";
+  const tables =
+    dialect === "postgres"
+      ? await introspectPostgres(db)
+      : await introspectSqlite(db);
+
+  _cache = { key, expires: now + CACHE_TTL_MS, tables, dialect };
+  return { tables, dialect };
+}
+
+/** Manually drop the cache — useful from tests or after running a migration. */
+export function invalidateSchemaPromptCache(): void {
+  _cache = null;
+}
+
+// ─── Formatting ─────────────────────────────────────────────────────────────
+
+function shortType(type: string): string {
+  // Trim verbose Postgres type names for compactness in the prompt.
+  const t = type.toLowerCase();
+  if (t === "character varying") return "varchar";
+  if (t === "timestamp without time zone") return "timestamp";
+  if (t === "timestamp with time zone") return "timestamptz";
+  if (t === "double precision") return "double";
+  return t;
+}
+
+function formatTable(table: TableSchema): string {
+  const fkByCol = new Map<string, string>();
+  for (const fk of table.foreignKeys) {
+    fkByCol.set(fk.from, `${fk.table}.${fk.to}`);
+  }
+
+  const cols = table.columns.map((c) => {
+    const flags: string[] = [];
+    if (c.pk) flags.push("pk");
+    if (!c.notnull && !c.pk) flags.push("null");
+    const fk = fkByCol.get(c.name);
+    if (fk) flags.push(`→${fk}`);
+
+    // Flag scoping columns so the agent understands per-user/per-org filtering.
+    if (c.name === "owner_email") flags.push("user-scope");
+    if (c.name === "org_id") flags.push("org-scope");
+
+    const flagStr = flags.length ? ` [${flags.join(", ")}]` : "";
+    const commentStr = c.comment ? ` -- ${c.comment.replace(/\s+/g, " ")}` : "";
+    return `    ${c.name} ${shortType(c.type)}${flagStr}${commentStr}`;
+  });
+
+  const header = table.comment
+    ? `  ${table.name}  -- ${table.comment.replace(/\s+/g, " ")}`
+    : `  ${table.name}`;
+
+  return [header, ...cols].join("\n");
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Build the `<sql-database>` block appended to the system prompt on every turn.
+ *
+ * `owner` and `orgId` come from the per-request context (AGENT_USER_EMAIL /
+ * AGENT_ORG_ID) and are surfaced so the agent knows who it is acting on behalf
+ * of — and understands that rows are already filtered for that identity.
+ */
+export async function loadSchemaPromptBlock(opts: {
+  owner?: string | null;
+  orgId?: string | null;
+  /** If true, mention db-query/db-exec/db-schema as available tools. */
+  hasRawDbTools?: boolean;
+}): Promise<string> {
+  let tables: TableSchema[];
+  let dialect: "postgres" | "sqlite";
+  try {
+    const res = await getSchema();
+    tables = res.tables;
+    dialect = res.dialect;
+  } catch (err) {
+    // DB not ready, or introspection blew up — don't take the chat down.
+    return "";
+  }
+
+  if (tables.length === 0) return "";
+
+  // Partition framework-internal tables from template tables so the agent
+  // focuses on the data model it's most likely to touch.
+  const CORE_TABLES = new Set([
+    "application_state",
+    "settings",
+    "oauth_tokens",
+    "sessions",
+    "resources",
+    "chat_threads",
+    "_collab_docs",
+    "usage_events",
+    "usage_totals",
+    "user",
+    "account",
+    "verification",
+    "organization",
+    "member",
+    "invitation",
+  ]);
+
+  const templateTables = tables.filter((t) => !CORE_TABLES.has(t.name));
+  const coreTables = tables.filter((t) => CORE_TABLES.has(t.name));
+
+  const lines: string[] = [];
+  lines.push("<sql-database>");
+  lines.push(
+    `The app's state lives in a SQL database (${dialect}). The schema below is auto-introspected fresh each turn — treat it as authoritative.`,
+  );
+  lines.push("");
+
+  if (templateTables.length > 0) {
+    lines.push("## Template tables");
+    lines.push("");
+    for (const t of templateTables) {
+      lines.push(formatTable(t));
+      lines.push("");
+    }
+  }
+
+  if (coreTables.length > 0) {
+    lines.push(
+      "## Framework tables (auth, resources, chat threads, app-state, etc.) — usually read/written via dedicated tools, not raw SQL",
+    );
+    lines.push("");
+    for (const t of coreTables) {
+      lines.push(formatTable(t));
+      lines.push("");
+    }
+  }
+
+  // Tooling references.
+  if (opts.hasRawDbTools) {
+    lines.push("## SQL tools");
+    lines.push(
+      "- `db-schema` — refresh the full schema with indexes and foreign keys",
+    );
+    lines.push(
+      "- `db-query` — run a SELECT (read-only; results already filtered to the current user/org)",
+    );
+    lines.push(
+      "- `db-exec` — run INSERT / UPDATE / DELETE (writes already scoped; owner_email and org_id are auto-injected on INSERT)",
+    );
+    lines.push(
+      "Prefer template-specific actions when one exists — they encode business rules. Drop to raw SQL only when no action fits.",
+    );
+    lines.push("");
+  } else {
+    lines.push(
+      "SQL is accessed through the template actions listed above. The schema is shown for context — so you understand the data model those actions operate on.",
+    );
+    lines.push("");
+  }
+
+  // Data scoping context.
+  const ownerLine = opts.owner ? opts.owner : "(unresolved)";
+  const orgLine = opts.orgId ? opts.orgId : "(none)";
+  lines.push("## Data scoping (enforced at the SQL layer)");
+  lines.push(`- Current user: \`${ownerLine}\``);
+  lines.push(`- Current org:  \`${orgLine}\``);
+  lines.push(
+    "- Tables with an `owner_email` column are automatically filtered to the current user via temporary views before every query.",
+  );
+  lines.push(
+    "- Tables with an `org_id` column are automatically filtered to the current org as well.",
+  );
+  lines.push(
+    "- On INSERT, `owner_email` and `org_id` are auto-injected — do NOT set them manually.",
+  );
+  lines.push(
+    "- Do NOT add `WHERE owner_email = ...` or `WHERE org_id = ...` to your queries — the filter is already applied, and re-adding it will confuse the scoped view.",
+  );
+  lines.push("</sql-database>");
+
+  return "\n\n" + lines.join("\n");
+}

--- a/packages/mobile-app/components/AppWebView.tsx
+++ b/packages/mobile-app/components/AppWebView.tsx
@@ -67,6 +67,25 @@ export default function AppWebView({ url }: AppWebViewProps) {
     return true;
   }, []);
 
+  // Handle messages from the web app (e.g. open a URL in the system browser)
+  const handleMessage = useCallback(
+    (event: { nativeEvent: { data: string } }) => {
+      try {
+        const msg = JSON.parse(event.nativeEvent.data);
+        if (msg.type === "openUrl" && typeof msg.url === "string") {
+          const parsed = new URL(msg.url);
+          // Only open external hosts in Safari — anything else is ignored
+          if (EXTERNAL_HOSTS.includes(parsed.hostname)) {
+            Linking.openURL(msg.url);
+          }
+        }
+      } catch {
+        // Ignore malformed messages
+      }
+    },
+    [],
+  );
+
   // Append the session token as a query param so the server can promote it to
   // an httpOnly cookie. This bridges the Safari/WKWebView cookie jar gap.
   const webviewUrl = sessionToken
@@ -82,6 +101,7 @@ export default function AppWebView({ url }: AppWebViewProps) {
         onLoadStart={() => setLoading(true)}
         onLoadEnd={() => setLoading(false)}
         onShouldStartLoadWithRequest={handleShouldStartLoad}
+        onMessage={handleMessage}
         javaScriptEnabled
         domStorageEnabled
         sharedCookiesEnabled

--- a/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
+++ b/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
@@ -294,7 +294,7 @@ export function GoogleConnectBanner({
   }
 
   // Connected with accounts — show compact account strip
-  if (hasAccounts && allConfigured) {
+  if (hasAccounts) {
     return (
       <div className="border-b border-border/30 bg-card">
         <div className="flex items-center justify-between gap-3 px-4 py-1.5">

--- a/templates/macros/AGENTS.md
+++ b/templates/macros/AGENTS.md
@@ -90,6 +90,8 @@ cd templates/macros && pnpm action <name> [args]
 
 ## Voice Commands
 
+Input comes from voice transcription and will contain speech recognition errors. Always interpret based on context — numbers, fitness vocabulary, and common mishearings.
+
 When users speak via the microphone button, their transcribed text is sent to the agent chat. Parse their natural language to determine the action:
 
 - **ADD**: "breakfast 400 calories", "ran for 30 min 300 calories", "I weigh 165"
@@ -97,6 +99,25 @@ When users speak via the microphone button, their transcribed text is sent to th
 - **DELETE**: "delete the pizza", "remove lunch"
 
 Handle multiple items in one command. For weight entries, require explicit weight-related keywords.
+
+### Common Voice Transcription Errors
+
+Speech recognition frequently mishears fitness-related words. Always apply context to resolve ambiguity:
+
+| Heard                    | Likely means                  | Reasoning                                                                                       |
+| ------------------------ | ----------------------------- | ----------------------------------------------------------------------------------------------- |
+| "wait 150" / "wait 1:50" | log weight as 150             | "wait" → "weight"; colons in numbers are artifacts                                              |
+| "dinner 4:40"            | dinner was 440 calories       | Colons in numbers are transcription artifacts; 4:40 → 440 cal is plausible, 4h40m dinner is not |
+| "lunch 3:20"             | lunch was 320 calories        | Same colon artifact pattern                                                                     |
+| "protein shake to 50"    | protein shake, 250 calories   | "to" → "two"; leading digit dropped                                                             |
+| "add away to 300"        | add a workout, 300 cal burned | Phonetic mishear                                                                                |
+
+**General rules:**
+
+- A colon inside a number (e.g. "4:40", "1:50") is almost always a transcription artifact — collapse it: `4:40 → 440`, `1:50 → 150`
+- "wait" / "waited" near a number almost always means "weight" (body weight log)
+- When a number is ambiguous (calories vs. weight vs. duration), use context: meal entries → calories, standalone number after "weigh"/"wait" → body weight
+- If still ambiguous, ask a one-line clarifying question rather than guessing
 
 ## UI Components
 

--- a/templates/mail/app/components/GoogleConnectBanner.tsx
+++ b/templates/mail/app/components/GoogleConnectBanner.tsx
@@ -469,7 +469,7 @@ export function GoogleConnectBanner({
   }
 
   // Connected with accounts — show compact account strip
-  if (hasAccounts && allConfigured) {
+  if (hasAccounts) {
     return (
       <div className="border-b border-border/30 bg-card">
         <div className="flex items-center justify-between gap-3 px-4 py-1.5">

--- a/templates/mail/app/components/GoogleConnectBanner.tsx
+++ b/templates/mail/app/components/GoogleConnectBanner.tsx
@@ -83,6 +83,8 @@ export function GoogleConnectBanner({
   const accounts = googleStatus.data?.accounts ?? [];
   const hasAccounts = accounts.length > 0;
 
+  const [authError, setAuthError] = useState<string | null>(null);
+
   // Wizard state
   const [currentStep, setCurrentStep] = useState(0);
   const [saving, setSaving] = useState(false);
@@ -119,16 +121,18 @@ export function GoogleConnectBanner({
   // When auth URL is ready, open it and poll for connection
   useEffect(() => {
     if (authUrl.data?.url) {
+      const url = authUrl.data.url;
       // In a React Native WebView, window.open() is silently blocked (WKWebView
-      // doesn't support it without onOpenWindow). Use window.location.href
-      // instead — the native WebView's URL interceptor catches Google domains
-      // and opens Safari. The navigation is cancelled so the page stays intact.
-      const isNativeWebView =
-        typeof (window as any).ReactNativeWebView !== "undefined";
+      // doesn't support it without onOpenWindow). Use postMessage to ask the
+      // native wrapper to open the URL in the system browser (Safari), falling
+      // back to window.location.href which triggers onShouldStartLoadWithRequest.
+      const rnWebView = (window as any).ReactNativeWebView;
+      const isNativeWebView = typeof rnWebView !== "undefined";
       if (isNativeWebView) {
-        window.location.href = authUrl.data.url;
+        // postMessage is the most reliable bridge to the native layer
+        rnWebView.postMessage(JSON.stringify({ type: "openUrl", url }));
       } else {
-        window.open(authUrl.data.url, "_blank");
+        window.open(url, "_blank");
       }
       setWantAuthUrl(false);
 
@@ -153,12 +157,15 @@ export function GoogleConnectBanner({
     }
   }, [authUrl.data]);
 
-  // When auth URL fails with missing credentials, show wizard instead of error toast
+  // When auth URL fails, show wizard (for missing credentials) or an error message
   useEffect(() => {
     if (authUrl.error) {
       setWantAuthUrl(false);
       setShowWizard(true);
       fetchStatus();
+      setAuthError(
+        (authUrl.error as any)?.message || "Failed to connect. Try again.",
+      );
     }
   }, [authUrl.error, fetchStatus]);
 
@@ -277,7 +284,10 @@ export function GoogleConnectBanner({
         <Button
           size="sm"
           className="mt-8 gap-2 px-5 h-9 text-sm font-medium bg-white text-black hover:bg-white/90"
-          onClick={handleConnect}
+          onClick={() => {
+            setAuthError(null);
+            handleConnect();
+          }}
           disabled={authUrl.isLoading || authUrl.isFetching}
         >
           <GoogleIcon className="h-4 w-4" />
@@ -287,6 +297,10 @@ export function GoogleConnectBanner({
               ? "Sign in with Google"
               : "Set up Google"}
         </Button>
+
+        {authError && allConfigured && (
+          <p className="mt-3 text-xs text-red-400">{authError}</p>
+        )}
 
         {showWizard && !allConfigured && (
           <div className="mt-10 w-full max-w-lg text-left">
@@ -526,7 +540,10 @@ export function GoogleConnectBanner({
             <Button
               size="sm"
               className="gap-1.5 text-xs h-7 font-medium bg-white text-black hover:bg-white/90"
-              onClick={handleConnect}
+              onClick={() => {
+                setAuthError(null);
+                handleConnect();
+              }}
               disabled={authUrl.isLoading || authUrl.isFetching}
             >
               <GoogleIcon className="h-3 w-3" />

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -630,6 +630,84 @@ export function EmailList({
     toggleStar.mutate({ id: email.id, isStarred: !email.isStarred });
   };
 
+  // ── Swipe gesture handlers ─────────────────────────────────────────────
+  // Swipe targets exactly one thread (the swiped one) — unlike the keyboard
+  // `e` shortcut, which respects multi-selection.
+  const handleSwipeArchive = useCallback(
+    (thread: ThreadSummary) => {
+      const id = thread.latestMessage.id;
+      const tid = thread.latestMessage.threadId || id;
+
+      // Advance focus past the row that's about to disappear.
+      const idx = threads.findIndex((t) => t.latestMessage.id === id);
+      if (threads.length > 1) {
+        const nextIdx =
+          idx < threads.length - 1 ? idx + 1 : Math.max(0, idx - 1);
+        setFocusedId(threads[nextIdx].latestMessage.id);
+      } else {
+        setFocusedId(null);
+      }
+
+      // Snapshot so undo can restore.
+      const snapshots = emails.filter((e) => (e.threadId || e.id) === tid);
+      onArchived?.(id);
+
+      const undo = () => {
+        queryClient.setQueriesData<InfiniteEmails>(
+          { queryKey: ["emails"] },
+          (old) => {
+            if (!old) return old;
+            const firstPage = old.pages[0];
+            const restored = [...(firstPage?.emails ?? []), ...snapshots].sort(
+              (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+            );
+            return {
+              ...old,
+              pages: [
+                { ...firstPage, emails: restored },
+                ...old.pages.slice(1),
+              ],
+            };
+          },
+        );
+        unarchiveEmail.mutate(id);
+      };
+      setUndoAction(undo);
+      toast("Marked as Done.", {
+        action: { label: "UNDO", onClick: undo },
+      });
+      archiveEmail.mutate({
+        id,
+        accountEmail: thread.latestMessage.accountEmail,
+        removeLabel: labelParam || undefined,
+      });
+    },
+    [
+      threads,
+      emails,
+      archiveEmail,
+      unarchiveEmail,
+      onArchived,
+      labelParam,
+      setFocusedId,
+      queryClient,
+    ],
+  );
+
+  // Snooze fires a global event that AppLayout's SnoozeModal listens for.
+  // Routing through an event (instead of prop drilling) avoids coupling
+  // the list to the layout's modal state.
+  const handleSwipeSnooze = useCallback((thread: ThreadSummary) => {
+    window.dispatchEvent(
+      new CustomEvent("email:request-snooze", {
+        detail: {
+          emailId: thread.latestMessage.id,
+          accountEmail: thread.latestMessage.accountEmail,
+        },
+      }),
+    );
+  }, []);
+
   // Error state
   if (emailsError) {
     const needsCredentials =
@@ -751,6 +829,8 @@ export function EmailList({
                 staleTime: 30_000,
               });
             }}
+            onSwipeArchive={() => handleSwipeArchive(thread)}
+            onSwipeSnooze={() => handleSwipeSnooze(thread)}
           />
         ))}
         {/* Sentinel for infinite scroll + loading indicator */}

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -632,11 +632,15 @@ export function EmailList({
 
   // ── Swipe gesture handlers ─────────────────────────────────────────────
   // Swipe targets exactly one thread (the swiped one) — unlike the keyboard
-  // `e` shortcut, which respects multi-selection.
+  // `e` shortcut, which respects multi-selection. We also clear any existing
+  // multi-selection so the next keyboard shortcut (e/d/u/s) doesn't act on a
+  // stale set — getActionIds() prefers selectedIds over focusedId.
   const handleSwipeArchive = useCallback(
     (thread: ThreadSummary) => {
       const id = thread.latestMessage.id;
       const tid = thread.latestMessage.threadId || id;
+
+      setSelectedIds(new Set());
 
       // Advance focus past the row that's about to disappear.
       const idx = threads.findIndex((t) => t.latestMessage.id === id);
@@ -690,23 +694,29 @@ export function EmailList({
       onArchived,
       labelParam,
       setFocusedId,
+      setSelectedIds,
       queryClient,
     ],
   );
 
   // Snooze fires a global event that AppLayout's SnoozeModal listens for.
   // Routing through an event (instead of prop drilling) avoids coupling
-  // the list to the layout's modal state.
-  const handleSwipeSnooze = useCallback((thread: ThreadSummary) => {
-    window.dispatchEvent(
-      new CustomEvent("email:request-snooze", {
-        detail: {
-          emailId: thread.latestMessage.id,
-          accountEmail: thread.latestMessage.accountEmail,
-        },
-      }),
-    );
-  }, []);
+  // the list to the layout's modal state. Clear multi-selection for the
+  // same reason as handleSwipeArchive.
+  const handleSwipeSnooze = useCallback(
+    (thread: ThreadSummary) => {
+      setSelectedIds(new Set());
+      window.dispatchEvent(
+        new CustomEvent("email:request-snooze", {
+          detail: {
+            emailId: thread.latestMessage.id,
+            accountEmail: thread.latestMessage.accountEmail,
+          },
+        }),
+      );
+    },
+    [setSelectedIds],
+  );
 
   // Error state
   if (emailsError) {

--- a/templates/mail/app/components/email/EmailListItem.tsx
+++ b/templates/mail/app/components/email/EmailListItem.tsx
@@ -1,6 +1,6 @@
-import { memo } from "react";
+import { memo, useRef, useState, useCallback } from "react";
 import { cn, formatEmailDate, truncate } from "@/lib/utils";
-import { IconStarFilled } from "@tabler/icons-react";
+import { IconStarFilled, IconCheck, IconClock } from "@tabler/icons-react";
 import type { EmailMessage } from "@shared/types";
 import type { ThreadSummary } from "@/lib/threads";
 import { useAccountFilter } from "@/hooks/use-account-filter";
@@ -14,7 +14,18 @@ interface EmailListItemProps {
   onSelect: () => void;
   onStar: (e: React.MouseEvent) => void;
   onHover: () => void;
+  /** Called after a left-swipe past the threshold (archive). */
+  onSwipeArchive?: () => void;
+  /** Called after a right-swipe past the threshold (snooze). */
+  onSwipeSnooze?: () => void;
 }
+
+// Minimum horizontal distance before we lock into a swipe gesture.
+const SWIPE_SLOP = 10;
+// Distance past which a swipe commits the action.
+const SWIPE_COMMIT_THRESHOLD = 80;
+// Distance past which the action icon "snaps" to filled state.
+const SWIPE_ICON_SNAP = 56;
 
 /** Format participant names for thread display, e.g. "Kaitlyn .. Sam, Andrew" */
 function formatParticipants(participants: string[], maxWidth = 3): string {
@@ -90,9 +101,139 @@ export const EmailListItem = memo(function EmailListItem({
   onSelect,
   onStar,
   onHover,
+  onSwipeArchive,
+  onSwipeSnooze,
 }: EmailListItemProps) {
   const { allAccounts } = useAccountFilter();
   const isMultiAccount = allAccounts.length > 1;
+
+  // ── Swipe state ─────────────────────────────────────────────────────────
+  // `dragX` drives the row's translateX. `isDragging` disables the snap
+  // transition while the finger is on the screen. Refs hold the active gesture
+  // so event handlers don't thrash state on every touchmove.
+  const [dragX, setDragX] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const gestureRef = useRef<{
+    startX: number;
+    startY: number;
+    // "none" until we know which axis the user is swiping; then "h" or "v".
+    locked: "none" | "h" | "v";
+    // Set to true once we commit an action — blocks the trailing click.
+    committed: boolean;
+  } | null>(null);
+  const didSwipeRef = useRef(false);
+
+  const canSwipe = Boolean(onSwipeArchive || onSwipeSnooze);
+
+  const resetSwipe = useCallback(() => {
+    setDragX(0);
+    setIsDragging(false);
+    gestureRef.current = null;
+  }, []);
+
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (!canSwipe) return;
+      const t = e.touches[0];
+      gestureRef.current = {
+        startX: t.clientX,
+        startY: t.clientY,
+        locked: "none",
+        committed: false,
+      };
+      didSwipeRef.current = false;
+    },
+    [canSwipe],
+  );
+
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      const g = gestureRef.current;
+      if (!g) return;
+      const t = e.touches[0];
+      const dx = t.clientX - g.startX;
+      const dy = t.clientY - g.startY;
+
+      // Decide the axis on first meaningful movement. Bias toward vertical
+      // so hesitant scrolls don't accidentally start a swipe.
+      if (g.locked === "none") {
+        if (Math.abs(dx) < SWIPE_SLOP && Math.abs(dy) < SWIPE_SLOP) return;
+        if (Math.abs(dx) > Math.abs(dy) * 1.2) {
+          g.locked = "h";
+          setIsDragging(true);
+          didSwipeRef.current = true;
+        } else {
+          // Vertical scroll — disengage swipe for the rest of this gesture.
+          g.locked = "v";
+          gestureRef.current = null;
+          return;
+        }
+      }
+
+      if (g.locked === "h") {
+        // Only one side may be active at a time.
+        if (dx < 0 && !onSwipeArchive) {
+          setDragX(0);
+          return;
+        }
+        if (dx > 0 && !onSwipeSnooze) {
+          setDragX(0);
+          return;
+        }
+        setDragX(dx);
+      }
+    },
+    [onSwipeArchive, onSwipeSnooze],
+  );
+
+  const handleTouchEnd = useCallback(() => {
+    const g = gestureRef.current;
+    if (!g || g.locked !== "h") {
+      resetSwipe();
+      return;
+    }
+
+    // Left swipe → archive.
+    if (dragX <= -SWIPE_COMMIT_THRESHOLD && onSwipeArchive) {
+      g.committed = true;
+      // Fly the row off-screen, then hand off to the parent to actually
+      // remove it from the list. The snap transition makes this feel fluid
+      // instead of an abrupt disappearance.
+      setIsDragging(false);
+      setDragX(-window.innerWidth);
+      setTimeout(() => {
+        onSwipeArchive();
+        // Parent will unmount us; reset defensively if it doesn't.
+        resetSwipe();
+      }, 180);
+      return;
+    }
+
+    // Right swipe → snooze. We don't remove the row — the modal takes over.
+    if (dragX >= SWIPE_COMMIT_THRESHOLD && onSwipeSnooze) {
+      g.committed = true;
+      onSwipeSnooze();
+      // Snap back so the row is in place when the modal closes.
+      resetSwipe();
+      return;
+    }
+
+    // Not enough — snap back.
+    resetSwipe();
+  }, [dragX, onSwipeArchive, onSwipeSnooze, resetSwipe]);
+
+  const handleTouchCancel = useCallback(() => {
+    resetSwipe();
+  }, [resetSwipe]);
+
+  // Suppress click fired at the end of a swipe.
+  const handleRowClick = useCallback(() => {
+    if (didSwipeRef.current) {
+      didSwipeRef.current = false;
+      return;
+    }
+    onSelect();
+  }, [onSelect]);
 
   const isThread = thread && thread.messageCount > 1;
   const senderName = isThread
@@ -136,114 +277,190 @@ export const EmailListItem = memo(function EmailListItem({
     (l) => !systemLabels.has(l),
   );
 
+  // Progress (0–1+) in each direction — used to scale icon feedback.
+  const archiveProgress = dragX < 0 ? Math.min(1, -dragX / SWIPE_ICON_SNAP) : 0;
+  const snoozeProgress = dragX > 0 ? Math.min(1, dragX / SWIPE_ICON_SNAP) : 0;
+  const showSwipeBackgrounds = canSwipe && dragX !== 0;
+
   return (
     <div
-      role="row"
-      tabIndex={0}
+      className="relative overflow-hidden"
       data-thread-id={email.threadId || email.id}
-      onClick={onSelect}
-      onMouseEnter={onHover}
-      onKeyDown={(e) => e.key === "Enter" && onSelect()}
-      className={cn(
-        "email-list-row group relative flex cursor-pointer items-center h-[48px] sm:h-[38px] px-3 transition-colors",
-        isSelected && "selected",
-        isFocused && !isSelected && "focused",
-        isMultiSelected && "multi-selected",
-      )}
     >
-      {/* Multi-select left border indicator */}
-      {isMultiSelected && (
-        <div className="absolute left-0 top-0 bottom-0 w-[3px] bg-primary rounded-r" />
+      {/* Swipe-reveal backgrounds — only rendered while the row is displaced
+          so they never flash into the layout for non-touch interactions. */}
+      {showSwipeBackgrounds && (
+        <>
+          {/* Snooze background — revealed under the row when swiping right */}
+          <div
+            className="pointer-events-none absolute inset-y-0 left-0 flex items-center justify-start pl-6 bg-amber-500"
+            style={{ width: Math.max(0, dragX) }}
+            aria-hidden
+          >
+            <div
+              className="flex items-center gap-2 text-white"
+              style={{
+                opacity: 0.4 + snoozeProgress * 0.6,
+                transform: `scale(${0.85 + snoozeProgress * 0.25})`,
+              }}
+            >
+              <IconClock className="h-5 w-5" stroke={2.25} />
+            </div>
+          </div>
+          {/* Archive background — revealed under the row when swiping left */}
+          <div
+            className="pointer-events-none absolute inset-y-0 right-0 flex items-center justify-end pr-6 bg-emerald-600"
+            style={{ width: Math.max(0, -dragX) }}
+            aria-hidden
+          >
+            <div
+              className="flex items-center gap-2 text-white"
+              style={{
+                opacity: 0.4 + archiveProgress * 0.6,
+                transform: `scale(${0.85 + archiveProgress * 0.25})`,
+              }}
+            >
+              <IconCheck className="h-5 w-5" stroke={2.5} />
+            </div>
+          </div>
+        </>
       )}
 
-      {/* Unread / account dot */}
-      <div className="w-5 shrink-0 flex items-center justify-center">
-        {isUnread ? (
-          <div className="h-[7px] w-[7px] rounded-full bg-primary" />
-        ) : isMultiAccount && email.accountEmail ? (
-          <div
-            className={cn(
-              "h-[5px] w-[5px] rounded-full opacity-50",
-              getAccountColor(email.accountEmail, allAccounts),
-            )}
-          />
-        ) : null}
-      </div>
-
-      {/* Sender name — fixed width column */}
-      <span
-        className={cn(
-          "w-[100px] sm:w-[160px] shrink-0 text-sm sm:text-[13px] truncate mr-3",
-          isUnread
-            ? "font-semibold text-foreground"
-            : "font-normal text-foreground/90",
-        )}
-        title={
-          isMultiAccount && email.accountEmail
-            ? `Account: ${email.accountEmail}`
+      <div
+        role="row"
+        tabIndex={0}
+        onClick={handleRowClick}
+        onMouseEnter={onHover}
+        onKeyDown={(e) => e.key === "Enter" && onSelect()}
+        onTouchStart={canSwipe ? handleTouchStart : undefined}
+        onTouchMove={canSwipe ? handleTouchMove : undefined}
+        onTouchEnd={canSwipe ? handleTouchEnd : undefined}
+        onTouchCancel={canSwipe ? handleTouchCancel : undefined}
+        style={
+          canSwipe
+            ? {
+                transform: `translateX(${dragX}px)`,
+                transition: isDragging ? "none" : "transform 180ms ease-out",
+                touchAction: "pan-y",
+                // While the row is displaced we need a solid background so the
+                // colored reveal backgrounds don't bleed through. When idle we
+                // leave this unset so the .focused / .selected CSS classes can
+                // apply their own backgrounds naturally.
+                ...(dragX !== 0
+                  ? {
+                      backgroundColor: isSelected
+                        ? "hsl(var(--secondary))"
+                        : isFocused
+                          ? "hsl(var(--accent))"
+                          : isMultiSelected
+                            ? "hsl(var(--card))"
+                            : "hsl(var(--background))",
+                    }
+                  : {}),
+              }
             : undefined
         }
+        className={cn(
+          "email-list-row group relative flex cursor-pointer items-center h-[48px] sm:h-[38px] px-3 transition-colors",
+          isSelected && "selected",
+          isFocused && !isSelected && "focused",
+          isMultiSelected && "multi-selected",
+        )}
       >
-        {senderName}
-      </span>
+        {/* Multi-select left border indicator */}
+        {isMultiSelected && (
+          <div className="absolute left-0 top-0 bottom-0 w-[3px] bg-primary rounded-r" />
+        )}
 
-      {/* Label badges */}
-      {displayLabels.length > 0 && (
-        <div className="flex items-center gap-1 shrink-0 mr-2">
-          {displayLabels.slice(0, 2).map((labelId) => {
-            const style = getLabelStyle(labelId);
-            const displayName = labelId
-              .replace(/^label:/, "")
-              .replace(/^CATEGORY_/, "")
-              .toLowerCase();
-            return (
-              <span
-                key={labelId}
-                className={cn("label-badge", style.bg, style.text)}
-              >
-                {truncate(displayName, 16)}
-              </span>
-            );
-          })}
+        {/* Unread / account dot */}
+        <div className="w-5 shrink-0 flex items-center justify-center">
+          {isUnread ? (
+            <div className="h-[7px] w-[7px] rounded-full bg-primary" />
+          ) : isMultiAccount && email.accountEmail ? (
+            <div
+              className={cn(
+                "h-[5px] w-[5px] rounded-full opacity-50",
+                getAccountColor(email.accountEmail, allAccounts),
+              )}
+            />
+          ) : null}
         </div>
-      )}
 
-      {/* Subject + snippet — fills remaining space */}
-      <div className="flex-1 min-w-0 flex items-center gap-1.5 overflow-hidden">
+        {/* Sender name — fixed width column */}
         <span
           className={cn(
-            "text-sm sm:text-[13px] truncate shrink-0 max-w-[45%]",
+            "w-[100px] sm:w-[160px] shrink-0 text-sm sm:text-[13px] truncate mr-3",
             isUnread
-              ? "font-medium text-foreground"
+              ? "font-semibold text-foreground"
               : "font-normal text-foreground/90",
           )}
+          title={
+            isMultiAccount && email.accountEmail
+              ? `Account: ${email.accountEmail}`
+              : undefined
+          }
         >
-          {email.subject}
+          {senderName}
         </span>
-        <span className="text-sm sm:text-[13px] text-muted-foreground/80 truncate">
-          {email.snippet}
+
+        {/* Label badges */}
+        {displayLabels.length > 0 && (
+          <div className="flex items-center gap-1 shrink-0 mr-2">
+            {displayLabels.slice(0, 2).map((labelId) => {
+              const style = getLabelStyle(labelId);
+              const displayName = labelId
+                .replace(/^label:/, "")
+                .replace(/^CATEGORY_/, "")
+                .toLowerCase();
+              return (
+                <span
+                  key={labelId}
+                  className={cn("label-badge", style.bg, style.text)}
+                >
+                  {truncate(displayName, 16)}
+                </span>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Subject + snippet — fills remaining space */}
+        <div className="flex-1 min-w-0 flex items-center gap-1.5 overflow-hidden">
+          <span
+            className={cn(
+              "text-sm sm:text-[13px] truncate shrink-0 max-w-[45%]",
+              isUnread
+                ? "font-medium text-foreground"
+                : "font-normal text-foreground/90",
+            )}
+          >
+            {email.subject}
+          </span>
+          <span className="text-sm sm:text-[13px] text-muted-foreground/80 truncate">
+            {email.snippet}
+          </span>
+        </div>
+
+        {/* Time — right aligned, hidden on hover */}
+        <span className="row-time shrink-0 ml-3 text-xs sm:text-[12px] text-muted-foreground tabular-nums">
+          {formatEmailDate(email.date)}
         </span>
-      </div>
 
-      {/* Time — right aligned, hidden on hover */}
-      <span className="row-time shrink-0 ml-3 text-xs sm:text-[12px] text-muted-foreground tabular-nums">
-        {formatEmailDate(email.date)}
-      </span>
-
-      {/* Hover actions — overlay on top of time */}
-      <div className="hover-actions items-center gap-0.5">
-        <button
-          onClick={onStar}
-          className={cn(
-            "flex h-6 w-6 items-center justify-center rounded transition-colors",
-            isStarred
-              ? "text-amber-400"
-              : "text-muted-foreground hover:text-foreground hover:bg-accent",
-          )}
-          title="Pin"
-        >
-          <IconStarFilled className="h-3.5 w-3.5" />
-        </button>
+        {/* Hover actions — overlay on top of time */}
+        <div className="hover-actions items-center gap-0.5">
+          <button
+            onClick={onStar}
+            className={cn(
+              "flex h-6 w-6 items-center justify-center rounded transition-colors",
+              isStarred
+                ? "text-amber-400"
+                : "text-muted-foreground hover:text-foreground hover:bg-accent",
+            )}
+            title="Pin"
+          >
+            <IconStarFilled className="h-3.5 w-3.5" />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -73,6 +73,13 @@ export function AppLayout({ children }: AppLayoutProps) {
   const compose = useComposeState();
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [snoozeOpen, setSnoozeOpen] = useState(false);
+  // When the user swipes a row to snooze, we need to snooze that specific
+  // email — not whatever is currently focused in navigation state. This
+  // override wins over `targetEmail` while a swipe-triggered modal is open.
+  const [snoozeOverride, setSnoozeOverride] = useState<{
+    id: string;
+    accountEmail?: string;
+  } | null>(null);
   const [searchFocused, setSearchFocused] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const navigate = useNavigate();
@@ -536,8 +543,29 @@ export function AppLayout({ children }: AppLayoutProps) {
       toast.error("No email selected.");
       return;
     }
+    setSnoozeOverride(null);
     setSnoozeOpen(true);
   }, [targetEmail]);
+
+  // Swipe-to-snooze: EmailList dispatches this when a row is swiped right.
+  // We capture the email id here so the modal snoozes the swiped row even
+  // if the user hasn't opened it (and navigation state still points
+  // elsewhere).
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (
+        e as CustomEvent<{ emailId: string; accountEmail?: string }>
+      ).detail;
+      if (!detail?.emailId) return;
+      setSnoozeOverride({
+        id: detail.emailId,
+        accountEmail: detail.accountEmail,
+      });
+      setSnoozeOpen(true);
+    };
+    window.addEventListener("email:request-snooze", handler);
+    return () => window.removeEventListener("email:request-snooze", handler);
+  }, []);
 
   useKeyboardShortcuts([
     {
@@ -1176,10 +1204,18 @@ export function AppLayout({ children }: AppLayoutProps) {
         />
         <SnoozeModal
           open={snoozeOpen}
-          emailId={targetEmail?.id ?? null}
-          accountEmail={targetEmail?.accountEmail}
-          onClose={() => setSnoozeOpen(false)}
-          onSnoozed={() => setSnoozeOpen(false)}
+          emailId={snoozeOverride?.id ?? targetEmail?.id ?? null}
+          accountEmail={
+            snoozeOverride?.accountEmail ?? targetEmail?.accountEmail
+          }
+          onClose={() => {
+            setSnoozeOpen(false);
+            setSnoozeOverride(null);
+          }}
+          onSnoozed={() => {
+            setSnoozeOpen(false);
+            setSnoozeOverride(null);
+          }}
         />
       </div>
     </AccountFilterContext.Provider>


### PR DESCRIPTION
## Summary

- **Mobile Google OAuth fix**: The mail app's Google connect flow was silently failing in the mobile WebView. Click "Connect" → brief loading → nothing happened. Fixed by switching from `window.location.href` (which relied on `onShouldStartLoadWithRequest` intercepting the Google URL — unreliable depending on react-native-webview config) to an explicit `postMessage` bridge. The native `AppWebView` now handles `{ type: "openUrl", url }` messages by calling `Linking.openURL()`, which opens Safari. Errors from the auth URL fetch are now surfaced to the user when credentials are configured, instead of being silently swallowed by the wizard-only error handler.
- **Email list swipe gestures**: `EmailListItem` gets left-swipe-to-archive and right-swipe-to-snooze with reveal backgrounds.
- **Agent chat schema prompts**: Extracted schema prompt generation into `packages/core/src/server/schema-prompt.ts` and wired it through `agent-chat-plugin`, with supporting updates in `AgentPanel`, `AssistantChat`, and `agent-chat-adapter`.
- **Macros AGENTS.md**: Minor updates.

## Test plan

- [ ] Open the mobile app, tap Mail, click "Sign in with Google" → Safari should open with the Google consent screen
- [ ] Complete OAuth flow → deep link should return to the app and mail should load
- [ ] If `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` are misconfigured, verify an error message appears in the banner
- [ ] Swipe left on an email row → archive action reveals and commits past threshold
- [ ] Swipe right on an email row → snooze action reveals and commits past threshold
- [ ] Verify no regressions in desktop/web Google connect flow