### PR TITLE
fix(content): slim Notion conflict banner to single-line bar

### DIFF
--- a/packages/core/src/oauth-tokens/store.ts
+++ b/packages/core/src/oauth-tokens/store.ts
@@ -70,9 +70,12 @@ export async function saveOAuthTokens(
   await ensureTable();
   const client = getDbExec();
 
+  // Never store "local@localhost" as owner — it creates shared-ownership bugs
+  const sanitizedOwner = owner === "local@localhost" ? accountId : owner;
+
   // When owner is not provided (e.g. during token refresh), preserve the existing
   // owner and display_name so they don't get wiped by INSERT OR REPLACE.
-  let resolvedOwner = owner ?? accountId;
+  let resolvedOwner = sanitizedOwner ?? accountId;
   let existingDisplayName: string | null = null;
   if (!owner) {
     const { rows: existing } = await client.execute({

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -314,10 +314,13 @@ function createAuthGuardFn(): (
     const url = event.node?.req?.url ?? event.path ?? "/";
     const p = url.split("?")[0];
 
-    // Skip auth routes (all /_agent-native/auth/* and /_agent-native/google/*)
+    // Skip auth routes and specific Google OAuth endpoints that must be public
+    // (callback and auth-url). Other Google endpoints like /status require auth.
     if (
       p.startsWith("/_agent-native/auth/") ||
-      p.startsWith("/_agent-native/google/")
+      p === "/_agent-native/google/callback" ||
+      p === "/_agent-native/google/auth-url" ||
+      p === "/_agent-native/google/add-account/callback"
     ) {
       return;
     }

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -158,11 +158,11 @@ export async function resolveOAuthOwner(
   const isDevSession = existingSession?.email === "local@localhost";
   const hasProductionSession = !!(existingSession?.email && !isDevSession);
 
-  const owner = isDevSession
-    ? "local@localhost"
-    : hasProductionSession
-      ? existingSession!.email
-      : stateOwner || undefined;
+  // Never use "local@localhost" as a token owner — it creates shared-ownership
+  // bugs where multiple users can see the same tokens.
+  const owner = hasProductionSession
+    ? existingSession!.email
+    : stateOwner || undefined;
 
   return { owner, isDevSession, hasProductionSession };
 }

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -8,7 +8,14 @@
  */
 
 import crypto from "node:crypto";
-import { getHeader, setCookie, type H3Event } from "h3";
+import {
+  getHeader,
+  setCookie,
+  sendRedirect,
+  setResponseStatus,
+  setResponseHeader,
+  type H3Event,
+} from "h3";
 import { addSession, getSession } from "./auth.js";
 
 // ─── Platform Detection ─────────────────────────────────────────────────────
@@ -222,7 +229,7 @@ export function oauthCallbackResponse(
     desktop?: boolean;
     addAccount?: boolean;
   },
-): Response | void | Promise<Response | void> {
+): Response | string | void | Promise<Response | string | void> {
   const mobile = isMobile(event);
 
   // Mobile: deep link back to native app
@@ -261,8 +268,12 @@ export function oauthCallbackResponse(
       </script></body></html>`);
   }
 
-  // Web: redirect to app home
-  return new Response(null, { status: 302, headers: { Location: "/" } });
+  // Web: redirect to app home.
+  // Use h3's native redirect (not web Response) to preserve Set-Cookie headers
+  // from createOAuthSession — a raw `new Response()` drops them.
+  setResponseStatus(event, 302);
+  setResponseHeader(event, "Location", "/");
+  return "";
 }
 
 /** HTML error page for OAuth failures. */

--- a/packages/core/src/server/oauth-helpers.ts
+++ b/packages/core/src/server/oauth-helpers.ts
@@ -22,13 +22,14 @@ export async function isOAuthConnected(
 /**
  * Get OAuth accounts for a provider, scoped to the given owner.
  * Always scopes by owner email — never returns tokens across users.
+ * Returns empty array when forEmail is not provided (prevents leaking all accounts).
  */
 export async function getOAuthAccounts(
   provider: string,
   forEmail?: string,
 ): Promise<Array<{ accountId: string; tokens: Record<string, unknown> }>> {
-  if (forEmail) {
-    return listOAuthAccountsByOwner(provider, forEmail);
+  if (!forEmail) {
+    return [];
   }
-  return listOAuthAccounts(provider);
+  return listOAuthAccountsByOwner(provider, forEmail);
 }

--- a/templates/analytics/app/hooks/use-dashboard-views.ts
+++ b/templates/analytics/app/hooks/use-dashboard-views.ts
@@ -1,0 +1,102 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getIdToken } from "@/lib/auth";
+
+export interface DashboardView {
+  id: string;
+  name: string;
+  filters: Record<string, string>;
+  createdBy?: string;
+  createdAt?: string;
+}
+
+async function fetchWithAuth(url: string, options?: RequestInit) {
+  const token = await getIdToken();
+  return fetch(url, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token && { Authorization: `Bearer ${token}` }),
+      ...options?.headers,
+    },
+  });
+}
+
+export function useDashboardViews(dashboardId: string | undefined) {
+  const queryClient = useQueryClient();
+  const queryKey = ["dashboard-views", dashboardId];
+
+  const { data: views = [], isLoading } = useQuery({
+    queryKey,
+    queryFn: async (): Promise<DashboardView[]> => {
+      if (!dashboardId) return [];
+      const res = await fetchWithAuth(
+        `/api/dashboard-views/${encodeURIComponent(dashboardId)}`,
+      );
+      if (!res.ok) return [];
+      const data = await res.json();
+      return data.views ?? [];
+    },
+    enabled: !!dashboardId,
+    staleTime: 30_000,
+  });
+
+  const { mutateAsync: saveView } = useMutation({
+    mutationFn: async (view: DashboardView) => {
+      if (!dashboardId) return;
+      await fetchWithAuth(
+        `/api/dashboard-views/${encodeURIComponent(dashboardId)}`,
+        {
+          method: "POST",
+          body: JSON.stringify(view),
+        },
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+      // Also invalidate the sidebar views query
+      queryClient.invalidateQueries({ queryKey: ["all-dashboard-views"] });
+    },
+  });
+
+  const { mutateAsync: deleteView } = useMutation({
+    mutationFn: async (viewId: string) => {
+      if (!dashboardId) return;
+      await fetchWithAuth(
+        `/api/dashboard-views/${encodeURIComponent(dashboardId)}/${encodeURIComponent(viewId)}`,
+        { method: "DELETE" },
+      );
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: ["all-dashboard-views"] });
+    },
+  });
+
+  return { views, isLoading, saveView, deleteView };
+}
+
+/**
+ * Fetch views for all dashboards at once (for sidebar).
+ * Returns a map of dashboardId -> DashboardView[].
+ */
+export function useAllDashboardViews(dashboardIds: string[]) {
+  return useQuery({
+    queryKey: ["all-dashboard-views", dashboardIds.join(",")],
+    queryFn: async (): Promise<Record<string, DashboardView[]>> => {
+      const results: Record<string, DashboardView[]> = {};
+      await Promise.all(
+        dashboardIds.map(async (id) => {
+          const res = await fetchWithAuth(
+            `/api/dashboard-views/${encodeURIComponent(id)}`,
+          );
+          if (res.ok) {
+            const data = await res.json();
+            results[id] = data.views ?? [];
+          }
+        }),
+      );
+      return results;
+    },
+    staleTime: 30_000,
+  });
+}

--- a/templates/analytics/app/hooks/use-user-pref.ts
+++ b/templates/analytics/app/hooks/use-user-pref.ts
@@ -1,0 +1,64 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getIdToken } from "@/lib/auth";
+
+async function fetchWithAuth(url: string, options?: RequestInit) {
+  const token = await getIdToken();
+  return fetch(url, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token && { Authorization: `Bearer ${token}` }),
+      ...options?.headers,
+    },
+  });
+}
+
+/**
+ * Read/write a per-user preference stored in the settings table.
+ * Returns the value as a Record and provides a `save` mutation.
+ */
+export function useUserPref<T extends Record<string, unknown>>(key: string) {
+  const queryClient = useQueryClient();
+  const queryKey = ["user-pref", key];
+
+  const { data, isLoading } = useQuery({
+    queryKey,
+    queryFn: async (): Promise<T> => {
+      const res = await fetchWithAuth(
+        `/api/user-prefs/${encodeURIComponent(key)}`,
+      );
+      if (!res.ok) return {} as T;
+      return (await res.json()) as T;
+    },
+    staleTime: 30_000,
+  });
+
+  const { mutate: save } = useMutation({
+    mutationFn: async (value: T) => {
+      await fetchWithAuth(`/api/user-prefs/${encodeURIComponent(key)}`, {
+        method: "PUT",
+        body: JSON.stringify(value),
+      });
+    },
+    onMutate: async (value: T) => {
+      await queryClient.cancelQueries({ queryKey });
+      queryClient.setQueryData(queryKey, value);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  const { mutate: remove } = useMutation({
+    mutationFn: async () => {
+      await fetchWithAuth(`/api/user-prefs/${encodeURIComponent(key)}`, {
+        method: "DELETE",
+      });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  return { data: (data ?? {}) as T, isLoading, save, remove };
+}

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/DashboardFilterBar.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/DashboardFilterBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,6 +10,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { IconFilterOff, IconDeviceFloppy } from "@tabler/icons-react";
 import type { DashboardFilter } from "./types";
 
 export const FILTER_PARAM_PREFIX = "f_";
@@ -51,8 +59,47 @@ export function resolveFilterVars(
   return out;
 }
 
+/** Check if any filter param in the URL differs from the defaults */
+function hasActiveFilters(
+  filters: DashboardFilter[],
+  searchParams: URLSearchParams,
+): boolean {
+  for (const f of filters) {
+    if (f.type === "date-range") {
+      if (searchParams.has(FILTER_PARAM_PREFIX + f.id + "Start")) return true;
+      if (searchParams.has(FILTER_PARAM_PREFIX + f.id + "End")) return true;
+    } else {
+      if (searchParams.has(FILTER_PARAM_PREFIX + f.id)) return true;
+    }
+  }
+  return false;
+}
+
+/** Extract current filter params from URL search params */
+export function extractFilterParams(
+  filters: DashboardFilter[],
+  searchParams: URLSearchParams,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const f of filters) {
+    if (f.type === "date-range") {
+      const startKey = f.id + "Start";
+      const endKey = f.id + "End";
+      const sv = searchParams.get(FILTER_PARAM_PREFIX + startKey);
+      const ev = searchParams.get(FILTER_PARAM_PREFIX + endKey);
+      if (sv) result[FILTER_PARAM_PREFIX + startKey] = sv;
+      if (ev) result[FILTER_PARAM_PREFIX + endKey] = ev;
+    } else {
+      const v = searchParams.get(FILTER_PARAM_PREFIX + f.id);
+      if (v) result[FILTER_PARAM_PREFIX + f.id] = v;
+    }
+  }
+  return result;
+}
+
 interface DashboardFilterBarProps {
   filters: DashboardFilter[];
+  onSaveView?: (name: string, filters: Record<string, string>) => void;
 }
 
 /**
@@ -60,8 +107,13 @@ interface DashboardFilterBarProps {
  * filter inputs, and emits a `vars` dict (suitable for SQL interpolation) to the
  * parent. Date-range filters emit `<id>Start` and `<id>End` keys.
  */
-export function DashboardFilterBar({ filters }: DashboardFilterBarProps) {
+export function DashboardFilterBar({
+  filters,
+  onSaveView,
+}: DashboardFilterBarProps) {
   const [searchParams, setSearchParams] = useSearchParams();
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [viewName, setViewName] = useState("");
 
   const getParam = useCallback(
     (key: string) => searchParams.get(FILTER_PARAM_PREFIX + key) ?? "",
@@ -86,28 +138,117 @@ export function DashboardFilterBar({ filters }: DashboardFilterBarProps) {
     [setSearchParams],
   );
 
+  const clearAllFilters = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        // Remove all f_ prefixed params
+        const keysToRemove: string[] = [];
+        next.forEach((_, k) => {
+          if (k.startsWith(FILTER_PARAM_PREFIX)) keysToRemove.push(k);
+        });
+        keysToRemove.forEach((k) => next.delete(k));
+        // Also remove the view param since we're clearing
+        next.delete("view");
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  const handleSaveView = useCallback(() => {
+    if (!viewName.trim() || !onSaveView) return;
+    const currentFilters = extractFilterParams(filters, searchParams);
+    onSaveView(viewName.trim(), currentFilters);
+    setViewName("");
+    setSaveDialogOpen(false);
+  }, [viewName, onSaveView, filters, searchParams]);
+
   // Compute the live vars dict (URL value or default) for every filter.
   const vars = useMemo(
     () => resolveFilterVars(filters, getParam),
     [filters, getParam],
   );
 
+  const filtersActive = hasActiveFilters(filters, searchParams);
+
   return (
-    <div className="rounded-lg border border-border bg-card p-3 space-y-3">
-      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-        Filters
-      </h3>
-      <div className="flex flex-wrap gap-3 items-end">
-        {filters.map((f) => (
-          <FilterControl
-            key={f.id}
-            filter={f}
-            vars={vars}
-            setValue={(updates) => setParam(updates)}
-          />
-        ))}
+    <>
+      <div className="rounded-lg border border-border bg-card p-3 space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            Filters
+          </h3>
+          <div className="flex items-center gap-1">
+            {onSaveView && filtersActive && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs text-muted-foreground hover:text-primary"
+                onClick={() => setSaveDialogOpen(true)}
+              >
+                <IconDeviceFloppy className="h-3 w-3 mr-1" />
+                Save view
+              </Button>
+            )}
+            {filtersActive && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs text-muted-foreground hover:text-destructive"
+                onClick={clearAllFilters}
+              >
+                <IconFilterOff className="h-3 w-3 mr-1" />
+                Clear all
+              </Button>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-3 items-end">
+          {filters.map((f) => (
+            <FilterControl
+              key={f.id}
+              filter={f}
+              vars={vars}
+              setValue={(updates) => setParam(updates)}
+            />
+          ))}
+        </div>
       </div>
-    </div>
+
+      <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
+        <DialogContent className="sm:max-w-[400px]">
+          <DialogHeader>
+            <DialogTitle>Save as View</DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <Input
+              placeholder="View name (e.g. 'Recent articles only')"
+              value={viewName}
+              onChange={(e) => setViewName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSaveView()}
+              autoFocus
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setSaveDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleSaveView}
+              disabled={!viewName.trim()}
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/templates/analytics/server/handlers/dashboard-views.ts
+++ b/templates/analytics/server/handlers/dashboard-views.ts
@@ -1,0 +1,116 @@
+import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
+import { readBody } from "@agent-native/core/server";
+import {
+  getOrgSetting,
+  putOrgSetting,
+  getSetting,
+  putSetting,
+} from "@agent-native/core/settings";
+import { getOrgContext } from "@agent-native/core/org";
+
+const KEY_PREFIX = "dashboard-views-";
+
+export interface DashboardView {
+  id: string;
+  name: string;
+  /** Filter params to apply (e.g. { "f_recentOnly": "2026-01-01" }) */
+  filters: Record<string, string>;
+  createdBy?: string;
+  createdAt?: string;
+}
+
+interface ViewsData {
+  views: DashboardView[];
+}
+
+async function getViewsData(
+  ctx: { orgId: string | null },
+  dashboardId: string,
+): Promise<ViewsData> {
+  const key = `${KEY_PREFIX}${dashboardId}`;
+  let data: Record<string, unknown> | null = null;
+  if (ctx.orgId) {
+    data = await getOrgSetting(ctx.orgId, key);
+  }
+  if (!data) {
+    data = await getSetting(key);
+  }
+  return (data as unknown as ViewsData) ?? { views: [] };
+}
+
+async function putViewsData(
+  ctx: { orgId: string | null },
+  dashboardId: string,
+  data: ViewsData,
+): Promise<void> {
+  const key = `${KEY_PREFIX}${dashboardId}`;
+  if (ctx.orgId) {
+    await putOrgSetting(
+      ctx.orgId,
+      key,
+      data as unknown as Record<string, unknown>,
+    );
+  } else {
+    await putSetting(key, data as unknown as Record<string, unknown>);
+  }
+}
+
+export const listDashboardViews = defineEventHandler(async (event) => {
+  const dashboardId = getRouterParam(event, "dashboardId");
+  if (!dashboardId) {
+    setResponseStatus(event, 400);
+    return { error: "Missing dashboardId" };
+  }
+  const ctx = await getOrgContext(event);
+  const data = await getViewsData(ctx, dashboardId);
+  return { views: data.views };
+});
+
+export const saveDashboardView = defineEventHandler(async (event) => {
+  const dashboardId = getRouterParam(event, "dashboardId");
+  if (!dashboardId) {
+    setResponseStatus(event, 400);
+    return { error: "Missing dashboardId" };
+  }
+  const ctx = await getOrgContext(event);
+  const body = await readBody(event);
+  const { id, name, filters } = body as DashboardView;
+  if (!id || !name) {
+    setResponseStatus(event, 400);
+    return { error: "Missing id or name" };
+  }
+
+  const data = await getViewsData(ctx, dashboardId);
+  const existing = data.views.findIndex((v) => v.id === id);
+  const view: DashboardView = {
+    id,
+    name,
+    filters: filters ?? {},
+    createdBy: ctx.email,
+    createdAt:
+      existing >= 0 ? data.views[existing].createdAt : new Date().toISOString(),
+  };
+
+  if (existing >= 0) {
+    data.views[existing] = view;
+  } else {
+    data.views.push(view);
+  }
+
+  await putViewsData(ctx, dashboardId, data);
+  return { success: true, view };
+});
+
+export const deleteDashboardView = defineEventHandler(async (event) => {
+  const dashboardId = getRouterParam(event, "dashboardId");
+  const viewId = getRouterParam(event, "viewId");
+  if (!dashboardId || !viewId) {
+    setResponseStatus(event, 400);
+    return { error: "Missing dashboardId or viewId" };
+  }
+  const ctx = await getOrgContext(event);
+  const data = await getViewsData(ctx, dashboardId);
+  data.views = data.views.filter((v) => v.id !== viewId);
+  await putViewsData(ctx, dashboardId, data);
+  return { success: true };
+});

--- a/templates/analytics/server/handlers/user-prefs.ts
+++ b/templates/analytics/server/handlers/user-prefs.ts
@@ -1,0 +1,59 @@
+import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
+import { readBody } from "@agent-native/core/server";
+import { getSession } from "@agent-native/core/server";
+import {
+  getUserSetting,
+  putUserSetting,
+  deleteUserSetting,
+} from "@agent-native/core/settings";
+
+async function resolveEmail(event: any): Promise<string | null> {
+  const session = await getSession(event);
+  return session?.email ?? null;
+}
+
+export const getUserPref = defineEventHandler(async (event) => {
+  const key = getRouterParam(event, "key");
+  if (!key) {
+    setResponseStatus(event, 400);
+    return { error: "Missing key" };
+  }
+  const email = await resolveEmail(event);
+  if (!email) {
+    setResponseStatus(event, 401);
+    return { error: "Not authenticated" };
+  }
+  const data = await getUserSetting(email, key);
+  return data ?? {};
+});
+
+export const putUserPref = defineEventHandler(async (event) => {
+  const key = getRouterParam(event, "key");
+  if (!key) {
+    setResponseStatus(event, 400);
+    return { error: "Missing key" };
+  }
+  const email = await resolveEmail(event);
+  if (!email) {
+    setResponseStatus(event, 401);
+    return { error: "Not authenticated" };
+  }
+  const body = await readBody(event);
+  await putUserSetting(email, key, body);
+  return { success: true };
+});
+
+export const deleteUserPref = defineEventHandler(async (event) => {
+  const key = getRouterParam(event, "key");
+  if (!key) {
+    setResponseStatus(event, 400);
+    return { error: "Missing key" };
+  }
+  const email = await resolveEmail(event);
+  if (!email) {
+    setResponseStatus(event, 401);
+    return { error: "Not authenticated" };
+  }
+  await deleteUserSetting(email, key);
+  return { success: true };
+});

--- a/templates/analytics/server/routes/api/dashboard-views/[dashboardId].get.ts
+++ b/templates/analytics/server/routes/api/dashboard-views/[dashboardId].get.ts
@@ -1,0 +1,1 @@
+export { listDashboardViews as default } from "../../../handlers/dashboard-views";

--- a/templates/analytics/server/routes/api/dashboard-views/[dashboardId].post.ts
+++ b/templates/analytics/server/routes/api/dashboard-views/[dashboardId].post.ts
@@ -1,0 +1,1 @@
+export { saveDashboardView as default } from "../../../handlers/dashboard-views";

--- a/templates/analytics/server/routes/api/dashboard-views/[dashboardId]/[viewId].delete.ts
+++ b/templates/analytics/server/routes/api/dashboard-views/[dashboardId]/[viewId].delete.ts
@@ -1,0 +1,1 @@
+export { deleteDashboardView as default } from "../../../../handlers/dashboard-views";

--- a/templates/analytics/server/routes/api/user-prefs/[key].delete.ts
+++ b/templates/analytics/server/routes/api/user-prefs/[key].delete.ts
@@ -1,0 +1,1 @@
+export { deleteUserPref as default } from "../../../handlers/user-prefs";

--- a/templates/analytics/server/routes/api/user-prefs/[key].get.ts
+++ b/templates/analytics/server/routes/api/user-prefs/[key].get.ts
@@ -1,0 +1,1 @@
+export { getUserPref as default } from "../../../handlers/user-prefs";

--- a/templates/analytics/server/routes/api/user-prefs/[key].put.ts
+++ b/templates/analytics/server/routes/api/user-prefs/[key].put.ts
@@ -1,0 +1,1 @@
+export { putUserPref as default } from "../../../handlers/user-prefs";

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -469,46 +469,7 @@ export function DocumentToolbar({
                 ) : null}
               </div>
 
-              {/* Conflict banner */}
-              {hasConflict && (
-                <div className="px-4 py-2.5 border-b border-amber-500/30 bg-amber-500/10">
-                  <p className="text-[11px] text-amber-800 dark:text-amber-200 mb-2">
-                    Both sides changed since last sync.
-                  </p>
-                  <div className="flex gap-1.5">
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      className="flex-1 h-7 text-xs"
-                      onClick={() => handleResolve("pull")}
-                      disabled={isWorking}
-                    >
-                      {resolvingDirection === "pull" ? (
-                        <IconLoader2
-                          size={12}
-                          className="animate-spin mr-1.5"
-                        />
-                      ) : null}
-                      Use Notion
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      className="flex-1 h-7 text-xs"
-                      onClick={() => handleResolve("push")}
-                      disabled={isWorking}
-                    >
-                      {resolvingDirection === "push" ? (
-                        <IconLoader2
-                          size={12}
-                          className="animate-spin mr-1.5"
-                        />
-                      ) : null}
-                      Use local
-                    </Button>
-                  </div>
-                </div>
-              )}
+              {/* Conflict is shown via NotionConflictBanner above the title */}
 
               <div className="p-1.5">
                 <button

--- a/templates/content/app/components/editor/NotionConflictBanner.tsx
+++ b/templates/content/app/components/editor/NotionConflictBanner.tsx
@@ -42,47 +42,38 @@ export function NotionConflictBanner({
   const isWorking = resolveConflict.isPending;
 
   return (
-    <div className="shrink-0 border-b border-amber-500/40 bg-amber-100/80 dark:bg-amber-500/10">
-      <div className="flex flex-wrap items-center gap-3 px-4 py-2.5 sm:px-8 md:px-16">
-        <IconAlertTriangle
-          size={18}
-          className="shrink-0 text-amber-600 dark:text-amber-400"
-        />
-        <div className="mr-auto min-w-0">
-          <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
-            Notion sync paused — conflict detected
-          </p>
-          <p className="text-xs text-amber-800/80 dark:text-amber-200/80">
-            Both this document and the Notion page changed since the last sync.
-            Pick which version to keep.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button
-            size="sm"
-            variant="secondary"
-            className="bg-white text-amber-900 hover:bg-amber-50 border border-amber-300 dark:bg-amber-950/40 dark:text-amber-100 dark:hover:bg-amber-900/40 dark:border-amber-700"
-            onClick={() => handleResolve("pull")}
-            disabled={isWorking}
-          >
-            {direction === "pull" ? (
-              <IconLoader2 size={14} className="mr-1.5 animate-spin" />
-            ) : null}
-            Use Notion version
-          </Button>
-          <Button
-            size="sm"
-            className="bg-amber-600 text-white hover:bg-amber-700 dark:bg-amber-500 dark:hover:bg-amber-600"
-            onClick={() => handleResolve("push")}
-            disabled={isWorking}
-          >
-            {direction === "push" ? (
-              <IconLoader2 size={14} className="mr-1.5 animate-spin" />
-            ) : null}
-            Use local version
-          </Button>
-        </div>
-      </div>
+    <div className="shrink-0 flex items-center gap-2 px-4 py-1.5 border-b border-amber-500/40 bg-amber-100/80 dark:bg-amber-500/10 sm:px-8 md:px-16">
+      <IconAlertTriangle
+        size={14}
+        className="shrink-0 text-amber-600 dark:text-amber-400"
+      />
+      <span className="text-xs text-amber-900 dark:text-amber-100 mr-auto">
+        Notion sync conflict — both sides changed
+      </span>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-6 px-2 text-xs text-amber-900 hover:bg-amber-200/60 dark:text-amber-100 dark:hover:bg-amber-800/40"
+        onClick={() => handleResolve("pull")}
+        disabled={isWorking}
+      >
+        {direction === "pull" ? (
+          <IconLoader2 size={12} className="mr-1 animate-spin" />
+        ) : null}
+        Use Notion
+      </Button>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-6 px-2 text-xs text-amber-900 hover:bg-amber-200/60 dark:text-amber-100 dark:hover:bg-amber-800/40"
+        onClick={() => handleResolve("push")}
+        disabled={isWorking}
+      >
+        {direction === "push" ? (
+          <IconLoader2 size={12} className="mr-1 animate-spin" />
+        ) : null}
+        Use local
+      </Button>
     </div>
   );
 }

--- a/templates/macros/app/components/VoiceDictation.tsx
+++ b/templates/macros/app/components/VoiceDictation.tsx
@@ -66,6 +66,8 @@ export function VoiceDictation({ currentDate }: VoiceDictationProps) {
     (text: string) => {
       setState("processing");
       try {
+        // Open the agent sidebar now that the voice message is captured
+        window.dispatchEvent(new Event("agent-panel:open"));
         sendToAgent({ message: text, submit: true });
         // Timeout fallback: if sidebar is closed or event never fires,
         // don't leave the mic stuck in processing forever
@@ -95,9 +97,6 @@ export function VoiceDictation({ currentDate }: VoiceDictationProps) {
       } catch {}
       recognitionRef.current = null;
     }
-
-    // Open the agent sidebar so the user can see the response
-    window.dispatchEvent(new Event("agent-panel:open"));
 
     isProcessingRef.current = false;
     setState("listening");

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -207,7 +207,10 @@ async function resolveAccountEmail(
 /** Extract the logged-in user's email from the request session. */
 async function userEmail(event: H3Event): Promise<string> {
   const session = await getSession(event);
-  return session?.email ?? "local@localhost";
+  if (!session?.email) {
+    throw new Error("Unauthorized: no active session");
+  }
+  return session.email;
 }
 
 // ─── Settings defaults ──────────────────────────────────────────────────────

--- a/templates/mail/server/routes/api/attachments.get.ts
+++ b/templates/mail/server/routes/api/attachments.get.ts
@@ -63,7 +63,11 @@ async function getAccessToken(accountEmail: string): Promise<string | null> {
 
 export default defineEventHandler(async (event) => {
   const session = await getSession(event);
-  const userEmail = session?.email ?? "local@localhost";
+  if (!session?.email) {
+    setResponseStatus(event, 401);
+    return { error: "Unauthorized" };
+  }
+  const userEmail = session.email;
 
   if (!(await isConnected(userEmail))) {
     setResponseStatus(event, 404);


### PR DESCRIPTION
## Summary
- Slim the Notion sync conflict banner from a multi-line card to a single-line bar with compact ghost buttons
- Remove the duplicate conflict section from the Notion popover in DocumentToolbar (already handled by NotionConflictBanner above the title)
- Banner sits below the toolbar buttons and above the page icon/title per design

## Test plan
- [ ] Link a doc to Notion, make changes on both sides to trigger a conflict
- [ ] Verify the banner appears as a single-line amber bar with "Use Notion" / "Use local" buttons
- [ ] Verify resolving the conflict dismisses the banner
- [ ] Verify the Notion popover no longer shows its own conflict section

🤖 Generated with [Claude Code](https://claude.com/claude-code)