### PR TITLE
updates-112: feedback popover skeleton + auto-close on submit

### DIFF
--- a/packages/core/src/client/FeedbackButton.tsx
+++ b/packages/core/src/client/FeedbackButton.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, type CSSProperties } from "react";
+import { useState, useEffect, useRef, type CSSProperties } from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import { IconMessage2 } from "@tabler/icons-react";
+import { IconMessage2, IconCheck } from "@tabler/icons-react";
 import { cn } from "./utils.js";
 
 const DEFAULT_FEEDBACK_URL =
@@ -29,11 +29,49 @@ export interface FeedbackButtonProps {
   align?: "start" | "center" | "end";
 }
 
-const iframeWrapStyle: CSSProperties = {
+const surfaceStyle: CSSProperties = {
   width: "min(440px, calc(100vw - 32px))",
   height: "min(320px, calc(100vh - 120px))",
   background: "hsl(var(--background))",
 };
+
+function FeedbackSkeleton() {
+  return (
+    <div className="flex h-full w-full flex-col gap-4 p-5" aria-hidden>
+      <div className="flex flex-col gap-2">
+        <div className="h-4 w-40 rounded bg-muted animate-pulse" />
+        <div className="h-3 w-56 rounded bg-muted/70 animate-pulse" />
+      </div>
+      <div className="flex flex-col gap-3 pt-2">
+        <div className="h-3 w-24 rounded bg-muted animate-pulse" />
+        <div className="h-9 w-full rounded-md bg-muted animate-pulse" />
+      </div>
+      <div className="flex flex-col gap-3">
+        <div className="h-3 w-28 rounded bg-muted animate-pulse" />
+        <div className="h-20 w-full rounded-md bg-muted animate-pulse" />
+      </div>
+      <div className="mt-auto flex justify-end">
+        <div className="h-9 w-24 rounded-md bg-muted animate-pulse" />
+      </div>
+    </div>
+  );
+}
+
+function FeedbackThanks() {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 px-6 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-500">
+        <IconCheck size={22} stroke={2.5} />
+      </div>
+      <div className="text-sm font-medium text-foreground">
+        Thanks for the feedback!
+      </div>
+      <div className="text-xs text-muted-foreground">
+        We read every submission.
+      </div>
+    </div>
+  );
+}
 
 export function FeedbackButton({
   variant = "sidebar",
@@ -44,15 +82,39 @@ export function FeedbackButton({
   align = "end",
 }: FeedbackButtonProps) {
   const [open, setOpen] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const embedUrl = url.includes("?") ? `${url}&embed=1` : `${url}?embed=1`;
   const expectedOrigin = getExpectedOrigin(embedUrl);
+
+  // Reset transient state each time the popover opens so the skeleton shows
+  // on the next open and a stale "submitted" view doesn't leak across sessions.
+  useEffect(() => {
+    if (open) {
+      setLoaded(false);
+      setSubmitted(false);
+    }
+    return () => {
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+    };
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
     function onMessage(e: MessageEvent) {
       if (expectedOrigin && e.origin !== expectedOrigin) return;
-      if (e.data && e.data.type === "agent-native-feedback-close") {
+      const type = e.data && e.data.type;
+      if (type === "agent-native-feedback-close") {
         setOpen(false);
+      } else if (type === "agent-native-feedback-submitted") {
+        setSubmitted(true);
+        if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = setTimeout(() => setOpen(false), 1600);
       }
     }
     window.addEventListener("message", onMessage);
@@ -115,14 +177,29 @@ export function FeedbackButton({
           collisionPadding={16}
           className="z-[300] overflow-hidden rounded-lg border border-border bg-popover shadow-xl outline-none"
         >
-          <iframe
-            title="Feedback form"
-            src={embedUrl}
-            style={iframeWrapStyle}
-            sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
-            referrerPolicy="no-referrer"
-            className="block border-0"
-          />
+          <div className="relative" style={surfaceStyle}>
+            <iframe
+              title="Feedback form"
+              src={embedUrl}
+              sandbox="allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
+              referrerPolicy="no-referrer"
+              onLoad={() => setLoaded(true)}
+              className={cn(
+                "absolute inset-0 block h-full w-full border-0 transition-opacity duration-200",
+                loaded && !submitted ? "opacity-100" : "opacity-0",
+              )}
+            />
+            {!loaded && !submitted && (
+              <div className="absolute inset-0">
+                <FeedbackSkeleton />
+              </div>
+            )}
+            {submitted && (
+              <div className="absolute inset-0 bg-popover">
+                <FeedbackThanks />
+              </div>
+            )}
+          </div>
         </PopoverPrimitive.Content>
       </PopoverPrimitive.Portal>
     </PopoverPrimitive.Root>

--- a/templates/forms/server/lib/public-form-ssr.ts
+++ b/templates/forms/server/lib/public-form-ssr.ts
@@ -411,6 +411,9 @@ ${form.description ? `<meta name="description" content="${escapeHtml(form.descri
       if (REDIRECT) { window.location.href = REDIRECT; return; }
       document.querySelector(".container").style.display = "none";
       document.getElementById("successView").style.display = "flex";
+      if (html.classList.contains("embedded") && window.parent !== window) {
+        try { window.parent.postMessage({ type: "agent-native-feedback-submitted" }, "*"); } catch (_) {}
+      }
     })
     .catch(function(err) {
       showToast(err.message || "Failed to submit form");
@@ -569,6 +572,8 @@ html:not(.dark) .icon-moon{display:none}
 .embedded .header{margin-bottom:20px}
 .embedded .header h1{font-size:1.125rem}
 .embedded .desc{font-size:0.8125rem}
+.embedded .success-view{margin-top:32px}
+.embedded .success-view h1{font-size:1.125rem}
 
 .toast{
   position:fixed;bottom:24px;left:50%;transform:translateX(-50%);


### PR DESCRIPTION
## Summary
- Feedback popover shows a skeleton while the iframe loads instead of a blank surface
- Embedded forms post \`agent-native-feedback-submitted\` on success; the popover swaps to a \"Thanks\" card and auto-closes 1.6s later
- Embedded success-view tightened to fit the 320px popover

## Test plan
- [ ] Click the Feedback icon in the agent-panel header — skeleton shows, fades to the form
- [ ] Submit the form — \"Thanks for the feedback!\" appears, popover closes automatically
- [ ] Reopen — no stale \"Thanks\" view, fresh skeleton then fresh form
- [ ] Public form page (non-embed) still renders the normal success view

🤖 Generated with [Claude Code](https://claude.com/claude-code)