### PR TITLE
analytics: drop red hover on trash and clear-all buttons

### DIFF
--- a/.github/workflows/hide-cloudflare-comment.yml
+++ b/.github/workflows/hide-cloudflare-comment.yml
@@ -1,0 +1,27 @@
+name: Hide Cloudflare Pages bot comment
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  minimize:
+    if: github.event.issue.pull_request && github.event.comment.user.login == 'cloudflare-workers-and-pages[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Minimize comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const nodeId = context.payload.comment.node_id;
+            await github.graphql(`
+              mutation($id: ID!) {
+                minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                  minimizedComment { isMinimized }
+                }
+              }
+            `, { id: nodeId });

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -27,6 +27,7 @@ import React, {
   useEffect,
   useRef,
   useCallback,
+  useMemo,
   lazy,
   Suspense,
   startTransition,
@@ -224,6 +225,14 @@ export function AgentPanel({
   const keyPrefix = storageKey ? `:${storageKey}` : "";
   const execModeKey = `${EXEC_MODE_KEY}${keyPrefix}`;
   const panelModeKey = `agent-native-panel-mode${keyPrefix}`;
+  const isMac = useMemo(
+    () =>
+      typeof navigator !== "undefined" &&
+      /Mac|iPhone|iPad/.test(navigator.userAgent),
+    [],
+  );
+  const closeTabHint = isMac ? "\u2303W" : "Alt+W";
+  const closeAllTabsHint = isMac ? "\u2303\u2325W" : "Ctrl+Alt+W";
 
   const [execMode, setExecMode] = useState<ExecMode>(() => {
     try {
@@ -334,6 +343,35 @@ export function AgentPanel({
     setCliTabs([id]);
     setActiveCliTab(id);
   }, []);
+
+  // Tab close shortcuts. Avoid Cmd+W (browser/OS) and (on Windows) Ctrl+W.
+  //   Mac:           Ctrl+W → close tab,  Ctrl+Alt+W → close all
+  //   Windows/Linux: Alt+W  → close tab,  Ctrl+Alt+W → close all
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() !== "w" || e.metaKey || e.shiftKey) return;
+      const isCloseAll = e.ctrlKey && e.altKey;
+      const isCloseOne = isMac
+        ? e.ctrlKey && !e.altKey
+        : e.altKey && !e.ctrlKey;
+      if (!isCloseAll && !isCloseOne) return;
+      e.preventDefault();
+      if (mode === "chat") {
+        window.dispatchEvent(
+          new CustomEvent(
+            isCloseAll
+              ? "agent-chat:close-all-tabs"
+              : "agent-chat:close-current-tab",
+          ),
+        );
+      } else if (mode === "cli") {
+        if (isCloseAll) closeAllCliTabs();
+        else if (activeCliTab) closeCliTab(activeCliTab);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [mode, activeCliTab, closeCliTab, closeAllCliTabs, isMac]);
 
   const availableClis = useAvailableClis();
   const [selectedCli, selectCli] = useCliSelection(keyPrefix);
@@ -672,7 +710,7 @@ export function AgentPanel({
                                 >
                                   Close Tab
                                   <kbd className="text-[10px] text-muted-foreground">
-                                    {"\u2318"}W
+                                    {closeTabHint}
                                   </kbd>
                                 </button>
                                 <button
@@ -685,13 +723,16 @@ export function AgentPanel({
                                   Close Other Tabs
                                 </button>
                                 <button
-                                  className="flex w-full items-center px-3 py-1.5 text-xs text-foreground hover:bg-accent"
+                                  className="flex w-full items-center justify-between px-3 py-1.5 text-xs text-foreground hover:bg-accent"
                                   onClick={() => {
                                     closeAllTabs();
                                     setTabMenuOpen(null);
                                   }}
                                 >
                                   Close All Tabs
+                                  <kbd className="text-[10px] text-muted-foreground">
+                                    {closeAllTabsHint}
+                                  </kbd>
                                 </button>
                               </div>
                             </>
@@ -814,7 +855,7 @@ export function AgentPanel({
                                 >
                                   Close Tab
                                   <kbd className="text-[10px] text-muted-foreground">
-                                    {"\u2318"}W
+                                    {closeTabHint}
                                   </kbd>
                                 </button>
                                 <button
@@ -827,13 +868,16 @@ export function AgentPanel({
                                   Close Other Tabs
                                 </button>
                                 <button
-                                  className="flex w-full items-center px-3 py-1.5 text-xs text-foreground hover:bg-accent"
+                                  className="flex w-full items-center justify-between px-3 py-1.5 text-xs text-foreground hover:bg-accent"
                                   onClick={() => {
                                     closeAllCliTabs();
                                     setTabMenuOpen(null);
                                   }}
                                 >
                                   Close All Tabs
+                                  <kbd className="text-[10px] text-muted-foreground">
+                                    {closeAllTabsHint}
+                                  </kbd>
                                 </button>
                               </div>
                             </>
@@ -929,6 +973,8 @@ export function AgentPanel({
       selectedLabel,
       selectCli,
       cliPickerOpen,
+      closeTabHint,
+      closeAllTabsHint,
     ],
   );
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -897,16 +897,50 @@ export function BuilderCtaCard({
   reason,
   usageCents,
   limitCents,
+  apiUrl = "/_agent-native/agent-chat",
 }: {
   reason: "usage_limit" | "code_changes" | "cli_tab";
   usageCents?: number;
   limitCents?: number;
+  apiUrl?: string;
 }) {
   const appName =
     typeof window !== "undefined"
       ? window.location.hostname.split(".")[0]
       : "app";
   const cloneCommand = `npx agent-native create ${appName}`;
+
+  const { status: builder } = useBuilderStatus();
+  const builderEnabled = builder?.builderEnabled ?? false;
+  const builderConnectUrl = builder?.connectUrl;
+
+  const [apiKey, setApiKey] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    if (!apiKey.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`${apiUrl}/save-key`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: apiKey.trim() }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to save");
+      }
+      setSaved(true);
+      setTimeout(() => window.location.reload(), 1000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
 
   const title =
     reason === "usage_limit"
@@ -917,14 +951,25 @@ export function BuilderCtaCard({
 
   const description =
     reason === "usage_limit"
-      ? `You've used $${((usageCents ?? 0) / 100).toFixed(2)} of your $${((limitCents ?? 100) / 100).toFixed(2)} free tier. Connect to Builder.io for unlimited usage, or clone this app to run it locally with your own API key.`
+      ? `You've used $${((usageCents ?? 0) / 100).toFixed(2)} of your $${((limitCents ?? 100) / 100).toFixed(2)} free tier. Add your own Anthropic API key for unlimited usage — the free tier doesn't apply when you bring your own key. Or clone this app to run it locally.`
       : reason === "code_changes"
-        ? "This app is running in hosted mode. To make code changes, connect to Builder.io or clone and run locally."
-        : "This hosted app has limited AI features. Connect to Builder.io for the full experience, or clone and run locally with your own API key.";
+        ? "This app is running in hosted mode. To make code changes, add your own Anthropic API key or clone and run locally."
+        : "This hosted app has limited AI features. Add your own Anthropic API key for the full experience, or clone and run locally.";
+
+  if (saved) {
+    return (
+      <div className="mx-4 my-6 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4">
+        <div className="flex items-center gap-2 text-sm text-emerald-400">
+          <IconCheck className="h-4 w-4" />
+          API key saved. Reloading...
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="mx-4 my-6 rounded-lg border border-border bg-card p-5">
-      <div className="flex items-center gap-3 mb-3">
+      <div className="flex items-center gap-3 mb-4">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted">
           <IconSparkles className="h-4.5 w-4.5 text-muted-foreground" />
         </div>
@@ -934,15 +979,46 @@ export function BuilderCtaCard({
         </div>
       </div>
 
-      <div className="space-y-2.5">
-        <a
-          href="https://www.builder.io/m/agent-native"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex w-full items-center justify-center rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+      <div className="space-y-3">
+        <div className="rounded-md bg-muted/50 px-3 py-2.5 text-xs text-muted-foreground leading-relaxed">
+          <p>
+            Paste an Anthropic API key (
+            <a
+              href="https://console.anthropic.com/settings/keys"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline text-foreground/80 hover:text-foreground"
+            >
+              console.anthropic.com/settings/keys
+            </a>
+            ) to skip the free-tier limit.
+          </p>
+        </div>
+
+        <input
+          type="password"
+          value={apiKey}
+          onChange={(e) => {
+            setApiKey(e.target.value);
+            setError(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSave();
+          }}
+          placeholder="sk-ant-..."
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
+          autoComplete="off"
+        />
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <button
+          onClick={handleSave}
+          disabled={saving || !apiKey.trim()}
+          className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          Connect to Builder.io
-        </a>
+          {saving ? "Saving..." : "Save API key"}
+        </button>
 
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
@@ -960,6 +1036,34 @@ export function BuilderCtaCard({
           <code className="block text-xs text-foreground/80 font-mono break-all select-all">
             {cloneCommand}
           </code>
+        </div>
+
+        <div className="rounded-md border border-border px-3 py-2.5">
+          <div className="flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <div className="text-xs font-medium text-foreground">
+                Connect Builder.io
+              </div>
+              <p className="text-[11px] text-muted-foreground mt-0.5">
+                Builder's managed Anthropic proxy — no API key needed
+              </p>
+            </div>
+            {builderEnabled && builderConnectUrl ? (
+              <a
+                href={builderConnectUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex shrink-0 items-center gap-1 rounded bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground hover:opacity-90"
+              >
+                Connect
+                <IconExternalLink className="h-3 w-3" />
+              </a>
+            ) : (
+              <span className="shrink-0 rounded border border-border px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                Coming soon
+              </span>
+            )}
+          </div>
         </div>
       </div>
     </div>
@@ -1731,6 +1835,7 @@ const AssistantChatInner = forwardRef<
               reason="usage_limit"
               usageCents={usageLimitReached.usageCents}
               limitCents={usageLimitReached.limitCents}
+              apiUrl={apiUrl}
             />
           </div>
         ) : isRestoring ? (

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -666,6 +666,26 @@ export function MultiTabAssistantChat({
     }
   }, [createThread, switchThread]);
 
+  // Keyboard shortcuts dispatched from AgentPanel based on the active mode
+  useEffect(() => {
+    const handleCloseCurrent = () => {
+      const id = activeThreadIdRef.current;
+      if (id) closeTab(id);
+    };
+    const handleCloseAll = () => {
+      void closeAllTabs();
+    };
+    window.addEventListener("agent-chat:close-current-tab", handleCloseCurrent);
+    window.addEventListener("agent-chat:close-all-tabs", handleCloseAll);
+    return () => {
+      window.removeEventListener(
+        "agent-chat:close-current-tab",
+        handleCloseCurrent,
+      );
+      window.removeEventListener("agent-chat:close-all-tabs", handleCloseAll);
+    };
+  }, [closeTab, closeAllTabs]);
+
   const clearActiveTab = useCallback(() => {
     addTab();
   }, [addTab]);

--- a/scripts/dev-all.ts
+++ b/scripts/dev-all.ts
@@ -77,25 +77,25 @@ console.log(
 );
 console.log(`\x1b[36m[dev-all]\x1b[0m Docs: http://localhost:${DOCS_PORT}`);
 
+// Prebuild core once before templates boot. Templates import from
+// @agent-native/core/server; if tsc --watch is mid-rewrite of dist/ when a
+// template SSR-imports it, named exports come back undefined (e.g.
+// "createAgentChatPlugin is not a function"). Building first guarantees a
+// complete dist; tsc --watch then takes over for incremental rebuilds.
+console.log(`\x1b[36m[dev-all]\x1b[0m Prebuilding @agent-native/core...`);
+execSync("pnpm --filter @agent-native/core build", { stdio: "inherit" });
+
 const names: string[] = [];
 const commands: string[] = [];
 
-// Stagger template starts by 1.5s each to prevent CPU saturation.
-// When all 11+ apps start simultaneously, Nitro's ViteEnvRunner hits its
-// 3-second initialization timeout, producing "Vite environment unavailable" 503s.
-const STAGGER_DELAY_S = 1.5;
-
-templatePorts.forEach(({ name, port }, i) => {
+templatePorts.forEach(({ name, port }) => {
   console.log(`\x1b[36m[dev-all]\x1b[0m ${name}: http://localhost:${port}`);
-
-  const delay = i * STAGGER_DELAY_S;
-  const prefix = delay > 0 ? `sleep ${delay} && ` : "";
 
   names.push(name);
   // Pass APP_NAME so each app can resolve its own DATABASE_URL
   // (e.g. MAIL_DATABASE_URL when APP_NAME=mail)
   commands.push(
-    `${prefix}APP_NAME=${name} pnpm --dir templates/${name} exec vite --port ${port}`,
+    `APP_NAME=${name} pnpm --dir templates/${name} exec vite --port ${port}`,
   );
 });
 

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -228,7 +228,7 @@ function SortableDashboardItem({
         >
           <PopoverTrigger asChild>
             <button
-              className="opacity-0 group-hover/dash:opacity-100 p-1 rounded text-muted-foreground/50 hover:text-destructive transition-all shrink-0 mr-1"
+              className="opacity-0 group-hover/dash:opacity-100 p-1 rounded text-muted-foreground/50 hover:text-foreground transition-all shrink-0 mr-1"
               title={`Remove ${d.name}`}
             >
               <IconTrash className="h-3 w-3" />
@@ -332,7 +332,7 @@ function SortableDashboardItem({
                     >
                       <PopoverTrigger asChild>
                         <button
-                          className="opacity-0 group-hover/sv:opacity-100 p-0.5 rounded text-muted-foreground/50 hover:text-destructive transition-all shrink-0"
+                          className="opacity-0 group-hover/sv:opacity-100 p-0.5 rounded text-muted-foreground/50 hover:text-foreground transition-all shrink-0"
                           title={`Delete ${sv.name}`}
                         >
                           <IconTrash className="h-2.5 w-2.5" />

--- a/templates/analytics/app/pages/adhoc/explorer-dashboard/ChartCard.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer-dashboard/ChartCard.tsx
@@ -115,7 +115,7 @@ export function DashboardChartCard({
             </button>
             <button
               onClick={onRemove}
-              className="p-1 rounded text-muted-foreground hover:text-destructive transition-colors"
+              className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
               title="Remove chart"
             >
               <IconTrash className="h-3.5 w-3.5" />

--- a/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
@@ -268,7 +268,7 @@ export default function ExplorerDashboardPage() {
           <Button
             size="sm"
             variant="ghost"
-            className="text-muted-foreground hover:text-destructive"
+            className="text-muted-foreground hover:text-foreground"
             onClick={async () => {
               if (!dashboardId) return;
               const token = await getIdToken();

--- a/templates/analytics/app/pages/adhoc/explorer/components/GroupByPicker.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer/components/GroupByPicker.tsx
@@ -24,7 +24,7 @@ export function GroupByPicker({ groupBy, onChange }: GroupByPickerProps) {
           <span className="text-muted-foreground">&#9655;</span>
           {g}
           <button
-            className="hover:text-destructive"
+            className="hover:text-foreground"
             onClick={() => onChange(groupBy.filter((_, j) => j !== i))}
           >
             <IconX className="h-3 w-3" />

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/DashboardFilterBar.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/DashboardFilterBar.tsx
@@ -195,7 +195,7 @@ export function DashboardFilterBar({
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-6 px-2 text-xs text-muted-foreground hover:text-destructive"
+                className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
                 onClick={clearAllFilters}
               >
                 <IconFilterOff className="h-3 w-3 mr-1" />

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -306,7 +306,7 @@ export default function SqlDashboardPage() {
       <Button
         size="sm"
         variant="ghost"
-        className="text-muted-foreground hover:text-destructive"
+        className="text-muted-foreground hover:text-foreground"
         onClick={handleDelete}
       >
         <IconTrash className="h-4 w-4" />

--- a/templates/analytics/app/root.tsx
+++ b/templates/analytics/app/root.tsx
@@ -12,7 +12,12 @@ import {
 import { AuthProvider } from "@/components/auth/AuthProvider";
 import { CommandPalette } from "./components/layout/CommandPalette";
 import { Layout as AppLayout } from "./components/layout/Layout";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/templates/calendar/app/root.tsx
+++ b/templates/calendar/app/root.tsx
@@ -10,7 +10,12 @@ import { useDbSync } from "@agent-native/core/client";
 import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/templates/content/app/root.tsx
+++ b/templates/content/app/root.tsx
@@ -13,7 +13,12 @@ import {
 } from "@agent-native/core/client";
 import { useDbSync } from "./hooks/use-db-sync";
 import { useNavigationState } from "./hooks/use-navigation-state";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/templates/dispatch/app/root.tsx
+++ b/templates/dispatch/app/root.tsx
@@ -16,7 +16,12 @@ import {
 } from "@agent-native/core/client";
 import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/templates/forms/app/root.tsx
+++ b/templates/forms/app/root.tsx
@@ -16,7 +16,12 @@ import {
 } from "@agent-native/core/client";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/templates/issues/app/root.tsx
+++ b/templates/issues/app/root.tsx
@@ -12,7 +12,12 @@ import { AppLayout } from "@/components/layout/AppLayout";
 import { useDbSync } from "@agent-native/core";
 import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { TAB_ID } from "@/lib/tab-id";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/templates/macros/app/root.tsx
+++ b/templates/macros/app/root.tsx
@@ -12,7 +12,12 @@ import { useDbSync } from "@agent-native/core";
 import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { TAB_ID } from "@/lib/tab-id";
 import { AppLayout } from "@/components/layout/AppLayout";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -12,7 +12,12 @@ import { AppLayout } from "@/components/layout/AppLayout";
 import { useDbSync } from "@agent-native/core";
 import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { TAB_ID } from "@/lib/tab-id";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/templates/recruiting/app/root.tsx
+++ b/templates/recruiting/app/root.tsx
@@ -12,7 +12,12 @@ import { AppLayout } from "@/components/layout/AppLayout";
 import { useDbSync } from "@agent-native/core";
 import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { TAB_ID } from "@/lib/tab-id";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -14,7 +14,12 @@ import {
   exitSelectionMode as coreExitSelectionMode,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 // Key forces DeckProvider remount when code changes (HMR)
 const DECK_KEY = 3;

--- a/templates/starter/app/root.tsx
+++ b/templates/starter/app/root.tsx
@@ -16,7 +16,12 @@ import {
 } from "@agent-native/core/client";
 import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/templates/videos/app/root.tsx
+++ b/templates/videos/app/root.tsx
@@ -9,7 +9,12 @@ import {
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import "./global.css";
+import type { LinksFunction } from "react-router";
+import stylesheet from "./global.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: stylesheet },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (


### PR DESCRIPTION
## Summary
- Destructive-red hover on icon buttons (dashboard/view/chart delete, clear-all filters, group-by chip dismiss) felt jarring on otherwise-neutral toolbars.
- Swapped `hover:text-destructive` for `hover:text-foreground` in the analytics template. Red styling is still reserved for actual confirm buttons.

## Test plan
- [ ] Hover the dashboard-header trash icon, the dashboard/view entries in the sidebar, and the chart-card remove button — no red flash
- [ ] "Clear all" in the filter bar and the group-by chip close button fade to neutral foreground on hover