### PR TITLE
updates-128: address PR #241 feedback (core race + mail security)

### DIFF
--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -3,6 +3,40 @@ import { emitChatThreadChange } from "./emitter.js";
 
 let _initPromise: Promise<void> | undefined;
 
+/**
+ * Per-thread async mutex. Read-modify-write on the `thread_data` JSON blob
+ * is not atomic at the DB level — two concurrent callers (e.g. the UI
+ * persisting queued messages while `onRunComplete` appends agent output)
+ * would both read the same row, each mutate it independently, and the
+ * second write clobbers the first. Serializing on thread id inside this
+ * process eliminates the race for the usual single-process deployment
+ * while leaving straight reads and other thread-data-unrelated updates
+ * untouched.
+ *
+ * Cross-process races (multiple Node replicas writing the same thread at
+ * the same instant) are not fixed here — acceptable for `thread_data`
+ * today because writes come from either the user's own tab or an agent
+ * run owned by that user, which run in one place at a time.
+ */
+const _threadDataLocks = new Map<string, Promise<unknown>>();
+
+export function withThreadDataLock<T>(
+  threadId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prev = _threadDataLocks.get(threadId) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  _threadDataLocks.set(
+    threadId,
+    next.finally(() => {
+      if (_threadDataLocks.get(threadId) === next) {
+        _threadDataLocks.delete(threadId);
+      }
+    }),
+  );
+  return next as Promise<T>;
+}
+
 async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
@@ -184,20 +218,22 @@ export async function setThreadEngineMeta(
   threadId: string,
   meta: ThreadEngineMeta,
 ): Promise<void> {
-  const thread = await getThread(threadId);
-  if (!thread) return;
-  let data: Record<string, unknown> = {};
-  try {
-    data = JSON.parse(thread.threadData);
-  } catch {}
-  data.engineMeta = meta;
-  await updateThreadData(
-    threadId,
-    JSON.stringify(data),
-    thread.title,
-    thread.preview,
-    thread.messageCount,
-  );
+  return withThreadDataLock(threadId, async () => {
+    const thread = await getThread(threadId);
+    if (!thread) return;
+    let data: Record<string, unknown> = {};
+    try {
+      data = JSON.parse(thread.threadData);
+    } catch {}
+    data.engineMeta = meta;
+    await updateThreadData(
+      threadId,
+      JSON.stringify(data),
+      thread.title,
+      thread.preview,
+      thread.messageCount,
+    );
+  });
 }
 
 export interface QueuedMessage {
@@ -216,24 +252,26 @@ export async function setThreadQueuedMessages(
   threadId: string,
   queuedMessages: QueuedMessage[],
 ): Promise<void> {
-  const thread = await getThread(threadId);
-  if (!thread) return;
-  let data: Record<string, unknown> = {};
-  try {
-    data = JSON.parse(thread.threadData);
-  } catch {}
-  if (queuedMessages.length === 0) {
-    delete data.queuedMessages;
-  } else {
-    data.queuedMessages = queuedMessages;
-  }
-  await updateThreadData(
-    threadId,
-    JSON.stringify(data),
-    thread.title,
-    thread.preview,
-    thread.messageCount,
-  );
+  return withThreadDataLock(threadId, async () => {
+    const thread = await getThread(threadId);
+    if (!thread) return;
+    let data: Record<string, unknown> = {};
+    try {
+      data = JSON.parse(thread.threadData);
+    } catch {}
+    if (queuedMessages.length === 0) {
+      delete data.queuedMessages;
+    } else {
+      data.queuedMessages = queuedMessages;
+    }
+    await updateThreadData(
+      threadId,
+      JSON.stringify(data),
+      thread.title,
+      thread.preview,
+      thread.messageCount,
+    );
+  });
 }
 
 export async function deleteThread(id: string): Promise<boolean> {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -55,6 +55,7 @@ import {
   listThreads,
   searchThreads,
   updateThreadData,
+  withThreadDataLock,
   deleteThread,
   setThreadQueuedMessages,
 } from "../chat-threads/store.js";
@@ -2316,83 +2317,93 @@ export function createAgentChatPlugin(
     // Reconstructs the assistant message from buffered events and appends to thread_data.
     const onRunComplete = async (run: any, threadId: string | undefined) => {
       if (!threadId) return;
-      try {
-        const thread = await getThread(threadId);
-        if (!thread) return;
-
-        const assistantMsg = buildAssistantMessage(run.events ?? [], run.runId);
-        if (!assistantMsg) {
-          // No content produced — just bump timestamp
-          await updateThreadData(
-            threadId,
-            thread.threadData,
-            thread.title,
-            thread.preview,
-            thread.messageCount,
-          );
-          return;
-        }
-
-        // Parse existing thread_data, append assistant message only if
-        // the frontend hasn't already saved it (avoids duplicates when
-        // the client is still connected during a normal flow).
-        let repo: any;
+      // Serialize the read-modify-write against the same thread's other
+      // `thread_data` writers (setThreadQueuedMessages, setThreadEngineMeta,
+      // the frontend-triggered saves below). Without the lock, a concurrent
+      // queued-message save can clobber the assistant message we just
+      // appended here, or vice versa.
+      await withThreadDataLock(threadId, async () => {
         try {
-          repo = JSON.parse(thread.threadData || "{}");
-        } catch {
-          repo = {};
-        }
-        if (!Array.isArray(repo.messages)) repo.messages = [];
+          const thread = await getThread(threadId);
+          if (!thread) return;
 
-        const lastMsg = repo.messages[repo.messages.length - 1];
-        // Check both wrapped ({ message: { role } }) and unwrapped ({ role }) formats
-        const lastRole = lastMsg?.message?.role ?? lastMsg?.role;
-        const lastContent = lastMsg?.message?.content ?? lastMsg?.content;
-        const lastContentIsEmpty = Array.isArray(lastContent)
-          ? lastContent.length === 0
-          : lastContent == null || lastContent === "";
-        if (lastRole === "assistant" && !lastContentIsEmpty) {
-          // Frontend already saved the assistant response — just bump timestamp
+          const assistantMsg = buildAssistantMessage(
+            run.events ?? [],
+            run.runId,
+          );
+          if (!assistantMsg) {
+            // No content produced — just bump timestamp
+            await updateThreadData(
+              threadId,
+              thread.threadData,
+              thread.title,
+              thread.preview,
+              thread.messageCount,
+            );
+            return;
+          }
+
+          // Parse existing thread_data, append assistant message only if
+          // the frontend hasn't already saved it (avoids duplicates when
+          // the client is still connected during a normal flow).
+          let repo: any;
+          try {
+            repo = JSON.parse(thread.threadData || "{}");
+          } catch {
+            repo = {};
+          }
+          if (!Array.isArray(repo.messages)) repo.messages = [];
+
+          const lastMsg = repo.messages[repo.messages.length - 1];
+          // Check both wrapped ({ message: { role } }) and unwrapped ({ role }) formats
+          const lastRole = lastMsg?.message?.role ?? lastMsg?.role;
+          const lastContent = lastMsg?.message?.content ?? lastMsg?.content;
+          const lastContentIsEmpty = Array.isArray(lastContent)
+            ? lastContent.length === 0
+            : lastContent == null || lastContent === "";
+          if (lastRole === "assistant" && !lastContentIsEmpty) {
+            // Frontend already saved the assistant response — just bump timestamp
+            await updateThreadData(
+              threadId,
+              thread.threadData,
+              thread.title,
+              thread.preview,
+              thread.messageCount,
+            );
+            return;
+          }
+          if (lastRole === "assistant" && lastContentIsEmpty) {
+            // The frontend wrote an empty assistant placeholder before the stream
+            // had any content (common when the user reloads mid-run, and the 5s
+            // periodic save raced with the first text chunk). Replace it with
+            // the server's reconstructed message so the turn isn't lost.
+            repo.messages.pop();
+          }
+
+          // Determine if repo uses wrapped format ({ message, parentId }) or flat format
+          const isWrapped = lastMsg && "message" in lastMsg;
+          if (isWrapped) {
+            const parentId =
+              repo.messages.length > 0
+                ? (repo.messages[repo.messages.length - 1].message?.id ?? null)
+                : null;
+            repo.messages.push({ message: assistantMsg, parentId });
+          } else {
+            repo.messages.push(assistantMsg);
+          }
+
+          const meta = extractThreadMeta(repo);
           await updateThreadData(
             threadId,
-            thread.threadData,
-            thread.title,
-            thread.preview,
-            thread.messageCount,
+            JSON.stringify(repo),
+            meta.title || thread.title,
+            meta.preview || thread.preview,
+            repo.messages.length,
           );
-          return;
+        } catch {
+          // Best-effort — don't break cleanup
         }
-        if (lastRole === "assistant" && lastContentIsEmpty) {
-          // The frontend wrote an empty assistant placeholder before the stream
-          // had any content (common when the user reloads mid-run, and the 5s
-          // periodic save raced with the first text chunk). Replace it with
-          // the server's reconstructed message so the turn isn't lost.
-          repo.messages.pop();
-        }
-
-        // Determine if repo uses wrapped format ({ message, parentId }) or flat format
-        const isWrapped = lastMsg && "message" in lastMsg;
-        if (isWrapped) {
-          const parentId =
-            repo.messages.length > 0
-              ? (repo.messages[repo.messages.length - 1].message?.id ?? null)
-              : null;
-          repo.messages.push({ message: assistantMsg, parentId });
-        } else {
-          repo.messages.push(assistantMsg);
-        }
-
-        const meta = extractThreadMeta(repo);
-        await updateThreadData(
-          threadId,
-          JSON.stringify(repo),
-          meta.title || thread.title,
-          meta.preview || thread.preview,
-          repo.messages.length,
-        );
-      } catch {
-        // Best-effort — don't break cleanup
-      }
+      });
     };
 
     // ─── Agent Teams: per-run send reference ─────────────────────────

--- a/templates/mail/.env.example
+++ b/templates/mail/.env.example
@@ -1,3 +1,10 @@
 # Add your Google OAuth credentials here (or configure via the setup wizard in the app)
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=
+
+# Gmail Pub/Sub push notifications (production only — see docs)
+# Only set in environments with a publicly-reachable push endpoint.
+# Leaving these unset disables push; the app falls back to history-delta polling.
+# GMAIL_WATCH_TOPIC=projects/<project>/topics/<topic>
+# GMAIL_PUSH_AUDIENCE=https://<your-domain>/api/gmail/push
+# GMAIL_PUSH_SIGNER_EMAIL=<pubsub-signer>@<project>.iam.gserviceaccount.com

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -13,6 +13,7 @@ import {
   getOAuthTokens,
   saveOAuthTokens,
   deleteOAuthTokens,
+  listOAuthAccounts,
   listOAuthAccountsByOwner,
   hasOAuthTokens,
 } from "@agent-native/core/oauth-tokens";
@@ -209,6 +210,36 @@ export async function getClient(
   const accountId = account.accountId;
   const accessToken = await getValidAccessToken(accountId, tokens, email);
 
+  return { accessToken, email: accountId };
+}
+
+/**
+ * Look up an OAuth client by accountId regardless of ownership.
+ *
+ * `getClient()` filters by owner, which works for a user's primary account
+ * (where `owner === accountId`) but returns null for added secondary accounts
+ * (where `owner` is the primary email). Background jobs that iterate
+ * `listOAuthAccounts("google")` — notably Gmail watch renewal — need to
+ * refresh tokens for every stored account, not just the primary of each
+ * owner. This helper scans all accounts and uses the stored `owner` (falling
+ * back to `accountId`) when persisting refreshed tokens.
+ */
+export async function getClientForAccount(
+  accountId: string,
+): Promise<{ accessToken: string; email: string } | null> {
+  const all = await listOAuthAccounts("google");
+  const account = all.find((a) => a.accountId === accountId);
+  if (!account) return null;
+
+  const tokens = account.tokens as unknown as GoogleTokens;
+  if (!tokens) return null;
+
+  const ownerForRefresh = account.owner ?? accountId;
+  const accessToken = await getValidAccessToken(
+    accountId,
+    tokens,
+    ownerForRefresh,
+  );
   return { accessToken, email: accountId };
 }
 
@@ -550,11 +581,23 @@ async function hydrateAccountInbox(
     messageIds.map((m) => m.id),
     "metadata",
   );
-  const messages: any[] = [];
-  for (const r of batchResults) {
-    if (!r.data) continue;
-    messages.push({ ...r.data, _accountEmail: email });
+
+  // Partial batch failures would leave gaps in the inbox window while we
+  // still cache `historyId` — those messages then never appear in history
+  // deltas (deltas only surface events since the cached id) and silently
+  // vanish from the UI until the next full rehydrate. Fail the whole
+  // hydrate instead; the caller retries, which is cheaper than serving a
+  // wrong list indefinitely.
+  if (batchResults.some((r) => !r.data)) {
+    throw new Error(
+      `Batch message fetch returned incomplete results (${batchResults.filter((r) => !r.data).length}/${batchResults.length} missing) — aborting hydrate to avoid caching an incomplete inbox`,
+    );
   }
+
+  const messages: any[] = batchResults.map((r) => ({
+    ...r.data,
+    _accountEmail: email,
+  }));
 
   return { messages, historyId, nextPageToken };
 }

--- a/templates/mail/server/plugins/auth.ts
+++ b/templates/mail/server/plugins/auth.ts
@@ -5,4 +5,8 @@ import { createAuthPlugin } from "@agent-native/core/server";
 // creation, since that path can't be used to access mail.
 export default createAuthPlugin({
   googleOnly: true,
+  // Gmail Pub/Sub push notifications POST here from Google's servers — no
+  // user session. The handler itself verifies the OIDC token when
+  // GMAIL_PUSH_AUDIENCE is configured.
+  publicPaths: ["/api/gmail/push"],
 });

--- a/templates/mail/server/plugins/mail-jobs.ts
+++ b/templates/mail/server/plugins/mail-jobs.ts
@@ -11,7 +11,7 @@ import {
 } from "../lib/jobs.js";
 import { processAutomations } from "../lib/automation-engine.js";
 import { listOAuthAccounts } from "@agent-native/core/oauth-tokens";
-import { getClient, startWatch } from "../lib/google-auth.js";
+import { getClientForAccount, startWatch } from "../lib/google-auth.js";
 
 const INTERVAL_MS = 60_000; // 1 minute
 const WATCH_RENEW_INTERVAL_MS = 12 * 60 * 60_000;
@@ -22,7 +22,10 @@ async function renewAllWatches(): Promise<void> {
   const accounts = await listOAuthAccounts("google");
   for (const acc of accounts) {
     try {
-      const client = await getClient(acc.accountId);
+      // Use accountId-based lookup so secondary/added accounts (where
+      // `owner !== accountId`) also get their watch renewed. Gmail watches
+      // expire in ~7 days and must be renewed regularly.
+      const client = await getClientForAccount(acc.accountId);
       if (!client) continue;
       await startWatch(client.accessToken);
     } catch (err: any) {

--- a/templates/mail/server/routes/api/gmail/push.post.ts
+++ b/templates/mail/server/routes/api/gmail/push.post.ts
@@ -39,10 +39,15 @@ async function verifyPubSubToken(authHeader: string): Promise<JWTPayload> {
     throw new Error("email_verified claim is not true");
   }
 
-  // Optional pin to the specific service account Pub/Sub signs as. Blocks
-  // any other Google-issued token that happens to have the right audience.
+  // Pin to the specific service account Pub/Sub signs as. Without this any
+  // Google-issued token with the right audience (e.g. a different GCP
+  // project) would pass verification and spoof mailbox updates. Required
+  // whenever OIDC auth is on.
   const expectedSigner = process.env.GMAIL_PUSH_SIGNER_EMAIL;
-  if (expectedSigner && payload.email !== expectedSigner) {
+  if (!expectedSigner) {
+    throw new Error("GMAIL_PUSH_SIGNER_EMAIL not configured");
+  }
+  if (payload.email !== expectedSigner) {
     throw new Error(`unexpected signer: ${payload.email}`);
   }
 
@@ -50,12 +55,23 @@ async function verifyPubSubToken(authHeader: string): Promise<JWTPayload> {
 }
 
 export default defineEventHandler(async (event: H3Event) => {
-  // OIDC verification is opt-in via env. When GMAIL_PUSH_AUDIENCE is unset
-  // we run unauthenticated — matching the subscription's default state
-  // before "Enable authentication" is flipped on. Once the env var is set,
-  // we reject any request that fails verification with 401 so Pub/Sub
-  // surfaces the misconfiguration in its delivery metrics.
-  if (process.env.GMAIL_PUSH_AUDIENCE) {
+  // Fail closed when watches are enabled. If GMAIL_WATCH_TOPIC is set we are
+  // actively subscribing for push notifications, so the endpoint MUST verify
+  // incoming payloads — otherwise any public caller can post forged
+  // historyId bumps and force the server into garbage-hydrate loops. OIDC
+  // verification is keyed off GMAIL_PUSH_AUDIENCE; both must be configured
+  // together. Without GMAIL_WATCH_TOPIC (watches disabled) we accept
+  // unauthenticated pushes as a no-op pathway for local/dev testing.
+  const watchesEnabled = !!process.env.GMAIL_WATCH_TOPIC;
+  const audience = process.env.GMAIL_PUSH_AUDIENCE;
+  if (watchesEnabled && !audience) {
+    console.error(
+      "[gmail-push] GMAIL_WATCH_TOPIC set but GMAIL_PUSH_AUDIENCE missing — rejecting to avoid unauthenticated push processing",
+    );
+    setResponseStatus(event, 503);
+    return { ok: false, error: "push auth not configured" };
+  }
+  if (audience) {
     const authHeader = getHeader(event, "authorization") || "";
     try {
       await verifyPubSubToken(authHeader);


### PR DESCRIPTION
## Summary
Addresses Builder's review feedback on #241.

**Core chat-threads** — fixes a race on `thread_data` read-modify-write:
- New per-thread async mutex (`withThreadDataLock`) in `chat-threads/store.ts`.
- Applied to `setThreadEngineMeta`, `setThreadQueuedMessages`, and `onRunComplete` in `agent-chat-plugin.ts`. Prevents concurrent queued-message saves from clobbering the assistant-message append and vice versa.

**Mail / Gmail push webhook** — security hardening:
- Fail closed when `GMAIL_WATCH_TOPIC` is set but `GMAIL_PUSH_AUDIENCE` isn't. Previously this left the endpoint open to forged historyId bumps.
- `GMAIL_PUSH_SIGNER_EMAIL` is now mandatory whenever OIDC is on. Previously any Google-signed token with the right audience could spoof mailbox updates.

**Mail / google-auth** — data integrity:
- `hydrateAccountInbox` throws instead of silently dropping messages on batch partial failure. Previously we'd cache the new `historyId` and those messages would permanently vanish from the UI until a full rehydrate.
- New `getClientForAccount(accountId)` helper scans all accounts by accountId. Fixes Gmail watch renewal silently skipping secondary accounts (where `owner != accountId`) — previously watches expired after ~7 days and push sync stopped.

**Skipped (left to concurrent agent):** the 2 clips/desktop comments on #241 (dual stop/cancel listeners, cancel/abort race) — both are in the in-flight recording-lifecycle work.

## Test plan
- [ ] CI green
- [ ] Manual: concurrent tab typing + agent run → no lost messages
- [ ] Manual: add a secondary Google account → watch renewal fires for both
- [ ] Spot-check Builder doesn't re-raise the same comments