### PR TITLE
fix(desktop-app): isolate app webviews with persist partitions

### DIFF
--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -940,10 +940,11 @@ export function AgentPanel({
             ".agent-tab-close{opacity:0}.agent-tab:hover .agent-tab-close{opacity:1}",
         }}
       />
-      {/* Framework onboarding — appears above the chat when setup is
-          incomplete. The panel hides itself once all required steps are
-          done or the user dismisses it. */}
-      {mounted && mode === "chat" && (
+      {/* Framework onboarding — appears above the chat/cli/settings tabs
+          so it's visible regardless of which tab the user is on. The panel
+          hides itself once all required steps are done or the user
+          dismisses it. */}
+      {mounted && (
         <Suspense fallback={null}>
           <OnboardingPanel />
         </Suspense>

--- a/packages/core/src/client/onboarding/OnboardingPanel.tsx
+++ b/packages/core/src/client/onboarding/OnboardingPanel.tsx
@@ -54,6 +54,9 @@ export function OnboardingPanel({
 
   if (loading || totalCount === 0) return null;
   if (dismissed) return null;
+  // Auto-hide once every required step is done — no need to take up sidebar
+  // space when there's nothing left to do.
+  if (allComplete) return null;
 
   if (!expanded) {
     return (

--- a/packages/core/src/client/use-dev-mode.ts
+++ b/packages/core/src/client/use-dev-mode.ts
@@ -14,6 +14,12 @@ function notifyListeners(state: DevModeState) {
   listeners.forEach((fn) => fn(state));
 }
 
+function isLocalhostHostname(): boolean {
+  if (typeof window === "undefined") return false;
+  const h = window.location.hostname;
+  return h === "localhost" || h === "127.0.0.1" || h === "::1";
+}
+
 function fetchDevMode(apiBase: string): Promise<DevModeState> {
   if (!fetchPromise) {
     fetchPromise = fetch(`${apiBase}/mode`)
@@ -26,7 +32,16 @@ function fetchDevMode(apiBase: string): Promise<DevModeState> {
         return cached;
       })
       .catch(() => {
-        cached = { devMode: false, canToggle: false };
+        // If the server isn't reachable (503 during boot, connection refused,
+        // etc.) but we're clearly on localhost, assume dev mode so the CLI
+        // tab and dev toggle still work. Without this, a transient server
+        // error permanently disables dev features in the sidebar.
+        cached = isLocalhostHostname()
+          ? { devMode: true, canToggle: true }
+          : { devMode: false, canToggle: false };
+        // Null the in-flight promise so the next call retries the fetch
+        // and we can pick up the real answer once the server is back.
+        fetchPromise = null;
         return cached;
       });
   }

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -28,7 +28,7 @@ export async function getOrgContext(event: H3Event): Promise<OrgContext> {
   }> = [];
   try {
     const { rows } = await exec.execute({
-      sql: `SELECT m.org_id AS orgId, m.role AS role, o.name AS orgName
+      sql: `SELECT m.org_id AS "orgId", m.role AS role, o.name AS "orgName"
             FROM org_members m
             INNER JOIN organizations o ON m.org_id = o.id
             WHERE m.email = ?`,

--- a/packages/core/src/org/handlers.ts
+++ b/packages/core/src/org/handlers.ts
@@ -70,7 +70,7 @@ export const getMyOrgHandler = defineEventHandler(async (event: H3Event) => {
 
   const e = await exec();
   const allOrgsRes = await e.execute({
-    sql: `SELECT m.org_id AS orgId, m.role AS role, o.name AS orgName
+    sql: `SELECT m.org_id AS "orgId", m.role AS role, o.name AS "orgName"
           FROM org_members m
           INNER JOIN organizations o ON m.org_id = o.id
           WHERE m.email = ?`,
@@ -83,7 +83,7 @@ export const getMyOrgHandler = defineEventHandler(async (event: H3Event) => {
   }));
 
   const invitesRes = await e.execute({
-    sql: `SELECT i.id AS id, i.org_id AS orgId, o.name AS orgName, i.invited_by AS invitedBy
+    sql: `SELECT i.id AS id, i.org_id AS "orgId", o.name AS "orgName", i.invited_by AS "invitedBy"
           FROM org_invitations i
           INNER JOIN organizations o ON i.org_id = o.id
           WHERE i.email = ? AND i.status = 'pending'`,
@@ -146,7 +146,7 @@ export const listMembersHandler = defineEventHandler(async (event: H3Event) => {
 
   const e = await exec();
   const { rows } = await e.execute({
-    sql: `SELECT email, role, joined_at AS joinedAt FROM org_members WHERE org_id = ?`,
+    sql: `SELECT email, role, joined_at AS "joinedAt" FROM org_members WHERE org_id = ?`,
     args: [ctx.orgId],
   });
   const members = rows.map((r: any) => ({
@@ -222,7 +222,7 @@ export const listInvitationsHandler = defineEventHandler(
 
     const e = await exec();
     const { rows } = await e.execute({
-      sql: `SELECT id, email, invited_by AS invitedBy, created_at AS createdAt, status
+      sql: `SELECT id, email, invited_by AS "invitedBy", created_at AS "createdAt", status
             FROM org_invitations
             WHERE org_id = ? AND status = 'pending'`,
       args: [ctx.orgId],
@@ -255,7 +255,7 @@ export const acceptInvitationHandler = defineEventHandler(
     const e = await exec();
 
     const invRes = await e.execute({
-      sql: `SELECT id, org_id AS orgId FROM org_invitations
+      sql: `SELECT id, org_id AS "orgId" FROM org_invitations
             WHERE id = ? AND email = ? AND status = 'pending' LIMIT 1`,
       args: [invitationId, email],
     });
@@ -370,7 +370,7 @@ export const switchOrgHandler = defineEventHandler(async (event: H3Event) => {
 
   const e = await exec();
   const membership = await e.execute({
-    sql: `SELECT m.role AS role, o.name AS orgName
+    sql: `SELECT m.role AS role, o.name AS "orgName"
           FROM org_members m
           INNER JOIN organizations o ON m.org_id = o.id
           WHERE m.org_id = ? AND m.email = ? LIMIT 1`,

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -437,6 +437,9 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
           headers: event.headers,
         });
         if (baSession?.user?.email) {
+          // Successful real sign-in — clear the upgrade-pending marker so
+          // the dev fallback becomes reachable again for future local work.
+          clearUpgradePendingCookie(event);
           return mapBetterAuthSession(baSession);
         }
       }
@@ -448,7 +451,10 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
     const cookie = getCookie(event, COOKIE_NAME);
     if (cookie) {
       const email = await getSessionEmail(cookie);
-      if (email) return { email, token: cookie };
+      if (email) {
+        clearUpgradePendingCookie(event);
+        return { email, token: cookie };
+      }
     }
   }
 
@@ -473,11 +479,51 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
   // so the app is usable without any auth configuration. This prevents 401
   // errors when Better Auth isn't configured, the marker file is missing, or
   // the user simply wants to play around locally.
-  if (isDevEnvironment()) {
+  //
+  // EXCEPTION: if the user has explicitly exited local mode (clicked "Upgrade
+  // to real account"), they've signaled they want real auth. The upgrade
+  // cookie suppresses this fallback so the onboarding/sign-in page is served
+  // instead of silently re-authenticating them as local@localhost.
+  if (isDevEnvironment() && !isUpgradePending(event)) {
     return LOCAL_SESSION;
   }
 
   return null;
+}
+
+/**
+ * Cookie set by POST /_agent-native/auth/exit-local-mode so we know the user
+ * is in the middle of upgrading from local@localhost to a real account.
+ * While this cookie is present we skip the dev-mode "auto local session"
+ * fallback so the onboarding/sign-in page can actually render.
+ * Cleared on successful sign-in/sign-up.
+ */
+const UPGRADE_COOKIE = "an_upgrade_pending";
+
+function isUpgradePending(event: H3Event): boolean {
+  try {
+    return getCookie(event, UPGRADE_COOKIE) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function setUpgradePendingCookie(event: H3Event): void {
+  setCookie(event, UPGRADE_COOKIE, "1", {
+    httpOnly: true,
+    secure: !isDevEnvironment(),
+    sameSite: "lax",
+    path: "/",
+    maxAge: 60 * 60, // 1 hour — enough to complete sign-in
+  });
+}
+
+function clearUpgradePendingCookie(event: H3Event): void {
+  try {
+    deleteCookie(event, UPGRADE_COOKIE, { path: "/" });
+  } catch {
+    // ignore
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -718,6 +764,9 @@ async function mountBetterAuthRoutes(
         setResponseStatus(event, 500);
         return { error: "Failed to disable local mode" };
       }
+      // Mark the browser so getSession's dev-mode fallback won't silently
+      // re-authenticate the user as local@localhost on the next request.
+      setUpgradePendingCookie(event);
       return { ok: true };
     }),
   );
@@ -970,6 +1019,9 @@ function mountLocalModeRoutes(app: H3App): void {
         setResponseStatus(event, 500);
         return { error: "Failed to disable local mode" };
       }
+      // Mark the browser so getSession's dev-mode fallback won't silently
+      // re-authenticate the user as local@localhost on the next request.
+      setUpgradePendingCookie(event);
       return { ok: true };
     }),
   );
@@ -1110,6 +1162,9 @@ function mountAuthFallbackRoutes(app: H3App): void {
         setResponseStatus(event, 500);
         return { error: "Failed to disable local mode" };
       }
+      // Mark the browser so getSession's dev-mode fallback won't silently
+      // re-authenticate the user as local@localhost on the next request.
+      setUpgradePendingCookie(event);
       return { ok: true };
     }),
   );

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -12,6 +12,7 @@
  * first call to `getH3App()` per nitroApp instance.
  */
 import type { EventHandler, H3Event } from "h3";
+import { setResponseHeader, setResponseStatus } from "h3";
 import { getMissingDefaultPlugins } from "../deploy/route-discovery.js";
 
 const BOOTSTRAPPED = new WeakSet<object>();
@@ -141,6 +142,36 @@ function registerMiddleware(
     try {
       const result = await handler(event);
       return result === undefined ? next() : result;
+    } catch (err) {
+      // Log 500s to the server console so they're debuggable, and respond
+      // with JSON instead of the default HTML error page so clients can
+      // surface error messages. This only applies to routes mounted under
+      // the framework prefix (or middleware mounted at `/`, for which we
+      // still want visibility).
+      const reqPath = originalPathname ?? event.url?.pathname ?? "";
+      const e = err as any;
+      const status =
+        typeof e?.statusCode === "number"
+          ? e.statusCode
+          : typeof e?.status === "number"
+            ? e.status
+            : 500;
+      console.error(
+        `[agent-native] ${event.method ?? ""} ${reqPath} failed (${status}):`,
+        e?.stack || e?.message || e,
+      );
+      try {
+        setResponseStatus(event, status);
+        setResponseHeader(event, "content-type", "application/json");
+      } catch {
+        // Response already sent — best effort.
+      }
+      return {
+        error: e?.message || "Internal server error",
+        ...(process.env.NODE_ENV !== "production" && e?.stack
+          ? { stack: e.stack }
+          : {}),
+      };
     } finally {
       // Restore the original pathname so downstream middleware sees the
       // full URL.

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -68,10 +68,22 @@ async function injectSessionAndReload(token: string) {
   }
   const targets: { session: Electron.Session; origin: string }[] = [];
   for (const appConfig of apps) {
-    targets.push({
-      session: session.fromPartition(`persist:app-${appConfig.id}`),
-      origin: frameOrigin,
-    });
+    const sess = session.fromPartition(`persist:app-${appConfig.id}`);
+    // Dev-mode apps load through the frame (localhost:3334); prod-mode apps
+    // load their production URL directly. Set the cookie on whichever origin
+    // the app actually talks to. Dev-mode always gets the frame origin;
+    // prod-mode gets the configured URL if available.
+    const isProdMode = appConfig.mode !== "dev";
+    if (isProdMode && appConfig.url) {
+      try {
+        targets.push({
+          session: sess,
+          origin: new URL(appConfig.url).origin,
+        });
+      } catch {}
+    } else {
+      targets.push({ session: sess, origin: frameOrigin });
+    }
   }
   // Also cover any currently-live webview origins not matched above
   // (e.g. production URLs).
@@ -638,6 +650,11 @@ app.whenReady().then(() => {
       },
     );
   }
+
+  // Also configure session.defaultSession so the OAuth BrowserWindow (which
+  // is not a webview and uses defaultSession) gets the redirect handler.
+  // With no specific targetAppId, the handler falls back to mail/calendar.
+  configureWebviewSession(session.defaultSession, null);
 
   // Pre-configure each known app's partition so handlers are ready before
   // the first request fires. Each partition knows its own app id.

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -54,17 +54,23 @@ async function handleDeepLink(url: string) {
 }
 
 async function injectSessionAndReload(token: string) {
+  // Each webview runs in its own persisted partition (persist:app-<id>), so
+  // cookies must be set on each webview's session — not session.defaultSession.
   const allContents = webContents.getAllWebContents();
-  const origins = new Set<string>();
+  const pairs: { session: Electron.Session; origin: string }[] = [];
+  const seen = new Set<string>();
   for (const wc of allContents) {
-    if (wc.getType() === "webview") {
-      try {
-        origins.add(new URL(wc.getURL()).origin);
-      } catch {}
-    }
+    if (wc.getType() !== "webview") continue;
+    try {
+      const origin = new URL(wc.getURL()).origin;
+      const key = `${(wc.session as any).storagePath || ""}|${origin}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      pairs.push({ session: wc.session, origin });
+    } catch {}
   }
-  for (const origin of origins) {
-    await session.defaultSession.cookies.set({
+  for (const { session: sess, origin } of pairs) {
+    await sess.cookies.set({
       url: origin,
       name: "an_session",
       value: token,
@@ -556,43 +562,65 @@ app.whenReady().then(() => {
     pendingDeepLink = null;
   }
 
-  // Allow webviews to load any localhost URL during development
-  if (IS_DEV) {
-    session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-      callback({
-        responseHeaders: {
-          ...details.responseHeaders,
-          "Content-Security-Policy": [
-            "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:",
-          ],
-        },
+  // Webviews now run in per-app persisted partitions (persist:app-<id>), so
+  // webRequest handlers must be attached to each partitioned session, not
+  // just session.defaultSession.
+  const configuredSessions = new WeakSet<Electron.Session>();
+  function configureWebviewSession(sess: Electron.Session) {
+    if (configuredSessions.has(sess)) return;
+    configuredSessions.add(sess);
+
+    if (IS_DEV) {
+      sess.webRequest.onHeadersReceived((details, callback) => {
+        callback({
+          responseHeaders: {
+            ...details.responseHeaders,
+            "Content-Security-Policy": [
+              "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:",
+            ],
+          },
+        });
       });
-    });
+    }
+
+    // Intercept OAuth callbacks on the frame port and redirect to the app's server.
+    // Google redirects to localhost:3334/api/google/... but the frame doesn't
+    // serve API routes — the actual app server runs on a different port.
+    sess.webRequest.onBeforeRequest(
+      { urls: [`http://localhost:${FRAME_PORT}/api/google/*`] },
+      (details, callback) => {
+        const apps = AppStore.loadApps();
+        const app =
+          apps.find((a) => a.id === "mail") ||
+          apps.find((a) => a.id === "calendar");
+        if (app) {
+          const appUrl = details.url.replace(
+            `http://localhost:${FRAME_PORT}`,
+            `http://localhost:${app.devPort}`,
+          );
+          callback({ redirectURL: appUrl });
+        } else {
+          callback({});
+        }
+      },
+    );
   }
 
-  // Intercept OAuth callbacks on the frame port and redirect to the app's server.
-  // Google redirects to localhost:3334/api/google/... but the frame doesn't
-  // serve API routes — the actual app server runs on a different port.
-  session.defaultSession.webRequest.onBeforeRequest(
-    { urls: [`http://localhost:${FRAME_PORT}/api/google/*`] },
-    (details, callback) => {
-      // Route to the correct app's server based on the callback path
-      const apps = AppStore.loadApps();
-      // Try mail first, then calendar — both have Google OAuth
-      const app =
-        apps.find((a) => a.id === "mail") ||
-        apps.find((a) => a.id === "calendar");
-      if (app) {
-        const appUrl = details.url.replace(
-          `http://localhost:${FRAME_PORT}`,
-          `http://localhost:${app.devPort}`,
-        );
-        callback({ redirectURL: appUrl });
-      } else {
-        callback({});
-      }
-    },
-  );
+  // Pre-configure each known app's partition so handlers are ready before
+  // the first request fires.
+  for (const appConfig of AppStore.loadApps()) {
+    configureWebviewSession(
+      session.fromPartition(`persist:app-${appConfig.id}`),
+    );
+  }
+
+  // Catch any webview sessions we didn't pre-configure (e.g. custom apps
+  // added at runtime) when their web contents are created.
+  app.on("web-contents-created", (_event, wc) => {
+    if (wc.getType() === "webview") {
+      configureWebviewSession(wc.session);
+    }
+  });
 
   // Replace the default app menu so Cmd+Option+I doesn't open shell DevTools.
   // We handle this shortcut ourselves via before-input-event → toggleWebviewDevTools().

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -74,16 +74,18 @@ async function injectSessionAndReload(token: string) {
     // the app actually talks to. Dev-mode always gets the frame origin;
     // prod-mode gets the configured URL if available.
     const isProdMode = appConfig.mode !== "dev";
+    let origin = frameOrigin;
     if (isProdMode && appConfig.url) {
       try {
-        targets.push({
-          session: sess,
-          origin: new URL(appConfig.url).origin,
-        });
-      } catch {}
-    } else {
-      targets.push({ session: sess, origin: frameOrigin });
+        origin = new URL(appConfig.url).origin;
+      } catch (err) {
+        console.error(
+          `[main] invalid production URL for ${appConfig.id} (${appConfig.url}); falling back to frame origin:`,
+          err,
+        );
+      }
     }
+    targets.push({ session: sess, origin });
   }
   // Also cover any currently-live webview origins not matched above
   // (e.g. production URLs).

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -55,29 +55,49 @@ async function handleDeepLink(url: string) {
 
 async function injectSessionAndReload(token: string) {
   // Each webview runs in its own persisted partition (persist:app-<id>), so
-  // cookies must be set on each webview's session — not session.defaultSession.
-  const allContents = webContents.getAllWebContents();
-  const pairs: { session: Electron.Session; origin: string }[] = [];
-  const seen = new Set<string>();
-  for (const wc of allContents) {
+  // cookies must be written to every known app partition — not just the
+  // active webviews and not session.defaultSession. Otherwise apps that
+  // haven't been opened yet (e.g. Calendar when only Mail is visible at
+  // login) won't pick up the session cookie.
+  const frameOrigin = `http://localhost:${FRAME_PORT}`;
+  let apps: AppConfig[] = [];
+  try {
+    apps = AppStore.loadApps();
+  } catch (err) {
+    console.error("[main] failed to load apps for session injection:", err);
+  }
+  const targets: { session: Electron.Session; origin: string }[] = [];
+  for (const appConfig of apps) {
+    targets.push({
+      session: session.fromPartition(`persist:app-${appConfig.id}`),
+      origin: frameOrigin,
+    });
+  }
+  // Also cover any currently-live webview origins not matched above
+  // (e.g. production URLs).
+  const seenOrigins = new Set<string>(targets.map((t) => t.origin));
+  for (const wc of webContents.getAllWebContents()) {
     if (wc.getType() !== "webview") continue;
     try {
       const origin = new URL(wc.getURL()).origin;
-      const key = `${(wc.session as any).storagePath || ""}|${origin}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      pairs.push({ session: wc.session, origin });
+      if (seenOrigins.has(origin)) continue;
+      seenOrigins.add(origin);
+      targets.push({ session: wc.session, origin });
     } catch {}
   }
-  for (const { session: sess, origin } of pairs) {
-    await sess.cookies.set({
-      url: origin,
-      name: "an_session",
-      value: token,
-      httpOnly: true,
-      path: "/",
-      expirationDate: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
-    });
+  for (const { session: sess, origin } of targets) {
+    try {
+      await sess.cookies.set({
+        url: origin,
+        name: "an_session",
+        value: token,
+        httpOnly: true,
+        path: "/",
+        expirationDate: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+      });
+    } catch (err) {
+      console.error(`[main] cookie.set failed for ${origin}:`, err);
+    }
   }
   reloadAllWebviews();
   const win = BrowserWindow.getAllWindows()[0];
@@ -566,7 +586,10 @@ app.whenReady().then(() => {
   // webRequest handlers must be attached to each partitioned session, not
   // just session.defaultSession.
   const configuredSessions = new WeakSet<Electron.Session>();
-  function configureWebviewSession(sess: Electron.Session) {
+  function configureWebviewSession(
+    sess: Electron.Session,
+    targetAppId: string | null,
+  ) {
     if (configuredSessions.has(sess)) return;
     configuredSessions.add(sess);
 
@@ -586,11 +609,21 @@ app.whenReady().then(() => {
     // Intercept OAuth callbacks on the frame port and redirect to the app's server.
     // Google redirects to localhost:3334/api/google/... but the frame doesn't
     // serve API routes — the actual app server runs on a different port.
+    // Each partition is bound to a specific app, so route to that app's port
+    // rather than falling back to a hardcoded mail/calendar preference.
     sess.webRequest.onBeforeRequest(
       { urls: [`http://localhost:${FRAME_PORT}/api/google/*`] },
       (details, callback) => {
-        const apps = AppStore.loadApps();
+        let apps: AppConfig[] = [];
+        try {
+          apps = AppStore.loadApps();
+        } catch (err) {
+          console.error("[main] OAuth redirect: loadApps failed:", err);
+          callback({});
+          return;
+        }
         const app =
+          (targetAppId && apps.find((a) => a.id === targetAppId)) ||
           apps.find((a) => a.id === "mail") ||
           apps.find((a) => a.id === "calendar");
         if (app) {
@@ -607,19 +640,32 @@ app.whenReady().then(() => {
   }
 
   // Pre-configure each known app's partition so handlers are ready before
-  // the first request fires.
-  for (const appConfig of AppStore.loadApps()) {
-    configureWebviewSession(
-      session.fromPartition(`persist:app-${appConfig.id}`),
-    );
+  // the first request fires. Each partition knows its own app id.
+  let initialApps: AppConfig[] = [];
+  try {
+    initialApps = AppStore.loadApps();
+  } catch (err) {
+    console.error("[main] failed to load apps for session setup:", err);
+  }
+  const sessionToAppId = new Map<Electron.Session, string>();
+  for (const appConfig of initialApps) {
+    const sess = session.fromPartition(`persist:app-${appConfig.id}`);
+    sessionToAppId.set(sess, appConfig.id);
+    configureWebviewSession(sess, appConfig.id);
   }
 
   // Catch any webview sessions we didn't pre-configure (e.g. custom apps
-  // added at runtime) when their web contents are created.
+  // added at runtime) when their web contents are created. Derive the app
+  // id from the webview URL's ?app= param when possible.
   app.on("web-contents-created", (_event, wc) => {
-    if (wc.getType() === "webview") {
-      configureWebviewSession(wc.session);
+    if (wc.getType() !== "webview") return;
+    let id = sessionToAppId.get(wc.session) ?? null;
+    if (!id) {
+      try {
+        id = new URL(wc.getURL()).searchParams.get("app");
+      } catch {}
     }
+    configureWebviewSession(wc.session, id);
   });
 
   // Replace the default app menu so Cmd+Option+I doesn't open shell DevTools.

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -239,6 +239,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
             className="app-webview"
             allowpopups=""
             webpreferences="contextIsolation=false"
+            partition={`persist:app-${app.id}`}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- Each app webview now uses a `persist:app-<id>` Electron partition so localStorage, cookies, and sessions are fully isolated per app
- Fixes Frame chat tabs leaking across apps (open tab lists, active thread, and backend routing via the shared `frame_active_app` cookie were all being clobbered across apps)
- Bundles an in-flight framework-request-handler change from another agent that logs 500s and returns JSON for framework routes

## Test plan
- [ ] Open two different apps in the desktop app; verify Frame sidebar chat tabs are independent
- [ ] Create a thread in one app; confirm it does not appear in the other
- [ ] Confirm auth/session flows still work after partition change (one-time re-auth expected)