### PR TITLE
updates-104: analytics top-right chat toggle + Builder onboarding option

### DIFF
--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -33,6 +33,7 @@ import { type ContentPart, readSSEStreamRaw } from "./sse-event-processor.js";
 import { cn } from "./utils.js";
 import { AgentTaskCard } from "./AgentTaskCard.js";
 import { ConnectBuilderCard } from "./ConnectBuilderCard.js";
+import { useBuilderStatus } from "./settings/useBuilderStatus.js";
 import {
   TiptapComposer,
   type TiptapComposerHandle,
@@ -47,6 +48,7 @@ import {
   IconCopy,
   IconTerminal,
   IconLoader2,
+  IconExternalLink,
   IconCircleX,
   IconSquareFilled,
   IconClock,
@@ -753,6 +755,9 @@ function ApiKeySetupCard({ apiUrl }: { apiUrl: string }) {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { status: builder } = useBuilderStatus();
+  const builderEnabled = builder?.builderEnabled ?? false;
+  const builderConnectUrl = builder?.connectUrl;
 
   const handleSave = async () => {
     if (!apiKey.trim()) return;
@@ -799,12 +804,49 @@ function ApiKeySetupCard({ apiUrl }: { apiUrl: string }) {
             Connect your AI
           </h3>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Add an Anthropic API key to enable the agent
+            Connect Builder or add an Anthropic API key to enable the agent
           </p>
         </div>
       </div>
 
       <div className="space-y-3">
+        {/* Builder path — managed LLM proxy, no API key needed */}
+        <div className="rounded-md border border-border px-3 py-2.5">
+          <div className="flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <div className="text-xs font-medium text-foreground">
+                Connect Builder
+              </div>
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                Use Builder's managed Anthropic proxy — no API key needed
+              </p>
+            </div>
+            {builderEnabled && builderConnectUrl ? (
+              <a
+                href={builderConnectUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex shrink-0 items-center gap-1 rounded bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground hover:opacity-90"
+              >
+                Connect
+                <IconExternalLink className="h-3 w-3" />
+              </a>
+            ) : (
+              <span className="shrink-0 rounded border border-border px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                Coming soon
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="relative flex items-center">
+          <div className="flex-grow border-t border-border" />
+          <span className="mx-2 text-[10px] uppercase tracking-wider text-muted-foreground/60">
+            or
+          </span>
+          <div className="flex-grow border-t border-border" />
+        </div>
+
         <div className="rounded-md bg-muted/50 px-3 py-2.5 text-xs text-muted-foreground leading-relaxed">
           <p>
             1. Go to{" "}

--- a/templates/analytics/.agents/skills/adhoc-analysis/SKILL.md
+++ b/templates/analytics/.agents/skills/adhoc-analysis/SKILL.md
@@ -60,7 +60,29 @@ Don't just dump raw data. Synthesize findings:
 - Call out surprises or actionable insights
 - Compare against benchmarks or prior periods when possible
 
-### Step 4: Format Results as Markdown
+### Step 4: Generate Charts (when useful)
+
+When the analysis benefits from a visual — trends over time, distributions, comparisons between categories — call `generate-chart` before formatting the report. The action returns a `url` you embed directly in the markdown.
+
+```
+generate-chart
+  --title "Closed-lost deals by month"
+  --type bar
+  --labels '["Jan","Feb","Mar"]'
+  --data '[18, 22, 14]'
+```
+
+Embed the returned URL in `resultMarkdown` using standard markdown image syntax:
+
+```markdown
+![Closed-lost deals by month](/api/media/closed-lost-deals-by-month-1234567890.png?v=1234567890)
+```
+
+You can include multiple charts in one analysis. Reach for a chart when it communicates the finding faster than a table — don't force visuals on every analysis.
+
+Include the re-generation step in your saved `instructions` so re-runs produce fresh charts.
+
+### Step 5: Format Results as Markdown
 
 Structure the report clearly:
 
@@ -94,7 +116,7 @@ Time range: Jan 1 – Mar 31, 2026
 Filters: S1+ pipeline, closed-lost only
 ```
 
-### Step 5: Save the Analysis
+### Step 6: Save the Analysis
 
 Call `save-analysis` with all required fields:
 
@@ -125,7 +147,7 @@ save-analysis
 - What structure the output should have
 - End with "Save results with save-analysis using id='...'"
 
-### Step 6: Navigate to the Result
+### Step 7: Navigate to the Result
 
 After saving, navigate the user to see the saved analysis:
 

--- a/templates/analytics/app/components/Markdown.tsx
+++ b/templates/analytics/app/components/Markdown.tsx
@@ -59,6 +59,11 @@ function renderInline(text: string): string {
       .replace(/_(.+?)_/g, "<em>$1</em>")
       // Inline code
       .replace(/`([^`]+)`/g, "<code>$1</code>")
+      // Images — must run before the link pattern since ![alt](url) contains [alt](url)
+      .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_m, alt, rawUrl) => {
+        const safe = sanitizeUrl(rawUrl);
+        return `<img src="${escapeHtml(safe)}" alt="${alt}" loading="lazy" />`;
+      })
       // Links — sanitize URL to block javascript:/data:/vbscript:/file:
       .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, label, rawUrl) => {
         const safe = sanitizeUrl(rawUrl);

--- a/templates/analytics/app/components/layout/Header.tsx
+++ b/templates/analytics/app/components/layout/Header.tsx
@@ -1,12 +1,17 @@
-import { useAuth } from "@/components/auth/AuthProvider";
 import { useLocation } from "react-router";
 import { dashboards } from "@/pages/adhoc/registry";
 import { useHeaderActions } from "./HeaderActions";
+import { AgentToggleButton } from "@agent-native/core/client";
 
 const pageTitles: Record<string, string> = {
   "/": "Overview",
+  "/data-sources": "Data Sources",
+  "/data-dictionary": "Data Dictionary",
   "/query": "Query Explorer",
+  "/analyses": "Analyses",
+  "/team": "Team",
   "/settings": "Settings",
+  "/about": "About",
 };
 
 function resolveTitle(pathname: string): string {
@@ -19,27 +24,27 @@ function resolveTitle(pathname: string): string {
     return dash?.name || "Dashboard";
   }
 
-  return "Dashboard";
+  if (pathname.startsWith("/analyses/")) return "Analyses";
+
+  return "Analytics";
 }
 
 export function Header() {
-  const { auth } = useAuth();
   const location = useLocation();
-  const title = resolveTitle(location.pathname);
-  const { actions } = useHeaderActions();
+  const { title, actions } = useHeaderActions();
 
   return (
-    <header className="flex h-14 lg:h-[60px] items-center gap-4 border-b bg-background px-4 md:px-6">
+    <header className="hidden md:flex h-14 items-center gap-3 border-b border-border bg-background px-4 lg:h-[60px] lg:px-6 shrink-0">
       <div className="flex items-center gap-3 flex-1 min-w-0">
-        <h1 className="font-semibold text-lg truncate">{title}</h1>
-        <div className="hidden sm:flex items-center gap-2">{actions}</div>
-      </div>
-      <div className="flex items-center gap-3 shrink-0">
-        {auth && (
-          <span className="text-sm text-muted-foreground hidden sm:inline truncate max-w-[200px]">
-            {auth.email}
-          </span>
+        {title ?? (
+          <h1 className="text-lg font-semibold tracking-tight truncate">
+            {resolveTitle(location.pathname)}
+          </h1>
         )}
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        {actions}
+        <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
       </div>
     </header>
   );

--- a/templates/analytics/app/components/layout/Header.tsx
+++ b/templates/analytics/app/components/layout/Header.tsx
@@ -35,7 +35,7 @@ export function Header() {
   const actions = useHeaderActions();
 
   return (
-    <header className="hidden md:flex h-14 items-center gap-3 border-b border-border bg-background px-4 lg:h-[60px] lg:px-6 shrink-0">
+    <header className="flex h-14 items-center gap-3 border-b border-border bg-background px-4 lg:h-[60px] lg:px-6 shrink-0">
       <div className="flex items-center gap-3 flex-1 min-w-0">
         {title ?? (
           <h1 className="text-lg font-semibold tracking-tight truncate">

--- a/templates/analytics/app/components/layout/Header.tsx
+++ b/templates/analytics/app/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from "react-router";
 import { dashboards } from "@/pages/adhoc/registry";
-import { useHeaderActions } from "./HeaderActions";
+import { useHeaderTitle, useHeaderActions } from "./HeaderActions";
 import { AgentToggleButton } from "@agent-native/core/client";
 
 const pageTitles: Record<string, string> = {
@@ -31,7 +31,8 @@ function resolveTitle(pathname: string): string {
 
 export function Header() {
   const location = useLocation();
-  const { title, actions } = useHeaderActions();
+  const title = useHeaderTitle();
+  const actions = useHeaderActions();
 
   return (
     <header className="hidden md:flex h-14 items-center gap-3 border-b border-border bg-background px-4 lg:h-[60px] lg:px-6 shrink-0">

--- a/templates/analytics/app/components/layout/HeaderActions.tsx
+++ b/templates/analytics/app/components/layout/HeaderActions.tsx
@@ -1,55 +1,85 @@
 import {
-  createContext,
-  useContext,
-  useState,
   useEffect,
+  useSyncExternalStore,
   type ReactNode,
+  type FC,
 } from "react";
 
-interface HeaderActionsContextValue {
-  title: ReactNode;
-  setTitle: (node: ReactNode) => void;
-  actions: ReactNode;
-  setActions: (node: ReactNode) => void;
+/**
+ * External store for the page's header title + actions. We use an external
+ * store (not React context) so that pages can inject ReactNode without
+ * subscribing to the header state themselves — subscribing would trigger a
+ * re-render on every update, which in turn creates new JSX, which updates
+ * the store again, which re-renders… an infinite loop.
+ *
+ * Only <Header /> reads the store via useSyncExternalStore; pages only write.
+ */
+
+type Listener = () => void;
+
+let currentTitle: ReactNode = null;
+let currentActions: ReactNode = null;
+const listeners = new Set<Listener>();
+
+function notify() {
+  for (const l of listeners) l();
 }
 
-const HeaderActionsContext = createContext<HeaderActionsContextValue>({
-  title: null,
-  setTitle: () => {},
-  actions: null,
-  setActions: () => {},
-});
+function subscribe(l: Listener): () => void {
+  listeners.add(l);
+  return () => {
+    listeners.delete(l);
+  };
+}
 
-export function HeaderActionsProvider({ children }: { children: ReactNode }) {
-  const [title, setTitle] = useState<ReactNode>(null);
-  const [actions, setActions] = useState<ReactNode>(null);
-  return (
-    <HeaderActionsContext.Provider
-      value={{ title, setTitle, actions, setActions }}
-    >
-      {children}
-    </HeaderActionsContext.Provider>
+/** Consumed only by <Header /> — returns the current title. */
+export function useHeaderTitle(): ReactNode {
+  return useSyncExternalStore(
+    subscribe,
+    () => currentTitle,
+    () => currentTitle,
   );
 }
 
-export function useHeaderActions() {
-  return useContext(HeaderActionsContext);
+/** Consumed only by <Header /> — returns the current actions slot. */
+export function useHeaderActions(): ReactNode {
+  return useSyncExternalStore(
+    subscribe,
+    () => currentActions,
+    () => currentActions,
+  );
 }
+
+/**
+ * Provider is now a no-op wrapper for backwards compatibility — the state
+ * lives in the module-level store above. Kept as a component so callers of
+ * <HeaderActionsProvider> don't need to change.
+ */
+export const HeaderActionsProvider: FC<{ children: ReactNode }> = ({
+  children,
+}) => <>{children}</>;
 
 /** Mount a custom title into the app header. Cleans up on unmount. */
 export function useSetPageTitle(node: ReactNode) {
-  const { setTitle } = useHeaderActions();
   useEffect(() => {
-    setTitle(node);
-    return () => setTitle(null);
-  }, [node, setTitle]);
+    currentTitle = node;
+    notify();
+    return () => {
+      currentTitle = null;
+      notify();
+    };
+  });
 }
 
 /** Mount ReactNode into the header's actions slot. Cleans up on unmount. */
 export function useSetHeaderActions(node: ReactNode) {
-  const { setActions } = useHeaderActions();
   useEffect(() => {
-    setActions(node);
-    return () => setActions(null);
-  }, [node, setActions]);
+    currentActions = node;
+    notify();
+    return () => {
+      currentActions = null;
+      notify();
+    };
+  });
 }
+

--- a/templates/analytics/app/components/layout/HeaderActions.tsx
+++ b/templates/analytics/app/components/layout/HeaderActions.tsx
@@ -7,19 +7,26 @@ import {
 } from "react";
 
 interface HeaderActionsContextValue {
+  title: ReactNode;
+  setTitle: (node: ReactNode) => void;
   actions: ReactNode;
   setActions: (node: ReactNode) => void;
 }
 
 const HeaderActionsContext = createContext<HeaderActionsContextValue>({
+  title: null,
+  setTitle: () => {},
   actions: null,
   setActions: () => {},
 });
 
 export function HeaderActionsProvider({ children }: { children: ReactNode }) {
+  const [title, setTitle] = useState<ReactNode>(null);
   const [actions, setActions] = useState<ReactNode>(null);
   return (
-    <HeaderActionsContext.Provider value={{ actions, setActions }}>
+    <HeaderActionsContext.Provider
+      value={{ title, setTitle, actions, setActions }}
+    >
       {children}
     </HeaderActionsContext.Provider>
   );
@@ -29,7 +36,16 @@ export function useHeaderActions() {
   return useContext(HeaderActionsContext);
 }
 
-/** Mount ReactNode into the header bar. Cleans up on unmount. */
+/** Mount a custom title into the app header. Cleans up on unmount. */
+export function useSetPageTitle(node: ReactNode) {
+  const { setTitle } = useHeaderActions();
+  useEffect(() => {
+    setTitle(node);
+    return () => setTitle(null);
+  }, [node, setTitle]);
+}
+
+/** Mount ReactNode into the header's actions slot. Cleans up on unmount. */
 export function useSetHeaderActions(node: ReactNode) {
   const { setActions } = useHeaderActions();
   useEffect(() => {

--- a/templates/analytics/app/components/layout/HeaderActions.tsx
+++ b/templates/analytics/app/components/layout/HeaderActions.tsx
@@ -82,4 +82,3 @@ export function useSetHeaderActions(node: ReactNode) {
     };
   });
 }
-

--- a/templates/analytics/app/components/layout/Layout.tsx
+++ b/templates/analytics/app/components/layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { Sidebar } from "./Sidebar";
 import { MobileNav } from "./MobileNav";
+import { Header } from "./Header";
 import { HeaderActionsProvider } from "./HeaderActions";
 import { AgentSidebar } from "@agent-native/core/client";
 import { useNavigationState } from "@/hooks/use-navigation-state";
@@ -28,6 +29,7 @@ export function Layout({ children }: LayoutProps) {
         >
           <div className="flex h-full flex-1 flex-col overflow-hidden">
             <MobileNav />
+            <Header />
             <main className="flex-1 overflow-y-auto p-4 md:p-6 lg:p-8">
               {children}
             </main>

--- a/templates/analytics/app/components/layout/MobileNav.tsx
+++ b/templates/analytics/app/components/layout/MobileNav.tsx
@@ -3,7 +3,6 @@ import { useLocation } from "react-router";
 import { IconMenu, IconChartBar } from "@tabler/icons-react";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { Sidebar } from "./Sidebar";
-import { AgentToggleButton } from "@agent-native/core/client";
 
 export function MobileNav() {
   const [open, setOpen] = useState(false);
@@ -28,9 +27,6 @@ export function MobileNav() {
           <IconChartBar className="h-4 w-4" />
         </div>
         <span className="text-base font-bold tracking-tight">Analytics</span>
-      </div>
-      <div className="ml-auto">
-        <AgentToggleButton />
       </div>
 
       <Sheet open={open} onOpenChange={setOpen}>

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -50,7 +50,6 @@ import {
   PopoverContent,
 } from "@/components/ui/popover";
 import { Skeleton } from "@/components/ui/skeleton";
-import { AgentToggleButton } from "@agent-native/core/client";
 import { OrgSwitcher } from "@agent-native/core/client/org";
 import { NewDashboardDialog } from "./NewDashboardDialog";
 import { useUserPref } from "@/hooks/use-user-pref";
@@ -606,11 +605,10 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
           className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 z-10"
         />
       )}
-      <div className="flex h-14 items-center justify-between border-b border-border px-4 lg:h-[60px] lg:px-6">
+      <div className="flex h-14 items-center border-b border-border px-4 lg:h-[60px] lg:px-6">
         <Link to="/" className="font-semibold">
           <span className="text-lg font-bold tracking-tight">Analytics</span>
         </Link>
-        <AgentToggleButton />
       </div>
       <div className="flex-1 overflow-auto py-2">
         <nav className="grid items-start px-2 text-sm font-medium lg:px-4 space-y-1">

--- a/templates/analytics/app/pages/DataDictionary.tsx
+++ b/templates/analytics/app/pages/DataDictionary.tsx
@@ -42,6 +42,7 @@ import {
   IconSearch,
   IconExternalLink,
 } from "@tabler/icons-react";
+import { useSetHeaderActions } from "@/components/layout/HeaderActions";
 
 interface DictionaryEntry {
   id: string;
@@ -123,25 +124,20 @@ export default function DataDictionary() {
     [entries],
   );
 
+  useSetHeaderActions(
+    <Button size="sm" onClick={() => setEditing({ ...EMPTY_ENTRY })}>
+      <IconPlus className="h-4 w-4 mr-1" />
+      New entry
+    </Button>,
+  );
+
   return (
     <div className="space-y-6">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
-            <IconBook2 className="h-6 w-6 text-primary" />
-            Data Dictionary
-          </h1>
-          <p className="text-sm text-muted-foreground mt-1 max-w-2xl">
-            The catalog of metrics, tables, and business definitions the
-            analytics agent uses when building dashboards from prompts. Keep
-            entries accurate and the agent will stop guessing about your data.
-          </p>
-        </div>
-        <Button onClick={() => setEditing({ ...EMPTY_ENTRY })}>
-          <IconPlus className="h-4 w-4 mr-1" />
-          New entry
-        </Button>
-      </div>
+      <p className="text-sm text-muted-foreground max-w-2xl">
+        The catalog of metrics, tables, and business definitions the analytics
+        agent uses when building dashboards from prompts. Keep entries accurate
+        and the agent will stop guessing about your data.
+      </p>
 
       <div className="relative max-w-md">
         <IconSearch className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -803,17 +803,14 @@ export default function DataSources() {
 
   return (
     <div className="mx-auto max-w-5xl space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold tracking-tight">Data Sources</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Connect your data sources, then ask the agent to create dashboards.{" "}
-          {!isStatusLoading && connectedCount > 0 && (
-            <span className="text-emerald-500 font-medium">
-              {connectedCount} connected
-            </span>
-          )}
-        </p>
-      </div>
+      <p className="text-sm text-muted-foreground">
+        Connect your data sources, then ask the agent to create dashboards.{" "}
+        {!isStatusLoading && connectedCount > 0 && (
+          <span className="text-emerald-500 font-medium">
+            {connectedCount} connected
+          </span>
+        )}
+      </p>
 
       {/* Search bar */}
       <div className="relative">

--- a/templates/analytics/app/pages/QueryExplorer.tsx
+++ b/templates/analytics/app/pages/QueryExplorer.tsx
@@ -81,8 +81,6 @@ export default function QueryExplorer() {
 
   return (
     <div className="space-y-6">
-      <h2 className="text-2xl font-bold tracking-tight">Query Explorer</h2>
-
       <Card className="bg-card border-border/50">
         <CardHeader>
           <CardTitle className="text-base">SQL Query</CardTitle>

--- a/templates/analytics/app/pages/Settings.tsx
+++ b/templates/analytics/app/pages/Settings.tsx
@@ -8,8 +8,6 @@ export default function Settings() {
 
   return (
     <div className="space-y-6 max-w-2xl">
-      <h2 className="text-2xl font-bold tracking-tight">Settings</h2>
-
       <Card className="bg-card border-border/50">
         <CardHeader>
           <CardTitle className="text-base">Account</CardTitle>

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -18,6 +18,10 @@ import type { SqlDashboardConfig } from "./types";
 import { useUserPref } from "@/hooks/use-user-pref";
 import { useDashboardViews } from "@/hooks/use-dashboard-views";
 import {
+  useSetPageTitle,
+  useSetHeaderActions,
+} from "@/components/layout/HeaderActions";
+import {
   DndContext,
   closestCenter,
   PointerSensor,
@@ -271,6 +275,45 @@ export default function SqlDashboardPage() {
     [saveView],
   );
 
+  useSetPageTitle(
+    dashboard ? (
+      editingName ? (
+        <Input
+          value={nameInput}
+          onChange={(e) => setNameInput(e.target.value)}
+          onBlur={handleSaveName}
+          onKeyDown={(e) => e.key === "Enter" && handleSaveName()}
+          className="h-8 w-full sm:w-64 text-lg font-semibold"
+          autoFocus
+        />
+      ) : (
+        <button
+          className="text-lg font-semibold hover:text-primary flex items-center gap-1 truncate"
+          onClick={() => {
+            setNameInput(dashboard.name);
+            setEditingName(true);
+          }}
+        >
+          <span className="truncate">{dashboard.name}</span>
+          <IconPencil className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        </button>
+      )
+    ) : null,
+  );
+
+  useSetHeaderActions(
+    dashboard ? (
+      <Button
+        size="sm"
+        variant="ghost"
+        className="text-muted-foreground hover:text-destructive"
+        onClick={handleDelete}
+      >
+        <IconTrash className="h-4 w-4" />
+      </Button>
+    ) : null,
+  );
+
   if (!dashboardId) {
     return (
       <div className="flex items-center justify-center h-64 text-muted-foreground">
@@ -295,41 +338,6 @@ export default function SqlDashboardPage() {
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-3 flex-wrap">
-        <div className="flex items-center gap-2">
-          {editingName ? (
-            <Input
-              value={nameInput}
-              onChange={(e) => setNameInput(e.target.value)}
-              onBlur={handleSaveName}
-              onKeyDown={(e) => e.key === "Enter" && handleSaveName()}
-              className="h-8 w-full sm:w-64 text-lg font-semibold"
-              autoFocus
-            />
-          ) : (
-            <button
-              className="text-lg font-semibold hover:text-primary flex items-center gap-1"
-              onClick={() => {
-                setNameInput(dashboard.name);
-                setEditingName(true);
-              }}
-            >
-              {dashboard.name}
-              <IconPencil className="h-3.5 w-3.5 text-muted-foreground" />
-            </button>
-          )}
-        </div>
-        <Button
-          size="sm"
-          variant="ghost"
-          className="text-muted-foreground hover:text-destructive"
-          onClick={handleDelete}
-        >
-          <IconTrash className="h-4 w-4" />
-        </Button>
-      </div>
-
       {/* Filters */}
       {dashboard.filters && dashboard.filters.length > 0 && (
         <DashboardFilterBar

--- a/templates/analytics/app/pages/analyses/AnalysesList.tsx
+++ b/templates/analytics/app/pages/analyses/AnalysesList.tsx
@@ -61,14 +61,9 @@ export default function AnalysesList() {
     <>
       {codeRequiredDialog}
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight">Analyses</h1>
-            <p className="text-sm text-muted-foreground mt-1">
-              Ad-hoc analyses that can be re-run anytime for fresh results
-            </p>
-          </div>
-        </div>
+        <p className="text-sm text-muted-foreground">
+          Ad-hoc analyses that can be re-run anytime for fresh results
+        </p>
 
         {isLoading ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
+++ b/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
@@ -25,6 +25,10 @@ import { Link, useNavigate } from "react-router";
 import { getIdToken } from "@/lib/auth";
 import { useSendToAgentChat } from "@agent-native/core/client";
 import Markdown from "@/components/Markdown";
+import {
+  useSetPageTitle,
+  useSetHeaderActions,
+} from "@/components/layout/HeaderActions";
 
 interface Analysis {
   id: string;
@@ -101,6 +105,51 @@ export default function AnalysisDetail() {
     navigate("/analyses");
   };
 
+  useSetPageTitle(
+    analysis ? (
+      <h1 className="text-lg font-semibold tracking-tight truncate">
+        {analysis.name}
+      </h1>
+    ) : null,
+  );
+
+  useSetHeaderActions(
+    analysis ? (
+      <>
+        <Button
+          variant="default"
+          size="sm"
+          onClick={handleRerun}
+          disabled={isGenerating}
+        >
+          <IconRefresh className="h-4 w-4 mr-1.5" />
+          Re-run
+        </Button>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="ghost" size="sm">
+              <IconTrash className="h-4 w-4" />
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete analysis?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will permanently delete "{analysis.name}" and its results.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleDelete}>
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </>
+    ) : null,
+  );
+
   if (isLoading) {
     return (
       <div className="space-y-6">
@@ -138,51 +187,11 @@ export default function AnalysisDetail() {
             <IconArrowLeft className="h-3 w-3" />
             All analyses
           </Link>
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <h1 className="text-2xl font-bold tracking-tight">
-                {analysis.name}
-              </h1>
-              {analysis.description && (
-                <p className="text-sm text-muted-foreground mt-1">
-                  {analysis.description}
-                </p>
-              )}
-            </div>
-            <div className="flex items-center gap-2 shrink-0">
-              <Button
-                variant="default"
-                size="sm"
-                onClick={handleRerun}
-                disabled={isGenerating}
-              >
-                <IconRefresh className="h-4 w-4 mr-1.5" />
-                Re-run
-              </Button>
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button variant="ghost" size="sm">
-                    <IconTrash className="h-4 w-4" />
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Delete analysis?</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      This will permanently delete "{analysis.name}" and its
-                      results.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction onClick={handleDelete}>
-                      Delete
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            </div>
-          </div>
+          {analysis.description && (
+            <p className="text-sm text-muted-foreground">
+              {analysis.description}
+            </p>
+          )}
 
           {/* Metadata bar */}
           <div className="flex flex-wrap items-center gap-3 mt-3 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

- **Analytics: standard per-page header with chat toggle top-right.** Move `AgentToggleButton` out of the left sidebar / MobileNav into a new persistent `Header` rendered at `Layout` level. Pages inject dynamic titles/actions via `useSetPageTitle` / `useSetHeaderActions`. Migrated Settings, QueryExplorer, DataSources, DataDictionary, AnalysesList, AnalysisDetail, and sql-dashboard to use the shared header (removing duplicate in-body titles). Route-based default titles mean new pages get one automatically.
- **First-login API key card: add Builder option.** `ApiKeySetupCard` in `AssistantChat.tsx` now shows a "Connect Builder" card above the Anthropic key entry, gated on `builderEnabled` from `/builder/status` — falls back to a "Coming soon" badge. Mirrors the pattern in settings' `LLMSection`.

## Test plan

- [ ] Desktop: every analytics route (overview, dashboards, sql dashboards, data dictionary, data sources, analyses, query explorer, settings, team) shows the chat toggle in the top-right of the main content area
- [ ] Dynamic titles (sql dashboard name editor, analysis name) render in header; Re-run/Delete/New-entry buttons appear next to the toggle on the relevant pages
- [ ] Mobile: MobileNav still shows the toggle; new Header is hidden
- [ ] Fresh install without `ANTHROPIC_API_KEY`: first-login card shows Builder CTA; when `builderEnabled=false` the Connect button becomes a "Coming soon" badge