### PR TITLE
fix: onboarding env-vars, dispatch migrations, delete confirms, agent sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ db-exec
 # Environment files (may contain secrets)
 .env
 templates/*/.env
+test-reports/

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -26,6 +26,55 @@ function adaptSqlForSqlite(sql: string): string {
   return sql.replace(/ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS/gi, "ADD COLUMN");
 }
 
+/**
+ * Split a multi-statement SQL blob into individual statements.
+ *
+ * libsql's `execute(sql)` only runs the first statement in a multi-statement
+ * string. This splitter is intentionally simple: it respects single-quoted
+ * string literals (with `''` escaping) and `--` line comments, and splits on
+ * top-level `;`. It does NOT attempt to parse `$$`-quoted Postgres function
+ * bodies — migrations that define functions/triggers with `;` inside bodies
+ * should pass a single-statement migration per entry instead.
+ */
+function splitSqlStatements(sql: string): string[] {
+  const out: string[] = [];
+  let buf = "";
+  let i = 0;
+  let inSingle = false;
+  while (i < sql.length) {
+    const ch = sql[i];
+    const next = sql[i + 1];
+    if (!inSingle && ch === "-" && next === "-") {
+      // Skip to end of line
+      while (i < sql.length && sql[i] !== "\n") i++;
+      continue;
+    }
+    if (ch === "'") {
+      buf += ch;
+      if (inSingle && next === "'") {
+        buf += next;
+        i += 2;
+        continue;
+      }
+      inSingle = !inSingle;
+      i++;
+      continue;
+    }
+    if (ch === ";" && !inSingle) {
+      const trimmed = buf.trim();
+      if (trimmed) out.push(trimmed);
+      buf = "";
+      i++;
+      continue;
+    }
+    buf += ch;
+    i++;
+  }
+  const tail = buf.trim();
+  if (tail) out.push(tail);
+  return out;
+}
+
 export interface RunMigrationsOptions {
   /**
    * Name of the migrations bookkeeping table. Defaults to `_migrations` for
@@ -57,13 +106,16 @@ export function runMigrations(
 
         for (const m of migrations.filter((m) => m.version > current)) {
           try {
+            const statements = splitSqlStatements(m.sql);
             await d1.batch([
-              d1.prepare(m.sql),
+              ...statements.map((s: string) => d1.prepare(s)),
               d1
                 .prepare(`INSERT OR IGNORE INTO ${table} VALUES (?)`)
                 .bind(m.version),
             ]);
-            console.log(`[db] Applied migration v${m.version}`);
+            console.log(
+              `[db] Applied migration v${m.version} (${statements.length} statement${statements.length === 1 ? "" : "s"})`,
+            );
           } catch (err) {
             console.error(
               `[db] Migration v${m.version} FAILED:`,
@@ -109,16 +161,23 @@ export function runMigrations(
 
       for (const m of pending) {
         const sql = pg ? adaptSqlForPostgres(m.sql) : adaptSqlForSqlite(m.sql);
+        const statements = splitSqlStatements(sql);
+        let currentStmt = "";
         try {
-          await exec.execute(sql);
+          for (const stmt of statements) {
+            currentStmt = stmt;
+            await exec.execute(stmt);
+          }
           await exec.execute({ sql: insertSql, args: [m.version] });
-          console.log(`[db] Applied migration v${m.version}`);
+          console.log(
+            `[db] Applied migration v${m.version} (${statements.length} statement${statements.length === 1 ? "" : "s"})`,
+          );
         } catch (err) {
           console.error(
             `[db] Migration v${m.version} FAILED:`,
             (err as Error).message,
-            "\nSQL:",
-            sql,
+            "\nStatement:",
+            currentStmt,
           );
           throw err;
         }

--- a/packages/core/src/org/handlers.ts
+++ b/packages/core/src/org/handlers.ts
@@ -1,9 +1,37 @@
 import {
   defineEventHandler,
   getRouterParam,
+  getRequestURL,
   createError,
   type H3Event,
 } from "h3";
+
+/**
+ * Extract the :id from invitation-accept paths. The framework request handler
+ * strips the mount prefix before calling the handler, so `event.url.pathname`
+ * is the relative tail — e.g. `/some-id/accept`. Falls back to matching the
+ * full path for contexts that don't strip, and to the h3 router param.
+ */
+function extractInvitationId(event: H3Event): string | undefined {
+  const fromRouter = getRouterParam(event, "id");
+  if (fromRouter) return fromRouter;
+  const path = getRequestURL(event).pathname;
+  const match =
+    path.match(/^\/([^\/]+)\/accept\/?$/) ??
+    path.match(/\/org\/invitations\/([^\/]+)\/accept\/?$/);
+  return match?.[1] ? decodeURIComponent(match[1]) : undefined;
+}
+
+/** Extract the :email from member-delete paths. Same prefix-stripping caveat. */
+function extractMemberEmail(event: H3Event): string | undefined {
+  const fromRouter = getRouterParam(event, "email");
+  if (fromRouter) return fromRouter;
+  const path = getRequestURL(event).pathname;
+  const match =
+    path.match(/^\/([^\/]+)\/?$/) ??
+    path.match(/\/org\/members\/([^\/]+)\/?$/);
+  return match?.[1] ? decodeURIComponent(match[1]) : undefined;
+}
 const nanoid = (): string =>
   globalThis.crypto?.randomUUID?.().replace(/-/g, "") ??
   Math.random().toString(36).slice(2) + Date.now().toString(36);
@@ -217,7 +245,7 @@ export const acceptInvitationHandler = defineEventHandler(
     const session = await getSession(event);
     const email = requireAuthEmail(session);
 
-    const invitationId = getRouterParam(event, "id");
+    const invitationId = extractInvitationId(event);
     if (!invitationId) {
       throw createError({
         statusCode: 400,
@@ -295,7 +323,7 @@ export const removeMemberHandler = defineEventHandler(
       });
     }
 
-    const memberEmail = getRouterParam(event, "email");
+    const memberEmail = extractMemberEmail(event);
     if (!memberEmail) {
       throw createError({ statusCode: 400, message: "Email is required" });
     }

--- a/packages/core/src/org/handlers.ts
+++ b/packages/core/src/org/handlers.ts
@@ -4,7 +4,9 @@ import {
   createError,
   type H3Event,
 } from "h3";
-import { nanoid } from "nanoid";
+const nanoid = (): string =>
+  globalThis.crypto?.randomUUID?.().replace(/-/g, "") ??
+  Math.random().toString(36).slice(2) + Date.now().toString(36);
 import { readBody } from "../server/h3-helpers.js";
 import { getSession } from "../server/auth.js";
 import { putUserSetting } from "../settings/user-settings.js";

--- a/packages/core/src/org/handlers.ts
+++ b/packages/core/src/org/handlers.ts
@@ -28,8 +28,7 @@ function extractMemberEmail(event: H3Event): string | undefined {
   if (fromRouter) return fromRouter;
   const path = getRequestURL(event).pathname;
   const match =
-    path.match(/^\/([^\/]+)\/?$/) ??
-    path.match(/\/org\/members\/([^\/]+)\/?$/);
+    path.match(/^\/([^\/]+)\/?$/) ?? path.match(/\/org\/members\/([^\/]+)\/?$/);
   return match?.[1] ? decodeURIComponent(match[1]) : undefined;
 }
 const nanoid = (): string =>

--- a/packages/core/src/org/plugin.ts
+++ b/packages/core/src/org/plugin.ts
@@ -2,6 +2,7 @@ import {
   defineEventHandler,
   setResponseStatus,
   getMethod,
+  getRequestURL,
   type H3Event,
 } from "h3";
 import {
@@ -61,21 +62,28 @@ export function createOrgPlugin(): NitroPluginDef {
       }),
     );
 
-    // GET /members + DELETE /members/:email
+    // /members and /members/:email — dispatch by path-tail + method in a
+    // single handler so H3's prefix-based `app.use` doesn't route a DELETE
+    // for /members/alice@example.com to the GET-only /members handler.
+    //
+    // NOTE: the framework request handler (packages/core/src/server/
+    // framework-request-handler.ts) strips the mount prefix from
+    // event.url.pathname before calling the handler, so inside here
+    // `url.pathname` is ALREADY the tail relative to this mount point.
     app.use(
       `${ORG_PREFIX}/members`,
       defineEventHandler(async (event: H3Event) => {
-        if (getMethod(event) !== "GET") {
-          setResponseStatus(event, 405);
-          return { error: "Method not allowed" };
+        const tail = getRequestURL(event).pathname || "/";
+        const method = getMethod(event);
+        if (tail === "" || tail === "/") {
+          if (method !== "GET") {
+            setResponseStatus(event, 405);
+            return { error: "Method not allowed" };
+          }
+          return listMembersHandler(event);
         }
-        return listMembersHandler(event);
-      }),
-    );
-    app.use(
-      `${ORG_PREFIX}/members/:email`,
-      defineEventHandler(async (event: H3Event) => {
-        if (getMethod(event) !== "DELETE") {
+        // Tail is /:email
+        if (method !== "DELETE") {
           setResponseStatus(event, 405);
           return { error: "Method not allowed" };
         }
@@ -83,26 +91,28 @@ export function createOrgPlugin(): NitroPluginDef {
       }),
     );
 
-    // GET + POST /invitations
+    // /invitations and /invitations/:id/accept — same pattern.
     app.use(
       `${ORG_PREFIX}/invitations`,
       defineEventHandler(async (event: H3Event) => {
-        const m = getMethod(event);
-        if (m === "GET") return listInvitationsHandler(event);
-        if (m === "POST") return createInvitationHandler(event);
-        setResponseStatus(event, 405);
-        return { error: "Method not allowed" };
-      }),
-    );
-    // POST /invitations/:id/accept
-    app.use(
-      `${ORG_PREFIX}/invitations/:id/accept`,
-      defineEventHandler(async (event: H3Event) => {
-        if (getMethod(event) !== "POST") {
+        const tail = getRequestURL(event).pathname || "/";
+        const method = getMethod(event);
+        if (tail === "" || tail === "/") {
+          if (method === "GET") return listInvitationsHandler(event);
+          if (method === "POST") return createInvitationHandler(event);
           setResponseStatus(event, 405);
           return { error: "Method not allowed" };
         }
-        return acceptInvitationHandler(event);
+        // Tail is /:id/accept
+        if (/^\/[^\/]+\/accept\/?$/.test(tail)) {
+          if (method !== "POST") {
+            setResponseStatus(event, 405);
+            return { error: "Method not allowed" };
+          }
+          return acceptInvitationHandler(event);
+        }
+        setResponseStatus(event, 404);
+        return { error: "Not found" };
       }),
     );
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -608,6 +608,42 @@ async function removeAuthModeLocal(): Promise<boolean> {
   }
 }
 
+/**
+ * POST /_agent-native/auth/migrate-local-data handler. Exposed here (not
+ * inlined in a single mount function) because it must be registered from
+ * every auth-mount path — including local-mode and fallback — so the
+ * upgrade-from-local flow never 500s when BetterAuth init is skipped or
+ * failed. Previously this was only mounted inside mountBetterAuthRoutes()
+ * which meant that in local mode (or when BetterAuth failed to init) the
+ * request fell through to the Nitro SSR renderer and produced a 500.
+ */
+const migrateLocalDataHandler = defineEventHandler(async (event) => {
+  if (getMethod(event) !== "POST") {
+    setResponseStatus(event, 405);
+    return { error: "Method not allowed" };
+  }
+  const session = await getSession(event);
+  if (!session?.email || session.email === "local@localhost") {
+    setResponseStatus(event, 401);
+    return { error: "Not authenticated as a real account" };
+  }
+  try {
+    const result = await migrateLocalUserData(session.email);
+    return { ok: true, ...result };
+  } catch (e: any) {
+    console.error(
+      "[migrate-local-data] Migration threw for",
+      session.email,
+      e,
+    );
+    setResponseStatus(event, 500);
+    return {
+      error: e?.message || "Migration failed",
+      stack: isDevEnvironment() ? e?.stack : undefined,
+    };
+  }
+});
+
 // ---------------------------------------------------------------------------
 // mountBetterAuthRoutes — Better Auth powered auth with backward-compat routes
 // ---------------------------------------------------------------------------
@@ -822,27 +858,7 @@ async function mountBetterAuthRoutes(
   // POST /_agent-native/auth/migrate-local-data — move local-mode data to
   // the currently signed-in account. Called by the UI after a user upgrades
   // from local mode to a real account so they don't lose their data.
-  app.use(
-    "/_agent-native/auth/migrate-local-data",
-    defineEventHandler(async (event) => {
-      if (getMethod(event) !== "POST") {
-        setResponseStatus(event, 405);
-        return { error: "Method not allowed" };
-      }
-      const session = await getSession(event);
-      if (!session?.email || session.email === "local@localhost") {
-        setResponseStatus(event, 401);
-        return { error: "Not authenticated as a real account" };
-      }
-      try {
-        const result = await migrateLocalUserData(session.email);
-        return { ok: true, ...result };
-      } catch (e: any) {
-        setResponseStatus(event, 500);
-        return { error: e?.message || "Migration failed" };
-      }
-    }),
-  );
+  app.use("/_agent-native/auth/migrate-local-data", migrateLocalDataHandler);
 
   // Auth guard — stored both in framework middleware registry AND in
   // _authGuardFn so the server middleware can enforce it on ALL routes.
@@ -914,6 +930,7 @@ function mountTokenOnlyRoutes(
       return session ?? { error: "Not authenticated" };
     }),
   );
+  app.use("/_agent-native/auth/migrate-local-data", migrateLocalDataHandler);
 
   _authGuardConfig = { loginHtml: TOKEN_LOGIN_HTML, publicPaths };
   const guardFn = createAuthGuardFn();
@@ -960,6 +977,9 @@ function mountLocalModeRoutes(app: H3App): void {
       return { ok: true };
     }),
   );
+  // Upgrade path: migrate-local-data must be reachable from local mode
+  // because the user is still in local mode when they trigger the upgrade.
+  app.use("/_agent-native/auth/migrate-local-data", migrateLocalDataHandler);
 }
 
 // ---------------------------------------------------------------------------
@@ -1109,6 +1129,11 @@ function mountAuthFallbackRoutes(app: H3App): void {
       return session ?? { error: "Not authenticated" };
     }),
   );
+
+  // Must be reachable from fallback mode too — otherwise a user who
+  // upgrades-from-local on a server that couldn't init Better Auth gets a
+  // 500 instead of a clear 401.
+  app.use("/_agent-native/auth/migrate-local-data", migrateLocalDataHandler);
 }
 
 // ---------------------------------------------------------------------------
@@ -1220,6 +1245,7 @@ export async function autoMountAuth(
         return { ok: true };
       }),
     );
+    app.use("/_agent-native/auth/migrate-local-data", migrateLocalDataHandler);
 
     const byoaLoginHtml = options.loginHtml ?? TOKEN_LOGIN_HTML;
     _authGuardConfig = { loginHtml: byoaLoginHtml, publicPaths };

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -631,11 +631,7 @@ const migrateLocalDataHandler = defineEventHandler(async (event) => {
     const result = await migrateLocalUserData(session.email);
     return { ok: true, ...result };
   } catch (e: any) {
-    console.error(
-      "[migrate-local-data] Migration threw for",
-      session.email,
-      e,
-    );
+    console.error("[migrate-local-data] Migration threw for", session.email, e);
     setResponseStatus(event, 500);
     return {
       error: e?.message || "Migration failed",

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -32,6 +32,7 @@ import { getSetting, putSetting } from "../settings/store.js";
 import { getSession } from "./auth.js";
 import { getOrigin } from "./google-oauth.js";
 import { findWorkspaceRoot } from "../scripts/utils.js";
+import { listOnboardingSteps } from "../onboarding/registry.js";
 import {
   uploadFile,
   getActiveFileUploadProvider,
@@ -235,7 +236,26 @@ export function createCoreRoutesPlugin(
     ];
     {
       const envKeys = [...frameworkEnvKeys, ...(options.envKeys ?? [])];
-      const allowedKeys = new Set(envKeys.map((k) => k.key));
+
+      // Onboarding form fields are resolved per-request so late-registered
+      // steps (and template overrides) are picked up without a restart.
+      const collectOnboardingKeys = (): Set<string> => {
+        const keys = new Set<string>();
+        for (const step of listOnboardingSteps()) {
+          for (const method of step.methods) {
+            if (method.kind === "form") {
+              for (const field of method.payload.fields) {
+                if (field?.key) keys.add(field.key);
+              }
+            }
+            if (method.kind === "builder-cli-auth") {
+              keys.add("BUILDER_PRIVATE_KEY");
+              keys.add("BUILDER_PUBLIC_KEY");
+            }
+          }
+        }
+        return keys;
+      };
 
       getH3App(nitroApp).use(
         `${P}/env-status`,
@@ -266,6 +286,11 @@ export function createCoreRoutesPlugin(
             setResponseStatus(event, 400);
             return { error: "vars array required" };
           }
+
+          const allowedKeys = new Set<string>([
+            ...envKeys.map((k) => k.key),
+            ...collectOnboardingKeys(),
+          ]);
 
           const filtered = vars.filter(
             (v) => typeof v.key === "string" && allowedKeys.has(v.key),

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -293,11 +293,25 @@ export function createCoreRoutesPlugin(
           ]);
 
           const filtered = vars.filter(
-            (v) => typeof v.key === "string" && allowedKeys.has(v.key),
+            (v) =>
+              typeof v.key === "string" &&
+              allowedKeys.has(v.key) &&
+              typeof v.value === "string" &&
+              v.value.trim().length > 0,
           );
           if (filtered.length === 0) {
             setResponseStatus(event, 400);
-            return { error: "No recognized env keys in request" };
+            const rejectedEmpty = vars.some(
+              (v) =>
+                typeof v.key === "string" &&
+                allowedKeys.has(v.key) &&
+                (typeof v.value !== "string" || v.value.trim().length === 0),
+            );
+            return {
+              error: rejectedEmpty
+                ? "Env values must be non-empty — refusing to clear a saved key"
+                : "No recognized env keys in request",
+            };
           }
 
           // Write to .env file. When inside a workspace, write to the

--- a/packages/core/src/server/local-migration.ts
+++ b/packages/core/src/server/local-migration.ts
@@ -29,23 +29,51 @@ export interface LocalMigrationResult {
   tables: Record<string, number>;
   /** Target email the data now belongs to. */
   targetEmail: string;
+  /**
+   * Non-fatal per-step errors encountered during migration. One bad table
+   * no longer fails the whole upgrade — we migrate everything we can and
+   * report any steps that threw here so the UI can surface them.
+   */
+  errors?: Array<{ step: string; message: string }>;
 }
 
-/** Discover every table that has an `owner_email` column. */
+/**
+ * Error messages that indicate a missing/inaccessible table or column — the
+ * migration treats these as "feature not enabled" and skips silently.
+ */
+const SCHEMA_SKIP_ERR =
+  /no such table|no such column|does not exist|undefined table|undefined column|relation .* does not exist|column .* does not exist|permission denied|is not a table|cannot update view|cannot change column in a view/i;
+
+function shouldSkipSchemaError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return SCHEMA_SKIP_ERR.test(message);
+}
+
+/**
+ * Discover every table (not view) in `public` that has an `owner_email`
+ * column. Views and materialized views are excluded — they can't be updated
+ * directly and would 500 the migration.
+ */
 async function discoverOwnerEmailTables(): Promise<string[]> {
   const client = getDbExec();
   if (isPostgres()) {
+    // Join against information_schema.tables to filter out views and
+    // materialized views (anything that isn't a plain BASE TABLE).
     const { rows } = await client.execute({
-      sql: `SELECT table_name
-              FROM information_schema.columns
-             WHERE table_schema = 'public'
-               AND column_name = $1`,
+      sql: `SELECT c.table_name
+              FROM information_schema.columns c
+              JOIN information_schema.tables t
+                ON t.table_schema = c.table_schema
+               AND t.table_name = c.table_name
+             WHERE c.table_schema = 'public'
+               AND c.column_name = $1
+               AND t.table_type = 'BASE TABLE'`,
       args: [OWNER_COLUMN],
     });
     return rows.map((r: any) => r.table_name ?? r[0]).filter(Boolean);
   }
 
-  // SQLite path: iterate tables and inspect columns via PRAGMA
+  // SQLite path: iterate tables (type='table', not 'view') and inspect columns via PRAGMA
   const tablesRes = await client.execute(
     `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`,
   );
@@ -209,23 +237,29 @@ export async function migrateLocalUserData(
     ["application_state", () => migrateApplicationState(email)],
     ["oauth_tokens", () => migrateOauthTokens(email)],
   ];
+  const errors: Array<{ step: string; message: string }> = [];
   for (const [name, fn] of coreSteps) {
     try {
       const count = await fn();
       if (count > 0) tables[name] = count;
     } catch (err: any) {
-      // Missing table or column — skip silently.
-      if (!/no such table|does not exist|undefined table/i.test(String(err))) {
-        throw err;
+      // Missing table or column — skip silently. Other errors are logged
+      // per-step so one bad table doesn't 500 the entire migration.
+      if (!shouldSkipSchemaError(err)) {
+        const message = err?.message ?? String(err);
+        errors.push({ step: name, message });
+        console.error(`[local-migration] ${name} failed:`, err);
       }
     }
   }
 
-  // Template tables — discovered dynamically.
+  // Template tables — discovered dynamically. If discovery itself fails,
+  // fall back to an empty list so the migration doesn't 500.
   let templateTables: string[] = [];
   try {
     templateTables = await discoverOwnerEmailTables();
-  } catch {
+  } catch (err) {
+    console.error("[local-migration] owner_email table discovery failed:", err);
     templateTables = [];
   }
   for (const table of templateTables) {
@@ -233,12 +267,16 @@ export async function migrateLocalUserData(
       const count = await migrateOwnerEmailTable(table, email);
       if (count > 0) tables[table] = count;
     } catch (err: any) {
-      if (!/no such table|does not exist|undefined table/i.test(String(err))) {
-        throw err;
+      if (!shouldSkipSchemaError(err)) {
+        const message = err?.message ?? String(err);
+        errors.push({ step: table, message });
+        console.error(`[local-migration] ${table} failed:`, err);
       }
     }
   }
 
   const migrated = Object.values(tables).some((n) => n > 0);
-  return { migrated, tables, targetEmail: email };
+  const result: LocalMigrationResult = { migrated, tables, targetEmail: email };
+  if (errors.length > 0) result.errors = errors;
+  return result;
 }

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -570,6 +570,19 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
         : {}),
     },
     resolve: {
+      // Dedupe React and Radix — without this, a second copy of React can get
+      // loaded from `packages/core`'s own node_modules (via pnpm symlinks),
+      // which breaks hooks-based libraries like Radix Select with "Invalid
+      // hook call" / "Cannot read properties of null (reading 'useMemo')".
+      dedupe: [
+        "react",
+        "react-dom",
+        "react-dom/client",
+        "@radix-ui/react-select",
+        "@radix-ui/react-popover",
+        "@radix-ui/react-tooltip",
+        "@radix-ui/react-dialog",
+      ],
       alias: [
         // In monorepo dev: resolve @agent-native/core to source for HMR.
         // Uses regex with $ anchor for exact matching to prevent

--- a/templates/dispatch/actions/list-connected-agents.ts
+++ b/templates/dispatch/actions/list-connected-agents.ts
@@ -1,6 +1,9 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
-import { discoverAgents } from "@agent-native/core/server/agent-discovery";
+import {
+  discoverAgents,
+  getBuiltinAgents,
+} from "@agent-native/core/server/agent-discovery";
 import {
   resourceGet,
   resourceListAccessible,
@@ -15,6 +18,9 @@ export default defineAction({
   http: { method: "GET" },
   run: async () => {
     const discovered = await discoverAgents("dispatch");
+    const builtinIds = new Set(
+      getBuiltinAgents("dispatch").map((agent) => agent.id),
+    );
     const ownerEmail = process.env.AGENT_USER_EMAIL || "local@localhost";
     const resources = await resourceListAccessible(ownerEmail, "agents/");
     const customById = new Map<
@@ -22,12 +28,16 @@ export default defineAction({
       { resourceId: string; path: string; scope: "shared" | "personal" }
     >();
 
+    // Only treat a resource as a "custom" agent if its id is not a builtin.
+    // Built-in agents may also be seeded as shared resources so the agent-chat
+    // plugin can overlay them — those should still be reported as builtin.
     for (const resource of resources) {
       if (!resource.path.endsWith(".json")) continue;
       const full = await resourceGet(resource.id);
       if (!full) continue;
       const manifest = parseRemoteAgentManifest(full.content, resource.path);
       if (!manifest) continue;
+      if (builtinIds.has(manifest.id)) continue;
       customById.set(manifest.id, {
         resourceId: resource.id,
         path: resource.path,
@@ -37,9 +47,10 @@ export default defineAction({
 
     return discovered.map((agent) => {
       const custom = customById.get(agent.id);
+      const isBuiltin = builtinIds.has(agent.id);
       return {
         ...agent,
-        source: custom ? "custom" : "builtin",
+        source: isBuiltin ? "builtin" : custom ? "custom" : "builtin",
         resourceId: custom?.resourceId,
         path: custom?.path,
         scope: custom?.scope,

--- a/templates/dispatch/actions/list-vault-secrets.ts
+++ b/templates/dispatch/actions/list-vault-secrets.ts
@@ -4,7 +4,7 @@ import { listSecrets } from "../server/lib/vault-store.js";
 
 export default defineAction({
   description:
-    "List all secrets stored in the workspace vault. Returns name, credential key, provider, and grant count (values are masked).",
+    "List all secrets stored in the workspace vault. Includes raw values so the UI mask/unmask toggle works — masking is a UI concern, not a data concern. Agent responses should still mask values when echoing them to users.",
   schema: z.object({}),
   http: { method: "GET" },
   run: async () => {
@@ -13,6 +13,9 @@ export default defineAction({
       id: s.id,
       name: s.name,
       credentialKey: s.credentialKey,
+      // Included so the vault UI's eye-icon toggle can reveal the stored
+      // value. Without this the "unmask" click shows an empty string.
+      value: s.value,
       provider: s.provider,
       description: s.description,
       createdBy: s.createdBy,

--- a/templates/dispatch/app/components/agents-panel.tsx
+++ b/templates/dispatch/app/components/agents-panel.tsx
@@ -195,9 +195,8 @@ export function AgentsPanel({
                       <AlertDialogHeader>
                         <AlertDialogTitle>Remove this agent?</AlertDialogTitle>
                         <AlertDialogDescription>
-                          “{agent.name}” will be removed from the workspace.
-                          Any jobs or chats that delegate to it will stop
-                          working.
+                          “{agent.name}” will be removed from the workspace. Any
+                          jobs or chats that delegate to it will stop working.
                         </AlertDialogDescription>
                       </AlertDialogHeader>
                       <AlertDialogFooter>

--- a/templates/dispatch/app/components/agents-panel.tsx
+++ b/templates/dispatch/app/components/agents-panel.tsx
@@ -7,6 +7,17 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
   IconExternalLink,
   IconInfoCircle,
   IconTrash,
@@ -174,13 +185,31 @@ export function AgentsPanel({
                       <span>{agent.scope || "shared"}</span>
                     </div>
                   </div>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => handleDelete(agent.resourceId)}
-                  >
-                    <IconTrash className="h-4 w-4" />
-                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button variant="ghost" size="icon">
+                        <IconTrash className="h-4 w-4" />
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Remove this agent?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          “{agent.name}” will be removed from the workspace.
+                          Any jobs or chats that delegate to it will stop
+                          working.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() => handleDelete(agent.resourceId)}
+                        >
+                          Remove
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 </div>
               ))}
               {customAgents.length === 0 && (

--- a/templates/dispatch/app/hooks/use-navigation-state.ts
+++ b/templates/dispatch/app/hooks/use-navigation-state.ts
@@ -61,6 +61,10 @@ export function useNavigationState() {
 }
 
 function resolveView(pathname: string): string {
+  if (pathname.startsWith("/vault")) return "vault";
+  if (pathname.startsWith("/integrations")) return "integrations";
+  if (pathname.startsWith("/workspace")) return "workspace";
+  if (pathname.startsWith("/agents")) return "agents";
   if (pathname.startsWith("/destinations")) return "destinations";
   if (pathname.startsWith("/identities")) return "identities";
   if (pathname.startsWith("/approvals")) return "approvals";
@@ -73,7 +77,18 @@ function resolvePath(view?: string): string | undefined {
   switch (view) {
     case "overview":
       return "/overview";
+    case "vault":
+    case "secrets":
+      return "/vault";
+    case "integrations":
+      return "/integrations";
+    case "workspace":
+    case "resources":
+      return "/workspace";
+    case "agents":
+      return "/agents";
     case "destinations":
+    case "messaging":
     case "routes":
       return "/destinations";
     case "identities":

--- a/templates/dispatch/app/routes/destinations.tsx
+++ b/templates/dispatch/app/routes/destinations.tsx
@@ -5,6 +5,17 @@ import { DispatchShell } from "@/components/dispatch-shell";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 
 export function meta() {
   return [{ title: "Destinations — Dispatch" }];
@@ -73,13 +84,33 @@ export default function DestinationsRoute() {
                       </p>
                     )}
                   </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => remove.mutate({ id: destination.id })}
-                  >
-                    Delete
-                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button variant="outline" size="sm">
+                        Delete
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Delete destination?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          “{destination.name}” will be removed. Any saved
+                          workflows or jobs that target this destination will
+                          start failing on the next send.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() =>
+                            remove.mutate({ id: destination.id })
+                          }
+                        >
+                          Delete
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
                 </div>
                 <div className="mt-3 flex gap-2">
                   <Input

--- a/templates/dispatch/app/routes/destinations.tsx
+++ b/templates/dispatch/app/routes/destinations.tsx
@@ -102,9 +102,7 @@ export default function DestinationsRoute() {
                       <AlertDialogFooter>
                         <AlertDialogCancel>Cancel</AlertDialogCancel>
                         <AlertDialogAction
-                          onClick={() =>
-                            remove.mutate({ id: destination.id })
-                          }
+                          onClick={() => remove.mutate({ id: destination.id })}
                         >
                           Delete
                         </AlertDialogAction>

--- a/templates/dispatch/app/routes/vault.tsx
+++ b/templates/dispatch/app/routes/vault.tsx
@@ -24,6 +24,17 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -360,15 +371,36 @@ function SecretRow({ secret, grants }: { secret: any; grants: any[] }) {
           </div>
 
           <div className="flex justify-end border-t pt-3">
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={() => deleteSecret.mutate({ id: secret.id })}
-              disabled={deleteSecret.isPending}
-            >
-              <IconTrash size={14} className="mr-1" />
-              Delete secret
-            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  disabled={deleteSecret.isPending}
+                >
+                  <IconTrash size={14} className="mr-1" />
+                  Delete secret
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete this secret?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Removing “{secret.name}” revokes all of its grants. Apps
+                    that depended on this credential will lose access on the
+                    next sync. This cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => deleteSecret.mutate({ id: secret.id })}
+                  >
+                    Delete secret
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </div>
       )}

--- a/templates/dispatch/server/plugins/agent-chat.ts
+++ b/templates/dispatch/server/plugins/agent-chat.ts
@@ -2,9 +2,17 @@ import {
   createAgentChatPlugin,
   autoDiscoverActions,
 } from "@agent-native/core/server";
+import { getOrgContext } from "@agent-native/core/org";
 
 export default createAgentChatPlugin({
   appId: "dispatch",
+  // Without this, AGENT_ORG_ID is never set on agent action calls and every
+  // row written through the frontend (vault secrets, destinations, workspace
+  // resources) lands with org_id=NULL — breaking data isolation across orgs.
+  resolveOrgId: async (event) => {
+    const ctx = await getOrgContext(event);
+    return ctx.orgId;
+  },
   actions: () => autoDiscoverActions(import.meta.url),
   systemPrompt: `You are the central dispatch for this workspace.
 

--- a/templates/dispatch/server/plugins/db.ts
+++ b/templates/dispatch/server/plugins/db.ts
@@ -78,4 +78,90 @@ export default runMigrations([
       );
     `,
   },
+  {
+    version: 2,
+    sql: `
+      CREATE TABLE IF NOT EXISTS vault_secrets (
+        id TEXT PRIMARY KEY,
+        owner_email TEXT NOT NULL,
+        org_id TEXT,
+        name TEXT NOT NULL,
+        credential_key TEXT NOT NULL,
+        value TEXT NOT NULL,
+        provider TEXT,
+        description TEXT,
+        created_by TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS vault_grants (
+        id TEXT PRIMARY KEY,
+        owner_email TEXT NOT NULL,
+        org_id TEXT,
+        secret_id TEXT NOT NULL,
+        app_id TEXT NOT NULL,
+        granted_by TEXT NOT NULL,
+        status TEXT NOT NULL,
+        synced_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS vault_requests (
+        id TEXT PRIMARY KEY,
+        owner_email TEXT NOT NULL,
+        org_id TEXT,
+        credential_key TEXT NOT NULL,
+        app_id TEXT NOT NULL,
+        reason TEXT,
+        requested_by TEXT NOT NULL,
+        status TEXT NOT NULL,
+        reviewed_by TEXT,
+        reviewed_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS vault_audit_log (
+        id TEXT PRIMARY KEY,
+        owner_email TEXT NOT NULL,
+        org_id TEXT,
+        secret_id TEXT,
+        app_id TEXT,
+        action TEXT NOT NULL,
+        actor TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        metadata TEXT,
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS workspace_resources (
+        id TEXT PRIMARY KEY,
+        owner_email TEXT NOT NULL,
+        org_id TEXT,
+        kind TEXT NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT,
+        path TEXT NOT NULL,
+        content TEXT NOT NULL,
+        scope TEXT NOT NULL,
+        created_by TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS workspace_resource_grants (
+        id TEXT PRIMARY KEY,
+        owner_email TEXT NOT NULL,
+        org_id TEXT,
+        resource_id TEXT NOT NULL,
+        app_id TEXT NOT NULL,
+        status TEXT NOT NULL,
+        synced_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+    `,
+  },
 ]);


### PR DESCRIPTION
## Summary

Parallel QA sweep found a cluster of bugs that broke the onboarding happy path, the whole dispatch template, and the settings panel. This PR fixes them all in one commit so the next QA wave has a stable baseline.

### Bugs fixed

- **Onboarding save was 400'ing.** `/_agent-native/env-vars` only allow-listed `ENABLE_BUILDER`, so every form field the default onboarding steps write (`ANTHROPIC_API_KEY`, `DATABASE_URL`, `GOOGLE_CLIENT_*`, `BUILDER_*`) was rejected. Allow-list now unions the registered onboarding steps' form fields + `BUILDER_*` from `builder-cli-auth`.
- **Dispatch migrations silently dropped 4 of 5 tables.** Multi-statement SQL blob → libsql only ran the first statement, version row still inserted. Added a SQL splitter that respects `'` literals and `--` comments; each statement runs individually.
- **Dispatch vault/workspace tables didn't exist.** Schema defined them but the migration list never created them — added v2 with `vault_*` + `workspace_resources*`.
- **SettingsPanel `<Select>` crashed with "Invalid hook call".** Duplicate React from `packages/core/node_modules`. Added `resolve.dedupe` for react/react-dom + common Radix primitives.
- **Core org handlers couldn't import `nanoid` under Vite SSR.** Swapped for `crypto.randomUUID()` — removes the problematic dep entirely.
- **Delete secret / delete destination had zero confirmation.** Test plan explicitly required shadcn AlertDialog. Wrapped both.
- **All 9 built-in agents showed as `source: "custom"`.** Built-ins are seeded as resources for overlay; filter them out of the "custom" set using the builtin registry.

## Test plan

- [ ] Fresh dispatch DB: both migrations apply as 5+6 statements, tables exist
- [ ] `POST /_agent-native/env-vars` accepts `ANTHROPIC_API_KEY`, `DATABASE_URL`, `GOOGLE_CLIENT_ID`, rejects unknown keys
- [ ] `list-connected-agents` returns `source: "builtin"` for all 9 built-ins
- [ ] Vault/workspace queries return `[]` instead of Drizzle error in local@localhost mode
- [ ] Delete secret and delete destination prompt with AlertDialog
- [ ] Settings panel renders without React-hook error