### PR TITLE
updates-105: Gong + Jira credential schema updates

### DIFF
--- a/packages/core/src/client/org/TeamPage.tsx
+++ b/packages/core/src/client/org/TeamPage.tsx
@@ -359,11 +359,16 @@ function LocalModeSignInCard() {
         const body = await res.json().catch(() => ({}));
         throw new Error(body?.error || "Failed to exit local mode");
       }
-      // Reload → auth guard will serve the onboarding page so the user can
-      // sign in with Google or create an email/password account. The
-      // localStorage flag survives the reload so TeamPage can migrate data
-      // automatically once they're back.
-      window.location.reload();
+      // Reload with ?signin=1 → auth guard will serve the onboarding page so
+      // the user can sign in with Google or create an email/password account.
+      // The URL flag is used (rather than a cookie) because third-party iframe
+      // contexts (e.g. the Builder.io editor) block SameSite=Lax cookies, so a
+      // cookie-only signal would be lost on reload. The localStorage flag
+      // survives the reload so TeamPage can migrate data automatically once
+      // they're back.
+      const url = new URL(window.location.href);
+      url.searchParams.set("signin", "1");
+      window.location.href = url.toString();
     } catch (e: any) {
       setError(e?.message || "Failed to start sign-in");
       setIsSubmitting(false);

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -492,8 +492,7 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
     if (email) {
       setCookie(event, COOKIE_NAME, qToken, {
         httpOnly: true,
-        secure: !isDevEnvironment(),
-        sameSite: "lax",
+        ...crossSiteCookieAttrs(event),
         path: "/",
         maxAge: sessionMaxAge,
       });
@@ -511,7 +510,7 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
   // to real account"), they've signaled they want real auth. The upgrade
   // cookie suppresses this fallback so the onboarding/sign-in page is served
   // instead of silently re-authenticating them as local@localhost.
-  if (isDevEnvironment() && !isUpgradePending(event)) {
+  if (isDevEnvironment() && !isUpgradePending(event) && !hasSignInFlag(event)) {
     return LOCAL_SESSION;
   }
 
@@ -538,11 +537,65 @@ function isUpgradePending(event: H3Event): boolean {
 function setUpgradePendingCookie(event: H3Event): void {
   setCookie(event, UPGRADE_COOKIE, "1", {
     httpOnly: true,
-    secure: !isDevEnvironment(),
-    sameSite: "lax",
+    ...crossSiteCookieAttrs(event),
     path: "/",
     maxAge: 60 * 60, // 1 hour — enough to complete sign-in
   });
+}
+
+/**
+ * URL-flag fallback for third-party iframe contexts (e.g. the Builder.io
+ * editor) where SameSite=Lax cookies from an exit-local-mode POST are not
+ * delivered on the subsequent reload. TeamPage reloads with ?signin=1 so
+ * we can reliably suppress the dev-mode local fallback without a cookie.
+ */
+function hasSignInFlag(event: H3Event): boolean {
+  try {
+    return getQuery(event)?.signin === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Cookie attributes that work in both same-site and third-party iframe
+ * contexts. Over HTTPS we emit `SameSite=None; Secure` (required by browsers
+ * to ship the cookie back inside a cross-origin iframe); for plain HTTP dev
+ * we keep `SameSite=Lax` since `None` requires Secure.
+ */
+function crossSiteCookieAttrs(event: H3Event): {
+  sameSite: "lax" | "none";
+  secure: boolean;
+} {
+  return isHttpsRequest(event)
+    ? { sameSite: "none", secure: true }
+    : { sameSite: "lax", secure: false };
+}
+
+function isHttpsRequest(event: H3Event): boolean {
+  try {
+    const req: any = (event as any).req ?? event.node?.req;
+    const headers: any = req?.headers;
+    const get = (k: string): string | undefined => {
+      if (!headers) return undefined;
+      if (typeof headers.get === "function") {
+        return headers.get(k) ?? undefined;
+      }
+      const v = headers[k];
+      return Array.isArray(v) ? v[0] : v;
+    };
+    const xfProto = get("x-forwarded-proto");
+    if (xfProto && String(xfProto).split(",")[0].trim() === "https") {
+      return true;
+    }
+    const url: string | undefined = req?.url;
+    if (typeof url === "string" && url.startsWith("https://")) return true;
+    const appUrl = process.env.APP_URL || process.env.BETTER_AUTH_URL || "";
+    if (appUrl.startsWith("https://")) return true;
+  } catch {
+    // ignore
+  }
+  return false;
 }
 
 function clearUpgradePendingCookie(event: H3Event): void {
@@ -823,8 +876,7 @@ async function mountBetterAuthRoutes(
         await addSession(sessionToken, "user");
         setCookie(event, COOKIE_NAME, sessionToken, {
           httpOnly: true,
-          secure: !isDevEnvironment(),
-          sameSite: "lax",
+          ...crossSiteCookieAttrs(event),
           path: "/",
           maxAge: sessionMaxAge,
         });
@@ -847,8 +899,7 @@ async function mountBetterAuthRoutes(
         if (result?.token) {
           setCookie(event, COOKIE_NAME, result.token, {
             httpOnly: true,
-            secure: !isDevEnvironment(),
-            sameSite: "lax",
+            ...crossSiteCookieAttrs(event),
             path: "/",
             maxAge: sessionMaxAge,
           });
@@ -988,8 +1039,7 @@ function mountTokenOnlyRoutes(
       await addSession(sessionToken, "user");
       setCookie(event, COOKIE_NAME, sessionToken, {
         httpOnly: true,
-        secure: !isDevEnvironment(),
-        sameSite: "lax",
+        ...crossSiteCookieAttrs(event),
         path: "/",
         maxAge: sessionMaxAge,
       });
@@ -1103,8 +1153,7 @@ function mountAuthFallbackRoutes(app: H3App): void {
         if (result?.token) {
           setCookie(event, COOKIE_NAME, result.token, {
             httpOnly: true,
-            secure: !isDevEnvironment(),
-            sameSite: "lax",
+            ...crossSiteCookieAttrs(event),
             path: "/",
             maxAge: sessionMaxAge,
           });

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -387,6 +387,19 @@ async function createBetterAuthInstance(
     },
     advanced: {
       cookiePrefix: "an",
+      // Emit `SameSite=None; Secure` when the app is served over HTTPS so
+      // session cookies are delivered inside third-party iframes (e.g. the
+      // Builder.io editor). Plain-HTTP dev keeps the default (Lax) because
+      // `SameSite=None` requires Secure.
+      ...(appUrl.startsWith("https://")
+        ? {
+            defaultCookieAttributes: {
+              sameSite: "none" as const,
+              secure: true,
+              partitioned: true,
+            },
+          }
+        : {}),
     },
     plugins: [
       // Organizations: many:many user:org, roles, invitations

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -5,9 +5,15 @@ import {
   useState,
   useImperativeHandle,
 } from "react";
-import { IconAlertCircle, IconRefresh } from "@tabler/icons-react";
+import {
+  IconAlertCircle,
+  IconRefresh,
+  IconCopy,
+  IconCheck,
+  IconTerminal2,
+} from "@tabler/icons-react";
 import type { AppDefinition, AppConfig } from "@shared/app-registry";
-import { getAppUrl } from "@shared/app-registry";
+import { getAppUrl, FRAME_PORT } from "@shared/app-registry";
 
 const IS_DEV = window.location.protocol !== "file:";
 
@@ -55,8 +61,11 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
   ({ app, appConfig, isActive, refreshKey = 0 }: AppWebviewProps, ref) => {
     const webviewRef = useRef<ElectronWebviewElement>(null);
     const [error, setError] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+    const [slowLoad, setSlowLoad] = useState(false);
     const [isFullscreen, setIsFullscreen] = useState(false);
     const url = resolveUrl(app, appConfig);
+    const isDevMode = appConfig?.mode === "dev";
     const optimizeDepRecoveryRef = useRef(false);
 
     useImperativeHandle(
@@ -113,6 +122,8 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
 
       const onReady = () => {
         setError(false);
+        setIsLoading(false);
+        setSlowLoad(false);
         optimizeDepRecoveryRef.current = false;
         reportActiveWebview();
       };
@@ -129,6 +140,7 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
           return;
         }
         setError(true);
+        setIsLoading(false);
       };
       const onConsoleMessage = (e: Event) => {
         const message = String((e as any).message || "");
@@ -171,12 +183,23 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       }
     }, [refreshKey, isActive, app.placeholder]);
 
+    // If the webview hasn't fired dom-ready within a few seconds, surface
+    // a "still loading" hint. If it's still not ready after a bit longer,
+    // assume the dev server isn't running and show the error screen.
     useEffect(() => {
-      if (isActive && error && !app.placeholder) {
-        handleRetry();
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isActive]);
+      if (app.placeholder || error || !isLoading) return;
+      const slowT = setTimeout(() => setSlowLoad(true), 2500);
+      const failT = setTimeout(() => {
+        if (isLoading) {
+          setError(true);
+          setIsLoading(false);
+        }
+      }, 8000);
+      return () => {
+        clearTimeout(slowT);
+        clearTimeout(failT);
+      };
+    }, [app.placeholder, error, isLoading, url]);
 
     // Auto-focus the webview when it becomes active so keyboard events
     // (e.g. Tab to cycle mail filters) go to the app, not the shell.
@@ -204,9 +227,27 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
 
     function handleRetry() {
       setError(false);
+      setIsLoading(true);
+      setSlowLoad(false);
       const wv = webviewRef.current;
       if (wv) {
-        wv.src = url;
+        try {
+          wv.reloadIgnoringCache();
+        } catch {
+          wv.src = url;
+        }
+      }
+    }
+
+    async function handleSwitchToProd() {
+      if (!appConfig?.id) return;
+      try {
+        await window.electronAPI?.appConfig?.update(appConfig.id, {
+          mode: "prod",
+        });
+        // Reload will happen when parent re-renders with new appConfig.
+      } catch {
+        /* ignore */
       }
     }
 
@@ -223,12 +264,20 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
       >
         {app.placeholder && <PlaceholderScreen app={app} />}
 
+        {!app.placeholder && !error && isLoading && (
+          <LoadingScreen app={app} slow={slowLoad} isDev={isDevMode} />
+        )}
+
         {!app.placeholder && error && (
           <ErrorScreen
             app={app}
             appConfig={appConfig}
             url={url}
+            isDev={isDevMode}
             onRetry={handleRetry}
+            onSwitchToProd={
+              appConfig?.url && isDevMode ? handleSwitchToProd : undefined
+            }
           />
         )}
 
@@ -249,36 +298,136 @@ const AppWebview = forwardRef<AppWebviewHandle, AppWebviewProps>(
 
 export default AppWebview;
 
+function LoadingScreen({
+  app,
+  slow,
+  isDev,
+}: {
+  app: AppDefinition;
+  slow: boolean;
+  isDev: boolean;
+}) {
+  return (
+    <div className="loading-overlay">
+      <div className="loading-spinner" style={{ borderTopColor: app.color }} />
+      <p className="loading-title">Loading {app.name}…</p>
+      {slow && (
+        <p className="loading-hint">
+          {isDev ? "Still connecting to the dev server…" : "Still loading…"}
+        </p>
+      )}
+    </div>
+  );
+}
+
 function ErrorScreen({
   app,
   appConfig,
   url,
+  isDev,
   onRetry,
+  onSwitchToProd,
 }: {
   app: AppDefinition;
   appConfig?: AppConfig;
   url: string;
+  isDev: boolean;
   onRetry: () => void;
+  onSwitchToProd?: () => void;
 }) {
+  const [copied, setCopied] = useState(false);
+  const devCommand = appConfig?.devCommand?.trim();
+
+  const title = isDev
+    ? "Dev server not running"
+    : `Couldn't connect to ${app.name}`;
+  const subtitle = isDev
+    ? `${app.name} couldn't be reached at ${url}.`
+    : `Check that ${app.name} is running at ${url}.`;
+
+  async function copyCommand(cmd: string) {
+    try {
+      await navigator.clipboard.writeText(cmd);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* ignore */
+    }
+  }
+
   return (
     <div className="error-overlay">
       <IconAlertCircle size={40} className="error-icon" />
-      <p className="error-title">Could not connect to {app.name}</p>
-      <p className="error-hint">
-        {appConfig?.devCommand ? (
-          <>
-            Run: <code>{appConfig.devCommand}</code>
-          </>
-        ) : (
-          <>
-            Make sure the app is running at <code>{url}</code>
-          </>
+      <p className="error-title">{title}</p>
+      <p className="error-hint">{subtitle}</p>
+
+      {isDev && (
+        <div className="error-commands">
+          {devCommand ? (
+            <CommandRow
+              label={`Start ${app.name}`}
+              command={devCommand}
+              copied={copied}
+              onCopy={() => copyCommand(devCommand)}
+            />
+          ) : (
+            <p className="error-hint error-hint--muted">
+              Tip: set a dev command for this app in Settings so it appears
+              here.
+            </p>
+          )}
+          <p className="error-hint error-hint--muted">
+            The local frame also needs to be running on port {FRAME_PORT}.
+          </p>
+        </div>
+      )}
+
+      <div className="error-actions">
+        <button className="retry-button" onClick={onRetry}>
+          <IconRefresh size={11} style={{ marginRight: 5 }} />
+          Retry
+        </button>
+        {onSwitchToProd && (
+          <button
+            className="retry-button retry-button--primary"
+            onClick={onSwitchToProd}
+          >
+            Use Production
+          </button>
         )}
-      </p>
-      <button className="retry-button" onClick={onRetry}>
-        <IconRefresh size={11} style={{ display: "inline", marginRight: 5 }} />
-        Retry
-      </button>
+      </div>
+    </div>
+  );
+}
+
+function CommandRow({
+  label,
+  command,
+  copied,
+  onCopy,
+}: {
+  label: string;
+  command: string;
+  copied: boolean;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="command-row">
+      <div className="command-row__label">
+        <IconTerminal2 size={12} style={{ marginRight: 6, opacity: 0.6 }} />
+        {label}
+      </div>
+      <div className="command-row__code">
+        <code>{command}</code>
+        <button
+          className="command-copy"
+          onClick={onCopy}
+          title="Copy command"
+          aria-label="Copy command"
+        >
+          {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+        </button>
+      </div>
     </div>
   );
 }

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -500,6 +500,127 @@ body {
   color: rgba(255, 255, 255, 0.65);
 }
 
+.retry-button--primary {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.retry-button--primary:hover {
+  background: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.error-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.error-commands {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 6px;
+  width: min(420px, 80%);
+}
+
+.error-hint--muted {
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 11px;
+}
+
+.command-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+}
+
+.command-row__label {
+  display: flex;
+  align-items: center;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.45);
+  font-weight: 500;
+}
+
+.command-row__code {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.command-row__code code {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-copy {
+  flex: 0 0 auto;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.55);
+  border-radius: 5px;
+  padding: 4px 6px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  -webkit-app-region: no-drag;
+}
+
+.command-copy:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* ─── Loading overlay ────────────────────────────────────────── */
+.loading-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  background: var(--shell-bg);
+  z-index: 10;
+}
+
+.loading-spinner {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.08);
+  border-top-color: rgba(255, 255, 255, 0.6);
+  animation: app-webview-spin 0.9s linear infinite;
+}
+
+@keyframes app-webview-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-title {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.loading-hint {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.25);
+}
+
 /* ─── Placeholder screen ─────────────────────────────────────── */
 .placeholder-overlay {
   position: absolute;

--- a/packages/frame/vite.config.ts
+++ b/packages/frame/vite.config.ts
@@ -22,15 +22,19 @@ logger.error = (msg, opts) => {
   _loggerError(msg, opts);
 };
 
-// Import app registry to resolve ports by app ID
-const configPath = path.resolve(__dirname, "../shared-app-config/index.ts");
-// Quick parse: extract { id, devPort } pairs from DEFAULT_APPS
+// Import app registry to resolve ports by app ID. DEFAULT_APPS is built from
+// the TEMPLATES array in templates.ts, so we parse that file directly —
+// index.ts only has `id: t.name` dynamically, not literal ids.
+const templatesPath = path.resolve(
+  __dirname,
+  "../shared-app-config/templates.ts",
+);
 import fs from "fs";
-const configSrc = fs.readFileSync(configPath, "utf8");
+const templatesSrc = fs.readFileSync(templatesPath, "utf8");
 const portMap = new Map<string, number>();
-const re = /id:\s*"([^"]+)"[\s\S]*?devPort:\s*(\d+)/g;
+const re = /name:\s*"([^"]+)"[\s\S]*?devPort:\s*(\d+)/g;
 let m: RegExpExecArray | null;
-while ((m = re.exec(configSrc)) !== null) {
+while ((m = re.exec(templatesSrc)) !== null) {
   portMap.set(m[1], Number(m[2]));
 }
 

--- a/templates/analytics/app/lib/data-sources.ts
+++ b/templates/analytics/app/lib/data-sources.ts
@@ -391,7 +391,7 @@ export const dataSources: DataSource[] = [
     description: "Sales call recordings, transcripts, and analytics",
     category: "crm",
     icon: IconPhone,
-    envKeys: ["GONG_API_KEY"],
+    envKeys: ["GONG_ACCESS_KEY", "GONG_ACCESS_SECRET"],
     docsUrl: "https://gong.app.gong.io/settings/api/documentation",
     walkthroughSteps: [
       {
@@ -402,12 +402,19 @@ export const dataSources: DataSource[] = [
         linkText: "Gong API Settings",
       },
       {
-        title: "Enter your API Key",
-        description:
-          'Enter your API credentials in "accessKey:accessKeySecret" format.',
-        inputKey: "GONG_API_KEY",
-        inputLabel: "API Key (key:secret)",
-        inputPlaceholder: "accessKey:accessKeySecret",
+        title: "Enter your Access Key",
+        description: "Paste the Access Key from your Gong API settings.",
+        inputKey: "GONG_ACCESS_KEY",
+        inputLabel: "Access Key",
+        inputPlaceholder: "your-gong-access-key",
+        inputType: "password",
+      },
+      {
+        title: "Enter your Access Key Secret",
+        description: "Paste the Access Key Secret from your Gong API settings.",
+        inputKey: "GONG_ACCESS_SECRET",
+        inputLabel: "Access Key Secret",
+        inputPlaceholder: "your-gong-access-key-secret",
         inputType: "password",
       },
     ],
@@ -472,7 +479,7 @@ export const dataSources: DataSource[] = [
     description: "Tickets, sprints, and project tracking",
     category: "engineering",
     icon: IconTicket,
-    envKeys: ["JIRA_EMAIL", "JIRA_TOKEN"],
+    envKeys: ["JIRA_BASE_URL", "JIRA_USER_EMAIL", "JIRA_API_TOKEN"],
     docsUrl: "https://developer.atlassian.com/cloud/jira/platform/rest/v3/",
     walkthroughSteps: [
       {
@@ -483,10 +490,19 @@ export const dataSources: DataSource[] = [
         linkText: "Atlassian API Tokens",
       },
       {
+        title: "Enter your Jira Base URL",
+        description:
+          "The base URL of your Jira instance (e.g., https://your-org.atlassian.net).",
+        inputKey: "JIRA_BASE_URL",
+        inputLabel: "Base URL",
+        inputPlaceholder: "https://your-org.atlassian.net",
+        inputType: "text",
+      },
+      {
         title: "Enter your Jira email",
         description:
           "The email address associated with your Atlassian account.",
-        inputKey: "JIRA_EMAIL",
+        inputKey: "JIRA_USER_EMAIL",
         inputLabel: "Email",
         inputPlaceholder: "you@company.com",
         inputType: "text",
@@ -494,7 +510,7 @@ export const dataSources: DataSource[] = [
       {
         title: "Enter your API Token",
         description: "Paste the API token you just created.",
-        inputKey: "JIRA_TOKEN",
+        inputKey: "JIRA_API_TOKEN",
         inputLabel: "API Token",
         inputPlaceholder: "your-jira-api-token",
         inputType: "password",
@@ -533,7 +549,7 @@ export const dataSources: DataSource[] = [
     description: "Prometheus metrics, dashboards, and alerts",
     category: "engineering",
     icon: IconActivity,
-    envKeys: ["GRAFANA_URL", "GRAFANA_TOKEN"],
+    envKeys: ["GRAFANA_URL", "GRAFANA_API_TOKEN"],
     docsUrl: "https://grafana.com/docs/grafana/latest/developers/http_api/",
     walkthroughSteps: [
       {
@@ -559,7 +575,7 @@ export const dataSources: DataSource[] = [
       {
         title: "Enter your API Token",
         description: "Paste the service account token.",
-        inputKey: "GRAFANA_TOKEN",
+        inputKey: "GRAFANA_API_TOKEN",
         inputLabel: "API Token",
         inputPlaceholder: "glsa_...",
         inputType: "password",
@@ -602,7 +618,7 @@ export const dataSources: DataSource[] = [
     description: "Channel messages and workspace search",
     category: "communication",
     icon: IconMessage,
-    envKeys: ["SLACK_TOKEN"],
+    envKeys: ["SLACK_BOT_TOKEN"],
     docsUrl: "https://api.slack.com/methods",
     walkthroughSteps: [
       {
@@ -620,7 +636,7 @@ export const dataSources: DataSource[] = [
       {
         title: "Enter your Bot Token",
         description: 'Paste the Bot User OAuth Token (starts with "xoxb-").',
-        inputKey: "SLACK_TOKEN",
+        inputKey: "SLACK_BOT_TOKEN",
         inputLabel: "Bot Token",
         inputPlaceholder: "xoxb-...",
         inputType: "password",
@@ -721,7 +737,7 @@ export const dataSources: DataSource[] = [
     description: "Community member engagement and activity",
     category: "support",
     icon: IconUsers,
-    envKeys: ["COMMONROOM_API_KEY"],
+    envKeys: ["COMMONROOM_API_TOKEN"],
     docsUrl: "https://docs.commonroom.io/",
     walkthroughSteps: [
       {
@@ -732,7 +748,7 @@ export const dataSources: DataSource[] = [
       {
         title: "Enter your API Key",
         description: "Paste the API key.",
-        inputKey: "COMMONROOM_API_KEY",
+        inputKey: "COMMONROOM_API_TOKEN",
         inputLabel: "API Key",
         inputPlaceholder: "your-commonroom-api-key",
         inputType: "password",

--- a/templates/analytics/server/handlers/gong.ts
+++ b/templates/analytics/server/handlers/gong.ts
@@ -3,7 +3,9 @@ import { requireCredential } from "../lib/credentials";
 import { getCalls, searchCalls, getUsers } from "../lib/gong";
 
 export const handleGongCalls = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "GONG_ACCESS_KEY", "Gong");
+  const missing =
+    (await requireCredential(event, "GONG_ACCESS_KEY", "Gong")) ||
+    (await requireCredential(event, "GONG_ACCESS_SECRET", "Gong"));
   if (missing) return missing;
   try {
     const { company, days: daysParam } = getQuery(event);
@@ -27,7 +29,9 @@ export const handleGongCalls = defineEventHandler(async (event) => {
 });
 
 export const handleGongUsers = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "GONG_ACCESS_KEY", "Gong");
+  const missing =
+    (await requireCredential(event, "GONG_ACCESS_KEY", "Gong")) ||
+    (await requireCredential(event, "GONG_ACCESS_SECRET", "Gong"));
   if (missing) return missing;
   try {
     const users = await getUsers();

--- a/templates/analytics/server/handlers/gong.ts
+++ b/templates/analytics/server/handlers/gong.ts
@@ -3,7 +3,7 @@ import { requireCredential } from "../lib/credentials";
 import { getCalls, searchCalls, getUsers } from "../lib/gong";
 
 export const handleGongCalls = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "GONG_API_KEY", "Gong");
+  const missing = await requireCredential(event, "GONG_ACCESS_KEY", "Gong");
   if (missing) return missing;
   try {
     const { company, days: daysParam } = getQuery(event);
@@ -27,7 +27,7 @@ export const handleGongCalls = defineEventHandler(async (event) => {
 });
 
 export const handleGongUsers = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "GONG_API_KEY", "Gong");
+  const missing = await requireCredential(event, "GONG_ACCESS_KEY", "Gong");
   if (missing) return missing;
   try {
     const users = await getUsers();

--- a/templates/analytics/server/handlers/jira.ts
+++ b/templates/analytics/server/handlers/jira.ts
@@ -11,7 +11,10 @@ import {
 } from "../lib/jira";
 
 export const handleJiraSearch = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
+  const missing =
+    (await requireCredential(event, "JIRA_BASE_URL", "Jira")) ||
+    (await requireCredential(event, "JIRA_USER_EMAIL", "Jira")) ||
+    (await requireCredential(event, "JIRA_API_TOKEN", "Jira"));
   if (missing) return missing;
   try {
     const { jql, maxResults: maxResultsParam } = getQuery(event);
@@ -30,7 +33,10 @@ export const handleJiraSearch = defineEventHandler(async (event) => {
 });
 
 export const handleJiraIssue = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
+  const missing =
+    (await requireCredential(event, "JIRA_BASE_URL", "Jira")) ||
+    (await requireCredential(event, "JIRA_USER_EMAIL", "Jira")) ||
+    (await requireCredential(event, "JIRA_API_TOKEN", "Jira"));
   if (missing) return missing;
   try {
     const { key } = getQuery(event);
@@ -48,7 +54,10 @@ export const handleJiraIssue = defineEventHandler(async (event) => {
 });
 
 export const handleJiraProjects = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
+  const missing =
+    (await requireCredential(event, "JIRA_BASE_URL", "Jira")) ||
+    (await requireCredential(event, "JIRA_USER_EMAIL", "Jira")) ||
+    (await requireCredential(event, "JIRA_API_TOKEN", "Jira"));
   if (missing) return missing;
   try {
     const projects = await getProjects();
@@ -61,7 +70,10 @@ export const handleJiraProjects = defineEventHandler(async (event) => {
 });
 
 export const handleJiraStatuses = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
+  const missing =
+    (await requireCredential(event, "JIRA_BASE_URL", "Jira")) ||
+    (await requireCredential(event, "JIRA_USER_EMAIL", "Jira")) ||
+    (await requireCredential(event, "JIRA_API_TOKEN", "Jira"));
   if (missing) return missing;
   try {
     const { project } = getQuery(event);
@@ -75,7 +87,10 @@ export const handleJiraStatuses = defineEventHandler(async (event) => {
 });
 
 export const handleJiraBoards = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
+  const missing =
+    (await requireCredential(event, "JIRA_BASE_URL", "Jira")) ||
+    (await requireCredential(event, "JIRA_USER_EMAIL", "Jira")) ||
+    (await requireCredential(event, "JIRA_API_TOKEN", "Jira"));
   if (missing) return missing;
   try {
     const boards = await getBoards();
@@ -88,7 +103,10 @@ export const handleJiraBoards = defineEventHandler(async (event) => {
 });
 
 export const handleJiraSprints = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
+  const missing =
+    (await requireCredential(event, "JIRA_BASE_URL", "Jira")) ||
+    (await requireCredential(event, "JIRA_USER_EMAIL", "Jira")) ||
+    (await requireCredential(event, "JIRA_API_TOKEN", "Jira"));
   if (missing) return missing;
   try {
     const { boardId: boardIdParam } = getQuery(event);
@@ -107,7 +125,10 @@ export const handleJiraSprints = defineEventHandler(async (event) => {
 });
 
 export const handleJiraAnalytics = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
+  const missing =
+    (await requireCredential(event, "JIRA_BASE_URL", "Jira")) ||
+    (await requireCredential(event, "JIRA_USER_EMAIL", "Jira")) ||
+    (await requireCredential(event, "JIRA_API_TOKEN", "Jira"));
   if (missing) return missing;
   try {
     const { projects: projectsParam, days: daysParam } = getQuery(event);

--- a/templates/analytics/server/handlers/jira.ts
+++ b/templates/analytics/server/handlers/jira.ts
@@ -11,7 +11,7 @@ import {
 } from "../lib/jira";
 
 export const handleJiraSearch = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_EMAIL", "Jira");
+  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
   if (missing) return missing;
   try {
     const { jql, maxResults: maxResultsParam } = getQuery(event);
@@ -30,7 +30,7 @@ export const handleJiraSearch = defineEventHandler(async (event) => {
 });
 
 export const handleJiraIssue = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_EMAIL", "Jira");
+  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
   if (missing) return missing;
   try {
     const { key } = getQuery(event);
@@ -48,7 +48,7 @@ export const handleJiraIssue = defineEventHandler(async (event) => {
 });
 
 export const handleJiraProjects = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_EMAIL", "Jira");
+  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
   if (missing) return missing;
   try {
     const projects = await getProjects();
@@ -61,7 +61,7 @@ export const handleJiraProjects = defineEventHandler(async (event) => {
 });
 
 export const handleJiraStatuses = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_EMAIL", "Jira");
+  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
   if (missing) return missing;
   try {
     const { project } = getQuery(event);
@@ -75,7 +75,7 @@ export const handleJiraStatuses = defineEventHandler(async (event) => {
 });
 
 export const handleJiraBoards = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_EMAIL", "Jira");
+  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
   if (missing) return missing;
   try {
     const boards = await getBoards();
@@ -88,7 +88,7 @@ export const handleJiraBoards = defineEventHandler(async (event) => {
 });
 
 export const handleJiraSprints = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_EMAIL", "Jira");
+  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
   if (missing) return missing;
   try {
     const { boardId: boardIdParam } = getQuery(event);
@@ -107,7 +107,7 @@ export const handleJiraSprints = defineEventHandler(async (event) => {
 });
 
 export const handleJiraAnalytics = defineEventHandler(async (event) => {
-  const missing = await requireCredential(event, "JIRA_EMAIL", "Jira");
+  const missing = await requireCredential(event, "JIRA_USER_EMAIL", "Jira");
   if (missing) return missing;
   try {
     const { projects: projectsParam, days: daysParam } = getQuery(event);

--- a/templates/analytics/server/lib/credential-keys.ts
+++ b/templates/analytics/server/lib/credential-keys.ts
@@ -50,21 +50,29 @@ export const credentialKeys: CredentialKeyConfig[] = [
   // HubSpot
   { key: "HUBSPOT_ACCESS_TOKEN", label: "HubSpot", required: false },
   // Gong
-  { key: "GONG_API_KEY", label: "Gong", required: false },
+  { key: "GONG_ACCESS_KEY", label: "Gong Access Key", required: false },
+  { key: "GONG_ACCESS_SECRET", label: "Gong Access Secret", required: false },
   // Apollo
   { key: "APOLLO_API_KEY", label: "Apollo", required: false },
   // GitHub
   { key: "GITHUB_TOKEN", label: "GitHub", required: false },
   // Jira
-  { key: "JIRA_EMAIL", label: "Jira Email", required: false },
-  { key: "JIRA_TOKEN", label: "Jira Token", required: false },
+  { key: "JIRA_BASE_URL", label: "Jira Base URL", required: false },
+  { key: "JIRA_USER_EMAIL", label: "Jira Email", required: false },
+  { key: "JIRA_API_TOKEN", label: "Jira API Token", required: false },
   // Sentry
+  { key: "SENTRY_SERVER_TOKEN", label: "Sentry Server Token", required: false },
   { key: "SENTRY_AUTH_TOKEN", label: "Sentry", required: false },
   // Grafana
   { key: "GRAFANA_URL", label: "Grafana URL", required: false },
-  { key: "GRAFANA_TOKEN", label: "Grafana Token", required: false },
+  { key: "GRAFANA_API_TOKEN", label: "Grafana API Token", required: false },
   // Slack
-  { key: "SLACK_TOKEN", label: "Slack", required: false },
+  { key: "SLACK_BOT_TOKEN", label: "Slack Bot Token", required: false },
+  {
+    key: "SLACK_BOT_TOKEN_2",
+    label: "Slack Bot Token (secondary)",
+    required: false,
+  },
   // Notion
   { key: "NOTION_API_KEY", label: "Notion", required: false },
   // Twitter/X
@@ -72,7 +80,7 @@ export const credentialKeys: CredentialKeyConfig[] = [
   // Pylon
   { key: "PYLON_API_KEY", label: "Pylon", required: false },
   // Common Room
-  { key: "COMMONROOM_API_KEY", label: "Common Room", required: false },
+  { key: "COMMONROOM_API_TOKEN", label: "Common Room", required: false },
   // DataForSEO
   { key: "DATAFORSEO_LOGIN", label: "DataForSEO", required: false },
   {

--- a/templates/analytics/server/routes/api/test-connection.post.ts
+++ b/templates/analytics/server/routes/api/test-connection.post.ts
@@ -123,7 +123,7 @@ export default defineEventHandler(async (event) => {
 
       case "grafana": {
         const url = await resolveCredential("GRAFANA_URL");
-        const token = await resolveCredential("GRAFANA_TOKEN");
+        const token = await resolveCredential("GRAFANA_API_TOKEN");
         if (!url || !token) return { ok: false, error: "Missing credentials" };
         const res = await fetch(`${url}/api/org`, {
           headers: { Authorization: `Bearer ${token}` },
@@ -141,7 +141,7 @@ export default defineEventHandler(async (event) => {
       }
 
       case "slack": {
-        const token = await resolveCredential("SLACK_TOKEN");
+        const token = await resolveCredential("SLACK_BOT_TOKEN");
         if (!token) return { ok: false, error: "Missing token" };
         const res = await fetch("https://slack.com/api/auth.test", {
           headers: { Authorization: `Bearer ${token}` },
@@ -178,7 +178,7 @@ export default defineEventHandler(async (event) => {
       }
 
       case "commonroom": {
-        const key = await resolveCredential("COMMONROOM_API_KEY");
+        const key = await resolveCredential("COMMONROOM_API_TOKEN");
         if (!key) return { ok: false, error: "Missing API key" };
         return { ok: true };
       }

--- a/templates/analytics/server/routes/api/test-connection.post.ts
+++ b/templates/analytics/server/routes/api/test-connection.post.ts
@@ -103,9 +103,10 @@ export default defineEventHandler(async (event) => {
       }
 
       case "jira": {
-        const email = await resolveCredential("JIRA_EMAIL");
-        const token = await resolveCredential("JIRA_TOKEN");
-        if (!email || !token)
+        const baseUrl = await resolveCredential("JIRA_BASE_URL");
+        const email = await resolveCredential("JIRA_USER_EMAIL");
+        const token = await resolveCredential("JIRA_API_TOKEN");
+        if (!baseUrl || !email || !token)
           return { ok: false, error: "Missing credentials" };
         return { ok: true };
       }


### PR DESCRIPTION
## Summary

- **Gong**: split single \`GONG_API_KEY\` (previously stored as \`accessKey:accessKeySecret\`) into separate \`GONG_ACCESS_KEY\` + \`GONG_ACCESS_SECRET\` fields. Matches Gong's actual API auth model and removes the awkward colon-joined format.
- **Jira**: require \`JIRA_BASE_URL\` (so the template works for any Atlassian instance, not a hardcoded one) and rename \`JIRA_EMAIL\`/\`JIRA_TOKEN\` → \`JIRA_USER_EMAIL\`/\`JIRA_API_TOKEN\` to match Atlassian's naming.

## Test plan

- [ ] Data Sources page: Gong walkthrough now has two input fields (Access Key + Secret) instead of one combined
- [ ] Data Sources page: Jira walkthrough prompts for Base URL, User Email, and API Token
- [ ] Existing Gong/Jira env vars need to be re-entered after this change