### PR TITLE
updates-116: PR #225 feedback fixes (stacks on #225)

### DIFF
--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -31,8 +31,8 @@ export async function getOrgContext(event: H3Event): Promise<OrgContext> {
       sql: `SELECT m.org_id AS "orgId", m.role AS role, o.name AS "orgName"
             FROM org_members m
             INNER JOIN organizations o ON m.org_id = o.id
-            WHERE m.email = ?`,
-      args: [email],
+            WHERE LOWER(m.email) = ?`,
+      args: [email.toLowerCase()],
     });
     memberships = rows.map((r: any) => ({
       orgId: String(r.orgId ?? r.org_id),

--- a/packages/core/src/org/handlers.ts
+++ b/packages/core/src/org/handlers.ts
@@ -90,8 +90,8 @@ export const getMyOrgHandler = defineEventHandler(async (event: H3Event) => {
     sql: `SELECT m.org_id AS "orgId", m.role AS role, o.name AS "orgName"
           FROM org_members m
           INNER JOIN organizations o ON m.org_id = o.id
-          WHERE m.email = ?`,
-    args: [ctx.email],
+          WHERE LOWER(m.email) = ?`,
+    args: [ctx.email.toLowerCase()],
   });
   const orgs = allOrgsRes.rows.map((r: any) => ({
     orgId: String(r.orgId ?? r.org_id),

--- a/packages/core/src/secrets/register.ts
+++ b/packages/core/src/secrets/register.ts
@@ -64,8 +64,9 @@ const REGISTRY_KEY = Symbol.for("@agent-native/core/secrets.registry");
 interface GlobalWithRegistry {
   [REGISTRY_KEY]?: Map<string, RegisteredSecret>;
 }
-const registry: Map<string, RegisteredSecret> =
-  ((globalThis as unknown as GlobalWithRegistry)[REGISTRY_KEY] ??= new Map());
+const registry: Map<string, RegisteredSecret> = ((
+  globalThis as unknown as GlobalWithRegistry
+)[REGISTRY_KEY] ??= new Map());
 
 /**
  * Register (or override) a required secret.

--- a/packages/core/src/secrets/register.ts
+++ b/packages/core/src/secrets/register.ts
@@ -54,7 +54,18 @@ export interface RegisteredSecret {
   oauthConnectUrl?: string;
 }
 
-const registry = new Map<string, RegisteredSecret>();
+// Pin the registry to globalThis so templates that load `@agent-native/core`
+// via more than one ESM graph (e.g. dev-mode Vite + Nitro, symlinked
+// node_modules, dist/ vs src/) share a single registry. Without this, a
+// template's `register-secrets.ts` side-effect module may populate one
+// registry instance while the /_agent-native/secrets route reads from
+// another — net effect: the UI sees an empty list.
+const REGISTRY_KEY = Symbol.for("@agent-native/core/secrets.registry");
+interface GlobalWithRegistry {
+  [REGISTRY_KEY]?: Map<string, RegisteredSecret>;
+}
+const registry: Map<string, RegisteredSecret> =
+  ((globalThis as unknown as GlobalWithRegistry)[REGISTRY_KEY] ??= new Map());
 
 /**
  * Register (or override) a required secret.

--- a/packages/core/src/server/app-url.ts
+++ b/packages/core/src/server/app-url.ts
@@ -53,9 +53,9 @@ export function getAppProductionUrl(event?: H3Event): string {
   const envUrl = process.env.APP_URL || process.env.BETTER_AUTH_URL;
   if (envUrl) return stripTrailingSlash(envUrl);
 
-  const firstParty = getFirstPartyProdUrl();
-  if (firstParty) return stripTrailingSlash(firstParty);
-
+  // Prefer the incoming request's origin when we have one — for local dev
+  // this is `http://localhost:3000`, which keeps Better Auth from setting
+  // `Secure` cookies on plain-HTTP dev servers.
   if (event) {
     try {
       const url = getRequestURL(event);
@@ -63,6 +63,14 @@ export function getAppProductionUrl(event?: H3Event): string {
     } catch {
       // fall through
     }
+  }
+
+  // Only fall back to a first-party template's hard-coded prod URL when we
+  // are actually running in production. In dev the hard-coded URL is always
+  // wrong (wrong host) and breaks auth via the Secure-cookie issue above.
+  if (process.env.NODE_ENV === "production") {
+    const firstParty = getFirstPartyProdUrl();
+    if (firstParty) return stripTrailingSlash(firstParty);
   }
 
   return "http://localhost:3000";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,10 +118,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
@@ -190,7 +190,7 @@ importers:
         version: 4.0.2
       nitro:
         specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+        version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
       ollama-ai-provider:
         specifier: '>=1'
         version: 1.2.0(zod@3.25.76)
@@ -272,7 +272,7 @@ importers:
         version: 8.18.1
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -314,7 +314,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1)
@@ -637,6 +637,9 @@ importers:
       '@tabler/icons-react':
         specifier: ^3.40.0
         version: 3.41.1(react@18.3.1)
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9)
       h3:
         specifier: ^2.0.1-rc.20
         version: 2.0.1-rc.20(crossws@0.4.4(srvx@0.11.15))
@@ -1224,10 +1227,10 @@ importers:
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-router/dev':
         specifier: ^7.13.1
-        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+        version: 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       '@react-router/fs-routes':
         specifier: ^7.13.1
-        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
+        version: 7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)
       '@tanstack/react-query':
         specifier: ^5.84.2
         version: 5.96.2(react@18.3.1)
@@ -1323,7 +1326,7 @@ importers:
         version: 1.1.2(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vite:
         specifier: ^8.0.0
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
 
   templates/clips/desktop:
     dependencies:
@@ -19868,53 +19871,6 @@ snapshots:
       - supports-color
       - terser
 
-  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@react-router/node': 7.14.0(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
-      '@remix-run/node-fetch-server': 0.13.0
-      arg: 5.0.2
-      babel-dead-code-elimination: 1.0.12
-      chokidar: 4.0.3
-      dedent: 1.7.2
-      es-module-lexer: 1.7.0
-      exit-hook: 2.2.1
-      isbot: 5.1.37
-      jsesc: 3.0.2
-      lodash: 4.18.1
-      p-map: 7.0.4
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      pkg-types: 2.3.0
-      prettier: 3.8.1
-      react-refresh: 0.14.2
-      react-router: 7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      valibot: 1.3.1(typescript@5.9.3)
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@24.12.2)(lightningcss@1.32.0)(terser@5.46.1)
-    optionalDependencies:
-      typescript: 5.9.3
-      wrangler: 4.81.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -19962,7 +19918,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
+  '@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -19992,7 +19948,7 @@ snapshots:
       semver: 7.7.4
       tinyglobby: 0.2.15
       valibot: 1.3.1(typescript@5.9.3)
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@24.12.2)(lightningcss@1.32.0)(terser@5.46.1)
     optionalDependencies:
       typescript: 5.9.3
@@ -20023,13 +19979,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
-    dependencies:
-      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
-      minimatch: 10.2.5
-    optionalDependencies:
-      typescript: 5.9.3
-
   '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
     dependencies:
       '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
@@ -20037,9 +19986,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
+  '@react-router/fs-routes@7.14.0(@react-router/dev@7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0))(typescript@5.9.3)':
     dependencies:
-      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
+      '@react-router/dev': 7.14.0(@types/node@24.12.2)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(terser@5.46.1)(typescript@5.9.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))(wrangler@4.81.0)
       minimatch: 10.2.5
     optionalDependencies:
       typescript: 5.9.3
@@ -21358,6 +21307,14 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       '@swc/core': 1.15.21
       vite: 5.4.21(@types/node@24.12.2)(lightningcss@1.32.0)(sass@1.51.0)(terser@5.46.1)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
+  '@vitejs/plugin-react-swc@4.3.0(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      '@swc/core': 1.15.21
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -25927,7 +25884,7 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro@3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)):
+  nitro@3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(giget@3.2.0)(ioredis@5.10.1)(jiti@1.21.7)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.4(srvx@0.11.15)
@@ -25946,9 +25903,9 @@ snapshots:
     optionalDependencies:
       dotenv: 17.4.0
       giget: 3.2.0
-      jiti: 2.6.1
+      jiti: 1.21.7
       rollup: 4.60.1
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -107,16 +107,20 @@ Dashboard configs, explorer configs, and theme settings are stored in SQL via th
 
 Solo-mode dashboards/configs are user-scoped. Org dashboards/views are org-scoped. Legacy global rows still load as a fallback, and the Team-page upgrade flow can move those legacy rows onto the signed-in user during migration from local mode.
 
-### Sharing (follow-up)
+### Sharing
 
-The framework ships a standard sharing primitive (private-by-default resources with per-user/per-org share grants and a `<ShareButton>` UI — see the `sharing` skill). **This template does not yet opt in.** Dashboards and analyses are stored in the settings KV store (`u:<email>:dashboard-*`, `o:<orgId>:sql-dashboard-*`, `adhoc-analysis-*`), not SQL resource tables — so the `ownableColumns()` / `createSharesTable()` factories don't apply as-is.
+Dashboards and analyses are **private by default**. The framework's sharing primitive is wired up:
 
-Two options for adopting sharing here:
+| Action                    | Args                                                                                                                                         | Purpose                                |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| `share-resource`          | `--resourceType dashboard\|analysis --resourceId <id> --principalType user\|org --principalId <email-or-orgId> --role viewer\|editor\|admin` | Grant access to a dashboard / analysis |
+| `unshare-resource`        | `--resourceType dashboard\|analysis --resourceId <id> --principalType user\|org --principalId <value>`                                       | Revoke a share grant                   |
+| `list-resource-shares`    | `--resourceType dashboard\|analysis --resourceId <id>`                                                                                       | Show current visibility + grants       |
+| `set-resource-visibility` | `--resourceType dashboard\|analysis --resourceId <id> --visibility private\|org\|public`                                                     | Change coarse visibility               |
 
-1. **Migrate dashboards & analyses to SQL resource tables** (`dashboards`, `analyses`) with `ownableColumns()`, keep the current settings keys as a compatibility read path, then wire up `ShareButton` in the dashboard/analysis toolbars.
-2. **Add a parallel share overlay to the settings store** — e.g. a `settings_shares` table that maps a `setting_key` to principals with roles — and teach the settings read path to check it.
+Read (`/api/sql-dashboards/:id`, `/api/analyses/:id`) admits rows the current user owns, has been shared on, or that match the resource's visibility. Write (save / update via handlers or the `update-dashboard` / `save-analysis` actions) requires `editor` role; delete requires `admin`. Owners always satisfy.
 
-Option 1 is cleaner long-term; option 2 is less invasive. Tracked — ping before starting either.
+**Storage.** Dashboards and analyses now live in SQL (`dashboards`, `analyses`, `dashboard_shares`, `analysis_shares`, `dashboard_views`). Legacy settings-KV keys (`u:<email>:dashboard-*`, `u:<email>:sql-dashboard-*`, `o:<orgId>:sql-dashboard-*`, `adhoc-analysis-*`) are read as a fallback on first access and copied into SQL automatically — existing dashboards are preserved. See `server/lib/dashboards-store.ts` for the exact migration policy.
 
 ## Organizations & Team
 

--- a/templates/analytics/actions/delete-analysis.ts
+++ b/templates/analytics/actions/delete-analysis.ts
@@ -4,12 +4,7 @@ import {
   getRequestOrgId,
 } from "@agent-native/core/server";
 import { z } from "zod";
-import {
-  deleteOrgSetting,
-  deleteUserSetting,
-} from "@agent-native/core/settings";
-
-const KEY_PREFIX = "adhoc-analysis-";
+import { removeAnalysis } from "../server/lib/dashboards-store";
 
 export default defineAction({
   description: "Delete a saved ad-hoc analysis by ID.",
@@ -20,14 +15,7 @@ export default defineAction({
   run: async (args) => {
     const orgId = getRequestOrgId() || null;
     const email = getRequestUserEmail() || "local@localhost";
-    const key = `${KEY_PREFIX}${args.id}`;
-
-    // Scoped delete only — never touch the global settings table.
-    if (orgId) {
-      await deleteOrgSetting(orgId, key);
-    } else {
-      await deleteUserSetting(email, key);
-    }
+    await removeAnalysis(args.id, { email, orgId });
     return `Analysis "${args.id}" deleted.`;
   },
 });

--- a/templates/analytics/actions/get-analysis.ts
+++ b/templates/analytics/actions/get-analysis.ts
@@ -4,9 +4,7 @@ import {
   getRequestOrgId,
 } from "@agent-native/core/server";
 import { z } from "zod";
-import { getOrgSetting, getUserSetting } from "@agent-native/core/settings";
-
-const KEY_PREFIX = "adhoc-analysis-";
+import { getAnalysis } from "../server/lib/dashboards-store";
 
 export default defineAction({
   description: "Get a saved ad-hoc analysis by ID, including its full results.",
@@ -17,18 +15,23 @@ export default defineAction({
   run: async (args) => {
     const orgId = getRequestOrgId() || null;
     const email = getRequestUserEmail() || "local@localhost";
-    const key = `${KEY_PREFIX}${args.id}`;
-
-    // Always use a scoped lookup — never fall through to global `getSetting`,
-    // which would leak any user's analysis by ID guess. Local-mode analyses
-    // live at `u:local@localhost:adhoc-analysis-*`.
-    const data =
-      (orgId ? await getOrgSetting(orgId, key) : null) ||
-      (await getUserSetting(email, key));
-
-    if (!data) {
-      return { error: "Analysis not found" };
-    }
-    return data;
+    const a = await getAnalysis(args.id, { email, orgId });
+    if (!a) return { error: "Analysis not found" };
+    return {
+      id: a.id,
+      name: a.name,
+      description: a.description,
+      question: a.question,
+      instructions: a.instructions,
+      dataSources: a.dataSources,
+      resultMarkdown: a.resultMarkdown,
+      resultData: a.resultData,
+      author: a.author,
+      createdAt: a.createdAt,
+      updatedAt: a.updatedAt,
+      ownerEmail: a.ownerEmail,
+      orgId: a.orgId,
+      visibility: a.visibility,
+    };
   },
 });

--- a/templates/analytics/actions/list-analyses.ts
+++ b/templates/analytics/actions/list-analyses.ts
@@ -3,9 +3,7 @@ import {
   getRequestUserEmail,
   getRequestOrgId,
 } from "@agent-native/core/server";
-import { getAllSettings, listOrgSettings } from "@agent-native/core/settings";
-
-const KEY_PREFIX = "adhoc-analysis-";
+import { listAnalyses } from "../server/lib/dashboards-store";
 
 export default defineAction({
   description:
@@ -15,49 +13,22 @@ export default defineAction({
   run: async () => {
     const orgId = getRequestOrgId() || null;
     const email = getRequestUserEmail() || "local@localhost";
-
-    const analyses: Record<string, unknown>[] = [];
-    const seen = new Set<string>();
-
-    const collect = (raw: unknown) => {
-      const a = raw as Record<string, unknown> | null;
-      if (!a || typeof a !== "object") return;
-      const id = a.id as string | undefined;
-      if (!id || seen.has(id)) return;
-      seen.add(id);
-      analyses.push({
-        id,
+    const rows = await listAnalyses({ email, orgId });
+    return rows
+      .map((a) => ({
+        id: a.id,
         name: a.name,
         description: a.description,
         dataSources: a.dataSources,
         createdAt: a.createdAt,
         updatedAt: a.updatedAt,
         author: a.author,
-      });
-    };
-
-    // Org-scoped first (wins on id conflicts since it's collected first).
-    if (orgId) {
-      const orgAnalyses = await listOrgSettings(orgId, KEY_PREFIX);
-      for (const value of Object.values(orgAnalyses)) collect(value);
-    }
-
-    // User-scoped (namespaced by `u:<email>:` prefix). No public
-    // `listUserSettings` helper exists, so iterate the table once and
-    // filter by the exact user prefix — NOT a substring match (that was
-    // the vulnerability: it leaked every user's analyses to everyone).
-    const userPrefix = `u:${email}:${KEY_PREFIX}`;
-    const all = await getAllSettings();
-    for (const [fullKey, value] of Object.entries(all)) {
-      if (!fullKey.startsWith(userPrefix)) continue;
-      collect(value);
-    }
-
-    analyses.sort(
-      (a: any, b: any) =>
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-    );
-
-    return analyses;
+        ownerEmail: a.ownerEmail,
+        visibility: a.visibility,
+      }))
+      .sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+      );
   },
 });

--- a/templates/analytics/actions/save-analysis.ts
+++ b/templates/analytics/actions/save-analysis.ts
@@ -4,14 +4,7 @@ import {
   getRequestOrgId,
 } from "@agent-native/core/server";
 import { z } from "zod";
-import {
-  getOrgSetting,
-  getUserSetting,
-  putOrgSetting,
-  putUserSetting,
-} from "@agent-native/core/settings";
-
-const KEY_PREFIX = "adhoc-analysis-";
+import { upsertAnalysis } from "../server/lib/dashboards-store";
 
 function resolveScope() {
   const orgId = getRequestOrgId() || null;
@@ -70,44 +63,19 @@ export default defineAction({
   http: false,
   run: async (args) => {
     const { orgId, email } = resolveScope();
-    const key = `${KEY_PREFIX}${args.id}`;
-    const now = new Date().toISOString();
-
-    // Check if this analysis already exists (to preserve createdAt). Always
-    // look in a scoped key (org or user) — never in the global settings
-    // table, so one user's analyses can't bleed across tenants.
-    let existing: Record<string, unknown> | null = null;
-    try {
-      existing = orgId
-        ? await getOrgSetting(orgId, key)
-        : await getUserSetting(email, key);
-    } catch {
-      // Not found
-    }
-
-    const analysis = {
-      id: args.id,
-      name: args.name,
-      description: args.description,
-      question: args.question,
-      instructions: args.instructions,
-      dataSources: args.dataSources,
-      resultMarkdown: args.resultMarkdown,
-      resultData: args.resultData ?? null,
-      createdAt: (existing as any)?.createdAt ?? now,
-      updatedAt: now,
-      author: email,
-    };
-
-    // Always write to a scoped key (org or user). Local-mode analyses go
-    // under `u:local@localhost:adhoc-analysis-*` so the existing
-    // migrateLocalUserData flow renames them to the real account on sign-in.
-    if (orgId) {
-      await putOrgSetting(orgId, key, analysis);
-    } else {
-      await putUserSetting(email, key, analysis);
-    }
-
+    await upsertAnalysis(
+      args.id,
+      {
+        name: args.name,
+        description: args.description,
+        question: args.question,
+        instructions: args.instructions,
+        dataSources: args.dataSources,
+        resultMarkdown: args.resultMarkdown,
+        resultData: args.resultData ?? null,
+      },
+      { email, orgId },
+    );
     return `Analysis "${args.name}" saved as ${args.id}. Users can view it at /analyses/${args.id} and re-run it anytime for fresh results.`;
   },
 });

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -4,14 +4,7 @@ import {
   getRequestOrgId,
 } from "@agent-native/core/server";
 import { z } from "zod";
-import {
-  getOrgSetting,
-  getSetting,
-  getUserSetting,
-  putOrgSetting,
-  putSetting,
-  putUserSetting,
-} from "@agent-native/core/settings";
+import { getDashboard, upsertDashboard } from "../server/lib/dashboards-store";
 import { dryRunQuery } from "../server/lib/bigquery";
 import { interpolate } from "../app/pages/adhoc/sql-dashboard/interpolate";
 
@@ -44,7 +37,6 @@ function buildDryRunVars(
   return vars;
 }
 
-const KEY_PREFIX = "sql-dashboard-";
 const LOCAL_EMAIL = "local@localhost";
 
 type JsonOp = {
@@ -263,42 +255,9 @@ function resolveScope() {
   return { orgId, email };
 }
 
-async function readScoped(
-  scope: { orgId: string | null; email: string },
-  key: string,
-): Promise<{
-  value: Record<string, unknown>;
-  scope: "org" | "user" | "global";
-} | null> {
-  if (scope.orgId) {
-    const v = await getOrgSetting(scope.orgId, key);
-    if (v) return { value: v, scope: "org" };
-  }
-  if (scope.email && scope.email !== LOCAL_EMAIL) {
-    const v = await getUserSetting(scope.email, key);
-    if (v) return { value: v, scope: "user" };
-  }
-  const v = await getSetting(key);
-  return v ? { value: v, scope: "global" } : null;
-}
-
-async function writeScoped(
-  scope: { orgId: string | null; email: string },
-  key: string,
-  value: Record<string, unknown>,
-  resolvedScope: "org" | "user" | "global",
-): Promise<void> {
-  // Write back to the SAME scope we read from so we don't create drift.
-  if (resolvedScope === "org" && scope.orgId) {
-    await putOrgSetting(scope.orgId, key, value);
-    return;
-  }
-  if (resolvedScope === "user" && scope.email && scope.email !== LOCAL_EMAIL) {
-    await putUserSetting(scope.email, key, value);
-    return;
-  }
-  await putSetting(key, value);
-}
+// Reads + writes now go through the SQL-backed dashboards store, which
+// lazy-migrates legacy settings keys on first access. See
+// `server/lib/dashboards-store.ts`.
 
 export default defineAction({
   description:
@@ -354,25 +313,23 @@ export default defineAction({
     }
 
     const scope = resolveScope();
-    const key = `${KEY_PREFIX}${args.dashboardId}`;
+    const ctx = { email: scope.email, orgId: scope.orgId };
 
     if (args.config) {
       const validation = validateDashboardConfig(args.config);
       if (validation) return `Error: ${validation}`;
       const sqlError = await validatePanelSql(args.config);
       if (sqlError) return `Error: ${sqlError}`;
-      const existing = await readScoped(scope, key);
-      const resolvedScope = existing?.scope ?? (scope.orgId ? "org" : "user");
-      await writeScoped(scope, key, args.config, resolvedScope as any);
-      return `Dashboard "${args.dashboardId}" replaced (scope: ${resolvedScope}).`;
+      await upsertDashboard(args.dashboardId, "sql", args.config, ctx);
+      return `Dashboard "${args.dashboardId}" replaced.`;
     }
 
-    const existing = await readScoped(scope, key);
+    const existing = await getDashboard(args.dashboardId, ctx);
     if (!existing) {
-      return `Error: dashboard "${args.dashboardId}" not found in org, user, or global scope.`;
+      return `Error: dashboard "${args.dashboardId}" not found (or you don't have access).`;
     }
 
-    const root = existing.value as any;
+    const root = existing.config as any;
     const details: string[] = [];
     for (const op of args.ops!) {
       try {
@@ -385,10 +342,15 @@ export default defineAction({
     const sqlError = await validatePanelSql(root);
     if (sqlError) return `Error: ${sqlError}`;
 
-    await writeScoped(scope, key, root, existing.scope);
+    await upsertDashboard(
+      args.dashboardId,
+      existing.kind,
+      root as Record<string, unknown>,
+      ctx,
+    );
 
     return (
-      `Dashboard "${args.dashboardId}" updated (scope: ${existing.scope}). ` +
+      `Dashboard "${args.dashboardId}" updated. ` +
       `Applied ${details.length} op(s): ${details.join("; ")}. ` +
       `Call refresh-screen to update the UI.`
     );

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -8,6 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { IconPencil, IconPlus, IconTrash } from "@tabler/icons-react";
+import { ShareButton } from "@agent-native/core/client";
 import { getIdToken } from "@/lib/auth";
 import { SqlChartCard } from "./SqlChartCard";
 import {
@@ -396,6 +397,14 @@ export default function SqlDashboardPage() {
   useSetHeaderActions(
     dashboard ? (
       <>
+        {dashboardId ? (
+          <ShareButton
+            resourceType="dashboard"
+            resourceId={dashboardId}
+            resourceTitle={dashboard.name}
+            variant="compact"
+          />
+        ) : null}
         <Button size="sm" variant="outline" onClick={openAddPanel}>
           <IconPlus className="h-4 w-4 mr-1" />
           Add panel

--- a/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
+++ b/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
@@ -24,6 +24,7 @@ import {
   IconDatabase,
 } from "@tabler/icons-react";
 import { Link, useNavigate } from "react-router";
+import { ShareButton } from "@agent-native/core/client";
 import { getIdToken } from "@/lib/auth";
 import { useSendToAgentChat } from "@agent-native/core/client";
 import Markdown from "@/components/Markdown";
@@ -122,6 +123,12 @@ export default function AnalysisDetail() {
   useSetHeaderActions(
     analysis ? (
       <>
+        <ShareButton
+          resourceType="analysis"
+          resourceId={analysis.id}
+          resourceTitle={analysis.name}
+          variant="compact"
+        />
         <Button
           variant="default"
           size="sm"

--- a/templates/analytics/package.json
+++ b/templates/analytics/package.json
@@ -28,6 +28,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@libsql/client": "^0.15.8",
     "@tabler/icons-react": "^3.40.0",
+    "drizzle-orm": "^0.45.2",
     "h3": "^2.0.1-rc.20",
     "isbot": "^5",
     "zod": "^3.25.76"

--- a/templates/analytics/server/db/index.ts
+++ b/templates/analytics/server/db/index.ts
@@ -1,0 +1,24 @@
+import * as schema from "./schema.js";
+import { createGetDb } from "@agent-native/core/db";
+import { registerShareableResource } from "@agent-native/core/sharing";
+
+export const getDb = createGetDb(schema);
+export { schema };
+
+registerShareableResource({
+  type: "dashboard",
+  resourceTable: schema.dashboards,
+  sharesTable: schema.dashboardShares,
+  displayName: "Dashboard",
+  titleColumn: "title",
+  getDb,
+});
+
+registerShareableResource({
+  type: "analysis",
+  resourceTable: schema.analyses,
+  sharesTable: schema.analysisShares,
+  displayName: "Analysis",
+  titleColumn: "name",
+  getDb,
+});

--- a/templates/analytics/server/db/schema.ts
+++ b/templates/analytics/server/db/schema.ts
@@ -1,0 +1,84 @@
+import {
+  table,
+  text,
+  integer,
+  now,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
+
+/**
+ * Dashboards table — covers both Explorer and SQL dashboards. The
+ * distinction lives in `kind` and the shape of the `config` JSON blob.
+ * Previously stored in the settings KV store under
+ * `u:<email>:dashboard-{id}` / `u:<email>:sql-dashboard-{id}` /
+ * `o:<orgId>:sql-dashboard-{id}`. Those keys are read as a fallback
+ * during lazy migration (see server/lib/dashboards-store.ts) and the
+ * legacy rows can be removed once the team is sure everyone's migrated.
+ */
+export const dashboards = table("dashboards", {
+  id: text("id").primaryKey(),
+  kind: text("kind", { enum: ["explorer", "sql"] }).notNull(),
+  title: text("title").notNull().default("Untitled"),
+  /** Full dashboard config (SqlDashboardConfig or Explorer state) as JSON. */
+  config: text("config").notNull(),
+  createdAt: text("created_at").notNull().default(now()),
+  updatedAt: text("updated_at").notNull().default(now()),
+  ...ownableColumns(),
+});
+
+export const dashboardShares = createSharesTable("dashboard_shares");
+
+/**
+ * Saved filter views per dashboard. Lives alongside the parent and is
+ * governed by the parent's sharing (no separate share rows).
+ */
+export const dashboardViews = table("dashboard_views", {
+  id: text("id").primaryKey(),
+  dashboardId: text("dashboard_id").notNull(),
+  name: text("name").notNull(),
+  /** Filter params as JSON (Record<string, string>). */
+  filters: text("filters").notNull().default("{}"),
+  createdBy: text("created_by"),
+  createdAt: text("created_at").notNull().default(now()),
+});
+
+/**
+ * Ad-hoc analyses. Previously stored in the settings KV store under
+ * `adhoc-analysis-{id}`. Those keys are read as a fallback during lazy
+ * migration. See server/lib/analyses-store.ts.
+ */
+export const analyses = table("analyses", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  description: text("description").notNull().default(""),
+  /** Original user question that triggered the analysis. */
+  question: text("question").notNull().default(""),
+  /** Step-by-step re-run instructions. */
+  instructions: text("instructions").notNull().default(""),
+  /** Data sources referenced, as JSON array of strings. */
+  dataSources: text("data_sources").notNull().default("[]"),
+  /** Full findings in Markdown. */
+  resultMarkdown: text("result_markdown").notNull().default(""),
+  /** Optional structured result data, as JSON. */
+  resultData: text("result_data"),
+  author: text("author"),
+  createdAt: text("created_at").notNull().default(now()),
+  updatedAt: text("updated_at").notNull().default(now()),
+  ...ownableColumns(),
+});
+
+export const analysisShares = createSharesTable("analysis_shares");
+
+/**
+ * BigQuery result cache (pre-existing — moved here from db plugin so a
+ * single drizzle schema covers the template).
+ */
+export const bigqueryCache = table("bigquery_cache", {
+  key: text("key").primaryKey(),
+  sql: text("sql").notNull(),
+  result: text("result").notNull(),
+  bytesProcessed: integer("bytes_processed").notNull().default(0),
+  createdAt: text("created_at").notNull(),
+  expiresAt: text("expires_at").notNull(),
+});

--- a/templates/analytics/server/handlers/analyses.ts
+++ b/templates/analytics/server/handlers/analyses.ts
@@ -1,33 +1,36 @@
 import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
+import { getOrgContext } from "@agent-native/core/org";
 import {
-  deleteScopedSettingRecord,
-  getScopedSettingRecord,
-  listScopedSettingRecords,
-  resolveSettingsScope,
-} from "../lib/scoped-settings";
+  getAnalysis as loadAnalysis,
+  listAnalyses as loadAnalyses,
+  removeAnalysis,
+} from "../lib/dashboards-store";
 
-const KEY_PREFIX = "adhoc-analysis-";
+async function ctxFromEvent(event: any) {
+  const ctx = await getOrgContext(event);
+  return { email: ctx.email, orgId: ctx.orgId ?? null };
+}
 
 export const listAnalyses = defineEventHandler(async (event) => {
   try {
-    const scope = await resolveSettingsScope(event);
-    const all = await listScopedSettingRecords(scope, KEY_PREFIX);
-    const analyses = Object.entries(all).map(([key, data]) => {
-      const raw = data as any;
-      return {
-        id: raw.id ?? key.slice(KEY_PREFIX.length),
-        name: raw.name,
-        description: raw.description,
-        dataSources: raw.dataSources,
-        createdAt: raw.createdAt,
-        updatedAt: raw.updatedAt,
-        author: raw.author,
-      };
-    });
-    analyses.sort(
-      (a, b) =>
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-    );
+    const ctx = await ctxFromEvent(event);
+    const rows = await loadAnalyses(ctx);
+    const analyses = rows
+      .map((a) => ({
+        id: a.id,
+        name: a.name,
+        description: a.description,
+        dataSources: a.dataSources,
+        createdAt: a.createdAt,
+        updatedAt: a.updatedAt,
+        author: a.author,
+        ownerEmail: a.ownerEmail,
+        visibility: a.visibility,
+      }))
+      .sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+      );
     return { analyses };
   } catch (err: any) {
     setResponseStatus(event, 500);
@@ -42,16 +45,31 @@ export const getAnalysis = defineEventHandler(async (event) => {
     return { error: "Missing analysis id" };
   }
   try {
-    const key = `${KEY_PREFIX}${id}`;
-    const scope = await resolveSettingsScope(event);
-    const data = await getScopedSettingRecord(scope, key);
-    if (!data) {
+    const ctx = await ctxFromEvent(event);
+    const a = await loadAnalysis(id, ctx);
+    if (!a) {
       setResponseStatus(event, 404);
       return { error: "Analysis not found" };
     }
-    return { id, ...data };
+    return {
+      id,
+      name: a.name,
+      description: a.description,
+      question: a.question,
+      instructions: a.instructions,
+      dataSources: a.dataSources,
+      resultMarkdown: a.resultMarkdown,
+      resultData: a.resultData,
+      author: a.author,
+      createdAt: a.createdAt,
+      updatedAt: a.updatedAt,
+      ownerEmail: a.ownerEmail,
+      orgId: a.orgId,
+      visibility: a.visibility,
+    };
   } catch (err: any) {
-    setResponseStatus(event, 500);
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
     return { error: err.message };
   }
 });
@@ -62,8 +80,13 @@ export const deleteAnalysis = defineEventHandler(async (event) => {
     setResponseStatus(event, 400);
     return { error: "Missing analysis id" };
   }
-  const scope = await resolveSettingsScope(event);
-  const key = `${KEY_PREFIX}${id}`;
-  await deleteScopedSettingRecord(scope, key);
-  return { id, success: true };
+  try {
+    const ctx = await ctxFromEvent(event);
+    await removeAnalysis(id, ctx);
+    return { id, success: true };
+  } catch (err: any) {
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
+    return { error: err.message };
+  }
 });

--- a/templates/analytics/server/handlers/dashboard-views.ts
+++ b/templates/analytics/server/handlers/dashboard-views.ts
@@ -1,12 +1,16 @@
 import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
 import { readBody } from "@agent-native/core/server";
+import { getOrgContext } from "@agent-native/core/org";
 import {
-  getScopedSettingRecord,
-  putScopedSettingRecord,
-  resolveSettingsScope,
-} from "../lib/scoped-settings";
+  listDashboardViews as loadViews,
+  saveDashboardView as storeView,
+  deleteDashboardView as removeView,
+} from "../lib/dashboards-store";
 
-const KEY_PREFIX = "dashboard-views-";
+async function ctxFromEvent(event: any) {
+  const ctx = await getOrgContext(event);
+  return { email: ctx.email, orgId: ctx.orgId ?? null };
+}
 
 export interface DashboardView {
   id: string;
@@ -17,41 +21,21 @@ export interface DashboardView {
   createdAt?: string;
 }
 
-interface ViewsData {
-  views: DashboardView[];
-}
-
-async function getViewsData(
-  scope: { email: string; orgId: string | null },
-  dashboardId: string,
-): Promise<ViewsData> {
-  const key = `${KEY_PREFIX}${dashboardId}`;
-  const data = await getScopedSettingRecord(scope, key);
-  return (data as unknown as ViewsData) ?? { views: [] };
-}
-
-async function putViewsData(
-  scope: { email: string; orgId: string | null },
-  dashboardId: string,
-  data: ViewsData,
-): Promise<void> {
-  const key = `${KEY_PREFIX}${dashboardId}`;
-  await putScopedSettingRecord(
-    scope,
-    key,
-    data as unknown as Record<string, unknown>,
-  );
-}
-
 export const listDashboardViews = defineEventHandler(async (event) => {
   const dashboardId = getRouterParam(event, "dashboardId");
   if (!dashboardId) {
     setResponseStatus(event, 400);
     return { error: "Missing dashboardId" };
   }
-  const scope = await resolveSettingsScope(event);
-  const data = await getViewsData(scope, dashboardId);
-  return { views: data.views };
+  try {
+    const ctx = await ctxFromEvent(event);
+    const views = await loadViews(dashboardId, ctx);
+    return { views };
+  } catch (err: any) {
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
+    return { error: err.message };
+  }
 });
 
 export const saveDashboardView = defineEventHandler(async (event) => {
@@ -60,33 +44,25 @@ export const saveDashboardView = defineEventHandler(async (event) => {
     setResponseStatus(event, 400);
     return { error: "Missing dashboardId" };
   }
-  const scope = await resolveSettingsScope(event);
-  const body = await readBody(event);
-  const { id, name, filters } = body as DashboardView;
-  if (!id || !name) {
-    setResponseStatus(event, 400);
-    return { error: "Missing id or name" };
+  try {
+    const ctx = await ctxFromEvent(event);
+    const body = await readBody(event);
+    const { id, name, filters } = body as DashboardView;
+    if (!name) {
+      setResponseStatus(event, 400);
+      return { error: "Missing name" };
+    }
+    const view = await storeView(
+      dashboardId,
+      { id, name, filters: filters ?? {} },
+      ctx,
+    );
+    return { success: true, view };
+  } catch (err: any) {
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
+    return { error: err.message };
   }
-
-  const data = await getViewsData(scope, dashboardId);
-  const existing = data.views.findIndex((v) => v.id === id);
-  const view: DashboardView = {
-    id,
-    name,
-    filters: filters ?? {},
-    createdBy: scope.email,
-    createdAt:
-      existing >= 0 ? data.views[existing].createdAt : new Date().toISOString(),
-  };
-
-  if (existing >= 0) {
-    data.views[existing] = view;
-  } else {
-    data.views.push(view);
-  }
-
-  await putViewsData(scope, dashboardId, data);
-  return { success: true, view };
 });
 
 export const deleteDashboardView = defineEventHandler(async (event) => {
@@ -96,9 +72,13 @@ export const deleteDashboardView = defineEventHandler(async (event) => {
     setResponseStatus(event, 400);
     return { error: "Missing dashboardId or viewId" };
   }
-  const scope = await resolveSettingsScope(event);
-  const data = await getViewsData(scope, dashboardId);
-  data.views = data.views.filter((v) => v.id !== viewId);
-  await putViewsData(scope, dashboardId, data);
-  return { success: true };
+  try {
+    const ctx = await ctxFromEvent(event);
+    await removeView(dashboardId, viewId, ctx);
+    return { success: true };
+  } catch (err: any) {
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
+    return { error: err.message };
+  }
 });

--- a/templates/analytics/server/handlers/explorer-dashboards.ts
+++ b/templates/analytics/server/handlers/explorer-dashboards.ts
@@ -1,22 +1,28 @@
 import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
 import { readBody } from "@agent-native/core/server";
+import { getOrgContext } from "@agent-native/core/org";
 import {
-  deleteScopedSettingRecord,
-  getScopedSettingRecord,
-  listScopedSettingRecords,
-  putScopedSettingRecord,
-  resolveSettingsScope,
-} from "../lib/scoped-settings";
+  getDashboard,
+  listDashboards,
+  upsertDashboard,
+  removeDashboard,
+} from "../lib/dashboards-store";
 
-const KEY_PREFIX = "dashboard-";
+async function ctxFromEvent(event: any) {
+  const ctx = await getOrgContext(event);
+  return { email: ctx.email, orgId: ctx.orgId ?? null };
+}
 
 export const listExplorerDashboards = defineEventHandler(async (event) => {
   try {
-    const scope = await resolveSettingsScope(event);
-    const all = await listScopedSettingRecords(scope, KEY_PREFIX);
-    const dashboards = Object.entries(all).map(([key, data]) => ({
-      id: key.slice(KEY_PREFIX.length),
-      ...data,
+    const ctx = await ctxFromEvent(event);
+    const rows = await listDashboards(ctx, { kind: "explorer" });
+    const dashboards = rows.map((d) => ({
+      id: d.id,
+      ...(d.config as Record<string, unknown>),
+      ownerEmail: d.ownerEmail,
+      orgId: d.orgId,
+      visibility: d.visibility,
     }));
     return { dashboards };
   } catch (err: any) {
@@ -27,40 +33,62 @@ export const listExplorerDashboards = defineEventHandler(async (event) => {
 
 export const getExplorerDashboard = defineEventHandler(async (event) => {
   const id = getRouterParam(event, "id");
+  if (!id) {
+    setResponseStatus(event, 400);
+    return { error: "Missing dashboard id" };
+  }
   try {
-    const scope = await resolveSettingsScope(event);
-    const data = await getScopedSettingRecord(scope, `${KEY_PREFIX}${id}`);
-    if (!data) {
+    const ctx = await ctxFromEvent(event);
+    const dash = await getDashboard(id, ctx);
+    if (!dash || dash.kind !== "explorer") {
       setResponseStatus(event, 404);
       return { error: "Dashboard not found" };
     }
-    return { id, ...data };
+    return {
+      id,
+      ...(dash.config as Record<string, unknown>),
+      ownerEmail: dash.ownerEmail,
+      orgId: dash.orgId,
+      visibility: dash.visibility,
+    };
   } catch (err: any) {
-    setResponseStatus(event, 500);
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
     return { error: err.message };
   }
 });
 
 export const saveExplorerDashboard = defineEventHandler(async (event) => {
   const id = getRouterParam(event, "id");
+  if (!id) {
+    setResponseStatus(event, 400);
+    return { error: "Missing dashboard id" };
+  }
   try {
-    const body = await readBody(event);
-    const scope = await resolveSettingsScope(event);
-    await putScopedSettingRecord(
-      scope,
-      `${KEY_PREFIX}${id}`,
-      body as Record<string, unknown>,
-    );
+    const body = (await readBody(event)) as Record<string, unknown>;
+    const ctx = await ctxFromEvent(event);
+    await upsertDashboard(id, "explorer", body, ctx);
     return { id, success: true };
   } catch (err: any) {
-    setResponseStatus(event, 500);
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
     return { error: err.message };
   }
 });
 
 export const deleteExplorerDashboard = defineEventHandler(async (event) => {
   const id = getRouterParam(event, "id");
-  const scope = await resolveSettingsScope(event);
-  await deleteScopedSettingRecord(scope, `${KEY_PREFIX}${id}`);
-  return { id, success: true };
+  if (!id) {
+    setResponseStatus(event, 400);
+    return { error: "Missing dashboard id" };
+  }
+  try {
+    const ctx = await ctxFromEvent(event);
+    await removeDashboard(id, ctx);
+    return { id, success: true };
+  } catch (err: any) {
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
+    return { error: err.message };
+  }
 });

--- a/templates/analytics/server/handlers/sql-dashboards.ts
+++ b/templates/analytics/server/handlers/sql-dashboards.ts
@@ -1,16 +1,19 @@
 import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
 import { readBody } from "@agent-native/core/server";
+import { getOrgContext } from "@agent-native/core/org";
 import {
-  deleteScopedSettingRecord,
-  getScopedSettingRecord,
-  listScopedSettingRecords,
-  putScopedSettingRecord,
-  resolveSettingsScope,
-} from "../lib/scoped-settings";
+  getDashboard,
+  listDashboards,
+  upsertDashboard,
+  removeDashboard,
+} from "../lib/dashboards-store";
 import { dryRunQuery } from "../lib/bigquery";
 import { interpolate } from "../../app/pages/adhoc/sql-dashboard/interpolate";
 
-const KEY_PREFIX = "sql-dashboard-";
+async function ctxFromEvent(event: any) {
+  const ctx = await getOrgContext(event);
+  return { email: ctx.email, orgId: ctx.orgId ?? null };
+}
 
 /**
  * Build the variable map used when dry-running a panel's SQL. Variables
@@ -45,11 +48,14 @@ function buildDryRunVars(
 
 export const listSqlDashboards = defineEventHandler(async (event) => {
   try {
-    const scope = await resolveSettingsScope(event);
-    const all = await listScopedSettingRecords(scope, KEY_PREFIX);
-    const dashboards = Object.entries(all).map(([key, data]) => ({
-      id: key.slice(KEY_PREFIX.length),
-      ...data,
+    const ctx = await ctxFromEvent(event);
+    const rows = await listDashboards(ctx, { kind: "sql" });
+    const dashboards = rows.map((d) => ({
+      id: d.id,
+      ...(d.config as Record<string, unknown>),
+      ownerEmail: d.ownerEmail,
+      orgId: d.orgId,
+      visibility: d.visibility,
     }));
     return { dashboards };
   } catch (err: any) {
@@ -65,16 +71,22 @@ export const getSqlDashboard = defineEventHandler(async (event) => {
     return { error: "Missing dashboard id" };
   }
   try {
-    const key = `${KEY_PREFIX}${id}`;
-    const scope = await resolveSettingsScope(event);
-    const data = await getScopedSettingRecord(scope, key);
-    if (!data) {
+    const ctx = await ctxFromEvent(event);
+    const dash = await getDashboard(id, ctx);
+    if (!dash || dash.kind !== "sql") {
       setResponseStatus(event, 404);
       return { error: "Dashboard not found" };
     }
-    return { id, ...data };
+    return {
+      id,
+      ...(dash.config as Record<string, unknown>),
+      ownerEmail: dash.ownerEmail,
+      orgId: dash.orgId,
+      visibility: dash.visibility,
+    };
   } catch (err: any) {
-    setResponseStatus(event, 500);
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
     return { error: err.message };
   }
 });
@@ -97,12 +109,12 @@ export const saveSqlDashboard = defineEventHandler(async (event) => {
       setResponseStatus(event, 400);
       return { error: sqlError };
     }
-    const scope = await resolveSettingsScope(event);
-    const key = `${KEY_PREFIX}${id}`;
-    await putScopedSettingRecord(scope, key, body);
+    const ctx = await ctxFromEvent(event);
+    await upsertDashboard(id, "sql", body, ctx);
     return { id, success: true };
   } catch (err: any) {
-    setResponseStatus(event, 500);
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
     return { error: err.message };
   }
 });
@@ -222,8 +234,13 @@ export const deleteSqlDashboard = defineEventHandler(async (event) => {
     setResponseStatus(event, 400);
     return { error: "Missing dashboard id" };
   }
-  const scope = await resolveSettingsScope(event);
-  const key = `${KEY_PREFIX}${id}`;
-  await deleteScopedSettingRecord(scope, key);
-  return { id, success: true };
+  try {
+    const ctx = await ctxFromEvent(event);
+    await removeDashboard(id, ctx);
+    return { id, success: true };
+  } catch (err: any) {
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
+    return { error: err.message };
+  }
 });

--- a/templates/analytics/server/lib/dashboards-store.ts
+++ b/templates/analytics/server/lib/dashboards-store.ts
@@ -1,0 +1,744 @@
+/**
+ * Dashboards + analyses store — SQL first, legacy settings-KV as
+ * read-only fallback. Writes always go to SQL.
+ *
+ * Lazy migration: when a record is fetched by id and exists only in the
+ * legacy settings store, it is copied into SQL on the fly using the
+ * settings key as the source of truth for `ownerEmail` / `orgId` /
+ * `visibility`, then returned. Subsequent reads hit SQL directly.
+ *
+ * - `u:<email>:dashboard-{id}`     → kind='explorer', owner=email,  visibility='private'
+ * - `u:<email>:sql-dashboard-{id}` → kind='sql',      owner=email,  visibility='private'
+ * - `o:<orgId>:sql-dashboard-{id}` → kind='sql',      owner=caller, visibility='org'
+ * - `adhoc-analysis-{id}`          → owner=caller,   visibility='org' (if org ctx)
+ */
+import { and, eq } from "drizzle-orm";
+import {
+  accessFilter,
+  assertAccess,
+  resolveAccess,
+} from "@agent-native/core/sharing";
+import {
+  getAllSettings,
+  getOrgSetting,
+  getUserSetting,
+  getSetting,
+  deleteOrgSetting,
+  deleteUserSetting,
+  deleteSetting,
+} from "@agent-native/core/settings";
+import { getDb, schema } from "../db/index.js";
+
+export type DashboardKind = "explorer" | "sql";
+
+export interface DashboardRecord {
+  id: string;
+  kind: DashboardKind;
+  title: string;
+  config: Record<string, unknown>;
+  ownerEmail: string;
+  orgId: string | null;
+  visibility: "private" | "org" | "public";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AnalysisRecord {
+  id: string;
+  name: string;
+  description: string;
+  question: string;
+  instructions: string;
+  dataSources: string[];
+  resultMarkdown: string;
+  resultData: Record<string, unknown> | null;
+  author: string | null;
+  ownerEmail: string;
+  orgId: string | null;
+  visibility: "private" | "org" | "public";
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface AccessCtx {
+  email: string;
+  orgId: string | null;
+}
+
+const LOCAL_EMAIL = "local@localhost";
+const SQL_PREFIX = "sql-dashboard-";
+const EXPLORER_PREFIX = "dashboard-";
+const ANALYSIS_PREFIX = "adhoc-analysis-";
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function nanoidFallback(): string {
+  return (
+    Math.random().toString(36).slice(2, 10) +
+    Math.random().toString(36).slice(2, 10)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dashboards
+// ---------------------------------------------------------------------------
+
+function rowToDashboard(row: any): DashboardRecord {
+  return {
+    id: row.id,
+    kind: row.kind,
+    title: row.title,
+    config:
+      typeof row.config === "string" ? JSON.parse(row.config) : row.config,
+    ownerEmail: row.ownerEmail,
+    orgId: row.orgId ?? null,
+    visibility: row.visibility,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function configFromSettings(data: Record<string, unknown>): {
+  title: string;
+  config: Record<string, unknown>;
+} {
+  const title =
+    typeof (data as any).name === "string"
+      ? (data as any).name
+      : typeof (data as any).title === "string"
+        ? (data as any).title
+        : "Untitled";
+  return { title, config: data };
+}
+
+async function migrateDashboardFromSettings(
+  id: string,
+  kind: DashboardKind,
+  settingsValue: Record<string, unknown>,
+  ownerEmail: string,
+  orgId: string | null,
+  visibility: DashboardRecord["visibility"],
+): Promise<DashboardRecord> {
+  const { title, config } = configFromSettings(settingsValue);
+  const db = getDb() as any;
+  const createdAt =
+    (typeof (settingsValue as any).createdAt === "string" &&
+      (settingsValue as any).createdAt) ||
+    nowIso();
+  const updatedAt =
+    (typeof (settingsValue as any).updatedAt === "string" &&
+      (settingsValue as any).updatedAt) ||
+    createdAt;
+  await db
+    .insert(schema.dashboards)
+    .values({
+      id,
+      kind,
+      title,
+      config: JSON.stringify(config),
+      ownerEmail,
+      orgId,
+      visibility,
+      createdAt,
+      updatedAt,
+    })
+    .onConflictDoNothing();
+  const [row] = await db
+    .select()
+    .from(schema.dashboards)
+    .where(eq(schema.dashboards.id, id));
+  return rowToDashboard(row);
+}
+
+async function findLegacyDashboard(
+  id: string,
+  ctx: AccessCtx,
+): Promise<{
+  data: Record<string, unknown>;
+  kind: DashboardKind;
+  ownerEmail: string;
+  orgId: string | null;
+  visibility: DashboardRecord["visibility"];
+} | null> {
+  // Org-scoped SQL dashboard
+  if (ctx.orgId) {
+    const v = await getOrgSetting(ctx.orgId, `${SQL_PREFIX}${id}`);
+    if (v)
+      return {
+        data: v,
+        kind: "sql",
+        ownerEmail: ctx.email || LOCAL_EMAIL,
+        orgId: ctx.orgId,
+        visibility: "org",
+      };
+  }
+  // User-scoped SQL dashboard
+  if (ctx.email) {
+    const v = await getUserSetting(ctx.email, `${SQL_PREFIX}${id}`);
+    if (v)
+      return {
+        data: v,
+        kind: "sql",
+        ownerEmail: ctx.email,
+        orgId: null,
+        visibility: "private",
+      };
+  }
+  // User-scoped Explorer dashboard
+  if (ctx.email) {
+    const v = await getUserSetting(ctx.email, `${EXPLORER_PREFIX}${id}`);
+    if (v)
+      return {
+        data: v,
+        kind: "explorer",
+        ownerEmail: ctx.email,
+        orgId: null,
+        visibility: "private",
+      };
+  }
+  // Global fallback for both shapes
+  const sqlGlobal = await getSetting(`${SQL_PREFIX}${id}`);
+  if (sqlGlobal)
+    return {
+      data: sqlGlobal,
+      kind: "sql",
+      ownerEmail: ctx.email || LOCAL_EMAIL,
+      orgId: null,
+      visibility: "private",
+    };
+  const explorerGlobal = await getSetting(`${EXPLORER_PREFIX}${id}`);
+  if (explorerGlobal)
+    return {
+      data: explorerGlobal,
+      kind: "explorer",
+      ownerEmail: ctx.email || LOCAL_EMAIL,
+      orgId: null,
+      visibility: "private",
+    };
+  return null;
+}
+
+/** Fetch a dashboard by id, enforcing access. Lazy-migrates from legacy keys. */
+export async function getDashboard(
+  id: string,
+  ctx: AccessCtx,
+): Promise<DashboardRecord | null> {
+  const db = getDb() as any;
+  // 1) SQL first, with access check.
+  const access = await resolveAccess("dashboard", id, {
+    userEmail: ctx.email,
+    orgId: ctx.orgId ?? undefined,
+  });
+  if (access) return rowToDashboard(access.resource);
+  // 2) Legacy fallback.
+  const legacy = await findLegacyDashboard(id, ctx);
+  if (!legacy) return null;
+  return migrateDashboardFromSettings(
+    id,
+    legacy.kind,
+    legacy.data,
+    legacy.ownerEmail,
+    legacy.orgId,
+    legacy.visibility,
+  );
+}
+
+/** List dashboards visible to the caller. Union of SQL rows + not-yet-migrated legacy keys. */
+export async function listDashboards(
+  ctx: AccessCtx,
+  filter?: { kind?: DashboardKind },
+): Promise<DashboardRecord[]> {
+  const db = getDb() as any;
+  const where = filter?.kind
+    ? and(
+        eq(schema.dashboards.kind, filter.kind),
+        accessFilter(schema.dashboards, schema.dashboardShares, {
+          userEmail: ctx.email,
+          orgId: ctx.orgId ?? undefined,
+        }),
+      )
+    : accessFilter(schema.dashboards, schema.dashboardShares, {
+        userEmail: ctx.email,
+        orgId: ctx.orgId ?? undefined,
+      });
+  const rows = await db.select().from(schema.dashboards).where(where);
+  const out: DashboardRecord[] = rows.map(rowToDashboard);
+  const seen = new Set(out.map((r) => r.id));
+  // Legacy: scan settings once and surface anything not yet migrated.
+  try {
+    const all = await getAllSettings();
+    for (const [key, value] of Object.entries(all)) {
+      let id: string | null = null;
+      let kind: DashboardKind | null = null;
+      let ownerEmail = ctx.email || LOCAL_EMAIL;
+      let orgId: string | null = null;
+      let visibility: DashboardRecord["visibility"] = "private";
+      if (ctx.orgId && key.startsWith(`o:${ctx.orgId}:${SQL_PREFIX}`)) {
+        id = key.slice(`o:${ctx.orgId}:${SQL_PREFIX}`.length);
+        kind = "sql";
+        orgId = ctx.orgId;
+        visibility = "org";
+      } else if (ctx.email && key.startsWith(`u:${ctx.email}:${SQL_PREFIX}`)) {
+        id = key.slice(`u:${ctx.email}:${SQL_PREFIX}`.length);
+        kind = "sql";
+      } else if (
+        ctx.email &&
+        key.startsWith(`u:${ctx.email}:${EXPLORER_PREFIX}`)
+      ) {
+        id = key.slice(`u:${ctx.email}:${EXPLORER_PREFIX}`.length);
+        kind = "explorer";
+      }
+      if (!id || !kind) continue;
+      if (filter?.kind && filter.kind !== kind) continue;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const rec = await migrateDashboardFromSettings(
+        id,
+        kind,
+        value as Record<string, unknown>,
+        ownerEmail,
+        orgId,
+        visibility,
+      );
+      out.push(rec);
+    }
+  } catch {
+    // Legacy scan is best-effort.
+  }
+  return out;
+}
+
+/**
+ * Upsert a dashboard. On create, caller becomes owner and visibility
+ * defaults to `private` (single-user) or `org` (when org context is set).
+ * On update, `assertAccess` requires `editor`.
+ */
+export async function upsertDashboard(
+  id: string,
+  kind: DashboardKind,
+  body: Record<string, unknown>,
+  ctx: AccessCtx,
+): Promise<DashboardRecord> {
+  // If the row exists (or legacy-migrates), require editor.
+  const existing = await getDashboard(id, ctx);
+  const db = getDb() as any;
+  const { title, config } = configFromSettings(body);
+  if (existing) {
+    await assertAccess("dashboard", id, "editor", {
+      userEmail: ctx.email,
+      orgId: ctx.orgId ?? undefined,
+    });
+    await db
+      .update(schema.dashboards)
+      .set({
+        kind,
+        title,
+        config: JSON.stringify(config),
+        updatedAt: nowIso(),
+      })
+      .where(eq(schema.dashboards.id, id));
+  } else {
+    await db.insert(schema.dashboards).values({
+      id,
+      kind,
+      title,
+      config: JSON.stringify(config),
+      ownerEmail: ctx.email || LOCAL_EMAIL,
+      orgId: ctx.orgId,
+      // Default to org-wide when the user is in an org, private otherwise.
+      visibility: ctx.orgId ? "org" : "private",
+    });
+  }
+  const [row] = await db
+    .select()
+    .from(schema.dashboards)
+    .where(eq(schema.dashboards.id, id));
+  return rowToDashboard(row);
+}
+
+/** Delete a dashboard. Cleans legacy keys too. Requires admin/owner. */
+export async function removeDashboard(
+  id: string,
+  ctx: AccessCtx,
+): Promise<void> {
+  const existing = await getDashboard(id, ctx);
+  if (!existing) return;
+  await assertAccess("dashboard", id, "admin", {
+    userEmail: ctx.email,
+    orgId: ctx.orgId ?? undefined,
+  });
+  const db = getDb() as any;
+  await db.delete(schema.dashboards).where(eq(schema.dashboards.id, id));
+  await db
+    .delete(schema.dashboardShares)
+    .where(eq(schema.dashboardShares.resourceId, id));
+  // Best-effort legacy cleanup.
+  try {
+    if (ctx.orgId) await deleteOrgSetting(ctx.orgId, `${SQL_PREFIX}${id}`);
+    if (ctx.email) {
+      await deleteUserSetting(ctx.email, `${SQL_PREFIX}${id}`);
+      await deleteUserSetting(ctx.email, `${EXPLORER_PREFIX}${id}`);
+    }
+    await deleteSetting(`${SQL_PREFIX}${id}`);
+    await deleteSetting(`${EXPLORER_PREFIX}${id}`);
+  } catch {
+    // legacy cleanup is best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Analyses
+// ---------------------------------------------------------------------------
+
+function rowToAnalysis(row: any): AnalysisRecord {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    question: row.question,
+    instructions: row.instructions,
+    dataSources: safeJsonParse(row.dataSources, []),
+    resultMarkdown: row.resultMarkdown,
+    resultData: row.resultData ? safeJsonParse(row.resultData, null) : null,
+    author: row.author ?? null,
+    ownerEmail: row.ownerEmail,
+    orgId: row.orgId ?? null,
+    visibility: row.visibility,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function safeJsonParse<T>(s: unknown, fallback: T): T {
+  if (typeof s !== "string") return fallback;
+  try {
+    return JSON.parse(s) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+async function findLegacyAnalysis(
+  id: string,
+  ctx: AccessCtx,
+): Promise<{
+  data: Record<string, unknown>;
+  ownerEmail: string;
+  orgId: string | null;
+  visibility: AnalysisRecord["visibility"];
+} | null> {
+  const key = `${ANALYSIS_PREFIX}${id}`;
+  if (ctx.orgId) {
+    const v = await getOrgSetting(ctx.orgId, key);
+    if (v)
+      return {
+        data: v,
+        ownerEmail: ctx.email || LOCAL_EMAIL,
+        orgId: ctx.orgId,
+        visibility: "org",
+      };
+  }
+  if (ctx.email) {
+    const v = await getUserSetting(ctx.email, key);
+    if (v)
+      return {
+        data: v,
+        ownerEmail: ctx.email,
+        orgId: null,
+        visibility: "private",
+      };
+  }
+  const global = await getSetting(key);
+  if (global)
+    return {
+      data: global,
+      ownerEmail: ctx.email || LOCAL_EMAIL,
+      orgId: null,
+      visibility: "private",
+    };
+  return null;
+}
+
+async function migrateAnalysisFromSettings(
+  id: string,
+  data: Record<string, unknown>,
+  ownerEmail: string,
+  orgId: string | null,
+  visibility: AnalysisRecord["visibility"],
+): Promise<AnalysisRecord> {
+  const db = getDb() as any;
+  const createdAt =
+    (typeof data.createdAt === "string" && data.createdAt) || nowIso();
+  const updatedAt =
+    (typeof data.updatedAt === "string" && data.updatedAt) || createdAt;
+  await db
+    .insert(schema.analyses)
+    .values({
+      id,
+      name: (data.name as string) ?? "Untitled",
+      description: (data.description as string) ?? "",
+      question: (data.question as string) ?? "",
+      instructions: (data.instructions as string) ?? "",
+      dataSources: JSON.stringify(data.dataSources ?? []),
+      resultMarkdown: (data.resultMarkdown as string) ?? "",
+      resultData: data.resultData ? JSON.stringify(data.resultData) : null,
+      author: (data.author as string) ?? ownerEmail,
+      ownerEmail,
+      orgId,
+      visibility,
+      createdAt,
+      updatedAt,
+    })
+    .onConflictDoNothing();
+  const [row] = await db
+    .select()
+    .from(schema.analyses)
+    .where(eq(schema.analyses.id, id));
+  return rowToAnalysis(row);
+}
+
+export async function getAnalysis(
+  id: string,
+  ctx: AccessCtx,
+): Promise<AnalysisRecord | null> {
+  const access = await resolveAccess("analysis", id, {
+    userEmail: ctx.email,
+    orgId: ctx.orgId ?? undefined,
+  });
+  if (access) return rowToAnalysis(access.resource);
+  const legacy = await findLegacyAnalysis(id, ctx);
+  if (!legacy) return null;
+  return migrateAnalysisFromSettings(
+    id,
+    legacy.data,
+    legacy.ownerEmail,
+    legacy.orgId,
+    legacy.visibility,
+  );
+}
+
+export async function listAnalyses(ctx: AccessCtx): Promise<AnalysisRecord[]> {
+  const db = getDb() as any;
+  const rows = await db
+    .select()
+    .from(schema.analyses)
+    .where(
+      accessFilter(schema.analyses, schema.analysisShares, {
+        userEmail: ctx.email,
+        orgId: ctx.orgId ?? undefined,
+      }),
+    );
+  const out = rows.map(rowToAnalysis);
+  const seen = new Set<string>(out.map((r) => r.id));
+  try {
+    const all = await getAllSettings();
+    for (const [key, value] of Object.entries(all)) {
+      let id: string | null = null;
+      let ownerEmail = ctx.email || LOCAL_EMAIL;
+      let orgId: string | null = null;
+      let visibility: AnalysisRecord["visibility"] = "private";
+      if (ctx.orgId && key.startsWith(`o:${ctx.orgId}:${ANALYSIS_PREFIX}`)) {
+        id = key.slice(`o:${ctx.orgId}:${ANALYSIS_PREFIX}`.length);
+        orgId = ctx.orgId;
+        visibility = "org";
+      } else if (
+        ctx.email &&
+        key.startsWith(`u:${ctx.email}:${ANALYSIS_PREFIX}`)
+      ) {
+        id = key.slice(`u:${ctx.email}:${ANALYSIS_PREFIX}`.length);
+      } else if (
+        key.startsWith(ANALYSIS_PREFIX) &&
+        !key.startsWith("u:") &&
+        !key.startsWith("o:")
+      ) {
+        id = key.slice(ANALYSIS_PREFIX.length);
+      }
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      const rec = await migrateAnalysisFromSettings(
+        id,
+        value as Record<string, unknown>,
+        ownerEmail,
+        orgId,
+        visibility,
+      );
+      out.push(rec);
+    }
+  } catch {
+    // legacy scan best-effort
+  }
+  return out;
+}
+
+export async function upsertAnalysis(
+  id: string,
+  body: {
+    name?: string;
+    description?: string;
+    question?: string;
+    instructions?: string;
+    dataSources?: string[];
+    resultMarkdown?: string;
+    resultData?: Record<string, unknown> | null;
+  },
+  ctx: AccessCtx,
+): Promise<AnalysisRecord> {
+  const existing = await getAnalysis(id, ctx);
+  const db = getDb() as any;
+  if (existing) {
+    await assertAccess("analysis", id, "editor", {
+      userEmail: ctx.email,
+      orgId: ctx.orgId ?? undefined,
+    });
+    const patch: Record<string, unknown> = { updatedAt: nowIso() };
+    if (body.name !== undefined) patch.name = body.name;
+    if (body.description !== undefined) patch.description = body.description;
+    if (body.question !== undefined) patch.question = body.question;
+    if (body.instructions !== undefined) patch.instructions = body.instructions;
+    if (body.dataSources !== undefined)
+      patch.dataSources = JSON.stringify(body.dataSources);
+    if (body.resultMarkdown !== undefined)
+      patch.resultMarkdown = body.resultMarkdown;
+    if (body.resultData !== undefined)
+      patch.resultData = body.resultData
+        ? JSON.stringify(body.resultData)
+        : null;
+    await db
+      .update(schema.analyses)
+      .set(patch)
+      .where(eq(schema.analyses.id, id));
+  } else {
+    await db.insert(schema.analyses).values({
+      id,
+      name: body.name ?? "Untitled",
+      description: body.description ?? "",
+      question: body.question ?? "",
+      instructions: body.instructions ?? "",
+      dataSources: JSON.stringify(body.dataSources ?? []),
+      resultMarkdown: body.resultMarkdown ?? "",
+      resultData: body.resultData ? JSON.stringify(body.resultData) : null,
+      author: ctx.email || LOCAL_EMAIL,
+      ownerEmail: ctx.email || LOCAL_EMAIL,
+      orgId: ctx.orgId,
+      visibility: ctx.orgId ? "org" : "private",
+    });
+  }
+  const [row] = await db
+    .select()
+    .from(schema.analyses)
+    .where(eq(schema.analyses.id, id));
+  return rowToAnalysis(row);
+}
+
+export async function removeAnalysis(
+  id: string,
+  ctx: AccessCtx,
+): Promise<void> {
+  const existing = await getAnalysis(id, ctx);
+  if (!existing) return;
+  await assertAccess("analysis", id, "admin", {
+    userEmail: ctx.email,
+    orgId: ctx.orgId ?? undefined,
+  });
+  const db = getDb() as any;
+  await db.delete(schema.analyses).where(eq(schema.analyses.id, id));
+  await db
+    .delete(schema.analysisShares)
+    .where(eq(schema.analysisShares.resourceId, id));
+  try {
+    if (ctx.orgId) await deleteOrgSetting(ctx.orgId, `${ANALYSIS_PREFIX}${id}`);
+    if (ctx.email)
+      await deleteUserSetting(ctx.email, `${ANALYSIS_PREFIX}${id}`);
+    await deleteSetting(`${ANALYSIS_PREFIX}${id}`);
+  } catch {
+    // best-effort
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard views (child of dashboard — no separate sharing)
+// ---------------------------------------------------------------------------
+
+export interface DashboardViewRecord {
+  id: string;
+  dashboardId: string;
+  name: string;
+  filters: Record<string, string>;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+function rowToView(row: any): DashboardViewRecord {
+  return {
+    id: row.id,
+    dashboardId: row.dashboardId,
+    name: row.name,
+    filters: safeJsonParse(row.filters, {} as Record<string, string>),
+    createdBy: row.createdBy ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+export async function listDashboardViews(
+  dashboardId: string,
+  ctx: AccessCtx,
+): Promise<DashboardViewRecord[]> {
+  // Parent access gates view visibility.
+  const dash = await getDashboard(dashboardId, ctx);
+  if (!dash) return [];
+  const db = getDb() as any;
+  const rows = await db
+    .select()
+    .from(schema.dashboardViews)
+    .where(eq(schema.dashboardViews.dashboardId, dashboardId));
+  return rows.map(rowToView);
+}
+
+export async function saveDashboardView(
+  dashboardId: string,
+  view: { id?: string; name: string; filters: Record<string, string> },
+  ctx: AccessCtx,
+): Promise<DashboardViewRecord> {
+  await assertAccess("dashboard", dashboardId, "editor", {
+    userEmail: ctx.email,
+    orgId: ctx.orgId ?? undefined,
+  });
+  const db = getDb() as any;
+  const id = view.id ?? nanoidFallback();
+  if (view.id) {
+    await db
+      .update(schema.dashboardViews)
+      .set({ name: view.name, filters: JSON.stringify(view.filters) })
+      .where(eq(schema.dashboardViews.id, id));
+  } else {
+    await db.insert(schema.dashboardViews).values({
+      id,
+      dashboardId,
+      name: view.name,
+      filters: JSON.stringify(view.filters),
+      createdBy: ctx.email || null,
+    });
+  }
+  const [row] = await db
+    .select()
+    .from(schema.dashboardViews)
+    .where(eq(schema.dashboardViews.id, id));
+  return rowToView(row);
+}
+
+export async function deleteDashboardView(
+  dashboardId: string,
+  viewId: string,
+  ctx: AccessCtx,
+): Promise<void> {
+  await assertAccess("dashboard", dashboardId, "editor", {
+    userEmail: ctx.email,
+    orgId: ctx.orgId ?? undefined,
+  });
+  const db = getDb() as any;
+  await db
+    .delete(schema.dashboardViews)
+    .where(eq(schema.dashboardViews.id, viewId));
+}

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -79,22 +79,14 @@ export default createAgentChatPlugin({
       search: async (query: string, event?: any) => {
         if (!event) return [];
         try {
-          const scope = await resolveSettingsScope(event);
-          const all = await listScopedSettingRecords(
-            scope,
-            SQL_DASHBOARD_PREFIX,
+          const { getOrgContext } = await import("@agent-native/core/org");
+          const { listDashboards } = await import("../lib/dashboards-store.js");
+          const ctx = await getOrgContext(event);
+          const rows = await listDashboards(
+            { email: ctx.email, orgId: ctx.orgId ?? null },
+            { kind: "sql" },
           );
-          const items = Object.entries(all)
-            .map(([key, data]) => {
-              const id = key.slice(SQL_DASHBOARD_PREFIX.length);
-              const rawName = (data as { name?: unknown })?.name;
-              const name =
-                typeof rawName === "string" && rawName.trim().length > 0
-                  ? rawName.trim()
-                  : undefined;
-              return { id, name };
-            })
-            .filter((d) => d.id.length > 0);
+          const items = rows.map((d) => ({ id: d.id, name: d.title }));
 
           const q = (query || "").toLowerCase().trim();
           const filtered = q

--- a/templates/analytics/server/plugins/db.ts
+++ b/templates/analytics/server/plugins/db.ts
@@ -1,4 +1,7 @@
 import { runMigrations } from "@agent-native/core/db";
+// Side-effect import: ensures registerShareableResource runs on server
+// startup so the dashboard / analysis share actions know where to dispatch.
+import "../db/index.js";
 
 export default runMigrations([
   {
@@ -15,5 +18,88 @@ export default runMigrations([
   {
     version: 2,
     sql: `CREATE INDEX IF NOT EXISTS bigquery_cache_expires_at_idx ON bigquery_cache (expires_at)`,
+  },
+  // --- v3+: framework sharing — dashboards + analyses migrated from settings-KV.
+  //   Lazy migration: existing settings keys are read as a fallback on first
+  //   access and copied into these tables. See server/lib/dashboards-store.ts.
+  {
+    version: 3,
+    sql: `CREATE TABLE IF NOT EXISTS dashboards (
+      id TEXT PRIMARY KEY,
+      kind TEXT NOT NULL,
+      title TEXT NOT NULL DEFAULT 'Untitled',
+      config TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      owner_email TEXT NOT NULL DEFAULT 'local@localhost',
+      org_id TEXT,
+      visibility TEXT NOT NULL DEFAULT 'private'
+    )`,
+  },
+  {
+    version: 4,
+    sql: `CREATE TABLE IF NOT EXISTS dashboard_shares (
+      id TEXT PRIMARY KEY,
+      resource_id TEXT NOT NULL,
+      principal_type TEXT NOT NULL,
+      principal_id TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'viewer',
+      created_by TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+  },
+  {
+    version: 5,
+    sql: `CREATE TABLE IF NOT EXISTS dashboard_views (
+      id TEXT PRIMARY KEY,
+      dashboard_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      filters TEXT NOT NULL DEFAULT '{}',
+      created_by TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+  },
+  {
+    version: 6,
+    sql: `CREATE TABLE IF NOT EXISTS analyses (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      question TEXT NOT NULL DEFAULT '',
+      instructions TEXT NOT NULL DEFAULT '',
+      data_sources TEXT NOT NULL DEFAULT '[]',
+      result_markdown TEXT NOT NULL DEFAULT '',
+      result_data TEXT,
+      author TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      owner_email TEXT NOT NULL DEFAULT 'local@localhost',
+      org_id TEXT,
+      visibility TEXT NOT NULL DEFAULT 'private'
+    )`,
+  },
+  {
+    version: 7,
+    sql: `CREATE TABLE IF NOT EXISTS analysis_shares (
+      id TEXT PRIMARY KEY,
+      resource_id TEXT NOT NULL,
+      principal_type TEXT NOT NULL,
+      principal_id TEXT NOT NULL,
+      role TEXT NOT NULL DEFAULT 'viewer',
+      created_by TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+  },
+  {
+    version: 8,
+    sql: `CREATE INDEX IF NOT EXISTS dashboard_shares_resource_idx ON dashboard_shares (resource_id)`,
+  },
+  {
+    version: 9,
+    sql: `CREATE INDEX IF NOT EXISTS analysis_shares_resource_idx ON analysis_shares (resource_id)`,
+  },
+  {
+    version: 10,
+    sql: `CREATE INDEX IF NOT EXISTS dashboard_views_dashboard_idx ON dashboard_views (dashboard_id)`,
   },
 ]);

--- a/templates/clips/actions/request-transcript.ts
+++ b/templates/clips/actions/request-transcript.ts
@@ -125,14 +125,12 @@ export default defineAction({
     //  1. Dev fallback — finalize-recording stashed the assembled blob in
     //     application_state under `recording-blob-:id`. Read it directly
     //     instead of round-tripping through HTTP (avoids the localhost-port
-    //     guess and works under any port / host).
+    //     guess and works under any port / host). Covers both the current
+    //     `/api/video/:id` shape and the legacy `/api/uploads/:id/blob`.
     //  2. Production — videoUrl is an absolute URL on a real provider
     //     (Builder.io / R2 / S3). Fetch it normally.
     let videoBlob: Blob;
     try {
-      // Dev fallback path set by finalize-recording when no provider is
-      // configured. Current shape: `/api/video/:id`. Legacy shape
-      // `/api/uploads/:id/blob` is still accepted for old rows.
       const isLocalBlob =
         rec.videoUrl.startsWith("/api/video/") ||
         (rec.videoUrl.startsWith("/api/uploads/") &&
@@ -148,10 +146,12 @@ export default defineAction({
       } else {
         let videoUrl = rec.videoUrl;
         if (videoUrl.startsWith("/")) {
+          const port =
+            process.env.NITRO_PORT || process.env.PORT || "3000";
           const origin =
             process.env.PUBLIC_URL ??
             process.env.NITRO_PUBLIC_URL ??
-            `http://localhost:${process.env.PORT ?? 3000}`;
+            `http://localhost:${port}`;
           videoUrl = `${origin}${videoUrl}`;
         }
         const vidRes = await fetch(videoUrl);

--- a/templates/clips/actions/request-transcript.ts
+++ b/templates/clips/actions/request-transcript.ts
@@ -146,8 +146,7 @@ export default defineAction({
       } else {
         let videoUrl = rec.videoUrl;
         if (videoUrl.startsWith("/")) {
-          const port =
-            process.env.NITRO_PORT || process.env.PORT || "3000";
+          const port = process.env.NITRO_PORT || process.env.PORT || "3000";
           const origin =
             process.env.PUBLIC_URL ??
             process.env.NITRO_PUBLIC_URL ??

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -4,11 +4,18 @@
 //! toggles it. Pressing Cmd/Ctrl+Shift+L also toggles it. The popover itself
 //! is served by the Vite-built React UI (see `../dist`).
 
+use std::sync::Mutex;
 use tauri::{
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    AppHandle, Manager, PhysicalPosition, PhysicalSize, WebviewWindow,
+    AppHandle, Manager, PhysicalPosition, PhysicalSize, Rect, WebviewWindow,
 };
+
+/// Last-known tray icon rect, updated on every tray event. Used to anchor the
+/// popover directly under the icon (Loom-style) instead of floating in the
+/// top-right corner of the screen.
+#[derive(Default)]
+struct TrayAnchor(Mutex<Option<Rect>>);
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 
 fn toggle_popover(app: &AppHandle) {
@@ -18,30 +25,75 @@ fn toggle_popover(app: &AppHandle) {
     if window.is_visible().unwrap_or(false) {
         let _ = window.hide();
     } else {
-        position_popover(&window);
+        position_popover(app, &window);
         let _ = window.show();
         let _ = window.set_focus();
     }
 }
 
-fn position_popover(window: &WebviewWindow) {
-    // Place the popover near the top-right corner of the active monitor so it
-    // feels like it's hanging off the menu bar. We can't read the exact tray
-    // icon position in Tauri v2 yet, so top-right is a reasonable default that
-    // Raycast-style tray apps also use this pattern.
-    if let Ok(Some(monitor)) = window.current_monitor() {
-        let size = monitor.size();
-        let scale = monitor.scale_factor();
-        let win_size: PhysicalSize<u32> =
-            window.outer_size().unwrap_or(PhysicalSize::new(360, 440));
+fn position_popover(app: &AppHandle, window: &WebviewWindow) {
+    // If we have a recent tray icon rect, anchor the popover's top edge just
+    // below the icon and center it horizontally on the icon — same feel as
+    // Loom / Raycast / 1Password.
+    let anchor = app.state::<TrayAnchor>();
+    let tray_rect = anchor.0.lock().ok().and_then(|g| *g);
 
-        // 12px margin from the right, 36px from the top (below the menu bar).
-        let margin_right = (12.0 * scale) as i32;
-        let margin_top = (36.0 * scale) as i32;
-        let x = size.width as i32 - win_size.width as i32 - margin_right;
-        let y = margin_top;
+    let win_size: PhysicalSize<u32> =
+        window.outer_size().unwrap_or(PhysicalSize::new(360, 440));
+    let Ok(Some(monitor)) = window.current_monitor() else {
+        return;
+    };
+    let mon_size = monitor.size();
+    let mon_pos = monitor.position();
+
+    if let Some(rect) = tray_rect {
+        // `Rect { position, size }` on macOS is in physical pixels with the
+        // origin at the active monitor's top-left (matching macOS's coord
+        // system, y grows downward in Tauri v2).
+        let icon_x = match rect.position {
+            tauri::Position::Physical(p) => p.x,
+            tauri::Position::Logical(p) => p.x as i32,
+        };
+        let icon_y = match rect.position {
+            tauri::Position::Physical(p) => p.y,
+            tauri::Position::Logical(p) => p.y as i32,
+        };
+        let icon_w = match rect.size {
+            tauri::Size::Physical(s) => s.width as i32,
+            tauri::Size::Logical(s) => s.width as i32,
+        };
+        let icon_h = match rect.size {
+            tauri::Size::Physical(s) => s.height as i32,
+            tauri::Size::Logical(s) => s.height as i32,
+        };
+
+        // Center the popover horizontally on the icon.
+        let mut x = icon_x + icon_w / 2 - (win_size.width as i32) / 2;
+        // Drop below the icon with a tiny gap.
+        let gap = 6_i32;
+        let y = icon_y + icon_h + gap;
+
+        // Clamp horizontally so we don't run off the edge of the screen.
+        let min_x = mon_pos.x + 8;
+        let max_x = mon_pos.x + mon_size.width as i32 - win_size.width as i32 - 8;
+        if x < min_x {
+            x = min_x;
+        }
+        if x > max_x {
+            x = max_x;
+        }
         let _ = window.set_position(PhysicalPosition::new(x, y));
+        return;
     }
+
+    // Fallback: top-right of the active monitor (used before the tray has
+    // fired its first event).
+    let scale = monitor.scale_factor();
+    let margin_right = (12.0 * scale) as i32;
+    let margin_top = (36.0 * scale) as i32;
+    let x = mon_pos.x + mon_size.width as i32 - win_size.width as i32 - margin_right;
+    let y = mon_pos.y + margin_top;
+    let _ = window.set_position(PhysicalPosition::new(x, y));
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -64,6 +116,7 @@ pub fn run() {
                 })
                 .build(),
         )
+        .manage(TrayAnchor::default())
         .setup(|app| {
             // NOTE: we intentionally do NOT call set_activation_policy(Accessory)
             // in dev here. In unbundled dev runs, Accessory mode sometimes
@@ -104,6 +157,27 @@ pub fn run() {
                     _ => {}
                 })
                 .on_tray_icon_event(|tray, event| {
+                    // Remember the icon's rect so the popover can anchor
+                    // directly beneath it. Every tray event carries a fresh
+                    // rect — even hover/move — so the anchor stays current
+                    // even if the user drags menu-bar items around.
+                    let rect = match &event {
+                        TrayIconEvent::Click { rect, .. }
+                        | TrayIconEvent::DoubleClick { rect, .. }
+                        | TrayIconEvent::Enter { rect, .. }
+                        | TrayIconEvent::Move { rect, .. }
+                        | TrayIconEvent::Leave { rect, .. } => Some(*rect),
+                        _ => None,
+                    };
+                    if let Some(rect) = rect {
+                        let app = tray.app_handle();
+                        if let Some(anchor) = app.try_state::<TrayAnchor>() {
+                            if let Ok(mut g) = anchor.0.lock() {
+                                *g = Some(rect);
+                            }
+                        }
+                    }
+
                     if let TrayIconEvent::Click {
                         button: MouseButton::Left,
                         button_state: MouseButtonState::Up,

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -10,14 +10,21 @@ interface RecordingSummary {
 }
 
 const STORAGE_KEY = "clips:server-url";
-const DEFAULT_URL = "http://localhost:8080";
+// Sensible defaults so the user never has to type a URL on first launch.
+// Dev builds point at the local dev server; production builds point at the
+// hosted Clips instance. The user can still override from Settings.
+const DEFAULT_URL = import.meta.env.DEV
+  ? "http://localhost:8080"
+  : "https://clips.agent-native.com";
 
-function loadServerUrl(): string | null {
+function loadServerUrl(): string {
   try {
-    return localStorage.getItem(STORAGE_KEY);
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored && stored.trim()) return stored.replace(/\/+$/, "");
   } catch {
-    return null;
+    // ignore
   }
+  return DEFAULT_URL;
 }
 
 function saveServerUrl(url: string): void {

--- a/templates/clips/server/plugins/db.ts
+++ b/templates/clips/server/plugins/db.ts
@@ -1,4 +1,4 @@
-import { runMigrations } from "@agent-native/core/db";
+import { runMigrations, getDbExec, isPostgres } from "@agent-native/core/db";
 // Side-effect import — registers `recording` as a shareable resource with the
 // framework before any HTTP request runs. The framework's auto-mounted
 // share-resource / set-resource-visibility / list-resource-shares actions
@@ -6,9 +6,60 @@ import { runMigrations } from "@agent-native/core/db";
 // the registration eagerly from the always-loaded db plugin.
 import "../db/index.js";
 
-// Clips schema migrations — dialect-agnostic SQL. Drizzle schema lives in
-// server/db/schema.ts; this plugin creates the tables on first boot.
-export default runMigrations([
+/**
+ * Post-migration fixup for Postgres: retype boolean-mode columns from bigint
+ * to boolean.
+ *
+ * The early table-create migrations (v4–v14 below) used `INTEGER` because
+ * `runMigrations` needs dialect-neutral SQL; `adaptSqlForPostgres` rewrites
+ * INTEGER → BIGINT on Postgres. But the Drizzle schema declares these
+ * columns as `integer(..., { mode: "boolean" })` — which on Postgres maps
+ * to the `boolean` type. Drizzle then sends `true`/`false` at insert, which
+ * Postgres rejects against a bigint column (`invalid input syntax for type
+ * bigint: "true"`).
+ *
+ * This function runs the ALTERs needed to realign live DBs. It's a no-op on
+ * SQLite (where booleans are just 0/1 INTEGERs natively) and on Postgres
+ * installations where the columns are already BOOLEAN (idempotent check).
+ */
+async function retypeBooleanColumnsOnPostgres(): Promise<void> {
+  if (!isPostgres()) return;
+  const exec = getDbExec();
+  const alters: Array<[string, string, boolean]> = [
+    ["recordings", "has_audio", true],
+    ["recordings", "has_camera", false],
+    ["recordings", "enable_comments", true],
+    ["recordings", "enable_reactions", true],
+    ["recordings", "enable_downloads", true],
+    ["recordings", "animated_thumbnail_enabled", true],
+    ["spaces", "is_all_company", false],
+    ["recording_comments", "resolved", false],
+    ["recording_viewers", "counted_view", false],
+    ["recording_viewers", "cta_clicked", false],
+  ];
+  for (const [table, column, defaultTrue] of alters) {
+    try {
+      const probe = await exec.execute({
+        sql: `SELECT data_type FROM information_schema.columns WHERE table_name = $1 AND column_name = $2`,
+        args: [table, column],
+      });
+      const row = (probe.rows as Array<{ data_type?: string }>)[0];
+      if (!row || row.data_type === "boolean") continue;
+      const def = defaultTrue ? "TRUE" : "FALSE";
+      await exec.execute(
+        `ALTER TABLE ${table} ALTER COLUMN ${column} DROP DEFAULT, ALTER COLUMN ${column} TYPE BOOLEAN USING (${column} <> 0), ALTER COLUMN ${column} SET DEFAULT ${def}`,
+      );
+      console.log(`[db] Retyped ${table}.${column} → BOOLEAN`);
+    } catch (err) {
+      console.warn(
+        `[db] Could not retype ${table}.${column}:`,
+        (err as Error)?.message ?? err,
+      );
+    }
+  }
+}
+
+const migrations = runMigrations([
   // ---------------------------------------------------------------------------
   // Workspaces & members
   // ---------------------------------------------------------------------------
@@ -247,3 +298,8 @@ export default runMigrations([
     )`,
   },
 ]);
+
+export default async (nitroApp: any): Promise<void> => {
+  await migrations(nitroApp);
+  await retypeBooleanColumnsOnPostgres();
+};


### PR DESCRIPTION
## Summary

Addresses the review feedback on #225. Stacks on that branch — the commits in this PR's diff that come from #225 will drop off once #225 merges.

- **Better Auth cookies on dev HTTP** — \`getAppProductionUrl()\` now prefers the incoming request origin over the first-party production URL. The hard-coded prod URL only kicks in when \`NODE_ENV === "production"\`, so local dev gets \`http://localhost:3000\` and Better Auth stops setting \`Secure\` cookies on plain HTTP.
- **Org case-insensitive member lookup** — \`org/context.ts\` and \`org/handlers.ts\` compare \`org_members.email\` via \`LOWER(email) = ?\` so mixed-case signups match the lowercased rows that \`accept-pending\` inserts. Without this a user signing up as \`Alice@Example.com\` lands with no org context after invite auto-accept.
- **Desktop \`loadServerUrl\` null-safety** — returns a concrete \`string\` with a sensible dev/prod \`DEFAULT_URL\` fallback so \`useState<string>\` holds and first launch doesn't crash on missing localStorage.
- **Tray popover anchor** — popover positions under the last-known tray icon rect instead of floating top-right.

## Test plan

- [ ] Local signup at \`http://localhost:3000\` works (no Secure-cookie rejection)
- [ ] Invite \`Alice@Example.com\`, accept via that casing → user lands in the inviting org
- [ ] Desktop app first launch with empty localStorage → opens against DEFAULT_URL
- [ ] Tray click opens popover directly below the menu-bar icon