### PR TITLE
updates-124: mcp hub scope fix + create-workspace UX polish

### DIFF
--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -89,6 +89,16 @@ async function createWorkspaceInteractive(
 
   name = await promptNameIfMissing(name, clack, "workspace", "my-platform");
 
+  clack.note(
+    [
+      "A workspace is a monorepo that holds one or more apps sharing auth,",
+      "database, and the agent chat. Pick as many as you want — you can add",
+      "more later with `agent-native add-app`. Starter is a minimal scaffold,",
+      "useful as a blank app to build from scratch alongside the others.",
+    ].join("\n"),
+    "About workspaces",
+  );
+
   // Multi-select picker for apps to include.
   const preselected = parseTemplateList(opts?.template);
   const templates = await promptTemplatePicker(preselected, clack);
@@ -505,8 +515,9 @@ async function promptTemplatePicker(
         ? ["starter"]
         : [];
 
+  const baseMessage = opts?.message ?? "Which apps would you like to include?";
   const result = await clack.multiselect({
-    message: opts?.message ?? "Which apps would you like to include?",
+    message: `${baseMessage}\n  (↑/↓ move · space to toggle · enter to confirm)`,
     options,
     initialValues: defaults,
     required: false,

--- a/packages/core/src/mcp-client/hub-client.spec.ts
+++ b/packages/core/src/mcp-client/hub-client.spec.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetHubCacheForTests,
+  fetchHubServersDetailed,
+} from "./hub-client.js";
+
+// Minimal fake fetch response.
+function ok(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+function errStatus(status: number): Response {
+  return new Response("", { status });
+}
+
+describe("fetchHubServersDetailed", () => {
+  const prevUrl = process.env.AGENT_NATIVE_MCP_HUB_URL;
+  const prevToken = process.env.AGENT_NATIVE_MCP_HUB_TOKEN;
+
+  beforeEach(() => {
+    process.env.AGENT_NATIVE_MCP_HUB_URL = "https://hub.example";
+    process.env.AGENT_NATIVE_MCP_HUB_TOKEN = "token";
+    _resetHubCacheForTests();
+  });
+
+  afterEach(() => {
+    if (prevUrl === undefined) delete process.env.AGENT_NATIVE_MCP_HUB_URL;
+    else process.env.AGENT_NATIVE_MCP_HUB_URL = prevUrl;
+    if (prevToken === undefined) delete process.env.AGENT_NATIVE_MCP_HUB_TOKEN;
+    else process.env.AGENT_NATIVE_MCP_HUB_TOKEN = prevToken;
+    vi.restoreAllMocks();
+    _resetHubCacheForTests();
+  });
+
+  it("normalizes orgId in the merged key so mixed-case hub orgs pass the visibility gate", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      ok({
+        servers: [
+          {
+            orgId: "ACME-Corp",
+            name: "zapier",
+            url: "https://zapier.example",
+          },
+        ],
+      }),
+    );
+    const result = await fetchHubServersDetailed();
+    expect(result.state).toBe("ok");
+    if (result.state !== "ok") return;
+    // Key must be lowercased + symbol-stripped to match the normalization
+    // in `isMcpToolAllowedForRequest()` in visibility.ts.
+    expect(Object.keys(result.servers)).toEqual(["hub_acme-corp_zapier"]);
+  });
+
+  it("keeps cached servers across a transient 5xx", async () => {
+    const good = ok({
+      servers: [
+        { orgId: "acme", name: "zapier", url: "https://zapier.example" },
+      ],
+    });
+    const bad = errStatus(503);
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(good)
+      .mockResolvedValueOnce(bad);
+
+    const first = await fetchHubServersDetailed();
+    expect(first.state).toBe("ok");
+
+    const second = await fetchHubServersDetailed();
+    expect(second.state).toBe("unreachable");
+    if (second.state !== "unreachable") return;
+    // Cache served across the transient failure.
+    expect(Object.keys(second.servers)).toEqual(["hub_acme_zapier"]);
+  });
+
+  it("clears cached servers on a 401 so a rotated/revoked hub token actually revokes access", async () => {
+    const good = ok({
+      servers: [
+        { orgId: "acme", name: "zapier", url: "https://zapier.example" },
+      ],
+    });
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(good)
+      .mockResolvedValueOnce(errStatus(401));
+
+    const first = await fetchHubServersDetailed();
+    expect(first.state).toBe("ok");
+
+    const second = await fetchHubServersDetailed();
+    expect(second.state).toBe("unreachable");
+    if (second.state !== "unreachable") return;
+    // Auth error must NOT fall back to the cached set.
+    expect(Object.keys(second.servers)).toEqual([]);
+  });
+
+  it("clears cached servers on a 403 (forbidden) for the same reason as 401", async () => {
+    const good = ok({
+      servers: [
+        { orgId: "acme", name: "zapier", url: "https://zapier.example" },
+      ],
+    });
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(good)
+      .mockResolvedValueOnce(errStatus(403));
+
+    await fetchHubServersDetailed();
+    const second = await fetchHubServersDetailed();
+    expect(second.state).toBe("unreachable");
+    if (second.state !== "unreachable") return;
+    expect(Object.keys(second.servers)).toEqual([]);
+  });
+});

--- a/packages/core/src/mcp-client/hub-client.ts
+++ b/packages/core/src/mcp-client/hub-client.ts
@@ -16,10 +16,21 @@ import { isHubConsumeEnabled } from "./hub-routes.js";
 
 const FETCH_TIMEOUT_MS = 5_000;
 
+/**
+ * Normalize an orgId to the canonical form used by the visibility gate.
+ * Must match `isMcpToolAllowedForRequest()` in `visibility.ts` — otherwise
+ * a hub server published under "ACME-Corp" would build a key
+ * `hub_ACME-Corp_...` that can never match a request whose active org is
+ * normalized to "acme-corp", and the tool would be invisible to everyone.
+ */
+function normalizeOrgId(orgId: string): string {
+  return orgId.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+}
+
 /** Merged-config key prefix for hub-sourced servers — avoids collision with
  * the consuming app's own `org_<orgId>_<name>` entries. */
 function hubMergedKey(orgId: string, name: string): string {
-  return `hub_${orgId}_${name}`;
+  return `hub_${normalizeOrgId(orgId)}_${name}`;
 }
 
 /**
@@ -80,6 +91,24 @@ export async function fetchHubServersDetailed(): Promise<HubFetchResult> {
 
   if (!res.ok) {
     const msg = `hub returned ${res.status}`;
+    // Auth / config errors (401 unauthorized, 403 forbidden, 404 misconfig)
+    // must NOT fall back to the cached set — if the hub is deliberately
+    // revoking access (e.g. a rotated token), keeping servers in the
+    // manager would leave revoked tools callable until process restart.
+    // Transient errors (408 timeout, 429 rate limit, 5xx) are retryable,
+    // so for those we keep serving the last-known-good set.
+    const isAuthOrConfigError =
+      res.status === 401 ||
+      res.status === 403 ||
+      res.status === 404 ||
+      res.status === 410;
+    if (isAuthOrConfigError) {
+      console.warn(
+        `[mcp-client] hub fetch returned ${res.status} from ${url} — clearing cached servers`,
+      );
+      lastGoodServers = null;
+      return { state: "unreachable", servers: {}, error: msg };
+    }
     console.warn(
       `[mcp-client] hub fetch returned ${res.status} from ${url} — keeping last-known-good set`,
     );

--- a/packages/core/src/mcp-client/hub-client.ts
+++ b/packages/core/src/mcp-client/hub-client.ts
@@ -23,18 +23,35 @@ function hubMergedKey(orgId: string, name: string): string {
 }
 
 /**
- * Fetch the remote hub's org-scope servers and return them keyed by the
- * `hub_<orgId>_<name>` merged-key shape that `McpClientManager` consumes.
- *
- * Returns an empty object when hub consume isn't enabled or the call fails.
+ * Last successful fetch, cached in-memory. A transient hub outage during a
+ * local reconfigure() call must NOT wipe loaded hub servers from the running
+ * MCP manager — we keep serving the last good snapshot until the hub is
+ * reachable again.
  */
-export async function fetchHubServers(): Promise<
-  Record<string, McpServerConfig>
-> {
-  if (!isHubConsumeEnabled()) return {};
+let lastGoodServers: Record<string, McpServerConfig> | null = null;
+
+export type HubFetchResult =
+  | { state: "disabled" }
+  | { state: "ok"; servers: Record<string, McpServerConfig> }
+  | {
+      state: "unreachable";
+      /** Last-known-good servers if we have them, otherwise an empty map. */
+      servers: Record<string, McpServerConfig>;
+      error: string;
+    };
+
+/**
+ * Fetch the remote hub's org-scope servers. Returns a tri-state so callers
+ * can distinguish "hub said empty" from "hub is unreachable" and keep the
+ * last-known-good set live across transient failures.
+ */
+export async function fetchHubServersDetailed(): Promise<HubFetchResult> {
+  if (!isHubConsumeEnabled()) return { state: "disabled" };
   const base = process.env.AGENT_NATIVE_MCP_HUB_URL!.trim();
   const token = process.env.AGENT_NATIVE_MCP_HUB_TOKEN!.trim();
   const url = joinUrl(base, "/_agent-native/mcp/hub/servers");
+
+  const fallbackServers = lastGoodServers ?? {};
 
   let res: Response;
   try {
@@ -56,29 +73,34 @@ export async function fetchHubServers(): Promise<
       if (timeout) clearTimeout(timeout);
     }
   } catch (err: any) {
-    console.warn(
-      `[mcp-client] hub fetch failed (${url}): ${err?.message ?? err}`,
-    );
-    return {};
+    const msg = err?.message ?? String(err);
+    console.warn(`[mcp-client] hub fetch failed (${url}): ${msg}`);
+    return { state: "unreachable", servers: fallbackServers, error: msg };
   }
 
   if (!res.ok) {
+    const msg = `hub returned ${res.status}`;
     console.warn(
-      `[mcp-client] hub fetch returned ${res.status} from ${url} — ignoring hub servers`,
+      `[mcp-client] hub fetch returned ${res.status} from ${url} — keeping last-known-good set`,
     );
-    return {};
+    return { state: "unreachable", servers: fallbackServers, error: msg };
   }
 
   let body: HubServersResponse;
   try {
     body = (await res.json()) as HubServersResponse;
   } catch (err: any) {
-    console.warn(
-      `[mcp-client] hub response was not JSON: ${err?.message ?? err}`,
-    );
-    return {};
+    const msg = err?.message ?? String(err);
+    console.warn(`[mcp-client] hub response was not JSON: ${msg}`);
+    return { state: "unreachable", servers: fallbackServers, error: msg };
   }
-  if (!body || !Array.isArray(body.servers)) return {};
+  if (!body || !Array.isArray(body.servers)) {
+    return {
+      state: "unreachable",
+      servers: fallbackServers,
+      error: "malformed hub response",
+    };
+  }
 
   const out: Record<string, McpServerConfig> = {};
   for (const s of body.servers) {
@@ -92,7 +114,26 @@ export async function fetchHubServers(): Promise<
     };
     out[hubMergedKey(s.orgId, s.name)] = cfg;
   }
-  return out;
+  lastGoodServers = out;
+  return { state: "ok", servers: out };
+}
+
+/**
+ * Back-compat convenience that always returns a server map. On unreachable,
+ * callers get the last-known-good set (empty on first-fetch failure) so one
+ * flaky hub call can't wipe loaded servers from the running manager.
+ */
+export async function fetchHubServers(): Promise<
+  Record<string, McpServerConfig>
+> {
+  const result = await fetchHubServersDetailed();
+  if (result.state === "disabled") return {};
+  return result.servers;
+}
+
+/** Reset the in-memory cache. Exposed for tests only. */
+export function _resetHubCacheForTests(): void {
+  lastGoodServers = null;
 }
 
 function joinUrl(base: string, path: string): string {

--- a/packages/core/src/mcp-client/remote-store.ts
+++ b/packages/core/src/mcp-client/remote-store.ts
@@ -245,6 +245,11 @@ export function mergedConfigKey(
  * `mcp__user_abcd1234ef_zapier__run-task`) back into its scope + owner + name
  * components. Returns null for non-merged keys (e.g. stdio file-config servers
  * like `claude-in-chrome`) so callers can treat them as always-visible.
+ *
+ * `hub_<orgId>_<name>` entries (pulled from a remote hub via
+ * `hub-client.ts`) project to `scope: "org"` so they pass through the same
+ * per-request visibility gate as locally-stored org servers — the tool is
+ * only visible to requests whose active org matches the hub entry's org.
  */
 export function parseMergedKey(
   keyOrToolName: string,
@@ -255,10 +260,14 @@ export function parseMergedKey(
     const idx = rest.indexOf("__");
     key = idx >= 0 ? rest.slice(0, idx) : rest;
   }
-  const m = /^(user|org)_([^_]+)_(.+)$/.exec(key);
+  const m = /^(user|org|hub)_([^_]+)_(.+)$/.exec(key);
   if (!m) return null;
+  const prefix = m[1];
+  // Hub-sourced servers are scoped to the org they came from — treat them
+  // as org-scope for visibility purposes (see isMcpToolAllowedForRequest).
+  const scope: RemoteMcpScope = prefix === "user" ? "user" : "org";
   return {
-    scope: m[1] as RemoteMcpScope,
+    scope,
     owner: m[2],
     name: m[3],
   };

--- a/packages/core/src/mcp-client/visibility.spec.ts
+++ b/packages/core/src/mcp-client/visibility.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { parseMergedKey } from "./remote-store.js";
+import { isMcpToolAllowedForRequest } from "./visibility.js";
+import { runWithRequestContext } from "../server/request-context.js";
+import { hashEmail } from "./remote-store.js";
+
+describe("parseMergedKey", () => {
+  it("parses user-scope keys", () => {
+    expect(parseMergedKey("user_ab12cd34ef_zapier")).toEqual({
+      scope: "user",
+      owner: "ab12cd34ef",
+      name: "zapier",
+    });
+  });
+
+  it("parses org-scope keys", () => {
+    expect(parseMergedKey("org_acme123_zapier")).toEqual({
+      scope: "org",
+      owner: "acme123",
+      name: "zapier",
+    });
+  });
+
+  it("projects hub-sourced keys to org scope so they pass through the same visibility gate", () => {
+    expect(parseMergedKey("hub_acme123_zapier")).toEqual({
+      scope: "org",
+      owner: "acme123",
+      name: "zapier",
+    });
+  });
+
+  it("strips the mcp__ prefix + tool name first", () => {
+    expect(parseMergedKey("mcp__hub_acme123_zapier__run-task")).toEqual({
+      scope: "org",
+      owner: "acme123",
+      name: "zapier",
+    });
+  });
+
+  it("returns null for non-merged keys (e.g. file-config stdio servers)", () => {
+    expect(parseMergedKey("claude-in-chrome")).toBeNull();
+    expect(parseMergedKey("mcp__claude-in-chrome__navigate")).toBeNull();
+  });
+});
+
+describe("isMcpToolAllowedForRequest — hub tools must not bypass the org gate", () => {
+  it("blocks a hub-sourced tool from a different org than the active request", async () => {
+    await runWithRequestContext(
+      { userEmail: "alice@acme.com", orgId: "acme" },
+      async () => {
+        expect(isMcpToolAllowedForRequest("mcp__hub_beta_zapier__run")).toBe(
+          false,
+        );
+      },
+    );
+  });
+
+  it("allows a hub-sourced tool from the active request's org", async () => {
+    await runWithRequestContext(
+      { userEmail: "alice@acme.com", orgId: "acme" },
+      async () => {
+        expect(isMcpToolAllowedForRequest("mcp__hub_acme_zapier__run")).toBe(
+          true,
+        );
+      },
+    );
+  });
+
+  it("still allows personal user-scope tools for the matching user", async () => {
+    const hash = hashEmail("alice@acme.com");
+    await runWithRequestContext(
+      { userEmail: "alice@acme.com", orgId: "acme" },
+      async () => {
+        expect(
+          isMcpToolAllowedForRequest(`mcp__user_${hash}_zapier__run`),
+        ).toBe(true);
+      },
+    );
+  });
+});
+
+afterEach(() => {
+  // No-op placeholder for future per-test cleanup.
+});

--- a/packages/docs/public/docs/creating-templates.md
+++ b/packages/docs/public/docs/creating-templates.md
@@ -209,7 +209,7 @@ Keep your data models simple — flat JSON files, one per entity. The agent can 
 
 This is the most important file in your template. `AGENTS.md` tells the AI agent how your app works, what it can and can't do, and how to make changes:
 
-````markdown
+```markdown
 # My Template — Agent-Native App
 
 ## Architecture
@@ -226,12 +226,10 @@ This is an **@agent-native/core** application.
 
 ### Directory Structure
 
-```
-app/             # React frontend (file-based routing in app/routes/)
-server/          # Nitro API server
-actions/         # Agent-callable actions
-data/            # File-based state
-```
+    app/             # React frontend (file-based routing in app/routes/)
+    server/          # Nitro API server
+    actions/         # Agent-callable actions
+    data/            # File-based state
 
 ### Available Actions
 
@@ -242,16 +240,16 @@ data/            # File-based state
 
 Items are stored as `data/items/<id>.json`:
 
-```json
-{ "id": "...", "title": "...", "status": "active" }
-```
+    { "id": "...", "title": "...", "status": "active" }
 
 ### Key Patterns
 
 - API routes in `server/routes/` serve files from `data/`
 - UI delegates AI work via `sendToAgentChat()`
 - Actions write results to `data/` — SSE updates the UI
-````
+```
+
+> Code blocks inside `AGENTS.md` would normally be fenced with triple backticks — they're shown as indented code here to keep this outer example readable.
 
 Be specific about your data models, available actions, and key patterns. The better your `AGENTS.md`, the better the agent will work with your template.
 

--- a/packages/docs/public/docs/integrations.md
+++ b/packages/docs/public/docs/integrations.md
@@ -63,7 +63,7 @@ Subscribe to the `message.im` bot event (and optionally `app_mention` for channe
 
 ### 3. Set environment variables
 
-```
+```bash
 SLACK_BOT_TOKEN=xoxb-your-bot-token
 SLACK_SIGNING_SECRET=your-signing-secret
 ```
@@ -78,7 +78,7 @@ Message [@BotFather](https://t.me/BotFather) on Telegram and use the `/newbot` c
 
 ### 2. Set environment variables
 
-```
+```bash
 TELEGRAM_BOT_TOKEN=your-bot-token
 ```
 
@@ -104,7 +104,7 @@ Go to the [Meta Developer Portal](https://developers.facebook.com/), create an a
 
 ### 2. Set environment variables
 
-```
+```bash
 WHATSAPP_ACCESS_TOKEN=your-access-token
 WHATSAPP_VERIFY_TOKEN=your-verify-token
 WHATSAPP_PHONE_NUMBER_ID=your-phone-number-id

--- a/packages/docs/public/docs/resources.md
+++ b/packages/docs/public/docs/resources.md
@@ -137,7 +137,7 @@ Use custom agents for delegation within one app. Use connected agents when you n
 
 Skills are Markdown files with optional YAML frontmatter for metadata:
 
-````markdown
+```markdown
 ---
 name: data-analysis
 description: BigQuery queries, data transforms, and visualization
@@ -157,11 +157,11 @@ Use this skill when the user asks about data, queries, or analytics.
 
 ## Patterns
 
-```sql
--- Standard BigQuery date filter
-WHERE DATE(created_at) BETWEEN @start_date AND @end_date
+    -- Standard BigQuery date filter
+    WHERE DATE(created_at) BETWEEN @start_date AND @end_date
 ```
-````
+
+> Skill bodies can embed fenced code blocks in any language — shown above as indented code to keep this outer example readable, but you'd normally use a language-tagged fence in your real skill file.
 
 ## @ Tagging {#at-tagging}
 

--- a/packages/docs/public/docs/resources.md
+++ b/packages/docs/public/docs/resources.md
@@ -44,19 +44,22 @@ At the start of every conversation, the agent automatically reads:
 
 A shared resource seeded by default. It contains custom instructions, preferences, and skill references. Edit this to change how the agent behaves for all users — tone, rules, domain context, and which skills to use.
 
-```text
+```markdown
 # Agent Instructions
 
 ## Tone
+
 Be concise. Lead with the answer.
 
 ## Code style
+
 - Use TypeScript, never JavaScript
 - Prefer named exports
 
 ## Skills
-| Skill | Path | Description |
-|-------|------|-------------|
+
+| Skill         | Path                      | Description                 |
+| ------------- | ------------------------- | --------------------------- |
 | data-analysis | `skills/data-analysis.md` | BigQuery and data workflows |
 ```
 
@@ -134,7 +137,7 @@ Use custom agents for delegation within one app. Use connected agents when you n
 
 Skills are Markdown files with optional YAML frontmatter for metadata:
 
-````text
+````markdown
 ---
 name: data-analysis
 description: BigQuery queries, data transforms, and visualization
@@ -143,19 +146,21 @@ description: BigQuery queries, data transforms, and visualization
 # Data Analysis
 
 ## When to use
+
 Use this skill when the user asks about data, queries, or analytics.
 
 ## Rules
+
 - Always validate SQL before executing
 - Prefer CTEs over subqueries
 - Include LIMIT on exploratory queries
 
 ## Patterns
+
 ```sql
 -- Standard BigQuery date filter
 WHERE DATE(created_at) BETWEEN @start_date AND @end_date
-````
-
+```
 ````
 
 ## @ Tagging {#at-tagging}
@@ -188,13 +193,13 @@ If no skills are configured, the dropdown shows a hint with a link to these docs
 
 The resource system works identically in both modes. The difference is what additional sources are available for `@` tagging and `/` commands:
 
-| Feature | Dev Mode | Production |
-|---------|----------|------------|
-| @ tagging | Codebase files + workspace resources + custom agents + connected agents | Workspace resources + custom agents + connected agents |
-| / slash commands | .agents/skills/ + resource skills | Resource skills only |
-| Agent file access | Filesystem + resources | Resources only |
-| Workspace panel | Full access | Full access |
-| AGENTS.md / learnings.md | Available | Available |
+| Feature                  | Dev Mode                                                                | Production                                             |
+| ------------------------ | ----------------------------------------------------------------------- | ------------------------------------------------------ |
+| @ tagging                | Codebase files + workspace resources + custom agents + connected agents | Workspace resources + custom agents + connected agents |
+| / slash commands         | .agents/skills/ + resource skills                                       | Resource skills only                                   |
+| Agent file access        | Filesystem + resources                                                  | Resources only                                         |
+| Workspace panel          | Full access                                                             | Full access                                            |
+| AGENTS.md / learnings.md | Available                                                               | Available                                              |
 
 ## Resource API {#resource-api}
 
@@ -204,15 +209,15 @@ Resources can be managed from server code, actions, or the REST API.
 
 REST endpoints mounted automatically:
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/_agent-native/resources?scope=all` | List resources |
-| `GET` | `/_agent-native/resources/tree?scope=all` | Get folder tree |
-| `POST` | `/_agent-native/resources` | Create a resource |
-| `GET` | `/_agent-native/resources/:id` | Get resource with content |
-| `PUT` | `/_agent-native/resources/:id` | Update a resource |
-| `DELETE` | `/_agent-native/resources/:id` | Delete a resource |
-| `POST` | `/_agent-native/resources/upload` | Upload a file as resource |
+| Method   | Endpoint                                  | Description               |
+| -------- | ----------------------------------------- | ------------------------- |
+| `GET`    | `/_agent-native/resources?scope=all`      | List resources            |
+| `GET`    | `/_agent-native/resources/tree?scope=all` | Get folder tree           |
+| `POST`   | `/_agent-native/resources`                | Create a resource         |
+| `GET`    | `/_agent-native/resources/:id`            | Get resource with content |
+| `PUT`    | `/_agent-native/resources/:id`            | Update a resource         |
+| `DELETE` | `/_agent-native/resources/:id`            | Delete a resource         |
+| `POST`   | `/_agent-native/resources/upload`         | Upload a file as resource |
 
 ### Action API {#script-api}
 
@@ -230,4 +235,4 @@ pnpm action resource-write --path "notes/meeting.md" --content "# Meeting Notes.
 
 # Delete a resource
 pnpm action resource-delete --path "notes/old.md"
-````
+```


### PR DESCRIPTION
## Summary

Three commits on this branch:

- **mcp hub scope fix** (`e6a48560`) — follow-ups from review bot on #234:
  - **Critical**: `hub_<orgId>_<name>` tool keys bypassed `isMcpToolAllowedForRequest()` because `parseMergedKey()` only recognized `user_/org_` prefixes. Any user in any org could see/call any hub-sourced tool. Extended `parseMergedKey` to project hub keys to `scope:"org"` so they flow through the same org-visibility gate.
  - **Medium**: `buildMergedConfig()` dropped all hub servers whenever `fetchHubServers()` failed (e.g. transient network hiccup during a local UI mutation), because `reconfigure()` saw them as "removed" and disconnected them. Added an in-memory last-known-good cache in `hub-client` and a tri-state `{ disabled | ok | unreachable }` result so callers keep serving the cached set across outages.
  - Unit tests lock in the visibility rule for hub / user / org keys.

- **cli/create UX polish** (`18cd75ca`) — workspace-create flow:
  - Adds a short explainer note about what a workspace is and that apps can be added later via `agent-native add-app`.
  - Adds a key-hint line under the multi-select prompt (↑/↓ move · space to toggle · enter to confirm).

- **docs code-block languages** (`aa46e25b`) — `/docs/resources` + `/docs/integrations`:
  - Two blocks on `/docs/resources` tagged `text` (no Shiki highlighting) switched to `markdown` — they contain actual markdown (AGENTS.md + skill-file examples).
  - Fixed a malformed 4-tick fence that was wrapping the whole "@ Tagging", "Slash Commands", "Dev vs Production", and "Resource API" sections as one giant plain `<pre>` block (the source of the "different background" in a couple of blocks).
  - Three no-language env-var blocks on `/docs/integrations` (Slack / Telegram / WhatsApp) → tagged `bash` so `KEY=value` lines get Shiki coloring like the rest of the page.

## Test plan

- [ ] Cross-org hub tool visibility test: a user in org A cannot list/call hub tools published to org B.
- [ ] Simulate transient hub outage (block `fetchHubServers`): confirm locally-connected hub servers stay connected and the client keeps serving their tools.
- [ ] Run `agent-native create` and confirm the new explainer + key-hint render cleanly in the TTY.
- [ ] Load `/docs/resources` — confirm all three visible code blocks have the same background and proper coloring (markdown syntax on the AGENTS.md + skill examples).
- [ ] Load `/docs/integrations` — env-var blocks should look consistent with the rest of the page's code blocks.
- [ ] CI green (local prep passed).