### PR TITLE
updates-108: persist user API key on hosted apps + dev-all stagger

### DIFF
--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -35,6 +35,26 @@ import { getRequestUserEmail } from "../server/request-context.js";
 // Register built-in engines on first import
 registerBuiltinEngines();
 
+/**
+ * Look up a user's persisted Anthropic API key by owner email. Returns
+ * `undefined` for unauthenticated/local callers so the shared platform key
+ * is never keyed off `local@localhost` in multi-tenant deployments.
+ */
+export async function getOwnerAnthropicApiKey(
+  ownerEmail: string | null | undefined,
+): Promise<string | undefined> {
+  if (!ownerEmail || ownerEmail === "local@localhost") return undefined;
+  try {
+    const { getSetting } = await import("../settings/store.js");
+    const stored = await getSetting(`user-anthropic-api-key:${ownerEmail}`);
+    const key =
+      stored && typeof stored.key === "string" ? stored.key.trim() : "";
+    return key || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Context passed to action run() for emitting intermediate events */
 export interface ActionRunContext {
   /** Emit an SSE event to the client (e.g., agent_call_text for streaming) */
@@ -464,18 +484,7 @@ export function createProductionAgentHandler(
       }
     }
 
-    let userApiKey: string | undefined;
-    if (ownerEmail && ownerEmail !== "local@localhost") {
-      try {
-        const { getSetting } = await import("../settings/store.js");
-        const stored = await getSetting(`user-anthropic-api-key:${ownerEmail}`);
-        const key =
-          stored && typeof stored.key === "string" ? stored.key.trim() : "";
-        if (key) userApiKey = key;
-      } catch {
-        // Settings store unavailable — fall through to env-based key
-      }
-    }
+    const userApiKey = await getOwnerAnthropicApiKey(ownerEmail);
 
     const effectiveApiKey =
       userApiKey ?? options.apiKey ?? process.env.ANTHROPIC_API_KEY;

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -451,23 +451,51 @@ export function createProductionAgentHandler(
       return { error: "message is required" };
     }
 
+    // Resolve owner first so we can look up a per-owner API key. Users
+    // who bring their own key bypass the platform's free-tier usage limit
+    // and use their key for this request (which is also durable across
+    // serverless cold starts via the settings table).
+    let ownerEmail: string | null = null;
+    if (options.resolveOwnerEmail) {
+      try {
+        ownerEmail = await options.resolveOwnerEmail(event);
+      } catch {
+        ownerEmail = null;
+      }
+    }
+
+    let userApiKey: string | undefined;
+    if (ownerEmail && ownerEmail !== "local@localhost") {
+      try {
+        const { getSetting } = await import("../settings/store.js");
+        const stored = await getSetting(`user-anthropic-api-key:${ownerEmail}`);
+        const key =
+          stored && typeof stored.key === "string" ? stored.key.trim() : "";
+        if (key) userApiKey = key;
+      } catch {
+        // Settings store unavailable — fall through to env-based key
+      }
+    }
+
+    const effectiveApiKey =
+      userApiKey ?? options.apiKey ?? process.env.ANTHROPIC_API_KEY;
+
     // Resolve engine (async — reads settings if needed)
     let engine: AgentEngine;
     try {
       engine = await resolveEngine({
         engineOption: options.engine,
-        apiKey: options.apiKey ?? process.env.ANTHROPIC_API_KEY,
+        apiKey: effectiveApiKey,
         model,
       });
     } catch {
       engine = await resolveEngine({
-        apiKey: options.apiKey ?? process.env.ANTHROPIC_API_KEY,
+        apiKey: effectiveApiKey,
       });
     }
 
     // Check for API key before starting a run (only for anthropic engine)
-    const apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY;
-    if (engine.name === "anthropic" && !apiKey) {
+    if (engine.name === "anthropic" && !effectiveApiKey) {
       setResponseHeader(event, "Content-Type", "text/event-stream");
       setResponseHeader(event, "Cache-Control", "no-cache");
       setResponseHeader(event, "Connection", "keep-alive");
@@ -484,32 +512,37 @@ export function createProductionAgentHandler(
       });
     }
 
-    // Check usage limit before starting a run (production hosted mode)
-    if (options.trackUsage && options.resolveOwnerEmail) {
+    // Check usage limit before starting a run (production hosted mode).
+    // Skip when the user has provided their own key — they're paying
+    // Anthropic directly, so the platform's free tier doesn't apply.
+    if (
+      !userApiKey &&
+      options.trackUsage &&
+      options.resolveOwnerEmail &&
+      ownerEmail &&
+      ownerEmail !== "local@localhost"
+    ) {
       try {
-        const ownerEmail = await options.resolveOwnerEmail(event);
-        if (ownerEmail && ownerEmail !== "local@localhost") {
-          const { checkUsageLimit } = await import("../usage/store.js");
-          const result = await checkUsageLimit(
-            ownerEmail,
-            options.usageLimitCents,
-          );
-          if (!result.allowed) {
-            setResponseHeader(event, "Content-Type", "text/event-stream");
-            setResponseHeader(event, "Cache-Control", "no-cache");
-            setResponseHeader(event, "Connection", "keep-alive");
-            const encoder = new TextEncoder();
-            return new ReadableStream({
-              start(controller) {
-                controller.enqueue(
-                  encoder.encode(
-                    `data: ${JSON.stringify({ type: "usage_limit_reached", usageCents: result.usageCents, limitCents: result.limitCents })}\n\n`,
-                  ),
-                );
-                controller.close();
-              },
-            });
-          }
+        const { checkUsageLimit } = await import("../usage/store.js");
+        const result = await checkUsageLimit(
+          ownerEmail,
+          options.usageLimitCents,
+        );
+        if (!result.allowed) {
+          setResponseHeader(event, "Content-Type", "text/event-stream");
+          setResponseHeader(event, "Cache-Control", "no-cache");
+          setResponseHeader(event, "Connection", "keep-alive");
+          const encoder = new TextEncoder();
+          return new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  `data: ${JSON.stringify({ type: "usage_limit_reached", usageCents: result.usageCents, limitCents: result.limitCents })}\n\n`,
+                ),
+              );
+              controller.close();
+            },
+          });
         }
       } catch {
         // Usage check failed — allow the request to proceed

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -9,6 +9,8 @@ import {
   getRunById,
   getRunByThread,
   cleanupOldRuns,
+  updateRunHeartbeat,
+  reapIfStale,
 } from "./run-store.js";
 
 export interface ActiveRun {
@@ -66,6 +68,14 @@ export function startRun(
   // Persist run to SQL (fire-and-forget — don't block the response)
   insertRun(runId, threadId).catch(() => {});
 
+  // Heartbeat: bump heartbeat_at every 5s so watchers can detect a dead
+  // producer (process crash, HMR restart, isolate eviction) and reap the
+  // row. Without this, the run's SQL status stays "running" forever and
+  // reconnect clients spin on "Thinking..." indefinitely.
+  const heartbeatTimer: ReturnType<typeof setInterval> = setInterval(() => {
+    updateRunHeartbeat(runId).catch(() => {});
+  }, 5000);
+
   // Periodic SQL abort check interval (for cross-isolate abort on Workers)
   let lastAbortCheck = Date.now();
 
@@ -112,6 +122,8 @@ export function startRun(
       send({ type: "error", error: err?.message ?? "Unknown error" });
     })
     .finally(() => {
+      // Stop the heartbeat — the run is done, no more liveness writes.
+      clearInterval(heartbeatTimer);
       // Send a terminal event so every subscriber's ReadableStream controller
       // gets closed.  Without this, SSE connections hang open forever when
       // the agent errors out in a way that bypasses the normal `send()` path.
@@ -329,6 +341,10 @@ function subscribeFromSQL(
 
           // Check if run completed (no terminal event but status changed)
           if (events.length === 0) {
+            // Opportunistically reap a stale producer before trusting SQL's
+            // "running" status — otherwise a crashed server leaves us polling
+            // forever.
+            await reapIfStale(runId).catch(() => {});
             const run = await getRunById(runId);
             if (!run || run.status !== "running") {
               // Run ended — do one final event read, then close
@@ -421,6 +437,11 @@ export async function getActiveRunForThreadAsync(
   try {
     const sqlRun = await getRunByThread(threadId);
     if (sqlRun && sqlRun.status === "running") {
+      // If the producer is dead (no recent heartbeat), reap before the
+      // client can see a stale "running" status and enter a reconnect
+      // loop it can never exit.
+      const reaped = await reapIfStale(sqlRun.id).catch(() => false);
+      if (reaped) return null;
       return {
         runId: sqlRun.id,
         threadId: sqlRun.threadId,

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -3,9 +3,16 @@
  * Enables cross-isolate access on Cloudflare Workers and
  * reliable reconnection after page refreshes.
  */
-import { getDbExec, intType } from "../db/client.js";
+import { getDbExec, intType, isPostgres } from "../db/client.js";
 
 let _initPromise: Promise<void> | undefined;
+
+/**
+ * Max time without a heartbeat before a "running" run is considered dead.
+ * The run-manager heartbeats every 5s, so 90s tolerates several missed
+ * writes from DB slowness before we assume the producer died.
+ */
+export const RUN_STALE_MS = 90_000;
 
 async function ensureRunTables(): Promise<void> {
   if (!_initPromise) {
@@ -17,9 +24,24 @@ async function ensureRunTables(): Promise<void> {
           thread_id TEXT NOT NULL,
           status TEXT NOT NULL DEFAULT 'running',
           started_at ${intType()} NOT NULL,
-          completed_at ${intType()}
+          completed_at ${intType()},
+          heartbeat_at ${intType()}
         )
       `);
+      // Backfill heartbeat_at on older deployments.
+      try {
+        if (isPostgres()) {
+          await client.execute(
+            `ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS heartbeat_at ${intType()}`,
+          );
+        } else {
+          await client.execute(
+            `ALTER TABLE agent_runs ADD COLUMN heartbeat_at ${intType()}`,
+          );
+        }
+      } catch {
+        // Column already exists — ignore
+      }
       await client.execute(`
         CREATE TABLE IF NOT EXISTS agent_run_events (
           run_id TEXT NOT NULL,
@@ -36,10 +58,44 @@ async function ensureRunTables(): Promise<void> {
 export async function insertRun(id: string, threadId: string): Promise<void> {
   await ensureRunTables();
   const client = getDbExec();
+  const now = Date.now();
   await client.execute({
-    sql: `INSERT INTO agent_runs (id, thread_id, status, started_at) VALUES (?, ?, 'running', ?)`,
-    args: [id, threadId, Date.now()],
+    sql: `INSERT INTO agent_runs (id, thread_id, status, started_at, heartbeat_at) VALUES (?, ?, 'running', ?, ?)`,
+    args: [id, threadId, now, now],
   });
+}
+
+/** Update the run's liveness heartbeat. Called periodically by run-manager. */
+export async function updateRunHeartbeat(runId: string): Promise<void> {
+  await ensureRunTables();
+  const client = getDbExec();
+  await client.execute({
+    sql: `UPDATE agent_runs SET heartbeat_at = ? WHERE id = ?`,
+    args: [Date.now(), runId],
+  });
+}
+
+/**
+ * If the given run is marked "running" in SQL but its heartbeat is stale
+ * (producer likely crashed), flip it to "errored" so watchers stop waiting.
+ * Returns true if the row was reaped.
+ */
+export async function reapIfStale(
+  runId: string,
+  maxStaleMs: number = RUN_STALE_MS,
+): Promise<boolean> {
+  await ensureRunTables();
+  const client = getDbExec();
+  const cutoff = Date.now() - maxStaleMs;
+  const { rowsAffected } = await client.execute({
+    sql: `UPDATE agent_runs
+          SET status = 'errored', completed_at = ?
+          WHERE id = ?
+            AND status = 'running'
+            AND COALESCE(heartbeat_at, started_at) < ?`,
+    args: [Date.now(), runId, cutoff],
+  });
+  return (rowsAffected ?? 0) > 0;
 }
 
 export async function updateRunStatus(
@@ -165,11 +221,20 @@ export async function cleanupOldRuns(olderThanMs: number): Promise<void> {
   await ensureRunTables();
   const client = getDbExec();
   const cutoff = Date.now() - olderThanMs;
-  // Expire stale running rows — if started more than threshold ago,
-  // the worker likely crashed. Mark as errored so clients stop waiting.
+  // Expire stale running rows on the absolute-age threshold — safety net
+  // for runs that never received a heartbeat (very old deployments).
   await client.execute({
     sql: `UPDATE agent_runs SET status = 'errored', completed_at = ? WHERE status = 'running' AND started_at < ?`,
     args: [Date.now(), cutoff],
+  });
+  // Also expire runs whose heartbeat is stale — producer has died.
+  const heartbeatCutoff = Date.now() - RUN_STALE_MS;
+  await client.execute({
+    sql: `UPDATE agent_runs
+          SET status = 'errored', completed_at = ?
+          WHERE status = 'running'
+            AND COALESCE(heartbeat_at, started_at) < ?`,
+    args: [Date.now(), heartbeatCutoff],
   });
   // Delete events for old non-running runs
   await client.execute({

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -47,6 +47,8 @@ import {
   IconDotsVertical,
   IconHistory,
   IconTrash,
+  IconArrowsMaximize,
+  IconArrowsMinimize,
 } from "@tabler/icons-react";
 import {
   MultiTabAssistantChat,
@@ -198,6 +200,10 @@ export interface AgentPanelProps extends Omit<
   className?: string;
   /** Called when the user clicks the collapse button. If provided, a collapse button appears in the header. */
   onCollapse?: () => void;
+  /** Whether the panel is currently in fullscreen (Claude-style centered) mode. */
+  isFullscreen?: boolean;
+  /** Called when the user clicks the maximize/minimize button. If provided, the button appears next to the collapse button. */
+  onToggleFullscreen?: () => void;
   /** URL of the app being developed (shown as "Open app in new tab" in settings). Set by frame. */
   devAppUrl?: string;
   /** Namespace for localStorage keys — used to isolate chat state per app in the frame. */
@@ -218,6 +224,8 @@ export function AgentPanel({
   suggestions,
   showHeader = true,
   onCollapse,
+  isFullscreen,
+  onToggleFullscreen,
   devAppUrl,
   storageKey,
 }: AgentPanelProps) {
@@ -481,6 +489,22 @@ export function AgentPanel({
             <SetupButton />
           </Suspense>
         )}
+        {onToggleFullscreen && (
+          <IconTooltip
+            content={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+          >
+            <button
+              onClick={onToggleFullscreen}
+              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
+            >
+              {isFullscreen ? (
+                <IconArrowsMinimize size={14} />
+              ) : (
+                <IconArrowsMaximize size={14} />
+              )}
+            </button>
+          </IconTooltip>
+        )}
         {onCollapse && (
           <IconTooltip content="Collapse sidebar">
             <button
@@ -493,7 +517,7 @@ export function AgentPanel({
         )}
       </div>
     ),
-    [onCollapse, isDevMode],
+    [onCollapse, isDevMode, onToggleFullscreen, isFullscreen],
   );
 
   const [tabMenuOpen, setTabMenuOpen] = useState<string | null>(null);
@@ -985,12 +1009,20 @@ export function AgentPanel({
         className,
       )}
       style={AGENT_PANEL_ROOT_STYLE}
+      data-agent-fullscreen={isFullscreen ? "true" : undefined}
     >
-      {/* Tailwind group-hover/tab doesn't work in core package — inject directly */}
+      {/* Tailwind group-hover/tab doesn't work in core package — inject directly.
+          Fullscreen rules center the message stream and composer to a Claude-style
+          column while leaving the header bar at full width so the action buttons
+          stay pinned to the top corners. */}
       <style
         dangerouslySetInnerHTML={{
           __html:
-            ".agent-tab-close{opacity:0}.agent-tab:hover .agent-tab-close{opacity:1}",
+            ".agent-tab-close{opacity:0}.agent-tab:hover .agent-tab-close{opacity:1}" +
+            `[data-agent-fullscreen='true'] .agent-thread-content,` +
+            `[data-agent-fullscreen='true'] .agent-composer-area{` +
+            `max-width:${FULLSCREEN_CONTENT_MAX_PX}px;` +
+            `margin-left:auto;margin-right:auto;width:100%;}`,
         }}
       />
       {/* Framework onboarding — appears above the chat/cli/settings tabs
@@ -1134,8 +1166,11 @@ export function AgentPanel({
 
 const SIDEBAR_STORAGE_KEY = "agent-native-sidebar-width";
 const SIDEBAR_OPEN_KEY = "agent-native-sidebar-open";
+const SIDEBAR_FULLSCREEN_KEY = "agent-native-sidebar-fullscreen";
 const SIDEBAR_MIN = 280;
 const SIDEBAR_MAX = 700;
+/** Max width of the centered chat column in fullscreen mode (Claude-style). */
+const FULLSCREEN_CONTENT_MAX_PX = 760;
 
 function ResizeHandle({
   position,
@@ -1422,6 +1457,21 @@ export function AgentSidebar({
   });
   const [presentationMode, setPresentationMode] = useState(false);
   const [width, setWidth] = useState(sidebarWidth);
+  const [fullscreen, setFullscreen] = useState(() => {
+    // Force-disable on mobile: a Claude-style centered column makes no sense
+    // when the sidebar already covers most of the viewport.
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(max-width: 767px)").matches
+    ) {
+      return false;
+    }
+    try {
+      return localStorage.getItem(SIDEBAR_FULLSCREEN_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
 
   // Track mobile viewport so we can switch to overlay mode.
   const [isMobile, setIsMobile] = useState(
@@ -1457,6 +1507,16 @@ export function AgentSidebar({
     },
     [],
   );
+
+  const toggleFullscreen = useCallback(() => {
+    setFullscreen((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(SIDEBAR_FULLSCREEN_KEY, String(next));
+      } catch {}
+      return next;
+    });
+  }, []);
 
   // Track whether the frame is controlling the sidebar (code mode = frame active).
   // Default to true when inside an iframe — assume the frame sidebar is active
@@ -1574,22 +1634,54 @@ export function AgentSidebar({
   }, []);
 
   const isLeft = position === "left";
+  // Fullscreen only applies on desktop — on mobile the existing overlay is
+  // already viewport-covering, so the maximize button is hidden and the
+  // mounted state ignores any persisted value.
+  const effectiveFullscreen = fullscreen && !isMobile;
 
   // On mobile the sidebar floats as a fixed overlay so the content below isn't
-  // squashed. On desktop it participates in the flex layout as before.
-  const mobileSidebarStyle: React.CSSProperties = isMobile
-    ? {
-        position: "fixed",
-        top: 0,
-        [isLeft ? "left" : "right"]: 0,
-        height: "100%",
-        maxWidth: "85vw",
-        zIndex: 50,
-        background: "hsl(var(--background))",
-        borderLeft: isLeft ? "none" : "1px solid hsl(var(--border))",
-        borderRight: isLeft ? "1px solid hsl(var(--border))" : "none",
-      }
-    : {};
+  // squashed. On desktop it participates in the flex layout as before, except
+  // in fullscreen mode where it overlays the entire viewport (Claude-style).
+  let panelStyle: React.CSSProperties;
+  if (isMobile) {
+    panelStyle = {
+      ...AGENT_PANEL_ROOT_STYLE,
+      position: "fixed",
+      top: 0,
+      [isLeft ? "left" : "right"]: 0,
+      height: "100%",
+      width,
+      maxWidth: "85vw",
+      maxHeight: "100vh",
+      zIndex: 50,
+      background: "hsl(var(--background))",
+      borderLeft: isLeft ? "none" : "1px solid hsl(var(--border))",
+      borderRight: isLeft ? "1px solid hsl(var(--border))" : "none",
+      display: open ? "flex" : "none",
+    };
+  } else if (effectiveFullscreen) {
+    panelStyle = {
+      ...AGENT_PANEL_ROOT_STYLE,
+      position: "fixed",
+      inset: 0,
+      width: "100%",
+      maxHeight: "100vh",
+      zIndex: 40,
+      background: "hsl(var(--background))",
+      display: open ? "flex" : "none",
+    };
+  } else {
+    panelStyle = {
+      ...AGENT_PANEL_ROOT_STYLE,
+      width,
+      maxHeight: "100vh",
+      display: open ? "flex" : "none",
+    };
+  }
+
+  // Hide the resize handle when not draggable: mobile (overlay) or fullscreen
+  // (no width to drag — the panel covers the viewport).
+  const showResizeHandle = !isMobile && !effectiveFullscreen && open;
 
   // Always render the sidebar panel (even when closed) so MultiTabAssistantChat
   // stays mounted and can receive messages (e.g. from voice dictation) while
@@ -1597,32 +1689,24 @@ export function AgentSidebar({
   // any in-progress or completed conversations.
   const sidebar = (
     <>
-      {!isMobile &&
-        (isLeft ? null : open ? (
-          <ResizeHandle position={position} onDrag={handleDrag} />
-        ) : null)}
+      {showResizeHandle && !isLeft && (
+        <ResizeHandle position={position} onDrag={handleDrag} />
+      )}
       <div
         className="agent-sidebar-panel flex shrink-0 flex-col overflow-hidden text-[13px] leading-[1.2] antialiased"
-        style={{
-          ...AGENT_PANEL_ROOT_STYLE,
-          ...mobileSidebarStyle,
-          width,
-          maxHeight: "100vh",
-          display: open ? "flex" : "none",
-        }}
+        style={panelStyle}
       >
         <AgentPanel
           emptyStateText={emptyStateText}
           suggestions={suggestions}
           onCollapse={() => setOpenPersisted(false)}
+          isFullscreen={effectiveFullscreen}
+          onToggleFullscreen={isMobile ? undefined : toggleFullscreen}
         />
       </div>
-      {!isMobile &&
-        (isLeft ? (
-          open ? (
-            <ResizeHandle position={position} onDrag={handleDrag} />
-          ) : null
-        ) : null)}
+      {showResizeHandle && isLeft && (
+        <ResizeHandle position={position} onDrag={handleDrag} />
+      )}
     </>
   );
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -566,35 +566,48 @@ function UserMessageText({ text }: { text: string }) {
 function UserMessageAttachments() {
   const messageRuntime = useMessageRuntime();
   const msg = messageRuntime.getState();
-  // Content parts may include image/file types from attachments
-  const parts = msg.content as unknown as Array<Record<string, any>>;
-  const images = parts.filter((p) => p.type === "image" && p.image);
-  const files = parts.filter((p) => p.type === "file");
-  if (images.length === 0 && files.length === 0) return null;
+  // assistant-ui stores user attachments on msg.attachments (separate from content).
+  // Each attachment has: { id, type, name, contentType?, content: MessagePart[] }.
+  // Image adapters put a {type:"image", image:"data:..."} part in content; text
+  // adapters put a {type:"text", text:"<attachment>..."} part. Fall back to a
+  // file chip when there's no inline image.
+  const attachments = (msg as { attachments?: readonly Attachment[] })
+    .attachments;
+  if (!attachments || attachments.length === 0) return null;
 
   return (
     <div className="flex flex-wrap justify-end gap-1.5 mb-1.5">
-      {images.map((img, i) => (
-        <div
-          key={i}
-          className="h-16 w-16 overflow-hidden rounded-lg border border-border/70 bg-muted/50"
-        >
-          <img
-            src={img.image}
-            alt="attachment"
-            className="h-full w-full object-cover"
-          />
-        </div>
-      ))}
-      {files.map((file, i) => (
-        <div
-          key={`f-${i}`}
-          className="flex items-center gap-1.5 rounded-lg border border-border/70 bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground"
-        >
-          <IconFile className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate max-w-[120px]">{file.name || "file"}</span>
-        </div>
-      ))}
+      {attachments.map((att) => {
+        const imagePart = att.content?.find(
+          (p): p is { type: "image"; image: string } =>
+            p.type === "image" && "image" in p && !!p.image,
+        );
+        if (imagePart) {
+          return (
+            <div
+              key={att.id}
+              className="h-16 w-16 overflow-hidden rounded-lg border border-border/70 bg-muted/50"
+              title={att.name}
+            >
+              <img
+                src={imagePart.image}
+                alt={att.name}
+                className="h-full w-full object-cover"
+              />
+            </div>
+          );
+        }
+        return (
+          <div
+            key={att.id}
+            className="flex items-center gap-1.5 rounded-lg border border-border/70 bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground"
+            title={att.name}
+          >
+            <IconFile className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate max-w-[120px]">{att.name || "file"}</span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -951,7 +951,7 @@ export function BuilderCtaCard({
 
   const description =
     reason === "usage_limit"
-      ? `You've used $${((usageCents ?? 0) / 100).toFixed(2)} of your $${((limitCents ?? 100) / 100).toFixed(2)} free tier. Add your own Anthropic API key for unlimited usage — the free tier doesn't apply when you bring your own key. Or clone this app to run it locally.`
+      ? null
       : reason === "code_changes"
         ? "This app is running in hosted mode. To make code changes, add your own Anthropic API key or clone and run locally."
         : "This hosted app has limited AI features. Add your own Anthropic API key for the full experience, or clone and run locally.";
@@ -975,7 +975,11 @@ export function BuilderCtaCard({
         </div>
         <div>
           <h3 className="text-sm font-medium text-foreground">{title}</h3>
-          <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+          {description && (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {description}
+            </p>
+          )}
         </div>
       </div>
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1344,6 +1344,18 @@ const AssistantChatInner = forwardRef<
                   }
                 }, 3000);
 
+                // Hard cap: no single reconnect should wedge the UI for
+                // more than 2 minutes. Even if the watchdog is fooled and
+                // the SSE stream never closes, this guarantees "Thinking..."
+                // eventually clears.
+                const maxReconnectTimer = setTimeout(
+                  () => {
+                    abortCtrl.abort();
+                    clearInterval(watchdog);
+                  },
+                  2 * 60 * 1000,
+                );
+
                 const streamReconnect = async () => {
                   try {
                     const sseRes = await fetch(
@@ -1383,6 +1395,7 @@ const AssistantChatInner = forwardRef<
                     // Stream error or abort — fall through to re-fetch
                   } finally {
                     clearInterval(watchdog);
+                    clearTimeout(maxReconnectTimer);
                   }
 
                   // Poll for thread data — server's updateThreadData may not have
@@ -1894,7 +1907,7 @@ const AssistantChatInner = forwardRef<
             )}
           </div>
         ) : (
-          <div className="flex flex-col gap-4 px-4 py-4">
+          <div className="agent-thread-content flex flex-col gap-4 px-4 py-4">
             <ThreadPrimitive.Messages
               components={{
                 UserMessage,
@@ -1967,7 +1980,7 @@ const AssistantChatInner = forwardRef<
 
       {composerSlot}
       {/* Input area */}
-      <div className="shrink-0 px-3 py-2">
+      <div className="agent-composer-area shrink-0 px-3 py-2">
         <ComposerPrimitive.Root className="flex flex-col rounded-lg border border-input bg-background focus-within:ring-1 focus-within:ring-ring">
           <ComposerAttachmentPreviewStrip />
           <TiptapComposer

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -35,7 +35,9 @@ export function createAgentChatAdapter(options?: {
           .map((p) => p.text)
           .join("\n") ?? "";
 
-      // Extract attachments (images as base64, text as content)
+      // Extract attachments (images as base64, text as content).
+      // assistant-ui puts user attachments on msg.attachments (not on content);
+      // each attachment carries its own content parts from the adapter.
       const attachments: {
         type: string;
         name: string;
@@ -43,24 +45,44 @@ export function createAgentChatAdapter(options?: {
         data?: string;
         text?: string;
       }[] = [];
-      if (lastUserMsg) {
-        for (const part of lastUserMsg.content) {
-          if (part.type === "image" && "image" in part) {
-            const img = part as { type: "image"; image: string };
-            attachments.push({ type: "image", name: "image", data: img.image });
-          } else if (part.type === "file" && "data" in part) {
-            const f = part as {
-              type: "file";
-              data: string;
-              mimeType?: string;
-              name?: string;
-            };
-            attachments.push({
-              type: "file",
-              name: f.name ?? "file",
-              contentType: f.mimeType,
-              text: f.data,
-            });
+      if (lastUserMsg && "attachments" in lastUserMsg) {
+        const msgAttachments = (
+          lastUserMsg as {
+            attachments?: readonly {
+              name: string;
+              contentType?: string;
+              content: readonly Record<string, unknown>[];
+            }[];
+          }
+        ).attachments;
+        for (const att of msgAttachments ?? []) {
+          for (const part of att.content) {
+            if (part.type === "image" && typeof part.image === "string") {
+              attachments.push({
+                type: "image",
+                name: att.name,
+                contentType: att.contentType,
+                data: part.image,
+              });
+            } else if (part.type === "file" && typeof part.data === "string") {
+              attachments.push({
+                type: "file",
+                name: att.name,
+                contentType:
+                  att.contentType ??
+                  (typeof part.mimeType === "string"
+                    ? part.mimeType
+                    : undefined),
+                text: part.data,
+              });
+            } else if (part.type === "text" && typeof part.text === "string") {
+              attachments.push({
+                type: "file",
+                name: att.name,
+                contentType: att.contentType,
+                text: part.text,
+              });
+            }
           }
         }
       }

--- a/packages/core/src/jobs/scheduler.ts
+++ b/packages/core/src/jobs/scheduler.ts
@@ -9,6 +9,7 @@ import {
 import {
   runAgentLoop,
   actionsToEngineTools,
+  getOwnerAnthropicApiKey,
   type ActionEntry,
 } from "../agent/production-agent.js";
 import { createAnthropicEngine } from "../agent/engine/index.js";
@@ -224,8 +225,13 @@ async function executeJob(
         const systemPrompt = await deps.getSystemPrompt(resource.owner);
         const tools = actionsToEngineTools(actions);
 
+        // Prefer the job runner's saved Anthropic key so recurring jobs
+        // don't silently bill the shared platform key once a user has
+        // brought their own. Falls back to the platform key when absent.
+        const userApiKey = await getOwnerAnthropicApiKey(jobUserEmail);
         const engine =
-          deps.engine ?? createAnthropicEngine({ apiKey: deps.apiKey });
+          deps.engine ??
+          createAnthropicEngine({ apiKey: userApiKey ?? deps.apiKey });
 
         // Create a chat thread for this run
         const threadTitle = `Job: ${jobName} — ${now.toLocaleDateString()}`;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2486,10 +2486,16 @@ export function createAgentChatPlugin(
 
         // Persist per-owner so the key survives cold starts in serverless
         // and so the user's key isn't shared across users on multi-tenant
-        // hosted deployments.
+        // hosted deployments. We require a real authenticated owner here —
+        // `local@localhost` is the unauthenticated fallback and must never
+        // become the shared key bucket on hosted deployments.
+        const ownerEmail = await getOwnerFromEvent(event);
+        if (isHostedProd && (!ownerEmail || ownerEmail === "local@localhost")) {
+          setResponseStatus(event, 401);
+          return { error: "Authentication required" };
+        }
         try {
-          const ownerEmail = await getOwnerFromEvent(event);
-          if (ownerEmail) {
+          if (ownerEmail && ownerEmail !== "local@localhost") {
             await putSetting(`user-anthropic-api-key:${ownerEmail}`, {
               key: trimmedKey,
             });
@@ -2498,20 +2504,27 @@ export function createAgentChatPlugin(
           // Settings store unavailable — fall back to env-only behavior
         }
 
-        try {
-          const path = await import("path");
-          const { upsertEnvFile } = await import("./create-server.js");
-          const envPath = path.join(process.cwd(), ".env");
-          await upsertEnvFile(envPath, [
-            { key: "ANTHROPIC_API_KEY", value: trimmedKey },
-          ]);
-        } catch {
-          // Edge runtime — can't write .env, but can still update process.env
+        // In hosted/multi-tenant mode we deliberately do NOT touch
+        // process.env or .env: the per-owner SQL lookup above is the
+        // single source of truth, and overwriting the shared env key
+        // would leak one tenant's credentials into every subsequent
+        // request that hit the same warm instance without its own key.
+        if (!isHostedProd) {
+          try {
+            const path = await import("path");
+            const { upsertEnvFile } = await import("./create-server.js");
+            const envPath = path.join(process.cwd(), ".env");
+            await upsertEnvFile(envPath, [
+              { key: "ANTHROPIC_API_KEY", value: trimmedKey },
+            ]);
+          } catch {
+            // Edge runtime — can't write .env, but can still update process.env
+          }
+          // Update process.env so the agent works immediately in the
+          // current local-dev invocation; the SQL persist above covers
+          // future invocations.
+          process.env.ANTHROPIC_API_KEY = trimmedKey;
         }
-
-        // Update process.env so the agent works immediately in the current
-        // invocation; the SQL persist above covers future invocations.
-        process.env.ANTHROPIC_API_KEY = trimmedKey;
 
         return { ok: true };
       }),
@@ -2931,7 +2944,7 @@ export function createAgentChatPlugin(
           setResponseStatus(event, 405);
           return { error: "Method not allowed" };
         }
-        await getOwnerFromEvent(event);
+        const ownerEmail = await getOwnerFromEvent(event);
         const body = await readBody(event);
         const message = body?.message;
         if (!message || typeof message !== "string") {
@@ -2940,7 +2953,12 @@ export function createAgentChatPlugin(
         }
         // Strip mention markup: @[Name|type] → @Name
         const cleanMessage = message.replace(/@\[([^\]|]+)\|[^\]]*\]/g, "@$1");
-        const apiKey = process.env.ANTHROPIC_API_KEY;
+        // Mirror the chat-run resolution so BYO-key users have title
+        // generation billed to their own key instead of the platform key.
+        const { getOwnerAnthropicApiKey } =
+          await import("../agent/production-agent.js");
+        const userApiKey = await getOwnerAnthropicApiKey(ownerEmail);
+        const apiKey = userApiKey ?? process.env.ANTHROPIC_API_KEY;
         if (!apiKey) {
           // Fallback: truncate the message
           return { title: cleanMessage.trim().slice(0, 60) };

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1135,6 +1135,21 @@ export interface AgentChatPluginOptions {
    * need custom org resolution logic (e.g., Atlassian org mapping).
    */
   resolveOrgId?: (event: any) => string | null | Promise<string | null>;
+  /**
+   * Optional callback to append template-specific context to the system
+   * prompt on each request. Runs after AGENTS.md / skills / memory are
+   * loaded and before the schema block — use it to inject dynamic SQL
+   * context like a data dictionary, active feature flags, or whatever
+   * the agent should know about *right now* for this user/org.
+   *
+   * Return `null` or an empty string to skip. The string you return is
+   * appended verbatim, so wrap it in your own XML tags (e.g.
+   * `<data-dictionary>…</data-dictionary>`) to keep the prompt scannable.
+   */
+  extraContext?: (
+    event: any,
+    owner: string,
+  ) => string | null | Promise<string | null>;
 }
 
 /**
@@ -2344,6 +2359,23 @@ export function createAgentChatPlugin(
     // Always build the production handler (includes resource tools + call-agent + team tools)
     // In production mode (!canToggle), enable usage tracking and limits
     const isHostedProd = !canToggle;
+    const resolveExtraContext = async (
+      event: any,
+      owner: string,
+    ): Promise<string> => {
+      if (!options?.extraContext) return "";
+      try {
+        const extra = await options.extraContext(event, owner);
+        return extra ? `\n\n${extra}` : "";
+      } catch (err) {
+        console.warn(
+          "[agent-chat] extraContext threw:",
+          err instanceof Error ? err.message : err,
+        );
+        return "";
+      }
+    };
+
     const prodHandler = createProductionAgentHandler({
       actions: prodActions,
       systemPrompt: async (event: any) => {
@@ -2355,7 +2387,8 @@ export function createAgentChatPlugin(
         _currentRunUserApiKey = await getOwnerAnthropicApiKey(owner);
         const resources = await loadResourcesForPrompt(owner);
         const schemaBlock = await buildSchemaBlock(owner, false);
-        _currentRunSystemPrompt = basePrompt + resources + schemaBlock;
+        const extra = await resolveExtraContext(event, owner);
+        _currentRunSystemPrompt = basePrompt + resources + schemaBlock + extra;
         return _currentRunSystemPrompt;
       },
       model:
@@ -2412,7 +2445,8 @@ export function createAgentChatPlugin(
           _currentRunUserApiKey = await getOwnerAnthropicApiKey(owner);
           const resources = await loadResourcesForPrompt(owner);
           const schemaBlock = await buildSchemaBlock(owner, true);
-          _currentRunSystemPrompt = devPrompt + resources + schemaBlock;
+          const extra = await resolveExtraContext(event, owner);
+          _currentRunSystemPrompt = devPrompt + resources + schemaBlock + extra;
           return _currentRunSystemPrompt;
         },
         model: options?.model,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2461,8 +2461,11 @@ export function createAgentChatPlugin(
       }),
     );
 
-    // Mount save-key BEFORE the prefix handler so it isn't shadowed
-    // Only functional in Node.js environments (writes to .env file)
+    // Mount save-key BEFORE the prefix handler so it isn't shadowed.
+    // Persists the user's key per-owner in the SQL settings table so it
+    // survives across serverless invocations (where mutating process.env
+    // and writing .env are both no-ops). Also updates process.env and
+    // .env when running locally for fast pickup by other handlers.
     getH3App(nitroApp).use(
       `${routePath}/save-key`,
       defineEventHandler(async (event) => {
@@ -2481,6 +2484,20 @@ export function createAgentChatPlugin(
 
         const trimmedKey = key.trim();
 
+        // Persist per-owner so the key survives cold starts in serverless
+        // and so the user's key isn't shared across users on multi-tenant
+        // hosted deployments.
+        try {
+          const ownerEmail = await getOwnerFromEvent(event);
+          if (ownerEmail) {
+            await putSetting(`user-anthropic-api-key:${ownerEmail}`, {
+              key: trimmedKey,
+            });
+          }
+        } catch {
+          // Settings store unavailable — fall back to env-only behavior
+        }
+
         try {
           const path = await import("path");
           const { upsertEnvFile } = await import("./create-server.js");
@@ -2492,7 +2509,8 @@ export function createAgentChatPlugin(
           // Edge runtime — can't write .env, but can still update process.env
         }
 
-        // Update process.env so the agent works immediately
+        // Update process.env so the agent works immediately in the current
+        // invocation; the SQL persist above covers future invocations.
         process.env.ANTHROPIC_API_KEY = trimmedKey;
 
         return { ok: true };

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2269,6 +2269,7 @@ export function createAgentChatPlugin(
       (event: import("../agent/types.js").AgentChatEvent) => void
     >();
     let _currentRunOwner = "local@localhost";
+    let _currentRunUserApiKey: string | undefined;
     let _currentRunThreadId = "";
     let _currentRunSystemPrompt = basePrompt;
     // Default to Haiku in production mode to manage costs for hosted apps
@@ -2300,7 +2301,13 @@ export function createAgentChatPlugin(
             },
       getEngine: () =>
         createAnthropicEngine({
-          apiKey: options?.apiKey ?? process.env.ANTHROPIC_API_KEY,
+          // Sub-agents must inherit the parent run's resolved key so a
+          // BYO-key user can't bypass the free-tier check on the parent
+          // run and then have spawn-task delegations bill the platform key.
+          apiKey:
+            _currentRunUserApiKey ??
+            options?.apiKey ??
+            process.env.ANTHROPIC_API_KEY,
         }),
       getModel: () => resolvedModel,
       getParentThreadId: () => _currentRunThreadId,
@@ -2343,6 +2350,9 @@ export function createAgentChatPlugin(
         _currentRequestOrigin = getOrigin(event);
         const owner = await getOwnerFromEvent(event);
         _currentRunOwner = owner;
+        const { getOwnerAnthropicApiKey } =
+          await import("../agent/production-agent.js");
+        _currentRunUserApiKey = await getOwnerAnthropicApiKey(owner);
         const resources = await loadResourcesForPrompt(owner);
         const schemaBlock = await buildSchemaBlock(owner, false);
         _currentRunSystemPrompt = basePrompt + resources + schemaBlock;
@@ -2397,6 +2407,9 @@ export function createAgentChatPlugin(
           _currentRequestOrigin = getOrigin(event);
           const owner = await getOwnerFromEvent(event);
           _currentRunOwner = owner;
+          const { getOwnerAnthropicApiKey } =
+            await import("../agent/production-agent.js");
+          _currentRunUserApiKey = await getOwnerAnthropicApiKey(owner);
           const resources = await loadResourcesForPrompt(owner);
           const schemaBlock = await buildSchemaBlock(owner, true);
           _currentRunSystemPrompt = devPrompt + resources + schemaBlock;

--- a/packages/core/src/server/agent-teams.ts
+++ b/packages/core/src/server/agent-teams.ts
@@ -23,6 +23,7 @@ import { createAnthropicEngine } from "../agent/engine/anthropic-engine.js";
 import { createThread } from "../chat-threads/store.js";
 import { startRun, subscribeToRun } from "../agent/run-manager.js";
 import { runAgentLoop } from "../agent/production-agent.js";
+import { buildAssistantMessage } from "../agent/thread-data-builder.js";
 import {
   readAppState,
   writeAppState,
@@ -275,72 +276,35 @@ You are a focused sub-agent with a specific task. You have been given a curated 
 
       // Persist the full conversation to threadData so the sub-agent tab
       // can restore it later (after the in-memory run is cleaned up).
-      // Convert EngineMessage[] to the assistant-ui repository format.
+      // Rebuild from run.events via buildAssistantMessage so partial text
+      // streamed in an interrupted final iteration is preserved — the
+      // EngineMessage[] array only picks up a turn after runAgentLoop
+      // finishes pushing, so an aborted mid-stream would otherwise be lost.
       try {
         const { updateThreadData } = await import("../chat-threads/store.js");
-        const repoMessages = messages.map((msg: EngineMessage, i: number) => {
-          const parts: any[] = [];
-          for (const part of msg.content) {
-            if (part.type === "text") {
-              parts.push({ type: "text", text: part.text });
-            } else if (part.type === "tool-call") {
-              parts.push({
-                type: "tool-call",
-                toolCallId: part.id,
-                toolName: part.name,
-                args: part.input,
-              });
-            } else if (part.type === "tool-result") {
-              // Tool results in the user message — will be matched to tool-call below
-            }
-          }
-          const repoMsg: any = {
-            id: `msg-${taskId}-${i}`,
-            role: msg.role,
-            content: parts.length > 0 ? parts : [{ type: "text", text: "" }],
-            metadata: {},
-          };
-          if (msg.role === "assistant") {
-            repoMsg.status = { type: "complete", reason: "stop" };
-          }
-          return repoMsg;
-        });
+        const userMsg = {
+          id: `msg-${taskId}-user`,
+          role: "user" as const,
+          content: [{ type: "text", text: opts.description }],
+          metadata: {},
+        };
+        const repo: {
+          messages: Array<{ message: Record<string, unknown> }>;
+        } = { messages: [{ message: userMsg }] };
 
-        // Attach tool results to their corresponding tool-call parts
-        for (const msg of messages) {
-          if (msg.role !== "user") continue;
-          for (const part of msg.content) {
-            if (part.type !== "tool-result") continue;
-            // Find the assistant message with the matching tool-call
-            for (const repoMsg of repoMessages) {
-              if (repoMsg.role !== "assistant") continue;
-              const tc = repoMsg.content?.find(
-                (p: any) =>
-                  p.type === "tool-call" && p.toolCallId === part.toolCallId,
-              );
-              if (tc) {
-                tc.result = part.content;
-                break;
-              }
-            }
-          }
+        const assistantMsg = buildAssistantMessage(
+          run.events ?? [],
+          `task-${taskId}`,
+        );
+        if (assistantMsg) {
+          repo.messages.push({
+            message: {
+              ...assistantMsg,
+              status: { type: "complete", reason: "stop" },
+            },
+          });
         }
 
-        // Filter out user messages that only contain tool_result blocks (empty content)
-        const filteredMessages = repoMessages.filter(
-          (m: any) =>
-            m.content.length > 0 &&
-            !(
-              m.content.length === 1 &&
-              m.content[0].type === "text" &&
-              m.content[0].text === ""
-            ),
-        );
-
-        // Wrap in assistant-ui's { message: ... } format
-        const repo = {
-          messages: filteredMessages.map((m: any) => ({ message: m })),
-        };
         const title = opts.description.slice(0, 100);
         const preview = accumulatedText.slice(0, 200);
         await updateThreadData(
@@ -348,7 +312,7 @@ You are a focused sub-agent with a specific task. You have been given a curated 
           JSON.stringify(repo),
           title,
           preview,
-          filteredMessages.length,
+          repo.messages.length,
         );
       } catch {
         // Best effort — the in-memory replay path still works

--- a/scripts/dev-all.ts
+++ b/scripts/dev-all.ts
@@ -88,14 +88,23 @@ execSync("pnpm --filter @agent-native/core build", { stdio: "inherit" });
 const names: string[] = [];
 const commands: string[] = [];
 
-templatePorts.forEach(({ name, port }) => {
+// Tiny stagger keeps cold-boot requests from racing Nitro's ViteEnvRunner
+// 3-second init (which returns 503 "Vite environment unavailable"). With
+// core prebuilt, 250ms is enough to avoid the race without noticeably
+// slowing startup.
+const STAGGER_DELAY_S = 0.25;
+
+templatePorts.forEach(({ name, port }, i) => {
   console.log(`\x1b[36m[dev-all]\x1b[0m ${name}: http://localhost:${port}`);
+
+  const delay = i * STAGGER_DELAY_S;
+  const prefix = delay > 0 ? `sleep ${delay} && ` : "";
 
   names.push(name);
   // Pass APP_NAME so each app can resolve its own DATABASE_URL
   // (e.g. MAIL_DATABASE_URL when APP_NAME=mail)
   commands.push(
-    `APP_NAME=${name} pnpm --dir templates/${name} exec vite --port ${port}`,
+    `${prefix}APP_NAME=${name} pnpm --dir templates/${name} exec vite --port ${port}`,
   );
 });
 

--- a/templates/analytics/.agents/skills/dashboard-management/SKILL.md
+++ b/templates/analytics/.agents/skills/dashboard-management/SKILL.md
@@ -74,15 +74,17 @@ From the agent itself, always use `db-query` / `db-exec` / `db-patch` instead of
 
 The typical flow when the user asks for a new dashboard:
 
-1. Determine what data to show (ask clarifying questions if needed).
-2. Build a complete config object that includes **at minimum** a `name` and a `panels` array. Every panel MUST have `id`, `title`, `sql`, `source`, `chartType`, and `width` — the UI assumes these fields exist and missing values will produce a blank sidebar entry or crash the dashboard renderer.
-3. Write it via the `update-dashboard` action — never via raw `db-exec INSERT INTO settings`. The action handles org/user/global scope correctly and is the only supported entry point for writing SQL dashboards:
+1. **Consult the `<data-dictionary>` block** injected into your system prompt. If the metrics the user wants are already documented there, use those `table` / `columns` / `queryTemplate` values verbatim — column names in the underlying warehouse use prefixes (`hs_`, `m_`, `sfdc_`, etc.) that **cannot be guessed**. Guessing produces `Unrecognized name: is_closed; Did you mean hs_is_closed?` errors and a broken dashboard.
+2. If the metric isn't documented, do NOT invent column names. Either ask the user, or introspect the schema: `db-query --sql "SELECT column_name, data_type FROM \`project.dataset.INFORMATION_SCHEMA.COLUMNS\` WHERE table_name = '<table>'"`. Once you've learned the real columns, propose a dictionary entry via `save-data-dictionary-entry` so the next dashboard doesn't pay the same cost.
+3. Build a complete config object that includes **at minimum** a `name` and a `panels` array. Every panel MUST have `id`, `title`, `sql`, `source`, `chartType`, and `width` — the UI assumes these fields exist and missing values will produce a blank sidebar entry or crash the dashboard renderer.
+4. Write it via the `update-dashboard` action — never via raw `db-exec INSERT INTO settings`. The action handles org/user/global scope correctly and is the only supported entry point for writing SQL dashboards:
 
 ```
 pnpm action update-dashboard --dashboardId my-new-dashboard --config '<full json>'
 ```
 
-4. Navigate the user to it: `pnpm action navigate --view=adhoc --dashboardId={id}`.
+5. **The save endpoint dry-runs each BigQuery panel's SQL before persisting.** If it returns an error like `panel[2] "Foo" SQL is invalid: Unrecognized name: is_closed; Did you mean hs_is_closed?`, fix the SQL (usually by consulting the dictionary or introspecting the schema) and retry. Never work around the dry-run — a dashboard that can't dry-run cannot render.
+6. Navigate the user to it: `pnpm action navigate --view=adhoc --dashboardId={id}`.
 
 The UI picks up the new dashboard via SSE events on settings changes.
 

--- a/templates/analytics/.agents/skills/dashboard-management/SKILL.md
+++ b/templates/analytics/.agents/skills/dashboard-management/SKILL.md
@@ -75,10 +75,18 @@ From the agent itself, always use `db-query` / `db-exec` / `db-patch` instead of
 The typical flow when the user asks for a new dashboard:
 
 1. Determine what data to show (ask clarifying questions if needed).
-2. Write the dashboard config to settings via `db-exec` (INSERT ... ON CONFLICT DO UPDATE). See the "Reading and writing dashboards" section below for the exact command.
-3. Navigate the user to it: `pnpm action navigate --view=adhoc --dashboardId={id}`.
+2. Build a complete config object that includes **at minimum** a `name` and a `panels` array. Every panel MUST have `id`, `title`, `sql`, `source`, `chartType`, and `width` — the UI assumes these fields exist and missing values will produce a blank sidebar entry or crash the dashboard renderer.
+3. Write it via the `update-dashboard` action — never via raw `db-exec INSERT INTO settings`. The action handles org/user/global scope correctly and is the only supported entry point for writing SQL dashboards:
+
+```
+pnpm action update-dashboard --dashboardId my-new-dashboard --config '<full json>'
+```
+
+4. Navigate the user to it: `pnpm action navigate --view=adhoc --dashboardId={id}`.
 
 The UI picks up the new dashboard via SSE events on settings changes.
+
+> **Rule:** never `INSERT`/`UPDATE` the `settings` table directly for `sql-dashboard-*` keys. The save endpoint and the action both enforce shape; raw db writes can leave dashboards with no name or with panels missing `sql`, which crashes the page and produces nameless rows in the sidebar.
 
 ## Modifying a Dashboard
 

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -174,10 +174,14 @@ The data dictionary is the canonical catalog of the metrics, tables, columns, an
 
 **Workflow for "build me a dashboard":**
 
-1. `list-data-dictionary --search <topic>` — find existing definitions that match the user's intent.
-2. If relevant entries exist, use their `queryTemplate`, `table`, and `cuts` verbatim — don't reinvent.
-3. If the user mentions a metric that isn't in the dictionary, either ask them to define it or propose an entry via `save-data-dictionary-entry` (set `aiGenerated: true`, `approved: false` for human review).
-4. Obey `knownGotchas` from any entry you use — note them to the user if the data has limitations.
+A `<data-dictionary>` block is injected into your system prompt with the approved entries for this workspace. Read it before you write any SQL. If the entry you need is there, you MUST use its `table` and `columns` values verbatim — column names in the underlying warehouse use prefixes (`hs_`, `m_`, `sfdc_`, etc.) that you cannot guess. Making them up produces `Unrecognized name` errors and a broken dashboard.
+
+1. **Check the `<data-dictionary>` block** in your system prompt for entries that match the user's request.
+2. If something looks relevant but you need the full entry (example output, join pattern, etc.), call `list-data-dictionary --search <topic>`.
+3. If relevant entries exist, use their `queryTemplate`, `table`, `columns`, and `cuts` **verbatim** — never rename or guess column names.
+4. If the user mentions a metric that isn't in the dictionary, do NOT invent column names. Instead: (a) ask the user for the table/columns, OR (b) run an exploratory BigQuery query against `INFORMATION_SCHEMA.COLUMNS` to discover the real column names before writing the panel SQL, then propose an entry via `save-data-dictionary-entry` (set `aiGenerated: true`, `approved: false` for human review).
+5. Obey `knownGotchas` from any entry you use — note them to the user if the data has limitations.
+6. The dashboard save endpoint now dry-runs every panel's SQL through BigQuery before persisting. If a panel fails validation you'll get a 400 with the BigQuery error text (e.g. `Unrecognized name: is_closed; Did you mean hs_is_closed?`) — fix the SQL and retry; never try to persist broken SQL.
 
 **Populating the dictionary:** When the user has existing metric definitions elsewhere (team docs, Confluence, Notion, dbt descriptions, a Google Sheet, a wiki), fetch them with whatever tools you have — generic `WebFetch`, an MCP server the user has configured, a CSV import, or asking the user to paste — then upsert each via `save-data-dictionary-entry`. The dictionary itself is source-agnostic.
 

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -8,6 +8,7 @@ import {
   putSetting,
   putUserSetting,
 } from "@agent-native/core/settings";
+import { dryRunQuery } from "../server/lib/bigquery";
 
 const KEY_PREFIX = "sql-dashboard-";
 const LOCAL_EMAIL = "local@localhost";
@@ -187,6 +188,34 @@ function validateDashboardConfig(
   return null;
 }
 
+/**
+ * Dry-run each BigQuery panel's SQL so bad column names or type
+ * mismatches fail here, with the full BigQuery error text, rather than
+ * silently saving a broken dashboard that crashes on render.
+ */
+async function validatePanelSql(
+  config: Record<string, unknown>,
+): Promise<string | null> {
+  const panels = config.panels;
+  if (!Array.isArray(panels)) return null;
+  for (let i = 0; i < panels.length; i++) {
+    const p = panels[i] as Record<string, unknown>;
+    if (p.source !== "bigquery") continue;
+    const sql = typeof p.sql === "string" ? p.sql : "";
+    if (!sql.trim()) continue;
+    let err: string | null;
+    try {
+      err = await dryRunQuery(sql);
+    } catch (e: any) {
+      err = e?.message ?? String(e);
+    }
+    if (err) {
+      return `panel[${i}] "${p.title || p.id}" SQL is invalid: ${err}`;
+    }
+  }
+  return null;
+}
+
 function resolveScope() {
   const orgId = process.env.AGENT_ORG_ID || null;
   const email = process.env.AGENT_USER_EMAIL || LOCAL_EMAIL;
@@ -289,6 +318,8 @@ export default defineAction({
     if (args.config) {
       const validation = validateDashboardConfig(args.config);
       if (validation) return `Error: ${validation}`;
+      const sqlError = await validatePanelSql(args.config);
+      if (sqlError) return `Error: ${sqlError}`;
       const existing = await readScoped(scope, key);
       const resolvedScope = existing?.scope ?? (scope.orgId ? "org" : "user");
       await writeScoped(scope, key, args.config, resolvedScope as any);
@@ -309,6 +340,9 @@ export default defineAction({
         return `Error applying op ${JSON.stringify(op)}: ${err.message}`;
       }
     }
+
+    const sqlError = await validatePanelSql(root);
+    if (sqlError) return `Error: ${sqlError}`;
 
     await writeScoped(scope, key, root, existing.scope);
 

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -142,6 +142,51 @@ function applyJsonOp(root: any, op: JsonOp): string {
   }
 }
 
+/**
+ * Reject configs missing the fields the UI assumes are always present.
+ * Returns a human-readable error string, or `null` when the config passes.
+ * Mirrors the shape required by `app/pages/adhoc/sql-dashboard/types.ts`.
+ */
+function validateDashboardConfig(
+  config: Record<string, unknown>,
+): string | null {
+  if (!config || typeof config !== "object") {
+    return "config must be an object";
+  }
+  if (typeof config.name !== "string" || config.name.trim().length === 0) {
+    return "config.name is required (non-empty string) — without it the dashboard renders as a blank row in the sidebar";
+  }
+  const panels = config.panels;
+  if (!Array.isArray(panels)) {
+    return "config.panels must be an array (use [] for an empty dashboard)";
+  }
+  for (let i = 0; i < panels.length; i++) {
+    const p = panels[i] as Record<string, unknown> | null;
+    if (!p || typeof p !== "object") {
+      return `panel[${i}] must be an object`;
+    }
+    const required = [
+      "id",
+      "title",
+      "sql",
+      "source",
+      "chartType",
+      "width",
+    ] as const;
+    for (const field of required) {
+      const v = p[field];
+      if (field === "width") {
+        if (v !== 1 && v !== 2) return `panel[${i}].width must be 1 or 2`;
+        continue;
+      }
+      if (typeof v !== "string" || v.trim().length === 0) {
+        return `panel[${i}].${field} is required (non-empty string)`;
+      }
+    }
+  }
+  return null;
+}
+
 function resolveScope() {
   const orgId = process.env.AGENT_ORG_ID || null;
   const email = process.env.AGENT_USER_EMAIL || LOCAL_EMAIL;
@@ -242,6 +287,8 @@ export default defineAction({
     const key = `${KEY_PREFIX}${args.dashboardId}`;
 
     if (args.config) {
+      const validation = validateDashboardConfig(args.config);
+      if (validation) return `Error: ${validation}`;
       const existing = await readScoped(scope, key);
       const resolvedScope = existing?.scope ?? (scope.orgId ? "org" : "user");
       await writeScoped(scope, key, args.config, resolvedScope as any);

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -524,18 +524,30 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
         setHiddenIds(getHiddenDashboards());
         return;
       }
-      const token = await getIdToken();
-      const res = await fetch(`/api/sql-dashboards/${d.id}`, {
-        method: "DELETE",
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-      });
-      if (!res.ok) {
-        // Surface failures instead of silently "succeeding" — otherwise the
-        // sidebar refreshes and the deleted-looking row reappears, leaving
-        // the user confused about what happened.
-        throw new Error(`Delete failed: ${res.status}`);
+      // Optimistic: remove from the sidebar query cache immediately so the
+      // row disappears without waiting for the DELETE round-trip. Snapshot
+      // the prior value so we can roll back on failure.
+      const queryKey = ["sql-dashboards-sidebar"] as const;
+      const prev =
+        queryClient.getQueryData<{ id: string; name: string }[]>(queryKey);
+      queryClient.setQueryData<{ id: string; name: string }[]>(
+        queryKey,
+        (old) => (old ?? []).filter((item) => item.id !== d.id),
+      );
+      try {
+        const token = await getIdToken();
+        const res = await fetch(`/api/sql-dashboards/${d.id}`, {
+          method: "DELETE",
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!res.ok) {
+          throw new Error(`Delete failed: ${res.status}`);
+        }
+        queryClient.invalidateQueries({ queryKey });
+      } catch (err) {
+        if (prev) queryClient.setQueryData(queryKey, prev);
+        throw err;
       }
-      queryClient.invalidateQueries({ queryKey: ["sql-dashboards-sidebar"] });
     },
     [queryClient],
   );

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -401,7 +401,15 @@ async function fetchSqlDashboards(): Promise<{ id: string; name: string }[]> {
   });
   if (!res.ok) return [];
   const data = await res.json();
-  return (data.dashboards ?? []).map((d: any) => ({ id: d.id, name: d.name }));
+  return (data.dashboards ?? [])
+    .filter((d: any) => d && typeof d.id === "string" && d.id.length > 0)
+    .map((d: any) => ({
+      id: d.id,
+      name:
+        typeof d.name === "string" && d.name.trim().length > 0
+          ? d.name
+          : "Untitled dashboard",
+    }));
 }
 
 // --- Sidebar ---

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/interpolate.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/interpolate.ts
@@ -15,9 +15,14 @@ function escapeSqlValue(value: string): string {
 }
 
 export function interpolate(
-  sql: string,
+  sql: string | undefined | null,
   vars: Record<string, string> = {},
 ): string {
+  // Defensive: a malformed dashboard config (e.g. agent wrote a panel without
+  // a `sql` field) should not crash the page. Treat missing/non-string SQL
+  // as empty so the panel renders an empty result instead of throwing.
+  if (typeof sql !== "string") return "";
+
   // Strip conditional blocks first so the inner {{name}} tokens are also processed
   // (or removed) in a single pass.
   const conditionalRe = /\{\{\?(\w+)\}\}([\s\S]*?)\{\{\/\1\}\}/g;

--- a/templates/analytics/server/handlers/sql-dashboards.ts
+++ b/templates/analytics/server/handlers/sql-dashboards.ts
@@ -7,6 +7,7 @@ import {
   putScopedSettingRecord,
   resolveSettingsScope,
 } from "../lib/scoped-settings";
+import { dryRunQuery } from "../lib/bigquery";
 
 const KEY_PREFIX = "sql-dashboard-";
 
@@ -59,6 +60,11 @@ export const saveSqlDashboard = defineEventHandler(async (event) => {
       setResponseStatus(event, 400);
       return { error: validation };
     }
+    const sqlError = await validatePanelSql(body);
+    if (sqlError) {
+      setResponseStatus(event, 400);
+      return { error: sqlError };
+    }
     const scope = await resolveSettingsScope(event);
     const key = `${KEY_PREFIX}${id}`;
     await putScopedSettingRecord(scope, key, body);
@@ -68,6 +74,36 @@ export const saveSqlDashboard = defineEventHandler(async (event) => {
     return { error: err.message };
   }
 });
+
+/**
+ * Dry-run every BigQuery panel's SQL so compilation errors (unknown
+ * columns, type mismatches, bad joins) surface as a 400 here instead of
+ * being persisted and blowing up every render. Free via BigQuery's
+ * `dryRun` flag (no bytes billed). Returns the first error found — one
+ * broken panel is enough to tell the agent to fix its SQL before saving.
+ */
+async function validatePanelSql(
+  config: Record<string, unknown>,
+): Promise<string | null> {
+  const panels = config.panels;
+  if (!Array.isArray(panels)) return null;
+  for (let i = 0; i < panels.length; i++) {
+    const p = panels[i] as Record<string, unknown>;
+    if (p.source !== "bigquery") continue;
+    const sql = typeof p.sql === "string" ? p.sql : "";
+    if (!sql.trim()) continue;
+    let err: string | null;
+    try {
+      err = await dryRunQuery(sql);
+    } catch (e: any) {
+      err = e?.message ?? String(e);
+    }
+    if (err) {
+      return `panel[${i}] "${p.title || p.id}" SQL is invalid: ${err}`;
+    }
+  }
+  return null;
+}
 
 /**
  * Reject configs that would render as a blank sidebar row or crash the

--- a/templates/analytics/server/handlers/sql-dashboards.ts
+++ b/templates/analytics/server/handlers/sql-dashboards.ts
@@ -86,14 +86,18 @@ function validateDashboardConfig(
     return "panels must be an array";
   }
   if (Array.isArray(panels)) {
+    const requiredStrings = ["id", "title", "sql", "source", "chartType"];
     for (let i = 0; i < panels.length; i++) {
       const p = panels[i] as Record<string, unknown> | null;
       if (!p || typeof p !== "object") return `panel[${i}] must be an object`;
-      if (typeof p.id !== "string" || p.id.length === 0) {
-        return `panel[${i}].id is required`;
+      for (const field of requiredStrings) {
+        const v = p[field];
+        if (typeof v !== "string" || v.trim().length === 0) {
+          return `panel[${i}].${field} is required`;
+        }
       }
-      if (typeof p.sql !== "string" || p.sql.length === 0) {
-        return `panel[${i}].sql is required`;
+      if (p.width !== 1 && p.width !== 2) {
+        return `panel[${i}].width must be 1 or 2`;
       }
     }
   }

--- a/templates/analytics/server/handlers/sql-dashboards.ts
+++ b/templates/analytics/server/handlers/sql-dashboards.ts
@@ -53,16 +53,52 @@ export const saveSqlDashboard = defineEventHandler(async (event) => {
     return { error: "Missing dashboard id" };
   }
   try {
-    const body = await readBody(event);
+    const body = (await readBody(event)) as Record<string, unknown>;
+    const validation = validateDashboardConfig(body);
+    if (validation) {
+      setResponseStatus(event, 400);
+      return { error: validation };
+    }
     const scope = await resolveSettingsScope(event);
     const key = `${KEY_PREFIX}${id}`;
-    await putScopedSettingRecord(scope, key, body as Record<string, unknown>);
+    await putScopedSettingRecord(scope, key, body);
     return { id, success: true };
   } catch (err: any) {
     setResponseStatus(event, 500);
     return { error: err.message };
   }
 });
+
+/**
+ * Reject configs that would render as a blank sidebar row or crash the
+ * dashboard page. Mirrors `actions/update-dashboard.ts` so both write
+ * paths refuse the same shapes — see `app/pages/adhoc/sql-dashboard/types.ts`.
+ */
+function validateDashboardConfig(
+  config: Record<string, unknown> | null | undefined,
+): string | null {
+  if (!config || typeof config !== "object") return "config must be an object";
+  if (typeof config.name !== "string" || config.name.trim().length === 0) {
+    return "name is required";
+  }
+  const panels = config.panels;
+  if (panels !== undefined && !Array.isArray(panels)) {
+    return "panels must be an array";
+  }
+  if (Array.isArray(panels)) {
+    for (let i = 0; i < panels.length; i++) {
+      const p = panels[i] as Record<string, unknown> | null;
+      if (!p || typeof p !== "object") return `panel[${i}] must be an object`;
+      if (typeof p.id !== "string" || p.id.length === 0) {
+        return `panel[${i}].id is required`;
+      }
+      if (typeof p.sql !== "string" || p.sql.length === 0) {
+        return `panel[${i}].sql is required`;
+      }
+    }
+  }
+  return null;
+}
 
 export const deleteSqlDashboard = defineEventHandler(async (event) => {
   const id = getRouterParam(event, "id");

--- a/templates/analytics/server/lib/bigquery.ts
+++ b/templates/analytics/server/lib/bigquery.ts
@@ -227,6 +227,53 @@ function rowsToObjects(
   });
 }
 
+/**
+ * Validate a BigQuery SQL statement without executing it. Uses BigQuery's
+ * `dryRun` flag, which is free (no bytes billed) and returns query-compilation
+ * errors — unknown columns, type mismatches, missing tables — in the same
+ * format as a real run. Use this before persisting agent-generated SQL so
+ * the agent gets immediate feedback instead of saving a broken dashboard.
+ *
+ * Returns `null` when the query is valid; otherwise returns a short error
+ * string suitable for bubbling back to the agent.
+ */
+export async function dryRunQuery(sql: string): Promise<string | null> {
+  let resolvedSql = await resolveTablePlaceholder(sql);
+  resolvedSql = filterDevSchema(resolvedSql);
+
+  const projectId = await getProjectId();
+  const token = await getAccessToken();
+  const url = `https://bigquery.googleapis.com/bigquery/v2/projects/${projectId}/jobs`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      configuration: {
+        dryRun: true,
+        query: { query: resolvedSql, useLegacySql: false },
+      },
+    }),
+  });
+
+  if (res.ok) return null;
+
+  const text = await res.text();
+  try {
+    const parsed = JSON.parse(text) as {
+      error?: { message?: string };
+    };
+    const msg = parsed.error?.message?.trim();
+    if (msg) return msg;
+  } catch {
+    // Fall through
+  }
+  return `BigQuery validation failed (${res.status})`;
+}
+
 export async function runQuery(sql: string): Promise<QueryResult> {
   let resolvedSql = await resolveTablePlaceholder(sql);
   resolvedSql = filterDevSchema(resolvedSql);

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -3,11 +3,66 @@ import {
   autoDiscoverActions,
 } from "@agent-native/core/server";
 import { getOrgContext } from "@agent-native/core/org";
+import {
+  listScopedSettingRecords,
+  resolveSettingsScope,
+} from "../lib/scoped-settings";
+
+const SQL_DASHBOARD_PREFIX = "sql-dashboard-";
 
 export default createAgentChatPlugin({
   actions: () => autoDiscoverActions(import.meta.url),
   resolveOrgId: async (event) => {
     const ctx = await getOrgContext(event);
     return ctx.orgId;
+  },
+  mentionProviders: {
+    dashboards: {
+      label: "Dashboards",
+      icon: "deck",
+      search: async (query: string, event?: any) => {
+        if (!event) return [];
+        try {
+          const scope = await resolveSettingsScope(event);
+          const all = await listScopedSettingRecords(
+            scope,
+            SQL_DASHBOARD_PREFIX,
+          );
+          const items = Object.entries(all)
+            .map(([key, data]) => {
+              const id = key.slice(SQL_DASHBOARD_PREFIX.length);
+              const rawName = (data as { name?: unknown })?.name;
+              const name =
+                typeof rawName === "string" && rawName.trim().length > 0
+                  ? rawName.trim()
+                  : undefined;
+              return { id, name };
+            })
+            .filter((d) => d.id.length > 0);
+
+          const q = (query || "").toLowerCase().trim();
+          const filtered = q
+            ? items.filter(
+                (d) =>
+                  (d.name || "").toLowerCase().includes(q) ||
+                  d.id.toLowerCase().includes(q),
+              )
+            : items;
+
+          return filtered.slice(0, 20).map((d) => ({
+            id: `dashboard:${d.id}`,
+            label: d.name || "Untitled dashboard",
+            description: `/adhoc/${d.id}`,
+            icon: "deck",
+            refType: "dashboard",
+            refId: d.id,
+            refPath: `/adhoc/${d.id}`,
+          }));
+        } catch (err) {
+          console.error("[analytics] Dashboard mention provider failed:", err);
+          return [];
+        }
+      },
+    },
   },
 });

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -9,12 +9,67 @@ import {
 } from "../lib/scoped-settings";
 
 const SQL_DASHBOARD_PREFIX = "sql-dashboard-";
+const DATA_DICT_PREFIX = "data-dict-";
+
+/**
+ * Render the data-dictionary entries available to this request as a
+ * compact prompt block. Lets the agent pick the right table / column
+ * names up front instead of hallucinating them and hitting a BigQuery
+ * error after save. Only includes fields that are actually useful for
+ * SQL generation (metric / definition / table / columnsUsed / query
+ * template / gotchas) — the full entry is still fetchable via
+ * `list-data-dictionary` when the agent wants more.
+ */
+function renderDataDictionary(entries: Array<Record<string, unknown>>): string {
+  if (!entries.length) return "";
+  const lines: string[] = [];
+  for (const e of entries) {
+    const metric = String(e.metric ?? "").trim();
+    const definition = String(e.definition ?? "").trim();
+    if (!metric) continue;
+    lines.push(`- **${metric}**${definition ? ` — ${definition}` : ""}`);
+    const table = String(e.table ?? "").trim();
+    if (table) lines.push(`  - table: ${table}`);
+    const columns = String(e.columnsUsed ?? "").trim();
+    if (columns) lines.push(`  - columns: ${columns}`);
+    const template = String(e.queryTemplate ?? "").trim();
+    if (template) {
+      const oneLine = template.replace(/\s+/g, " ").slice(0, 240);
+      lines.push(`  - query: ${oneLine}${template.length > 240 ? "…" : ""}`);
+    }
+    const gotchas = String(e.knownGotchas ?? "").trim();
+    if (gotchas) lines.push(`  - gotchas: ${gotchas}`);
+  }
+  if (!lines.length) return "";
+  return (
+    "<data-dictionary>\n" +
+    "Canonical metric/table/column definitions for this workspace. " +
+    "Use the table and column names below verbatim when writing SQL — they are what actually exist in BigQuery. " +
+    "If the metric you need isn't here, call `list-data-dictionary` / `save-data-dictionary-entry` before guessing.\n\n" +
+    lines.join("\n") +
+    "\n</data-dictionary>"
+  );
+}
 
 export default createAgentChatPlugin({
   actions: () => autoDiscoverActions(import.meta.url),
   resolveOrgId: async (event) => {
     const ctx = await getOrgContext(event);
     return ctx.orgId;
+  },
+  extraContext: async (event) => {
+    try {
+      const scope = await resolveSettingsScope(event);
+      const all = await listScopedSettingRecords(scope, DATA_DICT_PREFIX);
+      const entries = Object.values(all) as Array<Record<string, unknown>>;
+      return renderDataDictionary(entries);
+    } catch (err) {
+      console.warn(
+        "[analytics] data dictionary context failed:",
+        err instanceof Error ? err.message : err,
+      );
+      return null;
+    }
   },
   mentionProviders: {
     dashboards: {

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -1823,10 +1823,17 @@ export const listContacts = defineEventHandler(async (event: H3Event) => {
         }
       }
 
-      // If People API returned nothing (e.g. missing scopes), extract from Gmail
-      if (contactMap.size === 0) {
+      // Always merge in addresses from Gmail headers. People API's
+      // otherContacts only surfaces senders, so people the user has emailed
+      // (but who haven't replied) won't appear unless we scan sent messages.
+      // We query sent first to ensure outgoing recipients are captured, then
+      // fall back to a general scan when People API returned nothing (e.g.
+      // missing scopes).
+      const gmailQueries =
+        contactMap.size === 0 ? ["in:sent", ""] : ["in:sent"];
+      for (const query of gmailQueries) {
         try {
-          const { messages } = await listGmailMessages("", 100, email);
+          const { messages } = await listGmailMessages(query, 100, email);
           for (const msg of messages) {
             const headers = msg.payload?.headers || [];
             for (const field of ["From", "To", "Cc", "Bcc"]) {
@@ -1866,7 +1873,10 @@ export const listContacts = defineEventHandler(async (event: H3Event) => {
             }
           }
         } catch (err: any) {
-          console.error("[listContacts] Gmail fallback error:", err.message);
+          console.error(
+            `[listContacts] Gmail header scan error (query="${query}"):`,
+            err.message,
+          );
         }
       }
 

--- a/templates/videos/actions/delete-composition.ts
+++ b/templates/videos/actions/delete-composition.ts
@@ -1,6 +1,8 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
+import fs from "fs/promises";
+import path from "path";
 import { getDb, schema } from "../server/db/index.js";
 
 export default defineAction({
@@ -18,6 +20,77 @@ export default defineAction({
       .delete(schema.compositions)
       .where(eq(schema.compositions.id, args.id));
 
+    // The UI reads compositions from app/remotion/registry.ts (a static source
+    // file the agent edits), not from the DB. Deleting only from the DB means
+    // the entry reappears on reload. In dev, also remove it from the source.
+    if (process.env.NODE_ENV === "development") {
+      try {
+        await removeFromRegistry(args.id);
+      } catch (err) {
+        console.error("[delete-composition] Failed to update registry:", err);
+      }
+    }
+
     return { success: true };
   },
 });
+
+async function removeFromRegistry(id: string) {
+  const registryPath = path.join(process.cwd(), "app/remotion/registry.ts");
+  const source = await fs.readFile(registryPath, "utf-8");
+
+  // Find `id: "<id>"` inside an object literal, then walk back to its `{`
+  // and forward to the matching `}`, and remove that object (plus its
+  // trailing comma/whitespace) from the array.
+  const idPattern = new RegExp(`id:\\s*["']${escapeRegex(id)}["']`);
+  const idMatch = idPattern.exec(source);
+  if (!idMatch) return; // nothing to do
+
+  let open = -1;
+  for (let i = idMatch.index - 1; i >= 0; i--) {
+    if (source[i] === "{") {
+      open = i;
+      break;
+    }
+  }
+  if (open === -1) return;
+
+  let depth = 0;
+  let close = -1;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        close = i;
+        break;
+      }
+    }
+  }
+  if (close === -1) return;
+
+  // Expand the removal range to swallow a trailing comma + following
+  // whitespace so we don't leave `,\n  ,` or a dangling blank line.
+  let end = close + 1;
+  while (end < source.length && /[ \t]/.test(source[end])) end++;
+  if (source[end] === ",") {
+    end++;
+    while (end < source.length && /[ \t\r\n]/.test(source[end])) end++;
+  } else {
+    // No trailing comma (last element) — strip leading comma instead.
+    let start = open;
+    while (start > 0 && /[ \t\r\n]/.test(source[start - 1])) start--;
+    if (source[start - 1] === ",") {
+      const next = source.slice(0, start - 1) + source.slice(close + 1);
+      await fs.writeFile(registryPath, next, "utf-8");
+      return;
+    }
+  }
+
+  const next = source.slice(0, open) + source.slice(end);
+  await fs.writeFile(registryPath, next, "utf-8");
+}
+
+function escapeRegex(s: string) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/templates/videos/actions/delete-composition.ts
+++ b/templates/videos/actions/delete-composition.ts
@@ -41,32 +41,18 @@ async function removeFromRegistry(id: string) {
 
   // Find `id: "<id>"` inside an object literal, then walk back to its `{`
   // and forward to the matching `}`, and remove that object (plus its
-  // trailing comma/whitespace) from the array.
+  // trailing comma/whitespace) from the array. Use a string/comment-aware
+  // walker so braces inside string and template literals (e.g. the
+  // `Array.from({ length: 24 })` snippets we render in the Properties
+  // panel) don't desync the depth counter and corrupt the registry.
   const idPattern = new RegExp(`id:\\s*["']${escapeRegex(id)}["']`);
   const idMatch = idPattern.exec(source);
   if (!idMatch) return; // nothing to do
 
-  let open = -1;
-  for (let i = idMatch.index - 1; i >= 0; i--) {
-    if (source[i] === "{") {
-      open = i;
-      break;
-    }
-  }
+  const open = scanBackwardForObjectStart(source, idMatch.index - 1);
   if (open === -1) return;
 
-  let depth = 0;
-  let close = -1;
-  for (let i = open; i < source.length; i++) {
-    if (source[i] === "{") depth++;
-    else if (source[i] === "}") {
-      depth--;
-      if (depth === 0) {
-        close = i;
-        break;
-      }
-    }
-  }
+  const close = scanForwardForObjectEnd(source, open);
   if (close === -1) return;
 
   // Expand the removal range to swallow a trailing comma + following
@@ -93,4 +79,182 @@ async function removeFromRegistry(id: string) {
 
 function escapeRegex(s: string) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Scan backward from `from` for the nearest unmatched `{` that opens an
+ * object literal, skipping characters inside strings, template literals,
+ * and comments so braces in user-authored snippets don't fool us.
+ */
+function scanBackwardForObjectStart(src: string, from: number): number {
+  // Strip strings/comments first so we can do a simple linear scan
+  // backward over a normalized buffer of the same length.
+  const sanitized = sanitizeForBraceScan(src);
+  let depth = 0;
+  for (let i = from; i >= 0; i--) {
+    const ch = sanitized[i];
+    if (ch === "}") depth++;
+    else if (ch === "{") {
+      if (depth === 0) return i;
+      depth--;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Scan forward from the opening `{` at `open` to its matching `}`,
+ * ignoring braces inside strings, template literals, and comments.
+ */
+function scanForwardForObjectEnd(src: string, open: number): number {
+  const sanitized = sanitizeForBraceScan(src);
+  let depth = 0;
+  for (let i = open; i < sanitized.length; i++) {
+    const ch = sanitized[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Replace the contents of every JS/TS string literal, template literal,
+ * and comment with spaces so brace-counting on the resulting buffer
+ * matches the source's structural braces only. Lengths and offsets are
+ * preserved 1:1 so callers can reuse offsets in the original source.
+ */
+function sanitizeForBraceScan(src: string): string {
+  const out = src.split("");
+  let i = 0;
+  let templateDepth = 0;
+  // Stack of `${` interpolation contexts inside template literals so a
+  // `}` that closes an interpolation doesn't get treated as structural.
+  const exprBraceStack: number[] = [];
+
+  const skipUntil = (end: number) => {
+    for (let k = i; k < end; k++) out[k] = " ";
+    i = end;
+  };
+
+  while (i < src.length) {
+    const ch = src[i];
+    const next = src[i + 1];
+
+    // Line comment
+    if (ch === "/" && next === "/") {
+      const eol = src.indexOf("\n", i);
+      skipUntil(eol === -1 ? src.length : eol);
+      continue;
+    }
+    // Block comment
+    if (ch === "/" && next === "*") {
+      const close = src.indexOf("*/", i + 2);
+      skipUntil(close === -1 ? src.length : close + 2);
+      continue;
+    }
+    // Single/double-quoted string
+    if (ch === "'" || ch === '"') {
+      const quote = ch;
+      let j = i + 1;
+      while (j < src.length) {
+        if (src[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (src[j] === quote) {
+          j++;
+          break;
+        }
+        j++;
+      }
+      skipUntil(j);
+      continue;
+    }
+    // Template literal — track interpolations so structural braces
+    // outside `${...}` stay invisible while braces inside count toward
+    // structural depth (because user code inside `${}` is real JS).
+    if (ch === "`" && templateDepth === 0) {
+      templateDepth = 1;
+      out[i] = " ";
+      i++;
+      while (i < src.length && templateDepth > 0) {
+        const c = src[i];
+        if (c === "\\") {
+          out[i] = " ";
+          out[i + 1] = " ";
+          i += 2;
+          continue;
+        }
+        if (c === "`") {
+          templateDepth = 0;
+          out[i] = " ";
+          i++;
+          break;
+        }
+        if (c === "$" && src[i + 1] === "{") {
+          // Leave the `${` invisible but step into the expression so its
+          // braces are scanned normally; track our own depth with the
+          // stack so we know when the matching `}` closes interpolation.
+          out[i] = " ";
+          out[i + 1] = " ";
+          exprBraceStack.push(1);
+          i += 2;
+          while (i < src.length && exprBraceStack.length > 0) {
+            const cc = src[i];
+            if (cc === "{") {
+              exprBraceStack[exprBraceStack.length - 1]++;
+              out[i] = " ";
+              i++;
+              continue;
+            }
+            if (cc === "}") {
+              const top = exprBraceStack[exprBraceStack.length - 1] - 1;
+              if (top === 0) {
+                exprBraceStack.pop();
+                out[i] = " ";
+                i++;
+                break;
+              }
+              exprBraceStack[exprBraceStack.length - 1] = top;
+              out[i] = " ";
+              i++;
+              continue;
+            }
+            // Strings inside interpolation can themselves contain
+            // template literals — keep it simple and just blank
+            // string/template content while inside.
+            if (cc === "'" || cc === '"') {
+              const quote = cc;
+              let k = i + 1;
+              while (k < src.length) {
+                if (src[k] === "\\") {
+                  k += 2;
+                  continue;
+                }
+                if (src[k] === quote) {
+                  k++;
+                  break;
+                }
+                k++;
+              }
+              for (let m = i; m < k; m++) out[m] = " ";
+              i = k;
+              continue;
+            }
+            out[i] = " ";
+            i++;
+          }
+          continue;
+        }
+        out[i] = " ";
+        i++;
+      }
+      continue;
+    }
+    i++;
+  }
+  return out.join("");
 }


### PR DESCRIPTION
## Summary

### Hosted: fix free-usage-limit loop when user supplies their own key
- Saving an Anthropic key from the usage-limit card only mutated `process.env` and tried to write `.env` — neither sticks on serverless hosts, so after reload the card kept reappearing.
- The usage check also fired regardless of whether the user had supplied their own key, so the platform free-tier was still enforced on people paying Anthropic directly.
- `save-key` now persists the key per-owner in the SQL `settings` table (`user-anthropic-api-key:<email>`), the production agent loads that key before resolving the engine, and the usage-limit check is skipped when a user-supplied key is in use.
- Drop the long descriptive paragraph from the `usage_limit` CTA card — the inline instructions cover it.

### Dev: tune dev-all stagger to 250ms
- Reintroduces a tiny 250ms stagger in `scripts/dev-all.ts` so the first templates don't race Nitro's `ViteEnvRunner` 3s init during cold boot.
- Without any stagger, simultaneous I/O contention (node_modules resolution + file mmap across ~12 processes) could push Nitro past the deadline and produce one-shot `NitroViteError` 503s.
- Total added startup ≈3s (vs ~18s with the old 1.5s × 12 stagger).

## Test plan
- [ ] On a hosted analytics deploy, hit the free-tier limit, paste a real `sk-ant-…` key, hit Enter, confirm reload settles into a working chat (no second `usage_limit_reached` event).
- [ ] Confirm the usage-limit card no longer renders the `You've used $X.XX of your $Y.YY free tier…` paragraph.
- [ ] Confirm a fresh user without a saved key still sees the free-tier limit after exceeding it.
- [ ] `pnpm dev:all` boots with no `NitroViteError` 503s and is noticeably faster than the old 1.5s stagger.