### PR TITLE
updates-97: unify dashboard sidebar UX + builder browser connect

### DIFF
--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -267,6 +267,7 @@ function ToolCallDisplay({
             builderEnabled={!!parsed.builderEnabled}
             connectUrl={parsed.connectUrl || ""}
             orgName={parsed.orgName ?? null}
+            prompt={typeof parsed.prompt === "string" ? parsed.prompt : ""}
           />
         );
       }

--- a/packages/core/src/client/ConnectBuilderCard.tsx
+++ b/packages/core/src/client/ConnectBuilderCard.tsx
@@ -115,21 +115,24 @@ export function ConnectBuilderCard({
     }
     setConnecting(true);
     setErr(null);
+    // Open the popup SYNCHRONOUSLY inside the click handler. Any await
+    // before window.open() lets the user-gesture token expire, which
+    // causes popup blockers to block entirely or fall back to same-tab
+    // navigation. The URL was generated server-side with the correct
+    // callback origin, so no re-fetch is needed.
     try {
-      const origin = getCallbackOrigin() || window.location.origin;
-      let connectUrl = initialConnectUrl;
-      try {
-        const res = await fetch(`${origin}/_agent-native/builder/status`);
-        if (res.ok) {
-          const s = (await res.json()) as { connectUrl?: string };
-          if (s.connectUrl) connectUrl = s.connectUrl;
-        }
-      } catch {
-        // fall back to the URL baked into the tool result
+      const popup = window.open(
+        initialConnectUrl,
+        "_blank",
+        "noopener,noreferrer",
+      );
+      // Some browsers return null with noopener — treat as "opened" since
+      // the navigation still happens. Only treat explicit popup-blocker
+      // errors as failures.
+      if (popup === null && !initialConnectUrl) {
+        throw new Error("Popup blocked — allow popups and retry.");
       }
-
-      const popup = window.open(connectUrl, "_blank", "noopener,noreferrer");
-      if (!popup) throw new Error("Popup blocked — allow popups and retry.");
+      const origin = getCallbackOrigin() || window.location.origin;
 
       const start = Date.now();
       const timeoutMs = 5 * 60 * 1000;

--- a/packages/core/src/client/ConnectBuilderCard.tsx
+++ b/packages/core/src/client/ConnectBuilderCard.tsx
@@ -11,6 +11,16 @@ export interface ConnectBuilderCardProps {
   builderEnabled: boolean;
   connectUrl: string;
   orgName?: string | null;
+  /** The user's feature/change request, forwarded to Builder's cloud agent
+   *  when they click Send. Empty for generic "connect Builder" prompts. */
+  prompt?: string;
+}
+
+interface BuilderRunResult {
+  branchName: string;
+  projectId: string;
+  url: string;
+  status: string;
 }
 
 const WAITLIST_URL = "https://www.builder.io/c/waitlist";
@@ -47,13 +57,45 @@ export function ConnectBuilderCard({
   builderEnabled,
   connectUrl: initialConnectUrl,
   orgName: initialOrgName,
+  prompt = "",
 }: ConnectBuilderCardProps) {
   const [configured, setConfigured] = useState(initialConfigured);
   const [orgName, setOrgName] = useState<string | null>(initialOrgName ?? null);
   const [connecting, setConnecting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [runResult, setRunResult] = useState<BuilderRunResult | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const mountedRef = useRef(true);
+
+  const handleSend = useCallback(async () => {
+    if (!prompt.trim()) return;
+    setSending(true);
+    setErr(null);
+    try {
+      const origin = getCallbackOrigin() || window.location.origin;
+      const res = await fetch(`${origin}/_agent-native/builder/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(
+          typeof data?.error === "string"
+            ? data.error
+            : `Request failed (${res.status})`,
+        );
+      }
+      if (!mountedRef.current) return;
+      setRunResult(data as BuilderRunResult);
+      setSending(false);
+    } catch (e) {
+      if (!mountedRef.current) return;
+      setErr(e instanceof Error ? e.message : "Send failed");
+      setSending(false);
+    }
+  }, [prompt]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -130,6 +172,51 @@ export function ConnectBuilderCard({
   }, [initialConnectUrl]);
 
   const showWaitlist = !configured && !builderEnabled;
+  const canSend = configured && builderEnabled && prompt.trim().length > 0;
+
+  // Title + subtitle depend on which mode we're in. We compute them up front
+  // so the render tree below stays flat.
+  let title: string;
+  let subtitle: React.ReactNode;
+  if (runResult) {
+    title = "Sent to Builder";
+    subtitle = (
+      <>
+        Working on branch{" "}
+        <span className="font-mono text-foreground">
+          {runResult.branchName}
+        </span>
+        . Click through to watch progress in the Visual Editor.
+      </>
+    );
+  } else if (canSend) {
+    title = "Send this to Builder";
+    subtitle = (
+      <>
+        Builder's cloud agent will code this change on a fresh branch — click
+        through when it's ready.
+      </>
+    );
+  } else if (configured) {
+    title = "Builder.io connected";
+    subtitle = orgName ? (
+      <>
+        Connected to{" "}
+        <span className="font-medium text-foreground">{orgName}</span>. LLM
+        access, browser automation, and more are ready to use.
+      </>
+    ) : (
+      <>LLM access, browser automation, and more are ready to use.</>
+    );
+  } else {
+    title = "Connect Builder.io";
+    subtitle = (
+      <>
+        One click to spin up a cloud code sandbox — Builder writes the changes
+        for you, no local setup needed.
+      </>
+    );
+  }
 
   return (
     <div className={cn("my-2 rounded-lg border border-border overflow-hidden")}>
@@ -140,7 +227,7 @@ export function ConnectBuilderCard({
             "bg-foreground text-background",
           )}
         >
-          {configured ? (
+          {runResult ? (
             <IconCheck className="h-5 w-5" />
           ) : (
             <BuilderBMark className="h-5 w-5" />
@@ -149,7 +236,7 @@ export function ConnectBuilderCard({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-sm font-semibold text-foreground">
-              {configured ? "Builder.io connected" : "Connect Builder.io"}
+              {title}
             </span>
             {showWaitlist && (
               <span className="inline-flex items-center rounded-sm bg-muted px-1.5 py-0 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
@@ -158,65 +245,93 @@ export function ConnectBuilderCard({
             )}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-            {configured ? (
-              orgName ? (
-                <>
-                  Connected to{" "}
-                  <span className="font-medium text-foreground">{orgName}</span>
-                  . LLM access, browser automation, and more are ready to use.
-                </>
-              ) : (
-                <>LLM access, browser automation, and more are ready to use.</>
-              )
-            ) : (
-              <>
-                One click to spin up a cloud code sandbox — Builder writes the
-                changes for you, no local setup needed.
-              </>
-            )}
+            {subtitle}
           </div>
-          {err && <div className="mt-2 text-xs text-destructive">{err}</div>}
-          {!configured && (
-            <div className="mt-3">
-              {showWaitlist ? (
-                <a
-                  href={WAITLIST_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className={cn(
-                    "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
-                    "bg-foreground text-background hover:bg-foreground/90",
-                  )}
-                >
-                  Join the waitlist
-                  <IconExternalLink className="h-3.5 w-3.5" />
-                </a>
-              ) : (
-                <button
-                  type="button"
-                  onClick={handleConnect}
-                  disabled={connecting}
-                  className={cn(
-                    "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
-                    "bg-foreground text-background hover:bg-foreground/90",
-                    connecting && "opacity-70 cursor-wait",
-                  )}
-                >
-                  {connecting ? (
-                    <>
-                      <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
-                      Waiting for Builder…
-                    </>
-                  ) : (
-                    <>
-                      Connect Builder
-                      <IconExternalLink className="h-3.5 w-3.5" />
-                    </>
-                  )}
-                </button>
-              )}
+
+          {canSend && prompt && !runResult && (
+            <div className="mt-2 rounded-md bg-muted/50 px-2.5 py-1.5 text-xs text-muted-foreground line-clamp-3 break-words">
+              {prompt}
             </div>
           )}
+
+          {err && <div className="mt-2 text-xs text-destructive">{err}</div>}
+
+          <div className="mt-3">
+            {runResult ? (
+              <a
+                href={runResult.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+                  "bg-foreground text-background hover:bg-foreground/90",
+                )}
+              >
+                <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+                Open branch in Builder
+                <IconExternalLink className="h-3.5 w-3.5" />
+              </a>
+            ) : canSend ? (
+              <button
+                type="button"
+                onClick={handleSend}
+                disabled={sending}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+                  "bg-foreground text-background hover:bg-foreground/90",
+                  sending && "opacity-70 cursor-wait",
+                )}
+              >
+                {sending ? (
+                  <>
+                    <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+                    Sending to Builder…
+                  </>
+                ) : (
+                  <>
+                    Send to Builder
+                    <IconExternalLink className="h-3.5 w-3.5" />
+                  </>
+                )}
+              </button>
+            ) : showWaitlist ? (
+              <a
+                href={WAITLIST_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+                  "bg-foreground text-background hover:bg-foreground/90",
+                )}
+              >
+                Join the waitlist
+                <IconExternalLink className="h-3.5 w-3.5" />
+              </a>
+            ) : !configured ? (
+              <button
+                type="button"
+                onClick={handleConnect}
+                disabled={connecting}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+                  "bg-foreground text-background hover:bg-foreground/90",
+                  connecting && "opacity-70 cursor-wait",
+                )}
+              >
+                {connecting ? (
+                  <>
+                    <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+                    Waiting for Builder…
+                  </>
+                ) : (
+                  <>
+                    Connect Builder
+                    <IconExternalLink className="h-3.5 w-3.5" />
+                  </>
+                )}
+              </button>
+            ) : null}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -11,9 +11,14 @@ import { useChatThreads, type ChatThreadSummary } from "./use-chat-threads.js";
 
 // ─── Skeleton Loader ─────────────────────────────────────────────────────────
 
-function ChatSkeleton() {
+function ChatSkeleton({ headerOnly = false }: { headerOnly?: boolean }) {
   return (
-    <div className="flex flex-1 flex-col h-full min-h-0">
+    <div
+      className={cn(
+        "flex flex-col min-h-0",
+        headerOnly ? "shrink-0" : "flex-1 h-full",
+      )}
+    >
       <div className="flex items-center h-8 px-2 border-b border-border shrink-0 gap-2">
         <div className="h-4 w-12 rounded bg-muted animate-pulse" />
         <div className="ml-auto flex gap-1">
@@ -21,12 +26,14 @@ function ChatSkeleton() {
           <div className="h-5 w-5 rounded bg-muted animate-pulse" />
         </div>
       </div>
-      <div className="flex-1 flex flex-col gap-3 p-4">
-        <div className="flex justify-center py-8">
-          <div className="h-10 w-10 rounded-full bg-muted animate-pulse" />
+      {!headerOnly && (
+        <div className="flex-1 flex flex-col gap-3 p-4">
+          <div className="flex justify-center py-8">
+            <div className="h-10 w-10 rounded-full bg-muted animate-pulse" />
+          </div>
+          <div className="h-3 w-32 rounded bg-muted animate-pulse mx-auto" />
         </div>
-        <div className="h-3 w-32 rounded bg-muted animate-pulse mx-auto" />
-      </div>
+      )}
     </div>
   );
 }
@@ -863,7 +870,7 @@ export function MultiTabAssistantChat({
   };
 
   if (isLoading) {
-    return <ChatSkeleton />;
+    return <ChatSkeleton headerOnly={contentHidden} />;
   }
 
   return (

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -19,11 +19,11 @@ function ChatSkeleton({ headerOnly = false }: { headerOnly?: boolean }) {
         headerOnly ? "shrink-0" : "flex-1 h-full",
       )}
     >
-      <div className="flex items-center h-8 px-2 border-b border-border shrink-0 gap-2">
-        <div className="h-4 w-12 rounded bg-muted animate-pulse" />
-        <div className="ml-auto flex gap-1">
-          <div className="h-5 w-5 rounded bg-muted animate-pulse" />
-          <div className="h-5 w-5 rounded bg-muted animate-pulse" />
+      <div className="flex items-center px-1 py-1 border-b border-border shrink-0 gap-0.5">
+        <div className="h-[22px] w-20 rounded-md bg-muted animate-pulse" />
+        <div className="ml-auto flex gap-0.5">
+          <div className="h-[22px] w-[22px] rounded-md bg-muted animate-pulse" />
+          <div className="h-[22px] w-[22px] rounded-md bg-muted animate-pulse" />
         </div>
       </div>
       {!headerOnly && (

--- a/packages/core/src/client/onboarding/OnboardingPanel.tsx
+++ b/packages/core/src/client/onboarding/OnboardingPanel.tsx
@@ -449,52 +449,63 @@ function BuilderCliAuthMethod({
 }) {
   const [connecting, setConnecting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [cachedConnectUrl, setCachedConnectUrl] = useState<string | null>(null);
 
-  const handleConnect = useCallback(async () => {
+  // Pre-fetch the connect URL on mount so the click handler can call
+  // window.open synchronously. Any async work between the click and
+  // window.open breaks the popup (blockers downgrade to same-tab nav).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const origin = getCallbackOrigin() || window.location.origin;
+        const res = await fetch(`${origin}/_agent-native/builder/status`);
+        if (!res.ok) return;
+        const s = (await res.json()) as { connectUrl?: string };
+        if (!cancelled && s.connectUrl) setCachedConnectUrl(s.connectUrl);
+      } catch {
+        // will fall back to fetching on click
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleConnect = useCallback(() => {
     setConnecting(true);
     setErr(null);
-    try {
-      // The /builder/status endpoint returns the builder connect URL that
-      // embeds the correct callback origin for this deployment.
-      const origin = getCallbackOrigin() || window.location.origin;
-      const res = await fetch(`${origin}/_agent-native/builder/status`);
-      if (!res.ok) throw new Error(`status: ${res.status}`);
-      const status = (await res.json()) as {
-        connectUrl: string;
-        configured: boolean;
-      };
-      const popup = window.open(
-        status.connectUrl,
-        "_blank",
-        "noopener,noreferrer",
-      );
-      if (!popup) throw new Error("Popup blocked — allow popups and retry.");
-
-      // Poll builder status until credentials appear (user finished the flow).
-      const start = Date.now();
-      const timeoutMs = 5 * 60 * 1000;
-      const interval = setInterval(async () => {
-        try {
-          const r = await fetch(`${origin}/_agent-native/builder/status`);
-          if (!r.ok) return;
-          const s = (await r.json()) as { configured: boolean };
-          if (s.configured) {
-            clearInterval(interval);
-            setConnecting(false);
-            await onCompleted();
-          } else if (Date.now() - start > timeoutMs) {
-            clearInterval(interval);
-            setConnecting(false);
-          }
-        } catch {
-          // ignore transient poll errors
-        }
-      }, 2000);
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "Connect failed");
+    // Open SYNCHRONOUSLY — user gesture is still active. With noopener
+    // the return is null in most browsers, but the new tab still opens.
+    if (!cachedConnectUrl) {
+      setErr("Still preparing the Builder link — try again in a moment.");
       setConnecting(false);
+      return;
     }
-  }, [onCompleted]);
+    window.open(cachedConnectUrl, "_blank", "noopener,noreferrer");
+
+    const origin = getCallbackOrigin() || window.location.origin;
+    // Poll builder status until credentials appear (user finished the flow).
+    const start = Date.now();
+    const timeoutMs = 5 * 60 * 1000;
+    const interval = setInterval(async () => {
+      try {
+        const r = await fetch(`${origin}/_agent-native/builder/status`);
+        if (!r.ok) return;
+        const s = (await r.json()) as { configured: boolean };
+        if (s.configured) {
+          clearInterval(interval);
+          setConnecting(false);
+          await onCompleted();
+        } else if (Date.now() - start > timeoutMs) {
+          clearInterval(interval);
+          setConnecting(false);
+        }
+      } catch {
+        // ignore transient poll errors
+      }
+    }, 2000);
+  }, [cachedConnectUrl, onCompleted]);
 
   return (
     <>

--- a/packages/core/src/client/onboarding/OnboardingPanel.tsx
+++ b/packages/core/src/client/onboarding/OnboardingPanel.tsx
@@ -449,42 +449,22 @@ function BuilderCliAuthMethod({
 }) {
   const [connecting, setConnecting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
-  const [cachedConnectUrl, setCachedConnectUrl] = useState<string | null>(null);
-
-  // Pre-fetch the connect URL on mount so the click handler can call
-  // window.open synchronously. Any async work between the click and
-  // window.open breaks the popup (blockers downgrade to same-tab nav).
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const origin = getCallbackOrigin() || window.location.origin;
-        const res = await fetch(`${origin}/_agent-native/builder/status`);
-        if (!res.ok) return;
-        const s = (await res.json()) as { connectUrl?: string };
-        if (!cancelled && s.connectUrl) setCachedConnectUrl(s.connectUrl);
-      } catch {
-        // will fall back to fetching on click
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const handleConnect = useCallback(() => {
     setConnecting(true);
     setErr(null);
-    // Open SYNCHRONOUSLY — user gesture is still active. With noopener
-    // the return is null in most browsers, but the new tab still opens.
-    if (!cachedConnectUrl) {
-      setErr("Still preparing the Builder link — try again in a moment.");
-      setConnecting(false);
-      return;
-    }
-    window.open(cachedConnectUrl, "_blank", "noopener,noreferrer");
-
+    // Open SYNCHRONOUSLY inside the click handler — any await before
+    // window.open lets the user gesture expire and popup blockers
+    // downgrade to same-tab navigation. The /builder/connect endpoint
+    // 302-redirects to the real CLI-auth URL so the new tab always
+    // ends up where it should, with no client-side prefetch needed.
     const origin = getCallbackOrigin() || window.location.origin;
+    window.open(
+      `${origin}/_agent-native/builder/connect`,
+      "_blank",
+      "noopener,noreferrer",
+    );
+
     // Poll builder status until credentials appear (user finished the flow).
     const start = Date.now();
     const timeoutMs = 5 * 60 * 1000;
@@ -505,7 +485,7 @@ function BuilderCliAuthMethod({
         // ignore transient poll errors
       }
     }, 2000);
-  }, [cachedConnectUrl, onCompleted]);
+  }, [onCompleted]);
 
   return (
     <>

--- a/packages/core/src/client/settings/LLMSection.tsx
+++ b/packages/core/src/client/settings/LLMSection.tsx
@@ -88,6 +88,8 @@ export function LLMSection() {
             ) : builder?.connectUrl ? (
               <a
                 href={builder.connectUrl}
+                target="_blank"
+                rel="noopener noreferrer"
                 className="flex items-center gap-1 rounded px-2 py-0.5 text-[10px] font-medium bg-accent text-foreground hover:bg-accent/80"
               >
                 Connect Builder

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -120,6 +120,7 @@ function UseBuilderCard({
   comingSoon,
   builderEnabled,
   label = "Connect Builder.io",
+  dim,
 }: {
   connectUrl?: string;
   connected: boolean;
@@ -127,12 +128,14 @@ function UseBuilderCard({
   comingSoon?: boolean;
   builderEnabled?: boolean;
   label?: string;
+  dim?: boolean;
 }) {
   const showComingSoon = comingSoon && !builderEnabled;
+  const bgClass = dim ? "" : "bg-accent/30";
 
   if (connected) {
     return (
-      <div className="rounded-md border border-border px-2.5 py-2">
+      <div className={`rounded-md border border-border px-2.5 py-2 ${bgClass}`}>
         <div className="flex items-center justify-between">
           <div className="text-[11px] font-medium text-foreground">
             Builder.io
@@ -148,6 +151,8 @@ function UseBuilderCard({
         {connectUrl && (
           <a
             href={connectUrl}
+            target="_blank"
+            rel="noopener noreferrer"
             className="inline-flex items-center gap-1 mt-2.5 rounded border border-border px-2 py-0.5 text-[10px] no-underline text-muted-foreground hover:text-foreground hover:bg-accent/40"
           >
             Reconnect
@@ -159,7 +164,7 @@ function UseBuilderCard({
   }
 
   return (
-    <div className="rounded-md border border-border bg-accent/30 px-2.5 py-2">
+    <div className={`rounded-md border border-border px-2.5 py-2 ${bgClass}`}>
       <div className="flex items-center justify-between">
         <div className="text-[11px] font-medium text-foreground">
           Connect Builder.io
@@ -187,6 +192,8 @@ function UseBuilderCard({
         connectUrl && (
           <a
             href={connectUrl}
+            target="_blank"
+            rel="noopener noreferrer"
             className="inline-flex items-center gap-1 mt-2.5 rounded bg-foreground px-2.5 py-1 text-[10px] font-medium no-underline text-background hover:opacity-90"
           >
             {label}
@@ -205,14 +212,18 @@ function ManualSetupCard({
   docsUrl,
   docsLabel = "Read the docs",
   children,
+  dim,
 }: {
   hint?: string;
   docsUrl?: string;
   docsLabel?: string;
   children?: React.ReactNode;
+  dim?: boolean;
 }) {
   return (
-    <div className="rounded-md border border-border bg-accent/30 px-2.5 py-2">
+    <div
+      className={`rounded-md border border-border px-2.5 py-2 ${dim ? "" : "bg-accent/30"}`}
+    >
       <div className="text-[11px] font-medium text-foreground mb-1">
         Set up manually
       </div>
@@ -308,11 +319,13 @@ function LLMSectionInner({
           comingSoon
           builderEnabled={builderEnabled}
           label="Connect Builder.io"
+          dim={anthropicConfigured && !connected}
         />
         <ManualSetupCard
           hint="Paste your Anthropic API key to power the agent chat."
           docsUrl="https://console.anthropic.com/settings/keys"
           docsLabel="Get an API key"
+          dim={connected && !anthropicConfigured}
         >
           {anthropicConfigured ? (
             <div className="flex items-center gap-1.5 text-[10px] text-green-500 mb-1">
@@ -454,6 +467,7 @@ export function SettingsPanel({
         icon={<IconCloud size={14} />}
         title="Hosting"
         subtitle="Deploy your app to the cloud."
+        connected={connected}
         open={openSection === "hosting"}
         onToggle={() => toggle("hosting")}
       >
@@ -477,6 +491,7 @@ export function SettingsPanel({
         icon={<IconDatabase size={14} />}
         title="Database"
         subtitle="Connect a cloud database for persistent storage."
+        connected={connected}
         open={openSection === "database"}
         onToggle={() => toggle("database")}
       >
@@ -524,6 +539,7 @@ export function SettingsPanel({
         icon={<IconShield size={14} />}
         title="Authentication"
         subtitle="Set up user authentication and access control."
+        connected={connected}
         open={openSection === "auth"}
         onToggle={() => toggle("auth")}
       >

--- a/packages/core/src/client/settings/SettingsSection.tsx
+++ b/packages/core/src/client/settings/SettingsSection.tsx
@@ -33,7 +33,7 @@ export function SettingsSection({
       <button
         type="button"
         onClick={onToggle}
-        className="flex w-full items-center justify-between px-3 py-2.5 text-left"
+        className="flex w-full cursor-pointer items-center justify-between px-3 py-2.5 text-left rounded-lg hover:bg-accent/40 transition-colors"
       >
         <div className="flex items-center gap-2 min-w-0">
           <span className="shrink-0 text-muted-foreground">{icon}</span>

--- a/packages/core/src/client/settings/SettingsSection.tsx
+++ b/packages/core/src/client/settings/SettingsSection.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { IconChevronDown } from "@tabler/icons-react";
+import { IconChevronDown, IconCheck } from "@tabler/icons-react";
 
 interface SettingsSectionProps {
   icon: ReactNode;
@@ -41,8 +41,8 @@ export function SettingsSection({
             {title}
           </span>
           {connected && (
-            <span className="flex items-center gap-1 shrink-0 text-[9px] font-medium text-green-500">
-              Connected
+            <span className="flex items-center justify-center shrink-0 rounded-full bg-green-500/15 text-green-500 w-4 h-4">
+              <IconCheck size={10} stroke={3} />
             </span>
           )}
           {required && !connected && (

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -453,19 +453,30 @@ function createBuilderBrowserTool(deps: {
     "connect-builder": {
       tool: {
         description:
-          "Render a one-click 'Connect Builder.io' card inline in the chat. Call this IMMEDIATELY — no exploration, no planning — whenever (a) the user asks to add a feature, change the UI, edit code, create a component, add a route, add an integration, fix a bug in the app itself, or anything else that requires source-file edits while in hosted/production mode, OR (b) the user needs Builder for LLM access, browser automation, or any other Builder-gated capability. Builder spins up a cloud code sandbox that codes the change for the user — no local setup required. The card handles the connect flow end-to-end; do not write implementation plans, save code to resources, or spawn sub-agents to plan. If Builder is already configured, the card shows a connected status. Takes no arguments.",
-        parameters: { type: "object", properties: {} },
+          "Render a Builder.io card inline in the chat. Call this IMMEDIATELY — no exploration, no planning — whenever (a) the user asks to add a feature, change the UI, edit code, create a component, add a route, add an integration, fix a bug in the app itself, or anything else that requires source-file edits while in hosted/production mode, OR (b) the user needs Builder for LLM access, browser automation, or any other Builder-gated capability. If Builder is already connected, the card shows a 'Send to Builder' button that hands the work off to Builder's cloud agent and returns a branch URL. When you call this for a code-change request, pass the user's request verbatim as the `prompt` arg so the card can forward it to Builder unchanged.",
+        parameters: {
+          type: "object",
+          properties: {
+            prompt: {
+              type: "string",
+              description:
+                "The user's feature / change request, verbatim. Forwarded to Builder's cloud agent when the user clicks Send. Omit only for generic 'connect Builder' requests that aren't tied to a specific code change.",
+            },
+          },
+        },
       },
-      run: async () => {
+      run: async (args) => {
         const configured = !!(
           process.env.BUILDER_PRIVATE_KEY && process.env.BUILDER_PUBLIC_KEY
         );
+        const prompt = typeof args?.prompt === "string" ? args.prompt : "";
         return JSON.stringify({
           kind: "connect-builder-card",
           configured,
           builderEnabled: !!process.env.ENABLE_BUILDER,
           connectUrl: getBuilderBrowserConnectUrl(deps.getOrigin()),
           orgName: process.env.BUILDER_ORG_NAME || null,
+          prompt,
         });
       },
     },
@@ -976,7 +987,7 @@ The agent and the UI are equal partners — everything the UI can do, you can do
 
 When the user asks you to change the UI, modify code, add a feature, fix a bug in the app itself, change styles, add a hook, create a component, add a route, add an integration, or anything else that requires editing source files — you MUST take exactly these steps, in order:
 
-1. Call the \`connect-builder\` tool (no arguments). This renders an inline Connect card with a one-click button. The user can spin up a cloud code sandbox in Builder.io and Builder will code the change for them — no local setup, no clone, no install.
+1. Call the \`connect-builder\` tool, passing the user's full request verbatim as the \`prompt\` argument. This renders an inline card. If Builder is connected, the card hands the prompt off to Builder's cloud agent on one click and returns a branch URL; otherwise it shows a connect / waitlist flow. Either way, Builder writes the code — no local setup, no clone, no install.
 2. After the card renders, write a single short sentence telling the user to click Connect Builder to have this built for them in the cloud, and mention they can also clone the app locally with \`npx agent-native create <app-name>\` if they'd rather work offline.
 
 **Hard rules — do NOT break these:**

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -166,13 +166,22 @@ export function createBuilderBrowserCallbackPage(previewUrl: string): string {
     <main class="card">
       <h1>Builder connected</h1>
       <p>Browser access is now available to your agent-native app.</p>
-      <p>Returning you to the workspace…</p>
-      <p><a href=${escapedUrl}>Open the workspace</a></p>
+      <p>You can close this tab and return to the workspace.</p>
+      <p><a href=${escapedUrl} target="_blank" rel="noopener noreferrer">Open the workspace</a></p>
     </main>
     <script>
+      // If we're a popup opened by the app, close ourselves and let the
+      // parent tab keep polling for connection status. If close() is
+      // blocked (e.g. we're the top-level tab because popups were
+      // downgraded), fall back to navigating back to the workspace.
       window.setTimeout(function () {
-        window.location.replace(${escapedUrl});
-      }, 900);
+        try { window.close(); } catch (e) {}
+        window.setTimeout(function () {
+          if (!window.closed) {
+            window.location.replace(${escapedUrl});
+          }
+        }, 200);
+      }, 700);
     </script>
   </body>
 </html>`;

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -178,6 +178,83 @@ export function createBuilderBrowserCallbackPage(previewUrl: string): string {
 </html>`;
 }
 
+export interface RunBuilderAgentArgs {
+  prompt: string;
+  projectId?: string;
+  branchName?: string;
+  userEmail?: string;
+  userId?: string;
+}
+
+export interface RunBuilderAgentResult {
+  branchName: string;
+  projectId: string;
+  url: string;
+  status: string;
+}
+
+/**
+ * POST a prompt to the Builder agents-run API. The Builder agent runs in a
+ * cloud sandbox and writes code to a branch; the returned URL opens that
+ * branch in the Visual Editor so the user can watch progress.
+ *
+ * Spec: https://www.builder.io/c/docs/agents-run-api
+ */
+export async function runBuilderAgent(
+  args: RunBuilderAgentArgs,
+): Promise<RunBuilderAgentResult> {
+  const privateKey = process.env.BUILDER_PRIVATE_KEY;
+  const publicKey = process.env.BUILDER_PUBLIC_KEY;
+  if (!privateKey || !publicKey) {
+    throw new Error("Builder keys are not configured");
+  }
+  if (!args.prompt || !args.prompt.trim()) {
+    throw new Error("prompt is required");
+  }
+  if (!args.userEmail && !args.userId) {
+    throw new Error("userEmail or userId is required");
+  }
+
+  const url = new URL("/agents/run", getBuilderApiHost());
+  url.searchParams.set("apiKey", publicKey);
+
+  const body: Record<string, unknown> = {
+    userMessage: { userPrompt: args.prompt },
+  };
+  if (args.projectId) body.projectId = args.projectId;
+  if (args.branchName) body.branchName = args.branchName;
+  if (args.userEmail) body.userEmail = args.userEmail;
+  if (args.userId) body.userId = args.userId;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${privateKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const parsed = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
+  if (!response.ok) {
+    const msg =
+      typeof parsed.error === "string"
+        ? parsed.error
+        : `Builder agent run failed (${response.status})`;
+    throw new Error(msg);
+  }
+
+  return {
+    branchName: String(parsed.branchName ?? ""),
+    projectId: String(parsed.projectId ?? ""),
+    url: String(parsed.url ?? ""),
+    status: String(parsed.status ?? "processing"),
+  };
+}
+
 export async function requestBuilderBrowserConnection(
   args: BrowserConnectionArgs,
 ): Promise<Record<string, unknown>> {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -118,6 +118,20 @@ export function createCoreRoutesPlugin(
       defineEventHandler((event) => getBuilderBrowserStatusForEvent(event)),
     );
 
+    // Lightweight 302 to the Builder CLI-auth URL. Lets clients do
+    // `window.open('/_agent-native/builder/connect', '_blank')` synchronously
+    // inside a click handler, avoiding the popup-blocker downgrade that
+    // happens when an await sits before window.open.
+    getH3App(nitroApp).use(
+      `${P}/builder/connect`,
+      defineEventHandler((event) => {
+        const status = getBuilderBrowserStatusForEvent(event);
+        setResponseStatus(event, 302);
+        setResponseHeader(event, "Location", status.connectUrl);
+        return "";
+      }),
+    );
+
     // Hardcoded for the early preview — later this will come from workspace/org
     // config so each team can point at its own Builder project.
     const DEFAULT_BUILDER_PROJECT_ID = "274d28fec94b48f2b2d68f2274d390eb";
@@ -137,11 +151,18 @@ export function createCoreRoutesPlugin(
         }
         const session = await getSession(event).catch(() => null);
         const userEmail = session?.email || "local@localhost";
+        // Server-controlled projectId — don't let clients target arbitrary
+        // Builder projects with our private key. When this feature graduates
+        // past the hardcoded preview, the projectId will come from
+        // workspace/org config, still resolved server-side.
         try {
           const result = await runBuilderAgent({
             prompt,
-            projectId: body?.projectId || DEFAULT_BUILDER_PROJECT_ID,
-            branchName: body?.branchName,
+            projectId: DEFAULT_BUILDER_PROJECT_ID,
+            branchName:
+              typeof body?.branchName === "string"
+                ? body.branchName
+                : undefined,
             userEmail,
           });
           return result;

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -17,6 +17,7 @@ import {
   getBuilderBrowserStatusForEvent,
   getBuilderCallbackEnvVars,
   resolveSafePreviewUrl,
+  runBuilderAgent,
 } from "./builder-browser.js";
 import {
   getState,
@@ -115,6 +116,42 @@ export function createCoreRoutesPlugin(
     getH3App(nitroApp).use(
       `${P}/builder/status`,
       defineEventHandler((event) => getBuilderBrowserStatusForEvent(event)),
+    );
+
+    // Hardcoded for the early preview — later this will come from workspace/org
+    // config so each team can point at its own Builder project.
+    const DEFAULT_BUILDER_PROJECT_ID = "274d28fec94b48f2b2d68f2274d390eb";
+
+    getH3App(nitroApp).use(
+      `${P}/builder/run`,
+      defineEventHandler(async (event: H3Event) => {
+        if (getMethod(event) !== "POST") {
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
+        const body = await readBody(event).catch(() => ({}) as any);
+        const prompt = typeof body?.prompt === "string" ? body.prompt : "";
+        if (!prompt.trim()) {
+          setResponseStatus(event, 400);
+          return { error: "prompt is required" };
+        }
+        const session = await getSession(event).catch(() => null);
+        const userEmail = session?.email || "local@localhost";
+        try {
+          const result = await runBuilderAgent({
+            prompt,
+            projectId: body?.projectId || DEFAULT_BUILDER_PROJECT_ID,
+            branchName: body?.branchName,
+            userEmail,
+          });
+          return result;
+        } catch (e) {
+          setResponseStatus(event, 500);
+          return {
+            error: e instanceof Error ? e.message : "Builder run failed",
+          };
+        }
+      }),
     );
 
     getH3App(nitroApp).use(

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -234,9 +234,12 @@ function SortableDashboardItem({
             </p>
             <div className="flex gap-2">
               <button
-                onClick={() => {
-                  onDelete(d);
-                  setDeletingId(null);
+                onClick={async () => {
+                  try {
+                    await onDelete(d);
+                  } finally {
+                    setDeletingId(null);
+                  }
                 }}
                 className="flex-1 rounded-md bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 transition-colors"
               >
@@ -430,10 +433,16 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
         return;
       }
       const token = await getIdToken();
-      await fetch(`/api/sql-dashboards/${d.id}`, {
+      const res = await fetch(`/api/sql-dashboards/${d.id}`, {
         method: "DELETE",
         headers: token ? { Authorization: `Bearer ${token}` } : {},
       });
+      if (!res.ok) {
+        // Surface failures instead of silently "succeeding" — otherwise the
+        // sidebar refreshes and the deleted-looking row reappears, leaving
+        // the user confused about what happened.
+        throw new Error(`Delete failed: ${res.status}`);
+      }
       queryClient.invalidateQueries({ queryKey: ["sql-dashboards-sidebar"] });
     },
     [queryClient],

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { Link, useLocation } from "react-router";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/components/auth/AuthProvider";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   IconFlask,
   IconLogout,
@@ -26,7 +26,15 @@ import {
   getDashboardOrder,
   setDashboardOrder,
   type DashboardMeta,
+  type DashboardSubview,
 } from "@/pages/adhoc/registry";
+
+type SidebarDashboard = {
+  id: string;
+  name: string;
+  subviews?: DashboardSubview[];
+  source: "static" | "sql";
+};
 import {
   Tooltip,
   TooltipTrigger,
@@ -103,17 +111,17 @@ function SortableDashboardItem({
   deletingId,
   onToggleFavorite,
   setDeletingId,
-  setHiddenIds,
+  onDelete,
   views,
 }: {
-  d: DashboardMeta;
+  d: SidebarDashboard;
   isActive: boolean;
   location: ReturnType<typeof useLocation>;
   favoriteIds: Set<string>;
   deletingId: string | null;
   onToggleFavorite: (id: string) => void;
   setDeletingId: (id: string | null) => void;
-  setHiddenIds: (ids: Set<string>) => void;
+  onDelete: (d: SidebarDashboard) => void;
   views?: DashboardView[];
 }) {
   const {
@@ -227,8 +235,7 @@ function SortableDashboardItem({
             <div className="flex gap-2">
               <button
                 onClick={() => {
-                  hideDashboard(d.id);
-                  setHiddenIds(getHiddenDashboards());
+                  onDelete(d);
                   setDeletingId(null);
                 }}
                 className="flex-1 rounded-md bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 transition-colors"
@@ -315,6 +322,7 @@ async function fetchSqlDashboards(): Promise<{ id: string; name: string }[]> {
 export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
   const location = useLocation();
   const { logout } = useAuth();
+  const queryClient = useQueryClient();
 
   const [dashOpen, setDashOpen] = useState(true);
 
@@ -388,18 +396,48 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
 
   const { data: allViewsMap = {} } = useAllDashboardViews(allDashboardIds);
 
-  const visibleDashboards = useMemo(() => {
-    const filtered = dashboards.filter((d) => !hiddenIds.has(d.id));
+  const visibleDashboards = useMemo<SidebarDashboard[]>(() => {
+    const staticItems: SidebarDashboard[] = dashboards
+      .filter((d) => !hiddenIds.has(d.id))
+      .map((d) => ({
+        id: d.id,
+        name: d.name,
+        subviews: d.subviews,
+        source: "static",
+      }));
+    const sqlItems: SidebarDashboard[] = sqlDashboards.map((d) => ({
+      id: d.id,
+      name: d.name,
+      source: "sql",
+    }));
+    const all = [...staticItems, ...sqlItems];
     // If no custom order yet, sort favorites to top
     if (dashboardOrderState.length === 0) {
-      return filtered.sort((a, b) => {
+      return all.sort((a, b) => {
         const aFav = favoriteIds.has(a.id) ? 0 : 1;
         const bFav = favoriteIds.has(b.id) ? 0 : 1;
         return aFav - bFav;
       });
     }
-    return applyOrder(filtered, dashboardOrderState);
-  }, [hiddenIds, favoriteIds, dashboardOrderState]);
+    return applyOrder(all, dashboardOrderState);
+  }, [hiddenIds, favoriteIds, dashboardOrderState, sqlDashboards]);
+
+  const handleDashboardDelete = useCallback(
+    async (d: SidebarDashboard) => {
+      if (d.source === "static") {
+        hideDashboard(d.id);
+        setHiddenIds(getHiddenDashboards());
+        return;
+      }
+      const token = await getIdToken();
+      await fetch(`/api/sql-dashboards/${d.id}`, {
+        method: "DELETE",
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      queryClient.invalidateQueries({ queryKey: ["sql-dashboards-sidebar"] });
+    },
+    [queryClient],
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -551,7 +589,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
                       deletingId={deletingId}
                       onToggleFavorite={toggleFavorite}
                       setDeletingId={setDeletingId}
-                      setHiddenIds={setHiddenIds}
+                      onDelete={handleDashboardDelete}
                       views={allViewsMap[d.id]}
                     />
                   ))}
@@ -569,98 +607,6 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
                         />
                       </div>
                     ))}
-                  {sqlDashboards.map((d) => {
-                    const isActive = location.pathname === `/adhoc/${d.id}`;
-                    const views = allViewsMap[d.id];
-                    return (
-                      <div key={`sql-${d.id}`} className="group/sqld">
-                        <div className="flex items-center min-w-0">
-                          <Link
-                            to={`/adhoc/${d.id}`}
-                            className={cn(
-                              "flex-1 min-w-0 flex items-center gap-2 rounded-md px-3 py-1 text-[13px] transition-all hover:text-primary",
-                              isActive
-                                ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                                : "text-muted-foreground hover:bg-sidebar-accent/50",
-                            )}
-                          >
-                            <span className="truncate">{d.name}</span>
-                          </Link>
-                          <button
-                            onClick={() => toggleFavorite(d.id)}
-                            className={cn(
-                              "p-1 rounded transition-all shrink-0",
-                              favoriteIds.has(d.id)
-                                ? "text-yellow-500 opacity-100"
-                                : "opacity-0 group-hover/sqld:opacity-100 text-muted-foreground/50 hover:text-yellow-500",
-                            )}
-                            title={
-                              favoriteIds.has(d.id) ? "Unfavorite" : "Favorite"
-                            }
-                          >
-                            <IconStar
-                              className={cn(
-                                "h-3 w-3",
-                                favoriteIds.has(d.id) && "fill-current",
-                              )}
-                            />
-                          </button>
-                        </div>
-                        {isActive && views && views.length > 0 && (
-                          <div className="ml-6 mt-0.5 space-y-0.5">
-                            {views.map((v) => {
-                              const params = new URLSearchParams(v.filters);
-                              params.set("view", v.id);
-                              const viewHref = `/adhoc/${d.id}?${params.toString()}`;
-                              const currentSearch = new URLSearchParams(
-                                location.search,
-                              );
-                              const isViewActive =
-                                currentSearch.get("view") === v.id;
-                              return (
-                                <Link
-                                  key={v.id}
-                                  to={viewHref}
-                                  className={cn(
-                                    "group/sv flex items-center gap-2 rounded-md px-3 py-1 text-[11px] transition-all hover:text-primary truncate",
-                                    isViewActive
-                                      ? "bg-primary/10 text-primary"
-                                      : "text-muted-foreground/70 hover:bg-sidebar-accent/50",
-                                  )}
-                                >
-                                  <span className="truncate flex-1">
-                                    {v.name}
-                                  </span>
-                                  <button
-                                    onClick={(e) => {
-                                      e.preventDefault();
-                                      e.stopPropagation();
-                                      toggleFavorite(`view:${d.id}:${v.id}`);
-                                    }}
-                                    className={cn(
-                                      "p-0.5 rounded shrink-0",
-                                      favoriteIds.has(`view:${d.id}:${v.id}`)
-                                        ? "text-yellow-500 opacity-100"
-                                        : "opacity-0 group-hover/sv:opacity-100 text-muted-foreground/50 hover:text-yellow-500",
-                                    )}
-                                  >
-                                    <IconStar
-                                      className={cn(
-                                        "h-2.5 w-2.5",
-                                        favoriteIds.has(
-                                          `view:${d.id}:${v.id}`,
-                                        ) && "fill-current",
-                                      )}
-                                    />
-                                  </button>
-                                </Link>
-                              );
-                            })}
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
                   <NewDashboardDialog />
                 </div>
               </SortableContext>


### PR DESCRIPTION
## Summary
- Analytics: merge static and SQL dashboards into a single sortable sidebar list so both sources share the same drag/star/trash UX. Delete branches by source (static → `hideDashboard`, SQL → `DELETE /api/sql-dashboards/:id`).
- Core: ConnectBuilderCard + builder-browser server changes, agent-chat and core-routes plugin updates (from another agent).

## Test plan
- [ ] Sidebar shows drag handle, star, and trash on hover for both static (Google Analytics) and SQL dashboards (DevRel Leaderboard)
- [ ] Deleting a static dashboard hides it locally; deleting a SQL dashboard removes it from the server and the list refreshes
- [ ] Drag-reorder works across both types
- [ ] Connect Builder flow still works end-to-end