### PR TITLE
updates-111: analytics sidebar + data-sources grid polish

### DIFF
--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -157,7 +157,7 @@ function SortableRow({
     <div ref={setNodeRef} style={style} className="group/item relative min-w-0">
       <div className="flex items-center min-w-0">
         <button
-          className="p-1 cursor-grab active:cursor-grabbing text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors shrink-0 opacity-0 group-hover/item:opacity-100"
+          className="-ml-5 p-1 cursor-grab active:cursor-grabbing text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors shrink-0 opacity-0 group-hover/item:opacity-100"
           {...attributes}
           {...listeners}
         >

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -157,7 +157,7 @@ function SortableRow({
     <div ref={setNodeRef} style={style} className="group/item relative min-w-0">
       <div className="flex items-center min-w-0">
         <button
-          className="-ml-5 p-1 cursor-grab active:cursor-grabbing text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors shrink-0 opacity-0 group-hover/item:opacity-100"
+          className="-ml-3 p-1 cursor-grab active:cursor-grabbing text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors shrink-0 opacity-0 group-hover/item:opacity-100"
           {...attributes}
           {...listeners}
         >

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -539,7 +539,7 @@ function DataSourceCard({
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between gap-6">
             <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
                 <Icon className="h-5 w-5" />
               </div>
               <div>

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -827,7 +827,7 @@ export default function DataSources() {
       {/* Filtered results */}
       {filteredSources !== null ? (
         filteredSources.length > 0 ? (
-          <div className="grid gap-3 sm:grid-cols-2">
+          <div className="grid gap-3 lg:grid-cols-2">
             {filteredSources.map((source) => (
               <DataSourceCard
                 key={source.id}
@@ -853,7 +853,7 @@ export default function DataSources() {
               <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
                 {categoryLabels[category]}
               </h3>
-              <div className="grid gap-3 sm:grid-cols-2">
+              <div className="grid gap-3 lg:grid-cols-2">
                 {sources.map((source) => (
                   <DataSourceCard
                     key={source.id}


### PR DESCRIPTION
## Summary
- analytics: data-source card icons get \`shrink-0\` so they don't squish when the label text wraps
- analytics: data-sources grid stays 1-col until the \`lg\` breakpoint (was switching too early and making cards awkwardly narrow)
- analytics: sidebar drag handle pulled into the left gutter via \`-ml-5\` so item labels align with the rest of the sidebar

## Test plan
- [ ] /data-sources: cards render cleanly on mobile, tablet, and desktop; icons keep their size when title wraps
- [ ] Sidebar: hover a dashboard/analysis row, drag handle appears in the gutter (not pushed inside the label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)