### PR TITLE
updates-123: remote MCP servers (user + org scope) from settings UI

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -120,7 +120,12 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "version=$(node -p "require('./packages/desktop-app/package.json').version")" >> $GITHUB_OUTPUT
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=$(node -p "require('./packages/desktop-app/package.json').version")" >> $GITHUB_OUTPUT
+          fi
 
       - name: Publish draft release
         env:

--- a/packages/core/docs/content/mcp-clients.md
+++ b/packages/core/docs/content/mcp-clients.md
@@ -9,6 +9,8 @@ Agent-native apps can also act as MCP **clients** — connecting to locally inst
 
 With one config file, every agent-native app in your workspace gains access to tools provided by MCP servers on your machine: `claude-in-chrome` for browser automation, `@modelcontextprotocol/server-filesystem` for reading files, `@modelcontextprotocol/server-playwright` for browser testing, and anything else that speaks MCP.
 
+You can also [connect remote (HTTP) MCP servers at runtime](#remote-via-ui) — individual users or whole organizations — without editing a config file.
+
 ## Adding a local MCP server {#adding-a-server}
 
 Create `mcp.config.json` at your workspace root (or at an individual app root — workspace root wins when both exist):
@@ -72,6 +74,31 @@ MCP tools only activate in Node runtimes — Cloudflare Workers and other edge t
 If you have **no** `mcp.config.json` and the `claude-in-chrome-mcp` binary is on `PATH` (or in the well-known install location `~/.claude-in-chrome/bin/claude-in-chrome-mcp`), agent-native auto-registers it as a default MCP server. Set `AGENT_NATIVE_DISABLE_MCP_AUTODETECT=1` to opt out.
 
 This means users who've installed the claude-in-chrome extension get browser control across every agent-native app they open with no config changes.
+
+## Remote MCP servers via the settings UI {#remote-via-ui}
+
+Users don't have to edit `mcp.config.json` to add a remote, HTTP-based MCP server (Zapier, Cloudflare, Composio, an internal tool, etc). Open the settings panel → **MCP Servers** and paste the server's URL. Two scopes are supported:
+
+- **Personal** — only the signed-in user gets the tools. Stored as a user-scope setting.
+- **Team** — everyone in the active organization gets the tools. Owners and admins can add; members see the list read-only. Stored as an org-scope setting.
+
+Adds and removes hot-reload into the running MCP manager — no process restart, and no server restart. The new `mcp__<scope>-<name>__*` tools appear to the agent on the next message.
+
+HTTPS URLs are accepted everywhere; plain `http://` is only allowed for `localhost` during development. Optional auth goes in as a Bearer token that's sent via `Authorization: Bearer …` on every request.
+
+Under the hood these servers are persisted in the framework's `settings` table under the key `u:<email>:mcp-servers-remote` (Personal) or `o:<orgId>:mcp-servers-remote` (Team) and merged with `mcp.config.json` on startup.
+
+### HTTP endpoints
+
+| Method | Route                                                 | Purpose                                                                |
+| ------ | ----------------------------------------------------- | ---------------------------------------------------------------------- |
+| GET    | `/_agent-native/mcp/servers`                          | List the current user's personal + org servers with live status.       |
+| POST   | `/_agent-native/mcp/servers`                          | Add a server. Body: `{ scope, name, url, headers?, description? }`.    |
+| DELETE | `/_agent-native/mcp/servers/:id?scope=user\|org`      | Remove a server and reconfigure the manager.                           |
+| POST   | `/_agent-native/mcp/servers/:id/test?scope=user\|org` | Dry-run the existing server's connect + list-tools.                    |
+| POST   | `/_agent-native/mcp/servers/test`                     | Dry-run an arbitrary URL before persisting. Body: `{ url, headers? }`. |
+
+Stdio servers are still a no-op outside Node runtimes, but remote HTTP MCP servers work in any environment with `fetch` — including desktop production builds.
 
 ## Status route {#status-route}
 

--- a/packages/core/docs/content/mcp-clients.md
+++ b/packages/core/docs/content/mcp-clients.md
@@ -100,6 +100,50 @@ Under the hood these servers are persisted in the framework's `settings` table u
 
 Stdio servers are still a no-op outside Node runtimes, but remote HTTP MCP servers work in any environment with `fetch` — including desktop production builds.
 
+## Shared MCP servers via a hub {#hub}
+
+If your workspace runs multiple agent-native apps (e.g. dispatch + mail + clips), you can configure **one** app as the hub and have the others pull its org-scope MCP servers automatically. No per-app copy-paste of URLs and bearer tokens.
+
+Dispatch is the conventional hub — it already coordinates across apps.
+
+### 1. Enable hub-serve on the hub app (dispatch)
+
+Set an env var in dispatch's deployment:
+
+```bash
+AGENT_NATIVE_MCP_HUB_TOKEN=<a-long-random-secret>
+```
+
+Dispatch now mounts `GET /_agent-native/mcp/hub/servers` which returns every org-scope MCP server stored in its `settings` table, with full URL + headers, authenticated by the token.
+
+### 2. Point consuming apps at the hub
+
+Set on every consumer (mail, clips, whatever):
+
+```bash
+AGENT_NATIVE_MCP_HUB_URL=https://dispatch.acme.com
+AGENT_NATIVE_MCP_HUB_TOKEN=<the-same-secret>
+```
+
+At startup, each consumer pulls the hub's server list and merges it into its own MCP manager. The tools appear to the agent as `mcp__hub_<orgId>_<name>__*` — distinct from the consumer's own local `mcp__org_…` so there's no collision.
+
+### 3. What gets shared
+
+Only **org-scope** servers are shared. User-scope (Personal) servers stay with the user who added them — the hub never re-exposes personal credentials across apps.
+
+Hub responses include the full auth headers (Bearer tokens etc). The transport is HTTPS, the endpoint requires the shared secret, and it only returns org-scope rows — treat the hub URL + token like a database credential.
+
+### 4. Hot reload vs restart
+
+Local UI adds in each app hot-reload via `McpClientManager.reconfigure()` — no restart. Hub-sourced servers currently re-fetch only when a local mutation triggers a reconfigure (or when the app restarts), so if you add a new server in dispatch, other apps pick it up on their next restart or next local change. Periodic background refresh is on the roadmap.
+
+### Endpoints summary
+
+| Method | Route                            | Purpose                                                                                                            |
+| ------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| GET    | `/_agent-native/mcp/hub/servers` | Serve all org-scope servers with full creds (bearer-gated, only mounted when `AGENT_NATIVE_MCP_HUB_TOKEN` is set). |
+| GET    | `/_agent-native/mcp/hub/status`  | Returns `{ serving, consuming, hubUrl }` for the settings UI card.                                                 |
+
 ## Status route {#status-route}
 
 Every app exposes `GET /_agent-native/mcp/status` for tooling and onboarding:

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -449,8 +449,10 @@ export function createProductionAgentHandler(
   // Resolve actions — prefer `actions`, fall back to deprecated `scripts`
   const resolvedActions = options.actions ?? options.scripts ?? {};
 
-  // Build engine tools from action registry
-  const engineTools = actionsToEngineTools(resolvedActions);
+  // Engine tools are derived from the action registry at request time so that
+  // registries which mutate after handler creation (e.g. MCP servers added via
+  // the settings UI) show up to the LLM without a process restart.
+  const getEngineTools = () => actionsToEngineTools(resolvedActions);
 
   return defineEventHandler(async (event) => {
     if (getMethod(event) !== "POST") {
@@ -830,7 +832,7 @@ export function createProductionAgentHandler(
                   engine,
                   model: profile.model ?? model,
                   systemPrompt: profilePrompt,
-                  tools: engineTools,
+                  tools: getEngineTools(),
                   messages: [
                     {
                       role: "user",
@@ -1035,7 +1037,7 @@ export function createProductionAgentHandler(
           engine,
           model,
           systemPrompt,
-          tools: engineTools,
+          tools: getEngineTools(),
           messages,
           actions: resolvedActions,
           send,

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -31,6 +31,7 @@ import {
 import type { ActiveRun } from "./run-manager.js";
 import { readBody } from "../server/h3-helpers.js";
 import { getRequestUserEmail } from "../server/request-context.js";
+import { isMcpToolAllowedForRequest } from "../mcp-client/visibility.js";
 
 // Register built-in engines on first import
 registerBuiltinEngines();
@@ -451,8 +452,19 @@ export function createProductionAgentHandler(
 
   // Engine tools are derived from the action registry at request time so that
   // registries which mutate after handler creation (e.g. MCP servers added via
-  // the settings UI) show up to the LLM without a process restart.
-  const getEngineTools = () => actionsToEngineTools(resolvedActions);
+  // the settings UI) show up to the LLM without a process restart. MCP tools
+  // are also scope-filtered per request — a user-scope server added by Alice
+  // must not appear in Bob's tool list in a shared-process deployment.
+  const getEngineTools = () => {
+    const filtered: Record<string, ActionEntry> = {};
+    for (const [name, entry] of Object.entries(resolvedActions)) {
+      if (name.startsWith("mcp__") && !isMcpToolAllowedForRequest(name)) {
+        continue;
+      }
+      filtered[name] = entry;
+    }
+    return actionsToEngineTools(filtered);
+  };
 
   return defineEventHandler(async (event) => {
     if (getMethod(event) !== "POST") {

--- a/packages/core/src/client/settings/McpServersSection.tsx
+++ b/packages/core/src/client/settings/McpServersSection.tsx
@@ -12,6 +12,7 @@ import {
   IconCheck,
   IconLoader2,
   IconPlus,
+  IconShare,
   IconTrash,
   IconUsers,
   IconUser,
@@ -20,6 +21,13 @@ import {
 import { useOrg } from "../org/hooks.js";
 
 const ENDPOINT = "/_agent-native/mcp/servers";
+const HUB_STATUS_ENDPOINT = "/_agent-native/mcp/hub/status";
+
+interface HubStatus {
+  serving: boolean;
+  consuming: boolean;
+  hubUrl: string | null;
+}
 
 type Scope = "user" | "org";
 
@@ -51,6 +59,16 @@ interface ListResponse {
 export function McpServersSection() {
   const org = useOrg().data;
   const qc = useQueryClient();
+
+  const { data: hub } = useQuery<HubStatus>({
+    queryKey: ["mcp-hub-status"],
+    queryFn: async () => {
+      const res = await fetch(HUB_STATUS_ENDPOINT, { credentials: "include" });
+      if (!res.ok) throw new Error(`Failed to load hub status (${res.status})`);
+      return (await res.json()) as HubStatus;
+    },
+    staleTime: 60_000,
+  });
 
   // Keying the query on (email, orgId) means switching orgs via useSwitchOrg
   // triggers a refetch automatically — the old cached entry stays around
@@ -98,6 +116,7 @@ export function McpServersSection() {
 
   return (
     <div className="space-y-2">
+      {hub && (hub.serving || hub.consuming) && <HubCard hub={hub} />}
       {/* Scope tabs */}
       <div className="flex gap-1 rounded-md bg-accent/30 p-0.5">
         <ScopeTab
@@ -483,6 +502,40 @@ function AddServerForm({
           </>
         )}
       </button>
+    </div>
+  );
+}
+
+function HubCard({ hub }: { hub: HubStatus }) {
+  return (
+    <div className="rounded-md border border-border px-2.5 py-2 bg-accent/20">
+      <div className="flex items-center gap-1.5">
+        <IconShare size={12} className="text-muted-foreground" />
+        <div className="text-[11px] font-medium text-foreground">
+          {hub.serving && hub.consuming
+            ? "Hub — serving and consuming"
+            : hub.serving
+              ? "Hub — serving other apps"
+              : "Consuming from hub"}
+        </div>
+      </div>
+      {hub.serving && (
+        <p className="text-[10px] text-muted-foreground mt-1 leading-relaxed">
+          Org-scope servers on this app are shared with other agent-native apps
+          in the workspace via{" "}
+          <code className="text-foreground">
+            /_agent-native/mcp/hub/servers
+          </code>
+          .
+        </p>
+      )}
+      {hub.consuming && hub.hubUrl && (
+        <p className="text-[10px] text-muted-foreground mt-1 leading-relaxed">
+          Team servers are pulled from{" "}
+          <code className="text-foreground">{hub.hubUrl}</code> at startup.
+          Add/remove them there; this app picks them up on next restart.
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/core/src/client/settings/McpServersSection.tsx
+++ b/packages/core/src/client/settings/McpServersSection.tsx
@@ -1,0 +1,493 @@
+/**
+ * <McpServersSection /> — lets the user connect remote MCP servers at
+ * user scope (personal) or org scope (shared with the team). Lives in the
+ * workspace settings panel and talks to `/_agent-native/mcp/servers`.
+ *
+ * Adds/removes hot-reload into the running MCP manager — no restart.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  IconCheck,
+  IconLoader2,
+  IconPlus,
+  IconTrash,
+  IconUsers,
+  IconUser,
+  IconX,
+} from "@tabler/icons-react";
+import { useOrg } from "../org/hooks.js";
+
+const ENDPOINT = "/_agent-native/mcp/servers";
+
+type Scope = "user" | "org";
+
+interface ServerStatus {
+  state: "connected" | "error" | "unknown";
+  toolCount?: number;
+  error?: string;
+}
+
+interface ClientServer {
+  id: string;
+  scope: Scope;
+  name: string;
+  url: string;
+  headers?: Record<string, { set: true }>;
+  description?: string;
+  createdAt: number;
+  mergedId: string;
+  status: ServerStatus;
+}
+
+interface ListResponse {
+  user: ClientServer[];
+  org: ClientServer[];
+  orgId: string | null;
+  role: string | null;
+}
+
+export function McpServersSection() {
+  const org = useOrg().data;
+  const [data, setData] = useState<ListResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(ENDPOINT, { credentials: "include" })
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`Failed to load (${r.status})`);
+        return (await r.json()) as ListResponse;
+      })
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err?.message ?? "Failed to load");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  const reload = useCallback(() => setReloadToken((t) => t + 1), []);
+
+  const hasOrg = !!org?.orgId;
+  const canWriteOrg =
+    hasOrg && (org?.role === "owner" || org?.role === "admin");
+
+  const [scope, setScope] = useState<Scope>("user");
+  useEffect(() => {
+    // If the user has no org, lock to user scope.
+    if (!hasOrg && scope === "org") setScope("user");
+  }, [hasOrg, scope]);
+
+  if (error) {
+    return (
+      <p className="text-[10px] text-red-500">
+        Failed to load MCP servers: {error}
+      </p>
+    );
+  }
+  if (data === null) {
+    return (
+      <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+        <IconLoader2 size={10} className="animate-spin" />
+        Loading…
+      </div>
+    );
+  }
+
+  const servers = scope === "user" ? data.user : data.org;
+
+  return (
+    <div className="space-y-2">
+      {/* Scope tabs */}
+      <div className="flex gap-1 rounded-md bg-accent/30 p-0.5">
+        <ScopeTab
+          active={scope === "user"}
+          onClick={() => setScope("user")}
+          icon={<IconUser size={10} />}
+          label="Personal"
+          count={data.user.length}
+        />
+        {hasOrg && (
+          <ScopeTab
+            active={scope === "org"}
+            onClick={() => setScope("org")}
+            icon={<IconUsers size={10} />}
+            label={org?.orgName ? `Team (${org.orgName})` : "Team"}
+            count={data.org.length}
+          />
+        )}
+      </div>
+
+      <p className="text-[10px] text-muted-foreground leading-relaxed">
+        {scope === "user"
+          ? "Servers you add here are only available to you."
+          : canWriteOrg
+            ? "Servers shared with everyone in your organization."
+            : "Servers shared with your organization. Only owners and admins can edit."}
+      </p>
+
+      {servers.length === 0 ? (
+        <p className="text-[10px] text-muted-foreground">
+          No servers connected yet.
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          {servers.map((server) => (
+            <ServerCard
+              key={server.id}
+              server={server}
+              readOnly={scope === "org" && !canWriteOrg}
+              onChanged={reload}
+            />
+          ))}
+        </div>
+      )}
+
+      {(scope === "user" || canWriteOrg) && (
+        <AddServerForm scope={scope} onAdded={reload} />
+      )}
+    </div>
+  );
+}
+
+function ScopeTab({
+  active,
+  onClick,
+  icon,
+  label,
+  count,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  count: number;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex flex-1 items-center justify-center gap-1 rounded px-2 py-1 text-[10px] font-medium ${
+        active
+          ? "bg-background text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground"
+      }`}
+    >
+      {icon}
+      {label}
+      <span className="text-muted-foreground">({count})</span>
+    </button>
+  );
+}
+
+function ServerCard({
+  server,
+  readOnly,
+  onChanged,
+}: {
+  server: ClientServer;
+  readOnly?: boolean;
+  onChanged: () => void;
+}) {
+  const [busy, setBusy] = useState<null | "delete" | "test">(null);
+  const [toast, setToast] = useState<{
+    kind: "ok" | "err";
+    text: string;
+  } | null>(null);
+
+  const setToastAndClear = (kind: "ok" | "err", text: string, ms = 2500) => {
+    setToast({ kind, text });
+    setTimeout(() => setToast(null), ms);
+  };
+
+  const handleDelete = async () => {
+    if (busy) return;
+    setBusy("delete");
+    try {
+      const res = await fetch(
+        `${ENDPOINT}/${encodeURIComponent(server.id)}?scope=${server.scope}`,
+        { method: "DELETE", credentials: "include" },
+      );
+      if (!res.ok) {
+        const err = await res
+          .json()
+          .then((j: { error?: string }) => j.error)
+          .catch(() => null);
+        setToastAndClear("err", err ?? `Remove failed (${res.status})`);
+        return;
+      }
+      onChanged();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handleTest = async () => {
+    if (busy) return;
+    setBusy("test");
+    try {
+      const res = await fetch(
+        `${ENDPOINT}/${encodeURIComponent(server.id)}/test?scope=${server.scope}`,
+        { method: "POST", credentials: "include" },
+      );
+      const body = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        toolCount?: number;
+        error?: string;
+      };
+      if (res.ok && body.ok) {
+        setToastAndClear(
+          "ok",
+          `Working — ${body.toolCount ?? 0} tool${body.toolCount === 1 ? "" : "s"}`,
+        );
+        onChanged();
+      } else {
+        setToastAndClear("err", body.error ?? "Test failed");
+      }
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const pill = useMemo(() => {
+    if (server.status.state === "connected") {
+      return (
+        <span className="flex items-center gap-1 text-[10px] text-green-500">
+          <IconCheck size={10} />
+          {server.status.toolCount ?? 0} tool
+          {(server.status.toolCount ?? 0) === 1 ? "" : "s"}
+        </span>
+      );
+    }
+    if (server.status.state === "error") {
+      return (
+        <span
+          className="flex items-center gap-1 text-[10px] text-red-500"
+          title={server.status.error}
+        >
+          <IconX size={10} />
+          Error
+        </span>
+      );
+    }
+    return (
+      <span className="rounded-full bg-accent/60 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground">
+        Unknown
+      </span>
+    );
+  }, [server.status]);
+
+  return (
+    <div className="rounded-md border border-border px-2.5 py-2 bg-accent/30">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-[11px] font-medium text-foreground truncate">
+            {server.name}
+          </div>
+          <p className="text-[10px] text-muted-foreground mt-0.5 truncate">
+            {server.url}
+          </p>
+          {server.description && (
+            <p className="text-[10px] text-muted-foreground mt-0.5">
+              {server.description}
+            </p>
+          )}
+          {server.status.state === "error" && server.status.error && (
+            <p className="text-[10px] text-red-500 mt-0.5 break-words">
+              {server.status.error}
+            </p>
+          )}
+          {server.headers && Object.keys(server.headers).length > 0 && (
+            <p className="text-[10px] text-muted-foreground mt-0.5">
+              {Object.keys(server.headers).length} auth header
+              {Object.keys(server.headers).length === 1 ? "" : "s"} set
+            </p>
+          )}
+        </div>
+        <div className="shrink-0">{pill}</div>
+      </div>
+      {!readOnly && (
+        <div className="mt-2 flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={handleTest}
+            disabled={busy !== null}
+            className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-40"
+          >
+            {busy === "test" ? (
+              <IconLoader2 size={10} className="animate-spin" />
+            ) : (
+              "Test"
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={busy !== null}
+            className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] text-muted-foreground hover:text-red-500 disabled:opacity-40"
+          >
+            {busy === "delete" ? (
+              <IconLoader2 size={10} className="animate-spin" />
+            ) : (
+              <>
+                <IconTrash size={10} />
+                Remove
+              </>
+            )}
+          </button>
+        </div>
+      )}
+      {toast && (
+        <p
+          className={`mt-1.5 text-[10px] ${
+            toast.kind === "ok" ? "text-green-500" : "text-red-500"
+          }`}
+        >
+          {toast.text}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function AddServerForm({
+  scope,
+  onAdded,
+}: {
+  scope: Scope;
+  onAdded: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [url, setUrl] = useState("");
+  const [token, setToken] = useState("");
+  const [description, setDescription] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setName("");
+    setUrl("");
+    setToken("");
+    setDescription("");
+    setError(null);
+  };
+
+  const handleAdd = async () => {
+    if (!name.trim() || !url.trim() || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const headers: Record<string, string> = {};
+      if (token.trim()) headers["Authorization"] = `Bearer ${token.trim()}`;
+      const res = await fetch(ENDPOINT, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scope,
+          name: name.trim(),
+          url: url.trim(),
+          headers: Object.keys(headers).length > 0 ? headers : undefined,
+          description: description.trim() || undefined,
+        }),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      if (!res.ok) {
+        setError(body.error ?? `Add failed (${res.status})`);
+        return;
+      }
+      reset();
+      setOpen(false);
+      onAdded();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1 rounded border border-dashed border-border px-2 py-1 text-[10px] font-medium text-muted-foreground hover:text-foreground hover:border-foreground/40"
+      >
+        <IconPlus size={10} />
+        Add a remote MCP server
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-border px-2.5 py-2 bg-accent/30 space-y-1.5">
+      <div className="flex items-center justify-between">
+        <div className="text-[11px] font-medium text-foreground">
+          Add remote MCP server
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            reset();
+          }}
+          className="text-muted-foreground hover:text-foreground"
+          aria-label="Cancel"
+        >
+          <IconX size={12} />
+        </button>
+      </div>
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Name (e.g. zapier, github, my-server)"
+        className="w-full rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+      />
+      <input
+        type="text"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        placeholder="https://mcp.example.com/..."
+        className="w-full rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+      />
+      <input
+        type="password"
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+        placeholder="Bearer token (optional)"
+        className="w-full rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+      />
+      <input
+        type="text"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        placeholder="Description (optional)"
+        className="w-full rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+      />
+      {error && <p className="text-[10px] text-red-500">{error}</p>}
+      <button
+        type="button"
+        onClick={handleAdd}
+        disabled={!name.trim() || !url.trim() || busy}
+        className="inline-flex items-center gap-1 rounded px-2 py-1 text-[10px] font-medium disabled:opacity-40"
+        style={{ backgroundColor: "#625DF5", color: "white" }}
+      >
+        {busy ? (
+          <IconLoader2 size={10} className="animate-spin" />
+        ) : (
+          <>
+            <IconPlus size={10} />
+            Add server
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/packages/core/src/client/settings/McpServersSection.tsx
+++ b/packages/core/src/client/settings/McpServersSection.tsx
@@ -6,7 +6,8 @@
  * Adds/removes hot-reload into the running MCP manager — no restart.
  */
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   IconCheck,
   IconLoader2,
@@ -49,29 +50,23 @@ interface ListResponse {
 
 export function McpServersSection() {
   const org = useOrg().data;
-  const [data, setData] = useState<ListResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [reloadToken, setReloadToken] = useState(0);
+  const qc = useQueryClient();
 
-  useEffect(() => {
-    let cancelled = false;
-    fetch(ENDPOINT, { credentials: "include" })
-      .then(async (r) => {
-        if (!r.ok) throw new Error(`Failed to load (${r.status})`);
-        return (await r.json()) as ListResponse;
-      })
-      .then((d) => {
-        if (!cancelled) setData(d);
-      })
-      .catch((err) => {
-        if (!cancelled) setError(err?.message ?? "Failed to load");
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [reloadToken]);
+  // Keying the query on (email, orgId) means switching orgs via useSwitchOrg
+  // triggers a refetch automatically — the old cached entry stays around
+  // under its old key, and the new key has no data, which forces the fetch.
+  const queryKey = ["mcp-servers", org?.email ?? null, org?.orgId ?? null];
+  const { data, error, isLoading } = useQuery<ListResponse>({
+    queryKey,
+    queryFn: async () => {
+      const res = await fetch(ENDPOINT, { credentials: "include" });
+      if (!res.ok) throw new Error(`Failed to load (${res.status})`);
+      return (await res.json()) as ListResponse;
+    },
+    staleTime: 10_000,
+  });
 
-  const reload = useCallback(() => setReloadToken((t) => t + 1), []);
+  const reload = () => qc.invalidateQueries({ queryKey: ["mcp-servers"] });
 
   const hasOrg = !!org?.orgId;
   const canWriteOrg =
@@ -86,11 +81,11 @@ export function McpServersSection() {
   if (error) {
     return (
       <p className="text-[10px] text-red-500">
-        Failed to load MCP servers: {error}
+        Failed to load MCP servers: {(error as Error).message}
       </p>
     );
   }
-  if (data === null) {
+  if (isLoading || !data) {
     return (
       <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
         <IconLoader2 size={10} className="animate-spin" />

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -18,6 +18,7 @@ import {
   IconMail,
   IconKey,
   IconMicrophone,
+  IconPuzzle,
 } from "@tabler/icons-react";
 import { SettingsSection } from "./SettingsSection.js";
 import { useBuilderStatus } from "./useBuilderStatus.js";
@@ -25,6 +26,7 @@ import { AgentsSection } from "./AgentsSection.js";
 import { UsageSection } from "./UsageSection.js";
 import { SecretsSection } from "./SecretsSection.js";
 import { VoiceTranscriptionSection } from "./VoiceTranscriptionSection.js";
+import { McpServersSection } from "./McpServersSection.js";
 
 const IntegrationsPanel = lazy(() =>
   import("../integrations/IntegrationsPanel.js").then((m) => ({
@@ -885,6 +887,17 @@ export function SettingsPanel({
         <Suspense fallback={null}>
           <IntegrationsPanel />
         </Suspense>
+      </SettingsSection>
+
+      {/* Remote MCP servers — user- and org-scope */}
+      <SettingsSection
+        icon={<IconPuzzle size={14} />}
+        title="MCP Servers"
+        subtitle="Connect remote MCP servers (Zapier, Cloudflare, internal tools). Scope to yourself or share with the team."
+        open={openSection === "mcp-servers"}
+        onToggle={() => toggle("mcp-servers")}
+      >
+        <McpServersSection />
       </SettingsSection>
 
       {/* Usage & spend */}

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -421,8 +421,10 @@ function SharePanel(
       <ul className="mb-4 flex flex-col gap-1 list-none p-0 m-0">
         {data?.ownerEmail ? (
           <li className="flex items-center gap-3 px-1 py-1.5 text-sm">
-            <Avatar label={data.ownerEmail} />
-            <span className="flex-1 min-w-0 truncate">{data.ownerEmail}</span>
+            <Avatar label={displayName(data.ownerEmail, orgMembers)} />
+            <span className="flex-1 min-w-0 truncate">
+              {displayName(data.ownerEmail, orgMembers)}
+            </span>
             <span className="text-xs text-muted-foreground">Owner</span>
           </li>
         ) : null}
@@ -434,8 +436,19 @@ function SharePanel(
               inFlight.has(keyOf(s)) && "opacity-60",
             )}
           >
-            <Avatar label={s.principalId} org={s.principalType === "org"} />
-            <span className="flex-1 min-w-0 truncate">{s.principalId}</span>
+            <Avatar
+              label={
+                s.principalType === "org"
+                  ? s.principalId
+                  : displayName(s.principalId, orgMembers)
+              }
+              org={s.principalType === "org"}
+            />
+            <span className="flex-1 min-w-0 truncate">
+              {s.principalType === "org"
+                ? s.principalId
+                : displayName(s.principalId, orgMembers)}
+            </span>
             {canManage ? (
               <RoleSelect
                 value={s.role}
@@ -655,4 +668,10 @@ function cap(s: string): string {
 function initials(s: string): string {
   const name = s.split("@")[0] ?? s;
   return (name[0] ?? "?").toUpperCase();
+}
+
+function displayName(email: string, members: OrgMember[]): string {
+  const match = members.find((m) => m.email === email);
+  if (match?.name && match.name.trim()) return match.name;
+  return email;
 }

--- a/packages/core/src/client/sharing/ShareDialog.tsx
+++ b/packages/core/src/client/sharing/ShareDialog.tsx
@@ -59,6 +59,43 @@ interface SharesResponse {
   shares: Share[];
 }
 
+interface OrgMember {
+  email: string;
+  name?: string | null;
+}
+
+function useOrgMembers(): OrgMember[] {
+  const [members, setMembers] = useState<OrgMember[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/_agent-native/org/members")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        const list = Array.isArray(data?.members) ? data.members : [];
+        setMembers(
+          list
+            .map((m: any) => ({
+              email: typeof m?.email === "string" ? m.email : "",
+              name: typeof m?.name === "string" ? m.name : null,
+            }))
+            .filter((m: OrgMember) => m.email),
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return members;
+}
+
+function displayName(email: string, members: OrgMember[]): string {
+  const match = members.find((m) => m.email === email);
+  if (match?.name && match.name.trim()) return match.name;
+  return email;
+}
+
 const BUTTON_BASE =
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0";
 const BUTTON_OUTLINE_SM = cn(
@@ -130,6 +167,7 @@ export function ShareDialog(props: ShareDialogProps) {
     resourceType,
     resourceId,
   });
+  const orgMembers = useOrgMembers();
 
   const hasLinkTab = Boolean(shareUrl);
   const hasEmbedTab = Boolean(embedUrl);
@@ -178,7 +216,7 @@ export function ShareDialog(props: ShareDialogProps) {
             </div>
             {sharesQuery.data?.ownerEmail ? (
               <div className="mt-0.5 truncate text-xs text-muted-foreground">
-                Owner: {sharesQuery.data.ownerEmail}
+                Owner: {displayName(sharesQuery.data.ownerEmail, orgMembers)}
               </div>
             ) : null}
           </div>
@@ -239,6 +277,7 @@ export function ShareDialog(props: ShareDialogProps) {
               resourceId={resourceId}
               sharesQuery={sharesQuery}
               showVisibility={!tabsEnabled}
+              orgMembers={orgMembers}
             />
           ) : null}
           {tabsEnabled && tab === "embed" && hasEmbedTab
@@ -355,8 +394,10 @@ function InviteTab(props: {
   resourceId: string;
   sharesQuery: ReturnType<typeof useActionQuery<SharesResponse>>;
   showVisibility: boolean;
+  orgMembers: OrgMember[];
 }) {
-  const { resourceType, resourceId, sharesQuery, showVisibility } = props;
+  const { resourceType, resourceId, sharesQuery, showVisibility, orgMembers } =
+    props;
 
   const share = useActionMutation("share-resource");
   const unshare = useActionMutation("unshare-resource");
@@ -437,8 +478,10 @@ function InviteTab(props: {
         <ul className="flex flex-col gap-1 list-none p-0 m-0">
           {data?.ownerEmail ? (
             <li className="flex items-center gap-3 px-1 py-1.5 text-sm">
-              <Avatar label={data.ownerEmail} />
-              <span className="flex-1 min-w-0 truncate">{data.ownerEmail}</span>
+              <Avatar label={displayName(data.ownerEmail, orgMembers)} />
+              <span className="flex-1 min-w-0 truncate">
+                {displayName(data.ownerEmail, orgMembers)}
+              </span>
               <span className="text-xs text-muted-foreground">Owner</span>
             </li>
           ) : null}
@@ -447,8 +490,19 @@ function InviteTab(props: {
               key={`${s.principalType}:${s.principalId}`}
               className="flex items-center gap-3 px-1 py-1.5 text-sm"
             >
-              <Avatar label={s.principalId} org={s.principalType === "org"} />
-              <span className="flex-1 min-w-0 truncate">{s.principalId}</span>
+              <Avatar
+                label={
+                  s.principalType === "org"
+                    ? s.principalId
+                    : displayName(s.principalId, orgMembers)
+                }
+                org={s.principalType === "org"}
+              />
+              <span className="flex-1 min-w-0 truncate">
+                {s.principalType === "org"
+                  ? s.principalId
+                  : displayName(s.principalId, orgMembers)}
+              </span>
               <span className="text-xs text-muted-foreground">
                 {cap(s.role)}
               </span>

--- a/packages/core/src/mcp-client/config.ts
+++ b/packages/core/src/mcp-client/config.ts
@@ -17,7 +17,12 @@ import path from "node:path";
 import os from "node:os";
 import { findWorkspaceRoot } from "../scripts/utils.js";
 
-export interface McpServerConfig {
+/**
+ * Stdio transport — spawns a local binary and speaks MCP over its stdio.
+ * This is the default when no `type` field is set (backward compat).
+ */
+export interface McpStdioServerConfig {
+  type?: "stdio";
   /** Executable or path to spawn over stdio */
   command: string;
   /** Arguments passed to the command */
@@ -29,6 +34,22 @@ export interface McpServerConfig {
   /** Human-readable description (optional, shown in /mcp/status) */
   description?: string;
 }
+
+/**
+ * HTTP transport — connects to a remote MCP server over Streamable HTTP
+ * (the transport hosted providers like Zapier / Cloudflare / Composio use).
+ */
+export interface McpHttpServerConfig {
+  type: "http";
+  /** Full URL of the remote MCP server's Streamable HTTP endpoint. */
+  url: string;
+  /** Extra headers to send with every request (e.g. Authorization). */
+  headers?: Record<string, string>;
+  /** Human-readable description (optional, shown in /mcp/status) */
+  description?: string;
+}
+
+export type McpServerConfig = McpStdioServerConfig | McpHttpServerConfig;
 
 export interface McpConfig {
   /** Map of server id → config */
@@ -58,20 +79,37 @@ function parseConfig(raw: string, source: string): McpConfig | null {
     for (const [id, cfg] of Object.entries(servers)) {
       if (!cfg || typeof cfg !== "object") continue;
       const c = cfg as any;
-      if (typeof c.command !== "string" || !c.command) continue;
-      valid[id] = {
-        command: c.command,
-        args: Array.isArray(c.args) ? c.args.map(String) : undefined,
-        env:
-          c.env && typeof c.env === "object"
-            ? Object.fromEntries(
-                Object.entries(c.env).map(([k, v]) => [k, String(v)]),
-              )
-            : undefined,
-        cwd: typeof c.cwd === "string" ? c.cwd : undefined,
-        description:
-          typeof c.description === "string" ? c.description : undefined,
-      };
+      const description =
+        typeof c.description === "string" ? c.description : undefined;
+      if (c.type === "http") {
+        if (typeof c.url !== "string" || !c.url) continue;
+        valid[id] = {
+          type: "http",
+          url: c.url,
+          headers:
+            c.headers && typeof c.headers === "object"
+              ? Object.fromEntries(
+                  Object.entries(c.headers).map(([k, v]) => [k, String(v)]),
+                )
+              : undefined,
+          description,
+        };
+      } else {
+        if (typeof c.command !== "string" || !c.command) continue;
+        valid[id] = {
+          type: "stdio",
+          command: c.command,
+          args: Array.isArray(c.args) ? c.args.map(String) : undefined,
+          env:
+            c.env && typeof c.env === "object"
+              ? Object.fromEntries(
+                  Object.entries(c.env).map(([k, v]) => [k, String(v)]),
+                )
+              : undefined,
+          cwd: typeof c.cwd === "string" ? c.cwd : undefined,
+          description,
+        };
+      }
     }
     if (Object.keys(valid).length === 0) return null;
     return { servers: valid, source };
@@ -166,6 +204,7 @@ export function autoDetectMcpConfig(): McpConfig | null {
         return {
           servers: {
             "claude-in-chrome": {
+              type: "stdio",
               command: candidate,
               description:
                 "Auto-detected claude-in-chrome MCP server (Chrome automation)",

--- a/packages/core/src/mcp-client/hub-client.ts
+++ b/packages/core/src/mcp-client/hub-client.ts
@@ -1,0 +1,102 @@
+/**
+ * Hub consume — fetches a remote agent-native app's org-scope MCP servers
+ * and projects them into the local MCP manager's config shape.
+ *
+ * Opt-in via env:
+ *   AGENT_NATIVE_MCP_HUB_URL   = https://dispatch.example.com
+ *   AGENT_NATIVE_MCP_HUB_TOKEN = <shared secret, matches hub's token>
+ *
+ * Failures are non-fatal — if the hub is unreachable or the token is
+ * wrong, the app boots with just its local MCP config and logs a warning.
+ */
+
+import type { McpHttpServerConfig, McpServerConfig } from "./config.js";
+import type { HubServersResponse } from "./hub-routes.js";
+import { isHubConsumeEnabled } from "./hub-routes.js";
+
+const FETCH_TIMEOUT_MS = 5_000;
+
+/** Merged-config key prefix for hub-sourced servers — avoids collision with
+ * the consuming app's own `org_<orgId>_<name>` entries. */
+function hubMergedKey(orgId: string, name: string): string {
+  return `hub_${orgId}_${name}`;
+}
+
+/**
+ * Fetch the remote hub's org-scope servers and return them keyed by the
+ * `hub_<orgId>_<name>` merged-key shape that `McpClientManager` consumes.
+ *
+ * Returns an empty object when hub consume isn't enabled or the call fails.
+ */
+export async function fetchHubServers(): Promise<
+  Record<string, McpServerConfig>
+> {
+  if (!isHubConsumeEnabled()) return {};
+  const base = process.env.AGENT_NATIVE_MCP_HUB_URL!.trim();
+  const token = process.env.AGENT_NATIVE_MCP_HUB_TOKEN!.trim();
+  const url = joinUrl(base, "/_agent-native/mcp/hub/servers");
+
+  let res: Response;
+  try {
+    const controller =
+      typeof AbortController !== "undefined" ? new AbortController() : null;
+    const timeout = controller
+      ? setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+      : null;
+    try {
+      res = await fetch(url, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
+        signal: controller?.signal,
+      });
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  } catch (err: any) {
+    console.warn(
+      `[mcp-client] hub fetch failed (${url}): ${err?.message ?? err}`,
+    );
+    return {};
+  }
+
+  if (!res.ok) {
+    console.warn(
+      `[mcp-client] hub fetch returned ${res.status} from ${url} — ignoring hub servers`,
+    );
+    return {};
+  }
+
+  let body: HubServersResponse;
+  try {
+    body = (await res.json()) as HubServersResponse;
+  } catch (err: any) {
+    console.warn(
+      `[mcp-client] hub response was not JSON: ${err?.message ?? err}`,
+    );
+    return {};
+  }
+  if (!body || !Array.isArray(body.servers)) return {};
+
+  const out: Record<string, McpServerConfig> = {};
+  for (const s of body.servers) {
+    if (!s || typeof s.url !== "string" || !s.name || !s.orgId) continue;
+    const cfg: McpHttpServerConfig = {
+      type: "http",
+      url: s.url,
+      headers:
+        s.headers && Object.keys(s.headers).length > 0 ? s.headers : undefined,
+      description: s.description,
+    };
+    out[hubMergedKey(s.orgId, s.name)] = cfg;
+  }
+  return out;
+}
+
+function joinUrl(base: string, path: string): string {
+  if (base.endsWith("/")) base = base.slice(0, -1);
+  if (!path.startsWith("/")) path = `/${path}`;
+  return `${base}${path}`;
+}

--- a/packages/core/src/mcp-client/hub-routes.ts
+++ b/packages/core/src/mcp-client/hub-routes.ts
@@ -1,0 +1,147 @@
+/**
+ * Hub serve — exposes this app's org-scope MCP servers to other agent-native
+ * apps in the same workspace.
+ *
+ * An app becomes a hub by setting `AGENT_NATIVE_MCP_HUB_TOKEN=<secret>` in
+ * its environment. Consuming apps set the same token plus
+ * `AGENT_NATIVE_MCP_HUB_URL` pointing at the hub; at startup they pull the
+ * hub's org-scope server list (URL + headers + description) and merge it
+ * into their own running MCP manager.
+ *
+ * Convention: dispatch is the hub. Any template can consume from it.
+ *
+ * User-scope servers are intentionally NOT shared — personal credentials
+ * stay with the user who added them. Only `o:<orgId>:mcp-servers-remote`
+ * entries are returned.
+ */
+
+import {
+  defineEventHandler,
+  getMethod,
+  getRequestHeader,
+  setResponseHeader,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+import { getH3App } from "../server/framework-request-handler.js";
+import { getAllSettings } from "../settings/store.js";
+import type { StoredRemoteMcpServer } from "./remote-store.js";
+
+/** Env var that enables hub-serve. Acts as the shared bearer secret. */
+const TOKEN_ENV = "AGENT_NATIVE_MCP_HUB_TOKEN";
+
+export interface HubServerRecord {
+  /** `<orgId>-<name>` — unique within the hub response. */
+  id: string;
+  orgId: string;
+  name: string;
+  url: string;
+  headers?: Record<string, string>;
+  description?: string;
+}
+
+export interface HubServersResponse {
+  servers: HubServerRecord[];
+  generatedAt: number;
+}
+
+/** Is this process configured to serve as a hub for other apps? */
+export function isHubServeEnabled(): boolean {
+  return !!process.env[TOKEN_ENV]?.trim();
+}
+
+/** Is this process configured to consume from a remote hub? */
+export function isHubConsumeEnabled(): boolean {
+  return (
+    !!process.env.AGENT_NATIVE_MCP_HUB_URL?.trim() &&
+    !!process.env.AGENT_NATIVE_MCP_HUB_TOKEN?.trim()
+  );
+}
+
+export async function listHubServers(): Promise<HubServerRecord[]> {
+  const all = await getAllSettings().catch(() => ({}));
+  const out: HubServerRecord[] = [];
+  for (const [fullKey, value] of Object.entries(all)) {
+    const m = /^o:([^:]+):mcp-servers-remote$/.exec(fullKey);
+    if (!m) continue;
+    const orgId = m[1];
+    const list = (value as { servers?: StoredRemoteMcpServer[] }).servers;
+    if (!Array.isArray(list)) continue;
+    for (const stored of list) {
+      if (!stored || typeof stored.url !== "string" || !stored.name) continue;
+      out.push({
+        id: `${orgId}-${stored.name}`,
+        orgId,
+        name: stored.name,
+        url: stored.url,
+        headers: stored.headers,
+        description: stored.description,
+      });
+    }
+  }
+  return out;
+}
+
+function checkBearer(event: H3Event): string | null {
+  const expected = process.env[TOKEN_ENV]?.trim();
+  if (!expected) return "Hub serve is not enabled on this app";
+  const header = getRequestHeader(event, "authorization") ?? "";
+  const match = /^Bearer\s+(.+)$/.exec(header);
+  if (!match) return "Bearer token required";
+  // Constant-time compare to avoid timing leaks on the shared secret.
+  const provided = match[1].trim();
+  if (provided.length !== expected.length) return "Invalid token";
+  let diff = 0;
+  for (let i = 0; i < provided.length; i++) {
+    diff |= provided.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  if (diff !== 0) return "Invalid token";
+  return null;
+}
+
+export function mountMcpHubRoutes(nitroApp: any): void {
+  if ((globalThis as any).__agentNativeMcpHubMounted) return;
+  (globalThis as any).__agentNativeMcpHubMounted = true;
+
+  try {
+    getH3App(nitroApp).use(
+      "/_agent-native/mcp/hub/servers",
+      defineEventHandler(async (event) => {
+        if (getMethod(event) !== "GET") {
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
+        const authError = checkBearer(event);
+        if (authError) {
+          setResponseStatus(event, 401);
+          return { error: authError };
+        }
+        setResponseHeader(event, "Content-Type", "application/json");
+        setResponseHeader(event, "Cache-Control", "no-store");
+        const servers = await listHubServers();
+        const payload: HubServersResponse = {
+          servers,
+          generatedAt: Date.now(),
+        };
+        return payload;
+      }),
+    );
+  } catch (err: any) {
+    console.warn(
+      `[mcp-client] Failed to mount /_agent-native/mcp/hub/servers: ${err?.message ?? err}`,
+    );
+  }
+}
+
+/** Status used by the UI to show a "hub mode" card. */
+export function getHubStatus(): {
+  serving: boolean;
+  consuming: boolean;
+  hubUrl: string | null;
+} {
+  return {
+    serving: isHubServeEnabled(),
+    consuming: isHubConsumeEnabled(),
+    hubUrl: process.env.AGENT_NATIVE_MCP_HUB_URL?.trim() || null,
+  };
+}

--- a/packages/core/src/mcp-client/index.ts
+++ b/packages/core/src/mcp-client/index.ts
@@ -27,12 +27,17 @@ export {
   validateRemoteUrl,
   normalizeServerName,
   mergedConfigKey,
+  parseMergedKey,
+  hashEmail,
   toHttpServerConfig,
   type RemoteMcpScope,
   type StoredRemoteMcpServer,
 } from "./remote-store.js";
 
 export { mountMcpServersRoutes, buildMergedConfig } from "./routes.js";
+
+export { isMcpToolAllowedForRequest } from "./visibility.js";
+import { isMcpToolAllowedForRequest } from "./visibility.js";
 
 /**
  * Convert MCP tools into `ActionEntry` values suitable for registration in
@@ -90,6 +95,12 @@ function mcpToolToActionEntry(
     },
     http: false,
     run: async (args: Record<string, string>) => {
+      // Defense-in-depth: even if a cross-scope MCP tool somehow makes it
+      // into the LLM's visible tool list, reject invocation here so we never
+      // execute a user's credentials on behalf of another user.
+      if (!isMcpToolAllowedForRequest(tool.name)) {
+        return `Error: MCP tool ${tool.name} is not available in the current request scope.`;
+      }
       try {
         const result = await manager.callTool(tool.name, args);
         // MCP tool results are typically `{ content: [{ type: "text", text: ... }], isError? }`.

--- a/packages/core/src/mcp-client/index.ts
+++ b/packages/core/src/mcp-client/index.ts
@@ -36,6 +36,18 @@ export {
 
 export { mountMcpServersRoutes, buildMergedConfig } from "./routes.js";
 
+export {
+  mountMcpHubRoutes,
+  listHubServers,
+  getHubStatus,
+  isHubServeEnabled,
+  isHubConsumeEnabled,
+  type HubServerRecord,
+  type HubServersResponse,
+} from "./hub-routes.js";
+
+export { fetchHubServers } from "./hub-client.js";
+
 export { isMcpToolAllowedForRequest } from "./visibility.js";
 import { isMcpToolAllowedForRequest } from "./visibility.js";
 

--- a/packages/core/src/mcp-client/index.ts
+++ b/packages/core/src/mcp-client/index.ts
@@ -20,6 +20,20 @@ export {
   type McpClientManagerOptions,
 } from "./manager.js";
 
+export {
+  listRemoteServers,
+  addRemoteServer,
+  removeRemoteServer,
+  validateRemoteUrl,
+  normalizeServerName,
+  mergedConfigKey,
+  toHttpServerConfig,
+  type RemoteMcpScope,
+  type StoredRemoteMcpServer,
+} from "./remote-store.js";
+
+export { mountMcpServersRoutes, buildMergedConfig } from "./routes.js";
+
 /**
  * Convert MCP tools into `ActionEntry` values suitable for registration in
  * the agent's action registry. Each tool is marked `http: false` so it's
@@ -36,6 +50,33 @@ export function mcpToolsToActionEntries(
     entries[tool.name] = mcpToolToActionEntry(manager, tool);
   }
   return entries;
+}
+
+/**
+ * Mutate a target action dict in place so it matches the current MCP tool set:
+ * - adds new `mcp__*` keys that aren't in target,
+ * - removes `mcp__*` keys that no longer exist in the manager,
+ * - leaves non-MCP keys untouched.
+ *
+ * Used by the agent-chat plugin to keep its `prodActions` / `devActions`
+ * registries in sync after `McpClientManager.reconfigure()` runs.
+ */
+export function syncMcpActionEntries(
+  manager: McpClientManager,
+  target: Record<string, ActionEntry>,
+): void {
+  const current = new Set<string>();
+  for (const tool of manager.getTools()) {
+    current.add(tool.name);
+    if (!target[tool.name]) {
+      target[tool.name] = mcpToolToActionEntry(manager, tool);
+    }
+  }
+  for (const key of Object.keys(target)) {
+    if (key.startsWith("mcp__") && !current.has(key)) {
+      delete target[key];
+    }
+  }
 }
 
 function mcpToolToActionEntry(

--- a/packages/core/src/mcp-client/manager.ts
+++ b/packages/core/src/mcp-client/manager.ts
@@ -1,10 +1,11 @@
 /**
- * McpClientManager — spawns configured MCP servers over stdio, enumerates
- * their tools, and exposes a flat tool registry prefixed with
- * `mcp__<server-id>__` so the agent's tool-use loop can call them.
+ * McpClientManager — connects to configured MCP servers (stdio or remote
+ * Streamable HTTP), enumerates their tools, and exposes a flat tool registry
+ * prefixed with `mcp__<server-id>__` so the agent's tool-use loop can call them.
  *
- * The manager is a strict no-op in non-Node runtimes (Cloudflare Workers,
- * browsers) — `start()` resolves immediately, `getTools()` returns `[]`.
+ * Stdio servers are a strict no-op in non-Node runtimes (Cloudflare Workers,
+ * browsers). HTTP servers work in any runtime with `fetch`; `reconfigure()`
+ * lets callers add or remove servers at runtime without restarting the process.
  */
 
 import type { McpConfig, McpServerConfig } from "./config.js";
@@ -67,23 +68,49 @@ export interface McpClientManagerOptions {
   debug?: boolean;
 }
 
+function sameServerConfig(a: McpServerConfig, b: McpServerConfig): boolean {
+  const typeA = a.type ?? "stdio";
+  const typeB = b.type ?? "stdio";
+  if (typeA !== typeB) return false;
+  if (typeA === "http" && b.type === "http" && a.type === "http") {
+    return (
+      a.url === b.url &&
+      JSON.stringify(a.headers ?? {}) === JSON.stringify(b.headers ?? {})
+    );
+  }
+  if (a.type !== "http" && b.type !== "http") {
+    return (
+      a.command === b.command &&
+      JSON.stringify(a.args ?? []) === JSON.stringify(b.args ?? []) &&
+      JSON.stringify(a.env ?? {}) === JSON.stringify(b.env ?? {}) &&
+      (a.cwd ?? "") === (b.cwd ?? "")
+    );
+  }
+  return false;
+}
+
+type SdkModules = {
+  Client: any;
+  StdioClientTransport: any | null;
+  StreamableHTTPClientTransport: any | null;
+};
+
 export class McpClientManager {
   private readonly servers: Map<string, ServerEntry> = new Map();
   private readonly debug: boolean;
   private started = false;
+  private config: McpConfig | null;
+  private sdk: SdkModules | null = null;
+  private readonly listeners: Set<() => void> = new Set();
 
-  constructor(
-    private readonly config: McpConfig | null,
-    options: McpClientManagerOptions = {},
-  ) {
+  constructor(config: McpConfig | null, options: McpClientManagerOptions = {}) {
+    this.config = config;
     this.debug = !!options.debug;
   }
 
-  /** True when MCP client support is active (Node runtime + non-empty config). */
+  /** True when the manager has any configured servers. */
   get enabled(): boolean {
-    return (
-      isNode() && !!this.config && Object.keys(this.config.servers).length > 0
-    );
+    return !!this.config && Object.keys(this.config.servers).length > 0;
   }
 
   /** List of configured server ids (whether or not they're connected). */
@@ -100,7 +127,82 @@ export class McpClientManager {
   }
 
   /**
-   * Connect to each configured MCP server over stdio and enumerate tools.
+   * Load MCP SDK modules lazily so non-Node bundles don't pull them in.
+   * Stdio transport is only loaded when a stdio server is actually configured.
+   */
+  private async loadSdk(needStdio: boolean): Promise<SdkModules | null> {
+    if (this.sdk) {
+      // If we previously loaded without stdio and now need it, top up.
+      if (needStdio && !this.sdk.StdioClientTransport && isNode()) {
+        try {
+          const stdioMod =
+            await import("@modelcontextprotocol/sdk/client/stdio.js");
+          this.sdk.StdioClientTransport = stdioMod.StdioClientTransport;
+        } catch (err: any) {
+          console.warn(
+            `[mcp-client] Failed to load stdio transport: ${err?.message ?? err}.`,
+          );
+        }
+      }
+      return this.sdk;
+    }
+    try {
+      const clientMod =
+        await import("@modelcontextprotocol/sdk/client/index.js");
+      const httpMod =
+        await import("@modelcontextprotocol/sdk/client/streamableHttp.js");
+      let StdioClientTransport: any = null;
+      if (needStdio && isNode()) {
+        try {
+          const stdioMod =
+            await import("@modelcontextprotocol/sdk/client/stdio.js");
+          StdioClientTransport = stdioMod.StdioClientTransport;
+        } catch (err: any) {
+          console.warn(
+            `[mcp-client] Failed to load stdio transport: ${err?.message ?? err}.`,
+          );
+        }
+      }
+      this.sdk = {
+        Client: clientMod.Client,
+        StdioClientTransport,
+        StreamableHTTPClientTransport: httpMod.StreamableHTTPClientTransport,
+      };
+      return this.sdk;
+    } catch (err: any) {
+      console.warn(
+        `[mcp-client] Failed to load MCP SDK: ${err?.message ?? err}. MCP tools disabled.`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Subscribe to tool-set changes (e.g. after `reconfigure()` adds/removes
+   * servers). The listener is called *after* connect/disconnect completes.
+   * Returns an unsubscribe function.
+   */
+  onChange(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emitChange(): void {
+    for (const l of this.listeners) {
+      try {
+        l();
+      } catch (err: any) {
+        console.warn(
+          `[mcp-client] onChange listener threw: ${err?.message ?? err}`,
+        );
+      }
+    }
+  }
+
+  /**
+   * Connect to each configured MCP server (stdio or http) and enumerate tools.
    * Individual server failures are logged and skipped — the manager stays
    * usable with whichever servers did come up.
    */
@@ -109,66 +211,83 @@ export class McpClientManager {
     this.started = true;
     if (!this.enabled) return;
 
-    // Dynamic imports so non-Node bundles don't pull in the SDK or node:child_process
-    let Client: any;
-    let StdioClientTransport: any;
-    try {
-      const clientMod =
-        await import("@modelcontextprotocol/sdk/client/index.js");
-      const stdioMod =
-        await import("@modelcontextprotocol/sdk/client/stdio.js");
-      Client = clientMod.Client;
-      StdioClientTransport = stdioMod.StdioClientTransport;
-    } catch (err: any) {
-      console.warn(
-        `[mcp-client] Failed to load MCP SDK: ${err?.message ?? err}. MCP tools disabled.`,
-      );
-      return;
-    }
+    const needStdio = Object.values(this.config!.servers).some(
+      (cfg) => (cfg.type ?? "stdio") === "stdio",
+    );
+    const sdk = await this.loadSdk(needStdio);
+    if (!sdk) return;
 
     const entries = Object.entries(this.config!.servers);
     await Promise.all(
-      entries.map(async ([id, cfg]) => {
-        const entry: ServerEntry = {
-          id,
-          config: cfg,
-          client: null,
-          transport: null,
-          tools: [],
-        };
-        this.servers.set(id, entry);
-        try {
-          await this.connectServer(entry, Client, StdioClientTransport);
-          console.log(
-            `[mcp-client] connected to ${id}: ${entry.tools.length} tools`,
-          );
-        } catch (err: any) {
-          entry.error = err?.message ?? String(err);
-          console.warn(
-            `[mcp-client] failed to connect to ${id}: ${entry.error}`,
-          );
-        }
-      }),
+      entries.map(async ([id, cfg]) => this.addServer(id, cfg, sdk)),
     );
+    this.emitChange();
+  }
+
+  /**
+   * Create a new ServerEntry and attempt to connect. Logs and records errors
+   * on the entry rather than throwing — callers iterate many servers.
+   */
+  private async addServer(
+    id: string,
+    cfg: McpServerConfig,
+    sdk: SdkModules,
+  ): Promise<void> {
+    const entry: ServerEntry = {
+      id,
+      config: cfg,
+      client: null,
+      transport: null,
+      tools: [],
+    };
+    this.servers.set(id, entry);
+    try {
+      await this.connectServer(entry, sdk);
+      console.log(
+        `[mcp-client] connected to ${id}: ${entry.tools.length} tools`,
+      );
+    } catch (err: any) {
+      entry.error = err?.message ?? String(err);
+      console.warn(`[mcp-client] failed to connect to ${id}: ${entry.error}`);
+    }
   }
 
   private async connectServer(
     entry: ServerEntry,
-    Client: any,
-    StdioClientTransport: any,
+    sdk: SdkModules,
   ): Promise<void> {
-    const { command, args = [], env, cwd } = entry.config;
+    const cfg = entry.config;
+    const { Client } = sdk;
 
-    // Merge env — spawn receives only the keys we pass, so include process.env
-    // by default to preserve PATH, HOME, etc.
-    const mergedEnv = env ? { ...process.env, ...env } : { ...process.env };
-
-    const transport = new StdioClientTransport({
-      command,
-      args,
-      env: mergedEnv as Record<string, string>,
-      cwd,
-    });
+    let transport: any;
+    if (cfg.type === "http") {
+      if (!sdk.StreamableHTTPClientTransport) {
+        throw new Error("HTTP transport not available");
+      }
+      const requestInit: Record<string, unknown> = {};
+      if (cfg.headers && Object.keys(cfg.headers).length > 0) {
+        requestInit.headers = cfg.headers;
+      }
+      transport = new sdk.StreamableHTTPClientTransport(new URL(cfg.url), {
+        requestInit,
+      });
+    } else {
+      if (!sdk.StdioClientTransport) {
+        throw new Error(
+          "Stdio transport not available (needs Node runtime with MCP SDK)",
+        );
+      }
+      const { command, args = [], env, cwd } = cfg;
+      // Merge env — spawn receives only the keys we pass, so include process.env
+      // by default to preserve PATH, HOME, etc.
+      const mergedEnv = env ? { ...process.env, ...env } : { ...process.env };
+      transport = new sdk.StdioClientTransport({
+        command,
+        args,
+        env: mergedEnv as Record<string, string>,
+        cwd,
+      });
+    }
 
     const client = new Client(
       { name: "agent-native-mcp-client", version: "1.0.0" },
@@ -196,6 +315,87 @@ export class McpClientManager {
         properties: {},
       }) as Record<string, unknown>,
     }));
+  }
+
+  /**
+   * Replace the configured server set. Servers that appear in the new config
+   * under a different shape are reconnected; unchanged entries stay live;
+   * removed entries are disconnected. Safe to call while `start()` is in
+   * flight or after it has completed.
+   *
+   * Returns a summary describing what happened for logging / UI feedback.
+   */
+  async reconfigure(newConfig: McpConfig | null): Promise<{
+    added: string[];
+    removed: string[];
+    unchanged: string[];
+    reconnected: string[];
+  }> {
+    const prev = this.config;
+    this.config = newConfig;
+
+    const prevServers = prev?.servers ?? {};
+    const nextServers = newConfig?.servers ?? {};
+
+    const added: string[] = [];
+    const removed: string[] = [];
+    const unchanged: string[] = [];
+    const reconnected: string[] = [];
+
+    // Remove entries that vanished or changed shape.
+    for (const id of Object.keys(prevServers)) {
+      if (!(id in nextServers)) {
+        removed.push(id);
+      } else if (!sameServerConfig(prevServers[id], nextServers[id])) {
+        reconnected.push(id);
+      } else {
+        unchanged.push(id);
+      }
+    }
+    for (const id of Object.keys(nextServers)) {
+      if (!(id in prevServers)) added.push(id);
+    }
+
+    const toDisconnect = [...removed, ...reconnected];
+    await Promise.all(
+      toDisconnect.map(async (id) => {
+        const entry = this.servers.get(id);
+        if (!entry) return;
+        this.servers.delete(id);
+        try {
+          if (entry.client?.close) await entry.client.close();
+        } catch {
+          // ignore
+        }
+        try {
+          if (entry.transport?.close) await entry.transport.close();
+        } catch {
+          // ignore
+        }
+      }),
+    );
+
+    const toConnect = [...added, ...reconnected];
+    if (toConnect.length > 0) {
+      const needStdio = toConnect.some(
+        (id) => (nextServers[id].type ?? "stdio") === "stdio",
+      );
+      const sdk = await this.loadSdk(needStdio);
+      if (sdk) {
+        await Promise.all(
+          toConnect.map((id) => this.addServer(id, nextServers[id], sdk)),
+        );
+      }
+    }
+
+    // If the manager was never started (e.g. empty initial config) but now has
+    // servers, mark it started so subsequent start() calls don't duplicate work.
+    if (!this.started && Object.keys(nextServers).length > 0) {
+      this.started = true;
+    }
+
+    this.emitChange();
+    return { added, removed, unchanged, reconnected };
   }
 
   /** Flattened tool list across all connected servers. */

--- a/packages/core/src/mcp-client/manager.ts
+++ b/packages/core/src/mcp-client/manager.ts
@@ -102,6 +102,9 @@ export class McpClientManager {
   private config: McpConfig | null;
   private sdk: SdkModules | null = null;
   private readonly listeners: Set<() => void> = new Set();
+  /** Serialises reconfigure()/start() — two concurrent callers would
+   * otherwise race on `this.config` and on connect/disconnect ordering. */
+  private reconfigureQueue: Promise<unknown> = Promise.resolve();
 
   constructor(config: McpConfig | null, options: McpClientManagerOptions = {}) {
     this.config = config;
@@ -205,8 +208,19 @@ export class McpClientManager {
    * Connect to each configured MCP server (stdio or http) and enumerate tools.
    * Individual server failures are logged and skipped — the manager stays
    * usable with whichever servers did come up.
+   *
+   * Queued against `reconfigure()` so a `reconfigure` that lands before
+   * `start()` finishes can't race on `this.started` / `this.servers`.
    */
   async start(): Promise<void> {
+    const task = this.reconfigureQueue.then(() => this.startInternal());
+    this.reconfigureQueue = task.catch(() => {
+      /* failures surface on the caller, not on the queue */
+    });
+    return task;
+  }
+
+  private async startInternal(): Promise<void> {
     if (this.started) return;
     this.started = true;
     if (!this.enabled) return;
@@ -294,27 +308,43 @@ export class McpClientManager {
       { capabilities: {} },
     );
 
-    await client.connect(transport);
+    // If connect or listTools throws, we still need to release the child
+    // process (stdio) or pending HTTP session — otherwise repeated failures
+    // leak transports. Assign to the entry only after the handshake succeeds.
+    try {
+      await client.connect(transport);
+      const listed = await client.listTools();
+      const rawTools: Array<{
+        name: string;
+        description?: string;
+        inputSchema?: Record<string, unknown>;
+      }> = (listed?.tools ?? []) as any[];
 
-    const listed = await client.listTools();
-    const rawTools: Array<{
-      name: string;
-      description?: string;
-      inputSchema?: Record<string, unknown>;
-    }> = (listed?.tools ?? []) as any[];
-
-    entry.client = client;
-    entry.transport = transport;
-    entry.tools = rawTools.map((t) => ({
-      source: entry.id,
-      name: buildPrefixedName(entry.id, t.name),
-      originalName: t.name,
-      description: t.description ?? t.name,
-      inputSchema: (t.inputSchema ?? {
-        type: "object",
-        properties: {},
-      }) as Record<string, unknown>,
-    }));
+      entry.client = client;
+      entry.transport = transport;
+      entry.tools = rawTools.map((t) => ({
+        source: entry.id,
+        name: buildPrefixedName(entry.id, t.name),
+        originalName: t.name,
+        description: t.description ?? t.name,
+        inputSchema: (t.inputSchema ?? {
+          type: "object",
+          properties: {},
+        }) as Record<string, unknown>,
+      }));
+    } catch (err) {
+      try {
+        if (client?.close) await client.close();
+      } catch {
+        // ignore
+      }
+      try {
+        if (transport?.close) await transport.close();
+      } catch {
+        // ignore
+      }
+      throw err;
+    }
   }
 
   /**
@@ -323,9 +353,28 @@ export class McpClientManager {
    * removed entries are disconnected. Safe to call while `start()` is in
    * flight or after it has completed.
    *
+   * Serialised against `start()` and any other `reconfigure()` call via the
+   * internal queue — two concurrent mutations would otherwise interleave on
+   * `this.config` and on connect/disconnect ordering.
+   *
    * Returns a summary describing what happened for logging / UI feedback.
    */
   async reconfigure(newConfig: McpConfig | null): Promise<{
+    added: string[];
+    removed: string[];
+    unchanged: string[];
+    reconnected: string[];
+  }> {
+    const task = this.reconfigureQueue.then(() =>
+      this.reconfigureInternal(newConfig),
+    );
+    this.reconfigureQueue = task.catch(() => {
+      /* failures surface on the caller, not on the queue */
+    });
+    return task;
+  }
+
+  private async reconfigureInternal(newConfig: McpConfig | null): Promise<{
     added: string[];
     removed: string[];
     unchanged: string[];

--- a/packages/core/src/mcp-client/remote-store.ts
+++ b/packages/core/src/mcp-client/remote-store.ts
@@ -1,0 +1,203 @@
+/**
+ * Persistent store for user-added remote MCP servers.
+ *
+ * Servers added through the settings UI live in the framework's `settings`
+ * table, keyed by scope:
+ *   - User scope: `u:<email>:mcp-servers-remote`
+ *   - Org scope:  `o:<orgId>:mcp-servers-remote`
+ *
+ * Both scopes store the same shape — a list of `StoredRemoteMcpServer`
+ * records. The running MCP manager merges this list with the file-based
+ * `mcp.config.json` on startup and after every mutation.
+ */
+
+import {
+  getUserSetting,
+  putUserSetting,
+  deleteUserSetting,
+} from "../settings/user-settings.js";
+import {
+  getOrgSetting,
+  putOrgSetting,
+  deleteOrgSetting,
+} from "../settings/org-settings.js";
+import type { McpHttpServerConfig } from "./config.js";
+
+const SETTINGS_KEY = "mcp-servers-remote";
+
+export type RemoteMcpScope = "user" | "org";
+
+export interface StoredRemoteMcpServer {
+  /** Stable unique id — used for removal / URLs. */
+  id: string;
+  /** Human-readable name. Also used as the MCP server id (prefixed with scope). */
+  name: string;
+  /** Streamable HTTP MCP server URL. */
+  url: string;
+  /** Optional headers to pass (e.g. `Authorization: Bearer …`). */
+  headers?: Record<string, string>;
+  /** Optional description shown in the UI. */
+  description?: string;
+  /** ms since epoch. */
+  createdAt: number;
+}
+
+/** Tiny nanoid — matches the inline helper used elsewhere in this package. */
+function shortId(): string {
+  const rand =
+    globalThis.crypto?.randomUUID?.().replace(/-/g, "") ??
+    Math.random().toString(36).slice(2) + Date.now().toString(36);
+  return rand.slice(0, 16);
+}
+
+/**
+ * Validate a candidate MCP server name — used as a key in the merged config
+ * and as part of the prefixed tool name (`mcp__<name>__<tool>`).
+ *
+ * Allowed: letters, digits, hyphen, underscore; 1–40 chars. Lowercased.
+ */
+export function normalizeServerName(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "-")
+    .slice(0, 40);
+}
+
+/** Reject obviously-wrong URLs. Allows http only for localhost. */
+export function validateRemoteUrl(raw: string): {
+  ok: boolean;
+  url?: URL;
+  error?: string;
+} {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return { ok: false, error: "Not a valid URL" };
+  }
+  if (url.protocol === "https:") return { ok: true, url };
+  if (url.protocol === "http:") {
+    const host = url.hostname;
+    if (host === "localhost" || host === "127.0.0.1" || host === "::1") {
+      return { ok: true, url };
+    }
+    return { ok: false, error: "Plain http is only allowed for localhost" };
+  }
+  return { ok: false, error: `Unsupported protocol: ${url.protocol}` };
+}
+
+async function readList(
+  scope: RemoteMcpScope,
+  scopeId: string,
+): Promise<StoredRemoteMcpServer[]> {
+  const raw =
+    scope === "user"
+      ? await getUserSetting(scopeId, SETTINGS_KEY)
+      : await getOrgSetting(scopeId, SETTINGS_KEY);
+  if (!raw || !Array.isArray((raw as any).servers)) return [];
+  return ((raw as any).servers as StoredRemoteMcpServer[]).filter(
+    (s) => s && typeof s.id === "string" && typeof s.url === "string",
+  );
+}
+
+async function writeList(
+  scope: RemoteMcpScope,
+  scopeId: string,
+  servers: StoredRemoteMcpServer[],
+): Promise<void> {
+  if (scope === "user") {
+    await putUserSetting(scopeId, SETTINGS_KEY, { servers });
+  } else {
+    await putOrgSetting(scopeId, SETTINGS_KEY, { servers });
+  }
+}
+
+export async function listRemoteServers(
+  scope: RemoteMcpScope,
+  scopeId: string,
+): Promise<StoredRemoteMcpServer[]> {
+  return readList(scope, scopeId);
+}
+
+export async function addRemoteServer(
+  scope: RemoteMcpScope,
+  scopeId: string,
+  input: {
+    name: string;
+    url: string;
+    headers?: Record<string, string>;
+    description?: string;
+  },
+): Promise<
+  { ok: true; server: StoredRemoteMcpServer } | { ok: false; error: string }
+> {
+  const name = normalizeServerName(input.name);
+  if (!name) return { ok: false, error: "Name is required" };
+  const urlCheck = validateRemoteUrl(input.url);
+  if (!urlCheck.ok) return { ok: false, error: urlCheck.error ?? "Bad URL" };
+
+  const existing = await readList(scope, scopeId);
+  if (existing.some((s) => s.name === name)) {
+    return { ok: false, error: `A server named "${name}" already exists` };
+  }
+
+  const server: StoredRemoteMcpServer = {
+    id: `mcps_${shortId()}`,
+    name,
+    url: urlCheck.url!.toString(),
+    headers:
+      input.headers && Object.keys(input.headers).length > 0
+        ? { ...input.headers }
+        : undefined,
+    description: input.description?.trim() || undefined,
+    createdAt: Date.now(),
+  };
+  await writeList(scope, scopeId, [...existing, server]);
+  return { ok: true, server };
+}
+
+export async function removeRemoteServer(
+  scope: RemoteMcpScope,
+  scopeId: string,
+  id: string,
+): Promise<boolean> {
+  const existing = await readList(scope, scopeId);
+  const next = existing.filter((s) => s.id !== id);
+  if (next.length === existing.length) return false;
+  if (next.length === 0) {
+    if (scope === "user") {
+      await deleteUserSetting(scopeId, SETTINGS_KEY);
+    } else {
+      await deleteOrgSetting(scopeId, SETTINGS_KEY);
+    }
+  } else {
+    await writeList(scope, scopeId, next);
+  }
+  return true;
+}
+
+/**
+ * Project a stored server into the runtime `McpHttpServerConfig` shape that
+ * `McpClientManager` consumes. The merged-config key is the scope + name
+ * so a user-scope and org-scope server can both share a readable name
+ * without clobbering each other.
+ */
+export function toHttpServerConfig(
+  stored: StoredRemoteMcpServer,
+): McpHttpServerConfig {
+  return {
+    type: "http",
+    url: stored.url,
+    headers: stored.headers,
+    description: stored.description,
+  };
+}
+
+/** Build the merged-config key for a stored server at a given scope. */
+export function mergedConfigKey(
+  scope: RemoteMcpScope,
+  stored: StoredRemoteMcpServer,
+): string {
+  return `${scope}-${stored.name}`;
+}

--- a/packages/core/src/mcp-client/remote-store.ts
+++ b/packages/core/src/mcp-client/remote-store.ts
@@ -11,6 +11,7 @@
  * `mcp.config.json` on startup and after every mutation.
  */
 
+import { createHash } from "node:crypto";
 import {
   getUserSetting,
   putUserSetting,
@@ -52,16 +53,39 @@ function shortId(): string {
 
 /**
  * Validate a candidate MCP server name — used as a key in the merged config
- * and as part of the prefixed tool name (`mcp__<name>__<tool>`).
+ * and as part of the prefixed tool name (`mcp__<merged-key>__<tool>`).
  *
- * Allowed: letters, digits, hyphen, underscore; 1–40 chars. Lowercased.
+ * Allowed: letters, digits, hyphen; 1–40 chars. Lowercased. Underscores are
+ * excluded on purpose — the merged-key format uses `_` as a separator between
+ * `<scope>`, `<owner>`, and `<name>`, so allowing `_` in names would make the
+ * parse ambiguous.
  */
 export function normalizeServerName(input: string): string {
   return input
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9_-]/g, "-")
+    .replace(/[^a-z0-9-]/g, "-")
     .slice(0, 40);
+}
+
+/**
+ * Short, deterministic, URL-safe hash of an email. Used as the owner
+ * discriminator in user-scope merged keys so two users with the same server
+ * name don't collide in the global MCP manager.
+ */
+export function hashEmail(email: string): string {
+  return createHash("sha256")
+    .update(email.toLowerCase().trim())
+    .digest("hex")
+    .slice(0, 10);
+}
+
+/**
+ * Sanitise an org id to the character set allowed in merged keys.
+ * Org ids are already nanoid-style alphanumeric, but we normalise defensively.
+ */
+function sanitiseOrgId(orgId: string): string {
+  return orgId.toLowerCase().replace(/[^a-z0-9-]/g, "-");
 }
 
 /** Reject obviously-wrong URLs. Allows http only for localhost. */
@@ -194,10 +218,48 @@ export function toHttpServerConfig(
   };
 }
 
-/** Build the merged-config key for a stored server at a given scope. */
+/**
+ * Build the merged-config key for a stored server.
+ *
+ * The key encodes the owning scope + owner identity so two users adding a
+ * server called `zapier` produce distinct ids (`user_ab12cd34ef_zapier` vs
+ * `user_99aa88bb77_zapier`) and Alice's tool calls never route through Bob's
+ * credentials in a shared-process deployment.
+ *
+ * - User scope: `user_<emailhash>_<name>`
+ * - Org scope:  `org_<orgId>_<name>`
+ *
+ * `ownerId` is the raw email for user scope, and the org id for org scope.
+ */
 export function mergedConfigKey(
   scope: RemoteMcpScope,
   stored: StoredRemoteMcpServer,
+  ownerId: string,
 ): string {
-  return `${scope}-${stored.name}`;
+  const owner = scope === "user" ? hashEmail(ownerId) : sanitiseOrgId(ownerId);
+  return `${scope}_${owner}_${stored.name}`;
+}
+
+/**
+ * Parse a merged key (or a full prefixed tool name like
+ * `mcp__user_abcd1234ef_zapier__run-task`) back into its scope + owner + name
+ * components. Returns null for non-merged keys (e.g. stdio file-config servers
+ * like `claude-in-chrome`) so callers can treat them as always-visible.
+ */
+export function parseMergedKey(
+  keyOrToolName: string,
+): { scope: RemoteMcpScope; owner: string; name: string } | null {
+  let key = keyOrToolName;
+  if (key.startsWith("mcp__")) {
+    const rest = key.slice("mcp__".length);
+    const idx = rest.indexOf("__");
+    key = idx >= 0 ? rest.slice(0, idx) : rest;
+  }
+  const m = /^(user|org)_([^_]+)_(.+)$/.exec(key);
+  if (!m) return null;
+  return {
+    scope: m[1] as RemoteMcpScope,
+    owner: m[2],
+    name: m[3],
+  };
 }

--- a/packages/core/src/mcp-client/routes.ts
+++ b/packages/core/src/mcp-client/routes.ts
@@ -1,0 +1,473 @@
+/**
+ * HTTP routes for user- and org-scope remote MCP server management.
+ *
+ * Mounted under `/_agent-native/mcp/servers` by `agent-chat-plugin` —
+ * requires a reference to the running `McpClientManager` so mutations can
+ * hot-reload the configured server set.
+ *
+ *   GET    /_agent-native/mcp/servers           list user + org servers
+ *   POST   /_agent-native/mcp/servers           add a server
+ *   DELETE /_agent-native/mcp/servers/:id       remove a server (scope via ?scope=)
+ *   POST   /_agent-native/mcp/servers/:id/test  dry-run connect (no persist)
+ *   POST   /_agent-native/mcp/servers/test      dry-run a URL before persisting
+ */
+
+import {
+  defineEventHandler,
+  getMethod,
+  getQuery,
+  setResponseHeader,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+import { getH3App } from "../server/framework-request-handler.js";
+import { readBody } from "../server/h3-helpers.js";
+import { getOrgContext } from "../org/context.js";
+import { getSession } from "../server/auth.js";
+import { getAllSettings } from "../settings/store.js";
+import type { McpClientManager } from "./manager.js";
+import type { McpConfig, McpServerConfig } from "./config.js";
+import { loadMcpConfig, autoDetectMcpConfig } from "./config.js";
+import {
+  addRemoteServer,
+  listRemoteServers,
+  mergedConfigKey,
+  removeRemoteServer,
+  toHttpServerConfig,
+  validateRemoteUrl,
+  type RemoteMcpScope,
+  type StoredRemoteMcpServer,
+} from "./remote-store.js";
+
+/** Redact obvious auth header values before sending to the client. */
+function redactHeaders(
+  headers?: Record<string, string>,
+): Record<string, { set: true }> | undefined {
+  if (!headers) return undefined;
+  const out: Record<string, { set: true }> = {};
+  for (const k of Object.keys(headers)) out[k] = { set: true };
+  return out;
+}
+
+function projectForClient(
+  stored: StoredRemoteMcpServer,
+  scope: RemoteMcpScope,
+  status: ServerStatus,
+): ClientServer {
+  return {
+    id: stored.id,
+    scope,
+    name: stored.name,
+    url: stored.url,
+    headers: redactHeaders(stored.headers),
+    description: stored.description,
+    createdAt: stored.createdAt,
+    mergedId: mergedConfigKey(scope, stored),
+    status,
+  };
+}
+
+export interface ClientServer {
+  id: string;
+  scope: RemoteMcpScope;
+  name: string;
+  url: string;
+  headers?: Record<string, { set: true }>;
+  description?: string;
+  createdAt: number;
+  /** The key under which this server is registered in the running MCP manager. */
+  mergedId: string;
+  status: ServerStatus;
+}
+
+type ServerStatus =
+  | { state: "connected"; toolCount: number }
+  | { state: "error"; error: string }
+  | { state: "unknown" };
+
+function statusFor(manager: McpClientManager, mergedId: string): ServerStatus {
+  const snap = manager.getStatus();
+  if (snap.connectedServers.includes(mergedId)) {
+    const toolCount = snap.tools.filter((t) => t.source === mergedId).length;
+    return { state: "connected", toolCount };
+  }
+  if (snap.errors[mergedId]) {
+    return { state: "error", error: snap.errors[mergedId] };
+  }
+  if (snap.configuredServers.includes(mergedId)) {
+    return { state: "unknown" };
+  }
+  return { state: "unknown" };
+}
+
+/**
+ * Build the merged MCP config the manager should run with: file/env config
+ * plus **every** user-scope and org-scope remote server persisted in the
+ * settings store. Scanning all scopes means a mutation from one user's
+ * session never drops another user's servers from the running manager.
+ *
+ * The merged key is `<scope>-<name>` — `user-zapier` vs `org-zapier` can
+ * coexist without collision, and the tool name becomes
+ * `mcp__user-zapier__run-task`.
+ */
+export async function buildMergedConfig(): Promise<McpConfig | null> {
+  const base = loadMcpConfig() ?? autoDetectMcpConfig();
+  const servers: Record<string, McpServerConfig> = { ...(base?.servers ?? {}) };
+
+  const all = await getAllSettings().catch(() => ({}));
+  for (const [fullKey, value] of Object.entries(all)) {
+    const userMatch = /^u:([^:]+):mcp-servers-remote$/.exec(fullKey);
+    const orgMatch = /^o:([^:]+):mcp-servers-remote$/.exec(fullKey);
+    const scope: RemoteMcpScope | null = userMatch
+      ? "user"
+      : orgMatch
+        ? "org"
+        : null;
+    if (!scope) continue;
+    const list = (value as { servers?: StoredRemoteMcpServer[] }).servers;
+    if (!Array.isArray(list)) continue;
+    for (const stored of list) {
+      if (!stored || typeof stored.url !== "string" || !stored.name) continue;
+      servers[mergedConfigKey(scope, stored)] = toHttpServerConfig(stored);
+    }
+  }
+
+  if (Object.keys(servers).length === 0) return null;
+  return { servers, source: base?.source ?? "merged" };
+}
+
+async function resolveContextForRequest(event: H3Event): Promise<{
+  email: string | null;
+  orgId: string | null;
+  role: string | null;
+}> {
+  let email: string | null = null;
+  try {
+    const session = await getSession(event);
+    email = session?.email ?? null;
+  } catch {
+    email = null;
+  }
+  let orgId: string | null = null;
+  let role: string | null = null;
+  try {
+    const ctx = await getOrgContext(event);
+    orgId = ctx.orgId;
+    role = ctx.role;
+    if (!email) email = ctx.email;
+  } catch {
+    // ignore — no org context
+  }
+  // In solo/dev mode `getSession` can return nothing but getOrgContext still
+  // yields the fallback email. Keep that as the user-scope id so single-user
+  // desktop installs work without a login flow.
+  if (!email) email = "local@localhost";
+  return { email, orgId, role };
+}
+
+async function reconfigureManager(manager: McpClientManager): Promise<void> {
+  const merged = await buildMergedConfig();
+  await manager.reconfigure(merged);
+}
+
+export function mountMcpServersRoutes(
+  nitroApp: any,
+  manager: McpClientManager,
+): void {
+  if ((globalThis as any).__agentNativeMcpServersMounted) return;
+  (globalThis as any).__agentNativeMcpServersMounted = true;
+
+  try {
+    getH3App(nitroApp).use(
+      "/_agent-native/mcp/servers",
+      defineEventHandler(async (event: H3Event) => {
+        const method = getMethod(event);
+        const pathname = (event.url?.pathname || "")
+          .replace(/^\/+/, "")
+          .replace(/\/+$/, "");
+        const parts = pathname ? pathname.split("/") : [];
+
+        setResponseHeader(event, "Content-Type", "application/json");
+
+        // POST /servers/test — dry-run a URL+headers before persisting
+        if (method === "POST" && parts.length === 1 && parts[0] === "test") {
+          return handleTestUrl(event);
+        }
+
+        // Collection root
+        if (parts.length === 0) {
+          if (method === "GET") return handleList(event, manager);
+          if (method === "POST") return handleAdd(event, manager);
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
+
+        // /:id  /  /:id/test
+        if (parts.length === 1 || parts.length === 2) {
+          const id = parts[0];
+          if (parts.length === 2 && parts[1] === "test" && method === "POST") {
+            return handleTestExisting(event, manager, id);
+          }
+          if (parts.length === 1 && method === "DELETE") {
+            return handleDelete(event, manager, id);
+          }
+        }
+
+        setResponseStatus(event, 404);
+        return { error: "Not found" };
+      }),
+    );
+  } catch (err: any) {
+    console.warn(
+      `[mcp-client] Failed to mount /_agent-native/mcp/servers: ${err?.message ?? err}`,
+    );
+  }
+}
+
+async function handleList(
+  event: H3Event,
+  manager: McpClientManager,
+): Promise<{
+  user: ClientServer[];
+  org: ClientServer[];
+  orgId: string | null;
+  role: string | null;
+}> {
+  const { email, orgId, role } = await resolveContextForRequest(event);
+  const userServers = email ? await listRemoteServers("user", email) : [];
+  const orgServers = orgId ? await listRemoteServers("org", orgId) : [];
+  return {
+    user: userServers.map((s) =>
+      projectForClient(
+        s,
+        "user",
+        statusFor(manager, mergedConfigKey("user", s)),
+      ),
+    ),
+    org: orgServers.map((s) =>
+      projectForClient(s, "org", statusFor(manager, mergedConfigKey("org", s))),
+    ),
+    orgId,
+    role,
+  };
+}
+
+async function handleAdd(event: H3Event, manager: McpClientManager) {
+  const body = (await readBody(event).catch(() => ({}))) as {
+    scope?: unknown;
+    name?: unknown;
+    url?: unknown;
+    headers?: unknown;
+    description?: unknown;
+  };
+  const scope =
+    body.scope === "org" ? "org" : body.scope === "user" ? "user" : null;
+  if (!scope) {
+    setResponseStatus(event, 400);
+    return { error: 'scope must be "user" or "org"' };
+  }
+  const name = typeof body.name === "string" ? body.name : "";
+  const url = typeof body.url === "string" ? body.url : "";
+  if (!name.trim() || !url.trim()) {
+    setResponseStatus(event, 400);
+    return { error: "name and url are required" };
+  }
+  const headers = normalizeHeaders(body.headers);
+  const description =
+    typeof body.description === "string" ? body.description : undefined;
+
+  const { email, orgId, role } = await resolveContextForRequest(event);
+
+  let scopeId: string | null = null;
+  if (scope === "user") {
+    scopeId = email;
+  } else {
+    if (!orgId) {
+      setResponseStatus(event, 400);
+      return {
+        error: "You must belong to an organization to add an org-scope server",
+      };
+    }
+    if (role !== "owner" && role !== "admin") {
+      setResponseStatus(event, 403);
+      return { error: "Only owners and admins can add org-scope MCP servers" };
+    }
+    scopeId = orgId;
+  }
+  if (!scopeId) {
+    setResponseStatus(event, 401);
+    return { error: "Authentication required" };
+  }
+
+  const result = await addRemoteServer(scope, scopeId, {
+    name,
+    url,
+    headers,
+    description,
+  });
+  if (result.ok !== true) {
+    setResponseStatus(event, 400);
+    return { error: result.error };
+  }
+
+  await reconfigureManager(manager);
+  const mergedId = mergedConfigKey(scope, result.server);
+  return {
+    ok: true,
+    server: projectForClient(
+      result.server,
+      scope,
+      statusFor(manager, mergedId),
+    ),
+  };
+}
+
+async function handleDelete(
+  event: H3Event,
+  manager: McpClientManager,
+  id: string,
+) {
+  const scope = getQuery(event).scope;
+  const parsedScope =
+    scope === "org" ? "org" : scope === "user" ? "user" : null;
+  if (!parsedScope) {
+    setResponseStatus(event, 400);
+    return { error: 'scope query param must be "user" or "org"' };
+  }
+  const { email, orgId, role } = await resolveContextForRequest(event);
+
+  let scopeId: string | null = null;
+  if (parsedScope === "user") {
+    scopeId = email;
+  } else {
+    if (!orgId) {
+      setResponseStatus(event, 400);
+      return { error: "No active organization" };
+    }
+    if (role !== "owner" && role !== "admin") {
+      setResponseStatus(event, 403);
+      return {
+        error: "Only owners and admins can remove org-scope MCP servers",
+      };
+    }
+    scopeId = orgId;
+  }
+  if (!scopeId) {
+    setResponseStatus(event, 401);
+    return { error: "Authentication required" };
+  }
+
+  const removed = await removeRemoteServer(parsedScope, scopeId, id);
+  if (!removed) {
+    setResponseStatus(event, 404);
+    return { error: "Server not found" };
+  }
+  await reconfigureManager(manager);
+  return { ok: true };
+}
+
+async function handleTestUrl(event: H3Event) {
+  const body = (await readBody(event).catch(() => ({}))) as {
+    url?: unknown;
+    headers?: unknown;
+  };
+  const url = typeof body.url === "string" ? body.url : "";
+  const check = validateRemoteUrl(url);
+  if (!check.ok) {
+    setResponseStatus(event, 400);
+    return { ok: false, error: check.error };
+  }
+  const headers = normalizeHeaders(body.headers);
+  const result = await tryConnect(check.url!.toString(), headers);
+  if (result.ok !== true) {
+    setResponseStatus(event, 400);
+    return { ok: false, error: result.error };
+  }
+  return { ok: true, toolCount: result.toolCount, tools: result.tools };
+}
+
+async function handleTestExisting(
+  event: H3Event,
+  manager: McpClientManager,
+  id: string,
+) {
+  const scope = getQuery(event).scope;
+  const parsedScope =
+    scope === "org" ? "org" : scope === "user" ? "user" : null;
+  if (!parsedScope) {
+    setResponseStatus(event, 400);
+    return { error: 'scope query param must be "user" or "org"' };
+  }
+  const { email, orgId } = await resolveContextForRequest(event);
+  const scopeId = parsedScope === "user" ? email : orgId;
+  if (!scopeId) {
+    setResponseStatus(event, 401);
+    return { error: "Authentication required" };
+  }
+  const list = await listRemoteServers(parsedScope, scopeId);
+  const server = list.find((s) => s.id === id);
+  if (!server) {
+    setResponseStatus(event, 404);
+    return { error: "Server not found" };
+  }
+  const result = await tryConnect(server.url, server.headers);
+  if (result.ok !== true) {
+    setResponseStatus(event, 400);
+    return { ok: false, error: result.error };
+  }
+  return { ok: true, toolCount: result.toolCount, tools: result.tools };
+}
+
+async function tryConnect(
+  url: string,
+  headers?: Record<string, string>,
+): Promise<
+  | { ok: true; toolCount: number; tools: string[] }
+  | { ok: false; error: string }
+> {
+  try {
+    const [{ Client }, { StreamableHTTPClientTransport }] = await Promise.all([
+      import("@modelcontextprotocol/sdk/client/index.js"),
+      import("@modelcontextprotocol/sdk/client/streamableHttp.js"),
+    ]);
+    const requestInit: Record<string, unknown> = {};
+    if (headers && Object.keys(headers).length > 0) {
+      requestInit.headers = headers;
+    }
+    const transport = new StreamableHTTPClientTransport(new URL(url), {
+      requestInit,
+    });
+    const client = new Client(
+      { name: "agent-native-mcp-client-test", version: "1.0.0" },
+      { capabilities: {} },
+    );
+    try {
+      await client.connect(transport);
+      const listed = await client.listTools();
+      const names = ((listed?.tools ?? []) as Array<{ name: string }>).map(
+        (t) => t.name,
+      );
+      return { ok: true, toolCount: names.length, tools: names };
+    } finally {
+      try {
+        await client.close();
+      } catch {}
+      try {
+        await transport.close();
+      } catch {}
+    }
+  } catch (err: any) {
+    return { ok: false, error: err?.message ?? String(err) };
+  }
+}
+
+function normalizeHeaders(input: unknown): Record<string, string> | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+    if (typeof k !== "string" || !k.trim()) continue;
+    if (typeof v !== "string") continue;
+    out[k.trim()] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/packages/core/src/mcp-client/routes.ts
+++ b/packages/core/src/mcp-client/routes.ts
@@ -38,6 +38,7 @@ import {
   type RemoteMcpScope,
   type StoredRemoteMcpServer,
 } from "./remote-store.js";
+import { fetchHubServers } from "./hub-client.js";
 
 /** Redact obvious auth header values before sending to the client. */
 function redactHeaders(
@@ -138,6 +139,21 @@ export async function buildMergedConfig(): Promise<McpConfig | null> {
       servers[mergedConfigKey(scope, stored, ownerId)] =
         toHttpServerConfig(stored);
     }
+  }
+
+  // Hub-consume: if this app is configured to consume from a remote hub
+  // (AGENT_NATIVE_MCP_HUB_URL + AGENT_NATIVE_MCP_HUB_TOKEN), pull its
+  // org-scope servers and merge. Hub entries use `hub_<orgId>_<name>` so
+  // they never collide with local `org_<orgId>_<name>` rows.
+  try {
+    const hubServers = await fetchHubServers();
+    for (const [mergedKey, cfg] of Object.entries(hubServers)) {
+      servers[mergedKey] = cfg;
+    }
+  } catch (err: any) {
+    console.warn(
+      `[mcp-client] hub merge failed: ${err?.message ?? err}. Continuing with local config.`,
+    );
   }
 
   if (Object.keys(servers).length === 0) return null;

--- a/packages/core/src/mcp-client/routes.ts
+++ b/packages/core/src/mcp-client/routes.ts
@@ -52,6 +52,7 @@ function redactHeaders(
 function projectForClient(
   stored: StoredRemoteMcpServer,
   scope: RemoteMcpScope,
+  ownerId: string,
   status: ServerStatus,
 ): ClientServer {
   return {
@@ -62,7 +63,7 @@ function projectForClient(
     headers: redactHeaders(stored.headers),
     description: stored.description,
     createdAt: stored.createdAt,
-    mergedId: mergedConfigKey(scope, stored),
+    mergedId: mergedConfigKey(scope, stored, ownerId),
     status,
   };
 }
@@ -106,9 +107,11 @@ function statusFor(manager: McpClientManager, mergedId: string): ServerStatus {
  * settings store. Scanning all scopes means a mutation from one user's
  * session never drops another user's servers from the running manager.
  *
- * The merged key is `<scope>-<name>` — `user-zapier` vs `org-zapier` can
- * coexist without collision, and the tool name becomes
- * `mcp__user-zapier__run-task`.
+ * Each persisted server's merged key includes its owner discriminator
+ * (`user_<emailhash>_<name>` or `org_<orgId>_<name>`) so two users' servers
+ * with the same name coexist; the request-time gate in
+ * `isMcpToolAllowedForRequest` then scopes tool visibility back down to the
+ * calling user.
  */
 export async function buildMergedConfig(): Promise<McpConfig | null> {
   const base = loadMcpConfig() ?? autoDetectMcpConfig();
@@ -118,17 +121,22 @@ export async function buildMergedConfig(): Promise<McpConfig | null> {
   for (const [fullKey, value] of Object.entries(all)) {
     const userMatch = /^u:([^:]+):mcp-servers-remote$/.exec(fullKey);
     const orgMatch = /^o:([^:]+):mcp-servers-remote$/.exec(fullKey);
-    const scope: RemoteMcpScope | null = userMatch
-      ? "user"
-      : orgMatch
-        ? "org"
-        : null;
-    if (!scope) continue;
+    let scope: RemoteMcpScope | null = null;
+    let ownerId: string | null = null;
+    if (userMatch) {
+      scope = "user";
+      ownerId = userMatch[1];
+    } else if (orgMatch) {
+      scope = "org";
+      ownerId = orgMatch[1];
+    }
+    if (!scope || !ownerId) continue;
     const list = (value as { servers?: StoredRemoteMcpServer[] }).servers;
     if (!Array.isArray(list)) continue;
     for (const stored of list) {
       if (!stored || typeof stored.url !== "string" || !stored.name) continue;
-      servers[mergedConfigKey(scope, stored)] = toHttpServerConfig(stored);
+      servers[mergedConfigKey(scope, stored, ownerId)] =
+        toHttpServerConfig(stored);
     }
   }
 
@@ -241,11 +249,17 @@ async function handleList(
       projectForClient(
         s,
         "user",
-        statusFor(manager, mergedConfigKey("user", s)),
+        email ?? "",
+        statusFor(manager, mergedConfigKey("user", s, email ?? "")),
       ),
     ),
     org: orgServers.map((s) =>
-      projectForClient(s, "org", statusFor(manager, mergedConfigKey("org", s))),
+      projectForClient(
+        s,
+        "org",
+        orgId ?? "",
+        statusFor(manager, mergedConfigKey("org", s, orgId ?? "")),
+      ),
     ),
     orgId,
     role,
@@ -311,12 +325,13 @@ async function handleAdd(event: H3Event, manager: McpClientManager) {
   }
 
   await reconfigureManager(manager);
-  const mergedId = mergedConfigKey(scope, result.server);
+  const mergedId = mergedConfigKey(scope, result.server, scopeId);
   return {
     ok: true,
     server: projectForClient(
       result.server,
       scope,
+      scopeId,
       statusFor(manager, mergedId),
     ),
   };

--- a/packages/core/src/mcp-client/visibility.ts
+++ b/packages/core/src/mcp-client/visibility.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-request visibility gate for MCP tools.
+ *
+ * In a shared-process deployment (one Nitro server handling multiple users)
+ * every user's personal MCP servers are registered in the same manager. We
+ * want the LLM and the tool-call path to behave as if each user only has
+ * their own — no cross-user credential use, no tools from other orgs.
+ *
+ * Separated from `./index.ts` (which imports `ActionEntry` from
+ * `production-agent.js`) so `production-agent.js` can pull in this filter
+ * without a circular import.
+ */
+import {
+  getRequestUserEmail,
+  getRequestOrgId,
+} from "../server/request-context.js";
+import { parseMergedKey, hashEmail } from "./remote-store.js";
+
+/**
+ * Guard MCP tools against cross-user access in shared-process deployments.
+ *
+ * - Tools with no merged-key prefix (e.g. `mcp__claude-in-chrome__navigate`
+ *   from a file-based stdio config) are visible to everyone — those are
+ *   process-wide by design.
+ * - User-scope tools are only visible to the user whose email hashes to the
+ *   tool's owner component.
+ * - Org-scope tools are only visible to requests whose active org matches.
+ *
+ * Falls back to "visible" when there is no request context (CLI scripts,
+ * startup-time tool enumeration) — the runtime gate in `mcpToolToActionEntry`
+ * still prevents execution from a mismatched request.
+ */
+export function isMcpToolAllowedForRequest(toolName: string): boolean {
+  const parsed = parseMergedKey(toolName);
+  if (!parsed) return true;
+  const email = getRequestUserEmail();
+  const orgId = getRequestOrgId();
+  if (parsed.scope === "user") {
+    if (!email) return true; // no context → leave the runtime gate to block
+    return hashEmail(email) === parsed.owner;
+  }
+  // scope === "org"
+  if (!orgId) return true;
+  return orgId.toLowerCase().replace(/[^a-z0-9-]/g, "-") === parsed.owner;
+}

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -27,7 +27,10 @@ import {
   mcpToolsToActionEntries,
   syncMcpActionEntries,
   mountMcpServersRoutes,
+  mountMcpHubRoutes,
   buildMergedConfig,
+  getHubStatus,
+  isHubServeEnabled,
 } from "../mcp-client/index.js";
 import { discoverAgents } from "./agent-discovery.js";
 import { loadSchemaPromptBlock } from "./schema-prompt.js";
@@ -1767,6 +1770,22 @@ export function createAgentChatPlugin(
     // remove remote MCP servers and hot-reload the running manager.
     mountMcpStatusRoute(nitroApp, mcpManager);
     mountMcpServersRoutes(nitroApp, mcpManager);
+    // Hub-serve: expose org-scope servers to other agent-native apps in the
+    // workspace when `AGENT_NATIVE_MCP_HUB_TOKEN` is set (dispatch, by
+    // convention). Gated by the env var so mounting is a no-op otherwise.
+    if (isHubServeEnabled()) {
+      mountMcpHubRoutes(nitroApp);
+      console.log(
+        "[mcp-client] hub serve enabled — other apps can pull org servers via /_agent-native/mcp/hub/servers",
+      );
+    }
+    const hubStatus = getHubStatus();
+    if (hubStatus.consuming) {
+      console.log(
+        `[mcp-client] hub consume enabled — pulling from ${hubStatus.hubUrl}`,
+      );
+    }
+    mountMcpHubStatusRoute(nitroApp);
 
     // Ensure we tear down child processes if the host shuts down cleanly.
     if (
@@ -3470,6 +3489,28 @@ function setGlobalMcpManager(manager: McpClientManager): void {
 /** Internal: access the current process's MCP client manager, if any. */
 export function getGlobalMcpManager(): McpClientManager | null {
   return _globalMcpManager;
+}
+
+function mountMcpHubStatusRoute(nitroApp: any): void {
+  if ((globalThis as any).__agentNativeMcpHubStatusMounted) return;
+  (globalThis as any).__agentNativeMcpHubStatusMounted = true;
+  try {
+    getH3App(nitroApp).use(
+      "/_agent-native/mcp/hub/status",
+      defineEventHandler(async (event) => {
+        if (getMethod(event) !== "GET") {
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
+        setResponseHeader(event, "Content-Type", "application/json");
+        return getHubStatus();
+      }),
+    );
+  } catch (err: any) {
+    console.warn(
+      `[mcp-client] Failed to mount /_agent-native/mcp/hub/status: ${err?.message ?? err}`,
+    );
+  }
 }
 
 function mountMcpStatusRoute(nitroApp: any, manager: McpClientManager): void {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -25,6 +25,9 @@ import {
   loadMcpConfig,
   autoDetectMcpConfig,
   mcpToolsToActionEntries,
+  syncMcpActionEntries,
+  mountMcpServersRoutes,
+  buildMergedConfig,
 } from "../mcp-client/index.js";
 import { discoverAgents } from "./agent-discovery.js";
 import { loadSchemaPromptBlock } from "./schema-prompt.js";
@@ -1721,25 +1724,32 @@ export function createAgentChatPlugin(
     // function means "the user currently has dev mode ON" (live).
     const isDevMode = () => currentDevMode;
 
-    // Initialize MCP client (connects to user-configured local MCP servers).
-    // Graceful-degrade: any failure yields zero MCP tools and agent-chat keeps
-    // working as before. No-op outside Node runtimes.
-    let mcpConfig = loadMcpConfig();
+    // Initialize MCP client. Merges file/env config + auto-detected binaries
+    // + any remote servers users have added through the settings UI (persisted
+    // in the settings table, scanned across all scopes so we never drop
+    // another user's entries). Graceful-degrade: any failure yields zero MCP
+    // tools and agent-chat keeps working as before.
+    let mcpConfig = await buildMergedConfig().catch((err) => {
+      console.warn(
+        `[mcp-client] buildMergedConfig failed: ${err?.message ?? err}`,
+      );
+      return null;
+    });
     if (!mcpConfig) {
-      mcpConfig = autoDetectMcpConfig();
-      if (mcpConfig) {
-        const detected = Object.keys(mcpConfig.servers).join(", ");
+      const fileOrEnv = loadMcpConfig() ?? autoDetectMcpConfig();
+      mcpConfig = fileOrEnv;
+      if (mcpConfig?.source) {
         console.log(
-          `[mcp-client] auto-detected ${detected}, registering as MCP server — set AGENT_NATIVE_DISABLE_MCP_AUTODETECT=1 to opt out`,
+          `[mcp-client] loaded config from ${mcpConfig.source} (${Object.keys(mcpConfig.servers).length} server(s))`,
         );
       } else {
         console.log(
-          "[mcp-client] no mcp.config.json and no auto-detectable servers — skipping MCP tools",
+          "[mcp-client] no configured MCP servers — skipping MCP tools",
         );
       }
     } else if (mcpConfig.source) {
       console.log(
-        `[mcp-client] loaded config from ${mcpConfig.source} (${Object.keys(mcpConfig.servers).length} server(s))`,
+        `[mcp-client] merged config (${Object.keys(mcpConfig.servers).length} server(s), source: ${mcpConfig.source})`,
       );
     }
     const mcpManager = new McpClientManager(mcpConfig);
@@ -1753,8 +1763,10 @@ export function createAgentChatPlugin(
     setGlobalMcpManager(mcpManager);
     const mcpActionEntries = mcpToolsToActionEntries(mcpManager);
 
-    // Mount status route so tooling/onboarding can inspect MCP state.
+    // Mount status + management routes so the settings UI can list / add /
+    // remove remote MCP servers and hot-reload the running manager.
     mountMcpStatusRoute(nitroApp, mcpManager);
+    mountMcpServersRoutes(nitroApp, mcpManager);
 
     // Ensure we tear down child processes if the host shuts down cleanly.
     if (
@@ -2415,6 +2427,14 @@ export function createAgentChatPlugin(
       ...mcpActionEntries,
     };
 
+    // Keep the prod action dict's MCP entries in sync when the manager's
+    // server set changes at runtime (e.g. a user adds a remote MCP server
+    // through the settings UI). getEngineTools() in production-agent re-reads
+    // the registry per request, so updates here propagate without restart.
+    mcpManager.onChange(() => {
+      syncMcpActionEntries(mcpManager, prodActions);
+    });
+
     // Always build the production handler (includes resource tools + call-agent + team tools)
     // In production mode (!canToggle), enable usage tracking and limits
     const isHostedProd = !canToggle;
@@ -2509,6 +2529,14 @@ export function createAgentChatPlugin(
             ...mcpActionEntries,
             ...(await createDevScriptRegistry()),
           };
+      // Keep dev action dict in sync with runtime MCP additions. When
+      // leanPrompt is true, devActions === prodActions so the prod listener
+      // already covers it.
+      if (devActions !== prodActions) {
+        mcpManager.onChange(() => {
+          syncMcpActionEntries(mcpManager, devActions);
+        });
+      }
       devHandler = createProductionAgentHandler({
         actions: devActions,
         systemPrompt: async (event: any) => {

--- a/packages/desktop-app/electron-builder.yml
+++ b/packages/desktop-app/electron-builder.yml
@@ -26,13 +26,15 @@ mac:
   target:
     - target: dmg
       arch:
-        - universal
+        - arm64
+        - x64
     - target: zip
       arch:
-        - universal
+        - arm64
+        - x64
 
 dmg:
-  artifactName: ${productName}.${ext}
+  artifactName: ${productName}-${arch}.${ext}
 
 win:
   target:

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/desktop-app",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "main": "out/main/index.js",
   "productName": "Agent Native",

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/desktop-app",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "main": "out/main/index.js",
   "productName": "Agent Native",

--- a/packages/docs/app/routes/download.tsx
+++ b/packages/docs/app/routes/download.tsx
@@ -44,7 +44,7 @@ const PLATFORMS: Record<Platform, PlatformInfo> = {
     icon: <AppleIcon />,
     primary: {
       label: "Download for Mac",
-      href: `${DL}/Agent-Native.dmg`,
+      href: "https://github.com/BuilderIO/agent-native/releases/download/v0.1.3/Agent-Native.dmg",
     },
     note: "Universal binary — works on Apple Silicon and Intel.",
   },


### PR DESCRIPTION
## Summary

- New **MCP Servers** section in the workspace settings panel lets users connect remote (Streamable HTTP) MCP servers — Zapier, Cloudflare, Composio, internal tools — without editing \`mcp.config.json\`.
- Two scopes: **Personal** (per-user) and **Team** (shared across the active org, owner/admin only). Backed by the existing \`settings\` table.
- Hot reload: \`McpClientManager.reconfigure()\` diffs old-vs-new server sets, disconnects removed, connects added. A change listener keeps the agent's action dict in sync so new tools show up on the next message — no restart.
- Works in desktop production mode (HTTP transport needs only \`fetch\`).
- Fixes a separate hardcoded \`"Steve Sewell"\` fallback that landed in \`displayName\` for ShareDialog/ShareButton.

## What changed

- \`mcp-client/config.ts\` — \`McpServerConfig\` is now a discriminated union of \`stdio\` (existing, default) and \`http\` (new, with \`url\` + \`headers\`). Parser handles both shapes.
- \`mcp-client/manager.ts\` — branches on transport type; dynamic-imports \`StreamableHTTPClientTransport\`; \`reconfigure()\` and \`onChange()\` added.
- \`mcp-client/remote-store.ts\` (new) — CRUD helpers backed by \`putUserSetting\` / \`putOrgSetting\`; URL + name validation.
- \`mcp-client/routes.ts\` (new) — \`/_agent-native/mcp/servers\` (GET/POST/DELETE) + test endpoints, role-gated for org scope.
- \`client/settings/McpServersSection.tsx\` (new) + \`SettingsPanel.tsx\` — Personal / Team tabs, add form with optional Bearer token, remove + test buttons.
- \`agent/production-agent.ts\` — engine tools are now derived per request so runtime-added MCP tools reach the LLM.
- \`agent-chat-plugin.ts\` — merges file/env/DB-stored configs on startup, mounts routes, subscribes action dicts to onChange.
- \`docs/content/mcp-clients.md\` — new "Remote MCP servers via the settings UI" section.

## Test plan

- [ ] Open Settings → MCP Servers, switch between Personal and Team tabs
- [ ] Add a remote MCP server (Zapier / local inspector over http://localhost)
- [ ] Confirm tool count appears and agent can call an \`mcp__<scope>-<name>__*\` tool
- [ ] As a \`member\` role, confirm org Add button is disabled + POST returns 403
- [ ] Remove a server, confirm it disappears from \`/_agent-native/mcp/status\`
- [ ] Restart app, confirm servers persist and reload
- [ ] Confirm existing \`mcp.config.json\` + auto-detected \`claude-in-chrome\` still load