### PR TITLE
feat: pluggable AgentEngine abstraction + Vercel AI SDK multi-provider support

### DIFF
--- a/docs/plans/2026-04-10-001-feat-builder-llm-engine-plan.md
+++ b/docs/plans/2026-04-10-001-feat-builder-llm-engine-plan.md
@@ -1,0 +1,239 @@
+---
+title: "feat: Builder AI backend as a pluggable agent engine"
+type: feat
+status: blocked
+date: 2026-04-10
+---
+
+# Builder AI Backend as a Pluggable Agent Engine
+
+## Overview
+
+Add a `BuilderEngine` that routes LLM calls through Builder's hosted `ai-services` backend. This gives users of Builder-hosted agent-native deployments a single-key setup: drop in one Builder private key (`bpk-...`) instead of wiring up `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, Bedrock credentials, Vertex credentials, and so on. Builder handles multi-provider routing, automatic provider fallback (Anthropic direct -> Bedrock -> Vertex), token counting, billing, and rate limiting — all of which already exist inside `ai-services` as `completionLLM()`.
+
+**Value prop:**
+
+- One key (`BUILDER_PRIVATE_KEY=bpk-...`) replaces N per-provider keys.
+- Users get multi-provider model access (Claude Opus/Sonnet, GPT-5.4, Gemini 2.5) without signing up for each vendor.
+- Builder's internal provider hierarchy handles outages transparently — if Anthropic direct is degraded, requests fall through to Bedrock or Vertex without the caller seeing anything.
+- Billing is unified in Builder's existing credit system; traffic shows up on the existing Builder dashboards.
+- This is the recommended engine for Builder-hosted agent-native apps. Self-hosted apps can still use the direct `anthropic` or `ai-sdk:*` engines with their own keys.
+
+This plan lands a **third engine** on top of the existing `AgentEngine` registry (see "Dependencies" below). It is purely additive on the agent-native side — no existing engine code changes except a single `registerAgentEngine()` call in `builtin.ts` and a small tweak to the engine picker UI.
+
+## Status: Blocked
+
+This plan is **blocked** on the corresponding `ai-services` PRD landing first.
+
+- **Blocker:** `ai-services` must expose `POST /agent/messages` and `GET /agent/models`. That work is described in a separate PRD (`agent-native-llm-gateway.mdx`) which has been submitted to the ai-services team for approval. Until those endpoints exist (and their wire format is agreed on), `BuilderEngine` has nothing to call.
+- **Purpose of this file:** Placeholder so we can pick this plan up as soon as the ai-services team approves the PRD (or revise it according to their feedback). Keeping the agent-native-side plan written down now means we don't lose context on the details when we come back.
+- **When to unblock:** After the `ai-services` team either (a) approves `agent-native-llm-gateway.mdx` as-is and ships the endpoints, or (b) gives feedback that changes the wire format — in which case the "What gets built" section below needs to be updated before starting implementation.
+
+## Dependencies
+
+### 1. In-flight engine refactor (agent-native)
+
+The `AgentEngine` abstraction — the whole `packages/core/src/agent/engine/` tree — is currently being landed in a parallel refactor (the "engine registry" work on branch `updates-85`). Files already exist on disk: `types.ts`, `registry.ts`, `builtin.ts`, `anthropic-engine.ts`, `ai-sdk-engine.ts`, `translate-anthropic.ts`, `translate-ai-sdk.ts`. Built-in engines are `anthropic` (direct SDK) and `ai-sdk:*` (multi-provider via the Vercel AI SDK).
+
+This plan sits **entirely on top** of that refactor. Every file referenced below — `builtin.ts`, `anthropic-engine.ts`, `docs/agent-engines.md`, the agent-engines skill, the mail template engine picker — only exists after the in-flight refactor merges. Do not start implementation until the refactor is on `main`, otherwise we'll be editing files mid-refactor and hit rebase pain.
+
+### 2. ai-services endpoints (new PRD, blocker)
+
+See "Status: Blocked" above. The wire format below assumes the ai-services endpoints exist and match the expected shape.
+
+## Architecture
+
+```
+┌─────────────────────────┐         ┌──────────────────────────────┐
+│  agent-native app       │         │  ai-services                 │
+│  (Builder-hosted)       │         │  packages/service            │
+│                         │         │                              │
+│  BuilderEngine.stream() │ ──POST──▶ /agent/messages              │
+│    apiKey: bpk-…        │  HTTP    │   authMiddleware             │
+│    baseURL: https://…   │  JSONL   │   validateAICreditsMiddleware│
+│                         │  stream  │   │                          │
+│  ← parse EngineEvent    │ ────────── completionLLM()              │
+│    JSONL lines          │          │     ↓                        │
+│                         │          │   anthropic / openai /       │
+│                         │          │   gemini / bedrock / vertex  │
+└─────────────────────────┘         └──────────────────────────────┘
+```
+
+**Wire format.** JSONL. Each line is a JSON object that matches agent-native's `EngineEvent` union exactly: `text-delta`, `thinking-delta`, `tool-call-delta`, `tool-call`, `usage`, `stop`. Because the wire events are structurally identical to `EngineEvent`, `BuilderEngine` does zero translation — it's a one-line `JSON.parse` per line. This is the central simplification of the whole design: both sides own the type, so we ship bytes that already match the consumer shape.
+
+**Auth & billing.** `ai-services` reuses its existing `readCredentials()` + `validateAICreditsMiddleware`. The agent-native side just passes `Authorization: Bearer bpk-...`. No new billing code on either side.
+
+**Provider fallback.** Handled inside `ai-services` via `getModelHierachy()`. The caller (agent-native) never sees it. If Anthropic direct goes down, the user's chat keeps working.
+
+## What Gets Built
+
+### New file: `packages/core/src/agent/engine/builder-engine.ts`
+
+Implements `AgentEngine` by `fetch()`-ing the Builder gateway. Structure mirrors `anthropic-engine.ts`.
+
+- **Constructor** takes `{ apiKey: string; baseURL?: string; model?: string }`.
+  - `apiKey` is the `bpk-...` private key.
+  - `baseURL` defaults to `https://ai.builder.io` (override via `BUILDER_AI_BASE_URL` env var or per-call config).
+  - `model` defaults to `agent-native-default` (the Builder-side alias for the Claude Sonnet 4.6 provider hierarchy).
+- **`capabilities`**: `{ thinking: true, promptCaching: true, vision: true, computerUse: false, parallelToolCalls: true }`. The engine advertises the _union_ of capabilities across supported models; if the user picks a non-Claude model, runtime silently ignores `thinking` / `cacheControl` opts (same behavior as the current AI SDK engine).
+- **`stream()`** method body:
+  1. Build the JSON request body from `EngineStreamOptions` — `{ model, system, messages, tools, maxTokens, temperature, reasoning, providerOptions }`.
+  2. `fetch(baseURL + "/agent/messages", { method: "POST", headers: { Authorization: "Bearer " + apiKey, "Content-Type": "application/json", Accept: "application/jsonl" }, body: JSON.stringify(req), signal: abortSignal })`.
+  3. On non-2xx response, read the error body and yield `{ type: "stop", reason: "error", error: <structured> }`, then return.
+  4. Stream the response body via `response.body?.getReader()`. Decode to text, split on `\n`, buffer partial lines across reads. For each complete non-empty line, `JSON.parse` and yield the result as an `EngineEvent`.
+  5. Accumulate the assistant content parts as they arrive (text deltas -> text part, tool-call events -> tool-call part, thinking deltas -> thinking part) and stash the final assistant content via the `ASSISTANT_CONTENT_KEY` side-channel — mirroring exactly what `AnthropicEngine` does today. `runAgentLoop` reads that key to append the assistant turn to the message history.
+
+The `ASSISTANT_CONTENT_KEY` side-channel is a wart (the in-flight refactor may eventually clean it up by adding a `final-assistant` event to the `EngineEvent` union), but for now `BuilderEngine` matches the `AnthropicEngine` pattern to stay consistent and unblock landing.
+
+### Modify: `packages/core/src/agent/engine/builtin.ts`
+
+Add a single `registerAgentEngine()` call inside `registerBuiltinEngines()`:
+
+```ts
+registerAgentEngine({
+  name: "builder",
+  label: "Builder AI Backend",
+  description:
+    "Route LLM calls through Builder's hosted backend. One private key, multi-provider routing, automatic token counting and billing. Recommended for Builder-hosted agent-native apps.",
+  capabilities: {
+    thinking: true,
+    promptCaching: true,
+    vision: true,
+    computerUse: false,
+    parallelToolCalls: true,
+  },
+  defaultModel: "agent-native-default",
+  supportedModels: [
+    "agent-native-default",
+    "anthropic-claude-4-6-opus",
+    "anthropic-claude-4-6-sonnet",
+    "openai-gpt-5.4",
+    "openai-gpt-5.4-mini-20260317",
+    "vertexai-gemini-2-5-pro",
+    "vertexai-gemini-2-5-flash",
+  ],
+  requiredEnvVars: ["BUILDER_PRIVATE_KEY"],
+  create: (config) => createBuilderEngine(config),
+});
+```
+
+The `supportedModels` list is a static fallback. A follow-up can fetch `GET /agent/models` on first use and cache the dynamic list, but seeding the static list means `createBuilderEngine()` never needs a network call at construction time.
+
+### New tests: `packages/core/src/agent/engine/builder-engine.spec.ts`
+
+- Mock `fetch` with a canned JSONL response body (`text-delta` lines, `tool-call-delta` + `tool-call`, `usage`, `stop`).
+- Drive `BuilderEngine.stream()` and assert the yielded `EngineEvent`s match 1:1.
+- Assert the request body is well-formed JSON with the expected fields.
+- Assert `Authorization: Bearer bpk-test` header is set.
+- Assert non-2xx responses surface as a `stop` event with `reason: "error"` instead of throwing.
+- Assert partial-line buffering works: feed a response body split at arbitrary byte boundaries inside a JSON line and confirm the parser reassembles correctly.
+
+### Engine picker UI tweak
+
+The in-flight refactor lands an engine picker at `templates/mail/app/components/agent-engine-picker.tsx` (wired into `templates/mail/app/routes/settings.agent.tsx`). Builder will appear in the engine list automatically via `list-agent-engines` once registered. Two small UI tweaks are needed:
+
+- When `engine === "builder"` is selected, show a **"Builder Private Key (bpk-...)"** input field with a link to `https://builder.io/account/space` where users can generate one. The field writes to the `BUILDER_PRIVATE_KEY` env var via the existing env-vars flow.
+- Hide the per-provider key fields (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) when Builder is selected — they're not needed.
+
+The existing `test-agent-engine` action already runs a trivial "reply with OK" prompt through any registered engine, so it will work against `BuilderEngine` automatically once registered. No additional code needed for the test-connection button.
+
+### Docs
+
+Add a "Builder AI Backend" section to `docs/agent-engines.md` (which the in-flight refactor creates). Cover:
+
+- When to use Builder vs. direct Anthropic vs. `ai-sdk:*`.
+- How to obtain a `bpk-...` key at `https://builder.io/account/space`.
+- Env var setup: `BUILDER_PRIVATE_KEY`, optional `BUILDER_AI_BASE_URL`, `AGENT_ENGINE=builder`.
+- Supported models and how Builder handles provider fallback internally.
+- Billing model — credits are deducted per call against the owner of the private key.
+
+### Skill
+
+Add a "Builder AI Backend" entry to `packages/core/.agents/skills/agent-engines/SKILL.md` (created by the in-flight refactor). Include the same capabilities table and env var requirements so the agent knows when to suggest this engine.
+
+## Resolution Order
+
+The existing `resolveEngine()` in `registry.ts` already supports any registered engine by name, so no changes are needed there. Users select `builder` via (in priority order):
+
+1. `createAgentChatPlugin({ engine: "builder" })` in a template's server plugin.
+2. Settings store key `agent-engine.engine = "builder"` (written by the picker UI).
+3. Env var `AGENT_ENGINE=builder`.
+
+And `BUILDER_PRIVATE_KEY` (env var or per-call config override) supplies the key.
+
+## Wire Format Expectations
+
+The Builder gateway returns JSONL lines that match the `EngineEvent` union exactly:
+
+| Event             | Shape                                                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `text-delta`      | `{ type: "text-delta", text: string }`                                                                              |
+| `thinking-delta`  | `{ type: "thinking-delta", text: string }`                                                                          |
+| `tool-call-delta` | `{ type: "tool-call-delta", id: string, name: string, argsTextDelta: string }`                                      |
+| `tool-call`       | `{ type: "tool-call", id: string, name: string, input: unknown }`                                                   |
+| `usage`           | `{ type: "usage", inputTokens: number, outputTokens: number, cacheReadTokens?: number, cacheWriteTokens?: number }` |
+| `stop`            | `{ type: "stop", reason: "end_turn" \| "tool_use" \| "max_tokens" \| "stop_sequence" \| "error", error?: string }`  |
+
+Because these are identical to `EngineEvent`, `BuilderEngine` does zero translation. The line-splitting/buffering loop is the only parsing logic it owns.
+
+## Coordination With the In-Flight Refactor
+
+One tweak to `EngineEvent` is needed before this plan can land, and it needs to be coordinated with whoever is driving the in-flight refactor so we don't conflict on rebase:
+
+- **Add `tool-call-delta` to the `EngineEvent` union.** The wire format above relies on it for incremental tool-argument streaming — the Builder gateway streams tool args as they're generated so the UI can render tool arg JSON character-by-character. `runAgentLoop` ignores `tool-call-delta` for dispatch (only the terminal `tool-call` with fully-parsed `input` triggers tool execution) but forwards it as an `AgentChatEvent` to the chat UI.
+- **Teach `AnthropicEngine` to emit `tool-call-delta`.** Parse Anthropic's `input_json_delta` content-block events and translate them to `tool-call-delta` so the new wire event is supported by both engines, not just Builder. This keeps behavior consistent across engines — the chat UI should render tool arg streaming identically regardless of which engine is active.
+
+Both changes are small (a new variant on the union plus a translation case in `translate-anthropic.ts`) and should be coordinated with the in-flight refactor agent. If the refactor has already landed by the time we pick this up, these become part of this plan; if the refactor is still open, we should bundle these changes into it to avoid churn.
+
+## Failure Handling
+
+**Fail hard on Builder backend errors.** No silent fallback to direct Anthropic. Builder's internal hierarchy (`getModelHierachy()`) already covers provider outages — the caller never needs its own fallback.
+
+- **Non-2xx responses** surface as a `{ type: "stop", reason: "error", error: <body> }` event so the chat UI can render a clean error message.
+- **402 credit exhaustion** surfaces the structured error body through as the `error` field. The ai-services side is expected to return something like `{ type: "credit_exceeded", topUpUrl: "https://builder.io/account/billing" }`; the chat UI can detect this shape and render a "Top up credits" link. We may later promote this to a dedicated `stop` reason (`reason: "credit_exceeded"`) if it proves useful, but starting with structured-error-in-`error`-field avoids expanding the `EngineEvent` union prematurely.
+- **Network errors / aborts** pass through via the `AbortSignal` same as every other engine — no special handling.
+
+## Testing and Verification
+
+- `pnpm run prep` in the framework repo — typecheck, lint, unit tests (including the new `builder-engine.spec.ts`).
+- Manual end-to-end in `templates/mail`:
+  ```
+  BUILDER_PRIVATE_KEY=bpk-... AGENT_ENGINE=builder pnpm dev
+  ```
+  Open the chat, send "hello world", verify streaming reply, verify tool calls (for example, "list my emails") work identically to the direct Anthropic engine.
+- Flip the engine picker in `settings.agent` between `anthropic`, `ai-sdk:openai`, and `builder` — all three should produce indistinguishable chat behavior for a simple prompt.
+- Click "Test connection" on Builder in the picker — should return `ok: true, latencyMs: ...`.
+- Credit exhaustion: coordinate with ai-services to seed a `bpk-test` key at zero credits, verify the chat UI shows the structured error cleanly instead of crashing.
+- Bill dashboard: verify traffic from the test session appears under the `source: agent-native` credit category (that category is added on the ai-services side per the companion PRD).
+
+## Sequencing
+
+In order:
+
+1. **ai-services team approves** `agent-native-llm-gateway.mdx` PRD (or gives feedback that changes the wire format — update this plan accordingly).
+2. **ai-services ships** `POST /agent/messages` and `GET /agent/models`, with the JSONL wire format matching `EngineEvent`.
+3. **In-flight `AgentEngine` refactor merges** on agent-native `main`.
+4. **This plan can be picked up.** At that point, unblock the status (`status: in-progress`) and start implementation. The agent-native-side changes are a single afternoon's work — the hard part is the ai-services side, which is already done by step 2.
+
+## Out of Scope
+
+- Fine-grained credit metering UI on the agent-native side (beyond surfacing the credit-exhausted error). Credit display/top-up flows live in Builder's account UI, not inside agent-native apps.
+- Model auto-discovery. `GET /agent/models` exists but the initial implementation uses the static `supportedModels` list in `builtin.ts`. Dynamic model discovery is a reasonable follow-up, not a blocker.
+- Multi-key support (different `bpk-` per user inside a single deployment). Agent-native is single-tenant; one deployment = one Builder key.
+- Anthropic-compatible wire shim for third parties. Both sides of this are Builder-owned, so we use the cleaner JSONL format. If an external consumer ever needs Anthropic-compatible streaming, we can add a `/agent/messages?format=anthropic` variant without touching the JSONL path.
+
+## Sources
+
+- **Draft technical spec (both repos):** `~/.claude/plans/nested-exploring-feigenbaum.md` — the original cross-repo plan this file is derived from. Part 2 ("agent-native changes") maps directly to the "What Gets Built" section here; Part 1 ("ai-services changes") is the companion PRD (`agent-native-llm-gateway.mdx`).
+- **Engine abstraction (agent-native, in-flight refactor):**
+  - `packages/core/src/agent/engine/types.ts` — `EngineEvent`, `EngineStreamOptions`, `AgentEngine`
+  - `packages/core/src/agent/engine/registry.ts` — `registerAgentEngine`, `resolveEngine`
+  - `packages/core/src/agent/engine/anthropic-engine.ts` — pattern to mirror, including `ASSISTANT_CONTENT_KEY` usage
+  - `packages/core/src/agent/engine/builtin.ts` — where to register the new engine
+  - `packages/core/src/agent/engine/translate-anthropic.ts` — where to add `input_json_delta` -> `tool-call-delta` translation
+- **Reference implementations in `ai-services` (for context only — no edits):**
+  - `packages/service/genai/llm/index.ts` — `completionLLM()` dispatcher
+  - `packages/service/genai/types.ts` — `BaseStream` interface
+  - `packages/service/auth.ts` — `readCredentials()` handles `bpk-` auth
+  - `packages/service/middleware/ai-credits.ts` — credit validation
+  - `packages/service/genai/llm/model-configs.ts` — model hierarchy + full list

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -95,6 +95,13 @@
     "yjs": "^13.6.30"
   },
   "peerDependencies": {
+    "@ai-sdk/anthropic": ">=1",
+    "@ai-sdk/cohere": ">=1",
+    "@ai-sdk/google": ">=1",
+    "@ai-sdk/groq": ">=1",
+    "@ai-sdk/mistral": ">=1",
+    "@ai-sdk/ollama": ">=0.0.1",
+    "@ai-sdk/openai": ">=1",
     "@assistant-ui/react": ">=0.12",
     "@assistant-ui/react-markdown": ">=0.12",
     "@supabase/supabase-js": ">=2",
@@ -104,6 +111,7 @@
     "@xterm/addon-fit": ">=0.10",
     "@xterm/addon-web-links": ">=0.11",
     "@xterm/xterm": ">=5",
+    "ai": ">=4",
     "autoprefixer": ">=10",
     "convex": ">=1",
     "node-pty": ">=1",
@@ -119,6 +127,30 @@
     "ws": ">=8"
   },
   "peerDependenciesMeta": {
+    "ai": {
+      "optional": true
+    },
+    "@ai-sdk/anthropic": {
+      "optional": true
+    },
+    "@ai-sdk/openai": {
+      "optional": true
+    },
+    "@ai-sdk/google": {
+      "optional": true
+    },
+    "@ai-sdk/groq": {
+      "optional": true
+    },
+    "@ai-sdk/mistral": {
+      "optional": true
+    },
+    "@ai-sdk/cohere": {
+      "optional": true
+    },
+    "@ai-sdk/ollama": {
+      "optional": true
+    },
     "@tabler/icons-react": {
       "optional": true
     },
@@ -172,6 +204,10 @@
     }
   },
   "devDependencies": {
+    "@ai-sdk/anthropic": "^1.2.12",
+    "@ai-sdk/google": "^1.2.22",
+    "@ai-sdk/groq": "^1.2.9",
+    "@ai-sdk/openai": "^1.3.24",
     "@assistant-ui/react": "^0.12.19",
     "@assistant-ui/react-markdown": "^0.12.6",
     "@react-router/dev": "^7.13.1",
@@ -189,6 +225,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
+    "ai": "^4.3.19",
     "autoprefixer": "^10.4.21",
     "express": "^5.2.1",
     "firebase-admin": "^13.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,7 +100,7 @@
     "@ai-sdk/google": ">=1",
     "@ai-sdk/groq": ">=1",
     "@ai-sdk/mistral": ">=1",
-    "@ai-sdk/ollama": ">=0.0.1",
+    "ollama-ai-provider": ">=1",
     "@ai-sdk/openai": ">=1",
     "@assistant-ui/react": ">=0.12",
     "@assistant-ui/react-markdown": ">=0.12",
@@ -148,7 +148,7 @@
     "@ai-sdk/cohere": {
       "optional": true
     },
-    "@ai-sdk/ollama": {
+    "ollama-ai-provider": {
       "optional": true
     },
     "@tabler/icons-react": {

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -1,0 +1,363 @@
+/**
+ * AISDKEngine — wraps the Vercel AI SDK (ai package) for multi-provider support.
+ *
+ * Supports Anthropic, OpenAI, Google Gemini, Groq, and any provider with an
+ * @ai-sdk/* package. Provider is selected via the `provider` config option.
+ *
+ * When provider is "anthropic", Anthropic-native features (thinking, cacheControl)
+ * are forwarded through the AI SDK's providerOptions mechanism — no fidelity loss
+ * compared to the native AnthropicEngine.
+ *
+ * The ai package is an OPTIONAL peer dependency. This engine uses dynamic import()
+ * so the core package remains installable without the AI SDK.
+ */
+
+import type {
+  AgentEngine,
+  EngineCapabilities,
+  EngineStreamOptions,
+  EngineEvent,
+} from "./types.js";
+import {
+  engineToolsToAISDK,
+  engineMessagesToAISDK,
+  aiSdkPartToEngineEvents,
+  aiSdkStepToAssistantContent,
+} from "./translate-ai-sdk.js";
+
+// ---------------------------------------------------------------------------
+// Provider definitions
+// ---------------------------------------------------------------------------
+
+export type AISDKProvider =
+  | "anthropic"
+  | "openai"
+  | "google"
+  | "groq"
+  | "mistral"
+  | "cohere"
+  | "ollama";
+
+const PROVIDER_CAPABILITIES: Record<AISDKProvider, EngineCapabilities> = {
+  anthropic: {
+    thinking: true,
+    promptCaching: true,
+    vision: true,
+    computerUse: false, // not exposed through AI SDK yet
+    parallelToolCalls: true,
+  },
+  openai: {
+    thinking: false,
+    promptCaching: false,
+    vision: true,
+    computerUse: false,
+    parallelToolCalls: true,
+  },
+  google: {
+    thinking: true,
+    promptCaching: false,
+    vision: true,
+    computerUse: false,
+    parallelToolCalls: true,
+  },
+  groq: {
+    thinking: false,
+    promptCaching: false,
+    vision: false,
+    computerUse: false,
+    parallelToolCalls: true,
+  },
+  mistral: {
+    thinking: false,
+    promptCaching: false,
+    vision: false,
+    computerUse: false,
+    parallelToolCalls: true,
+  },
+  cohere: {
+    thinking: false,
+    promptCaching: false,
+    vision: false,
+    computerUse: false,
+    parallelToolCalls: true,
+  },
+  ollama: {
+    thinking: false,
+    promptCaching: false,
+    vision: false,
+    computerUse: false,
+    parallelToolCalls: false,
+  },
+};
+
+const PROVIDER_DEFAULT_MODELS: Record<AISDKProvider, string> = {
+  anthropic: "claude-sonnet-4-6",
+  openai: "gpt-4o",
+  google: "gemini-2.0-flash",
+  groq: "llama-3.3-70b-versatile",
+  mistral: "mistral-large-latest",
+  cohere: "command-r-plus",
+  ollama: "llama3.1",
+};
+
+const PROVIDER_SUPPORTED_MODELS: Record<AISDKProvider, readonly string[]> = {
+  anthropic: [
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+    "claude-opus-4-5",
+    "claude-sonnet-4-5",
+  ],
+  openai: [
+    "gpt-4o",
+    "gpt-4o-mini",
+    "gpt-4-turbo",
+    "o1",
+    "o1-mini",
+    "o3",
+    "o3-mini",
+  ],
+  google: [
+    "gemini-2.0-flash",
+    "gemini-2.0-pro",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+  ],
+  groq: [
+    "llama-3.3-70b-versatile",
+    "llama-3.1-70b-versatile",
+    "mixtral-8x7b-32768",
+  ],
+  mistral: [
+    "mistral-large-latest",
+    "mistral-medium-latest",
+    "mistral-small-latest",
+  ],
+  cohere: ["command-r-plus", "command-r"],
+  ollama: ["llama3.1", "llama3.2", "mistral", "codestral"],
+};
+
+const PROVIDER_ENV_VARS: Record<AISDKProvider, string[]> = {
+  anthropic: ["ANTHROPIC_API_KEY"],
+  openai: ["OPENAI_API_KEY"],
+  google: ["GOOGLE_GENERATIVE_AI_API_KEY"],
+  groq: ["GROQ_API_KEY"],
+  mistral: ["MISTRAL_API_KEY"],
+  cohere: ["COHERE_API_KEY"],
+  ollama: [], // runs locally
+};
+
+const PROVIDER_PACKAGES: Record<AISDKProvider, string> = {
+  anthropic: "@ai-sdk/anthropic",
+  openai: "@ai-sdk/openai",
+  google: "@ai-sdk/google",
+  groq: "@ai-sdk/groq",
+  mistral: "@ai-sdk/mistral",
+  cohere: "@ai-sdk/cohere",
+  ollama: "@ai-sdk/ollama",
+};
+
+// ---------------------------------------------------------------------------
+// AISDKEngine implementation
+// ---------------------------------------------------------------------------
+
+class AISDKEngine implements AgentEngine {
+  readonly name: string;
+  readonly label: string;
+  readonly defaultModel: string;
+  readonly supportedModels: readonly string[];
+  readonly capabilities: EngineCapabilities;
+
+  private readonly provider: AISDKProvider;
+  private readonly apiKey?: string;
+  private readonly baseUrl?: string;
+
+  constructor(provider: AISDKProvider, config: Record<string, unknown>) {
+    this.provider = provider;
+    this.name = `ai-sdk:${provider}`;
+    this.label = `${capitalize(provider)} (AI SDK)`;
+    this.defaultModel =
+      (config.model as string | undefined) ?? PROVIDER_DEFAULT_MODELS[provider];
+    this.supportedModels = PROVIDER_SUPPORTED_MODELS[provider];
+    this.capabilities = PROVIDER_CAPABILITIES[provider];
+    this.apiKey =
+      (config.apiKey as string | undefined) ?? getProviderApiKey(provider);
+    this.baseUrl = config.baseUrl as string | undefined;
+  }
+
+  async *stream(opts: EngineStreamOptions): AsyncIterable<EngineEvent> {
+    let aiModule: any;
+    try {
+      aiModule = await import("ai");
+    } catch {
+      yield {
+        type: "stop",
+        reason: "error",
+        error: `The "ai" package is not installed. Run: pnpm add ai ${PROVIDER_PACKAGES[this.provider]}`,
+      };
+      return;
+    }
+
+    const { streamText, jsonSchema } = aiModule;
+
+    let providerModel: any;
+    try {
+      providerModel = await this.createProviderModel(opts.model);
+    } catch (err: any) {
+      yield {
+        type: "stop",
+        reason: "error",
+        error: err?.message ?? String(err),
+      };
+      return;
+    }
+
+    const aiSdkTools =
+      opts.tools.length > 0
+        ? engineToolsToAISDK(opts.tools, jsonSchema)
+        : undefined;
+    const messages = engineMessagesToAISDK(opts.messages);
+
+    // Build providerOptions for Anthropic-native features when using Anthropic provider
+    const providerOpts: Record<string, unknown> = {};
+    if (this.provider === "anthropic" && opts.providerOptions?.anthropic) {
+      const anthropicOpts = opts.providerOptions.anthropic;
+      if (anthropicOpts.thinking) {
+        providerOpts.anthropic = {
+          ...((providerOpts.anthropic as object) ?? {}),
+          thinking: {
+            type: "enabled",
+            budgetTokens: anthropicOpts.thinking.budgetTokens,
+          },
+        };
+      }
+      if (anthropicOpts.cacheControl) {
+        // AI SDK v5 supports cache_control via system message providerOptions
+        providerOpts.anthropic = {
+          ...((providerOpts.anthropic as object) ?? {}),
+          cacheControl: anthropicOpts.cacheControl,
+        };
+      }
+    }
+
+    try {
+      const result = streamText({
+        model: providerModel,
+        system: opts.systemPrompt,
+        messages,
+        tools: aiSdkTools,
+        maxTokens: opts.maxTokens ?? 16384,
+        ...(opts.temperature !== undefined
+          ? { temperature: opts.temperature }
+          : {}),
+        abortSignal: opts.abortSignal,
+        // One step only — runAgentLoop drives the loop
+        maxSteps: 1,
+        // Collect tool calls but don't auto-execute them
+        experimental_toolCallStreaming: false,
+        ...(Object.keys(providerOpts).length > 0
+          ? { providerOptions: providerOpts }
+          : {}),
+      });
+
+      let hasEmittedStop = false;
+      let assistantContent: any[] = [];
+
+      for await (const part of result.fullStream) {
+        const events = aiSdkPartToEngineEvents(part);
+        for (const event of events) {
+          yield event;
+          if (event.type === "stop") hasEmittedStop = true;
+        }
+
+        // Capture step finish for assistant content reconstruction
+        if (part.type === "step-finish") {
+          assistantContent = aiSdkStepToAssistantContent(part);
+          (opts as any)[AISDK_ASSISTANT_CONTENT_KEY] = assistantContent;
+        }
+      }
+
+      if (!hasEmittedStop) {
+        yield { type: "stop", reason: "end_turn" };
+      }
+    } catch (err: any) {
+      yield {
+        type: "stop",
+        reason: "error",
+        error: err?.message ?? String(err),
+      };
+      throw err;
+    }
+  }
+
+  private async createProviderModel(model: string): Promise<any> {
+    const pkg = PROVIDER_PACKAGES[this.provider];
+    let providerModule: any;
+    try {
+      providerModule = await import(/* @vite-ignore */ pkg);
+    } catch {
+      throw new Error(
+        `Provider package "${pkg}" is not installed. Run: pnpm add ai ${pkg}`,
+      );
+    }
+
+    const createFnName = `create${capitalize(this.provider)}`;
+    const createFn = providerModule[createFnName] ?? providerModule.default;
+
+    if (typeof createFn !== "function") {
+      throw new Error(`Could not find provider factory in "${pkg}"`);
+    }
+
+    const config: Record<string, unknown> = {};
+    if (this.apiKey) config.apiKey = this.apiKey;
+    if (this.baseUrl) config.baseURL = this.baseUrl;
+
+    const provider = createFn(config);
+    return provider(model);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Symbol for assistant content pass-through
+// ---------------------------------------------------------------------------
+
+export const AISDK_ASSISTANT_CONTENT_KEY = Symbol("aiSdkAssistantContent");
+
+// ---------------------------------------------------------------------------
+// Factory functions
+// ---------------------------------------------------------------------------
+
+export function createAISDKEngine(
+  provider: AISDKProvider,
+  config: Record<string, unknown> = {},
+): AgentEngine {
+  return new AISDKEngine(provider, config);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function getProviderApiKey(provider: AISDKProvider): string | undefined {
+  const envVars = PROVIDER_ENV_VARS[provider];
+  for (const v of envVars) {
+    if (process.env[v]) return process.env[v];
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Exports for registry registration
+// ---------------------------------------------------------------------------
+
+export {
+  PROVIDER_CAPABILITIES,
+  PROVIDER_DEFAULT_MODELS,
+  PROVIDER_SUPPORTED_MODELS,
+  PROVIDER_ENV_VARS,
+  PROVIDER_PACKAGES,
+};

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -154,7 +154,7 @@ const PROVIDER_PACKAGES: Record<AISDKProvider, string> = {
   groq: "@ai-sdk/groq",
   mistral: "@ai-sdk/mistral",
   cohere: "@ai-sdk/cohere",
-  ollama: "@ai-sdk/ollama",
+  ollama: "ollama-ai-provider",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/agent/engine/anthropic-engine.spec.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createAnthropicEngine,
+  ANTHROPIC_CAPABILITIES,
+  ANTHROPIC_DEFAULT_MODEL,
+} from "./anthropic-engine.js";
+import type { EngineStreamOptions } from "./types.js";
+
+// Helper to collect all events from an async iterable
+async function collectEvents(iterable: AsyncIterable<any>) {
+  const events: any[] = [];
+  for await (const e of iterable) {
+    events.push(e);
+  }
+  return events;
+}
+
+describe("createAnthropicEngine", () => {
+  it("creates engine with correct metadata", () => {
+    const engine = createAnthropicEngine({ apiKey: "test-key" });
+    expect(engine.name).toBe("anthropic");
+    expect(engine.defaultModel).toBe(ANTHROPIC_DEFAULT_MODEL);
+    expect(engine.capabilities).toMatchObject(ANTHROPIC_CAPABILITIES);
+  });
+
+  it("stream emits text-delta events from SDK chunks", async () => {
+    // Mock the Anthropic SDK — stream() returns an object that is both
+    // iterable (yields chunks) and has a finalMessage() method.
+    const finalMsg = {
+      content: [{ type: "text", text: "Hello, world!" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 20, output_tokens: 10 },
+    };
+
+    const chunks = [
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Hello, " },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "world!" },
+      },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { output_tokens: 10 },
+      },
+      { type: "message_stop" },
+    ];
+
+    const mockStream = {
+      [Symbol.asyncIterator]: async function* () {
+        for (const chunk of chunks) yield chunk;
+      },
+      finalMessage: vi.fn().mockResolvedValue(finalMsg),
+    };
+
+    vi.doMock("@anthropic-ai/sdk", () => ({
+      default: vi.fn().mockImplementation(() => ({
+        messages: { stream: vi.fn().mockReturnValue(mockStream) },
+      })),
+    }));
+
+    vi.resetModules();
+    const { createAnthropicEngine: freshCreate } =
+      await import("./anthropic-engine.js");
+    const engine = freshCreate({ apiKey: "test" });
+
+    const opts: EngineStreamOptions = {
+      model: "claude-haiku-4-5-20251001",
+      systemPrompt: "You are helpful.",
+      messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      tools: [],
+      abortSignal: new AbortController().signal,
+    };
+
+    const events = await collectEvents(engine.stream(opts));
+    const textDeltas = events.filter((e) => e.type === "text-delta");
+    const texts = textDeltas.map((e: any) => e.text).join("");
+    expect(texts).toBe("Hello, world!");
+
+    const stopEvent = events.find((e) => e.type === "stop");
+    expect(stopEvent).toBeDefined();
+    expect(stopEvent?.reason).toBe("end_turn");
+
+    vi.doUnmock("@anthropic-ai/sdk");
+  });
+
+  it("stream emits stop with error when API key is missing", async () => {
+    const engine = createAnthropicEngine({});
+    const opts: EngineStreamOptions = {
+      model: "claude-haiku-4-5-20251001",
+      systemPrompt: "Test",
+      messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      tools: [],
+      abortSignal: new AbortController().signal,
+    };
+
+    const events = await collectEvents(engine.stream(opts));
+    const stopEvent = events.find((e) => e.type === "stop");
+    expect(stopEvent?.reason).toBe("error");
+    expect(stopEvent?.error).toContain("ANTHROPIC_API_KEY");
+  });
+});

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -1,0 +1,206 @@
+/**
+ * AnthropicEngine — wraps @anthropic-ai/sdk for use as an AgentEngine.
+ *
+ * This is the default, best-in-class engine. It supports all Anthropic-native
+ * features: extended thinking, prompt caching, vision, computer use, and
+ * parallel tool calls.
+ *
+ * All providerOptions.anthropic fields are forwarded directly to the SDK.
+ */
+
+import type {
+  AgentEngine,
+  EngineCapabilities,
+  EngineStreamOptions,
+  EngineEvent,
+  EngineContentPart,
+} from "./types.js";
+import {
+  engineToolsToAnthropic,
+  engineMessagesToAnthropic,
+  anthropicContentToEngine,
+  anthropicChunkToEngineEvents,
+} from "./translate-anthropic.js";
+
+export const ANTHROPIC_CAPABILITIES: EngineCapabilities = {
+  thinking: true,
+  promptCaching: true,
+  vision: true,
+  computerUse: true,
+  parallelToolCalls: true,
+};
+
+export const ANTHROPIC_SUPPORTED_MODELS = [
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  "claude-haiku-4-5-20251001",
+  "claude-opus-4-5",
+  "claude-sonnet-4-5",
+  "claude-haiku-4-5",
+] as const;
+
+export const ANTHROPIC_DEFAULT_MODEL = "claude-sonnet-4-6";
+
+class AnthropicEngine implements AgentEngine {
+  readonly name = "anthropic";
+  readonly label = "Claude (Anthropic SDK)";
+  readonly defaultModel = ANTHROPIC_DEFAULT_MODEL;
+  readonly supportedModels = ANTHROPIC_SUPPORTED_MODELS;
+  readonly capabilities = ANTHROPIC_CAPABILITIES;
+
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async *stream(opts: EngineStreamOptions): AsyncIterable<EngineEvent> {
+    const Anthropic = (await import("@anthropic-ai/sdk")).default;
+    const client = new Anthropic({ apiKey: this.apiKey });
+
+    const tools = engineToolsToAnthropic(opts.tools);
+    const messages = engineMessagesToAnthropic(opts.messages);
+    const anthropicOpts = opts.providerOptions?.anthropic;
+
+    // Build extra body params for Anthropic-native features
+    const extra: Record<string, unknown> = {};
+    if (anthropicOpts?.thinking) {
+      extra.thinking = {
+        type: anthropicOpts.thinking.type,
+        budget_tokens: anthropicOpts.thinking.budgetTokens,
+      };
+    }
+    if (anthropicOpts?.topK !== undefined) {
+      extra.top_k = anthropicOpts.topK;
+    }
+
+    // Apply prompt caching to the system prompt if requested.
+    // We pass the system prompt as a structured array so we can add cache_control.
+    const systemBlocks: any[] = [{ type: "text", text: opts.systemPrompt }];
+    if (anthropicOpts?.cacheControl) {
+      systemBlocks[0].cache_control = { type: "ephemeral" };
+    }
+
+    // Apply cache_control to the last tool definition when caching is enabled.
+    // Anthropic caches the prefix up to and including the last cached block.
+    let cachedTools = tools;
+    if (anthropicOpts?.cacheControl && tools.length > 0) {
+      cachedTools = [...tools];
+      const last = { ...cachedTools[cachedTools.length - 1] } as any;
+      last.cache_control = { type: "ephemeral" };
+      cachedTools[cachedTools.length - 1] = last;
+    }
+
+    const requestParams: any = {
+      model: opts.model,
+      max_tokens: opts.maxTokens ?? 16384,
+      system: systemBlocks,
+      tools: cachedTools.length > 0 ? cachedTools : undefined,
+      messages,
+      ...(opts.temperature !== undefined
+        ? { temperature: opts.temperature }
+        : {}),
+      ...extra,
+    };
+
+    // Remove undefined tools to avoid Anthropic API validation errors
+    if (!requestParams.tools) delete requestParams.tools;
+
+    const apiStream = client.messages.stream(requestParams, {
+      signal: opts.abortSignal,
+    });
+
+    let thinkingText = "";
+    let thinkingSignature = "";
+
+    try {
+      for await (const chunk of apiStream) {
+        const events = anthropicChunkToEngineEvents(chunk);
+        for (const event of events) {
+          if (event.type === "thinking-delta") {
+            thinkingText += event.text;
+            if (event.signature) thinkingSignature = event.signature;
+          }
+          yield event;
+        }
+      }
+
+      const finalMessage = await apiStream.finalMessage();
+      const assistantContent = anthropicContentToEngine(finalMessage.content);
+
+      // Emit usage
+      if (finalMessage.usage) {
+        yield {
+          type: "usage",
+          inputTokens: finalMessage.usage.input_tokens ?? 0,
+          outputTokens: finalMessage.usage.output_tokens ?? 0,
+          cacheReadTokens:
+            (finalMessage.usage as any).cache_read_input_tokens ?? 0,
+          cacheWriteTokens:
+            (finalMessage.usage as any).cache_creation_input_tokens ?? 0,
+        };
+      }
+
+      // Emit stop reason
+      const stopReason = finalMessage.stop_reason ?? "end_turn";
+      yield {
+        type: "stop",
+        reason:
+          stopReason === "tool_use"
+            ? "tool_use"
+            : stopReason === "max_tokens"
+              ? "max_tokens"
+              : "end_turn",
+      };
+
+      // Store the final assistant content for the caller via a side channel.
+      // runAgentLoop reads this via the assistantContentRef passed in opts.
+      // We attach it as a non-enumerable symbol property.
+      (opts as any)[ASSISTANT_CONTENT_KEY] = assistantContent;
+    } catch (err: any) {
+      yield {
+        type: "stop",
+        reason: "error",
+        error: err?.message ?? String(err),
+      };
+      throw err;
+    }
+  }
+}
+
+/**
+ * Symbol used by AnthropicEngine to return the final assistant content blocks
+ * back to runAgentLoop without changing the EngineEvent stream shape.
+ */
+export const ASSISTANT_CONTENT_KEY = Symbol("assistantContent");
+
+/**
+ * Create an AnthropicEngine instance.
+ * Falls back to ANTHROPIC_API_KEY env var if no key is provided.
+ */
+export function createAnthropicEngine(
+  config: Record<string, unknown> = {},
+): AgentEngine {
+  const apiKey =
+    (config.apiKey as string | undefined) ??
+    process.env.ANTHROPIC_API_KEY ??
+    "";
+  if (!apiKey) {
+    // Return a "missing key" engine that immediately errors
+    return {
+      name: "anthropic",
+      label: "Claude (Anthropic SDK)",
+      defaultModel: ANTHROPIC_DEFAULT_MODEL,
+      supportedModels: ANTHROPIC_SUPPORTED_MODELS,
+      capabilities: ANTHROPIC_CAPABILITIES,
+      async *stream() {
+        yield {
+          type: "stop" as const,
+          reason: "error" as const,
+          error: "ANTHROPIC_API_KEY is not set",
+        };
+      },
+    };
+  }
+  return new AnthropicEngine(apiKey);
+}

--- a/packages/core/src/agent/engine/builtin.ts
+++ b/packages/core/src/agent/engine/builtin.ts
@@ -1,0 +1,95 @@
+/**
+ * Registers built-in agent engines (anthropic, ai-sdk:*) into the global registry.
+ *
+ * This module is imported once at server startup via the agent-chat plugin.
+ * Additional engines can be registered by calling registerAgentEngine() from
+ * any server plugin after startup.
+ */
+
+import { registerAgentEngine } from "./registry.js";
+import {
+  createAnthropicEngine,
+  ANTHROPIC_CAPABILITIES,
+  ANTHROPIC_DEFAULT_MODEL,
+  ANTHROPIC_SUPPORTED_MODELS,
+} from "./anthropic-engine.js";
+import {
+  createAISDKEngine,
+  PROVIDER_CAPABILITIES,
+  PROVIDER_DEFAULT_MODELS,
+  PROVIDER_SUPPORTED_MODELS,
+  PROVIDER_ENV_VARS,
+  PROVIDER_PACKAGES,
+  type AISDKProvider,
+} from "./ai-sdk-engine.js";
+
+let _registered = false;
+
+/**
+ * Register all built-in engines. Safe to call multiple times (idempotent).
+ */
+export function registerBuiltinEngines(): void {
+  if (_registered) return;
+  _registered = true;
+
+  // ── Anthropic (default) ────────────────────────────────────────────────────
+  registerAgentEngine({
+    name: "anthropic",
+    label: "Claude (Anthropic SDK)",
+    description:
+      "Anthropic's SDK — best-in-class Claude models with full feature support (thinking, prompt caching, vision, computer use).",
+    capabilities: ANTHROPIC_CAPABILITIES,
+    defaultModel: ANTHROPIC_DEFAULT_MODEL,
+    supportedModels: ANTHROPIC_SUPPORTED_MODELS,
+    requiredEnvVars: ["ANTHROPIC_API_KEY"],
+    create: (config) => createAnthropicEngine(config),
+  });
+
+  // ── Vercel AI SDK providers ────────────────────────────────────────────────
+  const aiSdkProviders: AISDKProvider[] = [
+    "anthropic",
+    "openai",
+    "google",
+    "groq",
+    "mistral",
+    "cohere",
+    "ollama",
+  ];
+
+  const providerLabels: Record<AISDKProvider, string> = {
+    anthropic: "Claude via AI SDK",
+    openai: "OpenAI (AI SDK)",
+    google: "Google Gemini (AI SDK)",
+    groq: "Groq (AI SDK)",
+    mistral: "Mistral (AI SDK)",
+    cohere: "Cohere (AI SDK)",
+    ollama: "Ollama (local, AI SDK)",
+  };
+
+  const providerDescriptions: Record<AISDKProvider, string> = {
+    anthropic:
+      "Claude models through the Vercel AI SDK. Supports thinking and caching via AI SDK providerOptions.",
+    openai: "OpenAI GPT models via the Vercel AI SDK. Requires OPENAI_API_KEY.",
+    google:
+      "Google Gemini models via the Vercel AI SDK. Requires GOOGLE_GENERATIVE_AI_API_KEY.",
+    groq: "Groq LPU inference via the Vercel AI SDK. Requires GROQ_API_KEY.",
+    mistral: "Mistral models via the Vercel AI SDK. Requires MISTRAL_API_KEY.",
+    cohere:
+      "Cohere Command models via the Vercel AI SDK. Requires COHERE_API_KEY.",
+    ollama: "Local Ollama models via the Vercel AI SDK. No API key required.",
+  };
+
+  for (const provider of aiSdkProviders) {
+    registerAgentEngine({
+      name: `ai-sdk:${provider}`,
+      label: providerLabels[provider],
+      description: providerDescriptions[provider],
+      installPackage: `ai ${PROVIDER_PACKAGES[provider]}`,
+      capabilities: PROVIDER_CAPABILITIES[provider],
+      defaultModel: PROVIDER_DEFAULT_MODELS[provider],
+      supportedModels: PROVIDER_SUPPORTED_MODELS[provider],
+      requiredEnvVars: PROVIDER_ENV_VARS[provider],
+      create: (config) => createAISDKEngine(provider, config),
+    });
+  }
+}

--- a/packages/core/src/agent/engine/index.ts
+++ b/packages/core/src/agent/engine/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Public exports for the pluggable agent engine system.
+ */
+
+export type {
+  AgentEngine,
+  EngineCapabilities,
+  EngineTool,
+  EngineMessage,
+  EngineContentPart,
+  EngineTextPart,
+  EngineImagePart,
+  EngineToolCallPart,
+  EngineToolResultPart,
+  EngineThinkingPart,
+  EngineEvent,
+  EngineStreamOptions,
+} from "./types.js";
+
+export {
+  registerAgentEngine,
+  getAgentEngineEntry,
+  listAgentEngines,
+  resolveEngine,
+  type AgentEngineEntry,
+  type ResolveEngineConfig,
+} from "./registry.js";
+
+export {
+  createAnthropicEngine,
+  ANTHROPIC_DEFAULT_MODEL,
+  ANTHROPIC_SUPPORTED_MODELS,
+  ANTHROPIC_CAPABILITIES,
+} from "./anthropic-engine.js";
+export { createAISDKEngine, type AISDKProvider } from "./ai-sdk-engine.js";
+export { registerBuiltinEngines } from "./builtin.js";

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Registry uses a module-level Map — reset between tests by re-importing
+// with a fresh module via vi.resetModules().
+describe("AgentEngine registry", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // Clear env vars that influence resolveEngine
+    delete process.env.AGENT_ENGINE;
+  });
+
+  it("registers and retrieves an engine", async () => {
+    const { registerAgentEngine, getAgentEngineEntry } =
+      await import("./registry.js");
+
+    const fakeEngine = { name: "test", stream: vi.fn() } as any;
+    registerAgentEngine({
+      name: "test-engine",
+      label: "Test",
+      description: "A test engine",
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      requiredEnvVars: [],
+      create: () => fakeEngine,
+    });
+
+    const entry = getAgentEngineEntry("test-engine");
+    expect(entry).toBeDefined();
+    expect(entry?.label).toBe("Test");
+  });
+
+  it("listAgentEngines returns all registered entries", async () => {
+    const { registerAgentEngine, listAgentEngines } =
+      await import("./registry.js");
+
+    registerAgentEngine({
+      name: "engine-a",
+      label: "A",
+      description: "",
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      defaultModel: "a",
+      supportedModels: ["a"],
+      requiredEnvVars: [],
+      create: () => ({
+        name: "engine-a",
+        label: "A",
+        defaultModel: "a",
+        supportedModels: [],
+        capabilities: {} as any,
+        stream: vi.fn(),
+      }),
+    });
+
+    const list = listAgentEngines();
+    expect(list.length).toBeGreaterThanOrEqual(1);
+    expect(list.find((e) => e.name === "engine-a")).toBeDefined();
+  });
+
+  it("resolveEngine uses explicit AgentEngine instance directly", async () => {
+    const { resolveEngine } = await import("./registry.js");
+
+    const fakeEngine = {
+      name: "direct",
+      label: "Direct",
+      defaultModel: "m",
+      supportedModels: [],
+      capabilities: {} as any,
+      stream: vi.fn(),
+    };
+    const resolved = await resolveEngine({ engineOption: fakeEngine });
+    expect(resolved).toBe(fakeEngine);
+  });
+
+  it("resolveEngine falls back to default anthropic when nothing configured", async () => {
+    const { registerAgentEngine, resolveEngine } =
+      await import("./registry.js");
+
+    const fakeAnthropicEngine = {
+      name: "anthropic",
+      label: "Anthropic",
+      defaultModel: "m",
+      supportedModels: [],
+      capabilities: {} as any,
+      stream: vi.fn(),
+    };
+    const createFn = vi.fn().mockReturnValue(fakeAnthropicEngine);
+
+    registerAgentEngine({
+      name: "anthropic",
+      label: "Claude",
+      description: "",
+      capabilities: {
+        thinking: true,
+        promptCaching: true,
+        vision: true,
+        computerUse: true,
+        parallelToolCalls: true,
+      },
+      defaultModel: "claude-sonnet-4-6",
+      supportedModels: ["claude-sonnet-4-6"],
+      requiredEnvVars: ["ANTHROPIC_API_KEY"],
+      create: createFn,
+    });
+
+    const resolved = await resolveEngine({});
+    expect(createFn).toHaveBeenCalled();
+    expect(resolved).toBe(fakeAnthropicEngine);
+  });
+
+  it("resolveEngine uses env AGENT_ENGINE when set", async () => {
+    const { registerAgentEngine, resolveEngine } =
+      await import("./registry.js");
+
+    const fakeEngine = {
+      name: "env-engine",
+      label: "Env",
+      defaultModel: "m",
+      supportedModels: [],
+      capabilities: {} as any,
+      stream: vi.fn(),
+    };
+    const createFn = vi.fn().mockReturnValue(fakeEngine);
+
+    registerAgentEngine({
+      name: "env-engine",
+      label: "Env",
+      description: "",
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      defaultModel: "m",
+      supportedModels: [],
+      requiredEnvVars: [],
+      create: createFn,
+    });
+
+    // Also register anthropic so the fallback doesn't throw
+    registerAgentEngine({
+      name: "anthropic",
+      label: "Claude",
+      description: "",
+      capabilities: {
+        thinking: true,
+        promptCaching: true,
+        vision: true,
+        computerUse: true,
+        parallelToolCalls: true,
+      },
+      defaultModel: "claude-sonnet-4-6",
+      supportedModels: [],
+      requiredEnvVars: [],
+      create: vi.fn().mockReturnValue(fakeEngine),
+    });
+
+    process.env.AGENT_ENGINE = "env-engine";
+    const resolved = await resolveEngine({});
+    expect(createFn).toHaveBeenCalled();
+    expect(resolved).toBe(fakeEngine);
+  });
+});

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -1,0 +1,167 @@
+/**
+ * Agent Engine Registry.
+ *
+ * Mirrors the CLI_REGISTRY pattern (packages/core/src/terminal/cli-registry.ts)
+ * but is open — anyone can register a custom engine via registerAgentEngine()
+ * from a server plugin at startup.
+ *
+ * Built-in engines (anthropic, ai-sdk) are auto-registered by builtin.ts.
+ */
+
+import type {
+  AgentEngine,
+  EngineCapabilities,
+  EngineStreamOptions,
+} from "./types.js";
+import { getSetting } from "../../settings/store.js";
+
+export interface AgentEngineEntry {
+  /** Unique name, e.g. "anthropic", "ai-sdk:anthropic", "ai-sdk:openai" */
+  name: string;
+  /** Human-readable label for UI */
+  label: string;
+  /** Short description for engine picker */
+  description: string;
+  /** npm package hint displayed in UI when package is missing */
+  installPackage?: string;
+  /** Engine capabilities */
+  capabilities: EngineCapabilities;
+  /** Default model string */
+  defaultModel: string;
+  /** All supported models (shown in model picker) */
+  supportedModels: readonly string[];
+  /** Environment variables required for this engine to work */
+  requiredEnvVars: string[];
+  /** Create an engine instance from config */
+  create(config: Record<string, unknown>): AgentEngine;
+}
+
+const _registry = new Map<string, AgentEngineEntry>();
+
+/**
+ * Register a custom agent engine. Called at server startup (e.g., from a
+ * server plugin or builtin.ts). Throws if name is already registered.
+ */
+export function registerAgentEngine(entry: AgentEngineEntry): void {
+  if (_registry.has(entry.name)) {
+    // Allow re-registration in tests / hot-reload — just overwrite
+    if (process.env.NODE_ENV === "test") {
+      _registry.set(entry.name, entry);
+      return;
+    }
+    console.warn(
+      `[agent-engine] Engine "${entry.name}" is already registered. Skipping.`,
+    );
+    return;
+  }
+  _registry.set(entry.name, entry);
+}
+
+/** Get a registered engine entry by name, or undefined if not found */
+export function getAgentEngineEntry(
+  name: string,
+): AgentEngineEntry | undefined {
+  return _registry.get(name);
+}
+
+/** List all registered engine entries */
+export function listAgentEngines(): AgentEngineEntry[] {
+  return Array.from(_registry.values());
+}
+
+export interface ResolveEngineConfig {
+  /** Explicit engine name or instance from createAgentChatPlugin options */
+  engineOption?:
+    | string
+    | AgentEngine
+    | { name: string; config: Record<string, unknown> };
+  /** API key (used as config for the resolved engine) */
+  apiKey?: string;
+  /** Model override (used as part of engine config) */
+  model?: string;
+}
+
+/**
+ * Resolve an AgentEngine from options → settings → env → default.
+ *
+ * Resolution order:
+ * 1. Explicit `engineOption` from plugin options (string name, instance, or {name, config})
+ * 2. Settings store key "agent-engine" → { engine: string }
+ * 3. Env var AGENT_ENGINE
+ * 4. Default "anthropic" (requires ANTHROPIC_API_KEY)
+ */
+export async function resolveEngine(
+  config: ResolveEngineConfig,
+): Promise<AgentEngine> {
+  const { engineOption, apiKey, model: _model } = config;
+
+  // 1. Explicit instance passed directly
+  if (
+    engineOption &&
+    typeof engineOption === "object" &&
+    "stream" in engineOption
+  ) {
+    return engineOption as AgentEngine;
+  }
+
+  // 2. Explicit {name, config} object
+  if (
+    engineOption &&
+    typeof engineOption === "object" &&
+    "name" in engineOption
+  ) {
+    const { name, config: engineConfig } = engineOption as {
+      name: string;
+      config: Record<string, unknown>;
+    };
+    const entry = _registry.get(name);
+    if (!entry)
+      throw new Error(
+        `[agent-engine] Unknown engine: "${name}". Registered: ${[..._registry.keys()].join(", ")}`,
+      );
+    return entry.create({ apiKey, ...engineConfig });
+  }
+
+  // 3. Explicit string name from options
+  if (typeof engineOption === "string") {
+    const entry = _registry.get(engineOption);
+    if (!entry)
+      throw new Error(
+        `[agent-engine] Unknown engine: "${engineOption}". Registered: ${[..._registry.keys()].join(", ")}`,
+      );
+    return entry.create({ apiKey });
+  }
+
+  // 4. Settings store
+  try {
+    const stored = await getSetting("agent-engine");
+    if (stored && typeof stored.engine === "string") {
+      const entry = _registry.get(stored.engine);
+      if (entry) {
+        const storedApiKey = (stored.apiKey as string | undefined) ?? apiKey;
+        return entry.create({
+          apiKey: storedApiKey,
+          ...((stored.config as Record<string, unknown>) ?? {}),
+        });
+      }
+    }
+  } catch {
+    // Settings not available — fall through
+  }
+
+  // 5. Env var
+  const envEngine = process.env.AGENT_ENGINE;
+  if (envEngine) {
+    const entry = _registry.get(envEngine);
+    if (entry) return entry.create({ apiKey });
+  }
+
+  // 6. Default: anthropic
+  const anthropicEntry = _registry.get("anthropic");
+  if (!anthropicEntry) {
+    throw new Error(
+      "[agent-engine] Default Anthropic engine is not registered. Did builtin.ts fail to load?",
+    );
+  }
+  return anthropicEntry.create({ apiKey });
+}

--- a/packages/core/src/agent/engine/translate-ai-sdk.spec.ts
+++ b/packages/core/src/agent/engine/translate-ai-sdk.spec.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import {
+  engineToolsToAISDK,
+  engineMessagesToAISDK,
+  aiSdkPartToEngineEvents,
+} from "./translate-ai-sdk.js";
+import type { EngineTool, EngineMessage } from "./types.js";
+
+describe("engineToolsToAISDK", () => {
+  it("converts tools to AI SDK format (plain JSON Schema)", () => {
+    const tools: EngineTool[] = [
+      {
+        name: "search",
+        description: "Search for something",
+        inputSchema: {
+          type: "object",
+          properties: { q: { type: "string" } },
+          required: ["q"],
+        },
+      },
+    ];
+
+    const result = engineToolsToAISDK(tools);
+    expect(result).toHaveProperty("search");
+    expect(result.search.description).toBe("Search for something");
+    expect(result.search.parameters.properties).toHaveProperty("q");
+  });
+
+  it("wraps parameters with jsonSchema() when provided", () => {
+    const tools: EngineTool[] = [
+      {
+        name: "greet",
+        description: "Say hello",
+        inputSchema: {
+          type: "object",
+          properties: { name: { type: "string" } },
+          required: ["name"],
+        },
+      },
+    ];
+
+    // Simulate the AI SDK's jsonSchema() helper (wraps raw schema with marker)
+    const wrapped: Record<string, unknown>[] = [];
+    const mockJsonSchema = (schema: Record<string, unknown>) => {
+      wrapped.push(schema);
+      return { _aiSdkWrapped: true, ...schema };
+    };
+
+    const result = engineToolsToAISDK(tools, mockJsonSchema);
+    expect(wrapped).toHaveLength(1);
+    expect(result.greet.parameters).toHaveProperty("_aiSdkWrapped", true);
+    expect(result.greet.parameters.properties).toHaveProperty("name");
+  });
+});
+
+describe("engineMessagesToAISDK", () => {
+  it("converts user text message", () => {
+    const messages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "Hi" }] },
+    ];
+    const result = engineMessagesToAISDK(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+    // Single text part may be coerced to string
+    const content = result[0].content;
+    const text =
+      typeof content === "string" ? content : (content as any)?.[0]?.text;
+    expect(text).toBe("Hi");
+  });
+
+  it("converts assistant message with tool-call", () => {
+    const messages: EngineMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Calling tool" },
+          {
+            type: "tool-call",
+            id: "tc-1",
+            name: "search",
+            input: { q: "test" },
+          },
+        ],
+      },
+    ];
+    const result = engineMessagesToAISDK(messages);
+    const content = result[0].content as any[];
+    const tc = content.find((p: any) => p.type === "tool-call");
+    expect(tc).toBeDefined();
+    expect(tc.toolCallId).toBe("tc-1");
+    expect(tc.toolName).toBe("search");
+    expect(tc.args).toEqual({ q: "test" });
+  });
+});
+
+describe("aiSdkPartToEngineEvents", () => {
+  it("converts text-delta to text-delta event", () => {
+    const events = aiSdkPartToEngineEvents({
+      type: "text-delta",
+      textDelta: "hello",
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: "text-delta", text: "hello" });
+  });
+
+  it("converts reasoning to thinking-delta event", () => {
+    const events = aiSdkPartToEngineEvents({
+      type: "reasoning",
+      textDelta: "I'm thinking...",
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "thinking-delta",
+      text: "I'm thinking...",
+    });
+  });
+
+  it("converts tool-call to tool-call event", () => {
+    const events = aiSdkPartToEngineEvents({
+      type: "tool-call",
+      toolCallId: "tc-1",
+      toolName: "search",
+      args: { q: "test" },
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "tool-call",
+      id: "tc-1",
+      name: "search",
+      input: { q: "test" },
+    });
+  });
+
+  it("converts finish event to stop event", () => {
+    const events = aiSdkPartToEngineEvents({
+      type: "finish",
+      finishReason: "stop",
+      usage: { promptTokens: 10, completionTokens: 5 },
+    });
+    const stopEvent = events.find((e) => e.type === "stop");
+    expect(stopEvent).toBeDefined();
+    if (stopEvent?.type === "stop") {
+      expect(stopEvent.reason).toBe("end_turn");
+    }
+  });
+
+  it("converts error part to stop-with-error event", () => {
+    const events = aiSdkPartToEngineEvents({
+      type: "error",
+      error: new Error("some stream error"),
+    });
+    expect(events).toHaveLength(1);
+    const stop = events[0];
+    if (stop.type === "stop") {
+      expect(stop.reason).toBe("error");
+      expect((stop as any).error).toContain("some stream error");
+    }
+  });
+
+  it("converts tool_calls finish reason to tool_use stop", () => {
+    const events = aiSdkPartToEngineEvents({
+      type: "finish",
+      finishReason: "tool-calls",
+      usage: { promptTokens: 10, completionTokens: 5 },
+    });
+    const stopEvent = events.find((e) => e.type === "stop");
+    if (stopEvent?.type === "stop") {
+      expect(stopEvent.reason).toBe("tool_use");
+    }
+  });
+});

--- a/packages/core/src/agent/engine/translate-ai-sdk.ts
+++ b/packages/core/src/agent/engine/translate-ai-sdk.ts
@@ -1,0 +1,193 @@
+/**
+ * Translation helpers between AgentEngine normalized types and
+ * Vercel AI SDK (ai package) types.
+ */
+
+import type { EngineTool, EngineMessage, EngineContentPart } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// EngineTool → AI SDK CoreTool shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert EngineTool[] to the `tools` Record<string, CoreTool> shape
+ * that AI SDK's streamText expects.
+ *
+ * AI SDK v4 requires tool parameters to be Zod schemas or jsonSchema()-wrapped
+ * objects. Pass the `jsonSchema` helper from the `ai` package to produce a
+ * compatible schema wrapper; fall back to the raw JSON Schema object when the
+ * helper is not available (older AI SDK or tests).
+ */
+export function engineToolsToAISDK(
+  tools: EngineTool[],
+  jsonSchema?: (schema: Record<string, unknown>) => unknown,
+): Record<string, any> {
+  const result: Record<string, any> = {};
+  for (const tool of tools) {
+    const rawSchema: Record<string, unknown> = {
+      type: "object",
+      properties: tool.inputSchema.properties ?? {},
+      required: tool.inputSchema.required ?? [],
+    };
+    result[tool.name] = {
+      description: tool.description,
+      parameters: jsonSchema ? jsonSchema(rawSchema) : rawSchema,
+    };
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// EngineMessage → AI SDK CoreMessage
+// ---------------------------------------------------------------------------
+
+export function engineMessageToAISDK(msg: EngineMessage): any {
+  if (msg.role === "user") {
+    const content: any[] = [];
+    for (const part of msg.content) {
+      if (part.type === "text") {
+        content.push({ type: "text", text: part.text });
+      } else if (part.type === "image") {
+        content.push({
+          type: "image",
+          image: `data:${part.mediaType};base64,${part.data}`,
+        });
+      } else if (part.type === "tool-result") {
+        content.push({
+          type: "tool-result",
+          toolCallId: part.toolCallId,
+          result: part.content,
+          isError: part.isError,
+        });
+      }
+    }
+    return {
+      role: "user",
+      content:
+        content.length === 1 && content[0].type === "text"
+          ? content[0].text
+          : content,
+    };
+  }
+
+  if (msg.role === "assistant") {
+    const content: any[] = [];
+    for (const part of msg.content) {
+      if (part.type === "text") {
+        content.push({ type: "text", text: part.text });
+      } else if (part.type === "tool-call") {
+        content.push({
+          type: "tool-call",
+          toolCallId: part.id,
+          toolName: part.name,
+          args: part.input,
+        });
+      } else if (part.type === "thinking") {
+        // AI SDK 5+ supports reasoning content parts
+        content.push({ type: "reasoning", text: part.text });
+      }
+    }
+    return {
+      role: "assistant",
+      content:
+        content.length === 1 && content[0].type === "text"
+          ? content[0].text
+          : content,
+    };
+  }
+
+  // Exhaustive — EngineMessage only has "user" | "assistant" roles
+  return { role: (msg as any).role, content: "" };
+}
+
+export function engineMessagesToAISDK(messages: EngineMessage[]): any[] {
+  return messages.map(engineMessageToAISDK);
+}
+
+// ---------------------------------------------------------------------------
+// AI SDK stream part → EngineEvent
+// ---------------------------------------------------------------------------
+
+export function aiSdkPartToEngineEvents(
+  part: any,
+): import("./types.js").EngineEvent[] {
+  const events: import("./types.js").EngineEvent[] = [];
+
+  if (part.type === "text-delta") {
+    events.push({ type: "text-delta", text: part.textDelta ?? "" });
+  } else if (part.type === "reasoning") {
+    events.push({
+      type: "thinking-delta",
+      text: part.textDelta ?? part.text ?? "",
+    });
+  } else if (part.type === "tool-call") {
+    events.push({
+      type: "tool-call",
+      id: part.toolCallId,
+      name: part.toolName,
+      input: part.args,
+    });
+  } else if (part.type === "error") {
+    // AI SDK emits { type: "error", error: Error } when streaming fails
+    const errMsg =
+      (part.error instanceof Error ? part.error.message : String(part.error)) ??
+      "Unknown stream error";
+    events.push({ type: "stop", reason: "error", error: errMsg } as any);
+  } else if (part.type === "finish") {
+    // Usage info may arrive on the finish step
+    if (part.usage) {
+      events.push({
+        type: "usage",
+        inputTokens: part.usage.promptTokens ?? 0,
+        outputTokens: part.usage.completionTokens ?? 0,
+        cacheReadTokens: (part.usage as any).cacheReadTokens ?? 0,
+        cacheWriteTokens: (part.usage as any).cacheWriteTokens ?? 0,
+      });
+    }
+    const reason = part.finishReason;
+    events.push({
+      type: "stop",
+      reason:
+        reason === "tool-calls"
+          ? "tool_use"
+          : reason === "length"
+            ? "max_tokens"
+            : "end_turn",
+    });
+  }
+
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// AI SDK step result → EngineContentPart[] (assistant content for messages)
+// ---------------------------------------------------------------------------
+
+export function aiSdkStepToAssistantContent(step: any): EngineContentPart[] {
+  const parts: EngineContentPart[] = [];
+
+  if (typeof step.text === "string" && step.text) {
+    parts.push({ type: "text", text: step.text });
+  }
+
+  if (Array.isArray(step.toolCalls)) {
+    for (const tc of step.toolCalls) {
+      parts.push({
+        type: "tool-call",
+        id: tc.toolCallId,
+        name: tc.toolName,
+        input: tc.args,
+      });
+    }
+  }
+
+  if (Array.isArray(step.reasoning)) {
+    for (const r of step.reasoning) {
+      if (r.type === "text") {
+        parts.push({ type: "thinking", text: r.text });
+      }
+    }
+  }
+
+  return parts;
+}

--- a/packages/core/src/agent/engine/translate-anthropic.spec.ts
+++ b/packages/core/src/agent/engine/translate-anthropic.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import {
+  engineToolsToAnthropic,
+  engineMessagesToAnthropic,
+  anthropicContentToEngine,
+} from "./translate-anthropic.js";
+import type { EngineTool, EngineMessage } from "./types.js";
+
+describe("engineToolsToAnthropic", () => {
+  it("converts EngineTool to Anthropic tool format", () => {
+    const tools: EngineTool[] = [
+      {
+        name: "my-tool",
+        description: "Does something",
+        inputSchema: {
+          type: "object",
+          properties: { msg: { type: "string" } },
+          required: ["msg"],
+        },
+      },
+    ];
+
+    const result = engineToolsToAnthropic(tools);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("my-tool");
+    expect(result[0].description).toBe("Does something");
+    expect(result[0].input_schema.properties).toHaveProperty("msg");
+  });
+});
+
+describe("engineMessagesToAnthropic", () => {
+  it("converts simple user message", () => {
+    const messages: EngineMessage[] = [
+      { role: "user", content: [{ type: "text", text: "Hello" }] },
+    ];
+
+    const result = engineMessagesToAnthropic(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+    // Single text part should coerce to a string for Anthropic
+    const content = result[0].content;
+    const textPart = Array.isArray(content)
+      ? (content as any[]).find((p: any) => p.type === "text")
+      : null;
+    expect(textPart?.text ?? content).toBe("Hello");
+  });
+
+  it("converts assistant message with tool-call", () => {
+    const messages: EngineMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Using tool" },
+          {
+            type: "tool-call",
+            id: "tc-1",
+            name: "my-tool",
+            input: { msg: "hi" },
+          },
+        ],
+      },
+    ];
+
+    const result = engineMessagesToAnthropic(messages);
+    expect(result).toHaveLength(1);
+    const content = result[0].content as any[];
+    const tc = content.find((p: any) => p.type === "tool_use");
+    expect(tc).toBeDefined();
+    expect(tc.id).toBe("tc-1");
+    expect(tc.name).toBe("my-tool");
+    expect(tc.input).toEqual({ msg: "hi" });
+  });
+
+  it("converts user message with tool-result", () => {
+    const messages: EngineMessage[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-1",
+            content: "Tool output",
+          },
+        ],
+      },
+    ];
+
+    const result = engineMessagesToAnthropic(messages);
+    const content = result[0].content as any[];
+    const tr = content.find((p: any) => p.type === "tool_result");
+    expect(tr).toBeDefined();
+    expect(tr.tool_use_id).toBe("tc-1");
+    expect(tr.content).toBe("Tool output");
+  });
+});
+
+describe("anthropicContentToEngine", () => {
+  it("converts text block", () => {
+    const result = anthropicContentToEngine([{ type: "text", text: "hello" }]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ type: "text", text: "hello" });
+  });
+
+  it("converts tool_use block", () => {
+    const result = anthropicContentToEngine([
+      { type: "tool_use", id: "tu-1", name: "my-tool", input: { x: 1 } },
+    ]);
+    expect(result[0]).toMatchObject({
+      type: "tool-call",
+      id: "tu-1",
+      name: "my-tool",
+      input: { x: 1 },
+    });
+  });
+});

--- a/packages/core/src/agent/engine/translate-anthropic.ts
+++ b/packages/core/src/agent/engine/translate-anthropic.ts
@@ -1,0 +1,176 @@
+/**
+ * Translation helpers between the AgentEngine normalized types and
+ * @anthropic-ai/sdk's wire types.
+ *
+ * AnthropicEngine does very little translation because the framework's
+ * EngineMessage / EngineTool shapes were modeled on Anthropic's types.
+ * The main differences are: camelCase vs snake_case, and that
+ * Anthropic uses `input_schema` while we use `inputSchema`.
+ */
+
+import type Anthropic from "@anthropic-ai/sdk";
+import type {
+  EngineTool,
+  EngineMessage,
+  EngineContentPart,
+  EngineEvent,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// EngineTool → Anthropic.Tool
+// ---------------------------------------------------------------------------
+
+export function engineToolToAnthropic(tool: EngineTool): Anthropic.Tool {
+  return {
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.inputSchema as Anthropic.Tool["input_schema"],
+  };
+}
+
+export function engineToolsToAnthropic(tools: EngineTool[]): Anthropic.Tool[] {
+  return tools.map(engineToolToAnthropic);
+}
+
+// ---------------------------------------------------------------------------
+// EngineMessage → Anthropic.MessageParam
+// ---------------------------------------------------------------------------
+
+export function engineMessageToAnthropic(
+  msg: EngineMessage,
+): Anthropic.MessageParam {
+  return {
+    role: msg.role,
+    content: msg.content.map(enginePartToAnthropic),
+  };
+}
+
+export function engineMessagesToAnthropic(
+  messages: EngineMessage[],
+): Anthropic.MessageParam[] {
+  return messages.map(engineMessageToAnthropic);
+}
+
+function enginePartToAnthropic(
+  part: EngineContentPart,
+): Anthropic.ContentBlockParam {
+  switch (part.type) {
+    case "text":
+      return { type: "text", text: part.text };
+
+    case "image":
+      return {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: part.mediaType,
+          data: part.data,
+        },
+      };
+
+    case "tool-call":
+      return {
+        type: "tool_use",
+        id: part.id,
+        name: part.name,
+        input: part.input as Record<string, unknown>,
+      } as any; // tool_use is a ContentBlockParam in Anthropic SDK
+
+    case "tool-result":
+      return {
+        type: "tool_result",
+        tool_use_id: part.toolCallId,
+        content: part.content,
+        ...(part.isError ? { is_error: true } : {}),
+      } as any;
+
+    case "thinking":
+      // Anthropic thinking blocks — pass through with signature for context window continuity
+      return {
+        type: "thinking",
+        thinking: part.text,
+        signature: part.signature ?? "",
+      } as any;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic.ContentBlock → EngineContentPart (from final message)
+// ---------------------------------------------------------------------------
+
+export function anthropicContentToEngine(
+  content: Anthropic.ContentBlock[],
+): EngineContentPart[] {
+  return content
+    .map((block) => {
+      if (block.type === "text") {
+        return { type: "text" as const, text: block.text };
+      }
+      if (block.type === "tool_use") {
+        return {
+          type: "tool-call" as const,
+          id: block.id,
+          name: block.name,
+          input: block.input,
+        };
+      }
+      if ((block as any).type === "thinking") {
+        const b = block as any;
+        return {
+          type: "thinking" as const,
+          text: b.thinking ?? "",
+          signature: b.signature,
+        };
+      }
+      // Unknown block type — skip
+      return { type: "text" as const, text: "" };
+    })
+    .filter((p) => !(p.type === "text" && p.text === ""));
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic stream chunk → EngineEvent
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate an Anthropic stream chunk into zero or more EngineEvents.
+ * Called in a loop as chunks arrive from client.messages.stream().
+ */
+export function anthropicChunkToEngineEvents(chunk: any): EngineEvent[] {
+  const events: EngineEvent[] = [];
+
+  if (chunk.type === "content_block_delta") {
+    if (chunk.delta?.type === "text_delta") {
+      events.push({ type: "text-delta", text: chunk.delta.text });
+    } else if (chunk.delta?.type === "thinking_delta") {
+      events.push({ type: "thinking-delta", text: chunk.delta.thinking ?? "" });
+    } else if (chunk.delta?.type === "signature_delta") {
+      // Signature arrives after thinking — emit as a thinking-delta with empty text
+      // but carry the signature for the caller to store
+      events.push({
+        type: "thinking-delta",
+        text: "",
+        signature: chunk.delta.signature,
+      });
+    }
+  }
+
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// Build tool_result blocks to append to messages after tool dispatch
+// ---------------------------------------------------------------------------
+
+export function buildToolResultPart(
+  toolCallId: string,
+  content: string,
+  isError = false,
+): EngineContentPart {
+  return {
+    type: "tool-result",
+    toolCallId,
+    content,
+    ...(isError ? { isError } : {}),
+  };
+}

--- a/packages/core/src/agent/engine/types.ts
+++ b/packages/core/src/agent/engine/types.ts
@@ -1,0 +1,198 @@
+/**
+ * Pluggable Agent Engine abstraction.
+ *
+ * AgentEngine is the thin LLM adapter that sits beneath runAgentLoop.
+ * Every caller (HTTP handler, A2A, MCP, sub-agents, webhooks, jobs) uses
+ * an AgentEngine instead of a raw @anthropic-ai/sdk client.
+ *
+ * The framework's tool dispatch loop, sub-agents, SSE event stream, and all
+ * other harness features live above this layer and are unaffected by engine
+ * selection.
+ */
+
+// ---------------------------------------------------------------------------
+// Tool / parameter types
+// ---------------------------------------------------------------------------
+
+/**
+ * Engine-normalized tool definition. Structurally identical to Anthropic's
+ * Tool type, with snake_case renamed to camelCase for consistency.
+ */
+export interface EngineTool {
+  name: string;
+  description: string;
+  /** JSON Schema for the tool's input parameters */
+  inputSchema: {
+    type: "object";
+    properties?: Record<string, unknown>;
+    required?: string[];
+    [key: string]: unknown;
+  };
+  /**
+   * Provider-specific options for this tool.
+   * E.g. `{ anthropic: { cacheControl: { type: "ephemeral" } } }`
+   */
+  providerOptions?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Message / content part types
+// ---------------------------------------------------------------------------
+
+export interface EngineTextPart {
+  type: "text";
+  text: string;
+}
+
+export interface EngineImagePart {
+  type: "image";
+  /** Base64-encoded image data */
+  data: string;
+  mediaType: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+}
+
+export interface EngineToolCallPart {
+  type: "tool-call";
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+export interface EngineToolResultPart {
+  type: "tool-result";
+  toolCallId: string;
+  content: string;
+  isError?: boolean;
+}
+
+export interface EngineThinkingPart {
+  type: "thinking";
+  text: string;
+  /** Opaque signature for pass-through on next turn (Anthropic extended thinking) */
+  signature?: string;
+}
+
+export type EngineContentPart =
+  | EngineTextPart
+  | EngineImagePart
+  | EngineToolCallPart
+  | EngineToolResultPart
+  | EngineThinkingPart;
+
+export type EngineMessage =
+  | { role: "user"; content: EngineContentPart[] }
+  | { role: "assistant"; content: EngineContentPart[] };
+
+// ---------------------------------------------------------------------------
+// Streaming event types
+// ---------------------------------------------------------------------------
+
+export type EngineEvent =
+  | { type: "text-delta"; text: string }
+  | { type: "thinking-delta"; text: string; signature?: string }
+  | { type: "tool-call"; id: string; name: string; input: unknown }
+  | {
+      type: "usage";
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    }
+  | {
+      type: "stop";
+      reason:
+        | "end_turn"
+        | "tool_use"
+        | "max_tokens"
+        | "stop_sequence"
+        | "error";
+      error?: string;
+    };
+
+// ---------------------------------------------------------------------------
+// Capabilities
+// ---------------------------------------------------------------------------
+
+export interface EngineCapabilities {
+  /** Extended / adaptive thinking support */
+  thinking: boolean;
+  /** Anthropic-style prompt caching (cache_control blocks) */
+  promptCaching: boolean;
+  /** Vision / image input */
+  vision: boolean;
+  /** Computer use tool support */
+  computerUse: boolean;
+  /** Multiple tool calls in a single response */
+  parallelToolCalls: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Stream options
+// ---------------------------------------------------------------------------
+
+export interface EngineStreamOptions {
+  model: string;
+  systemPrompt: string;
+  messages: EngineMessage[];
+  tools: EngineTool[];
+  abortSignal: AbortSignal;
+  maxTokens?: number;
+  temperature?: number;
+  /**
+   * Provider-specific options passed opaquely.
+   * Engines forward options they understand and ignore unknown keys.
+   *
+   * Example (Anthropic):
+   * ```ts
+   * providerOptions: {
+   *   anthropic: {
+   *     thinking: { type: "enabled", budgetTokens: 8000 },
+   *     cacheControl: { type: "ephemeral" },
+   *   }
+   * }
+   * ```
+   */
+  providerOptions?: {
+    anthropic?: {
+      thinking?: { type: "enabled"; budgetTokens: number };
+      cacheControl?: { type: "ephemeral" };
+      topK?: number;
+    };
+    openai?: Record<string, unknown>;
+    google?: Record<string, unknown>;
+    [provider: string]: Record<string, unknown> | undefined;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AgentEngine interface
+// ---------------------------------------------------------------------------
+
+/**
+ * The pluggable LLM adapter interface.
+ *
+ * Each engine performs one LLM API round-trip per `stream()` call.
+ * The framework's runAgentLoop drives the tool-calling loop by calling
+ * stream() repeatedly with updated messages.
+ *
+ * Engines yield EngineEvent items as they receive them from the LLM.
+ * They MUST yield a `stop` event as the last item, even on error.
+ */
+export interface AgentEngine {
+  /** Unique identifier, e.g. "anthropic", "ai-sdk:anthropic", "ai-sdk:openai" */
+  readonly name: string;
+  /** Human-readable label for UI display */
+  readonly label: string;
+  /** Default model for this engine */
+  readonly defaultModel: string;
+  /** Models this engine supports */
+  readonly supportedModels: readonly string[];
+  /** Capability flags used to gate provider-specific features */
+  readonly capabilities: EngineCapabilities;
+
+  /**
+   * Stream a single LLM API call. Yields EngineEvent items.
+   * The caller (runAgentLoop) handles retries, tool dispatch, and looping.
+   */
+  stream(opts: EngineStreamOptions): AsyncIterable<EngineEvent>;
+}

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1,4 +1,3 @@
-import Anthropic from "@anthropic-ai/sdk";
 import {
   defineEventHandler,
   setResponseHeader,
@@ -12,6 +11,14 @@ import type {
   AgentChatEvent,
   AgentChatReference,
 } from "./types.js";
+import type {
+  AgentEngine,
+  EngineTool,
+  EngineMessage,
+  EngineContentPart,
+} from "./engine/types.js";
+import { resolveEngine, registerBuiltinEngines } from "./engine/index.js";
+import { ASSISTANT_CONTENT_KEY } from "./engine/anthropic-engine.js";
 import { readAppState } from "../application-state/script-helpers.js";
 import {
   startRun,
@@ -23,6 +30,9 @@ import {
 } from "./run-manager.js";
 import type { ActiveRun } from "./run-manager.js";
 import { readBody } from "../server/h3-helpers.js";
+
+// Register built-in engines on first import
+registerBuiltinEngines();
 
 /** Context passed to action run() for emitting intermediate events */
 export interface ActionRunContext {
@@ -50,10 +60,17 @@ export interface ProductionAgentOptions {
   scripts?: Record<string, ActionEntry>;
   /** Static system prompt string, or async function called per-request with the H3 event */
   systemPrompt: string | ((event: any) => string | Promise<string>);
-  /** Falls back to ANTHROPIC_API_KEY env var */
+  /** Falls back to ANTHROPIC_API_KEY env var. Ignored when `engine` is provided. */
   apiKey?: string;
+  /** Agent engine to use. Defaults to the "anthropic" engine. */
+  engine?:
+    | AgentEngine
+    | string
+    | { name: string; config: Record<string, unknown> };
   /** Model to use. Default: claude-sonnet-4-6 */
   model?: string;
+  /** Provider-specific options passed through to the engine */
+  providerOptions?: EngineMessage extends never ? never : any;
   /** Called when a run completes (for server-side thread persistence) */
   onRunComplete?: (run: ActiveRun, threadId: string | undefined) => void;
   /** Called when a run starts, with the send function for emitting events and the threadId */
@@ -159,26 +176,45 @@ function enrichMessage(
 export interface AgentLoopUsage {
   inputTokens: number;
   outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
   model: string;
 }
 
 /**
- * The core agent loop — calls Claude iteratively until no more tool calls.
+ * Convert ActionEntry registry to EngineTool array.
+ */
+export function actionsToEngineTools(
+  actions: Record<string, ActionEntry>,
+): EngineTool[] {
+  return Object.entries(actions).map(([name, entry]) => ({
+    name,
+    description: entry.tool.description,
+    inputSchema: (entry.tool.parameters ?? {
+      type: "object",
+      properties: {},
+    }) as EngineTool["inputSchema"],
+  }));
+}
+
+/**
+ * The core agent loop — calls the engine iteratively until no more tool calls.
  * Decoupled from HTTP transport so it can run in the background.
  * Returns accumulated token usage for cost tracking.
  */
 export async function runAgentLoop(opts: {
-  client: Anthropic;
+  engine: AgentEngine;
   model: string;
   systemPrompt: string;
-  tools: Anthropic.Tool[];
-  messages: Anthropic.MessageParam[];
+  tools: EngineTool[];
+  messages: EngineMessage[];
   actions: Record<string, ActionEntry>;
   send: (event: AgentChatEvent) => void;
   signal: AbortSignal;
+  providerOptions?: any;
 }): Promise<AgentLoopUsage> {
   const {
-    client,
+    engine,
     model,
     systemPrompt,
     tools,
@@ -188,7 +224,13 @@ export async function runAgentLoop(opts: {
     signal,
   } = opts;
 
-  const usage: AgentLoopUsage = { inputTokens: 0, outputTokens: 0, model };
+  const usage: AgentLoopUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    model,
+  };
 
   let iterations = 0;
   while (true) {
@@ -198,36 +240,56 @@ export async function runAgentLoop(opts: {
       break;
     }
 
-    let assistantContent: Anthropic.ContentBlock[] | undefined;
+    let assistantContent: EngineContentPart[] | undefined;
+    let hasToolCalls = false;
+
     for (let retry = 0; ; retry++) {
       try {
-        const apiStream = client.messages.stream(
-          {
-            model,
-            max_tokens: 16384,
-            system: systemPrompt,
-            tools,
-            messages,
-          },
-          { signal },
-        );
+        const streamOpts = {
+          model,
+          systemPrompt,
+          messages,
+          tools,
+          abortSignal: signal,
+          providerOptions: opts.providerOptions,
+        };
 
-        for await (const chunk of apiStream) {
-          if (
-            chunk.type === "content_block_delta" &&
-            chunk.delta.type === "text_delta"
-          ) {
-            send({ type: "text", text: chunk.delta.text });
+        const eventStream = engine.stream(streamOpts);
+        let thinkingBuffer = "";
+
+        for await (const event of eventStream) {
+          if (event.type === "text-delta") {
+            send({ type: "text", text: event.text });
+          } else if (event.type === "thinking-delta") {
+            thinkingBuffer += event.text;
+            // Thinking deltas are not forwarded to the SSE client yet —
+            // we accumulate them. In a future iteration, we can surface
+            // them as a collapsible "reasoning" section in the UI.
+          } else if (event.type === "tool-call") {
+            hasToolCalls = true;
+          } else if (event.type === "usage") {
+            usage.inputTokens += event.inputTokens;
+            usage.outputTokens += event.outputTokens;
+            usage.cacheReadTokens += event.cacheReadTokens ?? 0;
+            usage.cacheWriteTokens += event.cacheWriteTokens ?? 0;
+          } else if (event.type === "stop" && event.reason === "error") {
+            throw new Error(event.error ?? "Engine stream error");
           }
         }
 
-        const finalMessage = await apiStream.finalMessage();
-        assistantContent = finalMessage.content;
-        // Accumulate token usage
-        if (finalMessage.usage) {
-          usage.inputTokens += finalMessage.usage.input_tokens ?? 0;
-          usage.outputTokens += finalMessage.usage.output_tokens ?? 0;
+        // Retrieve the assistant content blocks stored by the engine.
+        // AnthropicEngine sets streamOpts[ASSISTANT_CONTENT_KEY] after streaming.
+        assistantContent = (streamOpts as any)[ASSISTANT_CONTENT_KEY];
+
+        // If engine didn't populate assistant content (e.g. AI SDK engine),
+        // rebuild it from the messages state we tracked via tool-call events.
+        // The AI SDK engine stores it under AISDK_ASSISTANT_CONTENT_KEY.
+        if (!assistantContent) {
+          const { AISDK_ASSISTANT_CONTENT_KEY } =
+            await import("./engine/ai-sdk-engine.js");
+          assistantContent = (streamOpts as any)[AISDK_ASSISTANT_CONTENT_KEY];
         }
+
         break;
       } catch (err: unknown) {
         if (signal.aborted) throw err;
@@ -245,64 +307,72 @@ export async function runAgentLoop(opts: {
         throw err;
       }
     }
-    if (!assistantContent) break;
+
+    if (!assistantContent) {
+      // No content — done
+      break;
+    }
 
     messages.push({ role: "assistant", content: assistantContent });
 
-    const toolUseBlocks = assistantContent.filter(
-      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use",
+    const toolCallParts = assistantContent.filter(
+      (p): p is import("./engine/types.js").EngineToolCallPart =>
+        p.type === "tool-call",
     );
 
-    if (toolUseBlocks.length === 0) break;
+    if (toolCallParts.length === 0) break;
 
-    // Run all tool calls in parallel — Claude often returns multiple tool_use
-    // blocks in one turn (e.g. adding several slides at once). Running them
-    // concurrently saves significant wall-clock time.
-    const toolResults: Anthropic.ToolResultBlockParam[] = await Promise.all(
-      toolUseBlocks.map(async (toolUse) => {
-        const actionEntry = actions[toolUse.name];
+    // Run all tool calls in parallel — engines often return multiple tool-call
+    // blocks in one turn. Running them concurrently saves wall-clock time.
+    const toolResultParts: EngineContentPart[] = await Promise.all(
+      toolCallParts.map(async (toolCall) => {
+        const actionEntry = actions[toolCall.name];
         if (!actionEntry) {
-          const result = `Error: Unknown tool "${toolUse.name}"`;
+          const result = `Error: Unknown tool "${toolCall.name}"`;
           send({
             type: "tool_start",
-            tool: toolUse.name,
-            input: toolUse.input as Record<string, string>,
+            tool: toolCall.name,
+            input: toolCall.input as Record<string, string>,
           });
-          send({ type: "tool_done", tool: toolUse.name, result });
+          send({ type: "tool_done", tool: toolCall.name, result });
           return {
-            type: "tool_result" as const,
-            tool_use_id: toolUse.id,
+            type: "tool-result" as const,
+            toolCallId: toolCall.id,
             content: result,
+            isError: true,
           };
         }
 
         send({
           type: "tool_start",
-          tool: toolUse.name,
-          input: toolUse.input as Record<string, string>,
+          tool: toolCall.name,
+          input: toolCall.input as Record<string, string>,
         });
 
         let result: string;
+        let isError = false;
         try {
           const raw = await actionEntry.run(
-            toolUse.input as Record<string, string>,
+            toolCall.input as Record<string, string>,
             { send },
           );
           result = typeof raw === "string" ? raw : JSON.stringify(raw, null, 2);
         } catch (err: any) {
-          result = `Error running ${toolUse.name}: ${err?.message ?? String(err)}`;
+          result = `Error running ${toolCall.name}: ${err?.message ?? String(err)}`;
+          isError = true;
         }
 
-        send({ type: "tool_done", tool: toolUse.name, result });
+        send({ type: "tool_done", tool: toolCall.name, result });
         return {
-          type: "tool_result" as const,
-          tool_use_id: toolUse.id,
+          type: "tool-result" as const,
+          toolCallId: toolCall.id,
           content: result,
+          ...(isError ? { isError } : {}),
         };
       }),
     );
 
-    messages.push({ role: "user", content: toolResults });
+    messages.push({ role: "user", content: toolResultParts });
   }
 
   send({ type: "done" });
@@ -317,16 +387,8 @@ export function createProductionAgentHandler(
   // Resolve actions — prefer `actions`, fall back to deprecated `scripts`
   const resolvedActions = options.actions ?? options.scripts ?? {};
 
-  // Build Anthropic tool definitions from action registry
-  const tools: Anthropic.Tool[] = Object.entries(resolvedActions).map(
-    ([name, entry]) => ({
-      name,
-      description: entry.tool.description,
-      input_schema: (entry.tool.parameters ?? {
-        type: "object",
-      }) as Anthropic.Tool["input_schema"],
-    }),
-  );
+  // Build engine tools from action registry
+  const engineTools = actionsToEngineTools(resolvedActions);
 
   return defineEventHandler(async (event) => {
     if (getMethod(event) !== "POST") {
@@ -354,9 +416,23 @@ export function createProductionAgentHandler(
       return { error: "message is required" };
     }
 
-    // Check for API key before starting a run
+    // Resolve engine (async — reads settings if needed)
+    let engine: AgentEngine;
+    try {
+      engine = await resolveEngine({
+        engineOption: options.engine,
+        apiKey: options.apiKey ?? process.env.ANTHROPIC_API_KEY,
+        model,
+      });
+    } catch {
+      engine = await resolveEngine({
+        apiKey: options.apiKey ?? process.env.ANTHROPIC_API_KEY,
+      });
+    }
+
+    // Check for API key before starting a run (only for anthropic engine)
     const apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY;
-    if (!apiKey) {
+    if (engine.name === "anthropic" && !apiKey) {
       setResponseHeader(event, "Content-Type", "text/event-stream");
       setResponseHeader(event, "Cache-Control", "no-cache");
       setResponseHeader(event, "Connection", "keep-alive");
@@ -428,13 +504,10 @@ export function createProductionAgentHandler(
       });
     }
 
-    const client = new Anthropic({ apiKey });
     const enrichedMessage = enrichMessage(message, references);
 
     // Auto-inject current screen context so the agent always knows what
     // the user is looking at without needing to call view-screen first.
-    // If the template registers a view-screen action, run it for rich context;
-    // otherwise fall back to raw navigation state.
     let screenContext = "";
     try {
       const viewScreenAction = resolvedActions["view-screen"];
@@ -457,7 +530,7 @@ export function createProductionAgentHandler(
     const agentRefs = references.filter((r) => r.type === "agent");
 
     // Build user content: text + any image attachments
-    const userContent: Anthropic.ContentBlockParam[] = [];
+    const userContent: EngineContentPart[] = [];
     if (attachments?.length) {
       for (const att of attachments) {
         if (att.type === "image" && att.data) {
@@ -465,15 +538,12 @@ export function createProductionAgentHandler(
           if (match) {
             userContent.push({
               type: "image",
-              source: {
-                type: "base64",
-                media_type: match[1] as
-                  | "image/jpeg"
-                  | "image/png"
-                  | "image/gif"
-                  | "image/webp",
-                data: match[2],
-              },
+              data: match[2],
+              mediaType: match[1] as
+                | "image/jpeg"
+                | "image/png"
+                | "image/gif"
+                | "image/webp",
             });
           }
         }
@@ -484,12 +554,12 @@ export function createProductionAgentHandler(
       text: enrichedMessage + screenContext,
     });
 
-    const messages: Anthropic.MessageParam[] = [
+    const messages: EngineMessage[] = [
       ...history
         .filter((m) => m.content.trim())
         .map((m) => ({
           role: m.role as "user" | "assistant",
-          content: m.content,
+          content: [{ type: "text" as const, text: m.content }],
         })),
       { role: "user" as const, content: userContent },
     ];
@@ -518,14 +588,11 @@ export function createProductionAgentHandler(
                 status: "start",
               });
               try {
-                // Try streaming first — shows progressive text in the UI
-                const client = new A2AClient(ref.path);
+                const a2aClient = new A2AClient(ref.path);
                 const callerEmail = process.env.AGENT_USER_EMAIL;
 
-                // Build A2A metadata with identity info
                 const a2aMetadata: Record<string, unknown> = {};
                 if (callerEmail) a2aMetadata.userEmail = callerEmail;
-                // In prod, include Google token for verification
                 if (process.env.NODE_ENV === "production" && callerEmail) {
                   try {
                     const { listOAuthAccountsByOwner } =
@@ -545,7 +612,7 @@ export function createProductionAgentHandler(
                 let lastSentLength = 0;
 
                 try {
-                  for await (const task of client.stream(
+                  for await (const task of a2aClient.stream(
                     {
                       role: "user",
                       parts: [
@@ -579,7 +646,6 @@ export function createProductionAgentHandler(
                     responseText = newText;
                   }
                 } catch {
-                  // Streaming failed — fall back to blocking call
                   if (!responseText) {
                     responseText = await callAgent(
                       ref.path,
@@ -605,37 +671,40 @@ export function createProductionAgentHandler(
             }),
           );
 
+          const agentResponses_local: string[] = [];
           for (const result of results) {
             if (result.status === "fulfilled") {
-              agentResponses.push(result.value);
+              agentResponses_local.push(result.value);
             }
           }
 
-          if (agentResponses.length > 0) {
+          if (agentResponses_local.length > 0) {
             const agentContext =
-              "Responses from other agents:\n\n" + agentResponses.join("\n\n");
-            // Prepend agent responses to the last user message's text content
+              "Responses from other agents:\n\n" +
+              agentResponses_local.join("\n\n");
             const lastMsg = messages[messages.length - 1];
             if (lastMsg?.role === "user" && Array.isArray(lastMsg.content)) {
-              const textBlock = lastMsg.content.find(
-                (b): b is Anthropic.TextBlockParam => b.type === "text",
+              const textPart = lastMsg.content.find(
+                (p): p is import("./engine/types.js").EngineTextPart =>
+                  p.type === "text",
               );
-              if (textBlock) {
-                textBlock.text = agentContext + "\n\n" + textBlock.text;
+              if (textPart) {
+                textPart.text = agentContext + "\n\n" + textPart.text;
               }
             }
           }
         }
 
         const loopUsage = await runAgentLoop({
-          client,
+          engine,
           model,
           systemPrompt,
-          tools,
+          tools: engineTools,
           messages,
           actions: resolvedActions,
           send,
           signal,
+          providerOptions: options.providerOptions,
         });
 
         // Record token usage for cost tracking (production hosted mode)

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -155,6 +155,51 @@ export async function updateThreadData(
   emitChatThreadChange(id);
 }
 
+export interface ThreadEngineMeta {
+  engineName: string;
+  model: string;
+}
+
+/**
+ * Read the engine pinned to a thread (stored in thread_data JSON).
+ * Returns null if no engine is pinned.
+ */
+export async function getThreadEngineMeta(
+  threadId: string,
+): Promise<ThreadEngineMeta | null> {
+  const thread = await getThread(threadId);
+  if (!thread?.threadData) return null;
+  try {
+    const data = JSON.parse(thread.threadData);
+    if (data.engineMeta?.engineName) return data.engineMeta as ThreadEngineMeta;
+  } catch {}
+  return null;
+}
+
+/**
+ * Pin an engine to a thread by storing engineMeta in thread_data JSON.
+ * Does not change messages, title, or preview.
+ */
+export async function setThreadEngineMeta(
+  threadId: string,
+  meta: ThreadEngineMeta,
+): Promise<void> {
+  const thread = await getThread(threadId);
+  if (!thread) return;
+  let data: Record<string, unknown> = {};
+  try {
+    data = JSON.parse(thread.threadData);
+  } catch {}
+  data.engineMeta = meta;
+  await updateThreadData(
+    threadId,
+    JSON.stringify(data),
+    thread.title,
+    thread.preview,
+    thread.messageCount,
+  );
+}
+
 export async function deleteThread(id: string): Promise<boolean> {
   await ensureTable();
   const client = getDbExec();

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -3,7 +3,13 @@ import { setResponseStatus } from "h3";
 import type { PlatformAdapter, IncomingMessage } from "./types.js";
 import { getThreadMapping, saveThreadMapping } from "./thread-mapping-store.js";
 import { createThread, getThread } from "../chat-threads/store.js";
-import { runAgentLoop, type ActionEntry } from "../agent/production-agent.js";
+import {
+  runAgentLoop,
+  actionsToEngineTools,
+  type ActionEntry,
+} from "../agent/production-agent.js";
+import { createAnthropicEngine } from "../agent/engine/index.js";
+import type { EngineMessage } from "../agent/engine/types.js";
 import { startRun, type ActiveRun } from "../agent/run-manager.js";
 import {
   buildAssistantMessage,
@@ -144,38 +150,31 @@ async function processMessageInBackground(
 
   // Load existing thread history for context
   const thread = await getThread(threadId);
-  const existingMessages: any[] = [];
+  const existingMessages: EngineMessage[] = [];
   if (thread?.threadData) {
     try {
       const data = JSON.parse(thread.threadData);
       if (Array.isArray(data.messages)) {
         for (const msg of data.messages) {
           const m = msg.message ?? msg;
+          const textContent =
+            typeof m.content === "string"
+              ? m.content
+              : Array.isArray(m.content)
+                ? m.content
+                    .filter((c: any) => c.type === "text")
+                    .map((c: any) => c.text)
+                    .join("\n")
+                : "";
           if (m.role === "user") {
             existingMessages.push({
               role: "user",
-              content:
-                typeof m.content === "string"
-                  ? m.content
-                  : Array.isArray(m.content)
-                    ? m.content
-                        .filter((c: any) => c.type === "text")
-                        .map((c: any) => c.text)
-                        .join("\n")
-                    : "",
+              content: [{ type: "text", text: textContent }],
             });
           } else if (m.role === "assistant") {
             existingMessages.push({
               role: "assistant",
-              content:
-                typeof m.content === "string"
-                  ? m.content
-                  : Array.isArray(m.content)
-                    ? m.content
-                        .filter((c: any) => c.type === "text")
-                        .map((c: any) => c.text)
-                        .join("\n")
-                    : "",
+              content: [{ type: "text", text: textContent }],
             });
           }
         }
@@ -184,23 +183,14 @@ async function processMessageInBackground(
   }
 
   // Add the new user message
-  const messages: any[] = [
+  const messages: EngineMessage[] = [
     ...existingMessages,
-    { role: "user", content: incoming.text },
+    { role: "user", content: [{ type: "text", text: incoming.text }] },
   ];
 
   // Step 6: Run agent loop via startRun
-  const Anthropic = (await import("@anthropic-ai/sdk")).default;
-  const client = new Anthropic({ apiKey });
-
-  const tools = Object.entries(actions).map(([name, entry]) => ({
-    name,
-    description: entry.tool.description,
-    input_schema: entry.tool.parameters ?? {
-      type: "object" as const,
-      properties: {},
-    },
-  }));
+  const engine = createAnthropicEngine({ apiKey });
+  const tools = actionsToEngineTools(actions);
 
   const runId = `integration-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -209,7 +199,7 @@ async function processMessageInBackground(
     threadId,
     async (send, signal) => {
       await runAgentLoop({
-        client,
+        engine,
         model,
         systemPrompt,
         tools,

--- a/packages/core/src/jobs/scheduler.ts
+++ b/packages/core/src/jobs/scheduler.ts
@@ -1,4 +1,3 @@
-import Anthropic from "@anthropic-ai/sdk";
 import { nextOccurrence, isValidCron, describeCron } from "./cron.js";
 import {
   resourceListAllOwners,
@@ -6,7 +5,13 @@ import {
   resourceGet,
   type Resource,
 } from "../resources/store.js";
-import { runAgentLoop, type ActionEntry } from "../agent/production-agent.js";
+import {
+  runAgentLoop,
+  actionsToEngineTools,
+  type ActionEntry,
+} from "../agent/production-agent.js";
+import { createAnthropicEngine } from "../agent/engine/index.js";
+import type { AgentEngine } from "../agent/engine/types.js";
 import { createThread } from "../chat-threads/store.js";
 import type { AgentChatEvent } from "../agent/types.js";
 
@@ -99,8 +104,9 @@ export function buildJobContent(meta: JobFrontmatter, body: string): string {
 export interface SchedulerDeps {
   getActions: () => Record<string, ActionEntry>;
   getSystemPrompt: (owner: string) => Promise<string>;
-  getTools: (actions: Record<string, ActionEntry>) => Anthropic.Tool[];
-  apiKey: string;
+  /** Optional engine override. Defaults to AnthropicEngine using apiKey or ANTHROPIC_API_KEY. */
+  engine?: AgentEngine;
+  apiKey?: string;
   model: string;
 }
 
@@ -184,18 +190,20 @@ async function executeJob(
   try {
     const actions = deps.getActions();
     const systemPrompt = await deps.getSystemPrompt(resource.owner);
-    const tools = deps.getTools(actions);
+    const tools = actionsToEngineTools(actions);
 
-    const client = new Anthropic({ apiKey: deps.apiKey });
+    const engine =
+      deps.engine ?? createAnthropicEngine({ apiKey: deps.apiKey });
 
     // Create a chat thread for this run
     const threadTitle = `Job: ${jobName} — ${now.toLocaleDateString()}`;
     const thread = await createThread(threadTitle);
 
-    const messages: Anthropic.MessageParam[] = [
+    const jobText = `[Recurring Job: ${jobName}]\nSchedule: ${describeCron(meta.schedule)}\n\nExecute the following job instructions:\n\n${body}`;
+    const messages = [
       {
-        role: "user",
-        content: `[Recurring Job: ${jobName}]\nSchedule: ${describeCron(meta.schedule)}\n\nExecute the following job instructions:\n\n${body}`,
+        role: "user" as const,
+        content: [{ type: "text" as const, text: jobText }],
       },
     ];
 
@@ -210,7 +218,7 @@ async function executeJob(
 
     try {
       await runAgentLoop({
-        client,
+        engine,
         model: deps.model,
         systemPrompt,
         tools,

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.ts
@@ -1,0 +1,56 @@
+/**
+ * list-agent-engines — returns the registered engine registry and current selection.
+ */
+
+import type { ActionTool } from "../../agent/types.js";
+import {
+  listAgentEngines,
+  registerBuiltinEngines,
+} from "../../agent/engine/index.js";
+import { getSetting } from "../../settings/index.js";
+
+export const tool: ActionTool = {
+  description:
+    "List all available AI agent engines (Anthropic, OpenAI, Gemini, Groq, etc.) and the currently selected engine. Use this to check what engines are available before calling set-agent-engine.",
+  parameters: {
+    type: "object",
+    properties: {},
+    required: [],
+  },
+};
+
+export async function run(): Promise<string> {
+  registerBuiltinEngines();
+
+  const engines = listAgentEngines();
+  const currentSetting = await getSetting("agent-engine");
+  const current = currentSetting
+    ? (currentSetting as { engine?: string; model?: string })
+    : null;
+
+  const result = {
+    engines: engines.map((e) => ({
+      name: e.name,
+      label: e.label,
+      description: e.description,
+      defaultModel: e.defaultModel,
+      supportedModels: e.supportedModels,
+      capabilities: e.capabilities,
+      requiredEnvVars: e.requiredEnvVars,
+      installPackage: e.installPackage,
+    })),
+    current: {
+      engine: current?.engine ?? process.env.AGENT_ENGINE ?? "anthropic",
+      model:
+        current?.model ??
+        engines.find(
+          (e) =>
+            e.name ===
+            (current?.engine ?? process.env.AGENT_ENGINE ?? "anthropic"),
+        )?.defaultModel ??
+        "claude-haiku-4-5-20251001",
+    },
+  };
+
+  return JSON.stringify(result, null, 2);
+}

--- a/packages/core/src/scripts/agent-engines/set-agent-engine.ts
+++ b/packages/core/src/scripts/agent-engines/set-agent-engine.ts
@@ -1,0 +1,76 @@
+/**
+ * set-agent-engine — validates and writes agent engine selection to settings.
+ */
+
+import type { ActionTool } from "../../agent/types.js";
+import {
+  listAgentEngines,
+  getAgentEngineEntry,
+  registerBuiltinEngines,
+} from "../../agent/engine/index.js";
+import { putSetting } from "../../settings/index.js";
+
+export const tool: ActionTool = {
+  description:
+    "Set the active AI agent engine and model. Changes take effect on the next conversation. Use list-agent-engines first to see available options.",
+  parameters: {
+    type: "object",
+    properties: {
+      engine: {
+        type: "string",
+        description:
+          'Engine name (e.g. "anthropic", "ai-sdk:openai", "ai-sdk:google"). Use list-agent-engines to see all options.',
+      },
+      model: {
+        type: "string",
+        description:
+          "Model ID to use with this engine (e.g. 'claude-sonnet-4-6', 'gpt-4o'). Defaults to the engine's default model if omitted.",
+      },
+    },
+    required: ["engine"],
+  },
+};
+
+export async function run(args: Record<string, string>): Promise<string> {
+  registerBuiltinEngines();
+
+  const { engine: engineName, model } = args;
+
+  if (!engineName) return "Error: --engine is required";
+
+  const entry = getAgentEngineEntry(engineName);
+  if (!entry) {
+    const available = listAgentEngines()
+      .map((e) => e.name)
+      .join(", ");
+    return `Error: Engine "${engineName}" not found. Available engines: ${available}`;
+  }
+
+  const resolvedModel = model ?? entry.defaultModel;
+
+  // Validate model is in supported list (if the list is non-empty)
+  if (
+    entry.supportedModels.length > 0 &&
+    !entry.supportedModels.includes(resolvedModel)
+  ) {
+    return `Error: Model "${resolvedModel}" is not supported by engine "${engineName}". Supported models: ${entry.supportedModels.join(", ")}`;
+  }
+
+  // Check required env vars
+  const missingEnvVars = entry.requiredEnvVars.filter((v) => !process.env[v]);
+  if (missingEnvVars.length > 0) {
+    return `Warning: Engine "${engineName}" requires the following environment variables which are not set: ${missingEnvVars.join(", ")}. The engine will fail at runtime without them.`;
+  }
+
+  await putSetting("agent-engine", {
+    engine: engineName,
+    model: resolvedModel,
+  });
+
+  return JSON.stringify({
+    ok: true,
+    engine: engineName,
+    model: resolvedModel,
+    message: `Agent engine set to ${entry.label} with model ${resolvedModel}. Takes effect on the next conversation.`,
+  });
+}

--- a/packages/core/src/scripts/agent-engines/test-agent-engine.ts
+++ b/packages/core/src/scripts/agent-engines/test-agent-engine.ts
@@ -1,0 +1,119 @@
+/**
+ * test-agent-engine — sends a trivial prompt to verify the engine is working.
+ */
+
+import type { ActionTool } from "../../agent/types.js";
+import {
+  getAgentEngineEntry,
+  registerBuiltinEngines,
+} from "../../agent/engine/index.js";
+
+export const tool: ActionTool = {
+  description:
+    "Test an agent engine by sending a trivial prompt and measuring latency. Useful for verifying API keys and connectivity before switching engines.",
+  parameters: {
+    type: "object",
+    properties: {
+      engine: {
+        type: "string",
+        description:
+          'Engine name to test (e.g. "anthropic", "ai-sdk:openai"). Defaults to "anthropic".',
+      },
+      model: {
+        type: "string",
+        description:
+          "Model to use for the test. Defaults to the engine's default model.",
+      },
+    },
+    required: [],
+  },
+};
+
+export async function run(args: Record<string, string>): Promise<string> {
+  registerBuiltinEngines();
+
+  const engineName = args.engine ?? "anthropic";
+  const entry = getAgentEngineEntry(engineName);
+  if (!entry) {
+    return JSON.stringify({
+      ok: false,
+      error: `Engine "${engineName}" not found`,
+    });
+  }
+
+  const model = args.model ?? entry.defaultModel;
+
+  try {
+    const engine = entry.create({
+      apiKey:
+        entry.requiredEnvVars.length > 0
+          ? process.env[entry.requiredEnvVars[0]]
+          : undefined,
+    });
+
+    const start = Date.now();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 30_000);
+
+    let responseText = "";
+    let stopReason = "";
+
+    let streamError: string | undefined;
+
+    try {
+      for await (const event of engine.stream({
+        model,
+        systemPrompt: "You are a test agent. Reply concisely.",
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Reply with exactly: OK" }],
+          },
+        ],
+        tools: [],
+        abortSignal: controller.signal,
+      })) {
+        if (event.type === "text-delta") {
+          responseText += event.text;
+        } else if (event.type === "stop") {
+          stopReason = event.reason;
+          if (event.reason === "error") {
+            streamError = (event as any).error ?? "Unknown error";
+          }
+        }
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const latencyMs = Date.now() - start;
+
+    if (streamError) {
+      return JSON.stringify({
+        ok: false,
+        engine: engineName,
+        model,
+        error: streamError,
+        capabilities: entry.capabilities,
+      });
+    }
+
+    return JSON.stringify({
+      ok: true,
+      engine: engineName,
+      model,
+      latencyMs,
+      response: responseText.slice(0, 100),
+      stopReason,
+      capabilities: entry.capabilities,
+    });
+  } catch (err: any) {
+    return JSON.stringify({
+      ok: false,
+      engine: engineName,
+      model,
+      error: err?.message ?? String(err),
+      capabilities: entry.capabilities,
+    });
+  }
+}

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -5,18 +5,18 @@ import { A2AClient, callAgent } from "../a2a/client.js";
 
 export const tool: ActionTool = {
   description:
-    "Call a separate external agent app to ask a question or delegate a task. Only use this when you need to communicate with a *different* deployed app's agent. Do NOT use this for operations your own app can handle directly — use your own actions instead.",
+    "Call a DIFFERENT, separately-deployed agent app to ask a question or delegate a task. This is strictly for cross-app A2A communication — for example, asking the mail agent to send an email while you are the calendar agent. NEVER use this to call your own app or perform actions you can do with your own tools. Using call-agent on yourself will fail and waste time.",
   parameters: {
     type: "object",
     properties: {
       agent: {
         type: "string",
         description:
-          "Agent name or URL of an external agent app to call (e.g., a separately deployed app). Must be a known external agent — do not guess names.",
+          "Name or URL of a DIFFERENT deployed agent app (e.g. 'mail', 'calendar', 'analytics'). Must not be the current app's own name.",
       },
       message: {
         type: "string",
-        description: "The message/question to send to the agent",
+        description: "The message/question to send to the other agent",
       },
     },
     required: ["agent", "message"],
@@ -26,15 +26,23 @@ export const tool: ActionTool = {
 export async function run(
   args: Record<string, string>,
   context?: ActionRunContext,
+  selfAppId?: string,
 ): Promise<string> {
   const { agent: agentIdOrName, message } = args;
 
   if (!agentIdOrName) return "Error: --agent is required";
   if (!message) return "Error: --message is required";
 
-  const agent = await findAgent(agentIdOrName);
+  // Prevent self-calls — the agent must use its own registered tools instead
+  if (selfAppId && agentIdOrName.toLowerCase() === selfAppId.toLowerCase()) {
+    return `Error: You cannot use call-agent to call yourself (${selfAppId}). Use your own registered actions/tools instead. call-agent is only for communicating with OTHER separately-deployed apps.`;
+  }
+
+  const agent = await findAgent(agentIdOrName, selfAppId);
   if (!agent) {
-    const available = (await discoverAgents()).map((a) => a.name).join(", ");
+    const available = (await discoverAgents(selfAppId))
+      .map((a) => a.name)
+      .join(", ");
     return `Error: Agent "${agentIdOrName}" not found. Available agents: ${available || "(none)"}`;
   }
 

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2,6 +2,7 @@ import { getH3App } from "./framework-request-handler.js";
 import {
   createProductionAgentHandler,
   runAgentLoop,
+  actionsToEngineTools,
   getActiveRunForThread,
   getActiveRunForThreadAsync,
   getRun,
@@ -9,6 +10,8 @@ import {
   subscribeToRun,
   type ActionEntry,
 } from "../agent/production-agent.js";
+import type { AgentEngine, EngineMessage } from "../agent/engine/types.js";
+import { resolveEngine, createAnthropicEngine } from "../agent/engine/index.js";
 import type {
   ActionTool,
   MentionProvider,
@@ -293,17 +296,42 @@ async function createChatScriptEntries(): Promise<Record<string, ActionEntry>> {
 }
 
 /**
- * Creates the call-agent ActionEntry for cross-agent A2A communication.
+ * Creates agent engine management tools (list-agent-engines, set-agent-engine,
+ * test-agent-engine). Let the agent inspect and configure the active LLM engine.
  */
-async function createCallAgentScriptEntry(): Promise<
+async function createAgentEngineScriptEntries(): Promise<
   Record<string, ActionEntry>
 > {
+  try {
+    const [listMod, setMod, testMod] = await Promise.all([
+      import("../scripts/agent-engines/list-agent-engines.js"),
+      import("../scripts/agent-engines/set-agent-engine.js"),
+      import("../scripts/agent-engines/test-agent-engine.js"),
+    ]);
+
+    return {
+      "list-agent-engines": { tool: listMod.tool, run: listMod.run },
+      "set-agent-engine": { tool: setMod.tool, run: setMod.run },
+      "test-agent-engine": { tool: testMod.tool, run: testMod.run },
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Creates the call-agent ActionEntry for cross-agent A2A communication.
+ * Binds selfAppId so the agent cannot call itself via call-agent.
+ */
+async function createCallAgentScriptEntry(
+  selfAppId?: string,
+): Promise<Record<string, ActionEntry>> {
   try {
     const mod = await import("../scripts/call-agent.js");
     return {
       "call-agent": {
         tool: mod.tool,
-        run: mod.run,
+        run: (args, context) => mod.run(args, context, selfAppId),
       },
     };
   } catch {
@@ -319,7 +347,7 @@ function createTeamTools(deps: {
   getOwner: () => string;
   getSystemPrompt: () => string;
   getActions: () => Record<string, ActionEntry>;
-  getApiKey: () => string;
+  getEngine: () => AgentEngine;
   getModel: () => string;
   getParentThreadId: () => string;
   getSend: () =>
@@ -377,7 +405,7 @@ function createTeamTools(deps: {
           ownerEmail: deps.getOwner(),
           systemPrompt: deps.getSystemPrompt(),
           actions: subAgentActions,
-          apiKey: deps.getApiKey(),
+          engine: deps.getEngine(),
           model: deps.getModel(),
           parentThreadId: deps.getParentThreadId(),
           parentSend: (event) => {
@@ -537,6 +565,15 @@ export interface AgentChatPluginOptions {
   model?: string;
   /** Anthropic API key. Falls back to ANTHROPIC_API_KEY env var */
   apiKey?: string;
+  /**
+   * Agent engine to use. Can be a pre-constructed AgentEngine, a registered
+   * engine name (e.g. "anthropic", "ai-sdk:openai"), or an object with name
+   * and config. Defaults to the "anthropic" engine using ANTHROPIC_API_KEY.
+   */
+  engine?:
+    | import("../agent/engine/types.js").AgentEngine
+    | string
+    | { name: string; config: Record<string, unknown> };
   /** Route path. Default: /_agent-native/agent-chat */
   path?: string;
   /** Custom mention providers for @-tagging template entities */
@@ -638,6 +675,22 @@ When the user asks for something recurring ("every morning", "daily at 9am", "we
 - "twice a day" / "morning and evening" → \`0 9,17 * * *\`
 
 Job instructions should be self-contained — include which actions to call, what conditions to check, and what to do with results. The agent executing the job has access to all the same tools you do.
+
+### call-agent — External Apps Only
+
+The \`call-agent\` tool sends a message to a DIFFERENT, separately-deployed app's agent (A2A protocol). It is **not** for calling actions within the current app.
+
+**NEVER use \`call-agent\` to:**
+- Call your own app by name (if you are the "macros" agent, never do \`call-agent(agent="macros")\`)
+- Perform tasks you can accomplish with your own registered tools
+- Wrap your own actions in an A2A round-trip
+
+**ONLY use \`call-agent\` when:**
+- The user explicitly asks you to communicate with a different app (e.g., "ask the mail agent to...")
+- You need data that only another deployed app can provide
+- You are coordinating across genuinely separate apps
+
+If \`call-agent\` returns an error saying the agent is yourself — stop and use your own tools instead.
 
 ### Auto-Memory
 
@@ -1007,8 +1060,12 @@ export function createAgentChatPlugin(
 
     // Resource, chat, and cross-agent scripts are available in both prod and dev modes
     const resourceScripts = await createResourceScriptEntries();
-    const chatScripts = await createChatScriptEntries();
-    const callAgentScript = await createCallAgentScriptEntry();
+    const engineScripts = await createAgentEngineScriptEntries();
+    const chatScripts = {
+      ...(await createChatScriptEntries()),
+      ...engineScripts,
+    };
+    const callAgentScript = await createCallAgentScriptEntry(options?.appId);
 
     // Auto-mount A2A protocol endpoints so every app is discoverable
     // and callable by other agents via the standard protocol.
@@ -1201,20 +1258,10 @@ export function createAgentChatPlugin(
 
         // Use the SAME agent setup as the interactive chat — identical tools,
         // prompt, and capabilities. The A2A agent IS the app's agent.
-        const Anthropic = (await import("@anthropic-ai/sdk")).default;
-        const apiKey = options?.apiKey ?? process.env.ANTHROPIC_API_KEY;
-        if (!apiKey) {
-          yield {
-            role: "agent" as const,
-            parts: [
-              {
-                type: "text" as const,
-                text: "Anthropic API key is not configured. Set ANTHROPIC_API_KEY in .env.",
-              },
-            ],
-          };
-          return;
-        }
+        const a2aEngine = await resolveEngine({
+          engineOption: options?.engine,
+          apiKey: options?.apiKey,
+        });
 
         // Use the same handler (dev or prod) that the interactive chat uses
         const handler = canToggle && devHandler ? devHandler : prodHandler;
@@ -1227,7 +1274,6 @@ export function createAgentChatPlugin(
           ? devPrompt + resources + schemaBlock
           : basePrompt + resources + schemaBlock;
 
-        const a2aClient = new Anthropic({ apiKey });
         const model =
           options?.model ??
           (canToggle ? "claude-sonnet-4-6" : "claude-haiku-4-5-20251001");
@@ -1248,33 +1294,26 @@ export function createAgentChatPlugin(
               ...chatScripts,
             };
 
-        const tools: any[] = Object.entries(a2aActions).map(
-          ([name, entry]) => ({
-            name,
-            description: entry.tool.description,
-            input_schema: entry.tool.parameters ?? {
-              type: "object" as const,
-              properties: {},
-            },
-          }),
-        );
+        const a2aTools = actionsToEngineTools(a2aActions);
 
-        const messages: any[] = [{ role: "user", content: text }];
+        const a2aMessages: EngineMessage[] = [
+          { role: "user", content: [{ type: "text", text }] },
+        ];
 
         // Run the SAME agent loop, collect text events, yield as A2A messages
         let accumulatedText = "";
         const controller = new AbortController();
 
         console.log(
-          `[A2A] Starting agent loop: ${tools.length} tools, prompt ${systemPrompt.length} chars`,
+          `[A2A] Starting agent loop: ${a2aTools.length} tools, prompt ${systemPrompt.length} chars`,
         );
 
         await runAgentLoop({
-          client: a2aClient,
+          engine: a2aEngine,
           model,
           systemPrompt,
-          tools,
-          messages,
+          tools: a2aTools,
+          messages: a2aMessages,
           actions: a2aActions,
           send: (event) => {
             if (event.type === "text") {
@@ -1345,11 +1384,10 @@ export function createAgentChatPlugin(
       description: `Agent-native ${options?.appId ?? "app"} agent`,
       actions: allScripts,
       askAgent: async (message: string) => {
-        const Anthropic = (await import("@anthropic-ai/sdk")).default;
-        const apiKey = options?.apiKey ?? process.env.ANTHROPIC_API_KEY;
-        if (!apiKey) return "Anthropic API key is not configured.";
-
-        const client = new Anthropic({ apiKey });
+        const mcpEngine = await resolveEngine({
+          engineOption: options?.engine,
+          apiKey: options?.apiKey,
+        });
         const model =
           options?.model ??
           (canToggle ? "claude-sonnet-4-6" : "claude-haiku-4-5-20251001");
@@ -1368,16 +1406,7 @@ export function createAgentChatPlugin(
               ...chatScripts,
             };
 
-        const tools: any[] = Object.entries(mcpActions).map(
-          ([name, entry]) => ({
-            name,
-            description: entry.tool.description,
-            input_schema: entry.tool.parameters ?? {
-              type: "object" as const,
-              properties: {},
-            },
-          }),
-        );
+        const mcpTools = actionsToEngineTools(mcpActions);
 
         const resources = await loadResourcesForPrompt("local@localhost");
         const schemaBlock = await buildSchemaBlock(
@@ -1392,11 +1421,13 @@ export function createAgentChatPlugin(
         const controller = new AbortController();
 
         await runAgentLoop({
-          client,
+          engine: mcpEngine,
           model,
           systemPrompt,
-          tools,
-          messages: [{ role: "user", content: message }],
+          tools: mcpTools,
+          messages: [
+            { role: "user", content: [{ type: "text", text: message }] },
+          ],
           actions: mcpActions,
           send: (event) => {
             if (event.type === "text") accumulatedText += event.text;
@@ -1419,9 +1450,12 @@ export function createAgentChatPlugin(
     };
 
     // Auto-mount template actions as HTTP endpoints under /_agent-native/actions/
-    // Only template actions (discoveredActions + templateScripts) are exposed — not
-    // built-in resource/chat/dev tools.
-    const httpActions = { ...discoveredActions, ...templateScripts };
+    // Include engine management scripts so the UI can call list/set/test-agent-engine.
+    const httpActions = {
+      ...discoveredActions,
+      ...templateScripts,
+      ...engineScripts,
+    };
     if (Object.keys(httpActions).length > 0) {
       const { mountActionRoutes } = await import("./action-routes.js");
       mountActionRoutes(nitroApp, httpActions, {
@@ -1535,7 +1569,10 @@ export function createAgentChatPlugin(
               ...resourceScripts,
               ...chatScripts,
             },
-      getApiKey: () => options?.apiKey ?? process.env.ANTHROPIC_API_KEY ?? "",
+      getEngine: () =>
+        createAnthropicEngine({
+          apiKey: options?.apiKey ?? process.env.ANTHROPIC_API_KEY,
+        }),
       getModel: () => resolvedModel,
       getParentThreadId: () => _currentRunThreadId,
       getSend: () => {
@@ -2364,49 +2401,37 @@ export function createAgentChatPlugin(
     // Poll every 60 seconds for due recurring jobs and execute them.
     // Uses setInterval so it works in all deployment environments without
     // requiring Nitro experimental tasks configuration.
-    const apiKey = options?.apiKey ?? process.env.ANTHROPIC_API_KEY;
-    if (apiKey) {
-      try {
-        const { processRecurringJobs } = await import("../jobs/scheduler.js");
+    try {
+      const { processRecurringJobs } = await import("../jobs/scheduler.js");
 
-        const schedulerDeps = {
-          getActions: () => ({
-            ...templateScripts,
-            ...resourceScripts,
-            ...chatScripts,
-            ...jobTools,
-          }),
-          getSystemPrompt: async (owner: string) => {
-            const resources = await loadResourcesForPrompt(owner);
-            const schemaBlock = await buildSchemaBlock(owner, false);
-            return basePrompt + resources + schemaBlock;
-          },
-          getTools: (actions: Record<string, ActionEntry>) =>
-            Object.entries(actions).map(([name, entry]) => ({
-              name,
-              description: entry.tool.description,
-              input_schema: entry.tool.parameters ?? {
-                type: "object" as const,
-                properties: {},
-              },
-            })),
-          apiKey,
-          model: resolvedModel,
-        };
+      const schedulerDeps = {
+        getActions: () => ({
+          ...templateScripts,
+          ...resourceScripts,
+          ...chatScripts,
+          ...jobTools,
+        }),
+        getSystemPrompt: async (owner: string) => {
+          const resources = await loadResourcesForPrompt(owner);
+          const schemaBlock = await buildSchemaBlock(owner, false);
+          return basePrompt + resources + schemaBlock;
+        },
+        apiKey: options?.apiKey ?? process.env.ANTHROPIC_API_KEY,
+        model: resolvedModel,
+      };
 
-        // Start after a 10-second delay to let the server fully initialize
-        setTimeout(() => {
-          setInterval(() => {
-            processRecurringJobs(schedulerDeps).catch((err) => {
-              console.error("[recurring-jobs] Scheduler error:", err?.message);
-            });
-          }, 60_000);
-          if (process.env.DEBUG)
-            console.log("[recurring-jobs] Scheduler started (60s interval)");
-        }, 10_000);
-      } catch (err) {
-        // Jobs module not available — skip silently
-      }
+      // Start after a 10-second delay to let the server fully initialize
+      setTimeout(() => {
+        setInterval(() => {
+          processRecurringJobs(schedulerDeps).catch((err) => {
+            console.error("[recurring-jobs] Scheduler error:", err?.message);
+          });
+        }, 60_000);
+        if (process.env.DEBUG)
+          console.log("[recurring-jobs] Scheduler started (60s interval)");
+      }, 10_000);
+    } catch (err) {
+      // Jobs module not available — skip silently
     }
   };
 }

--- a/packages/core/src/server/agent-teams.ts
+++ b/packages/core/src/server/agent-teams.ts
@@ -17,6 +17,9 @@
 
 import type { AgentChatEvent } from "../agent/types.js";
 import type { ActionEntry } from "../agent/production-agent.js";
+import { actionsToEngineTools } from "../agent/production-agent.js";
+import type { AgentEngine, EngineMessage } from "../agent/engine/types.js";
+import { createAnthropicEngine } from "../agent/engine/anthropic-engine.js";
 import { createThread } from "../chat-threads/store.js";
 import { startRun, subscribeToRun } from "../agent/run-manager.js";
 import { runAgentLoop } from "../agent/production-agent.js";
@@ -79,8 +82,10 @@ export interface SpawnTaskOptions {
   systemPrompt: string;
   /** Available actions for the sub-agent */
   actions: Record<string, ActionEntry>;
-  /** API key for Anthropic */
-  apiKey: string;
+  /** Agent engine to use. Falls back to creating an Anthropic engine with apiKey. */
+  engine?: AgentEngine;
+  /** API key for Anthropic (used only if engine is not provided) */
+  apiKey?: string;
   /** Callback to emit events to the parent chat stream */
   parentSend: (event: AgentChatEvent) => void;
   /** Parent thread ID — used to auto-respond when the sub-agent finishes */
@@ -171,22 +176,17 @@ You are a focused sub-agent with a specific task. You have been given a curated 
     systemPrompt += `\n\n## Task-Specific Instructions\n\n${opts.instructions}`;
   }
 
-  // Import Anthropic SDK
-  const Anthropic = (await import("@anthropic-ai/sdk")).default;
-  const client = new Anthropic({ apiKey: opts.apiKey });
-  const model = opts.model ?? "claude-sonnet-4-6";
+  // Resolve the engine — prefer the passed engine, fall back to Anthropic with apiKey
+  const engine: AgentEngine =
+    opts.engine ?? createAnthropicEngine({ apiKey: opts.apiKey });
+  const model = opts.model ?? engine.defaultModel;
 
-  // Build tools from actions
-  const tools: any[] = Object.entries(opts.actions).map(([name, entry]) => ({
-    name,
-    description: entry.tool.description,
-    input_schema: entry.tool.parameters ?? {
-      type: "object" as const,
-      properties: {},
-    },
-  }));
+  // Build tools from actions using the normalized EngineTool format
+  const tools = actionsToEngineTools(opts.actions);
 
-  const messages: any[] = [{ role: "user", content: opts.description }];
+  const messages: EngineMessage[] = [
+    { role: "user", content: [{ type: "text", text: opts.description }] },
+  ];
 
   // Start the agent run in background
   const runId = `run-task-${taskId}`;
@@ -233,7 +233,7 @@ You are a focused sub-agent with a specific task. You have been given a curated 
       };
 
       await runAgentLoop({
-        client,
+        engine,
         model,
         systemPrompt,
         tools,
@@ -274,30 +274,23 @@ You are a focused sub-agent with a specific task. You have been given a curated 
 
       // Persist the full conversation to threadData so the sub-agent tab
       // can restore it later (after the in-memory run is cleaned up).
-      // Convert Anthropic messages to the assistant-ui repository format.
+      // Convert EngineMessage[] to the assistant-ui repository format.
       try {
         const { updateThreadData } = await import("../chat-threads/store.js");
-        const repoMessages = messages.map((msg: any, i: number) => {
+        const repoMessages = messages.map((msg: EngineMessage, i: number) => {
           const parts: any[] = [];
-          const content = msg.content;
-          if (typeof content === "string") {
-            parts.push({ type: "text", text: content });
-          } else if (Array.isArray(content)) {
-            for (const block of content) {
-              if (block.type === "text") {
-                parts.push({ type: "text", text: block.text });
-              } else if (block.type === "tool_use") {
-                parts.push({
-                  type: "tool-call",
-                  toolCallId: block.id,
-                  toolName: block.name,
-                  args: block.input,
-                });
-              } else if (block.type === "tool_result") {
-                // Tool results are part of the user message in Anthropic format
-                // but in assistant-ui they're attached to the tool-call
-                // Skip here — they'll be matched to their tool-call
-              }
+          for (const part of msg.content) {
+            if (part.type === "text") {
+              parts.push({ type: "text", text: part.text });
+            } else if (part.type === "tool-call") {
+              parts.push({
+                type: "tool-call",
+                toolCallId: part.id,
+                toolName: part.name,
+                args: part.input,
+              });
+            } else if (part.type === "tool-result") {
+              // Tool results in the user message — will be matched to tool-call below
             }
           }
           const repoMsg: any = {
@@ -313,23 +306,19 @@ You are a focused sub-agent with a specific task. You have been given a curated 
         });
 
         // Attach tool results to their corresponding tool-call parts
-        for (let i = 0; i < messages.length; i++) {
-          const msg = messages[i];
-          if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
-          for (const block of msg.content) {
-            if (block.type !== "tool_result") continue;
-            // Find the assistant message with the matching tool_use
+        for (const msg of messages) {
+          if (msg.role !== "user") continue;
+          for (const part of msg.content) {
+            if (part.type !== "tool-result") continue;
+            // Find the assistant message with the matching tool-call
             for (const repoMsg of repoMessages) {
               if (repoMsg.role !== "assistant") continue;
               const tc = repoMsg.content?.find(
                 (p: any) =>
-                  p.type === "tool-call" && p.toolCallId === block.tool_use_id,
+                  p.type === "tool-call" && p.toolCallId === part.toolCallId,
               );
               if (tc) {
-                tc.result =
-                  typeof block.content === "string"
-                    ? block.content
-                    : JSON.stringify(block.content);
+                tc.result = part.content;
                 break;
               }
             }
@@ -376,9 +365,9 @@ You are a focused sub-agent with a specific task. You have been given a curated 
           // interrupt an ongoing conversation.
           const activeRun = getActiveRunForThread(opts.parentThreadId);
           if (!activeRun || activeRun.status !== "running") {
-            const Anthropic = (await import("@anthropic-ai/sdk")).default;
-            const followUpClient = new Anthropic({ apiKey: opts.apiKey });
-            const followUpModel = opts.model ?? "claude-sonnet-4-6";
+            const followUpEngine =
+              opts.engine ?? createAnthropicEngine({ apiKey: opts.apiKey });
+            const followUpModel = opts.model ?? followUpEngine.defaultModel;
 
             const statusEmoji = task.status === "errored" ? "!" : "done";
             const notification =
@@ -392,11 +381,16 @@ You are a focused sub-agent with a specific task. You have been given a curated 
               opts.parentThreadId,
               async (send, signal) => {
                 await runAgentLoop({
-                  client: followUpClient,
+                  engine: followUpEngine,
                   model: followUpModel,
                   systemPrompt: opts.systemPrompt,
                   tools: [], // No tools needed for a recap
-                  messages: [{ role: "user", content: notification }],
+                  messages: [
+                    {
+                      role: "user",
+                      content: [{ type: "text", text: notification }],
+                    },
+                  ],
                   actions: {},
                   send,
                   signal,

--- a/packages/core/src/templates/default/.agents/skills/agent-engines/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/agent-engines/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: agent-engines
+description: >-
+  How to inspect and configure the AI engine (model provider) powering the
+  agent. Use when the user asks to switch models, check which engine is active,
+  test a new provider, or register a custom engine.
+---
+
+# Agent Engines
+
+## Overview
+
+The framework supports pluggable AI engines beneath the agent loop. The **Anthropic engine** is the default and best-in-class path (Claude models). Additional engines can be added via the Vercel AI SDK (OpenAI, Google Gemini, Groq, Mistral, Cohere, Ollama).
+
+## Available Tools
+
+| Tool | Purpose |
+|---|---|
+| `list-agent-engines` | List all registered engines, their capabilities, and the current selection |
+| `set-agent-engine` | Set the active engine and model (persisted in settings) |
+| `test-agent-engine` | Send a trivial prompt to verify the engine works (connectivity + API key) |
+
+## Checking the Current Engine
+
+```
+list-agent-engines
+```
+
+Returns the registry of all engines (name, label, capabilities, supported models) plus the currently active engine and model.
+
+## Switching Engines
+
+```
+set-agent-engine --engine "ai-sdk:openai" --model "gpt-4o"
+```
+
+Changes take effect on the next conversation. The setting is persisted via the settings store (`agent-engine` key).
+
+Resolution order (highest priority first):
+1. Explicit `engine` option passed to `createAgentChatPlugin()` in the server plugin
+2. Settings store (`agent-engine` key)
+3. `AGENT_ENGINE` environment variable
+4. Default: `"anthropic"` (requires `ANTHROPIC_API_KEY`)
+
+## Testing a New Engine
+
+Before switching, verify the engine is working:
+
+```
+test-agent-engine --engine "ai-sdk:openai" --model "gpt-4o"
+```
+
+Returns `{ ok, latencyMs, response, capabilities }`. If `ok: false`, the error message explains what's wrong (missing API key, package not installed, etc.).
+
+## Built-in Engines
+
+| Engine Name | Provider | Requires |
+|---|---|---|
+| `anthropic` | Anthropic Claude SDK | `ANTHROPIC_API_KEY` |
+| `ai-sdk:anthropic` | Claude via Vercel AI SDK | `ANTHROPIC_API_KEY` |
+| `ai-sdk:openai` | OpenAI via Vercel AI SDK | `OPENAI_API_KEY` |
+| `ai-sdk:google` | Google Gemini via Vercel AI SDK | `GOOGLE_GENERATIVE_AI_API_KEY` |
+| `ai-sdk:groq` | Groq LPU via Vercel AI SDK | `GROQ_API_KEY` |
+| `ai-sdk:mistral` | Mistral via Vercel AI SDK | `MISTRAL_API_KEY` |
+| `ai-sdk:cohere` | Cohere via Vercel AI SDK | `COHERE_API_KEY` |
+| `ai-sdk:ollama` | Local Ollama via Vercel AI SDK | None (local) |
+
+## Engine Capabilities
+
+Each engine advertises its capabilities:
+
+| Capability | Anthropic | AI SDK: Anthropic | AI SDK: OpenAI | AI SDK: Google |
+|---|---|---|---|---|
+| `thinking` | ✓ | ✓ | ✗ | ✓ |
+| `promptCaching` | ✓ | ✓ | ✗ | ✗ |
+| `vision` | ✓ | ✓ | ✓ | ✓ |
+| `computerUse` | ✓ | ✗ | ✗ | ✗ |
+| `parallelToolCalls` | ✓ | ✓ | ✓ | ✓ |
+
+## Anthropic-Exclusive Features
+
+When using the `anthropic` engine (or `ai-sdk:anthropic`):
+
+- **Prompt caching** is applied automatically to the system prompt — cutting latency and cost on repeated turns.
+- **Extended thinking** can be enabled via `providerOptions.anthropic.thinking` — the agent reasons longer before responding.
+
+These features are silently ignored when a non-Anthropic engine is active (capability-gated, no breakage).
+
+## Registering a Custom Engine
+
+Register custom engines in a server plugin at startup:
+
+```ts
+// server/plugins/my-engine.ts
+import { registerAgentEngine } from "@agent-native/core/server";
+
+registerAgentEngine({
+  name: "my-engine",
+  label: "My Custom Engine",
+  description: "...",
+  capabilities: {
+    thinking: false,
+    promptCaching: false,
+    vision: false,
+    computerUse: false,
+    parallelToolCalls: true,
+  },
+  defaultModel: "my-model-v1",
+  supportedModels: ["my-model-v1", "my-model-v2"],
+  requiredEnvVars: ["MY_ENGINE_API_KEY"],
+  create: (config) => new MyEngine(config),
+});
+```
+
+After registering, the engine appears in `list-agent-engines` output and can be selected via `set-agent-engine`.
+
+## Env Vars Reference
+
+| Variable | Purpose |
+|---|---|
+| `ANTHROPIC_API_KEY` | Required for `anthropic` and `ai-sdk:anthropic` engines |
+| `OPENAI_API_KEY` | Required for `ai-sdk:openai` |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | Required for `ai-sdk:google` |
+| `GROQ_API_KEY` | Required for `ai-sdk:groq` |
+| `MISTRAL_API_KEY` | Required for `ai-sdk:mistral` |
+| `COHERE_API_KEY` | Required for `ai-sdk:cohere` |
+| `AGENT_ENGINE` | Default engine name (overridden by settings store) |

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -86,6 +86,7 @@ Skills in `.agents/skills/` provide detailed guidance for each architectural rul
 | `self-modifying-code` | Before editing source, components, or styles                   |
 | `capture-learnings`   | Before recording user preferences or corrections               |
 | `frontend-design`     | Before building or restyling any UI component, page, or layout |
+| `agent-engines`       | Before switching LLM providers or registering a custom engine  |
 
 ## When Adding Features
 

--- a/packages/desktop-app/shared/ipc-channels.ts
+++ b/packages/desktop-app/shared/ipc-channels.ts
@@ -32,7 +32,32 @@ export const IPC = {
   /** Frame settings (renderer ↔ main) */
   FRAME_LOAD: "frame:load",
   FRAME_UPDATE: "frame:update",
+
+  /** Auto-update (renderer ↔ main) */
+  UPDATE_CHECK: "update:check",
+  UPDATE_DOWNLOAD: "update:download",
+  UPDATE_INSTALL: "update:install",
+  UPDATE_GET_STATUS: "update:get-status",
+  /** Broadcast (main → renderer) */
+  UPDATE_STATUS_CHANGED: "update:status-changed",
 } as const;
+
+/** Auto-update status surfaced from electron-updater. */
+export type UpdateStatus =
+  | { state: "idle" }
+  | { state: "unsupported"; reason: string }
+  | { state: "checking" }
+  | { state: "available"; version: string; releaseNotes?: string }
+  | { state: "not-available"; currentVersion: string }
+  | {
+      state: "downloading";
+      percent: number;
+      bytesPerSecond?: number;
+      transferred?: number;
+      total?: number;
+    }
+  | { state: "downloaded"; version: string; releaseNotes?: string }
+  | { state: "error"; message: string };
 
 export interface ActiveWebviewTarget {
   appId: string;

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -15,6 +15,7 @@ import {
   IPC,
   type ActiveWebviewTarget,
   type InterAppMessage,
+  type UpdateStatus,
 } from "@shared/ipc-channels";
 import { FRAME_PORT } from "@shared/app-registry";
 import type { AppConfig } from "@shared/app-registry";
@@ -96,21 +97,130 @@ app.on("open-url", (event, url) => {
   }
 });
 
-// ---------- Auto-updates (production only) ----------
+// ---------- Auto-updates ----------
+//
+// In production, electron-updater pulls release metadata from the
+// `publish:` target in electron-builder.yml (currently the BuilderIO/agent-native
+// GitHub repo). We auto-download in the background, surface progress and
+// readiness to the renderer over IPC, and let the user trigger
+// quitAndInstall from a sidebar pill / restart prompt. The app also
+// installs queued updates automatically on quit.
+//
+// In dev, autoUpdater is unsupported (no app signature, no dev-app-update.yml),
+// so we report an "unsupported" status and skip all autoUpdater calls.
+
+let currentUpdateStatus: UpdateStatus = IS_DEV
+  ? { state: "unsupported", reason: "Auto-update is disabled in development" }
+  : { state: "idle" };
+
+function broadcastUpdateStatus(status: UpdateStatus) {
+  currentUpdateStatus = status;
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send(IPC.UPDATE_STATUS_CHANGED, status);
+    }
+  }
+}
 
 if (!IS_DEV) {
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
 
+  autoUpdater.on("checking-for-update", () => {
+    broadcastUpdateStatus({ state: "checking" });
+  });
+
+  autoUpdater.on("update-available", (info) => {
+    broadcastUpdateStatus({
+      state: "available",
+      version: info.version,
+      releaseNotes:
+        typeof info.releaseNotes === "string" ? info.releaseNotes : undefined,
+    });
+  });
+
+  autoUpdater.on("update-not-available", (info) => {
+    broadcastUpdateStatus({
+      state: "not-available",
+      currentVersion: info.version ?? app.getVersion(),
+    });
+  });
+
+  autoUpdater.on("download-progress", (progress) => {
+    broadcastUpdateStatus({
+      state: "downloading",
+      percent: Math.round(progress.percent ?? 0),
+      bytesPerSecond: progress.bytesPerSecond,
+      transferred: progress.transferred,
+      total: progress.total,
+    });
+  });
+
+  autoUpdater.on("update-downloaded", (info) => {
+    broadcastUpdateStatus({
+      state: "downloaded",
+      version: info.version,
+      releaseNotes:
+        typeof info.releaseNotes === "string" ? info.releaseNotes : undefined,
+    });
+  });
+
+  autoUpdater.on("error", (err) => {
+    broadcastUpdateStatus({
+      state: "error",
+      message: err?.message ?? String(err),
+    });
+  });
+
   app.whenReady().then(() => {
-    autoUpdater.checkForUpdatesAndNotify();
+    autoUpdater.checkForUpdates().catch(() => {
+      // Errors are surfaced via the 'error' event above; swallow the
+      // promise rejection so it doesn't become an unhandled rejection.
+    });
     // Re-check every 4 hours
     setInterval(
-      () => autoUpdater.checkForUpdatesAndNotify(),
+      () => {
+        autoUpdater.checkForUpdates().catch(() => {});
+      },
       4 * 60 * 60 * 1000,
     );
   });
 }
+
+ipcMain.handle(IPC.UPDATE_GET_STATUS, (): UpdateStatus => currentUpdateStatus);
+
+ipcMain.handle(IPC.UPDATE_CHECK, async (): Promise<UpdateStatus> => {
+  if (IS_DEV) return currentUpdateStatus;
+  try {
+    await autoUpdater.checkForUpdates();
+  } catch (err) {
+    broadcastUpdateStatus({
+      state: "error",
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return currentUpdateStatus;
+});
+
+ipcMain.handle(IPC.UPDATE_DOWNLOAD, async (): Promise<UpdateStatus> => {
+  if (IS_DEV) return currentUpdateStatus;
+  try {
+    await autoUpdater.downloadUpdate();
+  } catch (err) {
+    broadcastUpdateStatus({
+      state: "error",
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return currentUpdateStatus;
+});
+
+ipcMain.handle(IPC.UPDATE_INSTALL, () => {
+  if (IS_DEV) return;
+  // isSilent=false so any installer UI shows; isForceRunAfter=true so the
+  // app relaunches after the update completes.
+  autoUpdater.quitAndInstall(false, true);
+});
 
 function createWindow(): BrowserWindow {
   const isMac = process.platform === "darwin";

--- a/packages/desktop-app/src/preload/index.ts
+++ b/packages/desktop-app/src/preload/index.ts
@@ -3,6 +3,7 @@ import {
   IPC,
   type ActiveWebviewTarget,
   type InterAppMessage,
+  type UpdateStatus,
 } from "@shared/ipc-channels";
 
 /** The API surface exposed to the renderer via window.electronAPI */
@@ -70,6 +71,27 @@ const electronAPI = {
     load: (): Promise<any> => ipcRenderer.invoke(IPC.FRAME_LOAD),
     update: (settings: any): Promise<any> =>
       ipcRenderer.invoke(IPC.FRAME_UPDATE, settings),
+  },
+
+  /** Auto-update controls + status */
+  updater: {
+    check: (): Promise<UpdateStatus> => ipcRenderer.invoke(IPC.UPDATE_CHECK),
+    download: (): Promise<UpdateStatus> =>
+      ipcRenderer.invoke(IPC.UPDATE_DOWNLOAD),
+    install: (): void => {
+      ipcRenderer.invoke(IPC.UPDATE_INSTALL);
+    },
+    getStatus: (): Promise<UpdateStatus> =>
+      ipcRenderer.invoke(IPC.UPDATE_GET_STATUS),
+
+    /** Subscribe to update status changes. Returns an unsubscribe fn. */
+    onStatusChange: (cb: (status: UpdateStatus) => void): (() => void) => {
+      const handler = (_: Electron.IpcRendererEvent, status: UpdateStatus) =>
+        cb(status);
+      ipcRenderer.on(IPC.UPDATE_STATUS_CHANGED, handler);
+      return () =>
+        ipcRenderer.removeListener(IPC.UPDATE_STATUS_CHANGED, handler);
+    },
   },
 
   /** Inter-app communication — relay messages between loaded apps */

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import Sidebar from "./components/Sidebar.js";
 import TabBar from "./components/TabBar.js";
 import AppWebview, { type AppWebviewHandle } from "./components/AppWebview.js";
 import AppSettings from "./components/AppSettings.js";
+import UpdatePrompt from "./components/UpdatePrompt.js";
 
 export interface Tab {
   id: string;
@@ -435,6 +436,8 @@ export default function App() {
           onAppsChanged={handleAppsChanged}
         />
       )}
+
+      <UpdatePrompt />
     </div>
   );
 }

--- a/packages/desktop-app/src/renderer/components/Sidebar.tsx
+++ b/packages/desktop-app/src/renderer/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   IconSettings,
 } from "@tabler/icons-react";
 import type { AppDefinition } from "@shared/app-registry";
+import { UpdateIndicator } from "./UpdateIndicator.js";
 
 // Map icon name strings (from shared-app-config) to Tabler components
 const ICON_MAP: Record<string, React.ComponentType<Record<string, unknown>>> = {
@@ -77,9 +78,10 @@ export default function Sidebar({
         ))}
       </nav>
 
-      {/* Settings button at bottom */}
-      {onSettingsClick && (
-        <div className="sidebar-footer">
+      {/* Footer: update indicator (when relevant) + settings */}
+      <div className="sidebar-footer">
+        <UpdateIndicator />
+        {onSettingsClick && (
           <button
             className="sidebar-item"
             tabIndex={-1}
@@ -92,8 +94,8 @@ export default function Sidebar({
             </span>
             <span className="item-label">Settings</span>
           </button>
-        </div>
-      )}
+        )}
+      </div>
     </aside>
   );
 }

--- a/packages/desktop-app/src/renderer/components/UpdateIndicator.tsx
+++ b/packages/desktop-app/src/renderer/components/UpdateIndicator.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { IconDownload, IconRefresh, IconLoader2 } from "@tabler/icons-react";
+
+/**
+ * Subscribes to auto-update status from the main process. Returns the latest
+ * UpdateStatus, or null if Electron isn't available (e.g. browser preview).
+ */
+export function useUpdateStatus(): UpdateStatus | null {
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+
+  useEffect(() => {
+    const updater = window.electronAPI?.updater;
+    if (!updater) return;
+    updater.getStatus().then(setStatus);
+    return updater.onStatusChange(setStatus);
+  }, []);
+
+  return status;
+}
+
+/**
+ * Sidebar pill that becomes visible whenever an update is in flight or
+ * ready to install. Hidden in idle / not-available / dev / unsupported
+ * states so it doesn't add visual noise.
+ */
+export function UpdateIndicator() {
+  const status = useUpdateStatus();
+
+  if (!status) return null;
+
+  // Hide when there's nothing to show.
+  if (
+    status.state === "idle" ||
+    status.state === "checking" ||
+    status.state === "not-available" ||
+    status.state === "unsupported"
+  ) {
+    return null;
+  }
+
+  if (status.state === "error") {
+    // Errors are non-actionable from the UI; let the next periodic check retry.
+    return null;
+  }
+
+  if (status.state === "available") {
+    // Auto-download starts immediately, so this is usually a brief flash
+    // before "downloading" arrives. Render a subtle pending state.
+    return (
+      <button
+        className="sidebar-item update-indicator update-indicator--pending"
+        tabIndex={-1}
+        title={`Update ${status.version} available — downloading…`}
+        aria-label={`Update ${status.version} available`}
+      >
+        <span className="icon-wrapper">
+          <IconDownload size={18} strokeWidth={1.75} />
+        </span>
+        <span className="item-label">Update</span>
+      </button>
+    );
+  }
+
+  if (status.state === "downloading") {
+    return (
+      <button
+        className="sidebar-item update-indicator update-indicator--downloading"
+        tabIndex={-1}
+        title={`Downloading update — ${status.percent}%`}
+        aria-label={`Downloading update, ${status.percent} percent`}
+      >
+        <span className="icon-wrapper">
+          <IconLoader2 size={18} strokeWidth={1.75} className="spin" />
+        </span>
+        <span className="item-label">{status.percent}%</span>
+      </button>
+    );
+  }
+
+  // Downloaded — clicking restarts the app and applies the update.
+  return (
+    <button
+      className="sidebar-item update-indicator update-indicator--ready"
+      tabIndex={-1}
+      onClick={() => window.electronAPI?.updater.install()}
+      title={`Update ${status.version} ready — click to restart`}
+      aria-label={`Update ${status.version} ready, click to restart`}
+    >
+      <span className="icon-wrapper">
+        <IconRefresh size={18} strokeWidth={1.75} />
+      </span>
+      <span className="item-label">Restart</span>
+    </button>
+  );
+}

--- a/packages/desktop-app/src/renderer/components/UpdatePrompt.tsx
+++ b/packages/desktop-app/src/renderer/components/UpdatePrompt.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { IconX, IconRefresh } from "@tabler/icons-react";
+import { useUpdateStatus } from "./UpdateIndicator.js";
+
+/**
+ * One-time toast that appears the first time an update finishes downloading.
+ * The user can install now or dismiss; either way the persistent sidebar
+ * indicator stays visible so they can install later. Once dismissed for a
+ * given version, we don't re-show the toast for that same version.
+ */
+export default function UpdatePrompt() {
+  const status = useUpdateStatus();
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
+  const [shown, setShown] = useState(false);
+
+  // Show whenever a download finishes for a version we haven't dismissed yet.
+  useEffect(() => {
+    if (status?.state === "downloaded" && status.version !== dismissedVersion) {
+      setShown(true);
+    }
+  }, [status, dismissedVersion]);
+
+  if (!shown || status?.state !== "downloaded") return null;
+
+  const dismiss = () => {
+    setShown(false);
+    setDismissedVersion(status.version);
+  };
+
+  const installNow = () => {
+    window.electronAPI?.updater.install();
+  };
+
+  return (
+    <div
+      className="update-prompt"
+      role="alertdialog"
+      aria-labelledby="update-prompt-title"
+    >
+      <div className="update-prompt-body">
+        <div id="update-prompt-title" className="update-prompt-title">
+          Update ready
+        </div>
+        <div className="update-prompt-subtitle">
+          Version {status.version} has been downloaded. Restart Agent Native to
+          finish installing.
+        </div>
+      </div>
+      <div className="update-prompt-actions">
+        <button
+          type="button"
+          tabIndex={-1}
+          className="update-prompt-btn update-prompt-btn--ghost"
+          onClick={dismiss}
+        >
+          Later
+        </button>
+        <button
+          type="button"
+          tabIndex={-1}
+          className="update-prompt-btn update-prompt-btn--primary"
+          onClick={installNow}
+        >
+          <IconRefresh size={14} strokeWidth={2} />
+          Restart now
+        </button>
+      </div>
+      <button
+        type="button"
+        tabIndex={-1}
+        className="update-prompt-close"
+        onClick={dismiss}
+        aria-label="Dismiss update prompt"
+      >
+        <IconX size={14} strokeWidth={2} />
+      </button>
+    </div>
+  );
+}

--- a/packages/desktop-app/src/renderer/global.d.ts
+++ b/packages/desktop-app/src/renderer/global.d.ts
@@ -1,3 +1,20 @@
+/** Auto-update status surfaced from electron-updater (mirrors shared/ipc-channels.ts). */
+type UpdateStatus =
+  | { state: "idle" }
+  | { state: "unsupported"; reason: string }
+  | { state: "checking" }
+  | { state: "available"; version: string; releaseNotes?: string }
+  | { state: "not-available"; currentVersion: string }
+  | {
+      state: "downloading";
+      percent: number;
+      bytesPerSecond?: number;
+      transferred?: number;
+      total?: number;
+    }
+  | { state: "downloaded"; version: string; releaseNotes?: string }
+  | { state: "error"; message: string };
+
 /** Electron APIs exposed to the renderer via the preload contextBridge */
 interface ElectronAPI {
   platform: string;
@@ -40,6 +57,14 @@ interface ElectronAPI {
       mode: "dev" | "prod";
       prodUrl?: string;
     }>;
+  };
+
+  updater: {
+    check(): Promise<UpdateStatus>;
+    download(): Promise<UpdateStatus>;
+    install(): void;
+    getStatus(): Promise<UpdateStatus>;
+    onStatusChange(cb: (status: UpdateStatus) => void): () => void;
   };
 
   appConfig: {

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -905,3 +905,148 @@ body {
   justify-content: flex-end;
   margin-top: 16px;
 }
+
+/* ─── Update indicator (sidebar pill) ─────────────────────────── */
+.update-indicator .icon-wrapper {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.update-indicator .item-label {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.update-indicator--pending .icon-wrapper,
+.update-indicator--downloading .icon-wrapper {
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+}
+
+.update-indicator--pending .item-label,
+.update-indicator--downloading .item-label {
+  color: rgba(96, 165, 250, 0.85);
+}
+
+.update-indicator--ready .icon-wrapper {
+  background: rgba(34, 197, 94, 0.18);
+  color: #4ade80;
+  box-shadow: 0 0 0 1px rgba(74, 222, 128, 0.35);
+}
+
+.update-indicator--ready .item-label {
+  color: #4ade80;
+  font-weight: 600;
+}
+
+.update-indicator--ready:hover .icon-wrapper {
+  background: rgba(34, 197, 94, 0.28);
+}
+
+@keyframes update-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.update-indicator .spin {
+  animation: update-spin 1s linear infinite;
+}
+
+/* ─── Update prompt (toast) ───────────────────────────────────── */
+.update-prompt {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 200;
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px 18px 14px;
+  background: #161616;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
+  -webkit-app-region: no-drag;
+}
+
+.update-prompt-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.update-prompt-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.update-prompt-subtitle {
+  font-size: 12px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.update-prompt-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.update-prompt-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 7px;
+  border: 1px solid transparent;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.update-prompt-btn--ghost {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.update-prompt-btn--ghost:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #fff;
+}
+
+.update-prompt-btn--primary {
+  background: rgba(59, 130, 246, 0.18);
+  color: #60a5fa;
+  border-color: rgba(59, 130, 246, 0.28);
+}
+
+.update-prompt-btn--primary:hover {
+  background: rgba(59, 130, 246, 0.28);
+  color: #93c5fd;
+}
+
+.update-prompt-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.4);
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.update-prompt-close:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,10 +106,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
@@ -139,7 +139,7 @@ importers:
         version: 3.22.2
       better-auth:
         specifier: ^1.6.0
-        version: 1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))
+        version: 1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -175,7 +175,7 @@ importers:
         version: 10.2.5
       nitro:
         specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+        version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
@@ -207,6 +207,18 @@ importers:
         specifier: ^13.6.30
         version: 13.6.30
     devDependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^1.2.12
+        version: 1.2.12(zod@4.3.6)
+      '@ai-sdk/google':
+        specifier: ^1.2.22
+        version: 1.2.22(zod@4.3.6)
+      '@ai-sdk/groq':
+        specifier: ^1.2.9
+        version: 1.2.9(zod@4.3.6)
+      '@ai-sdk/openai':
+        specifier: ^1.3.24
+        version: 1.3.24(zod@4.3.6)
       '@assistant-ui/react':
         specifier: ^0.12.19
         version: 0.12.22(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -239,7 +251,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -249,6 +261,9 @@ importers:
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
+      ai:
+        specifier: ^4.3.19
+        version: 4.3.19(react@18.3.1)(zod@4.3.6)
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
@@ -278,10 +293,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
       ws:
         specifier: ^8.18.0
         version: 8.20.0
@@ -2505,10 +2520,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
       '@react-three/drei':
         specifier: ^9.122.0
         version: 9.122.0(@react-three/fiber@8.18.0(a4f87a1c9cd5afeda248b1850f15afe1))(@types/react@18.3.28)(@types/three@0.176.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.176.0)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -2538,7 +2553,7 @@ importers:
         version: 0.176.0
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
@@ -2625,10 +2640,10 @@ importers:
         version: 1.1.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vite:
         specifier: ^8.0.0
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
 
   templates/starter:
     dependencies:
@@ -3094,6 +3109,56 @@ packages:
 
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@ai-sdk/anthropic@1.2.12':
+    resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/google@1.2.22':
+    resolution: {integrity: sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/groq@1.2.9':
+    resolution: {integrity: sha512-7MoDaxm8yWtiRbD1LipYZG0kBl+Xe0sv/EeyxnHnGPZappXdlgtdOgTZVjjXkT3nWP30jjZi9A45zoVrBMb3Xg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/openai@1.3.24':
+    resolution: {integrity: sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+
+  '@ai-sdk/provider-utils@2.2.8':
+    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
+  '@ai-sdk/provider@1.1.3':
+    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@1.2.12':
+    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/ui-utils@1.2.11':
+    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -5670,6 +5735,10 @@ packages:
   '@npmcli/fs@4.0.0':
     resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -8545,6 +8614,16 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ai@4.3.19:
+    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      react:
+        optional: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -9021,6 +9100,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -11140,12 +11223,20 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
+    hasBin: true
+
+  jsondiffpatch@0.6.0:
+    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
   jsonfile@4.0.0:
@@ -13183,6 +13274,9 @@ packages:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
 
+  secure-json-parse@2.7.0:
+    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -13555,6 +13649,11 @@ packages:
     peerDependencies:
       react: '>=17.0'
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -13640,6 +13739,10 @@ packages:
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
@@ -14625,6 +14728,58 @@ snapshots:
   '@0no-co/graphql.web@1.2.0': {}
 
   '@acemir/cssom@0.9.31': {}
+
+  '@ai-sdk/anthropic@1.2.12(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/google@1.2.22(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/groq@1.2.9(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/openai@1.3.24(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@2.2.8(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 4.3.6
+
+  '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.3.6)
+      react: 18.3.1
+      swr: 2.4.1(react@18.3.1)
+      throttleit: 2.1.0
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@ai-sdk/ui-utils@1.2.11(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -17109,6 +17264,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@opentelemetry/api@1.9.1': {}
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
@@ -19178,53 +19335,6 @@ snapshots:
       - supports-color
       - terser
 
-  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@react-router/node': 7.14.0(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
-      '@remix-run/node-fetch-server': 0.13.0
-      arg: 5.0.2
-      babel-dead-code-elimination: 1.0.12
-      chokidar: 4.0.3
-      dedent: 1.7.2
-      es-module-lexer: 1.7.0
-      exit-hook: 2.2.1
-      isbot: 5.1.37
-      jsesc: 3.0.2
-      lodash: 4.18.1
-      p-map: 7.0.4
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      pkg-types: 2.3.0
-      prettier: 3.8.1
-      react-refresh: 0.14.2
-      react-router: 7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      valibot: 1.3.1(typescript@5.9.3)
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@24.12.2)(lightningcss@1.32.0)(terser@5.46.1)
-    optionalDependencies:
-      typescript: 5.9.3
-      wrangler: 4.81.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -19272,7 +19382,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
+  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -19302,7 +19412,7 @@ snapshots:
       semver: 7.7.4
       tinyglobby: 0.2.15
       valibot: 1.3.1(typescript@5.9.3)
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@24.12.2)(lightningcss@1.32.0)(terser@5.46.1)
     optionalDependencies:
       typescript: 5.9.3
@@ -19333,13 +19443,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
-    dependencies:
-      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
-      minimatch: 10.2.5
-    optionalDependencies:
-      typescript: 5.9.3
-
   '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
     dependencies:
       '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
@@ -19347,9 +19450,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
+  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
     dependencies:
-      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       minimatch: 10.2.5
     optionalDependencies:
       typescript: 5.9.3
@@ -20938,6 +21041,18 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ai@4.3.19(react@18.3.1)(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
+      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@4.3.6)
+      '@ai-sdk/ui-utils': 1.2.11(zod@4.3.6)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+      zod: 4.3.6
+    optionalDependencies:
+      react: 18.3.1
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -21253,7 +21368,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.14: {}
 
-  better-auth@1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)):
+  better-auth@1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))
@@ -21280,7 +21395,7 @@ snapshots:
       react: 18.3.1
       react-dom: 19.2.4(react@18.3.1)
       solid-js: 1.9.12
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -21522,6 +21637,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -24034,10 +24151,18 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
+  json-schema@0.4.0: {}
+
   json-stringify-safe@5.0.1:
     optional: true
 
   json5@2.2.3: {}
+
+  jsondiffpatch@0.6.0:
+    dependencies:
+      '@types/diff-match-patch': 1.0.36
+      chalk: 5.6.2
+      diff-match-patch: 1.0.5
 
   jsonfile@4.0.0:
     optionalDependencies:
@@ -25342,7 +25467,7 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro@3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)):
+  nitro@3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.4(srvx@0.11.15)
@@ -25361,9 +25486,9 @@ snapshots:
     optionalDependencies:
       dotenv: 17.4.0
       giget: 3.2.0
-      jiti: 2.6.1
+      jiti: 1.21.7
       rollup: 4.60.1
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -26829,6 +26954,8 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
+  secure-json-parse@2.7.0: {}
+
   secure-json-parse@4.1.0: {}
 
   semver-compare@1.0.0:
@@ -27248,6 +27375,12 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  swr@2.4.1(react@18.3.1):
+    dependencies:
+      dequal: 2.0.3
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
   symbol-tree@3.2.4: {}
 
   tailwind-merge@2.6.1: {}
@@ -27378,6 +27511,8 @@ snapshots:
   three@0.176.0: {}
 
   throat@5.0.0: {}
+
+  throttleit@2.1.0: {}
 
   tiny-async-pool@1.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,12 @@ importers:
 
   packages/core:
     dependencies:
+      '@ai-sdk/cohere':
+        specifier: '>=1'
+        version: 3.0.30(zod@4.3.6)
+      '@ai-sdk/mistral':
+        specifier: '>=1'
+        version: 3.0.30(zod@4.3.6)
       '@anthropic-ai/sdk':
         specifier: '>=0.81.0'
         version: 0.82.0(zod@4.3.6)
@@ -176,6 +182,9 @@ importers:
       nitro:
         specifier: 3.0.260311-beta
         version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+      ollama-ai-provider:
+        specifier: '>=1'
+        version: 1.2.0(zod@4.3.6)
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
@@ -3116,6 +3125,12 @@ packages:
     peerDependencies:
       zod: ^3.0.0
 
+  '@ai-sdk/cohere@3.0.30':
+    resolution: {integrity: sha512-j3fe/6lUUkHPD/51OgMXN9UD7p1QSQEAlroIinmb3MhJ1s+O0MnqdRa30IM7dRHafNp0FQ9X4YpobY85iMknUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/google@1.2.22':
     resolution: {integrity: sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==}
     engines: {node: '>=18'}
@@ -3127,6 +3142,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
+
+  '@ai-sdk/mistral@3.0.30':
+    resolution: {integrity: sha512-+j4IXRSk9E661cFSafmIr+XHOzwjFagawwzMOlSqwL6U4Sq4PCFLDF+oHbX5NUqNjUL7FD1zi/9lBIfa41pUvw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/openai@1.3.24':
     resolution: {integrity: sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==}
@@ -3140,8 +3161,18 @@ packages:
     peerDependencies:
       zod: ^3.23.8
 
+  '@ai-sdk/provider-utils@4.0.23':
+    resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@1.1.3':
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@1.2.12':
@@ -12281,6 +12312,15 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  ollama-ai-provider@1.2.0:
+    resolution: {integrity: sha512-jTNFruwe3O/ruJeppI/quoOUxG7NA6blG3ZyQj3lei4+NnJo7bi3eIRWqlVpRlu/mbzbFXeJSBuYQWF6pzGKww==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -12394,6 +12434,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
@@ -14735,6 +14778,12 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/cohere@3.0.30(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/google@1.2.22(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
@@ -14745,6 +14794,12 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
+      zod: 4.3.6
+
+  '@ai-sdk/mistral@3.0.30(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/openai@1.3.24(zod@4.3.6)':
@@ -14760,7 +14815,18 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@4.0.23(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
   '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 
@@ -25621,6 +25687,14 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  ollama-ai-provider@1.2.0(zod@4.3.6):
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.8(zod@4.3.6)
+      partial-json: 0.1.7
+    optionalDependencies:
+      zod: 4.3.6
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -25750,6 +25824,8 @@ snapshots:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
+
+  partial-json@0.1.7: {}
 
   path-data-parser@0.1.0: {}
 

--- a/templates/mail/app/components/agent-engine-picker.tsx
+++ b/templates/mail/app/components/agent-engine-picker.tsx
@@ -1,0 +1,399 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  IconCheck,
+  IconLoader2,
+  IconCircleCheck,
+  IconAlertCircle,
+  IconPlayerPlay,
+  IconCpu,
+} from "@tabler/icons-react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface EngineCapabilities {
+  thinking: boolean;
+  promptCaching: boolean;
+  vision: boolean;
+  computerUse: boolean;
+  parallelToolCalls: boolean;
+}
+
+interface EngineEntry {
+  name: string;
+  label: string;
+  description: string;
+  defaultModel: string;
+  supportedModels: readonly string[];
+  capabilities: EngineCapabilities;
+  requiredEnvVars: string[];
+  installPackage?: string;
+}
+
+interface EnginesResponse {
+  engines: EngineEntry[];
+  current: { engine: string; model: string };
+}
+
+// ─── API helpers ──────────────────────────────────────────────────────────────
+
+async function postAction<T>(
+  name: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(`/_agent-native/actions/${name}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => null);
+    throw new Error(err?.error || `Request failed (${res.status})`);
+  }
+  const text = await res.text();
+  try {
+    // The script returns a JSON string as the result
+    const outer = JSON.parse(text);
+    if (typeof outer === "string") return JSON.parse(outer) as T;
+    return outer as T;
+  } catch {
+    return text as unknown as T;
+  }
+}
+
+// ─── Capability badge ─────────────────────────────────────────────────────────
+
+function CapBadge({ label, enabled }: { label: string; enabled: boolean }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium",
+        enabled
+          ? "bg-emerald-500/15 text-emerald-400"
+          : "bg-muted/30 text-muted-foreground/30 line-through",
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+// ─── Engine card ──────────────────────────────────────────────────────────────
+
+function EngineCard({
+  engine,
+  isSelected,
+  selectedModel,
+  onSelect,
+}: {
+  engine: EngineEntry;
+  isSelected: boolean;
+  selectedModel: string;
+  onSelect: (model: string) => void;
+}) {
+  const caps = engine.capabilities;
+  const missingEnv = engine.requiredEnvVars.filter(
+    (v) => !import.meta.env?.[v],
+  );
+
+  return (
+    <button
+      onClick={() => onSelect(selectedModel || engine.defaultModel)}
+      className={cn(
+        "w-full rounded-lg border text-left p-4 transition-colors",
+        isSelected
+          ? "border-indigo-500/50 bg-indigo-500/5"
+          : "border-border/30 bg-card hover:border-border/60",
+      )}
+    >
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-0.5">
+            <span className="text-[13px] font-semibold text-foreground">
+              {engine.label}
+            </span>
+            {isSelected && (
+              <IconCheck className="h-3.5 w-3.5 text-indigo-400 shrink-0" />
+            )}
+          </div>
+          <p className="text-[11px] text-muted-foreground/60 font-mono">
+            {engine.name}
+          </p>
+        </div>
+      </div>
+
+      <p className="text-[12px] text-muted-foreground mb-3 line-clamp-2">
+        {engine.description}
+      </p>
+
+      <div className="flex flex-wrap gap-1 mb-3">
+        <CapBadge label="thinking" enabled={caps.thinking} />
+        <CapBadge label="caching" enabled={caps.promptCaching} />
+        <CapBadge label="vision" enabled={caps.vision} />
+        <CapBadge label="parallel tools" enabled={caps.parallelToolCalls} />
+      </div>
+
+      {engine.requiredEnvVars.length > 0 && (
+        <p className="text-[11px] text-muted-foreground/40 font-mono">
+          Requires: {engine.requiredEnvVars.join(", ")}
+        </p>
+      )}
+
+      {engine.installPackage && (
+        <p className="text-[11px] text-muted-foreground/30 font-mono mt-0.5">
+          Install: pnpm add {engine.installPackage}
+        </p>
+      )}
+    </button>
+  );
+}
+
+// ─── AgentEnginePicker ────────────────────────────────────────────────────────
+
+export function AgentEnginePicker() {
+  const qc = useQueryClient();
+  const [localEngine, setLocalEngine] = useState<string | null>(null);
+  const [localModel, setLocalModel] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<{
+    ok: boolean;
+    latencyMs?: number;
+    error?: string;
+  } | null>(null);
+
+  // Fetch engine list
+  const { data, isLoading, error } = useQuery<EnginesResponse>({
+    queryKey: ["agent-engines"],
+    queryFn: () => postAction<EnginesResponse>("list-agent-engines", {}),
+    staleTime: 30_000,
+  });
+
+  // Set engine mutation
+  const setEngine = useMutation({
+    mutationFn: ({ engine, model }: { engine: string; model: string }) =>
+      postAction("set-agent-engine", { engine, model }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["agent-engines"] });
+      setLocalEngine(null);
+      setLocalModel(null);
+      setTestResult(null);
+    },
+  });
+
+  // Test engine mutation
+  const testEngine = useMutation({
+    mutationFn: ({ engine, model }: { engine: string; model: string }) =>
+      postAction<{ ok: boolean; latencyMs?: number; error?: string }>(
+        "test-agent-engine",
+        { engine, model },
+      ),
+    onSuccess: (result) => {
+      setTestResult(result);
+    },
+    onError: (err: Error) => {
+      setTestResult({ ok: false, error: err.message });
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 py-8 justify-center text-muted-foreground/50">
+        <IconLoader2 className="h-4 w-4 animate-spin" />
+        <span className="text-[13px]">Loading engines…</span>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-4 text-[13px] text-destructive/70">
+        Failed to load engine list. Make sure the server is running.
+      </div>
+    );
+  }
+
+  const { engines, current } = data;
+  const activeEngine = localEngine ?? current.engine;
+  const engineEntry = engines.find((e) => e.name === activeEngine);
+  const activeModel =
+    localModel ??
+    (activeEngine === current.engine
+      ? current.model
+      : (engineEntry?.defaultModel ?? ""));
+
+  const isDirty =
+    activeEngine !== current.engine || activeModel !== current.model;
+
+  const handleEngineSelect = (name: string, model?: string) => {
+    const entry = engines.find((e) => e.name === name);
+    setLocalEngine(name);
+    setLocalModel(model ?? entry?.defaultModel ?? "");
+    setTestResult(null);
+  };
+
+  const handleSave = () => {
+    setEngine.mutate({ engine: activeEngine, model: activeModel });
+  };
+
+  const handleTest = () => {
+    testEngine.mutate({ engine: activeEngine, model: activeModel });
+  };
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      {/* Current status */}
+      <div className="flex items-center gap-3 rounded-lg border border-border/30 bg-muted/30 px-4 py-3">
+        <IconCpu className="h-4 w-4 text-indigo-400 shrink-0" />
+        <div className="flex-1 min-w-0">
+          <p className="text-[12px] font-medium text-foreground">
+            Active engine
+          </p>
+          <p className="text-[11px] text-muted-foreground font-mono">
+            {current.engine} / {current.model}
+          </p>
+        </div>
+        {isDirty && (
+          <Badge
+            variant="outline"
+            className="text-[10px] text-amber-400 border-amber-500/30"
+          >
+            unsaved
+          </Badge>
+        )}
+      </div>
+
+      {/* Engine cards */}
+      <div>
+        <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-2">
+          Select engine
+        </p>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {engines.map((engine) => (
+            <EngineCard
+              key={engine.name}
+              engine={engine}
+              isSelected={activeEngine === engine.name}
+              selectedModel={
+                activeEngine === engine.name ? activeModel : engine.defaultModel
+              }
+              onSelect={(model) => handleEngineSelect(engine.name, model)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Model picker */}
+      {engineEntry && (
+        <div>
+          <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-2">
+            Model
+          </p>
+          <Select
+            value={activeModel}
+            onValueChange={(v) => {
+              setLocalModel(v);
+              setTestResult(null);
+            }}
+          >
+            <SelectTrigger className="w-full max-w-xs text-[13px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {engineEntry.supportedModels.map((m) => (
+                <SelectItem key={m} value={m} className="text-[13px] font-mono">
+                  {m}
+                  {m === engineEntry.defaultModel && (
+                    <span className="ml-2 text-[10px] text-muted-foreground/50">
+                      default
+                    </span>
+                  )}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {/* Test result */}
+      {testResult && (
+        <div
+          className={cn(
+            "flex items-start gap-3 rounded-lg border px-4 py-3 text-[13px]",
+            testResult.ok
+              ? "border-emerald-500/20 bg-emerald-500/5 text-emerald-300"
+              : "border-destructive/20 bg-destructive/5 text-destructive/70",
+          )}
+        >
+          {testResult.ok ? (
+            <IconCircleCheck className="h-4 w-4 mt-0.5 shrink-0" />
+          ) : (
+            <IconAlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+          )}
+          <div>
+            {testResult.ok ? (
+              <p>Connected — {testResult.latencyMs}ms response time</p>
+            ) : (
+              <p>{testResult.error ?? "Connection failed"}</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={!isDirty || setEngine.isPending}
+        >
+          {setEngine.isPending && (
+            <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+          )}
+          {setEngine.isSuccess && !isDirty ? (
+            <>
+              <IconCheck className="h-3.5 w-3.5" />
+              Saved
+            </>
+          ) : (
+            "Save"
+          )}
+        </Button>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleTest}
+          disabled={testEngine.isPending}
+        >
+          {testEngine.isPending ? (
+            <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <IconPlayerPlay className="h-3.5 w-3.5" />
+          )}
+          Test connection
+        </Button>
+      </div>
+
+      {setEngine.isSuccess && !isDirty && (
+        <p className="text-[12px] text-emerald-400">
+          Engine saved. Takes effect on the next conversation.
+        </p>
+      )}
+
+      {setEngine.error && (
+        <p className="text-[12px] text-destructive/70">
+          {(setEngine.error as Error).message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -220,15 +220,26 @@ export function EmailList({
         0,
         Math.min(threads.length - 1, (current === -1 ? 0 : current) + delta),
       );
-      const newFocusId = threads[next].latestMessage.id;
+      const newFocusThread = threads[next];
+      const newFocusId = newFocusThread.latestMessage.id;
+      const newThreadKey = newFocusThread.latestMessage.threadId || newFocusId;
 
       setSelectedIds((prev) => {
         const updated = new Set(prev);
-        // Include anchor on first shift-move
+        // Include anchor on first shift-move — derive the thread key from the
+        // currently focused email id.
         if (prev.size === 0 && focusedIdRef.current) {
-          updated.add(focusedIdRef.current);
+          const anchorThread = threads.find(
+            (t) => t.latestMessage.id === focusedIdRef.current,
+          );
+          if (anchorThread) {
+            updated.add(
+              anchorThread.latestMessage.threadId ||
+                anchorThread.latestMessage.id,
+            );
+          }
         }
-        updated.add(newFocusId);
+        updated.add(newThreadKey);
         return updated;
       });
 
@@ -241,12 +252,17 @@ export function EmailList({
     [threads, setFocusedId, setSelectedIds],
   );
 
-  const getActionIds = useCallback((): string[] => {
+  // Returns thread keys (latestMessage.threadId || latestMessage.id) of the
+  // emails to act on — multi-selection if present, else the focused row.
+  const getActionThreadKeys = useCallback((): string[] => {
     if (selectedIdsRef.current.size > 0)
       return Array.from(selectedIdsRef.current);
-    const id = focusedIdRef.current;
-    return id ? [id] : [];
-  }, []);
+    const fid = focusedIdRef.current;
+    if (!fid) return [];
+    const thread = threads.find((t) => t.latestMessage.id === fid);
+    if (!thread) return [];
+    return [thread.latestMessage.threadId || thread.latestMessage.id];
+  }, [threads]);
 
   const openFocused = useCallback(() => {
     const id = focusedIdRef.current;
@@ -254,6 +270,9 @@ export function EmailList({
     const thread = threads.find((t) => t.latestMessage.id === id);
     if (!thread) return;
     const targetThreadId = thread.latestMessage.threadId || id;
+    // Enter on a single focused row is a single-thread action — clear any
+    // in-progress multi-selection so shortcuts in detail view start fresh.
+    setSelectedIds(new Set());
     if (thread.hasUnread) {
       markThreadRead.mutate(targetThreadId);
     }
@@ -263,19 +282,39 @@ export function EmailList({
       staleTime: 30_000,
     });
     navigate(`/${view}/${targetThreadId}${labelSuffix}`);
-  }, [threads, view, navigate, markThreadRead, labelSuffix, queryClient]);
+  }, [
+    threads,
+    view,
+    navigate,
+    markThreadRead,
+    labelSuffix,
+    queryClient,
+    setSelectedIds,
+  ]);
 
   const archiveFocused = useCallback(() => {
-    const ids = getActionIds();
-    if (ids.length === 0) return;
-    const actionIdSet = new Set(ids);
+    const threadKeys = getActionThreadKeys();
+    if (threadKeys.length === 0) return;
+    const actionKeySet = new Set(threadKeys);
 
-    // Move focus to the next non-selected email (or previous if at end)
+    // Resolve each thread key to its latestMessage + accountEmail up front.
+    const targets = threadKeys
+      .map((key) =>
+        threads.find(
+          (t) => (t.latestMessage.threadId || t.latestMessage.id) === key,
+        ),
+      )
+      .filter((t): t is ThreadSummary => !!t);
+    const emailIds = targets.map((t) => t.latestMessage.id);
+
+    // Move focus to the next non-selected thread (or previous if at end)
     const lastIdx = threads.findIndex(
-      (t) => t.latestMessage.id === ids[ids.length - 1],
+      (t) =>
+        (t.latestMessage.threadId || t.latestMessage.id) ===
+        threadKeys[threadKeys.length - 1],
     );
     const remaining = threads.filter(
-      (t) => !actionIdSet.has(t.latestMessage.id),
+      (t) => !actionKeySet.has(t.latestMessage.threadId || t.latestMessage.id),
     );
     if (remaining.length > 0) {
       const nextIdx = Math.min(lastIdx, remaining.length - 1);
@@ -286,12 +325,10 @@ export function EmailList({
 
     // Snapshot removed thread emails so undo can restore them
     const snapshots: EmailMessage[] = [];
-    for (const id of ids) {
-      const thread = threads.find((t) => t.latestMessage.id === id);
-      const tid = thread?.latestMessage.threadId || id;
-      snapshots.push(...emails.filter((e) => (e.threadId || e.id) === tid));
-      onArchived?.(id);
+    for (const key of threadKeys) {
+      snapshots.push(...emails.filter((e) => (e.threadId || e.id) === key));
     }
+    for (const id of emailIds) onArchived?.(id);
 
     const undo = () => {
       queryClient.setQueriesData<InfiniteEmails>(
@@ -309,20 +346,19 @@ export function EmailList({
           };
         },
       );
-      for (const id of ids) unarchiveEmail.mutate(id);
+      for (const id of emailIds) unarchiveEmail.mutate(id);
     };
     setUndoAction(undo);
     toast(
-      ids.length > 1
-        ? `Archived ${ids.length} conversations.`
+      threadKeys.length > 1
+        ? `Archived ${threadKeys.length} conversations.`
         : "Marked as Done.",
       { action: { label: "UNDO", onClick: undo } },
     );
-    for (const id of ids) {
-      const thread = threads.find((t) => t.latestMessage.id === id);
+    for (const t of targets) {
       archiveEmail.mutate({
-        id,
-        accountEmail: thread?.latestMessage.accountEmail,
+        id: t.latestMessage.id,
+        accountEmail: t.latestMessage.accountEmail,
         removeLabel: labelParam || undefined,
       });
     }
@@ -336,21 +372,32 @@ export function EmailList({
     labelParam,
     setFocusedId,
     setSelectedIds,
-    getActionIds,
+    getActionThreadKeys,
     queryClient,
   ]);
 
   const trashFocused = useCallback(() => {
-    const ids = getActionIds();
-    if (ids.length === 0) return;
-    const actionIdSet = new Set(ids);
+    const threadKeys = getActionThreadKeys();
+    if (threadKeys.length === 0) return;
+    const actionKeySet = new Set(threadKeys);
 
-    // Move focus to the next non-selected email
+    const targets = threadKeys
+      .map((key) =>
+        threads.find(
+          (t) => (t.latestMessage.threadId || t.latestMessage.id) === key,
+        ),
+      )
+      .filter((t): t is ThreadSummary => !!t);
+    const emailIds = targets.map((t) => t.latestMessage.id);
+
+    // Move focus to the next non-selected thread
     const lastIdx = threads.findIndex(
-      (t) => t.latestMessage.id === ids[ids.length - 1],
+      (t) =>
+        (t.latestMessage.threadId || t.latestMessage.id) ===
+        threadKeys[threadKeys.length - 1],
     );
     const remaining = threads.filter(
-      (t) => !actionIdSet.has(t.latestMessage.id),
+      (t) => !actionKeySet.has(t.latestMessage.threadId || t.latestMessage.id),
     );
     if (remaining.length > 0) {
       const nextIdx = Math.min(lastIdx, remaining.length - 1);
@@ -361,10 +408,8 @@ export function EmailList({
 
     // Snapshot removed thread emails so undo can restore them
     const snapshots: EmailMessage[] = [];
-    for (const id of ids) {
-      const thread = threads.find((t) => t.latestMessage.id === id);
-      const tid = thread?.latestMessage.threadId || id;
-      snapshots.push(...emails.filter((e) => (e.threadId || e.id) === tid));
+    for (const key of threadKeys) {
+      snapshots.push(...emails.filter((e) => (e.threadId || e.id) === key));
     }
 
     const undo = () => {
@@ -382,16 +427,16 @@ export function EmailList({
           };
         },
       );
-      for (const id of ids) untrashEmail.mutate(id);
+      for (const id of emailIds) untrashEmail.mutate(id);
     };
     setUndoAction(undo);
     toast(
-      ids.length > 1
-        ? `Trashed ${ids.length} conversations.`
+      threadKeys.length > 1
+        ? `Trashed ${threadKeys.length} conversations.`
         : "Moved to Trash.",
       { action: { label: "UNDO", onClick: undo } },
     );
-    for (const id of ids) trashEmail.mutate(id);
+    for (const id of emailIds) trashEmail.mutate(id);
     setSelectedIds(new Set());
   }, [
     threads,
@@ -400,64 +445,68 @@ export function EmailList({
     untrashEmail,
     setFocusedId,
     setSelectedIds,
-    getActionIds,
+    getActionThreadKeys,
     queryClient,
   ]);
 
+  const resolveTargets = useCallback(
+    (keys: string[]): ThreadSummary[] =>
+      keys
+        .map((key) =>
+          threads.find(
+            (t) => (t.latestMessage.threadId || t.latestMessage.id) === key,
+          ),
+        )
+        .filter((t): t is ThreadSummary => !!t),
+    [threads],
+  );
+
   const toggleFocusedRead = useCallback(() => {
-    const ids = getActionIds();
-    if (ids.length === 0) return;
-    for (const id of ids) {
-      const thread = threads.find((t) => t.latestMessage.id === id);
-      if (!thread) continue;
+    const keys = getActionThreadKeys();
+    if (keys.length === 0) return;
+    for (const t of resolveTargets(keys)) {
       markRead.mutate({
-        id,
-        isRead: !thread.latestMessage.isRead,
-        accountEmail: thread.latestMessage.accountEmail,
+        id: t.latestMessage.id,
+        isRead: !t.latestMessage.isRead,
+        accountEmail: t.latestMessage.accountEmail,
       });
     }
     setSelectedIds(new Set());
-  }, [threads, markRead, getActionIds, setSelectedIds]);
+  }, [markRead, getActionThreadKeys, resolveTargets, setSelectedIds]);
 
   const markFocusedRead = useCallback(() => {
-    const ids = getActionIds();
-    for (const id of ids) {
-      const thread = threads.find((t) => t.latestMessage.id === id);
+    for (const t of resolveTargets(getActionThreadKeys())) {
       markRead.mutate({
-        id,
+        id: t.latestMessage.id,
         isRead: true,
-        accountEmail: thread?.latestMessage.accountEmail,
+        accountEmail: t.latestMessage.accountEmail,
       });
     }
     setSelectedIds(new Set());
-  }, [threads, markRead, getActionIds, setSelectedIds]);
+  }, [markRead, getActionThreadKeys, resolveTargets, setSelectedIds]);
 
   const markFocusedUnread = useCallback(() => {
-    const ids = getActionIds();
-    for (const id of ids) {
-      const thread = threads.find((t) => t.latestMessage.id === id);
+    for (const t of resolveTargets(getActionThreadKeys())) {
       markRead.mutate({
-        id,
+        id: t.latestMessage.id,
         isRead: false,
-        accountEmail: thread?.latestMessage.accountEmail,
+        accountEmail: t.latestMessage.accountEmail,
       });
     }
     setSelectedIds(new Set());
-  }, [threads, markRead, getActionIds, setSelectedIds]);
+  }, [markRead, getActionThreadKeys, resolveTargets, setSelectedIds]);
 
   const starFocused = useCallback(() => {
-    const ids = getActionIds();
-    if (ids.length === 0) return;
-    for (const id of ids) {
-      const thread = threads.find((t) => t.latestMessage.id === id);
-      if (!thread) continue;
+    const keys = getActionThreadKeys();
+    if (keys.length === 0) return;
+    for (const t of resolveTargets(keys)) {
       toggleStar.mutate({
-        id,
-        isStarred: !thread.latestMessage.isStarred,
+        id: t.latestMessage.id,
+        isStarred: !t.latestMessage.isStarred,
       });
     }
     setSelectedIds(new Set());
-  }, [threads, toggleStar, getActionIds, setSelectedIds]);
+  }, [toggleStar, getActionThreadKeys, resolveTargets, setSelectedIds]);
 
   const replyFocused = useCallback(() => {
     const id = focusedIdRef.current;
@@ -608,6 +657,9 @@ export function EmailList({
     const email = thread.latestMessage;
     const targetThreadId = email.threadId || email.id;
     setFocusedId(email.id);
+    // A plain click is a single-thread action — clear any in-progress
+    // multi-selection so the next keyboard shortcut doesn't act on a stale set.
+    setSelectedIds(new Set());
     // Draft emails: open in compose window instead of thread view
     if (email.isDraft && onDraftOpen) {
       onDraftOpen(email);
@@ -634,7 +686,7 @@ export function EmailList({
   // Swipe targets exactly one thread (the swiped one) — unlike the keyboard
   // `e` shortcut, which respects multi-selection. We also clear any existing
   // multi-selection so the next keyboard shortcut (e/d/u/s) doesn't act on a
-  // stale set — getActionIds() prefers selectedIds over focusedId.
+  // stale set — getActionThreadKeys() prefers selectedIds over focusedId.
   const handleSwipeArchive = useCallback(
     (thread: ThreadSummary) => {
       const id = thread.latestMessage.id;
@@ -826,7 +878,9 @@ export function EmailList({
             thread={thread}
             isSelected={thread.latestMessage.id === threadId}
             isFocused={thread.latestMessage.id === focusedId}
-            isMultiSelected={selectedIds.has(thread.latestMessage.id)}
+            isMultiSelected={selectedIds.has(
+              thread.latestMessage.threadId || thread.latestMessage.id,
+            )}
             onSelect={() => handleSelect(thread)}
             onStar={(e) => handleStar(e, thread)}
             onHover={() => {

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -30,6 +30,7 @@ import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { setUndoAction } from "@/hooks/use-undo";
 import { toast } from "sonner";
 import type { EmailMessage, MobileActionId } from "@shared/types";
+import type { ThreadSummary } from "@/lib/threads";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   IconArrowLeft,
@@ -56,10 +57,26 @@ import { useIsMobile } from "@/hooks/use-mobile";
 export function EmailThread({
   onArchived,
   emailIds = [],
+  threads = [],
+  selectedIds,
+  setSelectedIds,
   onContactSelect,
 }: {
   onArchived?: (id: string) => void;
   emailIds?: string[];
+  /**
+   * Full thread summaries for the current view. Used to resolve thread keys
+   * back to their latestMessage (id, accountEmail) when bulk-archiving via
+   * shift+j/k multi-selection from the detail view.
+   */
+  threads?: ThreadSummary[];
+  /**
+   * Multi-selection of thread keys (`threadId || id`). Shared with the list
+   * view so selections survive navigation between list and detail views, and
+   * shift+j/k in detail view can extend the same set.
+   */
+  selectedIds?: Set<string>;
+  setSelectedIds?: React.Dispatch<React.SetStateAction<Set<string>>>;
   onContactSelect?: (email: string) => void;
 }) {
   const { view = "inbox", threadId } = useParams<{
@@ -75,16 +92,33 @@ export function EmailThread({
   const compose = useComposeState();
   const queryClient = useQueryClient();
 
-  // Pull any messages we already have from the list cache (instant, no fetch)
+  // Pull any messages we already have from the list cache (instant, no fetch).
+  // The emails query uses useInfiniteQuery so cached data is InfiniteData<{ emails: EmailMessage[] }>,
+  // not a flat array — flatten pages before searching.
   const cachedMessages = useMemo(() => {
     if (!threadId) return [];
     const allCached: EmailMessage[] = [];
-    const queries = queryClient.getQueriesData<EmailMessage[]>({
+    const queries = queryClient.getQueriesData<unknown>({
       queryKey: ["emails"],
     });
     for (const [, data] of queries) {
-      if (!Array.isArray(data)) continue;
-      for (const email of data) {
+      let emails: EmailMessage[];
+      if (Array.isArray(data)) {
+        emails = data as EmailMessage[];
+      } else if (
+        data &&
+        typeof data === "object" &&
+        "pages" in data &&
+        Array.isArray((data as any).pages)
+      ) {
+        // InfiniteData<EmailsPage> — flatten pages
+        emails = (data as any).pages.flatMap(
+          (p: any) => p.emails ?? [],
+        ) as EmailMessage[];
+      } else {
+        continue;
+      }
+      for (const email of emails) {
         if ((email.threadId || email.id) === threadId) {
           allCached.push(email);
         }
@@ -108,8 +142,26 @@ export function EmailThread({
     isFetching: isThreadFetching,
   } = useThreadMessages(threadId);
 
-  // Use full thread when loaded, otherwise show what we have from the list cache
-  const allMessages = threadMessages ?? cachedMessages;
+  // Use the latestMessage from the threads prop as a last-resort preview (avoids
+  // full skeleton when the user just clicked from the list and we have the data).
+  const previewMessage = useMemo(() => {
+    if (!threadId || !threads.length) return undefined;
+    const thread = threads.find(
+      (t) => (t.latestMessage.threadId || t.latestMessage.id) === threadId,
+    );
+    return thread?.latestMessage;
+  }, [threadId, threads]);
+
+  // Use full thread when loaded, fall back to list cache, then to the single
+  // preview message we already have from the list view — never show a full
+  // skeleton when we already have the subject/snippet visible in the list.
+  const allMessages =
+    threadMessages ??
+    (cachedMessages.length > 0
+      ? cachedMessages
+      : previewMessage
+        ? [previewMessage]
+        : []);
   // Hide Superhuman reminder messages — they're noise in the thread view
   const messages = useMemo(
     () =>
@@ -309,9 +361,41 @@ export function EmailThread({
       if (idx === -1) return;
       const nextIdx = idx + delta;
       if (nextIdx < 0 || nextIdx >= ids.length) return;
+      // Plain j/k is a single-thread action — clear any in-progress
+      // multi-selection so the next shortcut (e/d/s/u) doesn't act on it.
+      setSelectedIds?.(new Set());
       navigate(`/${view}/${ids[nextIdx]}${labelSuffix}`);
     },
-    [threadId, view, navigate, labelSuffix],
+    [threadId, view, navigate, labelSuffix, setSelectedIds],
+  );
+
+  // Shift+j/k extends multi-selection across siblings and auto-previews the
+  // newly selected thread. Selection is keyed by thread key (`threadId || id`)
+  // to match the list view so a selection can span both views seamlessly.
+  const extendSelection = useCallback(
+    (delta: number) => {
+      if (!setSelectedIds) return;
+      const ids = emailIdsRef.current;
+      if (!threadId || ids.length === 0) return;
+      const idx = ids.indexOf(threadId);
+      if (idx === -1) return;
+      const nextIdx = idx + delta;
+      if (nextIdx < 0 || nextIdx >= ids.length) return;
+      const nextThreadKey = ids[nextIdx];
+
+      setSelectedIds((prev) => {
+        const updated = new Set(prev);
+        // Anchor the current thread on first shift-move.
+        if (prev.size === 0) updated.add(threadId);
+        updated.add(nextThreadKey);
+        return updated;
+      });
+
+      // Auto-preview the latest selected thread. Use replace so the history
+      // stack doesn't fill up with every shift+j/k press.
+      navigate(`/${view}/${nextThreadKey}${labelSuffix}`, { replace: true });
+    },
+    [threadId, view, navigate, labelSuffix, setSelectedIds],
   );
 
   // Prefetch ±5 siblings in order (nearest first) for fast e/j/k navigation
@@ -412,17 +496,44 @@ export function EmailThread({
   // Mobile action bar
   const isMobile = useIsMobile();
 
+  // Resolve the set of thread keys the next action should operate on. If the
+  // user has a multi-selection (via shift+j/k in list or detail view), act on
+  // that; otherwise fall back to the currently viewed thread.
+  const getActionThreadKeys = useCallback((): string[] => {
+    if (selectedIds && selectedIds.size > 0) return Array.from(selectedIds);
+    if (threadId) return [threadId];
+    return [];
+  }, [selectedIds, threadId]);
+
   const handleArchive = useCallback(() => {
-    if (!email) return;
-    const id = email.id;
-    const tid = threadId || id;
-    // Snapshot thread emails from cache so undo can restore them instantly
+    const threadKeys = getActionThreadKeys();
+    if (threadKeys.length === 0) return;
+
+    // Resolve each thread key to its latestMessage via the threads prop, with
+    // a fallback to the current email when acting on the focused thread alone.
+    const targets = threadKeys
+      .map((key) => {
+        const t = threads.find(
+          (t) => (t.latestMessage.threadId || t.latestMessage.id) === key,
+        );
+        if (t) return t.latestMessage;
+        // Fallback: single-thread archive of the currently viewed thread.
+        if (email && (email.threadId || email.id) === key) return email;
+        return undefined;
+      })
+      .filter((m): m is EmailMessage => !!m);
+
+    if (targets.length === 0) return;
+
+    // Snapshot thread emails from cache so undo can restore them instantly.
     const cached = queryClient
       .getQueriesData<EmailMessage[]>({ queryKey: ["emails"] })
       .flatMap(([, data]) => data ?? []);
-    const snapshot = cached.filter((e) => (e.threadId || e.id) === tid);
+    const keySet = new Set(threadKeys);
+    const snapshot = cached.filter((e) => keySet.has(e.threadId || e.id));
 
-    onArchived?.(id);
+    for (const t of targets) onArchived?.(t.id);
+
     const undo = () => {
       queryClient.setQueriesData<EmailMessage[]>(
         { queryKey: ["emails"] },
@@ -431,25 +542,31 @@ export function EmailThread({
             (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
           ),
       );
-      unarchiveEmail.mutate(id);
+      for (const t of targets) unarchiveEmail.mutate(t.id);
     };
     setUndoAction(undo);
-    toast("Marked as Done.", {
-      action: {
-        label: "UNDO",
-        onClick: undo,
+    toast(
+      targets.length > 1
+        ? `Archived ${targets.length} conversations.`
+        : "Marked as Done.",
+      {
+        action: { label: "UNDO", onClick: undo },
+        position: isMobile ? "top-center" : undefined,
       },
-      position: isMobile ? "top-center" : undefined,
-    });
+    );
     advanceOrGoBack();
-    archiveEmail.mutate({
-      id,
-      accountEmail: email.accountEmail,
-      removeLabel: labelParam || undefined,
-    });
+    for (const t of targets) {
+      archiveEmail.mutate({
+        id: t.id,
+        accountEmail: t.accountEmail,
+        removeLabel: labelParam || undefined,
+      });
+    }
+    setSelectedIds?.(new Set());
   }, [
     email,
-    threadId,
+    threads,
+    getActionThreadKeys,
     archiveEmail,
     unarchiveEmail,
     advanceOrGoBack,
@@ -457,16 +574,31 @@ export function EmailThread({
     queryClient,
     labelParam,
     isMobile,
+    setSelectedIds,
   ]);
 
   const handleTrash = useCallback(() => {
-    if (!email) return;
-    const id = email.id;
-    const tid = threadId || id;
+    const threadKeys = getActionThreadKeys();
+    if (threadKeys.length === 0) return;
+
+    const targets = threadKeys
+      .map((key) => {
+        const t = threads.find(
+          (t) => (t.latestMessage.threadId || t.latestMessage.id) === key,
+        );
+        if (t) return t.latestMessage;
+        if (email && (email.threadId || email.id) === key) return email;
+        return undefined;
+      })
+      .filter((m): m is EmailMessage => !!m);
+
+    if (targets.length === 0) return;
+
     const cached = queryClient
       .getQueriesData<EmailMessage[]>({ queryKey: ["emails"] })
       .flatMap(([, data]) => data ?? []);
-    const snapshot = cached.filter((e) => (e.threadId || e.id) === tid);
+    const keySet = new Set(threadKeys);
+    const snapshot = cached.filter((e) => keySet.has(e.threadId || e.id));
 
     const undo = () => {
       queryClient.setQueriesData<EmailMessage[]>(
@@ -476,18 +608,28 @@ export function EmailThread({
             (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
           ),
       );
-      untrashEmail.mutate(id);
+      for (const t of targets) untrashEmail.mutate(t.id);
     };
     setUndoAction(undo);
-    toast("Moved to Trash.", {
-      action: {
-        label: "UNDO",
-        onClick: undo,
-      },
-    });
+    toast(
+      targets.length > 1
+        ? `Trashed ${targets.length} conversations.`
+        : "Moved to Trash.",
+      { action: { label: "UNDO", onClick: undo } },
+    );
     advanceOrGoBack();
-    trashEmail.mutate(id);
-  }, [email, threadId, trashEmail, untrashEmail, advanceOrGoBack, queryClient]);
+    for (const t of targets) trashEmail.mutate(t.id);
+    setSelectedIds?.(new Set());
+  }, [
+    email,
+    threads,
+    getActionThreadKeys,
+    trashEmail,
+    untrashEmail,
+    advanceOrGoBack,
+    queryClient,
+    setSelectedIds,
+  ]);
 
   const handleStar = useCallback(() => {
     if (!email) return;
@@ -641,9 +783,24 @@ export function EmailThread({
   // Keyboard shortcuts
   useKeyboardShortcuts(
     [
-      { key: "Escape", handler: goBack },
+      {
+        key: "Escape",
+        handler: () => {
+          // If a multi-selection is active, first Escape clears it; second
+          // Escape goes back to the list. Matches Gmail / Superhuman feel.
+          if (selectedIds && selectedIds.size > 0) {
+            setSelectedIds?.(new Set());
+            return;
+          }
+          goBack();
+        },
+      },
       { key: "j", handler: () => goToSibling(1) },
       { key: "k", handler: () => goToSibling(-1) },
+      { key: "j", shift: true, handler: () => extendSelection(1) },
+      { key: "k", shift: true, handler: () => extendSelection(-1) },
+      { key: "ArrowDown", shift: true, handler: () => extendSelection(1) },
+      { key: "ArrowUp", shift: true, handler: () => extendSelection(-1) },
       { key: "n", handler: () => focusMessage(1) },
       { key: "p", handler: () => focusMessage(-1) },
       { key: "Enter", handler: toggleFocused },

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -74,11 +74,15 @@ function ThreadListSidebar({
   activeThreadId,
   view,
   labelSuffix,
+  selectedIds,
+  setSelectedIds,
 }: {
   emails: EmailMessage[];
   activeThreadId: string;
   view: string;
   labelSuffix: string;
+  selectedIds: Set<string>;
+  setSelectedIds: React.Dispatch<React.SetStateAction<Set<string>>>;
 }) {
   const navigate = useNavigate();
   const markRead = useMarkRead();
@@ -89,26 +93,32 @@ function ThreadListSidebar({
       <div className="flex-1 overflow-y-auto">
         {threads.map((thread) => {
           const email = thread.latestMessage;
-          const isActive = (email.threadId || email.id) === activeThreadId;
+          const threadKey = email.threadId || email.id;
+          const isActive = threadKey === activeThreadId;
+          const isMultiSelected = selectedIds.has(threadKey);
           return (
             <button
               key={email.id}
               onClick={() => {
+                // A plain click is a single-thread action — clear any
+                // in-progress multi-selection so the next keyboard shortcut
+                // doesn't act on a stale set.
+                setSelectedIds(new Set());
                 if (!email.isRead)
                   markRead.mutate({
                     id: email.id,
                     isRead: true,
                     accountEmail: email.accountEmail,
                   });
-                navigate(
-                  `/${view}/${email.threadId || email.id}${labelSuffix}`,
-                );
+                navigate(`/${view}/${threadKey}${labelSuffix}`);
               }}
               className={cn(
                 "w-full text-left px-3 h-[38px] flex items-center border-b border-border/10 transition-colors",
-                isActive
-                  ? "bg-primary/10"
-                  : "hover:bg-accent dark:hover:bg-[hsl(220,5%,13%)]",
+                isMultiSelected
+                  ? "bg-primary/20 ring-1 ring-inset ring-primary/40"
+                  : isActive
+                    ? "bg-primary/10"
+                    : "hover:bg-accent dark:hover:bg-[hsl(220,5%,13%)]",
               )}
             >
               <div className="flex items-center gap-2 min-w-0 w-full">
@@ -289,8 +299,10 @@ export function InboxPage() {
     hasNoteToSelf,
   ]);
 
-  // Clear multi-selection when navigating to a different view, thread, or label tab
-  useEffect(() => setSelectedIds(new Set()), [view, threadId, activeLabel]);
+  // Clear multi-selection when switching views or label tabs. Do NOT clear on
+  // threadId changes — shift+j/k in detail view navigates between threads while
+  // extending the selection, so selection must persist across thread nav.
+  useEffect(() => setSelectedIds(new Set()), [view, activeLabel]);
 
   // Sync current navigation state to file (write-only, so agent can read it)
   const searchQ = searchParams.get("q") ?? undefined;
@@ -446,6 +458,8 @@ export function InboxPage() {
           activeThreadId={threadId!}
           view={view}
           labelSuffix={labelSuffix}
+          selectedIds={selectedIds}
+          setSelectedIds={setSelectedIds}
         />
       )}
 
@@ -455,6 +469,9 @@ export function InboxPage() {
           <EmailThread
             onArchived={setLastArchivedId}
             emailIds={threadIds}
+            threads={threads}
+            selectedIds={selectedIds}
+            setSelectedIds={setSelectedIds}
             onContactSelect={setSidebarContactEmail}
           />
         ) : (

--- a/templates/mail/app/pages/SettingsPage.tsx
+++ b/templates/mail/app/pages/SettingsPage.tsx
@@ -8,7 +8,9 @@ import {
   IconLoader2,
   IconBolt,
   IconX,
+  IconCpu,
 } from "@tabler/icons-react";
+import { AgentEnginePicker } from "@/components/agent-engine-picker";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -736,9 +738,28 @@ function AutomationsSection() {
   );
 }
 
+// ─── Agent Engine Section ─────────────────────────────────────────────────────
+
+function AgentEngineSection() {
+  return (
+    <div className="flex-1 p-4 sm:p-8 overflow-y-auto">
+      <div className="mb-6">
+        <h2 className="text-[16px] font-semibold text-foreground">
+          Agent Engine
+        </h2>
+        <p className="text-[13px] text-muted-foreground mt-0.5">
+          Choose which AI model powers the agent. The default is Claude
+          (Anthropic).
+        </p>
+      </div>
+      <AgentEnginePicker />
+    </div>
+  );
+}
+
 // ─── Settings Page ────────────────────────────────────────────────────────────
 
-type SettingsSection = "aliases" | "automations";
+type SettingsSection = "automations" | "aliases" | "agent";
 
 const navItems: {
   id: SettingsSection;
@@ -747,6 +768,7 @@ const navItems: {
 }[] = [
   { id: "automations", label: "Automations", icon: IconBolt },
   { id: "aliases", label: "Aliases", icon: IconUsers },
+  { id: "agent", label: "Agent", icon: IconCpu },
 ];
 
 export function SettingsPage() {
@@ -790,6 +812,7 @@ export function SettingsPage() {
       <div className="flex flex-1 overflow-hidden bg-background">
         {activeSection === "automations" && <AutomationsSection />}
         {activeSection === "aliases" && <AliasesSection />}
+        {activeSection === "agent" && <AgentEngineSection />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- **AgentEngine abstraction**: thin `stream(opts): AsyncIterable<EngineEvent>` interface beneath `runAgentLoop` — keeps our loop, tool dispatch, MCP, A2A, thread storage unchanged
- **AnthropicEngine**: wraps `@anthropic-ai/sdk` directly (default, full fidelity — thinking, cache_control, etc.)
- **AISDKEngine**: wraps Vercel AI SDK `streamText` for multi-provider (Anthropic, OpenAI, Google Gemini, Groq, Mistral, Cohere, Ollama) via optional peer deps
- **Open registry**: `registerAgentEngine()` / `listAgentEngines()` / `resolveEngine()` — mirrors CLI_REGISTRY pattern, open to third-party engines
- **Prompt caching** (automatic): applies `cache_control: ephemeral` to system prompt + last tool block when `capabilities.promptCaching === true`
- **Extended thinking** (opt-in): forwarded via `providerOptions.anthropic.thinking` — gated by `capabilities.thinking`
- **Thread-pinned engine**: engine + model stored in `chat_threads.thread_data` JSON on thread creation
- **Settings scripts**: `list-agent-engines`, `set-agent-engine`, `test-agent-engine`
- **Mail template settings UI**: `AgentEnginePicker` component + Settings > Agent tab
- **Agent skill + AGENTS.md**: documents engine system for the agent
- **Fix**: AI SDK v4 requires `jsonSchema()` wrapper on tool parameters — was causing `TypeError: Cannot read properties of undefined (reading 'typeName')` silently

## Test plan

- [ ] All 292 unit tests pass (`pnpm test`)
- [ ] TypeScript clean across all packages (`pnpm typecheck`)
- [ ] Default `anthropic` engine works identically to before
- [ ] `ai-sdk:anthropic` engine produces correct responses via Settings > Agent picker
- [ ] Test connection button returns `ok: true` with latency
- [ ] Engine selection persists across page reload
- [ ] All 10 other templates unaffected (fall through to default anthropic engine)
- [ ] Prompt caching tokens visible in Anthropic dashboard on second turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)