### PR TITLE
updates-117: hide local-mode on shared DBs + voice transcription

### DIFF
--- a/.agents/skills/voice-transcription/SKILL.md
+++ b/.agents/skills/voice-transcription/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: voice-transcription
+description: >-
+  Framework-wide voice dictation in the agent sidebar composer. Use when
+  changing composer microphone UX, the transcribe-voice route, or the
+  Voice Transcription settings section. Covers provider routing (OpenAI
+  Whisper / browser Web Speech API / Builder placeholder) and the
+  provider-preference application-state key.
+---
+
+# Voice Transcription
+
+Click-to-toggle microphone inside the sidebar composer turns speech into
+text. Users can pick a provider from Settings → Voice Transcription. The
+feature is available in every template that renders `TiptapComposer`.
+
+## UX rules
+
+- **Always show the mic alongside the send button.** Cursor replaces send
+  with mic when the composer is empty; their users complain. We keep both
+  visible — Lovable does the same.
+- **Click-to-toggle, not push-to-talk.** More forgiving in a sidebar, avoids
+  host-app hotkey clashes. Keyboard shortcut is `Cmd/Ctrl+Shift+M` and
+  `Escape` cancels mid-recording.
+- **Transcript lands in the composer, editable, never auto-sent.** Insert at
+  the caret via `editor.chain().focus().insertContent(text).run()`.
+- **No CSS transitions for the recording state.** Framework rule; use static
+  brand color (`#625DF5`) instead of pulses.
+- **Icon:** Tabler `IconMicrophone` (idle) / `IconPlayerStopFilled` (recording).
+  Never use a sparkle or robot icon.
+- **Errors via inline alert or toast, never `window.alert`.**
+
+## Providers
+
+| Provider  | Backend                                       | Quality | Needs key         |
+| --------- | --------------------------------------------- | ------- | ----------------- |
+| `openai`  | `POST /_agent-native/transcribe-voice` → Whisper | High    | `OPENAI_API_KEY`  |
+| `builder` | Reserved — shows as "Coming soon"             | —       | —                 |
+| `browser` | Web Speech API (`webkitSpeechRecognition`)    | Low     | No                |
+
+Selection is persisted in `application_state["voice-transcription-prefs"]`
+as `{ provider: "openai" | "browser" | "builder" }`. Default is `"browser"`.
+
+## Where the pieces live
+
+| File                                                                  | Purpose                                     |
+| --------------------------------------------------------------------- | ------------------------------------------- |
+| `packages/core/src/client/composer/useVoiceDictation.ts`              | Provider-routing hook (MediaRecorder / Web Speech) |
+| `packages/core/src/client/composer/VoiceButton.tsx`                   | Mic button + live amplitude + cancel overlay |
+| `packages/core/src/client/composer/TiptapComposer.tsx`                | Wires the hook, insertion, and keyboard shortcut |
+| `packages/core/src/client/settings/VoiceTranscriptionSection.tsx`     | Provider radio in sidebar settings          |
+| `packages/core/src/server/transcribe-voice.ts`                        | Whisper route handler                       |
+| `packages/core/src/secrets/register-framework-secrets.ts`             | Framework-level `OPENAI_API_KEY` registration |
+
+## Key resolution (server)
+
+`transcribe-voice.ts` follows the same priority as Clips:
+
+1. `readAppSecret({ key: "OPENAI_API_KEY", scope: "user", scopeId: session.email })` — the user's own encrypted secret from the sidebar.
+2. `resolveCredential("OPENAI_API_KEY")` — env var + SQL settings fallback.
+
+Never hardcode a shared key. Never log the value. Never echo it back to the
+client.
+
+## Overriding per-template
+
+Templates can:
+- **Disable the mic**: pass `voiceEnabled={false}` to `TiptapComposer`.
+- **Replace the button**: wrap `TiptapComposer` and render your own `extraActionButton` (the framework mic sits between `extraActionButton` and the send button).
+- **Pre-register `OPENAI_API_KEY` as `required: true`**: call `registerRequiredSecret(...)` from your own server plugin. Clips does this so the onboarding checklist prompts for it.
+
+## Don'ts
+
+- Don't call OpenAI from the client — go through `/_agent-native/transcribe-voice` so the user's secret stays server-side.
+- Don't remove the cancel affordance — mic permission abuse paranoia is real.
+- Don't auto-submit the transcript — users always edit before sending.
+- Don't copy Cursor's "hide send when empty" pattern — it confuses users.

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -33,6 +33,8 @@ import type {
   Reference,
   SlashCommand,
 } from "./types.js";
+import { useVoiceDictation } from "./useVoiceDictation.js";
+import { VoiceButton, VoiceRecordingOverlay } from "./VoiceButton.js";
 
 export interface TiptapComposerHandle {
   focus(): void;
@@ -65,6 +67,8 @@ interface TiptapComposerProps {
   execMode?: ExecMode;
   /** Callback to change execution mode */
   onExecModeChange?: (mode: ExecMode) => void;
+  /** Show the microphone button for voice dictation. Default true. */
+  voiceEnabled?: boolean;
 }
 
 function ModeSelector({
@@ -159,6 +163,7 @@ export function TiptapComposer({
   onSlashCommand,
   execMode,
   onExecModeChange,
+  voiceEnabled = true,
 }: TiptapComposerProps) {
   const [popover, setPopover] = useState<PopoverState>(null);
   const popoverRef = useRef<MentionPopoverRef>(null);
@@ -446,6 +451,54 @@ export function TiptapComposer({
       editor?.commands.focus("end");
     },
   }));
+
+  const insertTranscript = useCallback(
+    (text: string) => {
+      const ed = editor;
+      if (!ed || !text) return;
+      const { from } = ed.state.selection;
+      const prevChar = from > 1 ? ed.state.doc.textBetween(from - 1, from) : "";
+      const needsLead = prevChar && !/\s/.test(prevChar);
+      ed.chain()
+        .focus()
+        .insertContent((needsLead ? " " : "") + text + " ")
+        .run();
+    },
+    [editor],
+  );
+
+  const voice = useVoiceDictation({ onTranscript: insertTranscript });
+
+  // Global shortcut: Cmd/Ctrl + Shift + M toggles dictation. Escape cancels
+  // while recording. Scoped to avoid firing when focus is outside the app.
+  useEffect(() => {
+    if (!voiceEnabled || !voice.supported) return;
+    const handler = (e: KeyboardEvent) => {
+      const isToggleCombo =
+        e.key.toLowerCase() === "m" &&
+        e.shiftKey &&
+        (e.metaKey || e.ctrlKey) &&
+        !e.altKey;
+      if (isToggleCombo) {
+        e.preventDefault();
+        if (voice.state === "recording" || voice.state === "starting") {
+          voice.stop();
+        } else if (voice.state !== "transcribing") {
+          void voice.start();
+        }
+        return;
+      }
+      if (
+        e.key === "Escape" &&
+        (voice.state === "recording" || voice.state === "starting")
+      ) {
+        e.preventDefault();
+        voice.cancel();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [voiceEnabled, voice]);
 
   const extractComposerPayload = useCallback(() => {
     const ed = editor;
@@ -769,6 +822,7 @@ export function TiptapComposer({
           className="aui-composer flex-1 min-w-0 [&_.ProseMirror]:outline-none [&_.ProseMirror_p]:m-0 px-0.5"
         />
       </div>
+      {voiceEnabled && <VoiceRecordingOverlay voice={voice} />}
       <div className="flex items-center gap-1 px-2 py-1.5">
         {attachButton ?? (
           <ComposerPrimitive.AddAttachment asChild>
@@ -788,6 +842,9 @@ export function TiptapComposer({
               <ModeSelector mode={execMode} onChange={onExecModeChange} />
             )}
             {extraActionButton}
+            {voiceEnabled && (
+              <VoiceButton voice={voice} isMac={isMac} disabled={disabled} />
+            )}
             <button
               type="button"
               onClick={submitComposer}

--- a/packages/core/src/client/composer/VoiceButton.tsx
+++ b/packages/core/src/client/composer/VoiceButton.tsx
@@ -1,0 +1,154 @@
+/**
+ * Voice dictation button + recording overlay for the agent composer.
+ *
+ * UX mirrors Lovable: click-to-toggle record, a live amplitude bar and
+ * MM:SS timer replace the editor area while recording, and a cancel X
+ * discards without transcribing. The mic is always visible alongside the
+ * send button (Cursor replaces send with mic; their users complain — we
+ * don't copy that).
+ */
+
+import React from "react";
+import {
+  IconMicrophone,
+  IconPlayerStopFilled,
+  IconLoader2,
+  IconX,
+} from "@tabler/icons-react";
+import type { VoiceDictationApi } from "./useVoiceDictation.js";
+
+export interface VoiceButtonProps {
+  voice: VoiceDictationApi;
+  isMac: boolean;
+  disabled?: boolean;
+}
+
+export function VoiceButton({ voice, isMac, disabled }: VoiceButtonProps) {
+  const { state, start, stop, supported } = voice;
+
+  if (!supported) return null;
+
+  const recording = state === "recording" || state === "starting";
+  const transcribing = state === "transcribing";
+
+  const label = recording
+    ? "Stop recording"
+    : transcribing
+      ? "Transcribing…"
+      : `Dictate (${isMac ? "⌘⇧V" : "Ctrl+Shift+V"})`;
+
+  const onClick = () => {
+    if (recording) stop();
+    else if (!transcribing) void start();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled || transcribing}
+      title={label}
+      aria-label={label}
+      aria-pressed={recording}
+      className={`shrink-0 flex h-7 w-7 items-center justify-center rounded-md disabled:opacity-30 disabled:cursor-not-allowed ${
+        recording
+          ? "text-[#625DF5] bg-[#625DF5]/10 hover:bg-[#625DF5]/20"
+          : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+      }`}
+    >
+      {transcribing ? (
+        <IconLoader2 className="h-4 w-4 animate-spin" />
+      ) : recording ? (
+        <IconPlayerStopFilled className="h-3.5 w-3.5" />
+      ) : (
+        <IconMicrophone className="h-4 w-4" />
+      )}
+    </button>
+  );
+}
+
+export interface VoiceRecordingOverlayProps {
+  voice: VoiceDictationApi;
+}
+
+export function VoiceRecordingOverlay({ voice }: VoiceRecordingOverlayProps) {
+  const { state, amplitude, durationMs, errorMessage, cancel } = voice;
+
+  if (state === "error" && errorMessage) {
+    return (
+      <div
+        role="alert"
+        className="mx-2 mt-1 rounded-md border border-red-500/40 bg-red-500/10 px-2 py-1.5 text-[11px] text-red-500"
+      >
+        {errorMessage}
+      </div>
+    );
+  }
+
+  if (state !== "recording" && state !== "starting" && state !== "transcribing")
+    return null;
+
+  return (
+    <div
+      className="flex items-center gap-2 mx-2 mt-2 mb-1 h-[2rem] rounded-md border border-[#625DF5]/40 bg-[#625DF5]/10 px-2"
+      aria-live="polite"
+    >
+      <button
+        type="button"
+        onClick={cancel}
+        className="shrink-0 flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/40"
+        title="Cancel (Esc)"
+        aria-label="Cancel recording"
+      >
+        <IconX className="h-3 w-3" />
+      </button>
+
+      <div className="flex-1 flex items-center gap-[2px] min-w-0 h-4">
+        {state === "transcribing" ? (
+          <span className="text-[11px] text-muted-foreground">
+            Transcribing…
+          </span>
+        ) : (
+          <AmplitudeBars amplitude={amplitude} />
+        )}
+      </div>
+
+      <span className="shrink-0 text-[11px] font-medium tabular-nums text-muted-foreground">
+        {state === "transcribing" ? (
+          <IconLoader2 className="h-3 w-3 animate-spin" />
+        ) : (
+          formatDuration(durationMs)
+        )}
+      </span>
+    </div>
+  );
+}
+
+const BAR_COUNT = 24;
+
+function AmplitudeBars({ amplitude }: { amplitude: number }) {
+  // Render a symmetric meter — the middle bars peak first so the visual
+  // matches what voice input looks like in Lovable / iOS dictation.
+  const bars = [];
+  for (let i = 0; i < BAR_COUNT; i++) {
+    const centerDistance =
+      Math.abs(i - (BAR_COUNT - 1) / 2) / ((BAR_COUNT - 1) / 2);
+    const heightPct =
+      Math.max(0.1, amplitude * (1 - centerDistance * 0.6)) * 100;
+    bars.push(
+      <span
+        key={i}
+        className="flex-1 rounded-full bg-[#625DF5]"
+        style={{ height: `${heightPct}%`, minHeight: 2 }}
+      />,
+    );
+  }
+  return <>{bars}</>;
+}
+
+function formatDuration(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}

--- a/packages/core/src/client/composer/VoiceButton.tsx
+++ b/packages/core/src/client/composer/VoiceButton.tsx
@@ -35,7 +35,7 @@ export function VoiceButton({ voice, isMac, disabled }: VoiceButtonProps) {
     ? "Stop recording"
     : transcribing
       ? "Transcribing…"
-      : `Dictate (${isMac ? "⌘⇧V" : "Ctrl+Shift+V"})`;
+      : `Dictate (${isMac ? "⌘⇧M" : "Ctrl+Shift+M"})`;
 
   const onClick = () => {
     if (recording) stop();

--- a/packages/core/src/client/composer/useVoiceDictation.ts
+++ b/packages/core/src/client/composer/useVoiceDictation.ts
@@ -147,6 +147,17 @@ export function useVoiceDictation(
       audioContextRef.current.close().catch(() => {});
       audioContextRef.current = null;
     }
+    if (speechRef.current) {
+      // Stop the Web Speech session before dropping the ref so the browser
+      // releases the mic and stops dispatching onresult events into a stale
+      // closure. abort() is fire-and-forget (no final result); stop() would
+      // deliver remaining partials but we've already cleared state.
+      try {
+        speechRef.current.abort?.();
+      } catch {
+        /* ignore */
+      }
+    }
     analyserRef.current = null;
     mediaRecorderRef.current = null;
     chunksRef.current = [];
@@ -211,6 +222,14 @@ export function useVoiceDictation(
 
   const startOpenAi = useCallback(async () => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    // User may have pressed Escape (cancel) while the permission prompt was
+    // open. If so, stop the stream and bail before we start recording.
+    if (cancelledRef.current) {
+      for (const track of stream.getTracks()) track.stop();
+      cancelledRef.current = false;
+      setState("idle");
+      return;
+    }
     mediaStreamRef.current = stream;
     const mimeType = pickMimeType();
     const recorder = new MediaRecorder(stream, { mimeType });
@@ -287,6 +306,14 @@ export function useVoiceDictation(
       startMeter(stream);
     } catch {
       /* non-fatal — recognition can still work without our analyser */
+    }
+
+    if (cancelledRef.current) {
+      if (stream) for (const track of stream.getTracks()) track.stop();
+      mediaStreamRef.current = null;
+      cancelledRef.current = false;
+      setState("idle");
+      return;
     }
 
     const recognition = new Ctor();

--- a/packages/core/src/client/composer/useVoiceDictation.ts
+++ b/packages/core/src/client/composer/useVoiceDictation.ts
@@ -1,0 +1,420 @@
+/**
+ * Voice dictation hook for the agent composer.
+ *
+ * Wires three providers behind a single state machine:
+ *   - "openai"  — MediaRecorder → POST /_agent-native/transcribe-voice (Whisper)
+ *   - "browser" — Web Speech API (low quality, offline capable)
+ *   - "builder" — reserved (coming soon — same as "browser" today)
+ *
+ * Provider preference lives in application_state under
+ * `voice-transcription-prefs` (`{ provider: "openai" | "browser" }`).
+ * The composer reads it on every start so settings changes take effect
+ * immediately without unmounting the composer.
+ *
+ * The hook exposes amplitude (0..1) and duration (ms) so the composer can
+ * render the Lovable-style live waveform + MM:SS timer.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type VoiceProvider = "openai" | "browser" | "builder";
+
+export interface VoicePrefs {
+  provider: VoiceProvider;
+}
+
+const PREFS_KEY = "voice-transcription-prefs";
+const PREFS_URL = `/_agent-native/application-state/${PREFS_KEY}`;
+const TRANSCRIBE_URL = "/_agent-native/transcribe-voice";
+
+export type VoiceState =
+  | "idle"
+  | "starting"
+  | "recording"
+  | "transcribing"
+  | "error";
+
+export interface UseVoiceDictationOptions {
+  onTranscript: (text: string) => void;
+  onError?: (message: string) => void;
+}
+
+export interface VoiceDictationApi {
+  state: VoiceState;
+  amplitude: number;
+  durationMs: number;
+  errorMessage: string | null;
+  provider: VoiceProvider;
+  supported: boolean;
+  start: () => Promise<void>;
+  stop: () => void;
+  cancel: () => void;
+}
+
+async function readProviderPrefs(): Promise<VoiceProvider> {
+  try {
+    const res = await fetch(PREFS_URL);
+    if (!res.ok) return "browser";
+    const body = (await res.json()) as { value?: VoicePrefs } | null;
+    const p = body?.value?.provider;
+    if (p === "openai" || p === "browser" || p === "builder") return p;
+  } catch {
+    /* fall through */
+  }
+  return "browser";
+}
+
+function getSpeechRecognitionCtor(): any {
+  if (typeof window === "undefined") return null;
+  return (
+    (window as any).SpeechRecognition ||
+    (window as any).webkitSpeechRecognition ||
+    null
+  );
+}
+
+function pickMimeType(): string {
+  if (typeof MediaRecorder === "undefined") return "audio/webm";
+  const candidates = [
+    "audio/webm;codecs=opus",
+    "audio/webm",
+    "audio/mp4",
+    "audio/ogg;codecs=opus",
+  ];
+  for (const mime of candidates) {
+    try {
+      if (MediaRecorder.isTypeSupported(mime)) return mime;
+    } catch {
+      /* ignore */
+    }
+  }
+  return "audio/webm";
+}
+
+export function useVoiceDictation(
+  options: UseVoiceDictationOptions,
+): VoiceDictationApi {
+  const { onTranscript, onError } = options;
+  const onTranscriptRef = useRef(onTranscript);
+  const onErrorRef = useRef(onError);
+  onTranscriptRef.current = onTranscript;
+  onErrorRef.current = onError;
+
+  const [state, setState] = useState<VoiceState>("idle");
+  const [amplitude, setAmplitude] = useState(0);
+  const [durationMs, setDurationMs] = useState(0);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [provider, setProvider] = useState<VoiceProvider>("browser");
+
+  // Keep refs for teardown / cross-branch access.
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startedAtRef = useRef<number>(0);
+  const cancelledRef = useRef(false);
+  const speechRef = useRef<any>(null);
+  const speechTranscriptRef = useRef<string>("");
+  const activeProviderRef = useRef<VoiceProvider>("browser");
+
+  const mediaRecorderSupported =
+    typeof window !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    !!navigator.mediaDevices?.getUserMedia &&
+    typeof (window as any).MediaRecorder !== "undefined";
+  const speechSupported = !!getSpeechRecognitionCtor();
+  const supported = mediaRecorderSupported || speechSupported;
+
+  const teardown = useCallback(() => {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    if (timerRef.current != null) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    if (mediaStreamRef.current) {
+      for (const track of mediaStreamRef.current.getTracks()) {
+        track.stop();
+      }
+      mediaStreamRef.current = null;
+    }
+    if (audioContextRef.current) {
+      audioContextRef.current.close().catch(() => {});
+      audioContextRef.current = null;
+    }
+    analyserRef.current = null;
+    mediaRecorderRef.current = null;
+    chunksRef.current = [];
+    speechRef.current = null;
+    speechTranscriptRef.current = "";
+    setAmplitude(0);
+  }, []);
+
+  useEffect(() => teardown, [teardown]);
+
+  const failWith = useCallback(
+    (message: string) => {
+      setErrorMessage(message);
+      setState("error");
+      onErrorRef.current?.(message);
+      teardown();
+    },
+    [teardown],
+  );
+
+  const startMeter = useCallback((stream: MediaStream) => {
+    try {
+      const AudioCtor =
+        typeof window !== "undefined"
+          ? window.AudioContext || (window as any).webkitAudioContext || null
+          : null;
+      if (!AudioCtor) return;
+      const ctx: AudioContext = new AudioCtor();
+      const source = ctx.createMediaStreamSource(stream);
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 512;
+      source.connect(analyser);
+      audioContextRef.current = ctx;
+      analyserRef.current = analyser;
+
+      const buffer = new Uint8Array(analyser.frequencyBinCount);
+      const tick = () => {
+        if (!analyserRef.current) return;
+        analyserRef.current.getByteTimeDomainData(buffer);
+        let sumSquares = 0;
+        for (let i = 0; i < buffer.length; i++) {
+          const n = (buffer[i] - 128) / 128;
+          sumSquares += n * n;
+        }
+        const rms = Math.sqrt(sumSquares / buffer.length);
+        setAmplitude(Math.min(1, rms * 2.5));
+        rafRef.current = requestAnimationFrame(tick);
+      };
+      rafRef.current = requestAnimationFrame(tick);
+    } catch {
+      /* analyser is best-effort */
+    }
+  }, []);
+
+  const startTimer = useCallback(() => {
+    startedAtRef.current = Date.now();
+    setDurationMs(0);
+    timerRef.current = setInterval(() => {
+      setDurationMs(Date.now() - startedAtRef.current);
+    }, 100);
+  }, []);
+
+  const startOpenAi = useCallback(async () => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    mediaStreamRef.current = stream;
+    const mimeType = pickMimeType();
+    const recorder = new MediaRecorder(stream, { mimeType });
+    mediaRecorderRef.current = recorder;
+    chunksRef.current = [];
+
+    recorder.ondataavailable = (e) => {
+      if (e.data && e.data.size > 0) chunksRef.current.push(e.data);
+    };
+    recorder.onstop = async () => {
+      const localChunks = chunksRef.current.slice();
+      const localMime = recorder.mimeType || mimeType;
+      teardown();
+      if (cancelledRef.current) {
+        cancelledRef.current = false;
+        setState("idle");
+        return;
+      }
+      if (localChunks.length === 0) {
+        setState("idle");
+        return;
+      }
+      setState("transcribing");
+      try {
+        const audioBlob = new Blob(localChunks, { type: localMime });
+        const form = new FormData();
+        form.append(
+          "audio",
+          audioBlob,
+          `voice.${localMime.split("/")[1] ?? "webm"}`,
+        );
+        const res = await fetch(TRANSCRIBE_URL, {
+          method: "POST",
+          body: form,
+        });
+        if (!res.ok) {
+          const body = await res
+            .json()
+            .catch(() => ({ error: `HTTP ${res.status}` }));
+          throw new Error(body.error || `Transcription failed (${res.status})`);
+        }
+        const data = (await res.json()) as { text?: string };
+        const text = (data.text ?? "").trim();
+        setState("idle");
+        if (text) onTranscriptRef.current?.(text);
+      } catch (err) {
+        failWith(
+          (err as Error)?.message ??
+            "Transcription failed. Check your OpenAI key in settings.",
+        );
+      }
+    };
+
+    startMeter(stream);
+    startTimer();
+    setState("recording");
+    recorder.start();
+  }, [startMeter, startTimer, teardown, failWith]);
+
+  const startBrowser = useCallback(async () => {
+    const Ctor = getSpeechRecognitionCtor();
+    if (!Ctor) {
+      throw new Error(
+        "Your browser doesn't support speech recognition. Add an OpenAI API key in settings for Whisper transcription.",
+      );
+    }
+    // Still request mic to drive the amplitude meter, so the UI doesn't look
+    // dead while the user talks. SpeechRecognition manages its own capture
+    // under the hood in most browsers.
+    let stream: MediaStream | null = null;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaStreamRef.current = stream;
+      startMeter(stream);
+    } catch {
+      /* non-fatal — recognition can still work without our analyser */
+    }
+
+    const recognition = new Ctor();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang =
+      (typeof navigator !== "undefined" && navigator.language) || "en-US";
+    speechRef.current = recognition;
+    speechTranscriptRef.current = "";
+
+    recognition.onresult = (event: any) => {
+      let finalText = "";
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        if (result.isFinal) {
+          finalText += result[0]?.transcript ?? "";
+        }
+      }
+      if (finalText) speechTranscriptRef.current += finalText;
+    };
+    recognition.onerror = (event: any) => {
+      if (event?.error === "no-speech" || event?.error === "aborted") return;
+      failWith(
+        event?.error === "not-allowed"
+          ? "Microphone permission denied. Enable it in your browser settings."
+          : `Speech recognition error: ${event?.error ?? "unknown"}`,
+      );
+    };
+    recognition.onend = () => {
+      const text = speechTranscriptRef.current.trim();
+      const wasCancelled = cancelledRef.current;
+      cancelledRef.current = false;
+      teardown();
+      setState("idle");
+      if (!wasCancelled && text) onTranscriptRef.current?.(text);
+    };
+
+    startTimer();
+    setState("recording");
+    recognition.start();
+  }, [startMeter, startTimer, teardown, failWith]);
+
+  const start = useCallback(async () => {
+    if (state === "recording" || state === "starting") return;
+    setErrorMessage(null);
+    setState("starting");
+    cancelledRef.current = false;
+
+    const pref = await readProviderPrefs();
+    setProvider(pref);
+
+    // "builder" is a placeholder; behave like browser for now.
+    const resolvedProvider: VoiceProvider =
+      pref === "builder" ? "browser" : pref;
+    activeProviderRef.current = resolvedProvider;
+
+    try {
+      if (resolvedProvider === "openai") {
+        if (!mediaRecorderSupported) {
+          throw new Error(
+            "Your browser doesn't support audio recording. Use the browser provider in Settings → Voice Transcription.",
+          );
+        }
+        await startOpenAi();
+      } else {
+        await startBrowser();
+      }
+    } catch (err) {
+      const message =
+        (err as Error)?.name === "NotAllowedError"
+          ? "Microphone permission denied. Enable it in your browser settings."
+          : ((err as Error)?.message ?? "Could not start recording");
+      failWith(message);
+    }
+  }, [state, mediaRecorderSupported, startOpenAi, startBrowser, failWith]);
+
+  const stop = useCallback(() => {
+    if (state !== "recording") return;
+    cancelledRef.current = false;
+    if (activeProviderRef.current === "openai" && mediaRecorderRef.current) {
+      try {
+        mediaRecorderRef.current.stop();
+      } catch {
+        teardown();
+        setState("idle");
+      }
+    } else if (speechRef.current) {
+      try {
+        speechRef.current.stop();
+      } catch {
+        teardown();
+        setState("idle");
+      }
+    } else {
+      teardown();
+      setState("idle");
+    }
+  }, [state, teardown]);
+
+  const cancel = useCallback(() => {
+    if (state !== "recording" && state !== "starting") return;
+    cancelledRef.current = true;
+    if (activeProviderRef.current === "openai" && mediaRecorderRef.current) {
+      try {
+        mediaRecorderRef.current.stop();
+      } catch {
+        /* ignore */
+      }
+    } else if (speechRef.current) {
+      try {
+        speechRef.current.abort?.();
+      } catch {
+        /* ignore */
+      }
+    }
+    teardown();
+    setState("idle");
+  }, [state, teardown]);
+
+  return {
+    state,
+    amplitude,
+    durationMs,
+    errorMessage,
+    provider,
+    supported,
+    start,
+    stop,
+    cancel,
+  };
+}

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -17,12 +17,14 @@ import {
   IconCoin,
   IconMail,
   IconKey,
+  IconMicrophone,
 } from "@tabler/icons-react";
 import { SettingsSection } from "./SettingsSection.js";
 import { useBuilderStatus } from "./useBuilderStatus.js";
 import { AgentsSection } from "./AgentsSection.js";
 import { UsageSection } from "./UsageSection.js";
 import { SecretsSection } from "./SecretsSection.js";
+import { VoiceTranscriptionSection } from "./VoiceTranscriptionSection.js";
 
 const IntegrationsPanel = lazy(() =>
   import("../integrations/IntegrationsPanel.js").then((m) => ({
@@ -705,6 +707,17 @@ export function SettingsPanel({
         open={openSection === "llm"}
         onToggle={() => toggle("llm")}
       />
+
+      {/* Voice transcription */}
+      <SettingsSection
+        icon={<IconMicrophone size={14} />}
+        title="Voice Transcription"
+        subtitle="How the composer microphone turns your voice into text."
+        open={openSection === "voice"}
+        onToggle={() => toggle("voice")}
+      >
+        <VoiceTranscriptionSection />
+      </SettingsSection>
 
       {/* API Keys & Connections (only when a template has registered any) */}
       {hasSecrets && (

--- a/packages/core/src/client/settings/VoiceTranscriptionSection.tsx
+++ b/packages/core/src/client/settings/VoiceTranscriptionSection.tsx
@@ -1,0 +1,227 @@
+/**
+ * <VoiceTranscriptionSection /> — provider picker for composer voice input.
+ *
+ * Writes the selection to application_state under `voice-transcription-prefs`
+ * so the composer's `useVoiceDictation` hook picks it up on next record.
+ *
+ * Providers:
+ *   - "openai"  — best quality, requires OPENAI_API_KEY (user-scoped secret)
+ *   - "builder" — coming soon (disabled placeholder)
+ *   - "browser" — default; Web Speech API, low quality, works offline
+ */
+
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  IconCheck,
+  IconExternalLink,
+  IconLoader2,
+  IconMicrophone,
+} from "@tabler/icons-react";
+
+type Provider = "openai" | "builder" | "browser";
+
+interface Prefs {
+  provider: Provider;
+}
+
+interface SecretStatus {
+  key: string;
+  status: "set" | "unset" | "invalid";
+}
+
+const PREFS_URL = "/_agent-native/application-state/voice-transcription-prefs";
+const SECRETS_URL = "/_agent-native/secrets";
+const DEFAULT_PROVIDER: Provider = "browser";
+
+export function VoiceTranscriptionSection() {
+  const [provider, setProvider] = useState<Provider | null>(null);
+  const [openAiConfigured, setOpenAiConfigured] = useState<boolean | null>(
+    null,
+  );
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(PREFS_URL)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((body: { value?: Prefs } | null) => {
+        if (cancelled) return;
+        const p = body?.value?.provider;
+        setProvider(
+          p === "openai" || p === "builder" || p === "browser"
+            ? p
+            : DEFAULT_PROVIDER,
+        );
+      })
+      .catch(() => !cancelled && setProvider(DEFAULT_PROVIDER));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(SECRETS_URL)
+      .then((r) => (r.ok ? r.json() : []))
+      .then((list: SecretStatus[]) => {
+        if (cancelled) return;
+        const openAi = Array.isArray(list)
+          ? list.find((s) => s.key === "OPENAI_API_KEY")
+          : null;
+        setOpenAiConfigured(openAi?.status === "set");
+      })
+      .catch(() => !cancelled && setOpenAiConfigured(false));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const persist = useCallback(async (next: Provider) => {
+    setSaving(true);
+    try {
+      await fetch(PREFS_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: { provider: next } }),
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  const choose = (next: Provider) => {
+    if (next === provider) return;
+    if (next === "builder") return; // placeholder — disabled
+    setProvider(next);
+    void persist(next);
+  };
+
+  if (provider === null) {
+    return (
+      <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+        <IconLoader2 size={10} className="animate-spin" />
+        Loading…
+      </div>
+    );
+  }
+
+  const focusOpenAiKey = () => {
+    if (typeof window === "undefined") return;
+    window.location.hash = "#secrets:OPENAI_API_KEY";
+  };
+
+  return (
+    <div className="space-y-2">
+      <ProviderOption
+        id="openai"
+        selected={provider === "openai"}
+        onSelect={() => choose("openai")}
+        title="OpenAI Whisper"
+        subtitle="Best quality. Requires an OpenAI API key."
+        rightSlot={
+          openAiConfigured === null ? null : openAiConfigured ? (
+            <span className="flex items-center gap-1 text-[10px] text-green-500">
+              <IconCheck size={10} />
+              Key set
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                focusOpenAiKey();
+              }}
+              className="inline-flex items-center gap-1 rounded border border-border px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground hover:bg-accent/40"
+            >
+              Add key
+              <IconExternalLink size={10} />
+            </button>
+          )
+        }
+      />
+
+      <ProviderOption
+        id="builder"
+        selected={false}
+        onSelect={() => {}}
+        disabled
+        title="Builder"
+        subtitle="Shared key across Builder workspaces. No setup needed."
+        rightSlot={
+          <span className="rounded-full bg-accent/60 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Coming soon
+          </span>
+        }
+      />
+
+      <ProviderOption
+        id="browser"
+        selected={provider === "browser"}
+        onSelect={() => choose("browser")}
+        title="Browser (built-in)"
+        subtitle="Lower quality, works offline. No key required."
+      />
+
+      {saving && <p className="text-[10px] text-muted-foreground">Saving…</p>}
+    </div>
+  );
+}
+
+interface ProviderOptionProps {
+  id: string;
+  selected: boolean;
+  disabled?: boolean;
+  onSelect: () => void;
+  title: string;
+  subtitle?: string;
+  rightSlot?: React.ReactNode;
+}
+
+function ProviderOption({
+  id,
+  selected,
+  disabled,
+  onSelect,
+  title,
+  subtitle,
+  rightSlot,
+}: ProviderOptionProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={disabled}
+      aria-pressed={selected}
+      className={`w-full text-left rounded-md border px-2.5 py-2 flex items-start gap-2 ${
+        selected
+          ? "border-[#625DF5] bg-[#625DF5]/10"
+          : "border-border bg-accent/30 hover:bg-accent/50"
+      } ${disabled ? "opacity-60 cursor-not-allowed" : ""}`}
+    >
+      <span
+        className={`mt-[2px] shrink-0 flex h-3.5 w-3.5 items-center justify-center rounded-full border ${
+          selected
+            ? "border-[#625DF5] bg-[#625DF5]"
+            : "border-muted-foreground/40 bg-background"
+        }`}
+      >
+        {selected && (
+          <span className="h-1.5 w-1.5 rounded-full bg-background" />
+        )}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-[11px] font-medium text-foreground">{title}</div>
+          {rightSlot && <div className="shrink-0">{rightSlot}</div>}
+        </div>
+        {subtitle && (
+          <p className="text-[10px] text-muted-foreground mt-0.5">{subtitle}</p>
+        )}
+      </div>
+    </button>
+  );
+}
+
+export function VoiceTranscriptionIcon() {
+  return <IconMicrophone size={14} />;
+}

--- a/packages/core/src/client/settings/VoiceTranscriptionSection.tsx
+++ b/packages/core/src/client/settings/VoiceTranscriptionSection.tsx
@@ -39,6 +39,7 @@ export function VoiceTranscriptionSection() {
     null,
   );
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -76,24 +77,38 @@ export function VoiceTranscriptionSection() {
     };
   }, []);
 
-  const persist = useCallback(async (next: Provider) => {
-    setSaving(true);
-    try {
-      await fetch(PREFS_URL, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ value: { provider: next } }),
-      });
-    } finally {
-      setSaving(false);
-    }
-  }, []);
+  const persist = useCallback(
+    async (next: Provider, previous: Provider | null) => {
+      setSaving(true);
+      setSaveError(null);
+      try {
+        const res = await fetch(PREFS_URL, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ value: { provider: next } }),
+        });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+      } catch (err) {
+        // Revert the optimistic update so the UI matches server state.
+        setProvider(previous);
+        setSaveError(
+          `Couldn't save: ${(err as Error)?.message ?? "network error"}. Try again.`,
+        );
+      } finally {
+        setSaving(false);
+      }
+    },
+    [],
+  );
 
   const choose = (next: Provider) => {
     if (next === provider) return;
     if (next === "builder") return; // placeholder — disabled
+    const previous = provider;
     setProvider(next);
-    void persist(next);
+    void persist(next, previous);
   };
 
   if (provider === null) {
@@ -163,6 +178,11 @@ export function VoiceTranscriptionSection() {
       />
 
       {saving && <p className="text-[10px] text-muted-foreground">Saving…</p>}
+      {saveError && !saving && (
+        <p className="text-[10px] text-red-500" role="alert">
+          {saveError}
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -5,8 +5,7 @@ import {
   IconBuilding,
   IconWorld,
   IconTrash,
-  IconCheck,
-  IconX,
+  IconChevronDown,
 } from "@tabler/icons-react";
 import * as Popover from "@radix-ui/react-popover";
 import { useActionQuery, useActionMutation } from "../use-action.js";
@@ -15,7 +14,8 @@ export interface ShareButtonProps {
   resourceType: string;
   resourceId: string;
   resourceTitle?: string;
-  /** Visual style: "compact" (icon + current visibility) or "label". */
+  /** "compact" reflects the current visibility in the trigger label;
+   *  "label" always says "Share". */
   variant?: "compact" | "label";
 }
 
@@ -37,11 +37,33 @@ interface SharesResponse {
   shares: Share[];
 }
 
+const VIS_META: Record<
+  Visibility,
+  { label: string; description: string; Icon: typeof IconLock }
+> = {
+  private: {
+    label: "Private",
+    description: "Only people with access can view",
+    Icon: IconLock,
+  },
+  org: {
+    label: "Organization",
+    description: "Anyone in your organization can view",
+    Icon: IconBuilding,
+  },
+  public: {
+    label: "Public",
+    description: "Anyone signed in with the link can view",
+    Icon: IconWorld,
+  },
+};
+
 /**
- * Drop-in share control. Renders as a shadcn-outline-styled trigger that
- * opens a popover anchored beneath it — picks up the template's theme
- * (including dark mode) via CSS variables, so the same component looks
- * native in every template.
+ * Framework share control. Renders a shadcn-outline-styled trigger that
+ * opens a Google-Docs-style popover: a people-input at the top, a
+ * "People with access" list, and a "General access" row with a single
+ * visibility dropdown. All colors use CSS variables so dark mode works
+ * out of the box in any shadcn template.
  */
 export function ShareButton(props: ShareButtonProps) {
   const [open, setOpen] = useState(false);
@@ -49,32 +71,26 @@ export function ShareButton(props: ShareButtonProps) {
     resourceType: props.resourceType,
     resourceId: props.resourceId,
   });
-  const visibility: Visibility =
-    (sharesQuery.data?.visibility as Visibility | null) ?? "private";
 
-  const VisIcon =
-    visibility === "public"
+  const serverVisibility =
+    (sharesQuery.data?.visibility as Visibility | null) ?? "private";
+  const TriggerIcon =
+    serverVisibility === "public"
       ? IconWorld
-      : visibility === "org"
+      : serverVisibility === "org"
         ? IconBuilding
         : props.variant === "compact"
           ? IconLock
           : IconShare;
-  const label =
-    props.variant === "compact"
-      ? visibility === "private"
-        ? "Private"
-        : visibility === "org"
-          ? "Organization"
-          : "Public"
-      : "Share";
+  const triggerLabel =
+    props.variant === "compact" ? VIS_META[serverVisibility].label : "Share";
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <button type="button" style={triggerStyle}>
-          <VisIcon size={14} strokeWidth={1.75} />
-          <span>{label}</span>
+          <TriggerIcon size={16} strokeWidth={1.75} />
+          <span>{triggerLabel}</span>
         </button>
       </Popover.Trigger>
       <Popover.Portal>
@@ -95,6 +111,37 @@ export function ShareButton(props: ShareButtonProps) {
   );
 }
 
+interface OrgMember {
+  email: string;
+  name?: string | null;
+}
+
+function useOrgMembers(): OrgMember[] {
+  const [members, setMembers] = useState<OrgMember[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/_agent-native/org/members")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        const list = Array.isArray(data?.members) ? data.members : [];
+        setMembers(
+          list
+            .map((m: any) => ({
+              email: typeof m?.email === "string" ? m.email : "",
+              name: typeof m?.name === "string" ? m.name : null,
+            }))
+            .filter((m: OrgMember) => m.email),
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return members;
+}
+
 function SharePanel(
   props: ShareButtonProps & {
     sharesQuery: ReturnType<typeof useActionQuery<SharesResponse>>;
@@ -103,11 +150,21 @@ function SharePanel(
 ) {
   const { resourceType, resourceId, resourceTitle, sharesQuery, onClose } =
     props;
+
   const setVisibility = useActionMutation("set-resource-visibility");
   const share = useActionMutation("share-resource");
   const unshare = useActionMutation("unshare-resource");
+
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<Role>("viewer");
+  const orgMembers = useOrgMembers();
+  const datalistId = `share-autocomplete-${resourceType}-${resourceId}`;
+
+  // Optimistic overlays on top of server state so clicks feel instant.
+  const [visibilityOverride, setVisibilityOverride] =
+    useState<Visibility | null>(null);
+  const [pendingAdds, setPendingAdds] = useState<Share[]>([]);
+  const [pendingRemoves, setPendingRemoves] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     sharesQuery.refetch();
@@ -115,20 +172,43 @@ function SharePanel(
   }, []);
 
   const data = sharesQuery.data;
-  const visibility: Visibility =
-    (data?.visibility as Visibility | null) ?? "private";
+  const serverVisibility = (data?.visibility as Visibility | null) ?? "private";
+  const visibility: Visibility = visibilityOverride ?? serverVisibility;
   const canManage =
     data?.role === "owner" || data?.role === "admin" || !data?.role;
+  const meta = VIS_META[visibility];
+
+  const serverShares = data?.shares ?? [];
+  const shares: Share[] = [
+    ...serverShares.filter((s) => !pendingRemoves.has(keyOf(s))),
+    ...pendingAdds,
+  ];
 
   const handleVisibility = (next: Visibility) => {
+    if (next === visibility) return;
+    setVisibilityOverride(next);
     setVisibility.mutate(
       { resourceType, resourceId, visibility: next } as any,
-      { onSuccess: () => sharesQuery.refetch() },
+      {
+        onSuccess: () => {
+          sharesQuery.refetch().then(() => setVisibilityOverride(null));
+        },
+        onError: () => setVisibilityOverride(null),
+      },
     );
   };
+
   const handleAdd = () => {
     const trimmed = email.trim();
     if (!trimmed) return;
+    const optimistic: Share = {
+      id: `pending-${trimmed}`,
+      principalType: "user",
+      principalId: trimmed,
+      role,
+    };
+    setPendingAdds((p) => [...p, optimistic]);
+    setEmail("");
     share.mutate(
       {
         resourceType,
@@ -139,13 +219,20 @@ function SharePanel(
       } as any,
       {
         onSuccess: () => {
-          setEmail("");
-          sharesQuery.refetch();
+          sharesQuery.refetch().then(() => {
+            setPendingAdds((p) => p.filter((s) => s.id !== optimistic.id));
+          });
+        },
+        onError: () => {
+          setPendingAdds((p) => p.filter((s) => s.id !== optimistic.id));
         },
       },
     );
   };
+
   const handleRemove = (s: Share) => {
+    const k = keyOf(s);
+    setPendingRemoves((prev) => new Set(prev).add(k));
     unshare.mutate(
       {
         resourceType,
@@ -153,268 +240,301 @@ function SharePanel(
         principalType: s.principalType,
         principalId: s.principalId,
       } as any,
-      { onSuccess: () => sharesQuery.refetch() },
+      {
+        onSuccess: () => {
+          sharesQuery.refetch().then(() => {
+            setPendingRemoves((prev) => {
+              const next = new Set(prev);
+              next.delete(k);
+              return next;
+            });
+          });
+        },
+        onError: () => {
+          setPendingRemoves((prev) => {
+            const next = new Set(prev);
+            next.delete(k);
+            return next;
+          });
+        },
+      },
     );
   };
 
   return (
-    <div style={panelInnerStyle}>
-      <div style={headerRow}>
-        <div style={{ minWidth: 0 }}>
-          <div style={titleStyle}>
-            Share {resourceTitle ? `"${resourceTitle}"` : resourceType}
-          </div>
-          {data?.ownerEmail ? (
-            <div style={subtitleStyle}>Owner: {data.ownerEmail}</div>
-          ) : null}
-        </div>
-        <button
-          type="button"
-          aria-label="Close"
-          onClick={onClose}
-          style={iconBtnStyle}
-        >
-          <IconX size={14} />
-        </button>
+    <div style={panelInner}>
+      <div style={titleStyle}>
+        Share {resourceTitle ? `"${resourceTitle}"` : resourceType}
       </div>
-
-      <div style={sectionLabelStyle}>General access</div>
-      <div style={visRow}>
-        <VisOption
-          active={visibility === "private"}
-          disabled={!canManage}
-          label="Private"
-          sublabel="Only people with explicit access"
-          icon={<IconLock size={14} strokeWidth={1.75} />}
-          onClick={() => handleVisibility("private")}
-        />
-        <VisOption
-          active={visibility === "org"}
-          disabled={!canManage}
-          label="Organization"
-          sublabel="Anyone in your org can view"
-          icon={<IconBuilding size={14} strokeWidth={1.75} />}
-          onClick={() => handleVisibility("org")}
-        />
-        <VisOption
-          active={visibility === "public"}
-          disabled={!canManage}
-          label="Public"
-          sublabel="Any signed-in user can view"
-          icon={<IconWorld size={14} strokeWidth={1.75} />}
-          onClick={() => handleVisibility("public")}
-        />
-      </div>
-
-      <div style={sectionLabelStyle}>People with access</div>
-      <ul style={listStyle}>
-        {data?.ownerEmail ? (
-          <li style={itemStyle}>
-            <span style={principalStyle}>{data.ownerEmail}</span>
-            <span style={roleStyle}>Owner</span>
-          </li>
-        ) : null}
-        {(data?.shares ?? []).map((s) => (
-          <li key={s.id} style={itemStyle}>
-            <span style={principalStyle}>
-              {s.principalType === "org" ? "🏢 " : ""}
-              {s.principalId}
-            </span>
-            <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
-              <span style={roleStyle}>{cap(s.role)}</span>
-              {canManage ? (
-                <button
-                  type="button"
-                  aria-label="Remove"
-                  onClick={() => handleRemove(s)}
-                  style={iconBtnStyle}
-                >
-                  <IconTrash size={13} />
-                </button>
-              ) : null}
-            </span>
-          </li>
-        ))}
-        {!data?.shares?.length && !data?.ownerEmail ? (
-          <li style={{ ...itemStyle, color: mutedText }}>
-            No one has access yet.
-          </li>
-        ) : null}
-      </ul>
 
       {canManage ? (
-        <>
-          <div style={sectionLabelStyle}>Invite by email</div>
-          <div style={inviteRow}>
-            <input
-              type="email"
-              placeholder="email@example.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleAdd();
-              }}
-              style={inputStyle}
-            />
+        <div style={inviteRow}>
+          <input
+            type="email"
+            placeholder="Add people by email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleAdd();
+            }}
+            list={orgMembers.length > 0 ? datalistId : undefined}
+            autoComplete="off"
+            style={inputStyle}
+          />
+          {orgMembers.length > 0 ? (
+            <datalist id={datalistId}>
+              {orgMembers
+                .filter(
+                  (m) =>
+                    m.email !== sharesQuery.data?.ownerEmail &&
+                    !(sharesQuery.data?.shares ?? []).some(
+                      (s) =>
+                        s.principalType === "user" && s.principalId === m.email,
+                    ),
+                )
+                .map((m) => (
+                  <option
+                    key={m.email}
+                    value={m.email}
+                    label={m.name ?? undefined}
+                  />
+                ))}
+            </datalist>
+          ) : null}
+          <div style={selectWrap}>
             <select
               value={role}
               onChange={(e) => setRole(e.target.value as Role)}
               style={selectStyle}
+              aria-label="Role"
             >
               <option value="viewer">Viewer</option>
               <option value="editor">Editor</option>
               <option value="admin">Admin</option>
             </select>
-            <button
-              type="button"
-              onClick={handleAdd}
-              disabled={!email.trim() || share.isPending}
-              style={primaryBtnStyle(!email.trim() || share.isPending)}
-            >
-              <IconCheck size={13} /> Share
-            </button>
+            <IconChevronDown size={14} style={selectChevron} />
           </div>
-        </>
+        </div>
       ) : null}
+
+      <div style={sectionLabel}>People with access</div>
+      <ul style={listStyle}>
+        {data?.ownerEmail ? (
+          <li style={rowStyle}>
+            <span style={avatarStyle} aria-hidden>
+              {initials(data.ownerEmail)}
+            </span>
+            <span style={{ ...principalStyle, flex: 1, minWidth: 0 }}>
+              {data.ownerEmail}
+            </span>
+            <span style={roleStyle}>Owner</span>
+          </li>
+        ) : null}
+        {shares.map((s) => (
+          <li key={keyOf(s)} style={rowStyle}>
+            <span style={avatarStyle} aria-hidden>
+              {s.principalType === "org" ? "🏢" : initials(s.principalId)}
+            </span>
+            <span style={{ ...principalStyle, flex: 1, minWidth: 0 }}>
+              {s.principalId}
+            </span>
+            <span style={roleStyle}>{cap(s.role)}</span>
+            {canManage ? (
+              <button
+                type="button"
+                aria-label="Remove"
+                onClick={() => handleRemove(s)}
+                style={iconBtnStyle}
+              >
+                <IconTrash size={14} />
+              </button>
+            ) : null}
+          </li>
+        ))}
+        {!shares.length && !data?.ownerEmail ? (
+          <li style={{ ...rowStyle, color: "hsl(var(--muted-foreground))" }}>
+            No one has access yet.
+          </li>
+        ) : null}
+      </ul>
+
+      <div style={sectionLabel}>General access</div>
+      <div style={generalRow}>
+        <span style={generalIcon} aria-hidden>
+          <meta.Icon size={16} strokeWidth={1.75} />
+        </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={selectWrap}>
+            <select
+              value={visibility}
+              disabled={!canManage}
+              onChange={(e) => handleVisibility(e.target.value as Visibility)}
+              style={generalSelectStyle}
+              aria-label="General access"
+            >
+              <option value="private">{VIS_META.private.label}</option>
+              <option value="org">{VIS_META.org.label}</option>
+              <option value="public">{VIS_META.public.label}</option>
+            </select>
+            <IconChevronDown size={14} style={selectChevron} />
+          </div>
+          <div style={generalHint}>{meta.description}</div>
+        </div>
+      </div>
+
+      <div style={footerRow}>
+        <button type="button" onClick={onClose} style={doneBtnStyle}>
+          Done
+        </button>
+      </div>
     </div>
   );
 }
 
-function VisOption(props: {
-  active: boolean;
-  disabled?: boolean;
-  label: string;
-  sublabel: string;
-  icon: React.ReactNode;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={props.onClick}
-      disabled={props.disabled}
-      style={{
-        flex: 1,
-        minWidth: 0,
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "flex-start",
-        gap: 2,
-        padding: "8px 10px",
-        borderRadius: 6,
-        border: `1px solid ${props.active ? "hsl(var(--foreground))" : "hsl(var(--border))"}`,
-        background: props.active
-          ? "hsl(var(--foreground))"
-          : "hsl(var(--background))",
-        color: props.active
-          ? "hsl(var(--background))"
-          : "hsl(var(--foreground))",
-        cursor: props.disabled ? "not-allowed" : "pointer",
-        opacity: props.disabled ? 0.6 : 1,
-        textAlign: "left",
-        font: "inherit",
-      }}
-    >
-      <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
-        {props.icon}
-        <strong style={{ fontSize: 12, fontWeight: 600 }}>{props.label}</strong>
-      </span>
-      <span style={{ fontSize: 11, opacity: 0.75 }}>{props.sublabel}</span>
-    </button>
-  );
+function keyOf(s: Share): string {
+  return `${s.principalType}:${s.principalId}`;
 }
-
-function cap(s: string) {
+function cap(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
+function initials(s: string): string {
+  const name = s.split("@")[0] ?? s;
+  return (name[0] ?? "?").toUpperCase();
+}
 
-// --- theme-aware styles (use shadcn CSS variables so the same component
-//     renders correctly in light and dark mode without extra plumbing) ---
-
-const mutedText = "hsl(var(--muted-foreground))";
+// ---------------------------------------------------------------------------
+// Theme-aware styles — use shadcn CSS variables so the same component
+// renders correctly in light and dark mode without extra plumbing.
+// ---------------------------------------------------------------------------
 
 const triggerStyle: React.CSSProperties = {
   display: "inline-flex",
   alignItems: "center",
-  gap: 6,
-  height: 32,
+  justifyContent: "center",
+  gap: 8,
+  height: 36,
   padding: "0 12px",
   borderRadius: 6,
   border: "1px solid hsl(var(--border))",
   background: "hsl(var(--background))",
   color: "hsl(var(--foreground))",
-  fontSize: 12,
+  fontSize: 14,
   fontWeight: 500,
+  cursor: "pointer",
+  font: "inherit",
+  lineHeight: 1,
+  whiteSpace: "nowrap",
+};
+
+const panelStyle: React.CSSProperties = {
+  width: "min(460px, 92vw)",
+  background: "hsl(var(--popover, var(--background)))",
+  color: "hsl(var(--popover-foreground, var(--foreground)))",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 10,
+  boxShadow: "0 10px 30px rgba(0,0,0,0.25)",
+  zIndex: 2000,
+};
+
+const panelInner: React.CSSProperties = {
+  padding: 16,
+  fontFamily: "inherit",
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: 16,
+  fontWeight: 600,
+  marginBottom: 12,
+  paddingRight: 24,
+};
+
+const inviteRow: React.CSSProperties = {
+  display: "flex",
+  gap: 8,
+  alignItems: "center",
+  marginBottom: 16,
+};
+
+const inputStyle: React.CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  height: 36,
+  padding: "0 12px",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 6,
+  fontSize: 14,
+  background: "hsl(var(--background))",
+  color: "hsl(var(--foreground))",
+  outline: "none",
+};
+
+const selectWrap: React.CSSProperties = {
+  position: "relative",
+  display: "inline-block",
+};
+
+const selectStyle: React.CSSProperties = {
+  appearance: "none" as any,
+  WebkitAppearance: "none" as any,
+  MozAppearance: "none" as any,
+  height: 36,
+  padding: "0 28px 0 12px",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 6,
+  fontSize: 14,
+  background: "hsl(var(--background))",
+  color: "hsl(var(--foreground))",
   cursor: "pointer",
   font: "inherit",
   lineHeight: 1,
 };
 
-const panelStyle: React.CSSProperties = {
-  width: "min(420px, 92vw)",
-  background: "hsl(var(--popover, var(--background)))",
-  color: "hsl(var(--popover-foreground, var(--foreground)))",
-  border: "1px solid hsl(var(--border))",
-  borderRadius: 8,
-  boxShadow: "0 10px 30px rgba(0,0,0,0.25)",
-  zIndex: 2000,
+const selectChevron: React.CSSProperties = {
+  position: "absolute",
+  right: 8,
+  top: "50%",
+  transform: "translateY(-50%)",
+  pointerEvents: "none",
+  color: "hsl(var(--muted-foreground))",
 };
 
-const panelInnerStyle: React.CSSProperties = {
-  padding: 14,
-  fontFamily: "inherit",
-};
-
-const headerRow: React.CSSProperties = {
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "flex-start",
-  gap: 8,
-  marginBottom: 12,
-};
-
-const titleStyle: React.CSSProperties = {
+const sectionLabel: React.CSSProperties = {
   fontSize: 13,
   fontWeight: 600,
-};
-
-const subtitleStyle: React.CSSProperties = {
-  fontSize: 11,
-  color: mutedText,
-  marginTop: 2,
-};
-
-const sectionLabelStyle: React.CSSProperties = {
-  fontSize: 10,
-  fontWeight: 600,
-  color: mutedText,
-  textTransform: "uppercase",
-  letterSpacing: 0.4,
-  marginTop: 10,
-  marginBottom: 6,
-};
-
-const visRow: React.CSSProperties = {
-  display: "flex",
-  gap: 6,
+  marginBottom: 8,
+  marginTop: 4,
 };
 
 const listStyle: React.CSSProperties = {
   listStyle: "none",
   margin: 0,
   padding: 0,
-  border: "1px solid hsl(var(--border))",
-  borderRadius: 6,
-  overflow: "hidden",
+  display: "flex",
+  flexDirection: "column",
+  gap: 2,
+  marginBottom: 16,
 };
 
-const itemStyle: React.CSSProperties = {
+const rowStyle: React.CSSProperties = {
   display: "flex",
-  justifyContent: "space-between",
   alignItems: "center",
-  padding: "6px 10px",
-  borderBottom: "1px solid hsl(var(--border))",
-  fontSize: 12,
+  gap: 10,
+  padding: "6px 4px",
+  fontSize: 13,
+};
+
+const avatarStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  height: 28,
+  width: 28,
+  borderRadius: "50%",
+  background: "hsl(var(--muted))",
+  color: "hsl(var(--muted-foreground))",
+  fontSize: 11,
+  fontWeight: 600,
+  flexShrink: 0,
 };
 
 const principalStyle: React.CSSProperties = {
@@ -424,67 +544,79 @@ const principalStyle: React.CSSProperties = {
 };
 
 const roleStyle: React.CSSProperties = {
-  fontSize: 11,
-  color: mutedText,
+  fontSize: 12,
+  color: "hsl(var(--muted-foreground))",
 };
 
-const inviteRow: React.CSSProperties = {
+const generalRow: React.CSSProperties = {
   display: "flex",
-  gap: 6,
   alignItems: "center",
+  gap: 10,
+  padding: "4px 0",
+  marginBottom: 16,
 };
 
-const inputStyle: React.CSSProperties = {
-  flex: 1,
-  minWidth: 0,
-  height: 30,
-  padding: "0 10px",
-  border: "1px solid hsl(var(--border))",
-  borderRadius: 6,
-  fontSize: 12,
-  background: "hsl(var(--background))",
-  color: "hsl(var(--foreground))",
-};
-
-const selectStyle: React.CSSProperties = {
-  height: 30,
-  padding: "0 8px",
-  border: "1px solid hsl(var(--border))",
-  borderRadius: 6,
-  fontSize: 12,
-  background: "hsl(var(--background))",
-  color: "hsl(var(--foreground))",
-};
-
-const primaryBtnStyle = (disabled: boolean): React.CSSProperties => ({
+const generalIcon: React.CSSProperties = {
   display: "inline-flex",
   alignItems: "center",
-  gap: 4,
-  height: 30,
-  padding: "0 12px",
+  justifyContent: "center",
+  height: 36,
+  width: 36,
+  borderRadius: "50%",
+  background: "hsl(var(--muted))",
+  color: "hsl(var(--muted-foreground))",
+  flexShrink: 0,
+};
+
+const generalSelectStyle: React.CSSProperties = {
+  ...selectStyle,
+  // The general-access select is inline with its description below it;
+  // hide the border so it reads as plain text with a chevron, matching
+  // Google Docs' "Builder.io ▾" presentation.
   border: "none",
-  borderRadius: 6,
-  background: disabled
-    ? "hsl(var(--muted))"
-    : "hsl(var(--primary, var(--foreground)))",
-  color: disabled
-    ? "hsl(var(--muted-foreground))"
-    : "hsl(var(--primary-foreground, var(--background)))",
+  padding: "0 24px 0 0",
+  background: "transparent",
+  height: 22,
+  fontSize: 14,
+  fontWeight: 600,
+};
+
+const generalHint: React.CSSProperties = {
   fontSize: 12,
+  color: "hsl(var(--muted-foreground))",
+  marginTop: 2,
+};
+
+const footerRow: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "flex-end",
+  marginTop: 8,
+};
+
+const doneBtnStyle: React.CSSProperties = {
+  height: 36,
+  padding: "0 20px",
+  borderRadius: 999,
+  border: "none",
+  background: "hsl(var(--primary, var(--foreground)))",
+  color: "hsl(var(--primary-foreground, var(--background)))",
+  fontSize: 14,
   fontWeight: 500,
-  cursor: disabled ? "not-allowed" : "pointer",
-});
+  cursor: "pointer",
+  font: "inherit",
+  lineHeight: 1,
+};
 
 const iconBtnStyle: React.CSSProperties = {
   display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
-  height: 22,
-  width: 22,
+  height: 24,
+  width: 24,
   padding: 0,
   border: "none",
   background: "transparent",
-  color: mutedText,
+  color: "hsl(var(--muted-foreground))",
   cursor: "pointer",
   borderRadius: 4,
 };

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tabler/icons-react";
 import * as Popover from "@radix-ui/react-popover";
 import { useActionQuery, useActionMutation } from "../use-action.js";
+import { cn } from "../utils.js";
 
 export interface ShareButtonProps {
   resourceType: string;
@@ -37,6 +38,31 @@ interface SharesResponse {
   shares: Share[];
 }
 
+// Match the exact Tailwind classes emitted by shadcn's `<Button size="sm"
+// variant="outline">`. Templates vendor their own Button component, but
+// every template uses the same shadcn theme + preset, so the same class
+// string renders identically. Keeping them as literal strings here means
+// this component looks native in every template without importing from
+// the template itself (which wouldn't be possible from core).
+const BUTTON_BASE =
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0";
+const BUTTON_OUTLINE_SM = cn(
+  BUTTON_BASE,
+  "h-9 px-3 border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+);
+const BUTTON_PRIMARY_SM = cn(
+  BUTTON_BASE,
+  "h-9 px-4 bg-primary text-primary-foreground hover:bg-primary/90",
+);
+const BUTTON_GHOST_ICON = cn(
+  BUTTON_BASE,
+  "h-7 w-7 p-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+);
+const BUTTON_GHOST_INLINE = cn(
+  BUTTON_BASE,
+  "h-7 px-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+);
+
 const VIS_META: Record<
   Visibility,
   { label: string; description: string; Icon: typeof IconLock }
@@ -60,10 +86,9 @@ const VIS_META: Record<
 
 /**
  * Framework share control. Renders a shadcn-outline-styled trigger that
- * opens a Google-Docs-style popover: a people-input at the top, a
- * "People with access" list, and a "General access" row with a single
- * visibility dropdown. All colors use CSS variables so dark mode works
- * out of the box in any shadcn template.
+ * opens a Google-Docs-style popover anchored beneath it. Uses CSS
+ * variables and Tailwind classes that every shadcn template already
+ * ships, so the same component renders natively in light and dark mode.
  */
 export function ShareButton(props: ShareButtonProps) {
   const [open, setOpen] = useState(false);
@@ -88,7 +113,7 @@ export function ShareButton(props: ShareButtonProps) {
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
-        <button type="button" style={triggerStyle}>
+        <button type="button" className={BUTTON_OUTLINE_SM}>
           <TriggerIcon size={16} strokeWidth={1.75} />
           <span>{triggerLabel}</span>
         </button>
@@ -97,7 +122,7 @@ export function ShareButton(props: ShareButtonProps) {
         <Popover.Content
           align="end"
           sideOffset={6}
-          style={panelStyle}
+          className="z-[2000] w-[min(460px,92vw)] rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-lg outline-none"
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
           <SharePanel
@@ -160,7 +185,7 @@ function SharePanel(
   const orgMembers = useOrgMembers();
   const datalistId = `share-autocomplete-${resourceType}-${resourceId}`;
 
-  // Optimistic overlays on top of server state so clicks feel instant.
+  // Optimistic overlays so clicks feel instant.
   const [visibilityOverride, setVisibilityOverride] =
     useState<Visibility | null>(null);
   const [pendingAdds, setPendingAdds] = useState<Share[]>([]);
@@ -261,14 +286,18 @@ function SharePanel(
     );
   };
 
+  const titleText = resourceTitle
+    ? `Share "${resourceTitle}"`
+    : `Share ${resourceType}`;
+
   return (
-    <div style={panelInner}>
-      <div style={titleStyle}>
-        Share {resourceTitle ? `"${resourceTitle}"` : resourceType}
+    <div>
+      <div className="mb-3 truncate text-base font-semibold" title={titleText}>
+        {titleText}
       </div>
 
       {canManage ? (
-        <div style={inviteRow}>
+        <div className="mb-4 flex items-stretch gap-2">
           <input
             type="email"
             placeholder="Add people by email"
@@ -279,7 +308,7 @@ function SharePanel(
             }}
             list={orgMembers.length > 0 ? datalistId : undefined}
             autoComplete="off"
-            style={inputStyle}
+            className="flex-1 min-w-0 h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
           />
           {orgMembers.length > 0 ? (
             <datalist id={datalistId}>
@@ -301,50 +330,41 @@ function SharePanel(
                 ))}
             </datalist>
           ) : null}
-          <div style={selectWrap}>
-            <select
-              value={role}
-              onChange={(e) => setRole(e.target.value as Role)}
-              style={selectStyle}
-              aria-label="Role"
-            >
-              <option value="viewer">Viewer</option>
-              <option value="editor">Editor</option>
-              <option value="admin">Admin</option>
-            </select>
-            <IconChevronDown size={14} style={selectChevron} />
-          </div>
+          <ChevronSelect
+            value={role}
+            onChange={(v) => setRole(v as Role)}
+            options={[
+              { value: "viewer", label: "Viewer" },
+              { value: "editor", label: "Editor" },
+              { value: "admin", label: "Admin" },
+            ]}
+          />
         </div>
       ) : null}
 
-      <div style={sectionLabel}>People with access</div>
-      <ul style={listStyle}>
+      <div className="mb-2 text-sm font-semibold">People with access</div>
+      <ul className="mb-4 flex flex-col gap-1 list-none p-0 m-0">
         {data?.ownerEmail ? (
-          <li style={rowStyle}>
-            <span style={avatarStyle} aria-hidden>
-              {initials(data.ownerEmail)}
-            </span>
-            <span style={{ ...principalStyle, flex: 1, minWidth: 0 }}>
-              {data.ownerEmail}
-            </span>
-            <span style={roleStyle}>Owner</span>
+          <li className="flex items-center gap-3 px-1 py-1.5 text-sm">
+            <Avatar label={data.ownerEmail} />
+            <span className="flex-1 min-w-0 truncate">{data.ownerEmail}</span>
+            <span className="text-xs text-muted-foreground">Owner</span>
           </li>
         ) : null}
         {shares.map((s) => (
-          <li key={keyOf(s)} style={rowStyle}>
-            <span style={avatarStyle} aria-hidden>
-              {s.principalType === "org" ? "🏢" : initials(s.principalId)}
-            </span>
-            <span style={{ ...principalStyle, flex: 1, minWidth: 0 }}>
-              {s.principalId}
-            </span>
-            <span style={roleStyle}>{cap(s.role)}</span>
+          <li
+            key={keyOf(s)}
+            className="flex items-center gap-3 px-1 py-1.5 text-sm"
+          >
+            <Avatar label={s.principalId} org={s.principalType === "org"} />
+            <span className="flex-1 min-w-0 truncate">{s.principalId}</span>
+            <span className="text-xs text-muted-foreground">{cap(s.role)}</span>
             {canManage ? (
               <button
                 type="button"
                 aria-label="Remove"
                 onClick={() => handleRemove(s)}
-                style={iconBtnStyle}
+                className={BUTTON_GHOST_ICON}
               >
                 <IconTrash size={14} />
               </button>
@@ -352,41 +372,89 @@ function SharePanel(
           </li>
         ))}
         {!shares.length && !data?.ownerEmail ? (
-          <li style={{ ...rowStyle, color: "hsl(var(--muted-foreground))" }}>
+          <li className="px-1 py-1.5 text-sm text-muted-foreground">
             No one has access yet.
           </li>
         ) : null}
       </ul>
 
-      <div style={sectionLabel}>General access</div>
-      <div style={generalRow}>
-        <span style={generalIcon} aria-hidden>
+      <div className="mb-2 text-sm font-semibold">General access</div>
+      <div className="mb-4 flex items-center gap-3">
+        <span
+          aria-hidden
+          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"
+        >
           <meta.Icon size={16} strokeWidth={1.75} />
         </span>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={selectWrap}>
-            <select
-              value={visibility}
-              disabled={!canManage}
-              onChange={(e) => handleVisibility(e.target.value as Visibility)}
-              style={generalSelectStyle}
-              aria-label="General access"
-            >
-              <option value="private">{VIS_META.private.label}</option>
-              <option value="org">{VIS_META.org.label}</option>
-              <option value="public">{VIS_META.public.label}</option>
-            </select>
-            <IconChevronDown size={14} style={selectChevron} />
+        <div className="min-w-0 flex-1">
+          <ChevronSelect
+            value={visibility}
+            onChange={(v) => handleVisibility(v as Visibility)}
+            disabled={!canManage}
+            plain
+            options={[
+              { value: "private", label: VIS_META.private.label },
+              { value: "org", label: VIS_META.org.label },
+              { value: "public", label: VIS_META.public.label },
+            ]}
+          />
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            {meta.description}
           </div>
-          <div style={generalHint}>{meta.description}</div>
         </div>
       </div>
 
-      <div style={footerRow}>
-        <button type="button" onClick={onClose} style={doneBtnStyle}>
+      <div className="mt-2 flex justify-end">
+        <button type="button" onClick={onClose} className={BUTTON_PRIMARY_SM}>
           Done
         </button>
       </div>
+    </div>
+  );
+}
+
+function Avatar({ label, org }: { label: string; org?: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-semibold text-muted-foreground"
+    >
+      {org ? "🏢" : initials(label)}
+    </span>
+  );
+}
+
+function ChevronSelect(props: {
+  value: string;
+  onChange: (v: string) => void;
+  options: Array<{ value: string; label: string }>;
+  disabled?: boolean;
+  /** When true, render as inline text (no border/background) — matches
+   *  Google Docs' "General access" presentation. */
+  plain?: boolean;
+}) {
+  return (
+    <div className="relative inline-flex items-center">
+      <select
+        value={props.value}
+        onChange={(e) => props.onChange(e.target.value)}
+        disabled={props.disabled}
+        className={
+          props.plain
+            ? "appearance-none bg-transparent border-0 pr-6 pl-0 text-sm font-medium text-foreground cursor-pointer focus:outline-none disabled:opacity-60"
+            : "appearance-none h-9 rounded-md border border-input bg-background pl-3 pr-7 text-sm text-foreground cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+        }
+      >
+        {props.options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <IconChevronDown
+        size={14}
+        className="pointer-events-none absolute right-1.5 text-muted-foreground"
+      />
     </div>
   );
 }
@@ -401,222 +469,3 @@ function initials(s: string): string {
   const name = s.split("@")[0] ?? s;
   return (name[0] ?? "?").toUpperCase();
 }
-
-// ---------------------------------------------------------------------------
-// Theme-aware styles — use shadcn CSS variables so the same component
-// renders correctly in light and dark mode without extra plumbing.
-// ---------------------------------------------------------------------------
-
-const triggerStyle: React.CSSProperties = {
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  gap: 8,
-  height: 36,
-  padding: "0 12px",
-  borderRadius: 6,
-  border: "1px solid hsl(var(--border))",
-  background: "hsl(var(--background))",
-  color: "hsl(var(--foreground))",
-  fontSize: 14,
-  fontWeight: 500,
-  cursor: "pointer",
-  font: "inherit",
-  lineHeight: 1,
-  whiteSpace: "nowrap",
-};
-
-const panelStyle: React.CSSProperties = {
-  width: "min(460px, 92vw)",
-  background: "hsl(var(--popover, var(--background)))",
-  color: "hsl(var(--popover-foreground, var(--foreground)))",
-  border: "1px solid hsl(var(--border))",
-  borderRadius: 10,
-  boxShadow: "0 10px 30px rgba(0,0,0,0.25)",
-  zIndex: 2000,
-};
-
-const panelInner: React.CSSProperties = {
-  padding: 16,
-  fontFamily: "inherit",
-};
-
-const titleStyle: React.CSSProperties = {
-  fontSize: 16,
-  fontWeight: 600,
-  marginBottom: 12,
-  paddingRight: 24,
-};
-
-const inviteRow: React.CSSProperties = {
-  display: "flex",
-  gap: 8,
-  alignItems: "center",
-  marginBottom: 16,
-};
-
-const inputStyle: React.CSSProperties = {
-  flex: 1,
-  minWidth: 0,
-  height: 36,
-  padding: "0 12px",
-  border: "1px solid hsl(var(--border))",
-  borderRadius: 6,
-  fontSize: 14,
-  background: "hsl(var(--background))",
-  color: "hsl(var(--foreground))",
-  outline: "none",
-};
-
-const selectWrap: React.CSSProperties = {
-  position: "relative",
-  display: "inline-block",
-};
-
-const selectStyle: React.CSSProperties = {
-  appearance: "none" as any,
-  WebkitAppearance: "none" as any,
-  MozAppearance: "none" as any,
-  height: 36,
-  padding: "0 28px 0 12px",
-  border: "1px solid hsl(var(--border))",
-  borderRadius: 6,
-  fontSize: 14,
-  background: "hsl(var(--background))",
-  color: "hsl(var(--foreground))",
-  cursor: "pointer",
-  font: "inherit",
-  lineHeight: 1,
-};
-
-const selectChevron: React.CSSProperties = {
-  position: "absolute",
-  right: 8,
-  top: "50%",
-  transform: "translateY(-50%)",
-  pointerEvents: "none",
-  color: "hsl(var(--muted-foreground))",
-};
-
-const sectionLabel: React.CSSProperties = {
-  fontSize: 13,
-  fontWeight: 600,
-  marginBottom: 8,
-  marginTop: 4,
-};
-
-const listStyle: React.CSSProperties = {
-  listStyle: "none",
-  margin: 0,
-  padding: 0,
-  display: "flex",
-  flexDirection: "column",
-  gap: 2,
-  marginBottom: 16,
-};
-
-const rowStyle: React.CSSProperties = {
-  display: "flex",
-  alignItems: "center",
-  gap: 10,
-  padding: "6px 4px",
-  fontSize: 13,
-};
-
-const avatarStyle: React.CSSProperties = {
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  height: 28,
-  width: 28,
-  borderRadius: "50%",
-  background: "hsl(var(--muted))",
-  color: "hsl(var(--muted-foreground))",
-  fontSize: 11,
-  fontWeight: 600,
-  flexShrink: 0,
-};
-
-const principalStyle: React.CSSProperties = {
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
-};
-
-const roleStyle: React.CSSProperties = {
-  fontSize: 12,
-  color: "hsl(var(--muted-foreground))",
-};
-
-const generalRow: React.CSSProperties = {
-  display: "flex",
-  alignItems: "center",
-  gap: 10,
-  padding: "4px 0",
-  marginBottom: 16,
-};
-
-const generalIcon: React.CSSProperties = {
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  height: 36,
-  width: 36,
-  borderRadius: "50%",
-  background: "hsl(var(--muted))",
-  color: "hsl(var(--muted-foreground))",
-  flexShrink: 0,
-};
-
-const generalSelectStyle: React.CSSProperties = {
-  ...selectStyle,
-  // The general-access select is inline with its description below it;
-  // hide the border so it reads as plain text with a chevron, matching
-  // Google Docs' "Builder.io ▾" presentation.
-  border: "none",
-  padding: "0 24px 0 0",
-  background: "transparent",
-  height: 22,
-  fontSize: 14,
-  fontWeight: 600,
-};
-
-const generalHint: React.CSSProperties = {
-  fontSize: 12,
-  color: "hsl(var(--muted-foreground))",
-  marginTop: 2,
-};
-
-const footerRow: React.CSSProperties = {
-  display: "flex",
-  justifyContent: "flex-end",
-  marginTop: 8,
-};
-
-const doneBtnStyle: React.CSSProperties = {
-  height: 36,
-  padding: "0 20px",
-  borderRadius: 999,
-  border: "none",
-  background: "hsl(var(--primary, var(--foreground)))",
-  color: "hsl(var(--primary-foreground, var(--background)))",
-  fontSize: 14,
-  fontWeight: 500,
-  cursor: "pointer",
-  font: "inherit",
-  lineHeight: 1,
-};
-
-const iconBtnStyle: React.CSSProperties = {
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  height: 24,
-  width: 24,
-  padding: 0,
-  border: "none",
-  background: "transparent",
-  color: "hsl(var(--muted-foreground))",
-  cursor: "pointer",
-  borderRadius: 4,
-};

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -1,12 +1,15 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   IconShare,
   IconLock,
   IconBuilding,
   IconWorld,
+  IconTrash,
+  IconCheck,
+  IconX,
 } from "@tabler/icons-react";
-import { ShareDialog } from "./ShareDialog.js";
-import { useActionQuery } from "../use-action.js";
+import * as Popover from "@radix-ui/react-popover";
+import { useActionQuery, useActionMutation } from "../use-action.js";
 
 export interface ShareButtonProps {
   resourceType: string;
@@ -16,19 +19,40 @@ export interface ShareButtonProps {
   variant?: "compact" | "label";
 }
 
+type Visibility = "private" | "org" | "public";
+type Role = "viewer" | "editor" | "admin";
+
+interface Share {
+  id: string;
+  principalType: "user" | "org";
+  principalId: string;
+  role: Role;
+}
+
+interface SharesResponse {
+  ownerEmail: string | null;
+  orgId: string | null;
+  visibility: Visibility | null;
+  role?: "owner" | Role;
+  shares: Share[];
+}
+
 /**
- * Drop-in share button. Opens the framework-standard ShareDialog. Reflects the
- * current visibility with an icon so users can tell at a glance whether the
- * resource is private, org-visible, or public.
+ * Drop-in share control. Renders as a shadcn-outline-styled trigger that
+ * opens a popover anchored beneath it — picks up the template's theme
+ * (including dark mode) via CSS variables, so the same component looks
+ * native in every template.
  */
 export function ShareButton(props: ShareButtonProps) {
   const [open, setOpen] = useState(false);
-  const q = useActionQuery<{ visibility: "private" | "org" | "public" | null }>(
-    "list-resource-shares",
-    { resourceType: props.resourceType, resourceId: props.resourceId },
-  );
-  const visibility = q.data?.visibility ?? "private";
-  const Icon =
+  const sharesQuery = useActionQuery<SharesResponse>("list-resource-shares", {
+    resourceType: props.resourceType,
+    resourceId: props.resourceId,
+  });
+  const visibility: Visibility =
+    (sharesQuery.data?.visibility as Visibility | null) ?? "private";
+
+  const VisIcon =
     visibility === "public"
       ? IconWorld
       : visibility === "org"
@@ -46,33 +70,421 @@ export function ShareButton(props: ShareButtonProps) {
       : "Share";
 
   return (
-    <>
-      <button
-        onClick={() => setOpen(true)}
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: 6,
-          padding: "6px 10px",
-          border: "1px solid #e5e7eb",
-          borderRadius: 6,
-          background: "#fff",
-          color: "#111827",
-          fontSize: 13,
-          cursor: "pointer",
-          font: "inherit",
-        }}
-      >
-        <Icon size={14} />
-        {label}
-      </button>
-      <ShareDialog
-        open={open}
-        onClose={() => setOpen(false)}
-        resourceType={props.resourceType}
-        resourceId={props.resourceId}
-        resourceTitle={props.resourceTitle}
-      />
-    </>
+    <Popover.Root open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <button type="button" style={triggerStyle}>
+          <VisIcon size={14} strokeWidth={1.75} />
+          <span>{label}</span>
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="end"
+          sideOffset={6}
+          style={panelStyle}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <SharePanel
+            {...props}
+            sharesQuery={sharesQuery}
+            onClose={() => setOpen(false)}
+          />
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }
+
+function SharePanel(
+  props: ShareButtonProps & {
+    sharesQuery: ReturnType<typeof useActionQuery<SharesResponse>>;
+    onClose: () => void;
+  },
+) {
+  const { resourceType, resourceId, resourceTitle, sharesQuery, onClose } =
+    props;
+  const setVisibility = useActionMutation("set-resource-visibility");
+  const share = useActionMutation("share-resource");
+  const unshare = useActionMutation("unshare-resource");
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<Role>("viewer");
+
+  useEffect(() => {
+    sharesQuery.refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const data = sharesQuery.data;
+  const visibility: Visibility =
+    (data?.visibility as Visibility | null) ?? "private";
+  const canManage =
+    data?.role === "owner" || data?.role === "admin" || !data?.role;
+
+  const handleVisibility = (next: Visibility) => {
+    setVisibility.mutate(
+      { resourceType, resourceId, visibility: next } as any,
+      { onSuccess: () => sharesQuery.refetch() },
+    );
+  };
+  const handleAdd = () => {
+    const trimmed = email.trim();
+    if (!trimmed) return;
+    share.mutate(
+      {
+        resourceType,
+        resourceId,
+        principalType: "user",
+        principalId: trimmed,
+        role,
+      } as any,
+      {
+        onSuccess: () => {
+          setEmail("");
+          sharesQuery.refetch();
+        },
+      },
+    );
+  };
+  const handleRemove = (s: Share) => {
+    unshare.mutate(
+      {
+        resourceType,
+        resourceId,
+        principalType: s.principalType,
+        principalId: s.principalId,
+      } as any,
+      { onSuccess: () => sharesQuery.refetch() },
+    );
+  };
+
+  return (
+    <div style={panelInnerStyle}>
+      <div style={headerRow}>
+        <div style={{ minWidth: 0 }}>
+          <div style={titleStyle}>
+            Share {resourceTitle ? `"${resourceTitle}"` : resourceType}
+          </div>
+          {data?.ownerEmail ? (
+            <div style={subtitleStyle}>Owner: {data.ownerEmail}</div>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          style={iconBtnStyle}
+        >
+          <IconX size={14} />
+        </button>
+      </div>
+
+      <div style={sectionLabelStyle}>General access</div>
+      <div style={visRow}>
+        <VisOption
+          active={visibility === "private"}
+          disabled={!canManage}
+          label="Private"
+          sublabel="Only people with explicit access"
+          icon={<IconLock size={14} strokeWidth={1.75} />}
+          onClick={() => handleVisibility("private")}
+        />
+        <VisOption
+          active={visibility === "org"}
+          disabled={!canManage}
+          label="Organization"
+          sublabel="Anyone in your org can view"
+          icon={<IconBuilding size={14} strokeWidth={1.75} />}
+          onClick={() => handleVisibility("org")}
+        />
+        <VisOption
+          active={visibility === "public"}
+          disabled={!canManage}
+          label="Public"
+          sublabel="Any signed-in user can view"
+          icon={<IconWorld size={14} strokeWidth={1.75} />}
+          onClick={() => handleVisibility("public")}
+        />
+      </div>
+
+      <div style={sectionLabelStyle}>People with access</div>
+      <ul style={listStyle}>
+        {data?.ownerEmail ? (
+          <li style={itemStyle}>
+            <span style={principalStyle}>{data.ownerEmail}</span>
+            <span style={roleStyle}>Owner</span>
+          </li>
+        ) : null}
+        {(data?.shares ?? []).map((s) => (
+          <li key={s.id} style={itemStyle}>
+            <span style={principalStyle}>
+              {s.principalType === "org" ? "🏢 " : ""}
+              {s.principalId}
+            </span>
+            <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+              <span style={roleStyle}>{cap(s.role)}</span>
+              {canManage ? (
+                <button
+                  type="button"
+                  aria-label="Remove"
+                  onClick={() => handleRemove(s)}
+                  style={iconBtnStyle}
+                >
+                  <IconTrash size={13} />
+                </button>
+              ) : null}
+            </span>
+          </li>
+        ))}
+        {!data?.shares?.length && !data?.ownerEmail ? (
+          <li style={{ ...itemStyle, color: mutedText }}>
+            No one has access yet.
+          </li>
+        ) : null}
+      </ul>
+
+      {canManage ? (
+        <>
+          <div style={sectionLabelStyle}>Invite by email</div>
+          <div style={inviteRow}>
+            <input
+              type="email"
+              placeholder="email@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleAdd();
+              }}
+              style={inputStyle}
+            />
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value as Role)}
+              style={selectStyle}
+            >
+              <option value="viewer">Viewer</option>
+              <option value="editor">Editor</option>
+              <option value="admin">Admin</option>
+            </select>
+            <button
+              type="button"
+              onClick={handleAdd}
+              disabled={!email.trim() || share.isPending}
+              style={primaryBtnStyle(!email.trim() || share.isPending)}
+            >
+              <IconCheck size={13} /> Share
+            </button>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function VisOption(props: {
+  active: boolean;
+  disabled?: boolean;
+  label: string;
+  sublabel: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={props.onClick}
+      disabled={props.disabled}
+      style={{
+        flex: 1,
+        minWidth: 0,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-start",
+        gap: 2,
+        padding: "8px 10px",
+        borderRadius: 6,
+        border: `1px solid ${props.active ? "hsl(var(--foreground))" : "hsl(var(--border))"}`,
+        background: props.active
+          ? "hsl(var(--foreground))"
+          : "hsl(var(--background))",
+        color: props.active
+          ? "hsl(var(--background))"
+          : "hsl(var(--foreground))",
+        cursor: props.disabled ? "not-allowed" : "pointer",
+        opacity: props.disabled ? 0.6 : 1,
+        textAlign: "left",
+        font: "inherit",
+      }}
+    >
+      <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        {props.icon}
+        <strong style={{ fontSize: 12, fontWeight: 600 }}>{props.label}</strong>
+      </span>
+      <span style={{ fontSize: 11, opacity: 0.75 }}>{props.sublabel}</span>
+    </button>
+  );
+}
+
+function cap(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// --- theme-aware styles (use shadcn CSS variables so the same component
+//     renders correctly in light and dark mode without extra plumbing) ---
+
+const mutedText = "hsl(var(--muted-foreground))";
+
+const triggerStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 6,
+  height: 32,
+  padding: "0 12px",
+  borderRadius: 6,
+  border: "1px solid hsl(var(--border))",
+  background: "hsl(var(--background))",
+  color: "hsl(var(--foreground))",
+  fontSize: 12,
+  fontWeight: 500,
+  cursor: "pointer",
+  font: "inherit",
+  lineHeight: 1,
+};
+
+const panelStyle: React.CSSProperties = {
+  width: "min(420px, 92vw)",
+  background: "hsl(var(--popover, var(--background)))",
+  color: "hsl(var(--popover-foreground, var(--foreground)))",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 8,
+  boxShadow: "0 10px 30px rgba(0,0,0,0.25)",
+  zIndex: 2000,
+};
+
+const panelInnerStyle: React.CSSProperties = {
+  padding: 14,
+  fontFamily: "inherit",
+};
+
+const headerRow: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+  gap: 8,
+  marginBottom: 12,
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: 13,
+  fontWeight: 600,
+};
+
+const subtitleStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: mutedText,
+  marginTop: 2,
+};
+
+const sectionLabelStyle: React.CSSProperties = {
+  fontSize: 10,
+  fontWeight: 600,
+  color: mutedText,
+  textTransform: "uppercase",
+  letterSpacing: 0.4,
+  marginTop: 10,
+  marginBottom: 6,
+};
+
+const visRow: React.CSSProperties = {
+  display: "flex",
+  gap: 6,
+};
+
+const listStyle: React.CSSProperties = {
+  listStyle: "none",
+  margin: 0,
+  padding: 0,
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 6,
+  overflow: "hidden",
+};
+
+const itemStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "6px 10px",
+  borderBottom: "1px solid hsl(var(--border))",
+  fontSize: 12,
+};
+
+const principalStyle: React.CSSProperties = {
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const roleStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: mutedText,
+};
+
+const inviteRow: React.CSSProperties = {
+  display: "flex",
+  gap: 6,
+  alignItems: "center",
+};
+
+const inputStyle: React.CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  height: 30,
+  padding: "0 10px",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 6,
+  fontSize: 12,
+  background: "hsl(var(--background))",
+  color: "hsl(var(--foreground))",
+};
+
+const selectStyle: React.CSSProperties = {
+  height: 30,
+  padding: "0 8px",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: 6,
+  fontSize: 12,
+  background: "hsl(var(--background))",
+  color: "hsl(var(--foreground))",
+};
+
+const primaryBtnStyle = (disabled: boolean): React.CSSProperties => ({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 4,
+  height: 30,
+  padding: "0 12px",
+  border: "none",
+  borderRadius: 6,
+  background: disabled
+    ? "hsl(var(--muted))"
+    : "hsl(var(--primary, var(--foreground)))",
+  color: disabled
+    ? "hsl(var(--muted-foreground))"
+    : "hsl(var(--primary-foreground, var(--background)))",
+  fontSize: 12,
+  fontWeight: 500,
+  cursor: disabled ? "not-allowed" : "pointer",
+});
+
+const iconBtnStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  height: 22,
+  width: 22,
+  padding: 0,
+  border: "none",
+  background: "transparent",
+  color: mutedText,
+  cursor: "pointer",
+  borderRadius: 4,
+};

--- a/packages/core/src/secrets/register-framework-secrets.ts
+++ b/packages/core/src/secrets/register-framework-secrets.ts
@@ -1,0 +1,59 @@
+/**
+ * Framework-level secret registrations.
+ *
+ * Side-effect module — imported by the core-routes plugin at boot so the
+ * sidebar settings UI and the `/_agent-native/secrets` list route surface the
+ * relevant keys in every template.
+ *
+ * Each call uses a `getRequiredSecret` guard so a template that has already
+ * registered the same key (often with stricter settings like `required: true`)
+ * wins — the framework registration is a fallback, not an override.
+ */
+
+import { getRequiredSecret, registerRequiredSecret } from "./register.js";
+
+/**
+ * OpenAI API key.
+ *
+ * The framework uses this for voice transcription in the agent sidebar
+ * composer (Whisper). Templates like Clips register it as `required: true`
+ * in their own `register-secrets.ts`; the framework keeps it optional here
+ * so every other template still surfaces the input without forcing the
+ * onboarding checklist step.
+ */
+function registerOpenAiKey(): void {
+  if (getRequiredSecret("OPENAI_API_KEY")) return;
+  registerRequiredSecret({
+    key: "OPENAI_API_KEY",
+    label: "OpenAI API Key",
+    description:
+      "Used for voice transcription (Whisper) in the agent composer. Without this, voice input falls back to your browser's built-in speech recognition.",
+    docsUrl: "https://platform.openai.com/api-keys",
+    scope: "user",
+    kind: "api-key",
+    required: false,
+    validator: async (value) => {
+      if (!value || typeof value !== "string" || value.length < 20) {
+        return { ok: false, error: "Key looks too short." };
+      }
+      try {
+        const res = await fetch("https://api.openai.com/v1/models", {
+          headers: { Authorization: `Bearer ${value}` },
+        });
+        if (res.ok) return true;
+        if (res.status === 401)
+          return { ok: false, error: "OpenAI rejected this key (401)." };
+        return { ok: false, error: `OpenAI returned ${res.status}.` };
+      } catch (err: any) {
+        return {
+          ok: false,
+          error: `Could not reach OpenAI: ${err?.message ?? err}`,
+        };
+      }
+    },
+  });
+}
+
+export function registerFrameworkSecrets(): void {
+  registerOpenAiKey();
+}

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -889,6 +889,13 @@ async function mountBetterAuthRoutes(
             "Local mode is not available in production. Create an account to continue.",
         };
       }
+      if (!isLocalDatabase()) {
+        setResponseStatus(event, 400);
+        return {
+          error:
+            "Local mode is only available on a local SQLite database. Your DATABASE_URL points at a shared database — create an account instead.",
+        };
+      }
       const ok = await setAuthModeLocal();
       if (!ok) {
         setResponseStatus(event, 500);
@@ -1317,6 +1324,13 @@ function mountAuthFallbackRoutes(app: H3App): void {
         return {
           error:
             "Local mode is not available in production. Create an account to continue.",
+        };
+      }
+      if (!isLocalDatabase()) {
+        setResponseStatus(event, 400);
+        return {
+          error:
+            "Local mode is only available on a local SQLite database. Your DATABASE_URL points at a shared database — create an account instead.",
         };
       }
       const ok = await setAuthModeLocal();

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -45,6 +45,8 @@ import {
   createWriteSecretHandler,
   createTestSecretHandler,
 } from "../secrets/routes.js";
+import { registerFrameworkSecrets } from "../secrets/register-framework-secrets.js";
+import { createTranscribeVoiceHandler } from "./transcribe-voice.js";
 
 /**
  * The base path prefix for all framework-level routes.
@@ -96,6 +98,11 @@ export function createCoreRoutesPlugin(
     // No-op when called from inside the bootstrap (auto-mount path).
     // Otherwise wait so other default plugins finish mounting first.
     await awaitBootstrap(nitroApp);
+
+    // Register framework-level secrets (OPENAI_API_KEY for composer voice
+    // transcription, etc.). Each registration is guarded so templates that
+    // already registered the same key win.
+    registerFrameworkSecrets();
 
     const P = FRAMEWORK_ROUTE_PREFIX;
 
@@ -506,6 +513,13 @@ export function createCoreRoutesPlugin(
             "No file upload provider configured. Connect Builder.io in Settings → File uploads, or register a provider.",
         };
       }),
+    );
+
+    // ─── Voice transcription (Whisper) ───────────────────────────────
+    // POST /_agent-native/transcribe-voice — multipart audio → text
+    getH3App(nitroApp).use(
+      `${P}/transcribe-voice`,
+      createTranscribeVoiceHandler(),
     );
 
     // ─── Secrets registry ────────────────────────────────────────────

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -9,7 +9,12 @@
  * After first account exists, this page acts as a normal login page.
  * The "Use locally" escape hatch is hidden in production to ensure
  * real accounts are used (needed for per-user usage tracking/limits).
+ * It's also hidden when DATABASE_URL points at a non-local DB (Postgres,
+ * Turso, D1) — local@localhost has no per-user scoping, so enabling it
+ * against a shared DB would silently fail server-side.
  */
+
+import { isLocalDatabase } from "../db/client.js";
 
 function isProductionEnv(): boolean {
   const env = process.env.NODE_ENV;
@@ -45,7 +50,8 @@ export interface OnboardingHtmlOptions {
 const MIGRATE_FLAG_KEY = "an_migrate_from_local";
 
 export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
-  const showLocalMode = !isProductionEnv() && !opts.googleOnly;
+  const showLocalMode =
+    !isProductionEnv() && !opts.googleOnly && isLocalDatabase();
   const showGoogle = hasGoogleOAuth();
   const googleOnly = !!opts.googleOnly;
   const localModeBlock = showLocalMode
@@ -72,8 +78,14 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
       if (res.ok) {
         window.location.reload();
       } else {
-        btn.textContent = 'Failed — try again';
-        btn.disabled = false;
+        var data = await res.json().catch(function() { return {}; });
+        var info = document.getElementById('local-info');
+        if (info && data && data.error) {
+          info.textContent = data.error;
+          info.style.color = '#f87171';
+        }
+        btn.textContent = 'Not available';
+        btn.disabled = true;
       }
     } catch(e) {
       btn.textContent = 'Failed — try again';

--- a/packages/core/src/server/transcribe-voice.ts
+++ b/packages/core/src/server/transcribe-voice.ts
@@ -1,0 +1,128 @@
+/**
+ * POST /_agent-native/transcribe-voice
+ *
+ * Receives an audio blob from the agent sidebar composer and forwards it to
+ * OpenAI Whisper. Returns `{ text }` on success, `{ error }` on failure.
+ *
+ * Key resolution order (mirrors `templates/clips/actions/request-transcript.ts`):
+ *   1. User-scoped encrypted secret (`readAppSecret` — set via the sidebar
+ *      settings UI).
+ *   2. `resolveCredential("OPENAI_API_KEY")` — env var + SQL settings store.
+ *
+ * If no key is configured, returns 400 with an error the composer UI can
+ * surface (the client falls back to the browser Web Speech API).
+ *
+ * This is a framework route rather than a `defineAction` because multipart
+ * audio bodies aren't a clean fit for the action contract (actions are
+ * typed JSON-in / JSON-out).
+ */
+
+import {
+  defineEventHandler,
+  getMethod,
+  readMultipartFormData,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+import { readAppSecret } from "../secrets/storage.js";
+import { resolveCredential } from "../credentials/index.js";
+import { getSession } from "./auth.js";
+
+const WHISPER_URL = "https://api.openai.com/v1/audio/transcriptions";
+const MAX_AUDIO_BYTES = 25 * 1024 * 1024; // Whisper hard limit.
+
+export function createTranscribeVoiceHandler() {
+  return defineEventHandler(async (event: H3Event) => {
+    if (getMethod(event) !== "POST") {
+      setResponseStatus(event, 405);
+      return { error: "Method not allowed" };
+    }
+
+    const parts = await readMultipartFormData(event).catch(() => null);
+    const audio = parts?.find((p) => p.name === "audio");
+    if (!audio?.data?.length) {
+      setResponseStatus(event, 400);
+      return { error: "Missing audio payload" };
+    }
+    if (audio.data.length > MAX_AUDIO_BYTES) {
+      setResponseStatus(event, 413);
+      return { error: "Audio too large (max 25 MB)" };
+    }
+
+    const languagePart = parts?.find((p) => p.name === "language");
+    const language = languagePart?.data
+      ? languagePart.data.toString("utf8").trim().slice(0, 8)
+      : undefined;
+
+    // Resolve the key.
+    let apiKey: string | undefined;
+    const session = await getSession(event).catch(() => null);
+    if (session?.email) {
+      const userSecret = await readAppSecret({
+        key: "OPENAI_API_KEY",
+        scope: "user",
+        scopeId: session.email,
+      }).catch(() => null);
+      if (userSecret?.value) apiKey = userSecret.value;
+    }
+    if (!apiKey) {
+      apiKey = await resolveCredential("OPENAI_API_KEY");
+    }
+    if (!apiKey) {
+      setResponseStatus(event, 400);
+      return {
+        error:
+          "OPENAI_API_KEY not configured. Add it in Settings → API Keys to enable Whisper transcription.",
+      };
+    }
+
+    const mime = audio.type || "audio/webm";
+    const ext = pickExtension(mime);
+    const filename = `composer-voice.${ext}`;
+
+    const form = new FormData();
+    const bytes = new Uint8Array(
+      audio.data.buffer,
+      audio.data.byteOffset,
+      audio.data.byteLength,
+    );
+    form.append("file", new Blob([bytes], { type: mime }), filename);
+    form.append("model", "whisper-1");
+    form.append("response_format", "json");
+    if (language) form.append("language", language);
+
+    try {
+      const res = await fetch(WHISPER_URL, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: form,
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        setResponseStatus(event, res.status === 401 ? 401 : 502);
+        return {
+          error:
+            res.status === 401
+              ? "OpenAI rejected the API key. Update it in Settings → API Keys."
+              : `Whisper API error ${res.status}: ${text.slice(0, 300)}`,
+        };
+      }
+      const data = (await res.json()) as { text?: string };
+      return { text: (data.text ?? "").trim() };
+    } catch (err) {
+      setResponseStatus(event, 502);
+      return {
+        error: `Could not reach OpenAI: ${(err as Error)?.message ?? err}`,
+      };
+    }
+  });
+}
+
+function pickExtension(mime: string): string {
+  const lower = mime.toLowerCase();
+  if (lower.includes("mp4") || lower.includes("m4a")) return "mp4";
+  if (lower.includes("mpeg") || lower.includes("mp3")) return "mp3";
+  if (lower.includes("ogg")) return "ogg";
+  if (lower.includes("wav")) return "wav";
+  return "webm";
+}

--- a/packages/core/src/server/transcribe-voice.ts
+++ b/packages/core/src/server/transcribe-voice.ts
@@ -20,6 +20,7 @@
 import {
   defineEventHandler,
   getMethod,
+  getRequestHeader,
   readMultipartFormData,
   setResponseStatus,
   type H3Event,
@@ -31,11 +32,39 @@ import { getSession } from "./auth.js";
 const WHISPER_URL = "https://api.openai.com/v1/audio/transcriptions";
 const MAX_AUDIO_BYTES = 25 * 1024 * 1024; // Whisper hard limit.
 
+/**
+ * Reject cross-site POSTs. Cookies are `SameSite=None; Secure` over HTTPS so
+ * the browser would otherwise attach the session to a forged form submission
+ * from evil.com, causing us to spend OpenAI credits on the user's behalf.
+ * Same-origin browsers always send `Origin` on POST; if it's missing we fall
+ * back to `Sec-Fetch-Site` so Safari's fetch-spec behavior still works.
+ */
+function isSameOriginRequest(event: H3Event): boolean {
+  const host = getRequestHeader(event, "host");
+  const origin = getRequestHeader(event, "origin");
+  if (origin && host) {
+    try {
+      return new URL(origin).host === host;
+    } catch {
+      return false;
+    }
+  }
+  const fetchSite = getRequestHeader(event, "sec-fetch-site");
+  if (fetchSite) return fetchSite === "same-origin" || fetchSite === "none";
+  // No Origin and no Sec-Fetch-Site: likely a non-browser client (curl,
+  // server-side) — safe to allow, CSRF requires a browser with ambient cookies.
+  return true;
+}
+
 export function createTranscribeVoiceHandler() {
   return defineEventHandler(async (event: H3Event) => {
     if (getMethod(event) !== "POST") {
       setResponseStatus(event, 405);
       return { error: "Method not allowed" };
+    }
+    if (!isSameOriginRequest(event)) {
+      setResponseStatus(event, 403);
+      return { error: "Cross-origin request rejected" };
     }
 
     const parts = await readMultipartFormData(event).catch(() => null);

--- a/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
+++ b/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
@@ -17,6 +17,11 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   IconRefresh,
   IconTrash,
   IconClock,
@@ -129,15 +134,23 @@ export default function AnalysisDetail() {
           resourceTitle={analysis.name}
           variant="compact"
         />
-        <Button
-          variant="default"
-          size="sm"
-          onClick={handleRerun}
-          disabled={isGenerating}
-        >
-          <IconRefresh className="h-4 w-4 mr-1.5" />
-          Re-run
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="default"
+              size="sm"
+              onClick={handleRerun}
+              disabled={isGenerating}
+            >
+              <IconRefresh className="h-4 w-4" />
+              Re-run
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Re-run this analysis with the latest data and update the saved
+            results
+          </TooltipContent>
+        </Tooltip>
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button variant="ghost" size="sm">

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 
 interface RecordingSummary {
@@ -9,7 +9,17 @@ interface RecordingSummary {
   updatedAt: string;
 }
 
+type CaptureMode = "screen" | "screen-camera" | "camera";
+type CaptureSource = "full-screen" | "window" | "tab" | "custom";
+
 const STORAGE_KEY = "clips:server-url";
+const MODE_KEY = "clips:last-mode";
+const SOURCE_KEY = "clips:last-source";
+const CAM_KEY = "clips:last-camera-id";
+const MIC_KEY = "clips:last-mic-id";
+const CAM_ON_KEY = "clips:camera-on";
+const MIC_ON_KEY = "clips:mic-on";
+
 // Sensible defaults so the user never has to type a URL on first launch.
 // Dev builds point at the local dev server; production builds point at the
 // hosted Clips instance. The user can still override from Settings.
@@ -17,30 +27,37 @@ const DEFAULT_URL = import.meta.env.DEV
   ? "http://localhost:8080"
   : "https://clips.agent-native.com";
 
-function loadServerUrl(): string {
+function loadString(key: string, fallback: string): string {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored && stored.trim()) return stored.replace(/\/+$/, "");
+    const v = localStorage.getItem(key);
+    if (v && v.trim()) return v;
   } catch {
     // ignore
   }
-  return DEFAULT_URL;
+  return fallback;
 }
 
-function saveServerUrl(url: string): void {
+function saveString(key: string, value: string): void {
   try {
-    localStorage.setItem(STORAGE_KEY, url.replace(/\/+$/, ""));
+    localStorage.setItem(key, value);
   } catch {
     // non-fatal
   }
 }
 
-function formatDuration(ms: number): string {
-  if (!ms) return "0:00";
-  const total = Math.round(ms / 1000);
-  const m = Math.floor(total / 60);
-  const s = total % 60;
-  return `${m}:${s.toString().padStart(2, "0")}`;
+function loadBool(key: string, fallback: boolean): boolean {
+  try {
+    const v = localStorage.getItem(key);
+    if (v === "0" || v === "false") return false;
+    if (v === "1" || v === "true") return true;
+  } catch {
+    // ignore
+  }
+  return fallback;
+}
+
+function saveBool(key: string, value: boolean): void {
+  saveString(key, value ? "1" : "0");
 }
 
 function formatAgo(iso: string): string {
@@ -56,19 +73,56 @@ function formatAgo(iso: string): string {
 }
 
 export function App() {
-  const [serverUrl, setServerUrl] = useState<string>(loadServerUrl());
+  const [serverUrl, setServerUrl] = useState<string>(() =>
+    loadString(STORAGE_KEY, DEFAULT_URL).replace(/\/+$/, ""),
+  );
+  const [mode, setMode] = useState<CaptureMode>(
+    () => loadString(MODE_KEY, "screen-camera") as CaptureMode,
+  );
+  const [source, setSource] = useState<CaptureSource>(
+    () => loadString(SOURCE_KEY, "full-screen") as CaptureSource,
+  );
+  const [cameras, setCameras] = useState<MediaDeviceInfo[]>([]);
+  const [mics, setMics] = useState<MediaDeviceInfo[]>([]);
+  const [cameraId, setCameraId] = useState<string>(() =>
+    loadString(CAM_KEY, ""),
+  );
+  const [micId, setMicId] = useState<string>(() => loadString(MIC_KEY, ""));
+  const [cameraOn, setCameraOn] = useState<boolean>(() =>
+    loadBool(CAM_ON_KEY, true),
+  );
+  const [micOn, setMicOn] = useState<boolean>(() => loadBool(MIC_ON_KEY, true));
+
   const [recordings, setRecordings] = useState<RecordingSummary[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [showRecent, setShowRecent] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
 
+  // ---- device enumeration -------------------------------------------------
+
+  const loadDevices = useCallback(async () => {
+    try {
+      if (!navigator.mediaDevices?.enumerateDevices) return;
+      const list = await navigator.mediaDevices.enumerateDevices();
+      setCameras(list.filter((d) => d.kind === "videoinput"));
+      setMics(list.filter((d) => d.kind === "audioinput"));
+    } catch {
+      // Permission not granted yet — labels will be empty until the user
+      // grants access once on /record. We still render the row with a
+      // fallback label so the tray UI isn't broken.
+    }
+  }, []);
+
+  useEffect(() => {
+    loadDevices();
+  }, [loadDevices]);
+
+  // ---- recent list --------------------------------------------------------
+
   const fetchRecent = useCallback(async () => {
-    setLoading(true);
-    setError(null);
     try {
       const url = `${serverUrl.replace(/\/+$/, "")}/_agent-native/actions/list-recordings?limit=3&sort=recent`;
       const res = await fetch(url);
-      if (!res.ok) throw new Error(`Server returned ${res.status}`);
+      if (!res.ok) return;
       const json = await res.json();
       const list = Array.isArray(json?.recordings) ? json.recordings : [];
       setRecordings(
@@ -80,16 +134,25 @@ export function App() {
           updatedAt: r.updatedAt ?? r.createdAt,
         })),
       );
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load");
-    } finally {
-      setLoading(false);
+    } catch {
+      // ignore — server may be unreachable, we still render the chrome
     }
   }, [serverUrl]);
 
   useEffect(() => {
     fetchRecent();
   }, [fetchRecent]);
+
+  // ---- persist selections -------------------------------------------------
+
+  useEffect(() => saveString(MODE_KEY, mode), [mode]);
+  useEffect(() => saveString(SOURCE_KEY, source), [source]);
+  useEffect(() => saveString(CAM_KEY, cameraId), [cameraId]);
+  useEffect(() => saveString(MIC_KEY, micId), [micId]);
+  useEffect(() => saveBool(CAM_ON_KEY, cameraOn), [cameraOn]);
+  useEffect(() => saveBool(MIC_ON_KEY, micOn), [micOn]);
+
+  // ---- actions -----------------------------------------------------------
 
   function openInBrowser(path: string) {
     const href = `${serverUrl.replace(/\/+$/, "")}${path}`;
@@ -98,100 +161,120 @@ export function App() {
     });
   }
 
+  function startRecording() {
+    const params = new URLSearchParams({
+      auto: "1",
+      mode,
+      source,
+      cam: cameraOn ? "on" : "off",
+      mic: micOn ? "on" : "off",
+    });
+    if (cameraId) params.set("camId", cameraId);
+    if (micId) params.set("micId", micId);
+    openInBrowser(`/record?${params.toString()}`);
+  }
+
+  // Auto-hide on blur is handled on the Rust side (tauri::WindowEvent::Focused).
+
+  const showCameraRow = mode !== "screen"; // screen-only has no camera
+  const showSourceRow = mode !== "camera"; // camera-only has no screen source
+
   return (
     <div className="app">
-      <div className="header">
-        <div className="logo">C</div>
-        <div className="title">Clips</div>
-        <div className="spacer" />
-        <button
-          className="icon-button"
-          onClick={() => fetchRecent()}
-          aria-label="Refresh"
-          title="Refresh"
-        >
-          ↻
-        </button>
-        <button
-          className="icon-button"
-          onClick={() => setShowSettings(true)}
-          aria-label="Server"
-          title="Change server URL"
-        >
-          ⚙
-        </button>
+      <Header mode={mode} onModeChange={setMode} />
+
+      <div className="panel">
+        {showSourceRow ? (
+          <SourceRow value={source} onChange={setSource} />
+        ) : null}
+
+        {showCameraRow ? (
+          <DeviceRow
+            kind="camera"
+            devices={cameras}
+            selectedId={cameraId}
+            onSelect={setCameraId}
+            on={cameraOn}
+            onToggle={setCameraOn}
+          />
+        ) : null}
+
+        <DeviceRow
+          kind="mic"
+          devices={mics}
+          selectedId={micId}
+          onSelect={setMicId}
+          on={micOn}
+          onToggle={setMicOn}
+        />
       </div>
 
-      <button className="primary" onClick={() => openInBrowser("/record")}>
-        <span aria-hidden>●</span>
-        New recording
+      <button className="primary start" onClick={startRecording}>
+        <span className="rec-dot" aria-hidden />
+        Start recording
       </button>
 
-      <div>
-        <div className="section-label">Recent</div>
-        {loading ? (
-          <div className="empty">Loading…</div>
-        ) : error ? (
-          <div className="empty">{error}</div>
-        ) : recordings.length === 0 ? (
-          <div className="empty">No recordings yet</div>
-        ) : (
-          <div className="recent-list">
-            {recordings.map((r) => (
-              <button
-                key={r.id}
-                className="recent-item"
-                onClick={() => openInBrowser(`/r/${r.id}`)}
-              >
-                {r.thumbnailUrl ? (
-                  <img
-                    className="thumb"
-                    src={
-                      r.thumbnailUrl.startsWith("http")
-                        ? r.thumbnailUrl
-                        : `${serverUrl.replace(/\/+$/, "")}${r.thumbnailUrl}`
-                    }
-                    alt=""
-                  />
-                ) : (
-                  <div className="thumb" />
-                )}
-                <div className="recent-meta">
-                  <div className="recent-title">{r.title}</div>
-                  <div className="recent-sub">
-                    {formatDuration(r.durationMs)} · {formatAgo(r.updatedAt)}
-                  </div>
-                </div>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-
-      <div className="divider" />
-
-      <div className="links">
-        <button className="link-button" onClick={() => openInBrowser("/")}>
-          Open library
-        </button>
-        <button
-          className="link-button"
+      <div className="bottom-row">
+        <BottomButton
+          icon="library"
+          label="Library"
+          onClick={() => openInBrowser("/")}
+        />
+        <BottomButton
+          icon="settings"
+          label="Settings"
           onClick={() => openInBrowser("/settings")}
-        >
-          Settings
-        </button>
+        />
+        <BottomButton
+          icon="recent"
+          label="Recent"
+          badge={recordings.length > 0 ? String(recordings.length) : undefined}
+          onClick={() => setShowRecent((v) => !v)}
+        />
       </div>
+
+      {showRecent && recordings.length > 0 ? (
+        <div className="recent-list">
+          {recordings.map((r) => (
+            <button
+              key={r.id}
+              className="recent-item"
+              onClick={() => openInBrowser(`/r/${r.id}`)}
+            >
+              {r.thumbnailUrl ? (
+                <img
+                  className="thumb"
+                  src={
+                    r.thumbnailUrl.startsWith("http")
+                      ? r.thumbnailUrl
+                      : `${serverUrl.replace(/\/+$/, "")}${r.thumbnailUrl}`
+                  }
+                  alt=""
+                />
+              ) : (
+                <div className="thumb thumb-placeholder" />
+              )}
+              <div className="recent-meta">
+                <div className="recent-title">{r.title}</div>
+                <div className="recent-sub">{formatAgo(r.updatedAt)}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      ) : null}
 
       <div className="footer">
-        <span>Cmd/Ctrl+Shift+L</span>
-        <a onClick={() => setShowSettings(true)}>Change server</a>
+        <span className="kbd">⌘⇧L</span>
+        <a className="footer-link" onClick={() => setShowSettings(true)}>
+          Change server
+        </a>
       </div>
 
       {showSettings ? (
         <Setup
           initial={serverUrl}
           onConnect={(url) => {
-            saveServerUrl(url);
+            saveString(STORAGE_KEY, url.replace(/\/+$/, ""));
             setServerUrl(url.replace(/\/+$/, ""));
             setShowSettings(false);
           }}
@@ -201,6 +284,418 @@ export function App() {
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+
+function Header({
+  mode,
+  onModeChange,
+}: {
+  mode: CaptureMode;
+  onModeChange: (m: CaptureMode) => void;
+}) {
+  return (
+    <div className="header">
+      <div className="logo">C</div>
+      <div
+        className="mode-toggle"
+        role="radiogroup"
+        aria-label="Recording mode"
+      >
+        <button
+          className={mode === "screen" ? "active" : ""}
+          onClick={() => onModeChange("screen")}
+          aria-label="Screen only"
+          title="Screen only"
+        >
+          <ScreenIcon />
+        </button>
+        <button
+          className={mode === "screen-camera" ? "active" : ""}
+          onClick={() => onModeChange("screen-camera")}
+          aria-label="Screen + Camera"
+          title="Screen + Camera"
+        >
+          <ScreenCamIcon />
+        </button>
+        <button
+          className={mode === "camera" ? "active" : ""}
+          onClick={() => onModeChange("camera")}
+          aria-label="Camera only"
+          title="Camera only"
+        >
+          <CamIcon />
+        </button>
+      </div>
+      <button
+        className="icon-button"
+        onClick={() => window.close?.()}
+        aria-label="Close"
+        title="Close"
+      >
+        <CloseIcon />
+      </button>
+    </div>
+  );
+}
+
+function SourceRow({
+  value,
+  onChange,
+}: {
+  value: CaptureSource;
+  onChange: (v: CaptureSource) => void;
+}) {
+  const labels: Record<CaptureSource, string> = {
+    "full-screen": "Full screen",
+    window: "Window",
+    tab: "Browser tab",
+    custom: "Custom area",
+  };
+  return (
+    <label className="row">
+      <span className="row-icon">
+        <MonitorIcon />
+      </span>
+      <select
+        className="row-select"
+        value={value}
+        onChange={(e) => onChange(e.target.value as CaptureSource)}
+      >
+        {Object.entries(labels).map(([k, label]) => (
+          <option key={k} value={k}>
+            {label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function DeviceRow({
+  kind,
+  devices,
+  selectedId,
+  onSelect,
+  on,
+  onToggle,
+}: {
+  kind: "camera" | "mic";
+  devices: MediaDeviceInfo[];
+  selectedId: string;
+  onSelect: (id: string) => void;
+  on: boolean;
+  onToggle: (v: boolean) => void;
+}) {
+  const current = useMemo(
+    () => devices.find((d) => d.deviceId === selectedId) ?? devices[0],
+    [devices, selectedId],
+  );
+  const label = truncate(
+    current?.label || (kind === "camera" ? "Default camera" : "Default mic"),
+    22,
+  );
+  const Icon = kind === "camera" ? CameraIcon : MicIcon;
+
+  return (
+    <div className={`row ${on ? "row-on" : "row-off"}`}>
+      <span className="row-icon">
+        <Icon />
+      </span>
+      <select
+        className="row-select"
+        value={current?.deviceId ?? ""}
+        onChange={(e) => onSelect(e.target.value)}
+        disabled={!on || devices.length === 0}
+        title={current?.label ?? ""}
+      >
+        {devices.length === 0 ? <option value="">{label}</option> : null}
+        {devices.map((d) => (
+          <option key={d.deviceId} value={d.deviceId}>
+            {d.label || (kind === "camera" ? "Camera" : "Microphone")}
+          </option>
+        ))}
+      </select>
+      <Toggle
+        on={on}
+        onChange={onToggle}
+        label={kind === "camera" ? "Camera" : "Microphone"}
+      />
+      {kind === "mic" && on ? <MicWave /> : null}
+    </div>
+  );
+}
+
+function Toggle({
+  on,
+  onChange,
+  label,
+}: {
+  on: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+}) {
+  return (
+    <button
+      className={`toggle ${on ? "toggle-on" : "toggle-off"}`}
+      role="switch"
+      aria-checked={on}
+      aria-label={label}
+      onClick={() => onChange(!on)}
+    >
+      {on ? "On" : "Off"}
+    </button>
+  );
+}
+
+function MicWave() {
+  // Purely decorative — animates four bars to suggest input level. For real
+  // input level we'd need a live stream, which Loom starts only on "Start".
+  return (
+    <span className="mic-wave" aria-hidden>
+      <span className="bar b1" />
+      <span className="bar b2" />
+      <span className="bar b3" />
+      <span className="bar b4" />
+    </span>
+  );
+}
+
+function BottomButton({
+  icon,
+  label,
+  badge,
+  onClick,
+}: {
+  icon: "library" | "settings" | "recent";
+  label: string;
+  badge?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button className="bottom-btn" onClick={onClick}>
+      <span className="bottom-icon">
+        {icon === "library" ? (
+          <LibraryIcon />
+        ) : icon === "settings" ? (
+          <SettingsIcon />
+        ) : (
+          <ClockIcon />
+        )}
+        {badge ? <span className="badge">{badge}</span> : null}
+      </span>
+      <span className="bottom-label">{label}</span>
+    </button>
+  );
+}
+
+function truncate(s: string, n: number): string {
+  if (!s) return "";
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+// ---- inline icons (Tabler-style, monochrome, stroke=1.75) -----------------
+
+function ScreenIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+      <rect
+        x="3"
+        y="4"
+        width="18"
+        height="12"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M8 20h8M12 16v4"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function ScreenCamIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+      <rect
+        x="3"
+        y="4"
+        width="14"
+        height="10"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <circle
+        cx="17.5"
+        cy="15.5"
+        r="4.5"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        fill="var(--bg)"
+      />
+      <circle cx="17.5" cy="15.5" r="1.5" fill="currentColor" />
+    </svg>
+  );
+}
+
+function CamIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+      <rect
+        x="3"
+        y="7"
+        width="14"
+        height="10"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M17 10l4-2v8l-4-2z"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M6 6l12 12M18 6L6 18"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function MonitorIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+      <rect
+        x="3"
+        y="4"
+        width="18"
+        height="13"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M8 21h8M12 17v4"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function CameraIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+      <rect
+        x="3"
+        y="7"
+        width="14"
+        height="10"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M17 10l4-2v8l-4-2z"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function MicIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+      <rect
+        x="9"
+        y="3"
+        width="6"
+        height="12"
+        rx="3"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M5 11a7 7 0 0014 0M12 18v3M9 21h6"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function LibraryIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+      <rect
+        x="3"
+        y="5"
+        width="18"
+        height="14"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <path
+        d="M10 9l5 3-5 3z"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinejoin="round"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function SettingsIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+      <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="1.75" />
+      <path
+        d="M19.4 15a7.97 7.97 0 00.1-3l1.9-1.3-2-3.5-2.2.8a8 8 0 00-2.6-1.5L14 4h-4l-.6 2.5a8 8 0 00-2.6 1.5L4.6 7.2l-2 3.5L4.5 12a7.97 7.97 0 00.1 3l-1.9 1.3 2 3.5 2.2-.8a8 8 0 002.6 1.5L10 23h4l.6-2.5a8 8 0 002.6-1.5l2.2.8 2-3.5-1.9-1.3z"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ClockIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.75" />
+      <path
+        d="M12 7v5l3 2"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
 
 function Setup({
   initial,
@@ -212,6 +707,10 @@ function Setup({
   onCancel?: () => void;
 }) {
   const [url, setUrl] = useState(initial ?? DEFAULT_URL);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -225,11 +724,11 @@ function Setup({
       <h2>Connect to your Clips server</h2>
       <p>Enter the URL of your running Clips instance.</p>
       <input
+        ref={inputRef}
         type="url"
         value={url}
         onChange={(e) => setUrl(e.target.value)}
         placeholder="http://localhost:8080"
-        autoFocus
       />
       <button className="primary" type="submit">
         Connect

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1,25 +1,51 @@
+/* Clips tray popover — Loom-style layout, Clips brand, dark/light modes. */
+
 :root {
   color-scheme: light dark;
+
+  /* Clips brand */
   --brand: #625df5;
   --brand-hover: #5049d9;
+  --brand-ring: rgba(98, 93, 245, 0.28);
+
+  /* Light palette */
   --bg: #ffffff;
-  --fg: #111827;
-  --muted: #6b7280;
-  --border: #e5e7eb;
-  --subtle-bg: #f7f7f9;
-  --radius: 10px;
+  --surface: #f5f6f9;
+  --surface-hover: #eef0f5;
+  --surface-strong: #e8ebf2;
+  --fg: #0f172a;
+  --fg-muted: #64748b;
+  --fg-subtle: #94a3b8;
+  --border: #e2e6ef;
+  --border-strong: #d4d9e4;
+
+  --radius: 12px;
+  --radius-sm: 8px;
+  --radius-pill: 999px;
+
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --shadow-md:
+    0 4px 16px rgba(15, 23, 42, 0.08), 0 2px 4px rgba(15, 23, 42, 0.04);
+
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+    -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, sans-serif;
   font-size: 13px;
+  line-height: 1.4;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --bg: #0f1115;
-    --fg: #f3f4f6;
-    --muted: #9ca3af;
-    --border: #1f2937;
-    --subtle-bg: #151821;
+    --surface: #181b23;
+    --surface-hover: #1e2230;
+    --surface-strong: #252938;
+    --fg: #f1f5f9;
+    --fg-muted: #94a3b8;
+    --fg-subtle: #64748b;
+    --border: #252938;
+    --border-strong: #323747;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.5), 0 2px 6px rgba(0, 0, 0, 0.3);
   }
 }
 
@@ -33,10 +59,18 @@ body {
   padding: 0;
   background: var(--bg);
   color: var(--fg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body {
   overflow: hidden;
+}
+
+button {
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
 }
 
 #root {
@@ -44,126 +78,418 @@ body {
   min-height: 100vh;
 }
 
+/* ------------------------------------------------------------------------- */
+/* App shell                                                                  */
+/* ------------------------------------------------------------------------- */
+
 .app {
-  padding: 12px;
+  padding: 14px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 14px;
 }
 
+/* Header — logo + mode toggle + close */
+
 .header {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 8px;
-  padding: 2px 4px 4px;
+  gap: 10px;
+  padding: 0 2px;
 }
 
 .logo {
-  width: 20px;
-  height: 20px;
-  border-radius: 6px;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
   background: var(--brand);
   color: white;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-weight: 700;
-  font-size: 11px;
-  letter-spacing: 0.5px;
+  font-size: 14px;
+  letter-spacing: 0.3px;
+  box-shadow: 0 1px 2px rgba(98, 93, 245, 0.3);
 }
 
-.title {
-  font-weight: 600;
-  font-size: 13px;
+.mode-toggle {
+  display: inline-flex;
+  background: var(--surface);
+  border-radius: var(--radius-pill);
+  padding: 3px;
+  justify-self: center;
+  border: 1px solid var(--border);
 }
 
-.spacer {
-  flex: 1;
-}
-
-.icon-button {
-  background: transparent;
+.mode-toggle button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 28px;
   border: none;
-  color: var(--muted);
+  background: transparent;
+  color: var(--fg-muted);
+  border-radius: var(--radius-pill);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 6px;
+  transition:
+    background 120ms,
+    color 120ms,
+    box-shadow 120ms;
 }
-.icon-button:hover {
-  background: var(--subtle-bg);
+
+.mode-toggle button:hover {
   color: var(--fg);
 }
 
-.primary {
-  display: flex;
+.mode-toggle button.active {
+  background: var(--bg);
+  color: var(--brand);
+  box-shadow: var(--shadow-sm);
+}
+
+.icon-button {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  transition:
+    background 120ms,
+    color 120ms;
+}
+
+.icon-button:hover {
+  background: var(--surface-hover);
+  color: var(--fg);
+}
+
+/* ------------------------------------------------------------------------- */
+/* Source / device rows                                                       */
+/* ------------------------------------------------------------------------- */
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: default;
+  transition:
+    background 120ms,
+    border-color 120ms;
+}
+
+.row-off {
+  opacity: 0.6;
+}
+
+.row-icon {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+
+.row-on .row-icon {
+  color: var(--fg);
+}
+
+.row-select {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 0;
+  margin: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+  outline: none;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.row-select:disabled {
+  cursor: not-allowed;
+}
+
+.row-select:focus-visible {
+  box-shadow: 0 0 0 2px var(--brand-ring);
+  border-radius: 4px;
+}
+
+/* Toggle chip — mirrors Loom's On/Off pill. Green when on, subtle when off. */
+.toggle {
+  border: none;
+  border-radius: var(--radius-pill);
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  line-height: 1;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  transition:
+    background 120ms,
+    color 120ms;
+}
+
+.toggle-on {
+  background: #16a34a;
+  color: white;
+}
+
+.toggle-on:hover {
+  background: #15803d;
+}
+
+.toggle-off {
+  background: var(--surface-strong);
+  color: var(--fg-muted);
+}
+
+.toggle-off:hover {
+  color: var(--fg);
+}
+
+/* Mic level indicator — animated bars under the mic row. */
+.mic-wave {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 4px;
+  height: 3px;
+  display: flex;
+  gap: 2px;
+  align-items: flex-end;
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+.mic-wave .bar {
+  flex: 1;
+  background: var(--brand);
+  border-radius: 1px;
+  animation: mic-pulse 1.2s ease-in-out infinite;
+  height: 60%;
+}
+
+.mic-wave .b1 {
+  animation-delay: 0s;
+  height: 40%;
+}
+.mic-wave .b2 {
+  animation-delay: 0.15s;
+  height: 80%;
+}
+.mic-wave .b3 {
+  animation-delay: 0.3s;
+  height: 55%;
+}
+.mic-wave .b4 {
+  animation-delay: 0.45s;
+  height: 70%;
+}
+
+@keyframes mic-pulse {
+  0%,
+  100% {
+    transform: scaleY(1);
+  }
+  50% {
+    transform: scaleY(0.4);
+  }
+}
+
+/* ------------------------------------------------------------------------- */
+/* Primary CTA                                                                */
+/* ------------------------------------------------------------------------- */
+
+.primary {
+  width: 100%;
+  border: none;
+  border-radius: var(--radius);
+  padding: 12px 16px;
   background: var(--brand);
   color: white;
-  border: none;
-  padding: 11px 14px;
-  border-radius: var(--radius);
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
-  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  height: 44px;
+  box-shadow: 0 1px 2px rgba(98, 93, 245, 0.3);
+  transition:
+    background 120ms,
+    transform 80ms,
+    box-shadow 120ms;
 }
+
 .primary:hover {
   background: var(--brand-hover);
 }
+
 .primary:active {
   transform: translateY(1px);
 }
 
-.section-label {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--muted);
-  margin: 4px 4px 2px;
+.primary.start {
+  margin-top: 2px;
 }
+
+.rec-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.3);
+}
+
+/* ------------------------------------------------------------------------- */
+/* Bottom quick-actions row                                                   */
+/* ------------------------------------------------------------------------- */
+
+.bottom-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+}
+
+.bottom-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 4px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition:
+    background 120ms,
+    color 120ms;
+}
+
+.bottom-btn:hover {
+  background: var(--surface-hover);
+  color: var(--fg);
+}
+
+.bottom-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-muted);
+}
+
+.bottom-btn:hover .bottom-icon {
+  color: var(--fg);
+}
+
+.bottom-label {
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.badge {
+  position: absolute;
+  top: -4px;
+  right: -6px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 4px;
+  border-radius: 7px;
+  background: var(--brand);
+  color: white;
+  font-size: 9px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 0 2px var(--bg);
+}
+
+/* ------------------------------------------------------------------------- */
+/* Recent list (collapsible)                                                  */
+/* ------------------------------------------------------------------------- */
 
 .recent-list {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
 }
 
 .recent-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px;
+  gap: 10px;
+  padding: 6px 8px;
+  border: none;
   background: transparent;
-  border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  text-align: left;
-  color: inherit;
-  font: inherit;
   width: 100%;
+  text-align: left;
+  transition: background 120ms;
 }
+
 .recent-item:hover {
-  background: var(--subtle-bg);
-  border-color: var(--border);
+  background: var(--surface-hover);
 }
 
 .thumb {
-  width: 56px;
-  height: 32px;
-  background: #1f2937;
+  width: 48px;
+  height: 28px;
   border-radius: 4px;
   object-fit: cover;
   flex-shrink: 0;
+  background: var(--surface-strong);
+}
+
+.thumb-placeholder {
+  background: linear-gradient(
+    135deg,
+    var(--surface-strong),
+    var(--surface-hover)
+  );
 }
 
 .recent-meta {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
   flex: 1;
+  min-width: 0;
 }
+
 .recent-title {
   font-size: 12px;
   font-weight: 500;
@@ -172,87 +498,103 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
 .recent-sub {
   font-size: 11px;
-  color: var(--muted);
+  color: var(--fg-subtle);
+  margin-top: 1px;
 }
 
-.empty {
-  text-align: center;
-  padding: 12px;
-  color: var(--muted);
-  font-size: 12px;
-}
-
-.divider {
-  height: 1px;
-  background: var(--border);
-  margin: 4px -12px;
-}
-
-.links {
-  display: flex;
-  gap: 6px;
-}
-
-.link-button {
-  flex: 1;
-  background: var(--subtle-bg);
-  color: var(--fg);
-  border: 1px solid var(--border);
-  padding: 8px 10px;
-  border-radius: 8px;
-  font-size: 12px;
-  cursor: pointer;
-  text-align: center;
-}
-.link-button:hover {
-  background: var(--border);
-}
-
-.setup {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 16px;
-  text-align: center;
-}
-.setup h2 {
-  margin: 0;
-  font-size: 15px;
-}
-.setup p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 12px;
-}
-.setup input {
-  padding: 8px 10px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  font-size: 13px;
-  background: var(--bg);
-  color: var(--fg);
-  font-family: inherit;
-}
-.setup input:focus {
-  outline: 2px solid var(--brand);
-  outline-offset: 1px;
-}
+/* ------------------------------------------------------------------------- */
+/* Footer                                                                     */
+/* ------------------------------------------------------------------------- */
 
 .footer {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 0 4px;
+  justify-content: space-between;
   font-size: 11px;
-  color: var(--muted);
+  color: var(--fg-subtle);
+  padding: 0 4px;
 }
-.footer a {
-  color: var(--muted);
-  text-decoration: none;
+
+.kbd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 10px;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--fg-muted);
+  letter-spacing: 0.5px;
+}
+
+.footer-link {
+  color: var(--fg-muted);
   cursor: pointer;
+  text-decoration: none;
 }
-.footer a:hover {
+
+.footer-link:hover {
+  color: var(--brand);
+  text-decoration: underline;
+}
+
+/* ------------------------------------------------------------------------- */
+/* Setup overlay (server URL change)                                          */
+/* ------------------------------------------------------------------------- */
+
+.setup {
+  position: fixed;
+  inset: 0;
+  background: var(--bg);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 10;
+}
+
+.setup h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.setup p {
+  margin: 0;
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+
+.setup input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
   color: var(--fg);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 120ms;
+}
+
+.setup input:focus {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px var(--brand-ring);
+}
+
+.link-button {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--fg);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 13px;
+  transition: background 120ms;
+}
+
+.link-button:hover {
+  background: var(--surface-hover);
 }


### PR DESCRIPTION
## Summary
- **Local-mode onboarding bug fix:** "Use locally without an account" now hides when `DATABASE_URL` points at Postgres/Turso/D1 (not just in production). Previously clicking it wrote the marker file, reloaded, then `isLocalModeEnabled()` rejected because local@localhost has no per-user scoping on a shared DB — so users saw the login page "snap back" with no explanation. Server-side `POST /_agent-native/auth/local-mode` also now returns 400 with a clear message instead of silently succeeding into an unrecoverable state, and the client surfaces that error inline.
- **Voice transcription:** framework-wide mic button in the composer + Settings panel section. Routes through OpenAI Whisper when `OPENAI_API_KEY` is set, else falls back to the browser Web Speech API. `OPENAI_API_KEY` is registered as a framework-level secret so it appears in the sidebar setup UI.

## Test plan
- [ ] With `DATABASE_URL=postgres://...` set locally, visit the onboarding page — "Use locally without an account" should not render.
- [ ] With no `DATABASE_URL` (or `file:` SQLite), the button should render and clicking it still works.
- [ ] If the button somehow leaks through (e.g. env changes between SSR and POST), clicking it shows the server's error message inline instead of silently snapping back.
- [ ] Composer mic button: records audio, posts to `/_agent-native/transcribe-voice`, inserts transcript into the composer.
- [ ] Settings → Voice Transcription: section renders and reflects provider choice (OpenAI vs browser vs Builder placeholder).