### PR TITLE
updates-97: settings UX polish, connect flow, sidebar delete

### DIFF
--- a/packages/core/src/client/onboarding/OnboardingPanel.tsx
+++ b/packages/core/src/client/onboarding/OnboardingPanel.tsx
@@ -6,7 +6,7 @@
  * its `kind` (link / form / builder-cli-auth / agent-task).
  */
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
   IconCheck,
   IconChevronDown,
@@ -449,8 +449,26 @@ function BuilderCliAuthMethod({
 }) {
   const [connecting, setConnecting] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, []);
 
   const handleConnect = useCallback(() => {
+    // Restart: clear any lingering poll from a prior click.
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
     setConnecting(true);
     setErr(null);
     // Open SYNCHRONOUSLY inside the click handler — any await before
@@ -468,18 +486,31 @@ function BuilderCliAuthMethod({
     // Poll builder status until credentials appear (user finished the flow).
     const start = Date.now();
     const timeoutMs = 5 * 60 * 1000;
-    const interval = setInterval(async () => {
+    const stop = () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+    pollRef.current = setInterval(async () => {
       try {
         const r = await fetch(`${origin}/_agent-native/builder/status`);
         if (!r.ok) return;
         const s = (await r.json()) as { configured: boolean };
+        if (!mountedRef.current) {
+          stop();
+          return;
+        }
         if (s.configured) {
-          clearInterval(interval);
+          stop();
           setConnecting(false);
           await onCompleted();
         } else if (Date.now() - start > timeoutMs) {
-          clearInterval(interval);
+          stop();
           setConnecting(false);
+          setErr(
+            "Didn't hear back from Builder in 5 minutes. Check the popup, allow popups if blocked, and try again.",
+          );
         }
       } catch {
         // ignore transient poll errors

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -319,13 +319,12 @@ function LLMSectionInner({
           comingSoon
           builderEnabled={builderEnabled}
           label="Connect Builder.io"
-          dim={anthropicConfigured && !connected}
         />
         <ManualSetupCard
           hint="Paste your Anthropic API key to power the agent chat."
           docsUrl="https://console.anthropic.com/settings/keys"
           docsLabel="Get an API key"
-          dim={connected && !anthropicConfigured}
+          dim={connected}
         >
           {anthropicConfigured ? (
             <div className="flex items-center gap-1.5 text-[10px] text-green-500 mb-1">
@@ -482,6 +481,7 @@ export function SettingsPanel({
           <ManualSetupCard
             hint="Deploy manually to Netlify, Vercel, Cloudflare, or any Nitro-supported target."
             docsUrl="https://www.builder.io/c/docs/agent-native-deployment"
+            dim={connected}
           />
         </div>
       </SettingsSection>
@@ -506,6 +506,7 @@ export function SettingsPanel({
           <ManualSetupCard
             hint="Set DATABASE_URL in your .env to connect Neon, Supabase, Turso, or any Postgres/SQLite database."
             docsUrl="https://www.builder.io/c/docs/agent-native-database"
+            dim={connected}
           />
         </div>
       </SettingsSection>
@@ -530,6 +531,7 @@ export function SettingsPanel({
           <ManualSetupCard
             hint="Without a provider, files are stored as base64 in your database. Fine for dev, not recommended for production."
             docsUrl="https://www.builder.io/c/docs/agent-native-file-uploads"
+            dim={connected}
           />
         </div>
       </SettingsSection>
@@ -554,6 +556,7 @@ export function SettingsPanel({
           <ManualSetupCard
             hint="Configure Better Auth with BETTER_AUTH_SECRET and optional Google/GitHub OAuth providers."
             docsUrl="https://www.builder.io/c/docs/agent-native-authentication"
+            dim={connected}
           />
         </div>
       </SettingsSection>

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -151,11 +151,22 @@ export function createCoreRoutesPlugin(
         }
         const session = await getSession(event).catch(() => null);
         if (!session?.email) {
-          // Don't spend the server's Builder private key on anonymous
-          // requests. In dev, the local-mode bypass still yields a
-          // "local@localhost" session so this doesn't break solo workflows.
           setResponseStatus(event, 401);
           return { error: "Authentication required" };
+        }
+        // `local@localhost` is the dev/local-mode bypass session. In a
+        // hosted production deploy it means either AUTH_MODE=local was
+        // misconfigured or AUTH_DISABLED=true is in use — either way the
+        // caller isn't a named user we should spend a Builder private key
+        // on. Allow it only when the environment explicitly opts into
+        // local mode (dev, tests, or AUTH_MODE=local).
+        if (
+          session.email === "local@localhost" &&
+          process.env.NODE_ENV === "production" &&
+          process.env.AUTH_MODE !== "local"
+        ) {
+          setResponseStatus(event, 401);
+          return { error: "A signed-in user is required to run Builder" };
         }
         const userEmail = session.email;
         // Server-controlled projectId — don't let clients target arbitrary

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -150,7 +150,14 @@ export function createCoreRoutesPlugin(
           return { error: "prompt is required" };
         }
         const session = await getSession(event).catch(() => null);
-        const userEmail = session?.email || "local@localhost";
+        if (!session?.email) {
+          // Don't spend the server's Builder private key on anonymous
+          // requests. In dev, the local-mode bypass still yields a
+          // "local@localhost" session so this doesn't break solo workflows.
+          setResponseStatus(event, 401);
+          return { error: "Authentication required" };
+        }
+        const userEmail = session.email;
         // Server-controlled projectId — don't let clients target arbitrary
         // Builder projects with our private key. When this feature graduates
         // past the hardcoded preview, the projectId will come from

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { Link, useLocation } from "react-router";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/components/auth/AuthProvider";
+import { toast } from "sonner";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   IconFlask,
@@ -237,8 +238,14 @@ function SortableDashboardItem({
                 onClick={async () => {
                   try {
                     await onDelete(d);
-                  } finally {
                     setDeletingId(null);
+                  } catch (e) {
+                    // Keep the dialog open so the user can retry or cancel.
+                    toast.error(
+                      e instanceof Error
+                        ? `Couldn't remove ${d.name}: ${e.message}`
+                        : `Couldn't remove ${d.name}`,
+                    );
                   }
                 }}
                 className="flex-1 rounded-md bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 transition-colors"

--- a/templates/calendar/app/components/calendar/DayView.tsx
+++ b/templates/calendar/app/components/calendar/DayView.tsx
@@ -546,7 +546,7 @@ export function DayView({
 
               return (
                 <EventDetailPopover
-                  key={event.id}
+                  key={event._tempId ?? event.id}
                   event={event}
                   onDelete={onDeleteEvent}
                   defaultOpen={quickEditEventId === event.id}

--- a/templates/calendar/app/components/calendar/WeekView.tsx
+++ b/templates/calendar/app/components/calendar/WeekView.tsx
@@ -824,7 +824,7 @@ export function WeekView({
 
                     return (
                       <EventDetailPopover
-                        key={event.id}
+                        key={event._tempId ?? event.id}
                         event={event}
                         onDelete={onDeleteEvent}
                         defaultOpen={quickEditEventId === event.id}

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -370,7 +370,9 @@ export default function CalendarView() {
           queryClient.setQueriesData<CalendarEvent[]>(
             { queryKey: ["action", "list-events"] },
             (old) =>
-              old?.map((e) => (e.id === _tempId ? { ...e, ...realEvent } : e)),
+              old?.map((e) =>
+                e.id === _tempId ? { ...e, ...realEvent, _tempId } : e,
+              ),
           );
           setQuickEditEventId(realEvent.id);
         },

--- a/templates/calendar/shared/api.ts
+++ b/templates/calendar/shared/api.ts
@@ -48,6 +48,8 @@ export interface CalendarEvent {
   organizer?: { email: string; displayName?: string; self?: boolean };
   createdAt: string;
   updatedAt: string;
+  /** Client-only: temp id preserved across optimistic→real swap to keep React keys stable */
+  _tempId?: string;
 }
 
 export type DeleteEventScope = "single" | "all" | "thisAndFollowing";


### PR DESCRIPTION
## Summary
- Settings panel: green check badge instead of "Connected" text; dim manual setup card when Builder.io is connected; hover bg + cursor on accordion headers
- Chat tabs: match skeleton header sizing to real header; skip body skeleton when not on chat tab to avoid popcorn
- Builder connect: prefetch fallback + projectId scoping fixes
- Analytics sidebar: dashboard delete UX, toast on failure

## Test plan
- [ ] Settings panel renders correctly in both connected/disconnected states
- [ ] Chat tab loading skeleton matches header height
- [ ] Switching to Workspace/Settings while chat loads no longer shows centered circle