### PR TITLE
updates-101: auto-refresh UI after mutating actions

### DIFF
--- a/.agents/skills/actions/SKILL.md
+++ b/.agents/skills/actions/SKILL.md
@@ -66,6 +66,18 @@ Controls how the action is exposed as an HTTP endpoint:
 | `{ method: "GET", path: "custom" }` | Auto-exposed as `GET /_agent-native/actions/custom` | Custom route path                |
 | `false`                   | Agent-only, never exposed as HTTP                           | `navigate`, `view-screen`, internal actions |
 
+### Screen Refresh (automatic)
+
+The framework auto-refreshes the UI after any successful mutating action. On completion of a non-`GET` action, the server emits a poll event that the client's `useDbSync` picks up and uses to invalidate `["action"]` React Query keys — so `list-*` / `get-*` hooks refetch without a full page reload.
+
+Rules:
+
+- `http: { method: "GET" }` → read-only, does NOT trigger a refresh (inferred automatically).
+- Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
+- To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
+
+Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
+
 ### Return Values
 
 Actions should return **structured data** (objects, arrays) — not `JSON.stringify()`. The framework serializes the response automatically. If you return a string, the framework tries to parse it as JSON for a clean response.

--- a/.agents/skills/real-time-sync/SKILL.md
+++ b/.agents/skills/real-time-sync/SKILL.md
@@ -108,6 +108,27 @@ Without jitter prevention, a cycle occurs: the UI writes state, polling detects 
 
 Action routes (`/_agent-native/actions/:name`) work with the same polling system. When a POST/PUT/DELETE action writes to the database, the version counter increments and `useDbSync` picks up the change. Frontend mutations via `useActionMutation` automatically invalidate `["action"]` query keys on success, triggering refetches of `useActionQuery` hooks.
 
+### Auto-emit on mutating actions
+
+The framework emits a poll event with `source: "action"` whenever any non-read-only action runs to completion — whether called via HTTP (`/_agent-native/actions/:name`) or as an agent tool call. Read-only actions (`http: { method: "GET" }` or explicit `readOnly: true`) are skipped.
+
+This means UIs don't need the agent to remember to call `refresh-screen` after every mutation. A listener like this (used in the `macros` template) will refresh after any mutating agent call:
+
+```ts
+useDbSync({
+  queryClient,
+  queryKeys: [],
+  ignoreSource: TAB_ID,
+  onEvent: (data) => {
+    if (data.requestSource === TAB_ID) return;
+    // Invalidate all useActionQuery caches so list-*, get-*, etc. refetch
+    queryClient.invalidateQueries({ queryKey: ["action"] });
+  },
+});
+```
+
+`refresh-screen` remains available for unusual cases — e.g. the agent mutated data via a path the framework can't see (external system the app mirrors), or the agent wants to pass a `scope` hint for narrower invalidation.
+
 ## Related Skills
 
 - **storing-data** — Application-state and settings are the data stores that sync via polling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,9 +78,19 @@ Every template should have a `navigate` action that writes a one-shot command to
 
 When the agent writes to application-state, the UI updates via polling. But polling must NOT override the user's active edits. Only explicit agent writes should push changes to the UI. Templates use the `ignoreSource` option on `useDbSync()` with a per-tab ID so the UI ignores its own writes while still picking up agent and other-tab changes.
 
-### The `refresh-screen` Tool
+### Automatic Screen Refresh on Mutating Actions
 
-The framework registers a built-in `refresh-screen` tool available to every agent in every template. After the agent mutates data visible on the user's current screen (editing a dashboard config, updating a form schema, changing a row in a table the user is viewing, etc.), it should call `refresh-screen` as its final step. The tool writes a nonce to `application_state`; `AgentSidebar` polls for this event and bumps a React `key` on the main content subtree — so that region remounts and re-fetches its data while the chat sidebar, left nav, and any other persistent chrome keep their in-flight state. No full page reload.
+After any successful mutating action tool call — whether called by the agent or via HTTP — the framework emits a poll event (`source: "action"`) that the client's `useDbSync` picks up and uses to invalidate React Query caches. This means template `useActionQuery` hooks auto-refetch, with no full page reload and no per-action plumbing.
+
+- `http: { method: "GET" }` actions → read-only, do NOT trigger refresh (auto-inferred).
+- Any other action (default POST, `http: false`, etc.) → treated as mutating, triggers refresh on success.
+- Override with `readOnly: true` on `defineAction` for unusual cases (e.g. a POST that only reads).
+
+Agents do NOT need to call `refresh-screen` after a normal action — it's already handled.
+
+### The `refresh-screen` Tool (manual override)
+
+The framework registers a built-in `refresh-screen` tool for cases the auto-refresh path can't cover: the agent mutated data via a route the framework can't see (e.g. writing to an external system the app mirrors), or the agent wants to pass a `scope` hint so the UI narrows which queries to refetch. The tool writes a nonce to `application_state`; `AgentSidebar` polls for this event and bumps a React `key` on the main content subtree — so that region remounts and re-fetches its data while the chat sidebar, left nav, and any other persistent chrome keep their in-flight state. No full page reload.
 
 This is wired **automatically** for every template that uses `<AgentSidebar>` (all of them). No per-template code needed — the key wrapper lives inside `AgentSidebar` itself.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,6 +71,7 @@
     "@clack/prompts": "^1.2.0",
     "@libsql/client": "^0.15.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@neondatabase/serverless": "^1.0.2",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/packages/core/src/action.spec.ts
+++ b/packages/core/src/action.spec.ts
@@ -54,7 +54,7 @@ describe("defineAction — readOnly inference", () => {
     expect(action.readOnly).toBe(true);
   });
 
-  it("honors explicit readOnly=false even on GET", () => {
+  it("honors explicit readOnly=false even on GET (overrides method inference)", () => {
     const action = defineAction({
       description: "mutating get",
       parameters: { x: { type: "string" } },
@@ -62,6 +62,8 @@ describe("defineAction — readOnly inference", () => {
       readOnly: false,
       run: async () => "ok",
     });
-    expect(action.readOnly).toBeUndefined();
+    // Stored as explicit false so the HTTP router / agent dispatcher emit a
+    // refresh event even though the method is GET.
+    expect(action.readOnly).toBe(false);
   });
 });

--- a/packages/core/src/action.spec.ts
+++ b/packages/core/src/action.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { defineAction } from "./action.js";
+
+// Uses the legacy `parameters` mode so we don't need to pull in zod as a test
+// dep — the readOnly inference logic is independent of the schema path.
+describe("defineAction — readOnly inference", () => {
+  it("infers readOnly=true for GET actions", () => {
+    const action = defineAction({
+      description: "read things",
+      parameters: { id: { type: "string" } },
+      http: { method: "GET" },
+      run: async () => ({ ok: true }),
+    });
+    expect(action.readOnly).toBe(true);
+  });
+
+  it("leaves readOnly undefined for default POST actions", () => {
+    const action = defineAction({
+      description: "write things",
+      parameters: { value: { type: "string" } },
+      run: async () => ({ ok: true }),
+    });
+    expect(action.readOnly).toBeUndefined();
+  });
+
+  it("leaves readOnly undefined when http is false (agent-only)", () => {
+    const action = defineAction({
+      description: "agent-only",
+      parameters: { x: { type: "string" } },
+      http: false,
+      run: async () => "ok",
+    });
+    expect(action.readOnly).toBeUndefined();
+  });
+
+  it("leaves readOnly undefined for explicit POST", () => {
+    const action = defineAction({
+      description: "post",
+      parameters: { x: { type: "string" } },
+      http: { method: "POST" },
+      run: async () => "ok",
+    });
+    expect(action.readOnly).toBeUndefined();
+  });
+
+  it("honors explicit readOnly=true even on POST", () => {
+    const action = defineAction({
+      description: "read-only post",
+      parameters: { x: { type: "string" } },
+      http: { method: "POST" },
+      readOnly: true,
+      run: async () => "ok",
+    });
+    expect(action.readOnly).toBe(true);
+  });
+
+  it("honors explicit readOnly=false even on GET", () => {
+    const action = defineAction({
+      description: "mutating get",
+      parameters: { x: { type: "string" } },
+      http: { method: "GET" },
+      readOnly: false,
+      run: async () => "ok",
+    });
+    expect(action.readOnly).toBeUndefined();
+  });
+});

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -150,8 +150,16 @@ export function defineAction(options: any) {
     httpConfig !== false &&
     httpConfig !== undefined &&
     httpConfig.method === "GET";
-  const readOnly =
-    typeof options.readOnly === "boolean" ? options.readOnly : inferredReadOnly;
+  // Explicit `readOnly` (true OR false) wins. Otherwise infer from http.method.
+  // We store the resolved boolean so downstream checks can trust entry.readOnly
+  // without re-running method inference — including when a caller explicitly
+  // passes readOnly:false to override a GET (rare but valid).
+  const readOnly: boolean | undefined =
+    typeof options.readOnly === "boolean"
+      ? options.readOnly
+      : inferredReadOnly
+        ? true
+        : undefined;
 
   return {
     tool: {
@@ -161,7 +169,7 @@ export function defineAction(options: any) {
     run,
     ...(hasSchema ? { schema: options.schema } : {}),
     ...(options.http !== undefined ? { http: options.http } : {}),
-    ...(readOnly ? { readOnly: true } : {}),
+    ...(typeof readOnly === "boolean" ? { readOnly } : {}),
   };
 }
 

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -41,6 +41,11 @@ interface DefineActionWithSchema<
     args: StandardSchemaV1.InferOutput<TSchema>,
   ) => Promise<TReturn> | TReturn;
   http?: ActionHttpConfig | false;
+  /** If true, the framework will NOT emit a screen-refresh poll event after a
+   *  successful call. Auto-inferred as `true` when `http.method === "GET"`.
+   *  Only set this manually when you need to override the inference — e.g. a
+   *  POST action that only reads data but can't use GET for a protocol reason. */
+  readOnly?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -61,6 +66,9 @@ interface DefineActionWithParams<
   schema?: never;
   run: (args: InferParams<TParams>) => Promise<TReturn> | TReturn;
   http?: ActionHttpConfig | false;
+  /** If true, the framework will NOT emit a screen-refresh poll event after a
+   *  successful call. Auto-inferred as `true` when `http.method === "GET"`. */
+  readOnly?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -133,6 +141,18 @@ export function defineAction(options: any) {
     ? wrapWithValidation(options.schema, options.run, toolParameters)
     : options.run;
 
+  // Auto-infer readOnly from http.method === "GET" unless explicitly set.
+  // GET actions are idempotent reads; their completion should NOT trigger a
+  // screen refresh. Everything else is assumed to mutate — the dispatcher
+  // emits a poll event on success so the UI auto-refetches its queries.
+  const httpConfig = options.http as ActionHttpConfig | false | undefined;
+  const inferredReadOnly =
+    httpConfig !== false &&
+    httpConfig !== undefined &&
+    httpConfig.method === "GET";
+  const readOnly =
+    typeof options.readOnly === "boolean" ? options.readOnly : inferredReadOnly;
+
   return {
     tool: {
       description: options.description,
@@ -141,6 +161,7 @@ export function defineAction(options: any) {
     run,
     ...(hasSchema ? { schema: options.schema } : {}),
     ...(options.http !== undefined ? { http: options.http } : {}),
+    ...(readOnly ? { readOnly: true } : {}),
   };
 }
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -49,6 +49,9 @@ export interface ActionEntry {
   ) => Promise<any>;
   /** HTTP exposure config. `false` = agent-only. Omitted = auto-inferred from name. */
   http?: import("../action.js").ActionHttpConfig | false;
+  /** If true, completion does NOT trigger a screen-refresh poll event.
+   *  Set automatically by `defineAction` when `http.method === "GET"`. */
+  readOnly?: boolean;
 }
 
 /** @deprecated Use `ActionEntry` instead */
@@ -373,6 +376,25 @@ export async function runAgentLoop(opts: {
         } catch (err: any) {
           result = `Error running ${toolCall.name}: ${err?.message ?? String(err)}`;
           isError = true;
+        }
+
+        // Auto-refresh the UI after a successful mutating tool call. Any action
+        // that isn't explicitly read-only is assumed to mutate. The client's
+        // useDbSync listener sees a poll event with source:"action" and
+        // invalidates ["action"] queries so list-* / get-* refetch. This makes
+        // refresh after agent writes reliable without the model needing to
+        // remember to call `refresh-screen` itself.
+        if (!isError && actionEntry.readOnly !== true) {
+          try {
+            const { recordChange } = await import("../server/poll.js");
+            recordChange({
+              source: "action",
+              type: "change",
+              key: toolCall.name,
+            });
+          } catch {
+            // poll module may be unavailable in non-server contexts — ignore
+          }
         }
 
         send({ type: "tool_done", tool: toolCall.name, result });

--- a/packages/core/src/client/use-db-sync.ts
+++ b/packages/core/src/client/use-db-sync.ts
@@ -74,6 +74,14 @@ export function useDbSync(
             for (const key of keysRef.current) {
               queryClient.invalidateQueries({ queryKey: [key] });
             }
+
+            // Framework-level invalidation: useActionQuery caches under the
+            // ["action", ...] key prefix. We always invalidate that on any
+            // non-own change event so that any mutating action (agent or
+            // HTTP) auto-refreshes the UI — regardless of how the template
+            // configured queryKeys / onEvent. Templates still get their
+            // per-key list and onEvent callback for anything else.
+            queryClient.invalidateQueries({ queryKey: ["action"] });
           }
 
           // Always forward all events to onEvent — templates can decide

--- a/packages/core/src/db/create-get-db.ts
+++ b/packages/core/src/db/create-get-db.ts
@@ -42,7 +42,10 @@ function getNeonServerlessDrizzle() {
  * runtime we deploy to, so we prefer it whenever the URL points at Neon.
  */
 function isNeonUrl(url: string): boolean {
-  return /\.neon\.tech([:/]|$)/.test(url);
+  // Must match neon.tech followed by port/path/query/end — include `?` so
+  // URLs like `postgres://…@ep.neon.tech?sslmode=require` (no explicit port
+  // or path) still route through the serverless driver.
+  return /\.neon\.tech([:/?]|$)/.test(url);
 }
 
 let _libsqlDrizzle: Promise<{ drizzle: any }> | undefined;

--- a/packages/core/src/db/create-get-db.ts
+++ b/packages/core/src/db/create-get-db.ts
@@ -17,6 +17,34 @@ function getPgDrizzle() {
   return _pgDrizzle;
 }
 
+let _neonServerlessDrizzle: Promise<{ drizzle: any; Pool: any }> | undefined;
+function getNeonServerlessDrizzle() {
+  if (!_neonServerlessDrizzle) {
+    _neonServerlessDrizzle = Promise.all([
+      import("drizzle-orm/neon-serverless"),
+      import("@neondatabase/serverless"),
+    ]).then(([drizzleMod, neonMod]) => ({
+      drizzle: drizzleMod.drizzle,
+      Pool: neonMod.Pool,
+    }));
+  }
+  return _neonServerlessDrizzle;
+}
+
+/**
+ * Neon's pooler endpoints cold-start in 5–10s. Serverless environments
+ * (Netlify Functions, Vercel Edge, CF Workers) have short cold-start
+ * budgets of their own, and `postgres-js` opens a raw TCP connection on
+ * port 5432 that can't negotiate around Neon's wake-up window — every
+ * request after an idle period 502s. `@neondatabase/serverless` rides
+ * over WebSockets (HTTP/443 upgrade) and handles Neon wake-up
+ * transparently, supports transactions, and works in every serverless
+ * runtime we deploy to, so we prefer it whenever the URL points at Neon.
+ */
+function isNeonUrl(url: string): boolean {
+  return /\.neon\.tech([:/]|$)/.test(url);
+}
+
 let _libsqlDrizzle: Promise<{ drizzle: any }> | undefined;
 function getLibsqlDrizzle() {
   if (!_libsqlDrizzle) {
@@ -48,16 +76,23 @@ export function createGetDb<T extends Record<string, unknown>>(schema: T) {
     }
 
     if (dialect === "postgres") {
-      _dbReady = getPgDrizzle().then(({ drizzle, postgres }) => {
-        const client = postgres(url, {
-          onnotice: () => {},
-          idle_timeout: 240,
-          max_lifetime: 60 * 30,
-          connect_timeout: 10,
-          ...(url.includes("supabase") ? { prepare: false } : {}),
+      if (isNeonUrl(url)) {
+        _dbReady = getNeonServerlessDrizzle().then(({ drizzle, Pool }) => {
+          const pool = new Pool({ connectionString: url });
+          _db = drizzle(pool, { schema });
         });
-        _db = drizzle(client, { schema });
-      });
+      } else {
+        _dbReady = getPgDrizzle().then(({ drizzle, postgres }) => {
+          const client = postgres(url, {
+            onnotice: () => {},
+            idle_timeout: 240,
+            max_lifetime: 60 * 30,
+            connect_timeout: 10,
+            ...(url.includes("supabase") ? { prepare: false } : {}),
+          });
+          _db = drizzle(client, { schema });
+        });
+      }
     } else {
       _dbReady = getLibsqlDrizzle().then(({ drizzle }) => {
         _db = drizzle({

--- a/packages/core/src/server/action-discovery.ts
+++ b/packages/core/src/server/action-discovery.ts
@@ -259,6 +259,7 @@ async function loadActionsIntoRegistry(
           tool: mod.tool,
           run: mod.run,
           ...(mod.http !== undefined ? { http: mod.http } : {}),
+          ...(mod.readOnly === true ? { readOnly: true } : {}),
         };
       } else if (
         mod.default &&
@@ -270,6 +271,7 @@ async function loadActionsIntoRegistry(
           tool: mod.default.tool,
           run: mod.default.run,
           ...(mod.default.http !== undefined ? { http: mod.default.http } : {}),
+          ...(mod.default.readOnly === true ? { readOnly: true } : {}),
         };
       } else if (typeof mod.default === "function") {
         registry[name] = wrapDefaultExport(name, mod.default);

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -109,7 +109,14 @@ export function mountActionRoutes(
             // their action queries. The calling tab already refetches via
             // useActionMutation's onSuccess, so this is mainly cross-tab
             // sync (and parity with the agent's tool-call path).
-            const isReadOnly = entry.readOnly === true || method === "GET";
+            // Explicit entry.readOnly (true OR false) wins over the method
+            // heuristic. defineAction already auto-infers GET → readOnly=true,
+            // so for actions registered through that path entry.readOnly is
+            // always set and the fallback just guards legacy wrap paths.
+            const isReadOnly =
+              typeof entry.readOnly === "boolean"
+                ? entry.readOnly
+                : method === "GET";
             if (!isReadOnly) {
               try {
                 recordChange({

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -9,6 +9,7 @@ import { defineEventHandler, setResponseStatus, getMethod, getQuery } from "h3";
 import type { ActionEntry } from "../agent/production-agent.js";
 import { readBody } from "../server/h3-helpers.js";
 import { runWithRequestContext } from "./request-context.js";
+import { recordChange } from "./poll.js";
 
 const ROUTE_PREFIX = "/_agent-native/actions";
 
@@ -101,6 +102,25 @@ export function mountActionRoutes(
           // Run the action
           try {
             const result = await entry.run(params);
+
+            // Auto-refresh the UI after a successful mutating action. GET
+            // actions and actions explicitly flagged readOnly are skipped.
+            // Other tabs' useDbSync will see source:"action" and invalidate
+            // their action queries. The calling tab already refetches via
+            // useActionMutation's onSuccess, so this is mainly cross-tab
+            // sync (and parity with the agent's tool-call path).
+            const isReadOnly = entry.readOnly === true || method === "GET";
+            if (!isReadOnly) {
+              try {
+                recordChange({
+                  source: "action",
+                  type: "change",
+                  key: name,
+                });
+              } catch {
+                // ignore
+              }
+            }
 
             // If the action returned a string, try to parse as JSON for a clean response
             if (typeof result === "string") {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -83,9 +83,11 @@ async function lazyFs(): Promise<typeof import("fs")> {
 function wrapCliScript(
   tool: ActionTool,
   cliDefault: (args: string[]) => Promise<void>,
+  opts?: { readOnly?: boolean },
 ): ActionEntry {
   return {
     tool,
+    ...(opts?.readOnly ? { readOnly: true as const } : {}),
     run: async (args: Record<string, string>): Promise<string> => {
       const cliArgs: string[] = [];
       for (const [k, v] of Object.entries(args)) {
@@ -138,9 +140,13 @@ function wrapCliScript(
 function createRefreshScreenEntry(): Record<string, ActionEntry> {
   return {
     "refresh-screen": {
+      // Writes __screen_refresh__ to application_state, which emits its own
+      // distinct `screen-refresh` poll event. Don't double-emit a generic
+      // `action` event on top of that.
+      readOnly: true,
       tool: {
         description:
-          "Refresh the user's current screen so it picks up data you just changed. Call this immediately after any mutation (db-exec, template action, writeAppState) that affects what the user is currently looking at — a dashboard config, a form, a document, a row in a table they're viewing, etc. The UI re-fetches its queries without a full page reload. Prefer this over asking the user to reload. Optional `scope` hint is passed through to the client for templates that want to narrow the invalidation.",
+          "Manually refresh the user's current screen. The framework ALREADY auto-refreshes after any successful mutating action tool call (template actions, db-exec, db-patch) — you do NOT need to call this after a normal action. Use it only when (a) you mutated data via a path the framework can't detect (e.g. a direct write to an external system the app mirrors), or (b) you want to pass a `scope` hint so the UI narrows which queries to refetch. The UI re-fetches its queries without a full page reload.",
         parameters: {
           type: "object",
           properties: {
@@ -183,6 +189,9 @@ const SCREEN_REFRESH_KEY = "__screen_refresh__";
 function createUrlTools(): Record<string, ActionEntry> {
   return {
     "set-search-params": {
+      // Writes __set_url__ to application_state, which the app-state watcher
+      // already surfaces as a poll event. No need to double-emit.
+      readOnly: true,
       tool: {
         description:
           "Update the URL query string on the user's current page. Use this to change dashboard/list filters, search terms, or any other state the app stores in `?foo=bar` style query params. One-shot — the UI applies it in ~1s without a page reload. See the current URL + parsed search params in the auto-injected `<current-url>` block. Keys are the exact query param names as they appear in the URL (e.g. `f_pubDateStart`, not just `pubDateStart`). Set a value to null or empty string to clear that param. By default merges over existing params — pass `merge: false` to replace them all.",
@@ -221,6 +230,9 @@ function createUrlTools(): Record<string, ActionEntry> {
       },
     },
     "set-url-path": {
+      // Same as set-search-params — writes application_state, already emits
+      // via the app-state watcher.
+      readOnly: true,
       tool: {
         description:
           "Navigate the user to a different pathname, optionally also setting search params. For most template-specific routing prefer the template's `navigate` action if it exists — this is the generic fallback. One-shot, applied by the client without a page reload.",
@@ -304,6 +316,7 @@ async function createDbScriptEntries(): Promise<Record<string, ActionEntry>> {
           },
         },
         schemaMod.default,
+        { readOnly: true },
       ),
       "db-query": wrapCliScript(
         {
@@ -332,6 +345,7 @@ async function createDbScriptEntries(): Promise<Record<string, ActionEntry>> {
           },
         },
         queryMod.default,
+        { readOnly: true },
       ),
       "db-exec": wrapCliScript(
         {
@@ -443,6 +457,7 @@ async function createDocsScriptEntries(): Promise<Record<string, ActionEntry>> {
           },
         },
         mod.default,
+        { readOnly: true },
       ),
     };
   } catch {
@@ -1138,7 +1153,7 @@ const FRAMEWORK_CORE = `
 2. **Context awareness** — The user's current screen state is automatically included in each message as a \`<current-screen>\` block, and the current URL (path + search params) as a \`<current-url>\` block. Use both to understand what the user is looking at — filters, search terms, and other URL-driven state live in \`<current-url>\`'s \`searchParams\`, NOT in the settings table. To change URL state (e.g. toggle a filter, clear a query string), use the \`set-search-params\` or \`set-url-path\` tools — never try to edit URL state by writing to settings or application_state directly.
 3. **Navigate the UI** — Use the \`navigate\` tool to switch views, open items, or focus elements for the user.
 4. **Application state** — Ephemeral UI state (drafts, selections, navigation) lives in \`application_state\`. Use \`readAppState\`/\`writeAppState\` to read and write it. When you write state, the UI updates automatically.
-5. **Refresh after on-screen data changes** — Whenever you mutate data that is visible on the user's CURRENT screen (editing a dashboard config, updating a form schema, changing a row in a table they're viewing, etc.), call \`refresh-screen\` as your final step. The UI re-fetches its queries without a full page reload. Do NOT tell the user to reload the page — call \`refresh-screen\` instead. Skip it only when you're certain the change isn't on the current screen.
+5. **Screen refresh is automatic after action calls** — The framework auto-emits a refresh event after any successful mutating tool call (template actions like \`log-meal\`, \`update-form\`, \`edit-document\`, and the \`db-exec\` / \`db-patch\` tools). The UI re-fetches its queries without a full page reload. You do NOT need to call \`refresh-screen\` after an action — it's already handled. Only call \`refresh-screen\` explicitly when (a) you mutated data via a path the framework can't detect (e.g. writing directly to an external system whose results the app mirrors), or (b) you want to pass a \`scope\` hint so the UI narrows which queries to refetch. Do NOT tell the user to reload the page.
 6. **Memory** — Use the structured memory system to persist knowledge across sessions. Use \`save-memory\` proactively when you learn preferences, corrections, or project context. Update shared AGENTS.md for instructions that should apply to all users.
 7. **Security** — Always use \`defineAction\` with a Zod \`schema:\` for input validation. Never construct SQL with string concatenation — use parameterized queries via db-query/db-exec. Never use \`dangerouslySetInnerHTML\`, \`innerHTML\`, or \`eval()\`. Never expose secrets in responses or source code. Every table with user data must have \`owner_email\`.
 

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -374,17 +374,7 @@ async function createBetterAuthInstance(
       },
     },
     advanced: {
-      // Per-app cookie prefix so multi-template setups (dev:all, desktop,
-      // multi-app deploys on a shared domain) don't share one cookie slot.
-      // Browsers scope cookies by host, not host+port — without this, signing
-      // into one template overwrites another's session cookie.
-      cookiePrefix: (() => {
-        const slug = (process.env.APP_NAME || "")
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, "_")
-          .replace(/^_+|_+$/g, "");
-        return slug ? `an_${slug}` : "an";
-      })(),
+      cookiePrefix: "an",
     },
     plugins: [
       // Organizations: many:many user:org, roles, invitations

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
+      '@neondatabase/serverless':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
@@ -148,7 +151,7 @@ importers:
         version: 3.22.2
       better-auth:
         specifier: ^1.6.0
-        version: 1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1))
+        version: 1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1))
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
@@ -169,7 +172,7 @@ importers:
         version: 17.4.0
       drizzle-orm:
         specifier: ^0.44.0
-        version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+        version: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       h3:
         specifier: ^2.0.1-rc.20
         version: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
@@ -187,7 +190,7 @@ importers:
         version: 4.0.2
       nitro:
         specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
+        version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
       ollama-ai-provider:
         specifier: '>=1'
         version: 1.2.0(zod@4.3.6)
@@ -877,7 +880,7 @@ importers:
         version: 17.4.0
       drizzle-orm:
         specifier: ^0.44.2
-        version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+        version: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       h3:
         specifier: ^2.0.1-rc.20
         version: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
@@ -1169,7 +1172,7 @@ importers:
         version: 3.0.2(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
       drizzle-orm:
         specifier: ^0.44.0
-        version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+        version: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       h3:
         specifier: ^2.0.1-rc.20
         version: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
@@ -1311,7 +1314,7 @@ importers:
         version: 3.41.1(react@18.3.1)
       drizzle-orm:
         specifier: ^0.44.5
-        version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+        version: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       h3:
         specifier: ^2.0.1-rc.20
         version: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
@@ -1564,7 +1567,7 @@ importers:
         version: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       drizzle-orm:
         specifier: ^0.44.2
-        version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+        version: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@18.3.1)
@@ -1736,7 +1739,7 @@ importers:
         version: 3.41.1(react@18.3.1)
       drizzle-orm:
         specifier: ^0.44.0
-        version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+        version: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       h3:
         specifier: ^2.0.1-rc.20
         version: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
@@ -1926,7 +1929,7 @@ importers:
         version: 3.41.1(react@18.3.1)
       drizzle-orm:
         specifier: ^0.44.0
-        version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+        version: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       h3:
         specifier: ^2.0.1-rc.20
         version: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
@@ -2143,7 +2146,7 @@ importers:
         version: 2.9.0
       drizzle-orm:
         specifier: ^0.44.0
-        version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+        version: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@18.3.1)
@@ -2405,7 +2408,7 @@ importers:
         version: 3.41.1(react@18.3.1)
       drizzle-orm:
         specifier: ^0.44.0
-        version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+        version: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       h3:
         specifier: ^2.0.1-rc.20
         version: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
@@ -2625,7 +2628,7 @@ importers:
         version: 17.4.0
       drizzle-orm:
         specifier: ^0.44.0
-        version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+        version: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       h3:
         specifier: ^2.0.1-rc.20
         version: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
@@ -3092,7 +3095,7 @@ importers:
         version: 3.41.1(react@18.3.1)
       drizzle-orm:
         specifier: ^0.44.0
-        version: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+        version: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       h3:
         specifier: ^2.0.1-rc.20
         version: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
@@ -5953,6 +5956,10 @@ packages:
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
+  '@neondatabase/serverless@1.0.2':
+    resolution: {integrity: sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==}
+    engines: {node: '>=19.0.0'}
+
   '@noble/ciphers@2.1.1':
     resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
     engines: {node: '>= 20.19.0'}
@@ -8690,6 +8697,9 @@ packages:
 
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/plist@3.0.5':
     resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
@@ -15782,12 +15792,12 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/drizzle-adapter@1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))':
+  '@better-auth/drizzle-adapter@1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))':
     dependencies:
       '@better-auth/core': 1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
-      drizzle-orm: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+      drizzle-orm: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
 
   '@better-auth/kysely-adapter@1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.15)':
     dependencies:
@@ -17516,6 +17526,11 @@ snapshots:
     optional: true
 
   '@neon-rs/load@0.0.4': {}
+
+  '@neondatabase/serverless@1.0.2':
+    dependencies:
+      '@types/node': 22.19.17
+      '@types/pg': 8.20.0
 
   '@noble/ciphers@2.1.1': {}
 
@@ -21092,6 +21107,12 @@ snapshots:
 
   '@types/offscreencanvas@2019.7.3': {}
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 24.12.2
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
   '@types/plist@3.0.5':
     dependencies:
       '@types/node': 24.12.2
@@ -21672,10 +21693,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.14: {}
 
-  better-auth@1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)):
+  better-auth@1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)):
     dependencies:
       '@better-auth/core': 1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))
+      '@better-auth/drizzle-adapter': 1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))
       '@better-auth/kysely-adapter': 1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.15)
       '@better-auth/memory-adapter': 1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
       '@better-auth/mongo-adapter': 1.6.0(@better-auth/core@1.6.0(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.15)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
@@ -21694,7 +21715,7 @@ snapshots:
     optionalDependencies:
       better-sqlite3: 12.8.0
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+      drizzle-orm: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
       pg: 8.20.0
       react: 18.3.1
       react-dom: 19.2.4(react@18.3.1)
@@ -22497,11 +22518,11 @@ snapshots:
 
   dayjs@1.11.20: {}
 
-  db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)):
+  db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)):
     optionalDependencies:
       '@libsql/client': 0.15.15
       better-sqlite3: 12.8.0
-      drizzle-orm: 0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
+      drizzle-orm: 0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)
 
   debug@2.6.9:
     dependencies:
@@ -22676,11 +22697,13 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8):
+  drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8):
     optionalDependencies:
       '@libsql/client': 0.15.15
+      '@neondatabase/serverless': 1.0.2
       '@opentelemetry/api': 1.9.1
       '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.20.0
       better-sqlite3: 12.8.0
       kysely: 0.28.15
       pg: 8.20.0
@@ -25771,11 +25794,11 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro@3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)):
+  nitro@3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.4(srvx@0.11.15)
-      db0: 0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))
+      db0: 0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))
       env-runner: 0.1.7(miniflare@4.20260405.0)
       h3: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
       hookable: 6.1.0
@@ -25786,7 +25809,7 @@ snapshots:
       rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       srvx: 0.11.15
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)))(ioredis@5.10.1)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)))(ioredis@5.10.1)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.4.0
       giget: 3.2.0
@@ -26110,16 +26133,14 @@ snapshots:
   pg-connection-string@2.12.0:
     optional: true
 
-  pg-int8@1.0.1:
-    optional: true
+  pg-int8@1.0.1: {}
 
   pg-pool@3.13.0(pg@8.20.0):
     dependencies:
       pg: 8.20.0
     optional: true
 
-  pg-protocol@1.13.0:
-    optional: true
+  pg-protocol@1.13.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -26128,7 +26149,6 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
-    optional: true
 
   pg@8.20.0:
     dependencies:
@@ -26261,19 +26281,15 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgres-array@2.0.0:
-    optional: true
+  postgres-array@2.0.0: {}
 
-  postgres-bytea@1.0.1:
-    optional: true
+  postgres-bytea@1.0.1: {}
 
-  postgres-date@1.0.7:
-    optional: true
+  postgres-date@1.0.7: {}
 
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
-    optional: true
 
   postgres@3.4.8: {}
 
@@ -28084,10 +28100,10 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unstorage@2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)))(ioredis@5.10.1)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(chokidar@4.0.3)(db0@0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8)))(ioredis@5.10.1)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       chokidar: 4.0.3
-      db0: 0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))
+      db0: 0.3.4(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(drizzle-orm@0.44.7(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.8))
       ioredis: 5.10.1
       lru-cache: 11.2.7
       ofetch: 2.0.0-alpha.3
@@ -28651,8 +28667,7 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
-  xtend@4.0.2:
-    optional: true
+  xtend@4.0.2: {}
 
   y-protocols@1.0.7(yjs@13.6.30):
     dependencies:

--- a/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
+++ b/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
@@ -107,29 +107,29 @@ export function GoogleConnectBanner({
     fetchStatus();
   }, [fetchStatus]);
 
-  // When auth URL is ready, open it and poll for connection
+  // When auth URL is ready, open it and poll for connection.
+  // Gate on wantAuthUrl so a cached/refetched URL doesn't open a second
+  // popup behind the first when React Query returns stale data immediately
+  // and then refetches in the background.
   useEffect(() => {
-    if (authUrl.data?.url) {
-      window.open(authUrl.data.url, "_blank");
-      setWantAuthUrl(false);
+    if (!wantAuthUrl || !authUrl.data?.url) return;
+    setWantAuthUrl(false);
+    window.open(authUrl.data.url, "_blank");
 
-      const interval = setInterval(async () => {
-        const res = await fetch("/_agent-native/google/status").catch(
-          () => null,
-        );
-        if (res?.ok) {
-          const data = await res.json();
-          if (data.connected) {
-            clearInterval(interval);
-            setDismissed(true);
-            window.location.reload();
-          }
+    const interval = setInterval(async () => {
+      const res = await fetch("/_agent-native/google/status").catch(() => null);
+      if (res?.ok) {
+        const data = await res.json();
+        if (data.connected) {
+          clearInterval(interval);
+          setDismissed(true);
+          window.location.reload();
         }
-      }, 2000);
+      }
+    }, 2000);
 
-      return () => clearInterval(interval);
-    }
-  }, [authUrl.data]);
+    return () => clearInterval(interval);
+  }, [wantAuthUrl, authUrl.data]);
 
   // When auth URL fails with missing credentials, show wizard
   useEffect(() => {

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -189,11 +189,10 @@ function GoogleConnectSidebarButton() {
   const authUrl = useGoogleAuthUrl(wantAuthUrl);
 
   useEffect(() => {
-    if (authUrl.data?.url) {
-      window.open(authUrl.data.url, "_blank");
-      setWantAuthUrl(false);
-    }
-  }, [authUrl.data]);
+    if (!wantAuthUrl || !authUrl.data?.url) return;
+    setWantAuthUrl(false);
+    window.open(authUrl.data.url, "_blank");
+  }, [wantAuthUrl, authUrl.data]);
 
   return (
     <div className="border-t border-border p-3">

--- a/templates/calendar/app/pages/Settings.tsx
+++ b/templates/calendar/app/pages/Settings.tsx
@@ -68,11 +68,10 @@ export default function Settings() {
   }
 
   useEffect(() => {
-    if (authUrl.data?.url) {
-      window.open(authUrl.data.url, "_blank");
-      setWantAuthUrl(false);
-    }
-  }, [authUrl.data]);
+    if (!wantAuthUrl || !authUrl.data?.url) return;
+    setWantAuthUrl(false);
+    window.open(authUrl.data.url, "_blank");
+  }, [wantAuthUrl, authUrl.data]);
 
   useEffect(() => {
     if (authUrl.error) {

--- a/templates/macros/actions/run.ts
+++ b/templates/macros/actions/run.ts
@@ -1,0 +1,2 @@
+import { runScript } from "@agent-native/core/scripts";
+runScript();

--- a/templates/mail/app/components/GoogleConnectBanner.tsx
+++ b/templates/mail/app/components/GoogleConnectBanner.tsx
@@ -118,44 +118,39 @@ export function GoogleConnectBanner({
     fetchStatus();
   }, [fetchStatus]);
 
-  // When auth URL is ready, open it and poll for connection
+  // When auth URL is ready, open it and poll for connection.
+  // Gate on wantAuthUrl so a cached/refetched URL doesn't open a second
+  // popup behind the first when React Query returns stale data immediately
+  // and then refetches in the background.
   useEffect(() => {
-    if (authUrl.data?.url) {
-      const url = authUrl.data.url;
-      // In a React Native WebView, window.open() is silently blocked (WKWebView
-      // doesn't support it without onOpenWindow). Use postMessage to ask the
-      // native wrapper to open the URL in the system browser (Safari), falling
-      // back to window.location.href which triggers onShouldStartLoadWithRequest.
-      const rnWebView = (window as any).ReactNativeWebView;
-      const isNativeWebView = typeof rnWebView !== "undefined";
-      if (isNativeWebView) {
-        // postMessage is the most reliable bridge to the native layer
-        rnWebView.postMessage(JSON.stringify({ type: "openUrl", url }));
-      } else {
-        window.open(url, "_blank");
-      }
-      setWantAuthUrl(false);
-
-      // Poll for connection status while user completes OAuth in other tab.
-      // On mobile the native app reloads the WebView on return, so skip polling.
-      if (!isNativeWebView) {
-        const interval = setInterval(async () => {
-          const res = await fetch("/_agent-native/google/status").catch(
-            () => null,
-          );
-          if (res?.ok) {
-            const data = await res.json();
-            if (data.connected) {
-              clearInterval(interval);
-              window.location.reload();
-            }
-          }
-        }, 2000);
-
-        return () => clearInterval(interval);
-      }
+    if (!wantAuthUrl || !authUrl.data?.url) return;
+    const url = authUrl.data.url;
+    setWantAuthUrl(false);
+    // In a React Native WebView, window.open() is silently blocked (WKWebView
+    // doesn't support it without onOpenWindow). Use postMessage to ask the
+    // native wrapper to open the URL in the system browser (Safari).
+    const rnWebView = (window as any).ReactNativeWebView;
+    const isNativeWebView = typeof rnWebView !== "undefined";
+    if (isNativeWebView) {
+      rnWebView.postMessage(JSON.stringify({ type: "openUrl", url }));
+      return;
     }
-  }, [authUrl.data]);
+    window.open(url, "_blank");
+
+    // Poll for connection status while user completes OAuth in other tab.
+    const interval = setInterval(async () => {
+      const res = await fetch("/_agent-native/google/status").catch(() => null);
+      if (res?.ok) {
+        const data = await res.json();
+        if (data.connected) {
+          clearInterval(interval);
+          window.location.reload();
+        }
+      }
+    }, 2000);
+
+    return () => clearInterval(interval);
+  }, [wantAuthUrl, authUrl.data]);
 
   // When auth URL fails, show wizard (for missing credentials) or an error message
   useEffect(() => {

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -158,7 +158,7 @@ export function EmailList({
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-  } = useEmails(view, searchQuery);
+  } = useEmails(view, searchQuery, labelParam ?? undefined);
 
   const emails = emailsProp ?? fetchedEmails;
   const markRead = useMarkRead();

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -1499,26 +1499,23 @@ function AccountPopover({
   const disconnectGoogle = useDisconnectGoogle();
 
   useEffect(() => {
-    if (authUrl.data?.url) {
-      window.open(authUrl.data.url, "_blank");
-      setWantAuthUrl(false);
+    if (!wantAuthUrl || !authUrl.data?.url) return;
+    setWantAuthUrl(false);
+    window.open(authUrl.data.url, "_blank");
 
-      const interval = setInterval(async () => {
-        const res = await fetch("/_agent-native/google/status").catch(
-          () => null,
-        );
-        if (res?.ok) {
-          const data = await res.json();
-          if (data.accounts?.length > accounts.length) {
-            clearInterval(interval);
-            window.location.reload();
-          }
+    const interval = setInterval(async () => {
+      const res = await fetch("/_agent-native/google/status").catch(() => null);
+      if (res?.ok) {
+        const data = await res.json();
+        if (data.accounts?.length > accounts.length) {
+          clearInterval(interval);
+          window.location.reload();
         }
-      }, 2000);
+      }
+    }, 2000);
 
-      return () => clearInterval(interval);
-    }
-  }, [authUrl.data, accounts.length]);
+    return () => clearInterval(interval);
+  }, [wantAuthUrl, authUrl.data, accounts.length]);
 
   // Empty activeAccounts means "all selected"
   const allSelected = activeAccounts.size === 0;

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -249,12 +249,17 @@ interface EmailsPage {
   totalEstimate?: number;
 }
 
-export function useEmails(view: string = "inbox", search?: string) {
+export function useEmails(
+  view: string = "inbox",
+  search?: string,
+  label?: string,
+) {
   const q = useInfiniteQuery({
-    queryKey: ["emails", view, search],
+    queryKey: ["emails", view, search, label],
     queryFn: ({ pageParam }: { pageParam: string | undefined }) => {
       const params = new URLSearchParams({ view });
       if (search) params.set("q", search);
+      if (label) params.set("label", label);
       if (pageParam) params.set("pageToken", pageParam);
       return apiFetch<EmailsPage>(`/api/emails?${params}`);
     },

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -181,7 +181,7 @@ export function InboxPage() {
     isLoading,
     isError,
     refetch,
-  } = useEmails(view, searchQuery);
+  } = useEmails(view, searchQuery, activeLabel ?? undefined);
   const googleStatus = useGoogleAuthStatus();
   const { activeAccounts } = useAccountFilter();
 

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -307,9 +307,14 @@ function recomputeUnreadCounts(
 
 export const listEmails = defineEventHandler(async (event: H3Event) => {
   const email = await userEmail(event);
-  const { view = "inbox", q } = getQuery(event) as {
+  const {
+    view = "inbox",
+    q,
+    label,
+  } = getQuery(event) as {
     view?: string;
     q?: string;
+    label?: string;
   };
 
   if (view === "snoozed" || view === "scheduled") {
@@ -363,6 +368,15 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
         searchQuery = `{from:(${q}) to:(${q}) cc:(${q}) ${q}}`;
       } else {
         searchQuery = gmailQuery[view] ?? `label:${view}`;
+      }
+      // If a specific label filter is active (e.g. a pinned label tab), scope
+      // the Gmail query server-side. Gmail's `label:` operator wants the label
+      // name with spaces replaced by hyphens; nested labels use `/`.
+      if (label) {
+        const gmailLabel = label.replace(/\s+/g, "-");
+        searchQuery = searchQuery
+          ? `${searchQuery} label:${gmailLabel}`
+          : `label:${gmailLabel}`;
       }
 
       // Fetch label name mapping from all accounts (cached)

--- a/templates/mail/server/lib/automation-engine.ts
+++ b/templates/mail/server/lib/automation-engine.ts
@@ -53,6 +53,22 @@ interface RuleRecord {
   updatedAt: number;
 }
 
+// ─── Per-user Anthropic key ──────────────────────────────────────────────────
+
+async function resolveAnthropicKey(
+  ownerEmail: string,
+): Promise<string | undefined> {
+  const userKey = (await getUserSetting(ownerEmail, "anthropic-api-key")) as
+    | string
+    | { key?: string }
+    | undefined;
+  if (typeof userKey === "string" && userKey.trim()) return userKey.trim();
+  if (userKey && typeof userKey === "object" && userKey.key?.trim()) {
+    return userKey.key.trim();
+  }
+  return process.env.ANTHROPIC_API_KEY || undefined;
+}
+
 // ─── Token helpers ───────────────────────────────────────────────────────────
 
 async function getAccessToken(accountEmail: string): Promise<string | null> {
@@ -416,10 +432,13 @@ export async function processAutomationsForAccount(
   const rules = await loadActiveRules(ownerEmail, "mail");
   if (rules.length === 0) return result;
 
-  // 2. Check for API key
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  // 2. Resolve API key — prefer the user's own key from settings, fall back
+  //    to the server env var only if no per-user key is configured.
+  const apiKey = await resolveAnthropicKey(ownerEmail);
   if (!apiKey) {
-    console.warn("[automation-engine] No ANTHROPIC_API_KEY set, skipping");
+    console.warn(
+      `[automation-engine] No Anthropic API key for ${ownerEmail}, skipping`,
+    );
     return result;
   }
 

--- a/templates/mail/server/plugins/mail-jobs.ts
+++ b/templates/mail/server/plugins/mail-jobs.ts
@@ -49,6 +49,16 @@ async function processJobs(): Promise<void> {
 }
 
 export default () => {
+  // Background cron must only run in one place — otherwise every dev server
+  // processes jobs and automations for every connected user globally, leading
+  // to duplicate actions and duplicate Anthropic spend.
+  if (process.env.RUN_BACKGROUND_JOBS !== "1") {
+    console.log(
+      "[mail-jobs] Skipping background cron (set RUN_BACKGROUND_JOBS=1 to enable)",
+    );
+    return;
+  }
+
   setInterval(async () => {
     try {
       await processJobs();


### PR DESCRIPTION
## Summary

- Fixes the agent-native UI-not-refreshing bug observed in production macros (agent called \`log-meal\`/\`log-exercise\` but the dashboard stayed stale because it didn't call \`refresh-screen\`). Now every template auto-refreshes after any mutating action tool call — no model opt-in needed.
- Core change: \`production-agent\` and the auto-mounted action HTTP route emit \`recordChange({source:"action"})\` after any successful non-read-only action. \`useDbSync\` always invalidates \`["action"]\` on non-own change events, so every template's \`useActionQuery\` caches refresh automatically.
- \`defineAction\` gains a \`readOnly\` flag (auto-inferred from \`http.method === "GET"\`). Core scripts \`db-query\`, \`db-schema\`, \`docs-search\`, \`refresh-screen\`, \`set-url-*\` marked read-only so they don't double-emit.
- Framework system prompt + \`.agents/skills/actions\` + \`.agents/skills/real-time-sync\` + root \`CLAUDE.md\` updated so new actions and LLM-authored templates inherit the auto-refresh mental model by default.
- Also includes concurrent work: Neon serverless HTTP driver support in \`createGetDb\`, mail inbox/emails polish.

## Test plan

- [x] \`pnpm run prep\` green (build + typecheck + tests + fmt)
- [x] New unit tests for \`defineAction\` readOnly inference (6 cases)
- [ ] Manually verify in macros prod: agent logs a meal → daily totals card updates without calling \`refresh-screen\`
- [ ] Verify in calendar/forms/dispatch templates: agent mutation propagates to UI (these previously had narrow \`queryKeys\` that wouldn't match \`action\` events — the \`useDbSync\` change covers them now)