### PR TITLE
chore(desktop-app): bump version to 0.1.4

### DIFF
--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/desktop-app",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "main": "out/main/index.js",
   "productName": "Agent Native",


### PR DESCRIPTION
## Summary
- Bump desktop app version from 0.1.3 to 0.1.4

## Test plan
- [ ] Verify desktop app builds and launches