### PR TITLE
Auto-open agent sidebar on voice input (mobile + desktop)

### DIFF
--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1673,6 +1673,19 @@ export function AgentSidebar({
   });
   const [presentationMode, setPresentationMode] = useState(false);
   const [width, setWidth] = useState(sidebarWidth);
+
+  // Track mobile viewport so we can switch to overlay mode.
+  const [isMobile, setIsMobile] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(max-width: 767px)").matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 767px)");
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
   useEffect(() => {
     try {
       const saved = localStorage.getItem(SIDEBAR_STORAGE_KEY);
@@ -1813,19 +1826,34 @@ export function AgentSidebar({
 
   const isLeft = position === "left";
 
+  // On mobile the sidebar floats as a fixed overlay so the content below isn't
+  // squashed. On desktop it participates in the flex layout as before.
+  const mobileSidebarStyle: React.CSSProperties = isMobile
+    ? {
+        position: "fixed",
+        top: 0,
+        [isLeft ? "left" : "right"]: 0,
+        height: "100%",
+        maxWidth: "85vw",
+        zIndex: 50,
+      }
+    : {};
+
   // Always render the sidebar panel (even when closed) so MultiTabAssistantChat
   // stays mounted and can receive messages (e.g. from voice dictation) while
   // the sidebar is visually hidden. When the user opens the sidebar they'll see
   // any in-progress or completed conversations.
   const sidebar = (
     <>
-      {isLeft ? null : open ? (
-        <ResizeHandle position={position} onDrag={handleDrag} />
-      ) : null}
+      {!isMobile &&
+        (isLeft ? null : open ? (
+          <ResizeHandle position={position} onDrag={handleDrag} />
+        ) : null)}
       <div
         className="agent-sidebar-panel flex shrink-0 flex-col overflow-hidden text-[13px] leading-[1.2] antialiased"
         style={{
           ...AGENT_PANEL_ROOT_STYLE,
+          ...mobileSidebarStyle,
           width,
           maxHeight: "100vh",
           display: open ? "flex" : "none",
@@ -1837,16 +1865,24 @@ export function AgentSidebar({
           onCollapse={() => setOpenPersisted(false)}
         />
       </div>
-      {isLeft ? (
-        open ? (
-          <ResizeHandle position={position} onDrag={handleDrag} />
-        ) : null
-      ) : null}
+      {!isMobile &&
+        (isLeft ? (
+          open ? (
+            <ResizeHandle position={position} onDrag={handleDrag} />
+          ) : null
+        ) : null)}
     </>
   );
 
   return (
     <div className="flex min-w-0 flex-1 h-screen overflow-hidden">
+      {/* Mobile backdrop — tapping it closes the sidebar */}
+      {isMobile && open && !presentationMode && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40"
+          onClick={() => setOpenPersisted(false)}
+        />
+      )}
       {isLeft && !presentationMode ? sidebar : null}
       <div className="flex flex-1 flex-col overflow-auto min-w-0">
         {children}

--- a/templates/macros/app/components/VoiceDictation.tsx
+++ b/templates/macros/app/components/VoiceDictation.tsx
@@ -96,6 +96,9 @@ export function VoiceDictation({ currentDate }: VoiceDictationProps) {
       recognitionRef.current = null;
     }
 
+    // Open the agent sidebar so the user can see the response
+    window.dispatchEvent(new Event("agent-panel:open"));
+
     isProcessingRef.current = false;
     setState("listening");
     setTranscript("");


### PR DESCRIPTION
### Summary
When a user triggers voice input in the macros template, the agent sidebar now automatically opens so they can see the response — on both mobile and desktop. Mobile also gets a proper fixed-overlay sidebar with a tap-to-dismiss backdrop.

### Problem
Previously, if the agent sidebar was closed when the user activated voice dictation, the sidebar remained hidden. The user had no visual feedback that the agent was processing their voice input or responding, since the sidebar panel stayed collapsed.

### Solution
Dispatch an `agent-panel:open` event from `VoiceDictation.tsx` when voice recording starts, so the sidebar opens automatically. On mobile, the sidebar is rendered as a fixed overlay (instead of participating in the flex layout) so it doesn't squash page content, and a semi-transparent backdrop is added to allow tap-to-dismiss.

### Key Changes
- **`VoiceDictation.tsx`**: Dispatches `window.dispatchEvent(new Event("agent-panel:open"))` when voice input is activated, ensuring the agent sidebar opens automatically regardless of its current state.
- **`AgentPanel.tsx`**: Adds a `isMobile` state (tracked via `matchMedia`) that switches the sidebar to a `position: fixed` overlay on viewports ≤ 767px, with `maxWidth: 85vw` and `zIndex: 50`.
- **`AgentPanel.tsx`**: Adds a mobile backdrop (`fixed inset-0 z-40 bg-black/40`) that renders behind the sidebar when it is open on mobile; clicking/tapping it closes the sidebar.
- **`AgentPanel.tsx`**: Suppresses the desktop `ResizeHandle` on mobile to avoid layout conflicts with the overlay approach.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/magenta-part-n7jzjzfr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-magenta-part-n7jzjzfr_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<h3>Preview</h3>
<img src="https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F25dc86d0736e4271b25c064b295a5ac6?alt=media&token=1caa8f73-e569-4133-b6c3-111d2bcacf93&apiKey=YJIGb4i01jvw0SRdL5Bt" alt="Changes preview" style="max-width: 100%; height: auto;">
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 190`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>magenta-part-n7jzjzfr</branchName>-->