### PR TITLE
sharing: shadcn Select for role + visibility dropdowns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Run `agent-native setup-agents` to create all symlinks (done automatically by `a
 - **Prettier** — run `npx prettier --write <files>` after modifying source files.
 - **Client-side rendering** — all app content renders client-side via the `ClientOnly` wrapper in `root.tsx`.
 - **shadcn/ui components** for standard UI. Check `app/components/ui/` before building custom.
-- **Tabler Icons** (`@tabler/icons-react`) for all icons. No other icon libraries. No inline SVGs.
+- **Tabler Icons** (`@tabler/icons-react`) for all icons. **Never use emojis as icons** — not in buttons, not in avatars, not in labels, not in toasts/notifications, not in outbound messages (Slack, email). No other icon libraries, no inline SVGs. Emojis are fine when they are _user-authored content_ (a document title emoji picker, a reaction the user chose, a user-picked space icon) — the rule is about icons the UI picks, not data the user picks.
 - **No browser dialogs** — use shadcn AlertDialog instead of `window.confirm/alert/prompt`.
 
 ## Auto-Memory

--- a/packages/core/src/client/resources/ResourceEditor.tsx
+++ b/packages/core/src/client/resources/ResourceEditor.tsx
@@ -593,7 +593,7 @@ function InlineBubbleToolbar({ editor }: { editor: any }) {
     },
     { type: "divider" as const },
     {
-      label: "🔗",
+      label: "Link",
       title: "Link",
       action: toggleLink,
       isActive: () => editor.isActive("link"),

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -203,6 +203,20 @@ function SharePanel(
   const [pendingAdds, setPendingAdds] = useState<Share[]>([]);
   const [pendingRemoves, setPendingRemoves] = useState<Set<string>>(new Set());
   const [roleOverrides, setRoleOverrides] = useState<Record<string, Role>>({});
+  // Principals with an in-flight share/unshare mutation. We disable the
+  // role dropdown and the trash button for any share in this set so a
+  // user can't race a role-change against a remove (which would otherwise
+  // let the upsert silently re-grant access after the delete landed), and
+  // can't rapid-fire two creates for the same pending add.
+  const [inFlight, setInFlight] = useState<Set<string>>(new Set());
+  const addInFlight = (k: string) =>
+    setInFlight((prev) => new Set(prev).add(k));
+  const clearInFlight = (k: string) =>
+    setInFlight((prev) => {
+      const next = new Set(prev);
+      next.delete(k);
+      return next;
+    });
 
   useEffect(() => {
     sharesQuery.refetch();
@@ -247,8 +261,12 @@ function SharePanel(
       principalId: trimmed,
       role,
     };
+    const k = keyOf(optimistic);
+    // Ignore duplicate submits while an add for the same principal is in flight.
+    if (inFlight.has(k)) return;
     setPendingAdds((p) => [...p, optimistic]);
     setEmail("");
+    addInFlight(k);
     share.mutate(
       {
         resourceType,
@@ -261,10 +279,12 @@ function SharePanel(
         onSuccess: () => {
           sharesQuery.refetch().then(() => {
             setPendingAdds((p) => p.filter((s) => s.id !== optimistic.id));
+            clearInFlight(k);
           });
         },
         onError: () => {
           setPendingAdds((p) => p.filter((s) => s.id !== optimistic.id));
+          clearInFlight(k);
         },
       },
     );
@@ -273,7 +293,13 @@ function SharePanel(
   const handleChangeRole = (s: Share, next: Role) => {
     if (s.role === next) return;
     const k = keyOf(s);
+    // Don't stack a role change on top of an in-flight add/remove/role
+    // change for the same principal — it can race with unshare and end up
+    // re-granting access after a delete. UI already disables the control,
+    // but belt-and-suspenders here too.
+    if (inFlight.has(k)) return;
     setRoleOverrides((prev) => ({ ...prev, [k]: next }));
+    addInFlight(k);
     // share-resource is upsert: calling with same principal + new role
     // updates the existing share row. See sharing/actions/share-resource.ts.
     share.mutate(
@@ -291,6 +317,7 @@ function SharePanel(
               const { [k]: _, ...rest } = prev;
               return rest;
             });
+            clearInFlight(k);
           });
         },
         onError: () => {
@@ -298,6 +325,7 @@ function SharePanel(
             const { [k]: _, ...rest } = prev;
             return rest;
           });
+          clearInFlight(k);
         },
       },
     );
@@ -305,7 +333,12 @@ function SharePanel(
 
   const handleRemove = (s: Share) => {
     const k = keyOf(s);
+    // If any other mutation is in flight for this principal, don't start a
+    // remove — it can interleave with an upsert and leave the row in place.
+    // The UI already disables the trash button when inFlight.has(k).
+    if (inFlight.has(k)) return;
     setPendingRemoves((prev) => new Set(prev).add(k));
+    addInFlight(k);
     unshare.mutate(
       {
         resourceType,
@@ -321,6 +354,7 @@ function SharePanel(
               next.delete(k);
               return next;
             });
+            clearInFlight(k);
           });
         },
         onError: () => {
@@ -329,6 +363,7 @@ function SharePanel(
             next.delete(k);
             return next;
           });
+          clearInFlight(k);
         },
       },
     );
@@ -394,7 +429,10 @@ function SharePanel(
         {shares.map((s) => (
           <li
             key={keyOf(s)}
-            className="flex items-center gap-3 px-1 py-1.5 text-sm"
+            className={cn(
+              "flex items-center gap-3 px-1 py-1.5 text-sm",
+              inFlight.has(keyOf(s)) && "opacity-60",
+            )}
           >
             <Avatar label={s.principalId} org={s.principalType === "org"} />
             <span className="flex-1 min-w-0 truncate">{s.principalId}</span>
@@ -402,6 +440,7 @@ function SharePanel(
               <RoleSelect
                 value={s.role}
                 onChange={(r) => handleChangeRole(s, r)}
+                disabled={inFlight.has(keyOf(s))}
                 plain
               />
             ) : (
@@ -414,6 +453,7 @@ function SharePanel(
                 type="button"
                 aria-label="Remove"
                 onClick={() => handleRemove(s)}
+                disabled={inFlight.has(keyOf(s))}
                 className={BUTTON_GHOST_ICON}
               >
                 <IconTrash size={14} />
@@ -503,6 +543,7 @@ function SelectItems({ items }: { items: ShadSelectItemProps[] }) {
 function RoleSelect(props: {
   value: Role;
   onChange: (v: Role) => void;
+  disabled?: boolean;
   /** When true, render as inline text + chevron (no border / bg) — matches
    *  the per-person role picker in Google Docs. */
   plain?: boolean;
@@ -513,6 +554,7 @@ function RoleSelect(props: {
     <Select.Root
       value={props.value}
       onValueChange={(v) => props.onChange(v as Role)}
+      disabled={props.disabled}
     >
       <Select.Trigger
         className={

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, useEffect, useState, type ReactNode } from "react";
 import {
-  IconShare,
   IconLock,
   IconBuilding,
   IconWorld,
@@ -17,8 +16,8 @@ export interface ShareButtonProps {
   resourceType: string;
   resourceId: string;
   resourceTitle?: string;
-  /** "compact" reflects the current visibility in the trigger label;
-   *  "label" always says "Share". */
+  /** @deprecated No longer affects rendering — trigger always says
+   *  "Share". Kept for callsite compatibility. */
   variant?: "compact" | "label";
 }
 
@@ -102,6 +101,11 @@ export function ShareButton(props: ShareButtonProps) {
     resourceId: props.resourceId,
   });
 
+  // The trigger always says "Share" — the icon reflects the resource's
+  // current visibility (lock / building / globe), matching Google Docs.
+  // While the query is loading and we don't know the visibility yet,
+  // render a skeleton placeholder in the icon slot instead of guessing.
+  const loaded = sharesQuery.data !== undefined;
   const serverVisibility =
     (sharesQuery.data?.visibility as Visibility | null) ?? "private";
   const TriggerIcon =
@@ -109,18 +113,21 @@ export function ShareButton(props: ShareButtonProps) {
       ? IconWorld
       : serverVisibility === "org"
         ? IconBuilding
-        : props.variant === "compact"
-          ? IconLock
-          : IconShare;
-  const triggerLabel =
-    props.variant === "compact" ? VIS_META[serverVisibility].label : "Share";
+        : IconLock;
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <button type="button" className={BUTTON_OUTLINE_SM}>
-          <TriggerIcon size={16} strokeWidth={1.75} />
-          <span>{triggerLabel}</span>
+          {loaded ? (
+            <TriggerIcon size={16} strokeWidth={1.75} />
+          ) : (
+            <span
+              aria-hidden
+              className="inline-block h-4 w-4 rounded-sm bg-muted animate-pulse"
+            />
+          )}
+          <span>Share</span>
         </button>
       </Popover.Trigger>
       <Popover.Portal>
@@ -592,7 +599,7 @@ function Avatar({ label, org }: { label: string; org?: boolean }) {
       aria-hidden
       className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-semibold text-muted-foreground"
     >
-      {org ? "🏢" : initials(label)}
+      {org ? <IconBuilding size={14} strokeWidth={1.75} /> : initials(label)}
     </span>
   );
 }

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useState } from "react";
+import { forwardRef, useEffect, useState, type ReactNode } from "react";
 import {
   IconShare,
   IconLock,
   IconBuilding,
   IconWorld,
   IconTrash,
+  IconCheck,
   IconChevronDown,
 } from "@tabler/icons-react";
 import * as Popover from "@radix-ui/react-popover";
+import * as Select from "@radix-ui/react-select";
 import { useActionQuery, useActionMutation } from "../use-action.js";
 import { cn } from "../utils.js";
 
@@ -38,12 +40,8 @@ interface SharesResponse {
   shares: Share[];
 }
 
-// Match the exact Tailwind classes emitted by shadcn's `<Button size="sm"
-// variant="outline">`. Templates vendor their own Button component, but
-// every template uses the same shadcn theme + preset, so the same class
-// string renders identically. Keeping them as literal strings here means
-// this component looks native in every template without importing from
-// the template itself (which wouldn't be possible from core).
+// Mirror shadcn's <Button size="sm" variant="outline"> class string so the
+// trigger sits flush next to other sm outline buttons in the template.
 const BUTTON_BASE =
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0";
 const BUTTON_OUTLINE_SM = cn(
@@ -57,10 +55,6 @@ const BUTTON_PRIMARY_SM = cn(
 const BUTTON_GHOST_ICON = cn(
   BUTTON_BASE,
   "h-7 w-7 p-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-);
-const BUTTON_GHOST_INLINE = cn(
-  BUTTON_BASE,
-  "h-7 px-2 text-muted-foreground hover:bg-accent hover:text-accent-foreground",
 );
 
 const VIS_META: Record<
@@ -84,11 +78,22 @@ const VIS_META: Record<
   },
 };
 
+const ROLE_OPTIONS: Array<{ value: Role; label: string; description: string }> =
+  [
+    { value: "viewer", label: "Viewer", description: "Can view" },
+    { value: "editor", label: "Editor", description: "Can edit" },
+    {
+      value: "admin",
+      label: "Admin",
+      description: "Can edit and manage access",
+    },
+  ];
+
 /**
  * Framework share control. Renders a shadcn-outline-styled trigger that
- * opens a Google-Docs-style popover anchored beneath it. Uses CSS
- * variables and Tailwind classes that every shadcn template already
- * ships, so the same component renders natively in light and dark mode.
+ * opens a Google-Docs-style popover anchored beneath it. Uses Tailwind
+ * + CSS variables so the same component renders natively in light and
+ * dark mode in any shadcn template.
  */
 export function ShareButton(props: ShareButtonProps) {
   const [open, setOpen] = useState(false);
@@ -190,6 +195,7 @@ function SharePanel(
     useState<Visibility | null>(null);
   const [pendingAdds, setPendingAdds] = useState<Share[]>([]);
   const [pendingRemoves, setPendingRemoves] = useState<Set<string>>(new Set());
+  const [roleOverrides, setRoleOverrides] = useState<Record<string, Role>>({});
 
   useEffect(() => {
     sharesQuery.refetch();
@@ -205,7 +211,9 @@ function SharePanel(
 
   const serverShares = data?.shares ?? [];
   const shares: Share[] = [
-    ...serverShares.filter((s) => !pendingRemoves.has(keyOf(s))),
+    ...serverShares
+      .filter((s) => !pendingRemoves.has(keyOf(s)))
+      .map((s) => ({ ...s, role: roleOverrides[keyOf(s)] ?? s.role })),
     ...pendingAdds,
   ];
 
@@ -250,6 +258,39 @@ function SharePanel(
         },
         onError: () => {
           setPendingAdds((p) => p.filter((s) => s.id !== optimistic.id));
+        },
+      },
+    );
+  };
+
+  const handleChangeRole = (s: Share, next: Role) => {
+    if (s.role === next) return;
+    const k = keyOf(s);
+    setRoleOverrides((prev) => ({ ...prev, [k]: next }));
+    // share-resource is upsert: calling with same principal + new role
+    // updates the existing share row. See sharing/actions/share-resource.ts.
+    share.mutate(
+      {
+        resourceType,
+        resourceId,
+        principalType: s.principalType,
+        principalId: s.principalId,
+        role: next,
+      } as any,
+      {
+        onSuccess: () => {
+          sharesQuery.refetch().then(() => {
+            setRoleOverrides((prev) => {
+              const { [k]: _, ...rest } = prev;
+              return rest;
+            });
+          });
+        },
+        onError: () => {
+          setRoleOverrides((prev) => {
+            const { [k]: _, ...rest } = prev;
+            return rest;
+          });
         },
       },
     );
@@ -330,15 +371,7 @@ function SharePanel(
                 ))}
             </datalist>
           ) : null}
-          <ChevronSelect
-            value={role}
-            onChange={(v) => setRole(v as Role)}
-            options={[
-              { value: "viewer", label: "Viewer" },
-              { value: "editor", label: "Editor" },
-              { value: "admin", label: "Admin" },
-            ]}
-          />
+          <RoleSelect value={role} onChange={setRole} />
         </div>
       ) : null}
 
@@ -358,7 +391,17 @@ function SharePanel(
           >
             <Avatar label={s.principalId} org={s.principalType === "org"} />
             <span className="flex-1 min-w-0 truncate">{s.principalId}</span>
-            <span className="text-xs text-muted-foreground">{cap(s.role)}</span>
+            {canManage ? (
+              <RoleSelect
+                value={s.role}
+                onChange={(r) => handleChangeRole(s, r)}
+                plain
+              />
+            ) : (
+              <span className="text-xs text-muted-foreground">
+                {cap(s.role)}
+              </span>
+            )}
             {canManage ? (
               <button
                 type="button"
@@ -387,16 +430,10 @@ function SharePanel(
           <meta.Icon size={16} strokeWidth={1.75} />
         </span>
         <div className="min-w-0 flex-1">
-          <ChevronSelect
+          <VisibilitySelect
             value={visibility}
-            onChange={(v) => handleVisibility(v as Visibility)}
+            onChange={handleVisibility}
             disabled={!canManage}
-            plain
-            options={[
-              { value: "private", label: VIS_META.private.label },
-              { value: "org", label: VIS_META.org.label },
-              { value: "public", label: VIS_META.public.label },
-            ]}
           />
           <div className="mt-0.5 text-xs text-muted-foreground">
             {meta.description}
@@ -413,6 +450,142 @@ function SharePanel(
   );
 }
 
+// ---------------------------------------------------------------------------
+// Radix Select wrappers styled like shadcn Select (no native <select> anywhere)
+// ---------------------------------------------------------------------------
+
+const selectContentClass =
+  "z-[2100] min-w-[12rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0";
+const selectItemClass =
+  "relative flex w-full cursor-pointer select-none items-start gap-2 rounded-sm py-2 pl-8 pr-3 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50";
+
+interface ShadSelectItemProps {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+function SelectItems({ items }: { items: ShadSelectItemProps[] }) {
+  return (
+    <>
+      {items.map((it) => (
+        <Select.Item
+          key={it.value}
+          value={it.value}
+          className={selectItemClass}
+        >
+          <span className="absolute left-2 top-2 flex h-4 w-4 items-center justify-center">
+            <Select.ItemIndicator>
+              <IconCheck size={14} />
+            </Select.ItemIndicator>
+          </span>
+          <span className="flex flex-col">
+            <Select.ItemText>{it.label}</Select.ItemText>
+            {it.description ? (
+              <span className="text-xs text-muted-foreground">
+                {it.description}
+              </span>
+            ) : null}
+          </span>
+        </Select.Item>
+      ))}
+    </>
+  );
+}
+
+function RoleSelect(props: {
+  value: Role;
+  onChange: (v: Role) => void;
+  /** When true, render as inline text + chevron (no border / bg) — matches
+   *  the per-person role picker in Google Docs. */
+  plain?: boolean;
+}) {
+  const current =
+    ROLE_OPTIONS.find((o) => o.value === props.value) ?? ROLE_OPTIONS[0];
+  return (
+    <Select.Root
+      value={props.value}
+      onValueChange={(v) => props.onChange(v as Role)}
+    >
+      <Select.Trigger
+        className={
+          props.plain
+            ? cn(
+                BUTTON_BASE,
+                "h-7 px-2 bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+              )
+            : cn(
+                BUTTON_BASE,
+                "h-9 px-3 border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+              )
+        }
+        aria-label="Role"
+      >
+        <Select.Value>{current.label}</Select.Value>
+        <Select.Icon>
+          <IconChevronDown size={14} />
+        </Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content
+          className={selectContentClass}
+          position="popper"
+          sideOffset={4}
+        >
+          <Select.Viewport>
+            <SelectItems items={ROLE_OPTIONS} />
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  );
+}
+
+function VisibilitySelect(props: {
+  value: Visibility;
+  onChange: (v: Visibility) => void;
+  disabled?: boolean;
+}) {
+  const current = VIS_META[props.value];
+  return (
+    <Select.Root
+      value={props.value}
+      onValueChange={(v) => props.onChange(v as Visibility)}
+      disabled={props.disabled}
+    >
+      <Select.Trigger
+        className={cn(
+          BUTTON_BASE,
+          "h-7 px-1 -ml-1 bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+        )}
+        aria-label="General access"
+      >
+        <Select.Value>{current.label}</Select.Value>
+        <Select.Icon>
+          <IconChevronDown size={14} />
+        </Select.Icon>
+      </Select.Trigger>
+      <Select.Portal>
+        <Select.Content
+          className={selectContentClass}
+          position="popper"
+          sideOffset={4}
+        >
+          <Select.Viewport>
+            <SelectItems
+              items={(Object.keys(VIS_META) as Visibility[]).map((k) => ({
+                value: k,
+                label: VIS_META[k].label,
+                description: VIS_META[k].description,
+              }))}
+            />
+          </Select.Viewport>
+        </Select.Content>
+      </Select.Portal>
+    </Select.Root>
+  );
+}
+
 function Avatar({ label, org }: { label: string; org?: boolean }) {
   return (
     <span
@@ -421,41 +594,6 @@ function Avatar({ label, org }: { label: string; org?: boolean }) {
     >
       {org ? "🏢" : initials(label)}
     </span>
-  );
-}
-
-function ChevronSelect(props: {
-  value: string;
-  onChange: (v: string) => void;
-  options: Array<{ value: string; label: string }>;
-  disabled?: boolean;
-  /** When true, render as inline text (no border/background) — matches
-   *  Google Docs' "General access" presentation. */
-  plain?: boolean;
-}) {
-  return (
-    <div className="relative inline-flex items-center">
-      <select
-        value={props.value}
-        onChange={(e) => props.onChange(e.target.value)}
-        disabled={props.disabled}
-        className={
-          props.plain
-            ? "appearance-none bg-transparent border-0 pr-6 pl-0 text-sm font-medium text-foreground cursor-pointer focus:outline-none disabled:opacity-60"
-            : "appearance-none h-9 rounded-md border border-input bg-background pl-3 pr-7 text-sm text-foreground cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
-        }
-      >
-        {props.options.map((o) => (
-          <option key={o.value} value={o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
-      <IconChevronDown
-        size={14}
-        className="pointer-events-none absolute right-1.5 text-muted-foreground"
-      />
-    </div>
   );
 }
 

--- a/packages/core/src/client/sharing/ShareDialog.tsx
+++ b/packages/core/src/client/sharing/ShareDialog.tsx
@@ -180,8 +180,17 @@ export function ShareDialog(props: ShareDialogProps) {
             ) : null}
             {(data?.shares ?? []).map((s) => (
               <li key={s.id} style={itemStyle}>
-                <span style={principalStyle}>
-                  {s.principalType === "org" ? "🏢 " : ""}
+                <span
+                  style={{
+                    ...principalStyle,
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                  }}
+                >
+                  {s.principalType === "org" ? (
+                    <IconBuilding size={14} strokeWidth={1.75} />
+                  ) : null}
                   {s.principalId}
                 </span>
                 <span style={{ display: "flex", gap: 6, alignItems: "center" }}>

--- a/templates/clips/app/components/player/settings-panel.tsx
+++ b/templates/clips/app/components/player/settings-panel.tsx
@@ -6,6 +6,7 @@ import {
   IconDownload,
   IconPhoto,
   IconX,
+  IconMoodSmile,
 } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -171,7 +172,7 @@ export function SettingsPanel(props: SettingsPanelProps) {
             onChange={(v) => patch({ enableComments: v })}
           />
           <ToggleRow
-            icon={<span className="text-sm">😀</span>}
+            icon={<IconMoodSmile className="h-4 w-4" />}
             label="Reactions"
             checked={recording.enableReactions}
             onChange={(v) => patch({ enableReactions: v })}

--- a/templates/forms/server/lib/integrations.ts
+++ b/templates/forms/server/lib/integrations.ts
@@ -47,8 +47,8 @@ function buildSlackPayload(submission: SubmissionPayload) {
         type: "header",
         text: {
           type: "plain_text",
-          text: `📋 New submission: ${submission.formTitle}`,
-          emoji: true,
+          text: `New submission: ${submission.formTitle}`,
+          emoji: false,
         },
       },
       {
@@ -84,7 +84,7 @@ function buildDiscordPayload(submission: SubmissionPayload) {
   return {
     embeds: [
       {
-        title: `📋 New submission: ${submission.formTitle}`,
+        title: `New submission: ${submission.formTitle}`,
         fields: discordFields,
         timestamp: submission.submittedAt,
         color: 0x2563eb,

--- a/templates/mail/app/components/layout/CommandPalette.tsx
+++ b/templates/mail/app/components/layout/CommandPalette.tsx
@@ -19,6 +19,7 @@ import {
   IconPhoto,
   IconEye,
   IconAlarm,
+  IconCheck,
 } from "@tabler/icons-react";
 import { CommandMenu } from "@agent-native/core/client";
 import { useTheme } from "next-themes";
@@ -184,7 +185,9 @@ export function CommandPalette({
           <IconPhoto className="h-4 w-4" />
           Images: Show all
           {imagePolicy === "show" && (
-            <CommandMenu.Shortcut>✓</CommandMenu.Shortcut>
+            <CommandMenu.Shortcut>
+              <IconCheck className="h-4 w-4" />
+            </CommandMenu.Shortcut>
           )}
         </CommandMenu.Item>
         <CommandMenu.Item
@@ -196,7 +199,9 @@ export function CommandPalette({
           <IconEye className="h-4 w-4" />
           Images: Block known trackers
           {imagePolicy === "block-trackers" && (
-            <CommandMenu.Shortcut>✓</CommandMenu.Shortcut>
+            <CommandMenu.Shortcut>
+              <IconCheck className="h-4 w-4" />
+            </CommandMenu.Shortcut>
           )}
         </CommandMenu.Item>
         <CommandMenu.Item
@@ -206,7 +211,9 @@ export function CommandPalette({
           <IconPhotoOff className="h-4 w-4" />
           Images: Block all remote images
           {imagePolicy === "block-all" && (
-            <CommandMenu.Shortcut>✓</CommandMenu.Shortcut>
+            <CommandMenu.Shortcut>
+              <IconCheck className="h-4 w-4" />
+            </CommandMenu.Shortcut>
           )}
         </CommandMenu.Item>
       </CommandMenu.Group>


### PR DESCRIPTION
## Summary

Replaces the native `<select>` elements in the sharing popover with shadcn-style Radix Select dropdowns, and adds an in-place role picker for each person with access (Google-Docs style).

Context: the popover had been using `<select>` for the role next to the email input, the role column per shared user, and the general-access visibility. Those rendered as browser defaults in an otherwise-shadcn UI, which was jarring.

- **`RoleSelect`** — Radix Select wrapper with shadcn classes. Used in two places:
  - Bordered trigger (`h-9` outline) next to the "Add people by email" input
  - Plain inline trigger (ghost) next to each person in "People with access", so you can change someone's role in place (matches the screenshot Steve shared)
- **`VisibilitySelect`** — same wrapper for General access. Each item shows label + description (e.g. "Private — Only people with access can view").
- **Per-share role change** — `share-resource` is upsert by `(resourceId, principalType, principalId)`, so re-calling it with a new role updates the existing row. Optimistic overlay clears on refetch (or reverts on error) so clicks feel instant.
- No new deps; `@radix-ui/react-select` was already vendored.

## Test plan

- [ ] Open the share popover from any dashboard / analysis / document header
- [ ] Change general access: Private → Organization → Public — description line updates immediately, request resolves in the background
- [ ] Invite someone by email + pick a role from the new role dropdown; row appears instantly
- [ ] Open the role dropdown next to an existing shared person; switch them from Viewer → Editor → Admin in place; row updates instantly and persists on refetch
- [ ] Dark mode: every surface in the popover uses `bg-popover` / `text-popover-foreground` / `border-border` — verify no light-mode residue

🤖 Generated with [Claude Code](https://claude.com/claude-code)