### PR TITLE
auth: desktop SSO broker — fix cross-template logout

### DIFF
--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -40,26 +40,14 @@ import {
   writeDesktopSso,
   clearDesktopSso,
 } from "./desktop-sso.js";
+import { isElectron as isElectronRequest } from "./google-oauth.js";
 
 /**
- * True for requests coming from the Electron desktop app's webview.
- * Used to gate the desktop SSO broker — we only read/write the shared
- * on-disk session record when the request originates from the desktop,
- * so web deployments stay strictly DB-backed.
+ * Get the configured session max age. Desktop SSO broker writes from
+ * OAuth flows read this so expiration stays consistent with the cookie.
  */
-function isElectronRequest(event: H3Event): boolean {
-  try {
-    const req: any = (event as any).req ?? event.node?.req;
-    const headers: any = req?.headers;
-    const ua =
-      typeof headers?.get === "function"
-        ? headers.get("user-agent")
-        : headers?.["user-agent"];
-    const s = Array.isArray(ua) ? ua[0] : ua;
-    return typeof s === "string" && /Electron/i.test(s);
-  } catch {
-    return false;
-  }
+export function getSessionMaxAge(): number {
+  return sessionMaxAge;
 }
 
 // ---------------------------------------------------------------------------
@@ -480,6 +468,13 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
   if (customGetSession) {
     const session = await customGetSession(event);
     if (session) return session;
+    // Desktop SSO broker: even with BYOA auth, fall back to the broker
+    // for Electron requests so cross-template SSO works for custom-auth
+    // templates too.
+    if (isElectronRequest(event)) {
+      const sso = await readDesktopSso();
+      if (sso?.email) return { email: sso.email, token: sso.token };
+    }
     // Fall through to mobile _session check
   } else {
     // 4. Better Auth session (cookie or Bearer token)

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -35,6 +35,32 @@ import type { BetterAuthConfig } from "./better-auth-instance.js";
 import { getOnboardingHtml, getResetPasswordHtml } from "./onboarding-html.js";
 import { migrateLocalUserData } from "./local-migration.js";
 import { readBody } from "../server/h3-helpers.js";
+import {
+  readDesktopSso,
+  writeDesktopSso,
+  clearDesktopSso,
+} from "./desktop-sso.js";
+
+/**
+ * True for requests coming from the Electron desktop app's webview.
+ * Used to gate the desktop SSO broker — we only read/write the shared
+ * on-disk session record when the request originates from the desktop,
+ * so web deployments stay strictly DB-backed.
+ */
+function isElectronRequest(event: H3Event): boolean {
+  try {
+    const req: any = (event as any).req ?? event.node?.req;
+    const headers: any = req?.headers;
+    const ua =
+      typeof headers?.get === "function"
+        ? headers.get("user-agent")
+        : headers?.["user-agent"];
+    const s = Array.isArray(ua) ? ua[0] : ua;
+    return typeof s === "string" && /Electron/i.test(s);
+  } catch {
+    return false;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -483,6 +509,21 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
         return { email, token: cookie };
       }
     }
+
+    // 5b. Desktop SSO broker fallback.
+    // Each template in the Electron desktop app has its own database, so
+    // a session token created by one template doesn't resolve in another.
+    // When an Electron request has no resolvable session, trust the
+    // home-dir SSO record written by whichever template the user signed
+    // into. Gated on Electron user-agent so no non-desktop code path
+    // consults the file.
+    if (isElectronRequest(event)) {
+      const sso = await readDesktopSso();
+      if (sso?.email) {
+        clearUpgradePendingCookie(event);
+        return { email: sso.email, token: sso.token };
+      }
+    }
   }
 
   // 6. Mobile WebView bridge — _session query param
@@ -904,6 +945,13 @@ async function mountBetterAuthRoutes(
             maxAge: sessionMaxAge,
           });
           await addSession(result.token, email);
+          if (isElectronRequest(event)) {
+            await writeDesktopSso({
+              email,
+              token: result.token,
+              expiresAt: Date.now() + sessionMaxAge * 1000,
+            });
+          }
         }
         return { ok: true };
       } catch (e: any) {
@@ -960,6 +1008,8 @@ async function mountBetterAuthRoutes(
       } catch {
         // Ignore if no Better Auth session
       }
+
+      if (isElectronRequest(event)) await clearDesktopSso();
 
       return { ok: true };
     }),
@@ -1053,6 +1103,7 @@ function mountTokenOnlyRoutes(
       const cookie = getCookie(event, COOKIE_NAME);
       if (cookie) await removeSession(cookie);
       deleteCookie(event, COOKIE_NAME, { path: "/" });
+      if (isElectronRequest(event)) await clearDesktopSso();
       return { ok: true };
     }),
   );
@@ -1158,6 +1209,13 @@ function mountAuthFallbackRoutes(app: H3App): void {
             maxAge: sessionMaxAge,
           });
           await addSession(result.token, email);
+          if (isElectronRequest(event)) {
+            await writeDesktopSso({
+              email,
+              token: result.token,
+              expiresAt: Date.now() + sessionMaxAge * 1000,
+            });
+          }
         }
         return { ok: true };
       } catch (e: any) {
@@ -1214,6 +1272,8 @@ function mountAuthFallbackRoutes(app: H3App): void {
       } catch {
         // Ignore if Better Auth is still unavailable
       }
+
+      if (isElectronRequest(event)) await clearDesktopSso();
 
       return { ok: true };
     }),
@@ -1395,6 +1455,7 @@ export async function autoMountAuth(
         const cookie = getCookie(event, COOKIE_NAME);
         if (cookie) await removeSession(cookie);
         deleteCookie(event, COOKIE_NAME, { path: "/" });
+        if (isElectronRequest(event)) await clearDesktopSso();
         return { ok: true };
       }),
     );

--- a/packages/core/src/server/desktop-sso.ts
+++ b/packages/core/src/server/desktop-sso.ts
@@ -47,13 +47,9 @@ export async function readDesktopSso(): Promise<DesktopSsoRecord | null> {
     if (
       !rec ||
       typeof rec.email !== "string" ||
-      typeof rec.token !== "string"
-    ) {
-      return null;
-    }
-    if (
-      typeof rec.expiresAt === "number" &&
-      rec.expiresAt > 0 &&
+      typeof rec.token !== "string" ||
+      typeof rec.expiresAt !== "number" ||
+      rec.expiresAt <= 0 ||
       rec.expiresAt < Date.now()
     ) {
       return null;
@@ -68,7 +64,7 @@ export async function writeDesktopSso(rec: DesktopSsoRecord): Promise<void> {
   try {
     const fs = await getFs();
     const p = getSsoPath();
-    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.mkdirSync(path.dirname(p), { recursive: true, mode: 0o700 });
     const tmp = `${p}.tmp`;
     fs.writeFileSync(tmp, JSON.stringify(rec), { mode: 0o600 });
     fs.renameSync(tmp, p);

--- a/packages/core/src/server/desktop-sso.ts
+++ b/packages/core/src/server/desktop-sso.ts
@@ -1,0 +1,87 @@
+/**
+ * Desktop SSO broker.
+ *
+ * In the Electron desktop app each template runs in its own persistent
+ * session partition with its own Nitro server and database. Cookies are
+ * isolated per partition, and session tokens don't federate across the
+ * per-template `session` tables — so signing into Mail leaves Calendar
+ * with a useless cookie (same value, but no matching row in Calendar's
+ * database), and Calendar reads as "logged out" on the next request.
+ *
+ * This module is a file-based broker that lives in the user's home
+ * directory. When a template creates a session, it writes the token +
+ * email here. When any template's `getSession` can't resolve its own
+ * cookie, it falls back to this record (but only for requests from
+ * Electron, so web deployments stay DB-backed).
+ *
+ * The file is user-owned (0600) and lives under the OS home directory,
+ * so the trust boundary is the local machine — same as the desktop app
+ * itself. It is intentionally not written or read outside of Electron
+ * requests; plain-web/serverless deployments never touch it.
+ */
+
+import os from "node:os";
+import path from "node:path";
+
+let _fs: typeof import("fs") | undefined;
+async function getFs(): Promise<typeof import("fs")> {
+  if (!_fs) _fs = await import("node:fs");
+  return _fs;
+}
+
+export interface DesktopSsoRecord {
+  email: string;
+  token: string;
+  expiresAt: number;
+}
+
+function getSsoPath(): string {
+  return path.join(os.homedir(), ".agent-native", "desktop-sso.json");
+}
+
+export async function readDesktopSso(): Promise<DesktopSsoRecord | null> {
+  try {
+    const fs = await getFs();
+    const raw = fs.readFileSync(getSsoPath(), "utf-8");
+    const rec = JSON.parse(raw) as DesktopSsoRecord;
+    if (
+      !rec ||
+      typeof rec.email !== "string" ||
+      typeof rec.token !== "string"
+    ) {
+      return null;
+    }
+    if (
+      typeof rec.expiresAt === "number" &&
+      rec.expiresAt > 0 &&
+      rec.expiresAt < Date.now()
+    ) {
+      return null;
+    }
+    return rec;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeDesktopSso(rec: DesktopSsoRecord): Promise<void> {
+  try {
+    const fs = await getFs();
+    const p = getSsoPath();
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    const tmp = `${p}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(rec), { mode: 0o600 });
+    fs.renameSync(tmp, p);
+  } catch {
+    // Best-effort: SSO is a desktop optimization, never fatal.
+  }
+}
+
+export async function clearDesktopSso(): Promise<void> {
+  try {
+    const fs = await getFs();
+    fs.unlinkSync(getSsoPath());
+  } catch {
+    // File didn't exist — fine.
+  }
+}

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -16,7 +16,12 @@ import {
   setResponseHeader,
   type H3Event,
 } from "h3";
-import { addSession, getSession, COOKIE_NAME } from "./auth.js";
+import {
+  addSession,
+  getSession,
+  COOKIE_NAME,
+  getSessionMaxAge,
+} from "./auth.js";
 import { writeDesktopSso } from "./desktop-sso.js";
 
 // ─── Platform Detection ─────────────────────────────────────────────────────
@@ -197,6 +202,7 @@ export async function createOAuthSession(
 ): Promise<OAuthSessionResult> {
   const mobile = isMobile(event);
   const needsDeepLink = opts.desktop || mobile;
+  const maxAge = getSessionMaxAge();
 
   let sessionToken: string | undefined;
   if (!opts.hasProductionSession || needsDeepLink) {
@@ -207,16 +213,20 @@ export async function createOAuthSession(
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
       path: "/",
-      maxAge: 60 * 60 * 24 * 30, // 30 days
+      maxAge,
     });
     // Desktop SSO: record this session in the home-dir broker file so
     // sibling templates (each with its own database) can resolve the
-    // same token without a DB row of their own.
-    if (opts.desktop) {
+    // same token without a DB row of their own. Only the PRIMARY
+    // sign-in writes the broker — if a production session already
+    // exists, this is an add-account flow (connecting a secondary
+    // Google account for scraping) and must never switch the active
+    // user across sibling templates.
+    if (opts.desktop && !opts.hasProductionSession) {
       await writeDesktopSso({
         email,
         token: sessionToken,
-        expiresAt: Date.now() + 60 * 60 * 24 * 30 * 1000,
+        expiresAt: Date.now() + maxAge * 1000,
       });
     }
   }

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -17,6 +17,7 @@ import {
   type H3Event,
 } from "h3";
 import { addSession, getSession, COOKIE_NAME } from "./auth.js";
+import { writeDesktopSso } from "./desktop-sso.js";
 
 // ─── Platform Detection ─────────────────────────────────────────────────────
 
@@ -208,6 +209,16 @@ export async function createOAuthSession(
       path: "/",
       maxAge: 60 * 60 * 24 * 30, // 30 days
     });
+    // Desktop SSO: record this session in the home-dir broker file so
+    // sibling templates (each with its own database) can resolve the
+    // same token without a DB row of their own.
+    if (opts.desktop) {
+      await writeDesktopSso({
+        email,
+        token: sessionToken,
+        expiresAt: Date.now() + 60 * 60 * 24 * 30 * 1000,
+      });
+    }
   }
 
   return { sessionToken };

--- a/templates/analytics/server/routes/api/test-connection.post.ts
+++ b/templates/analytics/server/routes/api/test-connection.post.ts
@@ -191,6 +191,14 @@ export default defineEventHandler(async (event) => {
         return { ok: true };
       }
 
+      case "gong": {
+        const accessKey = await resolveCredential("GONG_ACCESS_KEY");
+        const secret = await resolveCredential("GONG_ACCESS_SECRET");
+        if (!accessKey || !secret)
+          return { ok: false, error: "Missing credentials" };
+        return { ok: true };
+      }
+
       default:
         return { ok: false, error: `Unknown source: ${source}` };
     }

--- a/templates/analytics/server/routes/api/test-connection.post.ts
+++ b/templates/analytics/server/routes/api/test-connection.post.ts
@@ -196,6 +196,12 @@ export default defineEventHandler(async (event) => {
         const secret = await resolveCredential("GONG_ACCESS_SECRET");
         if (!accessKey || !secret)
           return { ok: false, error: "Missing credentials" };
+        const auth = `Basic ${Buffer.from(`${accessKey}:${secret}`).toString("base64")}`;
+        const res = await fetch(
+          "https://us-65885.api.gong.io/v2/users?limit=1",
+          { headers: { Authorization: auth } },
+        );
+        if (!res.ok) return { ok: false, error: "Invalid credentials" };
         return { ok: true };
       }
 


### PR DESCRIPTION
## Summary

- Fix the infuriating cross-template logout in the Electron desktop app — signing into Mail no longer kicks Calendar back to the sign-in screen (and vice versa).
- Root cause: each template runs in its own session partition with its own database. The desktop main process broadcasts the same session token into every partition's cookie jar, but the token only exists in the sessions table of the template that created it — so sibling templates have a cookie they can't resolve.
- Fix: add a home-dir SSO broker (`~/.agent-native/desktop-sso.json`, 0600) that templates write on sign-in / OAuth completion and read as a fallback in `getSession()`. Gated on `User-Agent: Electron` so web deployments never touch the file.
- Bundled: analytics `test-connection` now handles the Gong source (concurrent edit sitting uncommitted on this branch).

## Test plan

- [ ] In the desktop app, sign into Mail via Google → open Calendar → Calendar is already signed in as the same user.
- [ ] Sign out of Calendar → Mail also loses its session (or next request shows sign-in) — confirms the broker clears.
- [ ] Email/password sign-in in Mail → Calendar picks up the session on next request.
- [ ] Web (browser) sign-in is unchanged — no SSO file is written or read.
- [ ] Unit/type checks pass (`pnpm prep`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)