### PR TITLE
updates-109: analytics panel.source validation + chat queue UI

### DIFF
--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1937,29 +1937,46 @@ const AssistantChatInner = forwardRef<
                 already-streamed reconnect content so the user sees both
                 "what it did so far" and "it's still working". */}
             {showRunningInUI && <ThinkingIndicator />}
-            {queuedMessages.map((msg, i) => (
-              <div key={`queued-${i}`} className="flex justify-end">
-                <div className="max-w-[85%] rounded-lg bg-accent/50 text-foreground/60 px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words">
-                  <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground mb-1 font-medium uppercase tracking-wide">
-                    <IconClock className="h-3 w-3" />
-                    Queued
-                  </div>
-                  {msg.text}
-                  {msg.images && msg.images.length > 0 && (
-                    <div className="flex flex-wrap gap-1.5 mt-1.5">
-                      {msg.images.map((img, j) => (
-                        <img
-                          key={j}
-                          src={img}
-                          alt=""
-                          className="h-12 w-12 rounded object-cover border border-border/50"
-                        />
-                      ))}
+            {queuedMessages.map((msg, i) => {
+              const displayText = msg.text
+                .replace(/<context>[\s\S]*?<\/context>\n?/g, "")
+                .trim();
+              return (
+                <div key={`queued-${i}`} className="flex justify-end group">
+                  <div className="relative max-w-[85%] rounded-lg bg-accent/50 text-foreground/60 px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words">
+                    <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground mb-1 font-medium uppercase tracking-wide">
+                      <IconClock className="h-3 w-3" />
+                      Queued
                     </div>
-                  )}
+                    {displayText}
+                    {msg.images && msg.images.length > 0 && (
+                      <div className="flex flex-wrap gap-1.5 mt-1.5">
+                        {msg.images.map((img, j) => (
+                          <img
+                            key={j}
+                            src={img}
+                            alt=""
+                            className="h-12 w-12 rounded object-cover border border-border/50"
+                          />
+                        ))}
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setQueuedMessages((prev) =>
+                          prev.filter((_, idx) => idx !== i),
+                        )
+                      }
+                      aria-label="Remove from queue"
+                      className="absolute -top-2 -right-2 hidden group-hover:flex h-5 w-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent shadow-sm"
+                    >
+                      <IconX className="h-3 w-3" />
+                    </button>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1177,7 +1177,12 @@ const AssistantChatInner = forwardRef<
     limitCents: number;
   } | null>(null);
   const [queuedMessages, setQueuedMessages] = useState<
-    Array<{ text: string; images?: string[]; references?: Reference[] }>
+    Array<{
+      id: string;
+      text: string;
+      images?: string[];
+      references?: Reference[];
+    }>
   >([]);
   const [showContinue, setShowContinue] = useState(false);
   const [isReconnecting, setIsReconnecting] = useState(false);
@@ -1637,7 +1642,18 @@ const AssistantChatInner = forwardRef<
     (text: string, images?: string[], references?: Reference[]) => {
       setShowContinue(false);
       if (isRunning) {
-        setQueuedMessages((prev) => [...prev, { text, images, references }]);
+        setQueuedMessages((prev) => [
+          ...prev,
+          {
+            id:
+              typeof crypto !== "undefined" && crypto.randomUUID
+                ? crypto.randomUUID()
+                : `q-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            text,
+            images,
+            references,
+          },
+        ]);
       } else {
         const content: Array<
           { type: "text"; text: string } | { type: "image"; image: string }
@@ -1903,12 +1919,12 @@ const AssistantChatInner = forwardRef<
                 already-streamed reconnect content so the user sees both
                 "what it did so far" and "it's still working". */}
             {showRunningInUI && <ThinkingIndicator />}
-            {queuedMessages.map((msg, i) => {
+            {queuedMessages.map((msg) => {
               const displayText = msg.text
                 .replace(/<context>[\s\S]*?<\/context>\n?/g, "")
                 .trim();
               return (
-                <div key={`queued-${i}`} className="flex justify-end group">
+                <div key={msg.id} className="flex justify-end group">
                   <div className="relative max-w-[85%] rounded-lg bg-accent/50 text-foreground/60 px-3 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words">
                     <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground mb-1 font-medium uppercase tracking-wide">
                       <IconClock className="h-3 w-3" />
@@ -1931,11 +1947,11 @@ const AssistantChatInner = forwardRef<
                       type="button"
                       onClick={() =>
                         setQueuedMessages((prev) =>
-                          prev.filter((_, idx) => idx !== i),
+                          prev.filter((m) => m.id !== msg.id),
                         )
                       }
                       aria-label="Remove from queue"
-                      className="absolute -top-2 -right-2 hidden group-hover:flex h-5 w-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent shadow-sm"
+                      className="absolute -top-2 -right-2 flex h-5 w-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:text-foreground hover:bg-accent shadow-sm"
                     >
                       <IconX className="h-3 w-3" />
                     </button>

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -33,7 +33,6 @@ import { type ContentPart, readSSEStreamRaw } from "./sse-event-processor.js";
 import { cn } from "./utils.js";
 import { AgentTaskCard } from "./AgentTaskCard.js";
 import { ConnectBuilderCard } from "./ConnectBuilderCard.js";
-import { useBuilderStatus } from "./settings/useBuilderStatus.js";
 import {
   TiptapComposer,
   type TiptapComposerHandle,
@@ -48,7 +47,6 @@ import {
   IconCopy,
   IconTerminal,
   IconLoader2,
-  IconExternalLink,
   IconCircleX,
   IconSquareFilled,
   IconClock,
@@ -768,10 +766,6 @@ function ApiKeySetupCard({ apiUrl }: { apiUrl: string }) {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const { status: builder } = useBuilderStatus();
-  const builderEnabled = builder?.builderEnabled ?? false;
-  const builderConnectUrl = builder?.connectUrl;
-
   const handleSave = async () => {
     if (!apiKey.trim()) return;
     setSaving(true);
@@ -834,21 +828,9 @@ function ApiKeySetupCard({ apiUrl }: { apiUrl: string }) {
                 Use Builder's managed Anthropic proxy — no API key needed
               </p>
             </div>
-            {builderEnabled && builderConnectUrl ? (
-              <a
-                href={builderConnectUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex shrink-0 items-center gap-1 rounded bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground hover:opacity-90"
-              >
-                Connect
-                <IconExternalLink className="h-3 w-3" />
-              </a>
-            ) : (
-              <span className="shrink-0 rounded border border-border px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-                Coming soon
-              </span>
-            )}
+            <span className="shrink-0 rounded border border-border px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+              Coming soon
+            </span>
           </div>
         </div>
 
@@ -922,10 +904,6 @@ export function BuilderCtaCard({
       ? window.location.hostname.split(".")[0]
       : "app";
   const cloneCommand = `npx agent-native create ${appName}`;
-
-  const { status: builder } = useBuilderStatus();
-  const builderEnabled = builder?.builderEnabled ?? false;
-  const builderConnectUrl = builder?.connectUrl;
 
   const [apiKey, setApiKey] = useState("");
   const [saving, setSaving] = useState(false);
@@ -1065,21 +1043,9 @@ export function BuilderCtaCard({
                 Builder's managed Anthropic proxy — no API key needed
               </p>
             </div>
-            {builderEnabled && builderConnectUrl ? (
-              <a
-                href={builderConnectUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex shrink-0 items-center gap-1 rounded bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground hover:opacity-90"
-              >
-                Connect
-                <IconExternalLink className="h-3 w-3" />
-              </a>
-            ) : (
-              <span className="shrink-0 rounded border border-border px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-                Coming soon
-              </span>
-            )}
+            <span className="shrink-0 rounded border border-border px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+              Coming soon
+            </span>
           </div>
         </div>
       </div>

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -124,6 +124,21 @@ export function isPostgres(): boolean {
   return getDialect() === "postgres";
 }
 
+/**
+ * Returns true when the database is a local-only SQLite file (or unset, which
+ * defaults to a local SQLite file). Returns false for Postgres, remote libsql
+ * (Turso), and D1 — any backend that could be shared across developers.
+ *
+ * Used to gate local@localhost mode: that mode uses a single shared virtual
+ * user with no per-machine scoping, so on any shared database two developers
+ * would read and write each other's settings, oauth tokens, and app state.
+ */
+export function isLocalDatabase(): boolean {
+  if (getDialect() !== "sqlite") return false;
+  const url = getDatabaseUrl();
+  return url === "" || url.startsWith("file:");
+}
+
 /** Returns BIGINT for Postgres (64-bit), INTEGER for SQLite (already 64-bit). */
 export function intType(): string {
   return isPostgres() ? "BIGINT" : "INTEGER";

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2541,14 +2541,40 @@ export function createAgentChatPlugin(
           setResponseStatus(event, 401);
           return { error: "Authentication required" };
         }
-        try {
-          if (ownerEmail && ownerEmail !== "local@localhost") {
+        if (ownerEmail && ownerEmail !== "local@localhost") {
+          try {
             await putSetting(`user-anthropic-api-key:${ownerEmail}`, {
               key: trimmedKey,
             });
+            // Verify the write actually landed — some managed DB drivers
+            // swallow errors on degraded connections. Without this the
+            // client sees "saved", reloads, and the usage-limit card
+            // re-appears on the next message because the key isn't
+            // really persisted.
+            const check = await getSetting(
+              `user-anthropic-api-key:${ownerEmail}`,
+            );
+            if (
+              !check ||
+              typeof check.key !== "string" ||
+              check.key !== trimmedKey
+            ) {
+              throw new Error("settings write did not persist");
+            }
+          } catch (err) {
+            if (isHostedProd) {
+              console.error(
+                "[agent-chat] save-key persistence failed:",
+                err instanceof Error ? err.message : err,
+              );
+              setResponseStatus(event, 500);
+              return {
+                error:
+                  "Failed to persist API key. Please try again or contact support.",
+              };
+            }
+            // Local dev falls through to the env-file path below.
           }
-        } catch {
-          // Settings store unavailable — fall back to env-only behavior
         }
 
         // In hosted/multi-tenant mode we deliberately do NOT touch

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -267,6 +267,7 @@ describe("server/auth", () => {
       vi.doMock("../db/client.js", () => ({
         getDbExec: () => ({ execute: mockExecute }),
         isPostgres: () => false,
+        isLocalDatabase: () => true,
         intType: () => "INTEGER",
       }));
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -29,7 +29,12 @@ function toWebRequest(event: H3Event): Request {
 }
 
 type H3App = H3AppShim;
-import { getDbExec, isPostgres, intType } from "../db/client.js";
+import {
+  getDbExec,
+  isPostgres,
+  intType,
+  isLocalDatabase,
+} from "../db/client.js";
 import { getBetterAuth, getBetterAuthSync } from "./better-auth-instance.js";
 import type { BetterAuthConfig } from "./better-auth-instance.js";
 import { getOnboardingHtml, getResetPasswordHtml } from "./onboarding-html.js";
@@ -130,6 +135,8 @@ const LOCAL_MODE_MARKER_PATH = path.resolve(
 // AUTH_MODE detection
 // ---------------------------------------------------------------------------
 
+let _warnedRemoteLocalMode = false;
+
 /**
  * Check if the app is in local-only mode (no auth).
  *
@@ -141,8 +148,23 @@ const LOCAL_MODE_MARKER_PATH = path.resolve(
  * no auth is used. In development, getSession() also falls back to
  * local@localhost automatically if no other auth method succeeds, so
  * apps are always usable without configuration in dev.
+ *
+ * Refuses to enable on any non-local database (Postgres, Turso, D1): local
+ * mode uses a single shared virtual user with no per-machine scoping, so on
+ * a shared DB every developer would land on the same account and collide.
  */
 async function isLocalModeEnabled(): Promise<boolean> {
+  if (!isLocalDatabase()) {
+    if (process.env.AUTH_MODE === "local" && !_warnedRemoteLocalMode) {
+      _warnedRemoteLocalMode = true;
+      console.warn(
+        "[agent-native] AUTH_MODE=local ignored: database is not local SQLite. " +
+          "local@localhost has no per-user scoping and would collide across developers on a shared DB.",
+      );
+    }
+    return false;
+  }
+
   if (process.env.AUTH_MODE === "local") return true;
 
   try {
@@ -537,16 +559,25 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
     }
   }
 
-  // 7. Dev-mode safety net — in development, always fall back to local@localhost
-  // so the app is usable without any auth configuration. This prevents 401
-  // errors when Better Auth isn't configured, the marker file is missing, or
-  // the user simply wants to play around locally.
+  // 7. Dev-mode safety net — in development on a local SQLite database, fall
+  // back to local@localhost so the app is usable without any auth configuration.
+  // This prevents 401 errors when Better Auth isn't configured, the marker file
+  // is missing, or the user simply wants to play around locally.
+  //
+  // Gated on isLocalDatabase() because local@localhost has no per-user scoping:
+  // on a shared DB (Postgres, Turso, D1) this fallback would land every
+  // developer on the same account and expose each other's data.
   //
   // EXCEPTION: if the user has explicitly exited local mode (clicked "Upgrade
   // to real account"), they've signaled they want real auth. The upgrade
   // cookie suppresses this fallback so the onboarding/sign-in page is served
   // instead of silently re-authenticating them as local@localhost.
-  if (isDevEnvironment() && !isUpgradePending(event) && !hasSignInFlag(event)) {
+  if (
+    isDevEnvironment() &&
+    isLocalDatabase() &&
+    !isUpgradePending(event) &&
+    !hasSignInFlag(event)
+  ) {
     return LOCAL_SESSION;
   }
 

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -445,6 +445,51 @@ function portExposer(): Plugin {
 }
 
 /**
+ * Silence benign `read ECONNRESET` noise from Vite's dev middleware.
+ * Fires when a browser closes/reloads/navigates mid-request — the peer has
+ * already gone away, there's nothing to fix, and Vite's error middleware
+ * spams the terminal with "Internal server error: read ECONNRESET". Our H3
+ * server layer already swallows this (create-server.ts onError); this plugin
+ * does the same for Vite's own connect pipeline.
+ */
+function silenceConnectionResets(): Plugin {
+  const isBenign = (err: unknown) => {
+    const e = err as NodeJS.ErrnoException | undefined;
+    const code = e?.code || (e?.cause as NodeJS.ErrnoException)?.code;
+    return (
+      code === "ECONNRESET" ||
+      code === "ECONNABORTED" ||
+      code === "EPIPE" ||
+      e?.message === "aborted"
+    );
+  };
+  return {
+    name: "agent-native-silence-connection-resets",
+    apply: "serve",
+    configureServer(server) {
+      // Swallow socket-level resets so Node doesn't surface them as uncaught.
+      server.httpServer?.on("connection", (socket) => {
+        socket.on("error", (err) => {
+          if (!isBenign(err)) throw err;
+        });
+      });
+      // Drop Vite's "Internal server error: read ECONNRESET" log lines.
+      const origError = server.config.logger.error.bind(server.config.logger);
+      server.config.logger.error = (msg, opts) => {
+        const text = typeof msg === "string" ? msg : String(msg ?? "");
+        if (
+          (opts?.error && isBenign(opts.error)) ||
+          /Internal server error:\s*(read ECONNRESET|aborted|EPIPE)/i.test(text)
+        ) {
+          return;
+        }
+        origError(msg, opts);
+      };
+    },
+  };
+}
+
+/**
  * Create the client Vite config with sensible agent-native defaults.
  * Supports two modes:
  * - Legacy SPA mode (default): React SWC plugin, client-only routing
@@ -543,6 +588,7 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
       autoReloadOnOptimizeDep(),
       baseRedirectGuard(),
       portExposer(),
+      silenceConnectionResets(),
       rolldownInputFix(),
       // Nitro Vite plugin for dev-mode API route serving and HMR.
       // Disabled during build — React Router's build handles production.

--- a/templates/analytics/.agents/skills/dashboard-management/SKILL.md
+++ b/templates/analytics/.agents/skills/dashboard-management/SKILL.md
@@ -84,7 +84,8 @@ pnpm action update-dashboard --dashboardId my-new-dashboard --config '<full json
 ```
 
 5. **The save endpoint dry-runs each BigQuery panel's SQL before persisting.** If it returns an error like `panel[2] "Foo" SQL is invalid: Unrecognized name: is_closed; Did you mean hs_is_closed?`, fix the SQL (usually by consulting the dictionary or introspecting the schema) and retry. Never work around the dry-run — a dashboard that can't dry-run cannot render.
-6. Navigate the user to it: `pnpm action navigate --view=adhoc --dashboardId={id}`.
+6. **`panel.source` is an enum, not a table ref.** It must be exactly `"bigquery"` (the warehouse) or `"app-db"` (the app's own SQLite/Postgres). Table names like `dbt_intermediate.uf_pageviews` go *inside* the `sql` string — `FROM \`dbt_intermediate.uf_pageviews\``. Writing the table name into `source` produces `Invalid source. Must be 'bigquery' or 'app-db'` on every render and the save endpoint will now reject it.
+7. Navigate the user to it: `pnpm action navigate --view=adhoc --dashboardId={id}`.
 
 The UI picks up the new dashboard via SSE events on settings changes.
 

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -183,6 +183,8 @@ A `<data-dictionary>` block is injected into your system prompt with the approve
 5. Obey `knownGotchas` from any entry you use — note them to the user if the data has limitations.
 6. The dashboard save endpoint now dry-runs every panel's SQL through BigQuery before persisting. If a panel fails validation you'll get a 400 with the BigQuery error text (e.g. `Unrecognized name: is_closed; Did you mean hs_is_closed?`) — fix the SQL and retry; never try to persist broken SQL.
 
+**Panel `source` is a backend, not a table.** The `source` field on every panel must be exactly `"bigquery"` or `"app-db"` — it selects _which database_ the SQL runs against. The table/dataset reference (e.g. `dbt_intermediate.uf_pageviews`) goes inside the `sql` string. Writing the table name into `source` produces `Invalid source` errors on every render.
+
 **Populating the dictionary:** When the user has existing metric definitions elsewhere (team docs, Confluence, Notion, dbt descriptions, a Google Sheet, a wiki), fetch them with whatever tools you have — generic `WebFetch`, an MCP server the user has configured, a CSV import, or asking the user to paste — then upsert each via `save-data-dictionary-entry`. The dictionary itself is source-agnostic.
 
 ### Ad-Hoc Analysis

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -161,6 +161,7 @@ function validateDashboardConfig(
   if (!Array.isArray(panels)) {
     return "config.panels must be an array (use [] for an empty dashboard)";
   }
+  const validSources = new Set(["bigquery", "app-db"]);
   for (let i = 0; i < panels.length; i++) {
     const p = panels[i] as Record<string, unknown> | null;
     if (!p || typeof p !== "object") {
@@ -183,6 +184,9 @@ function validateDashboardConfig(
       if (typeof v !== "string" || v.trim().length === 0) {
         return `panel[${i}].${field} is required (non-empty string)`;
       }
+    }
+    if (!validSources.has(p.source as string)) {
+      return `panel[${i}].source must be 'bigquery' or 'app-db' (got '${p.source}'). source selects the backend — put the table name in sql, not here.`;
     }
   }
   return null;

--- a/templates/analytics/server/handlers/sql-dashboards.ts
+++ b/templates/analytics/server/handlers/sql-dashboards.ts
@@ -123,6 +123,7 @@ function validateDashboardConfig(
   }
   if (Array.isArray(panels)) {
     const requiredStrings = ["id", "title", "sql", "source", "chartType"];
+    const validSources = new Set(["bigquery", "app-db"]);
     for (let i = 0; i < panels.length; i++) {
       const p = panels[i] as Record<string, unknown> | null;
       if (!p || typeof p !== "object") return `panel[${i}] must be an object`;
@@ -131,6 +132,9 @@ function validateDashboardConfig(
         if (typeof v !== "string" || v.trim().length === 0) {
           return `panel[${i}].${field} is required`;
         }
+      }
+      if (!validSources.has(p.source as string)) {
+        return `panel[${i}].source must be 'bigquery' or 'app-db' (got '${p.source}'). The table name belongs in the panel's sql, not in source — source selects the backend, not the table.`;
       }
       if (p.width !== 1 && p.width !== 2) {
         return `panel[${i}].width must be 1 or 2`;


### PR DESCRIPTION
## Summary
- Analytics: strict enum validation for `panel.source` in both write paths (`sql-dashboards.ts` handler + `update-dashboard.ts` action). Returns a clear 400 when a table name is passed instead of `bigquery` | `app-db`, and tightens AGENTS.md + `dashboard-management` SKILL.md so the agent doesn't make the mistake in the first place.
- Chat queue UI: strip `<context>...</context>` from queued message display (matching how `UserMessageText` strips it from threads), and add a hover-only X button to remove an individual message from the queue.

## Test plan
- [ ] Save a dashboard with `panel.source: "bigquery"` → succeeds; with a table name → 400 with helpful message.
- [ ] Queue a message that contains a `<context>` block while the agent is running → queued bubble renders without the context block.
- [ ] Hover a queued message → X appears; click removes that specific message from the queue.