### PR TITLE
updates-122: clips desktop auto-updater + download page

### DIFF
--- a/.github/workflows/clips-desktop-release.yml
+++ b/.github/workflows/clips-desktop-release.yml
@@ -48,6 +48,16 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Guard — refuse to release with placeholder updater pubkey
+        shell: bash
+        run: |
+          if grep -q 'REPLACE_WITH_TAURI_UPDATER_PUBKEY' "$TAURI_APP_PATH/src-tauri/tauri.conf.json"; then
+            echo "::error::tauri.conf.json still has the placeholder updater pubkey."
+            echo "::error::Generate a keypair with 'pnpm exec tauri signer generate' and commit the public key."
+            echo "::error::See templates/clips/desktop/README.md for the full setup."
+            exit 1
+          fi
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/clips-desktop-release.yml
+++ b/.github/workflows/clips-desktop-release.yml
@@ -29,9 +29,6 @@ jobs:
           - os: macos-latest
             target: universal-apple-darwin
             rust-targets: "aarch64-apple-darwin,x86_64-apple-darwin"
-          - os: ubuntu-latest
-            target: ""
-            rust-targets: ""
           - os: windows-latest
             target: ""
             rust-targets: ""
@@ -67,18 +64,6 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ${{ env.TAURI_APP_PATH }}/src-tauri
-
-      - name: Install Linux deps
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            libsoup-3.0-dev \
-            patchelf
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/clips-desktop-release.yml
+++ b/.github/workflows/clips-desktop-release.yml
@@ -1,0 +1,168 @@
+name: Clips Desktop Release
+
+# Release channel for the Clips Tauri menu-bar app, SEPARATE from the main
+# Electron desktop app. Uses tag prefix `clips-v*` so the two release trains
+# don't collide on GitHub Releases. The in-app updater fetches its manifest
+# from the `clips-latest` stable-pointer release (assets overwritten each run),
+# which is what `endpoints` in tauri.conf.json points at.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version (e.g. 0.2.0). Leave empty to use package.json version."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  TAURI_APP_PATH: templates/clips/desktop
+
+jobs:
+  build-tauri:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: universal-apple-darwin
+            rust-targets: "aarch64-apple-darwin,x86_64-apple-darwin"
+          - os: ubuntu-latest
+            target: ""
+            rust-targets: ""
+          - os: windows-latest
+            target: ""
+            rust-targets: ""
+    runs-on: ${{ matrix.os }}
+    outputs:
+      app-version: ${{ steps.resolve-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-targets }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ env.TAURI_APP_PATH }}/src-tauri
+
+      - name: Install Linux deps
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            patchelf
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Bump version
+        if: inputs.version != ''
+        working-directory: ${{ env.TAURI_APP_PATH }}
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: npm version "$RELEASE_VERSION" --no-git-tag-version
+
+      - name: Resolve version
+        id: resolve-version
+        shell: bash
+        run: |
+          V=$(node -p "require('./${{ env.TAURI_APP_PATH }}/package.json').version")
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+
+      - name: Build and release (tauri-action)
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Tauri signing — REQUIRED for the updater to accept downloaded
+          # bundles. See templates/clips/desktop/README.md for key setup.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.CLIPS_TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.CLIPS_TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # macOS codesign + notarize (reuses the Electron app's Apple creds).
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: W3PMF2T3MW
+        with:
+          projectPath: ${{ env.TAURI_APP_PATH }}
+          tagName: clips-v__VERSION__
+          releaseName: "Clips Desktop v__VERSION__"
+          releaseBody: |
+            Auto-updating build of the Clips menu-bar app.
+
+            The in-app updater fetches its manifest from the `clips-latest`
+            release — this versioned release is the immutable source of the
+            signed bundles it downloads.
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.target != '' && format('--target {0}', matrix.target) || '' }}
+          updaterJsonPreferNsis: false
+
+  publish-release:
+    needs: build-tauri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: v
+        run: echo "version=${{ needs.build-tauri.outputs.app-version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Mark versioned release as latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "clips-v${{ steps.v.outputs.version }}" \
+            --draft=false \
+            --latest=false
+
+      - name: Download latest.json from versioned release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p manifest
+          gh release download "clips-v${{ steps.v.outputs.version }}" \
+            --pattern 'latest.json' \
+            --dir manifest
+
+      # The updater endpoint in tauri.conf.json expects a file named
+      # `clips-latest.json` at a stable URL. We host it on the long-lived
+      # `clips-latest` release — overwriting its asset on every build.
+      - name: Rename manifest
+        run: mv manifest/latest.json manifest/clips-latest.json
+
+      - name: Publish / refresh clips-latest pointer release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view clips-latest >/dev/null 2>&1; then
+            gh release delete-asset clips-latest clips-latest.json --yes || true
+            gh release upload clips-latest manifest/clips-latest.json
+            gh release edit clips-latest \
+              --title "Clips Desktop — latest (updater manifest)" \
+              --notes "Stable URL for the Clips auto-updater. Overwritten on every release. Versioned bundles live in clips-v* releases."
+          else
+            gh release create clips-latest manifest/clips-latest.json \
+              --title "Clips Desktop — latest (updater manifest)" \
+              --notes "Stable URL for the Clips auto-updater. Overwritten on every release. Versioned bundles live in clips-v* releases." \
+              --latest=false
+          fi

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1587,12 +1587,21 @@ importers:
 
   templates/clips/desktop:
     dependencies:
+      '@tabler/icons-react':
+        specifier: ^3.26.0
+        version: 3.41.1(react@18.3.1)
       '@tauri-apps/api':
         specifier: ^2.1.1
         version: 2.10.1
+      '@tauri-apps/plugin-process':
+        specifier: ^2.0.1
+        version: 2.3.1
       '@tauri-apps/plugin-shell':
         specifier: ^2.0.1
         version: 2.3.5
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.0.1
+        version: 2.10.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -8856,8 +8865,14 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution: {integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==}
+
   '@tauri-apps/plugin-shell@2.3.5':
     resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -21064,7 +21079,15 @@ snapshots:
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
 
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
   '@tauri-apps/plugin-shell@2.3.5':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -7,6 +7,7 @@ import {
   IconUsersGroup,
   IconFolderPlus,
   IconPlayerRecord,
+  IconAppWindow,
 } from "@tabler/icons-react";
 import { AgentSidebar, AgentToggleButton } from "@agent-native/core/client";
 import { cn } from "@/lib/utils";
@@ -154,6 +155,16 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
                 );
               })}
             </nav>
+
+            <div className="mt-3 px-2">
+              <NavLink
+                to="/download"
+                className="flex items-center gap-2 rounded px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+              >
+                <IconAppWindow className="h-4 w-4" />
+                Get desktop app
+              </NavLink>
+            </div>
 
             <div className="mt-4 flex-1 overflow-y-auto px-2 pb-3 space-y-4">
               <div>

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import {
   IconBrandApple,
   IconBrandWindows,
-  IconBrandUbuntu,
   IconDownload,
   IconPlayerRecord,
   IconKeyboard,
@@ -17,124 +16,87 @@ export function meta() {
     {
       name: "description",
       content:
-        "Record your screen from the menu bar. Auto-updating desktop app for macOS, Windows, and Linux.",
+        "Record your screen from the menu bar. Auto-updating desktop app for macOS and Windows.",
     },
   ];
 }
 
-type PlatformId = "mac-apple-silicon" | "mac-intel" | "windows" | "linux";
+type PlatformId = "mac" | "windows";
 
 interface PlatformVariant {
   id: PlatformId;
   label: string;
   sublabel: string;
-  assetPattern: RegExp;
+  // Asset kinds (as classified by the server) that satisfy this variant.
+  // First match wins when picking the download URL.
+  assetKinds: readonly (
+    | "mac-universal"
+    | "mac-arm64"
+    | "mac-x64"
+    | "windows-msi"
+    | "windows-exe"
+  )[];
   icon: typeof IconBrandApple;
 }
 
-// Same-origin proxy for the Tauri updater manifest. We can't hit the raw
-// GitHub release URL from a browser because GitHub's asset responses lack
-// CORS headers. See `server/routes/api/clips-latest.json.get.ts`.
+// Same-origin endpoint that returns the latest `clips-v*` GitHub release
+// metadata with each asset classified as a specific installer kind. See
+// `server/routes/api/clips-latest.json.get.ts`.
 const LATEST_JSON_URL = "/api/clips-latest.json";
 
 // Fallback link when the manifest is unavailable — the all-releases
 // listing filtered to the `clips-v*` versioned releases, which is where
-// the actual DMG / MSI / AppImage assets live. The `clips-latest` tag
-// only holds the JSON manifest, so pointing users there would give them
-// a page with no installers. This is a real, browsable HTML URL (NOT
-// the JSON manifest), so the button never serves JSON by mistake.
+// the actual installer files live. This is a real, browsable HTML URL
+// (NOT the JSON manifest), so the button never serves JSON by mistake.
 const RELEASE_PAGE_URL =
   "https://github.com/BuilderIO/agent-native/releases?q=clips-v";
 
 const VARIANTS: PlatformVariant[] = [
   {
-    id: "mac-apple-silicon",
-    label: "macOS — Apple Silicon",
-    sublabel: "M1 / M2 / M3 / M4",
-    assetPattern: /aarch64.*\.dmg$|arm64.*\.dmg$/i,
-    icon: IconBrandApple,
-  },
-  {
-    id: "mac-intel",
-    label: "macOS — Intel",
-    sublabel: "x86_64",
-    assetPattern: /x64.*\.dmg$|x86_64.*\.dmg$/i,
+    id: "mac",
+    label: "macOS",
+    sublabel: "Universal (Apple Silicon + Intel)",
+    assetKinds: ["mac-universal", "mac-arm64", "mac-x64"],
     icon: IconBrandApple,
   },
   {
     id: "windows",
     label: "Windows",
     sublabel: "64-bit installer",
-    assetPattern: /\.msi$|\.exe$/i,
+    assetKinds: ["windows-msi", "windows-exe"],
     icon: IconBrandWindows,
-  },
-  {
-    id: "linux",
-    label: "Linux",
-    sublabel: "AppImage",
-    assetPattern: /\.AppImage$/i,
-    icon: IconBrandUbuntu,
   },
 ];
 
 interface Manifest {
   version: string;
+  tag: string;
+  pub_date: string | null;
   notes?: string;
-  pub_date?: string;
-  platforms: Record<string, { url: string; signature: string }>;
+  assets: {
+    name: string;
+    url: string;
+    size: number;
+    kind: string;
+  }[];
 }
 
-interface UserAgentData {
-  platform?: string;
-  getHighEntropyValues?: (
-    hints: string[],
-  ) => Promise<{ architecture?: string }>;
-}
-
-function syncPlatform(): PlatformId | null {
+function detectPlatform(): PlatformId | null {
   if (typeof navigator === "undefined") return null;
   const ua = navigator.userAgent;
   if (/Windows/i.test(ua)) return "windows";
-  if (/Linux/i.test(ua)) return "linux";
-  if (/Mac/i.test(ua)) {
-    // Synchronous default for Mac. `navigator.userAgentData.architecture`
-    // is an *empty string* on low-entropy access — the real value is
-    // only available via the async `getHighEntropyValues()` call (see
-    // `refinePlatform` below). Safari doesn't expose `userAgentData` at
-    // all. Default to Apple Silicon since it's the overwhelming majority
-    // on currently-shipping Macs, and let `refinePlatform` correct to
-    // mac-intel when Chromium confirms it.
-    return "mac-apple-silicon";
-  }
+  if (/Mac/i.test(ua)) return "mac";
   return null;
-}
-
-async function refinePlatform(
-  current: PlatformId | null,
-): Promise<PlatformId | null> {
-  if (current !== "mac-apple-silicon" && current !== "mac-intel")
-    return current;
-  if (typeof navigator === "undefined") return current;
-  const uad = (navigator as unknown as { userAgentData?: UserAgentData })
-    .userAgentData;
-  if (!uad?.getHighEntropyValues) return current;
-  try {
-    const high = await uad.getHighEntropyValues(["architecture"]);
-    if (high.architecture === "arm") return "mac-apple-silicon";
-    if (high.architecture === "x86") return "mac-intel";
-  } catch {
-    // Permissions / hint denied — keep the sync default.
-  }
-  return current;
 }
 
 function pickAsset(
   manifest: Manifest | null,
   variant: PlatformVariant,
-): string | null {
+): { url: string; name: string } | null {
   if (!manifest) return null;
-  for (const [, value] of Object.entries(manifest.platforms)) {
-    if (variant.assetPattern.test(value.url)) return value.url;
+  for (const kind of variant.assetKinds) {
+    const asset = manifest.assets.find((a) => a.kind === kind);
+    if (asset) return { url: asset.url, name: asset.name };
   }
   return null;
 }
@@ -142,19 +104,7 @@ function pickAsset(
 export default function DownloadPage() {
   const [manifest, setManifest] = useState<Manifest | null>(null);
   const [manifestError, setManifestError] = useState(false);
-  const initialPlatform = useMemo(() => syncPlatform(), []);
-  const [detected, setDetected] = useState<PlatformId | null>(initialPlatform);
-
-  useEffect(() => {
-    let cancelled = false;
-    refinePlatform(initialPlatform).then((refined) => {
-      if (!cancelled && refined !== detected) setDetected(refined);
-    });
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialPlatform]);
+  const detected = useMemo(() => detectPlatform(), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -212,7 +162,7 @@ export default function DownloadPage() {
           <div className="mt-10 flex flex-col items-center gap-3">
             {primaryAsset ? (
               <Button asChild size="lg" className="h-12 gap-2 px-6 text-base">
-                <a href={primaryAsset} download>
+                <a href={primaryAsset.url} download>
                   <primary.icon className="h-5 w-5" />
                   Download for {primary.label}
                 </a>
@@ -255,9 +205,9 @@ export default function DownloadPage() {
           </div>
         </div>
 
-        <div className="mt-16 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className="mt-16 grid grid-cols-1 gap-3 sm:grid-cols-2">
           {others.map((v) => {
-            const url = pickAsset(manifest, v);
+            const asset = pickAsset(manifest, v);
             const Icon = v.icon;
             return (
               <Card
@@ -273,9 +223,9 @@ export default function DownloadPage() {
                     {v.sublabel}
                   </div>
                 </div>
-                {url ? (
+                {asset ? (
                   <a
-                    href={url}
+                    href={asset.url}
                     download
                     className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
                   >

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -1,0 +1,263 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  IconBrandApple,
+  IconBrandWindows,
+  IconBrandUbuntu,
+  IconDownload,
+  IconPlayerRecord,
+  IconKeyboard,
+  IconRefresh,
+} from "@tabler/icons-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+export function meta() {
+  return [
+    { title: "Download Clips Desktop" },
+    {
+      name: "description",
+      content:
+        "Record your screen from the menu bar. Auto-updating desktop app for macOS, Windows, and Linux.",
+    },
+  ];
+}
+
+type PlatformId = "mac-apple-silicon" | "mac-intel" | "windows" | "linux";
+
+interface PlatformVariant {
+  id: PlatformId;
+  label: string;
+  sublabel: string;
+  assetPattern: RegExp;
+  icon: typeof IconBrandApple;
+}
+
+// The `clips-latest` release is a movable pointer; its assets are overwritten
+// on every Clips Tauri release by .github/workflows/clips-desktop-release.yml.
+// Versioned bundles live on immutable `clips-v*` releases and are referenced
+// by absolute URL inside the manifest we fetch.
+const LATEST_JSON_URL =
+  "https://github.com/BuilderIO/agent-native/releases/download/clips-latest/clips-latest.json";
+
+const VARIANTS: PlatformVariant[] = [
+  {
+    id: "mac-apple-silicon",
+    label: "macOS — Apple Silicon",
+    sublabel: "M1 / M2 / M3 / M4",
+    assetPattern: /aarch64.*\.dmg$|arm64.*\.dmg$/i,
+    icon: IconBrandApple,
+  },
+  {
+    id: "mac-intel",
+    label: "macOS — Intel",
+    sublabel: "x86_64",
+    assetPattern: /x64.*\.dmg$|x86_64.*\.dmg$/i,
+    icon: IconBrandApple,
+  },
+  {
+    id: "windows",
+    label: "Windows",
+    sublabel: "64-bit installer",
+    assetPattern: /\.msi$|\.exe$/i,
+    icon: IconBrandWindows,
+  },
+  {
+    id: "linux",
+    label: "Linux",
+    sublabel: "AppImage",
+    assetPattern: /\.AppImage$/i,
+    icon: IconBrandUbuntu,
+  },
+];
+
+interface Manifest {
+  version: string;
+  notes?: string;
+  pub_date?: string;
+  platforms: Record<string, { url: string; signature: string }>;
+}
+
+function detectPlatform(): PlatformId | null {
+  if (typeof navigator === "undefined") return null;
+  const ua = navigator.userAgent;
+  if (/Mac/i.test(ua)) {
+    // `navigator.userAgentData.platform` is the canonical arch hint, but
+    // Safari doesn't expose it. Fall back to the heuristic that Apple
+    // Silicon is now the default on any Mac running a shipping macOS.
+    const ud = (
+      navigator as unknown as { userAgentData?: { platform?: string } }
+    ).userAgentData;
+    if (ud?.platform === "macOS") return "mac-apple-silicon";
+    return /Intel/i.test(ua) ? "mac-intel" : "mac-apple-silicon";
+  }
+  if (/Windows/i.test(ua)) return "windows";
+  if (/Linux/i.test(ua)) return "linux";
+  return null;
+}
+
+function pickAsset(
+  manifest: Manifest | null,
+  variant: PlatformVariant,
+): string | null {
+  if (!manifest) return null;
+  for (const [, value] of Object.entries(manifest.platforms)) {
+    if (variant.assetPattern.test(value.url)) return value.url;
+  }
+  return null;
+}
+
+export default function DownloadPage() {
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const detected = useMemo(() => detectPlatform(), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(LATEST_JSON_URL, { cache: "no-cache" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        if (!cancelled && json) setManifest(json as Manifest);
+      })
+      .catch(() => {
+        // ignore — button falls back to the stable-pointer URL
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const primary = VARIANTS.find((v) => v.id === detected) ?? VARIANTS[0];
+  const others = VARIANTS.filter((v) => v.id !== primary.id);
+  const primaryUrl = pickAsset(manifest, primary) ?? LATEST_JSON_URL;
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="border-b border-border">
+        <div className="mx-auto flex max-w-5xl items-center gap-3 px-6 py-4">
+          <a href="/" className="flex items-center gap-2 font-semibold">
+            <span className="grid h-7 w-7 place-items-center rounded-md bg-primary text-primary-foreground">
+              <IconPlayerRecord className="h-4 w-4" />
+            </span>
+            <span>Clips</span>
+          </a>
+          <a
+            href="/library"
+            className="ml-auto text-sm text-muted-foreground hover:text-foreground"
+          >
+            Back to library
+          </a>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-5xl px-6 py-16">
+        <div className="flex flex-col items-center text-center">
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-border bg-muted/40 px-3 py-1 text-xs text-muted-foreground">
+            <IconRefresh className="h-3.5 w-3.5" />
+            Auto-updates — you always have the latest
+          </div>
+          <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+            Clips Desktop
+          </h1>
+          <p className="mt-4 max-w-xl text-base text-muted-foreground">
+            A menu-bar recorder for screen, camera, and screen + camera.
+            One-click start, draggable camera bubble, instant-share link when
+            you stop.
+          </p>
+
+          <div className="mt-10 flex flex-col items-center gap-3">
+            <Button asChild size="lg" className="h-12 gap-2 px-6 text-base">
+              <a href={primaryUrl} download>
+                <primary.icon className="h-5 w-5" />
+                Download for {primary.label}
+              </a>
+            </Button>
+            <div className="text-xs text-muted-foreground">
+              {manifest ? (
+                <>
+                  Version {manifest.version}
+                  {manifest.pub_date
+                    ? ` — released ${new Date(manifest.pub_date).toLocaleDateString()}`
+                    : null}
+                </>
+              ) : (
+                <>Loading latest release…</>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-16 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {others.map((v) => {
+            const url = pickAsset(manifest, v);
+            const Icon = v.icon;
+            return (
+              <Card
+                key={v.id}
+                className="flex items-center gap-3 border border-border bg-muted/20 p-4"
+              >
+                <span className="grid h-9 w-9 place-items-center rounded-md bg-background">
+                  <Icon className="h-5 w-5" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm font-medium">{v.label}</div>
+                  <div className="truncate text-xs text-muted-foreground">
+                    {v.sublabel}
+                  </div>
+                </div>
+                {url ? (
+                  <a
+                    href={url}
+                    download
+                    className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+                  >
+                    <IconDownload className="h-4 w-4" />
+                    Get
+                  </a>
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    Unavailable
+                  </span>
+                )}
+              </Card>
+            );
+          })}
+        </div>
+
+        <section className="mt-20 grid grid-cols-1 gap-6 sm:grid-cols-3">
+          <Feature
+            icon={IconKeyboard}
+            title="Global shortcut"
+            body="Press ⌘⇧L anywhere to open the tray — start recording without switching windows."
+          />
+          <Feature
+            icon={IconRefresh}
+            title="Stays current"
+            body="New builds install themselves in the background and prompt you to restart. No manual updates."
+          />
+          <Feature
+            icon={IconPlayerRecord}
+            title="Camera bubble"
+            body="Screen + camera mode floats a draggable PiP of your face over everything you capture."
+          />
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function Feature({
+  icon: Icon,
+  title,
+  body,
+}: {
+  icon: typeof IconRefresh;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border p-5">
+      <Icon className="mb-3 h-5 w-5 text-primary" />
+      <div className="text-sm font-semibold">{title}</div>
+      <p className="mt-1.5 text-sm text-muted-foreground">{body}</p>
+    </div>
+  );
+}

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -37,12 +37,14 @@ interface PlatformVariant {
 // CORS headers. See `server/routes/api/clips-latest.json.get.ts`.
 const LATEST_JSON_URL = "/api/clips-latest.json";
 
-// Fallback link when the manifest is unavailable — the public Releases
-// page for the `clips-latest` pointer, where users can pick an installer
-// by hand. This is a real, browsable URL (NOT the JSON manifest), so the
-// button never serves JSON by mistake.
+// Fallback link when the manifest is unavailable — the all-releases
+// listing filtered to the `clips-v*` versioned releases, which is where
+// the actual DMG / MSI / AppImage assets live. The `clips-latest` tag
+// only holds the JSON manifest, so pointing users there would give them
+// a page with no installers. This is a real, browsable HTML URL (NOT
+// the JSON manifest), so the button never serves JSON by mistake.
 const RELEASE_PAGE_URL =
-  "https://github.com/BuilderIO/agent-native/releases/tag/clips-latest";
+  "https://github.com/BuilderIO/agent-native/releases?q=clips-v";
 
 const VARIANTS: PlatformVariant[] = [
   {
@@ -82,24 +84,48 @@ interface Manifest {
   platforms: Record<string, { url: string; signature: string }>;
 }
 
-function detectPlatform(): PlatformId | null {
+interface UserAgentData {
+  platform?: string;
+  getHighEntropyValues?: (
+    hints: string[],
+  ) => Promise<{ architecture?: string }>;
+}
+
+function syncPlatform(): PlatformId | null {
   if (typeof navigator === "undefined") return null;
   const ua = navigator.userAgent;
-  if (/Mac/i.test(ua)) {
-    // Canonical arch signal (Chromium: "arm" | "x86"). Safari does not
-    // expose `userAgentData`, in which case we can't reliably tell Intel
-    // from Apple Silicon — default to Apple Silicon since it's the
-    // overwhelming majority on currently-shipping Macs.
-    const arch = (
-      navigator as unknown as { userAgentData?: { architecture?: string } }
-    ).userAgentData?.architecture;
-    if (arch === "arm") return "mac-apple-silicon";
-    if (arch === "x86") return "mac-intel";
-    return "mac-apple-silicon";
-  }
   if (/Windows/i.test(ua)) return "windows";
   if (/Linux/i.test(ua)) return "linux";
+  if (/Mac/i.test(ua)) {
+    // Synchronous default for Mac. `navigator.userAgentData.architecture`
+    // is an *empty string* on low-entropy access — the real value is
+    // only available via the async `getHighEntropyValues()` call (see
+    // `refinePlatform` below). Safari doesn't expose `userAgentData` at
+    // all. Default to Apple Silicon since it's the overwhelming majority
+    // on currently-shipping Macs, and let `refinePlatform` correct to
+    // mac-intel when Chromium confirms it.
+    return "mac-apple-silicon";
+  }
   return null;
+}
+
+async function refinePlatform(
+  current: PlatformId | null,
+): Promise<PlatformId | null> {
+  if (current !== "mac-apple-silicon" && current !== "mac-intel")
+    return current;
+  if (typeof navigator === "undefined") return current;
+  const uad = (navigator as unknown as { userAgentData?: UserAgentData })
+    .userAgentData;
+  if (!uad?.getHighEntropyValues) return current;
+  try {
+    const high = await uad.getHighEntropyValues(["architecture"]);
+    if (high.architecture === "arm") return "mac-apple-silicon";
+    if (high.architecture === "x86") return "mac-intel";
+  } catch {
+    // Permissions / hint denied — keep the sync default.
+  }
+  return current;
 }
 
 function pickAsset(
@@ -116,7 +142,19 @@ function pickAsset(
 export default function DownloadPage() {
   const [manifest, setManifest] = useState<Manifest | null>(null);
   const [manifestError, setManifestError] = useState(false);
-  const detected = useMemo(() => detectPlatform(), []);
+  const initialPlatform = useMemo(() => syncPlatform(), []);
+  const [detected, setDetected] = useState<PlatformId | null>(initialPlatform);
+
+  useEffect(() => {
+    let cancelled = false;
+    refinePlatform(initialPlatform).then((refined) => {
+      if (!cancelled && refined !== detected) setDetected(refined);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialPlatform]);
 
   useEffect(() => {
     let cancelled = false;

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -32,12 +32,17 @@ interface PlatformVariant {
   icon: typeof IconBrandApple;
 }
 
-// The `clips-latest` release is a movable pointer; its assets are overwritten
-// on every Clips Tauri release by .github/workflows/clips-desktop-release.yml.
-// Versioned bundles live on immutable `clips-v*` releases and are referenced
-// by absolute URL inside the manifest we fetch.
-const LATEST_JSON_URL =
-  "https://github.com/BuilderIO/agent-native/releases/download/clips-latest/clips-latest.json";
+// Same-origin proxy for the Tauri updater manifest. We can't hit the raw
+// GitHub release URL from a browser because GitHub's asset responses lack
+// CORS headers. See `server/routes/api/clips-latest.json.get.ts`.
+const LATEST_JSON_URL = "/api/clips-latest.json";
+
+// Fallback link when the manifest is unavailable — the public Releases
+// page for the `clips-latest` pointer, where users can pick an installer
+// by hand. This is a real, browsable URL (NOT the JSON manifest), so the
+// button never serves JSON by mistake.
+const RELEASE_PAGE_URL =
+  "https://github.com/BuilderIO/agent-native/releases/tag/clips-latest";
 
 const VARIANTS: PlatformVariant[] = [
   {
@@ -81,14 +86,16 @@ function detectPlatform(): PlatformId | null {
   if (typeof navigator === "undefined") return null;
   const ua = navigator.userAgent;
   if (/Mac/i.test(ua)) {
-    // `navigator.userAgentData.platform` is the canonical arch hint, but
-    // Safari doesn't expose it. Fall back to the heuristic that Apple
-    // Silicon is now the default on any Mac running a shipping macOS.
-    const ud = (
-      navigator as unknown as { userAgentData?: { platform?: string } }
-    ).userAgentData;
-    if (ud?.platform === "macOS") return "mac-apple-silicon";
-    return /Intel/i.test(ua) ? "mac-intel" : "mac-apple-silicon";
+    // Canonical arch signal (Chromium: "arm" | "x86"). Safari does not
+    // expose `userAgentData`, in which case we can't reliably tell Intel
+    // from Apple Silicon — default to Apple Silicon since it's the
+    // overwhelming majority on currently-shipping Macs.
+    const arch = (
+      navigator as unknown as { userAgentData?: { architecture?: string } }
+    ).userAgentData?.architecture;
+    if (arch === "arm") return "mac-apple-silicon";
+    if (arch === "x86") return "mac-intel";
+    return "mac-apple-silicon";
   }
   if (/Windows/i.test(ua)) return "windows";
   if (/Linux/i.test(ua)) return "linux";
@@ -108,17 +115,18 @@ function pickAsset(
 
 export default function DownloadPage() {
   const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [manifestError, setManifestError] = useState(false);
   const detected = useMemo(() => detectPlatform(), []);
 
   useEffect(() => {
     let cancelled = false;
     fetch(LATEST_JSON_URL, { cache: "no-cache" })
-      .then((r) => (r.ok ? r.json() : null))
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
       .then((json) => {
-        if (!cancelled && json) setManifest(json as Manifest);
+        if (!cancelled) setManifest(json as Manifest);
       })
       .catch(() => {
-        // ignore — button falls back to the stable-pointer URL
+        if (!cancelled) setManifestError(true);
       });
     return () => {
       cancelled = true;
@@ -127,7 +135,7 @@ export default function DownloadPage() {
 
   const primary = VARIANTS.find((v) => v.id === detected) ?? VARIANTS[0];
   const others = VARIANTS.filter((v) => v.id !== primary.id);
-  const primaryUrl = pickAsset(manifest, primary) ?? LATEST_JSON_URL;
+  const primaryAsset = pickAsset(manifest, primary);
 
   return (
     <div className="min-h-screen bg-background text-foreground">
@@ -164,12 +172,31 @@ export default function DownloadPage() {
           </p>
 
           <div className="mt-10 flex flex-col items-center gap-3">
-            <Button asChild size="lg" className="h-12 gap-2 px-6 text-base">
-              <a href={primaryUrl} download>
+            {primaryAsset ? (
+              <Button asChild size="lg" className="h-12 gap-2 px-6 text-base">
+                <a href={primaryAsset} download>
+                  <primary.icon className="h-5 w-5" />
+                  Download for {primary.label}
+                </a>
+              </Button>
+            ) : manifest === null && !manifestError ? (
+              <Button size="lg" className="h-12 gap-2 px-6 text-base" disabled>
                 <primary.icon className="h-5 w-5" />
-                Download for {primary.label}
-              </a>
-            </Button>
+                Loading latest release…
+              </Button>
+            ) : (
+              <Button
+                asChild
+                size="lg"
+                variant="outline"
+                className="h-12 gap-2 px-6 text-base"
+              >
+                <a href={RELEASE_PAGE_URL} rel="noreferrer">
+                  <primary.icon className="h-5 w-5" />
+                  Get the latest release
+                </a>
+              </Button>
+            )}
             <div className="text-xs text-muted-foreground">
               {manifest ? (
                 <>
@@ -177,6 +204,11 @@ export default function DownloadPage() {
                   {manifest.pub_date
                     ? ` — released ${new Date(manifest.pub_date).toLocaleDateString()}`
                     : null}
+                </>
+              ) : manifestError ? (
+                <>
+                  Could not load release manifest — pick an installer from the
+                  releases page.
                 </>
               ) : (
                 <>Loading latest release…</>

--- a/templates/clips/app/routes/download.tsx
+++ b/templates/clips/app/routes/download.tsx
@@ -108,7 +108,11 @@ export default function DownloadPage() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch(LATEST_JSON_URL, { cache: "no-cache" })
+    // Use default browser caching — the server sets `cache-control:
+    // max-age=60`, and there's a process-wide 5-minute cache behind
+    // it. Forcing `no-cache` would bypass both and amplify load on
+    // the GitHub REST upstream (60 req/hr/IP rate limit).
+    fetch(LATEST_JSON_URL)
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
       .then((json) => {
         if (!cancelled) setManifest(json as Manifest);

--- a/templates/clips/desktop/README.md
+++ b/templates/clips/desktop/README.md
@@ -33,3 +33,47 @@ On first launch the popover asks for the URL of your Clips server. This is store
 
 - Replace `src-tauri/icons/tray.png` with a real 16×16 (and 32×32 @2x) monochrome PNG. The default placeholder is a plain purple square so the app still compiles out of the box.
 - Add Apple Developer ID + Windows Authenticode signing config to `tauri.conf.json` — currently left blank.
+- Run the **Updater signing key** setup below before the first release. Without it, `tauri-action` will refuse to build a signed bundle and the in-app updater will reject whatever the workflow uploads.
+
+## Releases + auto-update
+
+Clips Desktop ships on its own release channel — tag prefix `clips-v*`, separate from the main `v*` tags used by `packages/desktop-app` (Electron). The in-app updater pulls its manifest from a stable pointer release (`clips-latest`) that the release workflow overwrites on every run.
+
+### Shipping a release
+
+1. Bump `templates/clips/desktop/package.json` version (or pass it via workflow input).
+2. Trigger **Clips Desktop Release** in GitHub Actions (`.github/workflows/clips-desktop-release.yml`). It builds on macOS (universal), Windows, and Linux in parallel, signs everything, and uploads to `clips-v{version}`.
+3. After all three platforms finish, the `publish-release` job flips the versioned release out of draft and refreshes the `clips-latest` pointer release with the new manifest. Within a few hours (next update check) every installed Clips starts auto-downloading in the background.
+
+### Auto-update flow (inside the app)
+
+- `src/lib/updater.ts` checks for updates 3s after launch and every 4 hours.
+- On `available` it auto-downloads; on `downloaded` the popover shows an "Update ready — Restart" banner.
+- Clicking Restart calls `@tauri-apps/plugin-process` `relaunch()`, which applies the already-staged bundle.
+- No banner is shown in idle / checking / not-available states — the popover stays focused on recording.
+
+### Updater signing key (one-time setup)
+
+Tauri's updater verifies every downloaded bundle against an ed25519 signature baked into `tauri.conf.json` under `plugins.updater.pubkey`. Without a matching private key on the CI side, nothing installs.
+
+```bash
+# Generate the keypair — run once, store the output in a password manager.
+pnpm tauri signer generate -w ~/.tauri/clips-updater.key
+
+# Print the public key to paste into tauri.conf.json → plugins.updater.pubkey
+cat ~/.tauri/clips-updater.key.pub
+```
+
+Then set these GitHub secrets on the repository:
+
+| Secret                                     | Source                                                  |
+| ------------------------------------------ | ------------------------------------------------------- |
+| `CLIPS_TAURI_SIGNING_PRIVATE_KEY`          | Contents of `~/.tauri/clips-updater.key` (full file)    |
+| `CLIPS_TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | The password you entered at `tauri signer generate`     |
+| `APPLE_CERTIFICATE`                        | Base64-encoded Developer ID .p12 (shared with Electron) |
+| `APPLE_CERTIFICATE_PASSWORD`               | .p12 password (shared with Electron)                    |
+| `APPLE_SIGNING_IDENTITY`                   | e.g. `Developer ID Application: Builder (W3PMF2T3MW)`   |
+| `APPLE_ID`                                 | Apple ID for notarization (shared with Electron)        |
+| `APPLE_APP_SPECIFIC_PASSWORD`              | App-specific password for notarization                  |
+
+Once the keys are in place and `tauri.conf.json` has the real `pubkey`, subsequent workflow runs produce bundles the updater will accept.

--- a/templates/clips/desktop/package.json
+++ b/templates/clips/desktop/package.json
@@ -13,8 +13,11 @@
     "vite:build": "vite build"
   },
   "dependencies": {
+    "@tabler/icons-react": "^3.26.0",
     "@tauri-apps/api": "^2.1.1",
+    "@tauri-apps/plugin-process": "^2.0.1",
     "@tauri-apps/plugin-shell": "^2.0.1",
+    "@tauri-apps/plugin-updater": "^2.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/templates/clips/desktop/src-tauri/Cargo.lock
+++ b/templates/clips/desktop/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,8 +481,10 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-global-shortcut",
+ "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "url",
 ]
 
@@ -687,6 +698,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -978,6 +1000,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1612,6 +1645,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,7 +2093,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2143,6 +2194,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2345,6 +2402,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2358,6 +2416,18 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2417,6 +2487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2440,6 +2516,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2491,7 +2581,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2717,6 +2807,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3012,6 +3108,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3085,15 +3190,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3103,6 +3213,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3134,6 +3258,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3343,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3204,6 +3410,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3533,7 +3762,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -3626,6 +3855,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3740,6 +3975,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3896,6 +4142,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3929,6 +4185,39 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -4158,6 +4447,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4465,6 +4764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4763,6 +5068,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4990,6 +5304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5437,6 +5760,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5568,6 +5901,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5598,6 +5937,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/templates/clips/desktop/src-tauri/Cargo.toml
+++ b/templates/clips/desktop/src-tauri/Cargo.toml
@@ -33,6 +33,8 @@ tauri = { version = "2", features = [
 tauri-plugin-shell = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-single-instance = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 url = "2"

--- a/templates/clips/desktop/src-tauri/capabilities/default.json
+++ b/templates/clips/desktop/src-tauri/capabilities/default.json
@@ -22,6 +22,9 @@
     "shell:allow-open",
     "global-shortcut:allow-register",
     "global-shortcut:allow-unregister",
-    "global-shortcut:allow-is-registered"
+    "global-shortcut:allow-is-registered",
+    "updater:default",
+    "process:default",
+    "process:allow-restart"
   ]
 }

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -904,6 +904,8 @@ pub fn run() {
             load_bubble_size,
         ])
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(
             tauri_plugin_global_shortcut::Builder::new()
                 .with_handler(|app, shortcut, event| {

--- a/templates/clips/desktop/src-tauri/tauri.conf.json
+++ b/templates/clips/desktop/src-tauri/tauri.conf.json
@@ -55,6 +55,14 @@
   "plugins": {
     "shell": {
       "open": true
+    },
+    "updater": {
+      "active": true,
+      "dialog": false,
+      "endpoints": [
+        "https://github.com/BuilderIO/agent-native/releases/latest/download/clips-latest.json"
+      ],
+      "pubkey": "REPLACE_WITH_TAURI_UPDATER_PUBKEY"
     }
   }
 }

--- a/templates/clips/desktop/src-tauri/tauri.conf.json
+++ b/templates/clips/desktop/src-tauri/tauri.conf.json
@@ -60,7 +60,7 @@
       "active": true,
       "dialog": false,
       "endpoints": [
-        "https://github.com/BuilderIO/agent-native/releases/latest/download/clips-latest.json"
+        "https://github.com/BuilderIO/agent-native/releases/download/clips-latest/clips-latest.json"
       ],
       "pubkey": "REPLACE_WITH_TAURI_UPDATER_PUBKEY"
     }

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -9,6 +9,7 @@ import {
   type BubbleWebrtcHandle,
 } from "./lib/bubble-webrtc";
 import { startNativeRecording, type RecorderHandle } from "./lib/recorder";
+import { UpdateBanner } from "./components/UpdateBanner";
 
 interface RecordingSummary {
   id: string;
@@ -785,6 +786,7 @@ export function App() {
     return (
       <div className="app" ref={appRef}>
         <Header mode={mode} onModeChange={setMode} />
+        <UpdateBanner />
         <SignInForm
           serverUrl={serverUrl}
           onSignedIn={async () => {
@@ -815,6 +817,7 @@ export function App() {
   return (
     <div className="app" ref={appRef}>
       <Header mode={mode} onModeChange={setMode} />
+      <UpdateBanner />
 
       <div className="panel">
         {showSourceRow ? (

--- a/templates/clips/desktop/src/components/UpdateBanner.tsx
+++ b/templates/clips/desktop/src/components/UpdateBanner.tsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
-import { useUpdateStatus, installAndRestart } from "../lib/updater";
+import {
+  useUpdateStatus,
+  installAndRestart,
+  retryUpdateCheck,
+} from "../lib/updater";
 
 /**
  * Compact banner that slots into the top of the popover whenever an update
@@ -9,11 +13,42 @@ import { useUpdateStatus, installAndRestart } from "../lib/updater";
 export function UpdateBanner() {
   const status = useUpdateStatus();
   const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
+  const [errorDismissed, setErrorDismissed] = useState(false);
 
   if (status.state === "idle") return null;
   if (status.state === "checking") return null;
   if (status.state === "not-available") return null;
-  if (status.state === "error") return null;
+
+  if (status.state === "error") {
+    if (errorDismissed) return null;
+    return (
+      <div className="update-banner update-banner--error">
+        <span className="update-banner-text">
+          Update check failed: {status.message}
+        </span>
+        <div className="update-banner-actions">
+          <button
+            type="button"
+            className="update-banner-btn update-banner-btn--ghost"
+            onClick={() => setErrorDismissed(true)}
+          >
+            Dismiss
+          </button>
+          <button
+            type="button"
+            className="update-banner-btn update-banner-btn--primary"
+            onClick={() => {
+              retryUpdateCheck().catch((err) => {
+                console.error("[clips-updater] retry failed:", err);
+              });
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   // User dismissed for this version — don't keep nagging.
   if (

--- a/templates/clips/desktop/src/components/UpdateBanner.tsx
+++ b/templates/clips/desktop/src/components/UpdateBanner.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { useUpdateStatus, installAndRestart } from "../lib/updater";
+
+/**
+ * Compact banner that slots into the top of the popover whenever an update
+ * is in flight or ready. Kept tight so it doesn't push the recording
+ * controls off-screen. Hidden in idle / checking / not-available states.
+ */
+export function UpdateBanner() {
+  const status = useUpdateStatus();
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
+
+  if (status.state === "idle") return null;
+  if (status.state === "checking") return null;
+  if (status.state === "not-available") return null;
+  if (status.state === "error") return null;
+
+  // User dismissed for this version — don't keep nagging.
+  if (
+    (status.state === "available" ||
+      status.state === "downloading" ||
+      status.state === "downloaded") &&
+    status.version === dismissedVersion
+  ) {
+    return null;
+  }
+
+  if (status.state === "available") {
+    return (
+      <div className="update-banner update-banner--pending">
+        <DownloadIcon />
+        <span className="update-banner-text">
+          Update {status.version} available — downloading…
+        </span>
+      </div>
+    );
+  }
+
+  if (status.state === "downloading") {
+    return (
+      <div className="update-banner update-banner--pending">
+        <SpinnerIcon />
+        <span className="update-banner-text">
+          Downloading update… {status.percent}%
+        </span>
+      </div>
+    );
+  }
+
+  // downloaded → actionable restart
+  return (
+    <div className="update-banner update-banner--ready">
+      <span className="update-banner-text">
+        Update {status.version} ready — restart to install.
+      </span>
+      <div className="update-banner-actions">
+        <button
+          type="button"
+          className="update-banner-btn update-banner-btn--ghost"
+          onClick={() => setDismissedVersion(status.version)}
+        >
+          Later
+        </button>
+        <button
+          type="button"
+          className="update-banner-btn update-banner-btn--primary"
+          onClick={() => {
+            installAndRestart().catch((err) => {
+              console.error("[clips-updater] relaunch failed:", err);
+            });
+          }}
+        >
+          Restart
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DownloadIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <path
+        d="M12 4v12m0 0l-4-4m4 4l4-4M5 20h14"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function SpinnerIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      className="update-spinner"
+      aria-hidden
+    >
+      <path
+        d="M12 3a9 9 0 019 9"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/templates/clips/desktop/src/components/UpdateBanner.tsx
+++ b/templates/clips/desktop/src/components/UpdateBanner.tsx
@@ -13,14 +13,20 @@ import {
 export function UpdateBanner() {
   const status = useUpdateStatus();
   const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
-  const [errorDismissed, setErrorDismissed] = useState(false);
+  // Dismissal is scoped to the specific error message so a new,
+  // different failure still surfaces. Users shouldn't have to see the
+  // same message twice, but they should hear about a new kind of
+  // failure.
+  const [dismissedErrorMessage, setDismissedErrorMessage] = useState<
+    string | null
+  >(null);
 
   if (status.state === "idle") return null;
   if (status.state === "checking") return null;
   if (status.state === "not-available") return null;
 
   if (status.state === "error") {
-    if (errorDismissed) return null;
+    if (status.message === dismissedErrorMessage) return null;
     return (
       <div className="update-banner update-banner--error">
         <span className="update-banner-text">
@@ -30,7 +36,7 @@ export function UpdateBanner() {
           <button
             type="button"
             className="update-banner-btn update-banner-btn--ghost"
-            onClick={() => setErrorDismissed(true)}
+            onClick={() => setDismissedErrorMessage(status.message)}
           >
             Dismiss
           </button>

--- a/templates/clips/desktop/src/lib/updater.ts
+++ b/templates/clips/desktop/src/lib/updater.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { check, Update } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+
+export type UpdateStatus =
+  | { state: "idle" }
+  | { state: "checking" }
+  | { state: "not-available" }
+  | { state: "available"; version: string; notes?: string }
+  | {
+      state: "downloading";
+      version: string;
+      notes?: string;
+      percent: number;
+    }
+  | { state: "downloaded"; version: string; notes?: string }
+  | { state: "error"; message: string };
+
+interface StatusListener {
+  (status: UpdateStatus): void;
+}
+
+let cachedStatus: UpdateStatus = { state: "idle" };
+let pendingUpdate: Update | null = null;
+const listeners = new Set<StatusListener>();
+let started = false;
+
+function setStatus(next: UpdateStatus) {
+  cachedStatus = next;
+  for (const l of listeners) l(next);
+}
+
+async function runCheck() {
+  try {
+    setStatus({ state: "checking" });
+    const update = await check();
+    if (!update) {
+      setStatus({ state: "not-available" });
+      return;
+    }
+    pendingUpdate = update;
+    const version = update.version;
+    const notes = update.body ?? undefined;
+    setStatus({ state: "available", version, notes });
+
+    let total = 0;
+    let downloaded = 0;
+    await update.downloadAndInstall((event) => {
+      if (event.event === "Started") {
+        total = event.data.contentLength ?? 0;
+        downloaded = 0;
+        setStatus({ state: "downloading", version, notes, percent: 0 });
+      } else if (event.event === "Progress") {
+        downloaded += event.data.chunkLength;
+        const percent =
+          total > 0 ? Math.min(100, Math.round((downloaded / total) * 100)) : 0;
+        setStatus({ state: "downloading", version, notes, percent });
+      } else if (event.event === "Finished") {
+        setStatus({ state: "downloaded", version, notes });
+      }
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    setStatus({ state: "error", message });
+  }
+}
+
+function startUpdateLoop() {
+  if (started) return;
+  started = true;
+  // Check 3s after launch (let the popover finish first paint), then every
+  // 4 hours. Matches the cadence used by the Electron app.
+  setTimeout(runCheck, 3000);
+  setInterval(runCheck, 4 * 60 * 60 * 1000);
+}
+
+export function useUpdateStatus(): UpdateStatus {
+  const [status, setLocal] = useState<UpdateStatus>(cachedStatus);
+
+  useEffect(() => {
+    startUpdateLoop();
+    listeners.add(setLocal);
+    setLocal(cachedStatus);
+    return () => {
+      listeners.delete(setLocal);
+    };
+  }, []);
+
+  return status;
+}
+
+export async function installAndRestart(): Promise<void> {
+  // downloadAndInstall already applied the bundle; relaunch completes it.
+  await relaunch();
+}

--- a/templates/clips/desktop/src/lib/updater.ts
+++ b/templates/clips/desktop/src/lib/updater.ts
@@ -93,3 +93,12 @@ export async function installAndRestart(): Promise<void> {
   // downloadAndInstall already applied the bundle; relaunch completes it.
   await relaunch();
 }
+
+/**
+ * Manual retry entry point. Used by the UpdateBanner's error state to let
+ * users re-attempt after a signature-verification / download / network
+ * failure. Runs a full check + download pass, same as the periodic loop.
+ */
+export function retryUpdateCheck(): Promise<void> {
+  return runCheck();
+}

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1465,3 +1465,88 @@ button {
   background: var(--surface-hover, var(--surface));
   border-color: var(--border-strong, var(--border));
 }
+
+/* --- Update banner -------------------------------------------------------
+ * Slots into the top of the popover when an update is in flight or ready.
+ * Two visual states:
+ *  - pending: subtle inline row, just keeps the user informed.
+ *  - ready:   accent color + actions (Later / Restart) since clicking
+ *             Restart is the thing we actually want them to do.
+ */
+.update-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 12px 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.update-banner--pending {
+  background: var(--surface);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+}
+
+.update-banner--ready {
+  background: var(--surface-strong);
+  color: var(--fg);
+  border: 1px solid var(--border-strong, var(--border));
+  flex-wrap: wrap;
+}
+
+.update-banner-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.update-banner-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.update-banner-btn {
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.update-banner-btn--ghost {
+  background: transparent;
+  color: var(--fg-muted);
+  border-color: var(--border);
+}
+
+.update-banner-btn--ghost:hover {
+  background: var(--surface-hover, var(--surface));
+  color: var(--fg);
+}
+
+.update-banner-btn--primary {
+  background: var(--brand);
+  color: var(--bg);
+}
+
+.update-banner-btn--primary:hover {
+  background: var(--brand-hover, var(--brand));
+}
+
+.update-spinner {
+  animation: update-spin 1s linear infinite;
+}
+
+@keyframes update-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1497,6 +1497,13 @@ button {
   flex-wrap: wrap;
 }
 
+.update-banner--error {
+  background: color-mix(in srgb, var(--error, #dc2626) 10%, transparent);
+  color: var(--error, #dc2626);
+  border: 1px solid color-mix(in srgb, var(--error, #dc2626) 40%, transparent);
+  flex-wrap: wrap;
+}
+
 .update-banner-text {
   flex: 1;
   min-width: 0;

--- a/templates/clips/server/routes/api/clips-latest.json.get.ts
+++ b/templates/clips/server/routes/api/clips-latest.json.get.ts
@@ -11,10 +11,22 @@ const UPSTREAM =
   "https://github.com/BuilderIO/agent-native/releases/download/clips-latest/clips-latest.json";
 
 export default defineEventHandler(async (event) => {
-  const res = await fetch(UPSTREAM, {
-    redirect: "follow",
-    headers: { accept: "application/json" },
-  });
+  let res: Response;
+  try {
+    res = await fetch(UPSTREAM, {
+      redirect: "follow",
+      headers: { accept: "application/json" },
+      // Don't let a slow GitHub hang the request. 10s is generous; the
+      // download page shows a fallback link if this errors out.
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err) {
+    const reason =
+      err instanceof Error && err.name === "TimeoutError"
+        ? "Upstream manifest fetch timed out"
+        : "Upstream manifest fetch failed";
+    throw createError({ statusCode: 502, statusMessage: reason });
+  }
   if (!res.ok) {
     throw createError({
       statusCode: 502,

--- a/templates/clips/server/routes/api/clips-latest.json.get.ts
+++ b/templates/clips/server/routes/api/clips-latest.json.get.ts
@@ -1,0 +1,30 @@
+import { defineEventHandler, setResponseHeaders, createError } from "h3";
+
+/**
+ * Same-origin proxy for the Tauri updater manifest hosted on the
+ * `clips-latest` GitHub release. The browser can't hit the GitHub URL
+ * directly — release assets don't include CORS headers, so a browser
+ * `fetch()` to them fails silently. This route proxies the JSON from the
+ * server so `/download` can show the right version + per-asset URLs.
+ */
+const UPSTREAM =
+  "https://github.com/BuilderIO/agent-native/releases/download/clips-latest/clips-latest.json";
+
+export default defineEventHandler(async (event) => {
+  const res = await fetch(UPSTREAM, {
+    redirect: "follow",
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw createError({
+      statusCode: 502,
+      statusMessage: `Upstream manifest fetch failed (${res.status})`,
+    });
+  }
+  const body = await res.text();
+  setResponseHeaders(event, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "public, max-age=60",
+  });
+  return body;
+});

--- a/templates/clips/server/routes/api/clips-latest.json.get.ts
+++ b/templates/clips/server/routes/api/clips-latest.json.get.ts
@@ -11,17 +11,32 @@ import { defineEventHandler, setResponseHeaders, createError } from "h3";
  * patch bundles for the already-installed app. End users arriving at
  * /download want the raw installers (.dmg / .msi / .exe / .AppImage).
  *
- * This route therefore hits GitHub's REST API, finds the most recent
- * release whose tag starts with `clips-v`, and returns its asset list
- * plus metadata. GitHub's API does CORS correctly, but we still proxy
- * server-side so:
- *   - rate limits hit one IP (the server), not every visitor.
- *   - the download page stays portable — it only touches same-origin.
- *   - we can add caching (`cache-control: max-age=60`).
+ * This route therefore hits GitHub's REST API, paginates through
+ * releases until it finds the most recent published `clips-v*` release,
+ * and returns its asset list plus metadata.
+ *
+ * ## Rate-limit hardening
+ *
+ * GitHub's unauthenticated REST API caps at 60 requests/hour/IP, so a
+ * modest burst of downloads would 429. We guard against that with:
+ *
+ *   - A 5-minute process-wide memoization (`cached`) — every request
+ *     for 5 min shares one upstream fetch.
+ *   - A stale-while-error fallback — if GitHub ever errors out AND we
+ *     have a previously-successful payload (even expired), we return
+ *     it. Avoids a download outage during a transient GitHub hiccup or
+ *     a rate-limit burst.
+ *   - HTTP `cache-control: max-age=60` on the response so downstream
+ *     CDNs + the browser cache this aggressively.
  */
 
-const RELEASES_URL =
-  "https://api.github.com/repos/BuilderIO/agent-native/releases?per_page=50";
+const RELEASES_URL_BASE =
+  "https://api.github.com/repos/BuilderIO/agent-native/releases";
+const PER_PAGE = 100;
+// Up to 10 pages = 1000 releases. If clips-v* hasn't shown up by then,
+// something else is wrong and the 404 is correct.
+const MAX_PAGES = 10;
+const CACHE_TTL_MS = 5 * 60_000;
 
 interface GhAsset {
   name: string;
@@ -95,45 +110,58 @@ function classifyAsset(
   return "unknown";
 }
 
-export default defineEventHandler(async (event) => {
-  let res: Response;
-  try {
-    res = await fetch(RELEASES_URL, {
-      headers: {
-        accept: "application/vnd.github+json",
-        "user-agent": "clips-download-page",
-      },
-      signal: AbortSignal.timeout(10_000),
-    });
-  } catch (err) {
-    const reason =
-      err instanceof Error && err.name === "TimeoutError"
-        ? "Upstream releases fetch timed out"
-        : "Upstream releases fetch failed";
-    throw createError({ statusCode: 502, statusMessage: reason });
-  }
+let cache: { data: DownloadManifest; ts: number } | null = null;
+let inFlight: Promise<DownloadManifest> | null = null;
+
+async function fetchPage(page: number): Promise<GhRelease[]> {
+  const url = `${RELEASES_URL_BASE}?per_page=${PER_PAGE}&page=${page}`;
+  const res = await fetch(url, {
+    headers: {
+      accept: "application/vnd.github+json",
+      "user-agent": "clips-download-page",
+    },
+    signal: AbortSignal.timeout(10_000),
+  });
   if (!res.ok) {
-    throw createError({
-      statusCode: 502,
-      statusMessage: `Upstream releases fetch failed (${res.status})`,
-    });
+    throw new Error(`Upstream releases fetch failed (${res.status})`);
   }
-  const releases = (await res.json()) as GhRelease[];
-  const latest = releases
-    .filter(
-      (r) => !r.draft && !r.prerelease && r.tag_name.startsWith("clips-v"),
-    )
-    .sort(
-      (a, b) =>
-        new Date(b.published_at).getTime() - new Date(a.published_at).getTime(),
-    )[0];
+  return (await res.json()) as GhRelease[];
+}
+
+async function findLatestClipsRelease(): Promise<GhRelease | null> {
+  let best: GhRelease | null = null;
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const batch = await fetchPage(page);
+    if (batch.length === 0) break;
+    for (const r of batch) {
+      if (r.draft || r.prerelease) continue;
+      if (!r.tag_name.startsWith("clips-v")) continue;
+      if (
+        !best ||
+        new Date(r.published_at).getTime() >
+          new Date(best.published_at).getTime()
+      ) {
+        best = r;
+      }
+    }
+    // Releases are returned newest-first by GitHub. Once we've seen a
+    // clips-v* match on any page, subsequent pages can only hold older
+    // matches — safe to stop.
+    if (best) break;
+    if (batch.length < PER_PAGE) break;
+  }
+  return best;
+}
+
+async function buildManifest(): Promise<DownloadManifest> {
+  const latest = await findLatestClipsRelease();
   if (!latest) {
     throw createError({
       statusCode: 404,
       statusMessage: "No published clips-v* release found",
     });
   }
-  const manifest: DownloadManifest = {
+  return {
     version: latest.tag_name.replace(/^clips-v/, ""),
     tag: latest.tag_name,
     pub_date: latest.published_at,
@@ -145,6 +173,39 @@ export default defineEventHandler(async (event) => {
       kind: classifyAsset(a.name),
     })),
   };
+}
+
+async function getManifest(): Promise<DownloadManifest> {
+  const now = Date.now();
+  if (cache && now - cache.ts < CACHE_TTL_MS) return cache.data;
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const data = await buildManifest();
+      cache = { data, ts: Date.now() };
+      return data;
+    } catch (err) {
+      // Stale-while-error: if we have an older payload, serve it. Only
+      // bubble the error if the cache is empty.
+      if (cache) return cache.data;
+      throw err;
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
+}
+
+export default defineEventHandler(async (event) => {
+  let manifest: DownloadManifest;
+  try {
+    manifest = await getManifest();
+  } catch (err) {
+    const e = err as { statusCode?: number; statusMessage?: string };
+    const status = typeof e.statusCode === "number" ? e.statusCode : 502;
+    const msg = e.statusMessage ?? "Upstream releases fetch failed";
+    throw createError({ statusCode: status, statusMessage: msg });
+  }
   setResponseHeaders(event, {
     "content-type": "application/json; charset=utf-8",
     "cache-control": "public, max-age=60",

--- a/templates/clips/server/routes/api/clips-latest.json.get.ts
+++ b/templates/clips/server/routes/api/clips-latest.json.get.ts
@@ -113,6 +113,14 @@ function classifyAsset(
 let cache: { data: DownloadManifest; ts: number } | null = null;
 let inFlight: Promise<DownloadManifest> | null = null;
 
+class UpstreamError extends Error {
+  statusCode: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.statusCode = status;
+  }
+}
+
 async function fetchPage(page: number): Promise<GhRelease[]> {
   const url = `${RELEASES_URL_BASE}?per_page=${PER_PAGE}&page=${page}`;
   const res = await fetch(url, {
@@ -123,12 +131,25 @@ async function fetchPage(page: number): Promise<GhRelease[]> {
     signal: AbortSignal.timeout(10_000),
   });
   if (!res.ok) {
-    throw new Error(`Upstream releases fetch failed (${res.status})`);
+    // Preserve the upstream status code so 429 (rate limit) and 503
+    // (service unavailable) surface correctly to callers / monitors
+    // instead of being flattened to 502.
+    throw new UpstreamError(
+      res.status,
+      `Upstream releases fetch failed (${res.status})`,
+    );
   }
   return (await res.json()) as GhRelease[];
 }
 
 async function findLatestClipsRelease(): Promise<GhRelease | null> {
+  // Walk every page (up to MAX_PAGES) and track the release with the
+  // highest `published_at`. We do NOT early-exit on first match: while
+  // GitHub typically returns releases in created_at-descending order,
+  // that's an unstated sort key and it can diverge from published_at
+  // (e.g. a draft published later than a created-later draft). Scanning
+  // all pages bounds our worst-case GitHub calls to MAX_PAGES while
+  // eliminating the ordering assumption entirely.
   let best: GhRelease | null = null;
   for (let page = 1; page <= MAX_PAGES; page++) {
     const batch = await fetchPage(page);
@@ -144,10 +165,6 @@ async function findLatestClipsRelease(): Promise<GhRelease | null> {
         best = r;
       }
     }
-    // Releases are returned newest-first by GitHub. Once we've seen a
-    // clips-v* match on any page, subsequent pages can only hold older
-    // matches — safe to stop.
-    if (best) break;
     if (batch.length < PER_PAGE) break;
   }
   return best;
@@ -201,9 +218,14 @@ export default defineEventHandler(async (event) => {
   try {
     manifest = await getManifest();
   } catch (err) {
-    const e = err as { statusCode?: number; statusMessage?: string };
+    const e = err as {
+      statusCode?: number;
+      statusMessage?: string;
+      message?: string;
+    };
     const status = typeof e.statusCode === "number" ? e.statusCode : 502;
-    const msg = e.statusMessage ?? "Upstream releases fetch failed";
+    const msg =
+      e.statusMessage ?? e.message ?? "Upstream releases fetch failed";
     throw createError({ statusCode: status, statusMessage: msg });
   }
   setResponseHeaders(event, {

--- a/templates/clips/server/routes/api/clips-latest.json.get.ts
+++ b/templates/clips/server/routes/api/clips-latest.json.get.ts
@@ -1,42 +1,153 @@
 import { defineEventHandler, setResponseHeaders, createError } from "h3";
 
 /**
- * Same-origin proxy for the Tauri updater manifest hosted on the
- * `clips-latest` GitHub release. The browser can't hit the GitHub URL
- * directly — release assets don't include CORS headers, so a browser
- * `fetch()` to them fails silently. This route proxies the JSON from the
- * server so `/download` can show the right version + per-asset URLs.
+ * Same-origin endpoint that tells the download page which user-facing
+ * installers (DMG / MSI / AppImage) are available for the latest
+ * published Clips Desktop release.
+ *
+ * Why NOT just proxy the Tauri updater manifest (`clips-latest.json`
+ * on the `clips-latest` release)? The updater manifest lists *updater*
+ * artifacts — `.app.tar.gz`, `.msi.zip`, `.AppImage.tar.gz` — which are
+ * patch bundles for the already-installed app. End users arriving at
+ * /download want the raw installers (.dmg / .msi / .exe / .AppImage).
+ *
+ * This route therefore hits GitHub's REST API, finds the most recent
+ * release whose tag starts with `clips-v`, and returns its asset list
+ * plus metadata. GitHub's API does CORS correctly, but we still proxy
+ * server-side so:
+ *   - rate limits hit one IP (the server), not every visitor.
+ *   - the download page stays portable — it only touches same-origin.
+ *   - we can add caching (`cache-control: max-age=60`).
  */
-const UPSTREAM =
-  "https://github.com/BuilderIO/agent-native/releases/download/clips-latest/clips-latest.json";
+
+const RELEASES_URL =
+  "https://api.github.com/repos/BuilderIO/agent-native/releases?per_page=50";
+
+interface GhAsset {
+  name: string;
+  browser_download_url: string;
+  size: number;
+}
+
+interface GhRelease {
+  tag_name: string;
+  name: string;
+  published_at: string;
+  draft: boolean;
+  prerelease: boolean;
+  assets: GhAsset[];
+  body?: string;
+}
+
+export interface DownloadManifest {
+  version: string;
+  tag: string;
+  pub_date: string | null;
+  notes?: string;
+  assets: {
+    name: string;
+    url: string;
+    size: number;
+    /**
+     * Classification used by the download UI. `"unknown"` is left in
+     * place for anything that doesn't obviously match an installer
+     * pattern (updater archives, .sig files, etc.) — the UI ignores
+     * those.
+     */
+    kind:
+      | "mac-universal"
+      | "mac-arm64"
+      | "mac-x64"
+      | "windows-msi"
+      | "windows-exe"
+      | "linux-appimage"
+      | "linux-deb"
+      | "linux-rpm"
+      | "unknown";
+  }[];
+}
+
+function classifyAsset(
+  name: string,
+): DownloadManifest["assets"][number]["kind"] {
+  const n = name.toLowerCase();
+  // Skip updater archives + signature files explicitly.
+  if (
+    n.endsWith(".sig") ||
+    n.endsWith(".app.tar.gz") ||
+    n.endsWith(".msi.zip") ||
+    n.endsWith(".appimage.tar.gz")
+  ) {
+    return "unknown";
+  }
+  if (n.endsWith(".dmg")) {
+    if (n.includes("universal")) return "mac-universal";
+    if (n.includes("aarch64") || n.includes("arm64")) return "mac-arm64";
+    if (n.includes("x64") || n.includes("x86_64")) return "mac-x64";
+    // No arch hint — assume universal (default target of clips workflow).
+    return "mac-universal";
+  }
+  if (n.endsWith(".msi")) return "windows-msi";
+  if (n.endsWith(".exe")) return "windows-exe";
+  if (n.endsWith(".appimage")) return "linux-appimage";
+  if (n.endsWith(".deb")) return "linux-deb";
+  if (n.endsWith(".rpm")) return "linux-rpm";
+  return "unknown";
+}
 
 export default defineEventHandler(async (event) => {
   let res: Response;
   try {
-    res = await fetch(UPSTREAM, {
-      redirect: "follow",
-      headers: { accept: "application/json" },
-      // Don't let a slow GitHub hang the request. 10s is generous; the
-      // download page shows a fallback link if this errors out.
+    res = await fetch(RELEASES_URL, {
+      headers: {
+        accept: "application/vnd.github+json",
+        "user-agent": "clips-download-page",
+      },
       signal: AbortSignal.timeout(10_000),
     });
   } catch (err) {
     const reason =
       err instanceof Error && err.name === "TimeoutError"
-        ? "Upstream manifest fetch timed out"
-        : "Upstream manifest fetch failed";
+        ? "Upstream releases fetch timed out"
+        : "Upstream releases fetch failed";
     throw createError({ statusCode: 502, statusMessage: reason });
   }
   if (!res.ok) {
     throw createError({
       statusCode: 502,
-      statusMessage: `Upstream manifest fetch failed (${res.status})`,
+      statusMessage: `Upstream releases fetch failed (${res.status})`,
     });
   }
-  const body = await res.text();
+  const releases = (await res.json()) as GhRelease[];
+  const latest = releases
+    .filter(
+      (r) => !r.draft && !r.prerelease && r.tag_name.startsWith("clips-v"),
+    )
+    .sort(
+      (a, b) =>
+        new Date(b.published_at).getTime() - new Date(a.published_at).getTime(),
+    )[0];
+  if (!latest) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "No published clips-v* release found",
+    });
+  }
+  const manifest: DownloadManifest = {
+    version: latest.tag_name.replace(/^clips-v/, ""),
+    tag: latest.tag_name,
+    pub_date: latest.published_at,
+    notes: latest.body,
+    assets: latest.assets.map((a) => ({
+      name: a.name,
+      url: a.browser_download_url,
+      size: a.size,
+      kind: classifyAsset(a.name),
+    })),
+  };
   setResponseHeaders(event, {
     "content-type": "application/json; charset=utf-8",
     "cache-control": "public, max-age=60",
   });
-  return body;
+  return manifest;
 });


### PR DESCRIPTION
## Summary

- **Clips desktop auto-updater**: Tauri updater wiring — `src/lib/updater.ts`, `UpdateBanner` component in `src/components/`, new capabilities + config flags.
- **Download landing page**: `templates/clips/app/routes/download.tsx` — public page users hit to grab the desktop DMG.
- **Release workflow**: `.github/workflows/clips-desktop-release.yml` — builds + publishes signed DMGs.
- **Library layout** + **styles.css** tweaks to surface the desktop install prompt.

## Test plan

- [ ] Visit `/download` on the clips template — confirm the landing page renders and links to the latest DMG.
- [ ] Launch the desktop app against a build with a newer published version — confirm the UpdateBanner surfaces and the updater can install + relaunch.
- [ ] Confirm the release workflow triggers on the expected event and produces signed arm64 + x64 DMGs with update manifest artifacts.
- [ ] CI green.