### PR TITLE
core: bump to 0.7.5

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump `@agent-native/core` from 0.7.4 → 0.7.5 so the GH Actions release workflow can publish a new version.

## Test plan
- [ ] CI green
- [ ] Release workflow publishes 0.7.5 to npm on merge