### PR TITLE
updates-129: address PR #242 feedback (lock leak, PUT race, push auth hole)

### DIFF
--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -26,14 +26,15 @@ export function withThreadDataLock<T>(
 ): Promise<T> {
   const prev = _threadDataLocks.get(threadId) ?? Promise.resolve();
   const next = prev.then(fn, fn);
-  _threadDataLocks.set(
-    threadId,
-    next.finally(() => {
-      if (_threadDataLocks.get(threadId) === next) {
-        _threadDataLocks.delete(threadId);
-      }
-    }),
-  );
+  // Store the same `next` promise we compare against at cleanup time —
+  // `next.finally(...)` returns a DIFFERENT promise, so comparing against
+  // it would never match and entries would leak forever.
+  _threadDataLocks.set(threadId, next);
+  next.finally(() => {
+    if (_threadDataLocks.get(threadId) === next) {
+      _threadDataLocks.delete(threadId);
+    }
+  });
   return next as Promise<T>;
 }
 

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -3346,40 +3346,48 @@ export function createAgentChatPlugin(
           }
 
           if (method === "PUT") {
-            const thread = await getThread(threadId);
-            if (!thread || thread.ownerEmail !== owner) {
-              setResponseStatus(event, 404);
-              return { error: "Thread not found" };
-            }
-            const body = await readBody(event);
-            let newThreadData = body.threadData || thread.threadData;
-            // Preserve queuedMessages from the existing thread_data when the
-            // incoming blob doesn't include it. Periodic full-thread saves
-            // (exported via threadRuntime.export) don't carry the queue, and
-            // we don't want them to clobber queued-message state persisted
-            // via POST /threads/:id/queued.
-            if (body.threadData) {
-              try {
-                const existing = JSON.parse(thread.threadData);
-                if (existing.queuedMessages !== undefined) {
-                  const incoming = JSON.parse(newThreadData);
-                  if (incoming.queuedMessages === undefined) {
-                    incoming.queuedMessages = existing.queuedMessages;
-                    newThreadData = JSON.stringify(incoming);
-                  }
-                }
-              } catch {
-                // Invalid JSON in either side — fall back to raw body blob.
+            // Hold the thread_data lock for the full read-modify-write so
+            // periodic saves from the frontend don't race with
+            // onRunComplete / setThreadQueuedMessages / setThreadEngineMeta.
+            // Without the lock, a client save that lands during an agent
+            // run could clobber the assistant message the server just
+            // appended (and vice versa).
+            return await withThreadDataLock(threadId, async () => {
+              const thread = await getThread(threadId);
+              if (!thread || thread.ownerEmail !== owner) {
+                setResponseStatus(event, 404);
+                return { error: "Thread not found" };
               }
-            }
-            await updateThreadData(
-              threadId,
-              newThreadData,
-              body.title ?? thread.title,
-              body.preview ?? thread.preview,
-              body.messageCount || thread.messageCount,
-            );
-            return { ok: true };
+              const body = await readBody(event);
+              let newThreadData = body.threadData || thread.threadData;
+              // Preserve queuedMessages from the existing thread_data when the
+              // incoming blob doesn't include it. Periodic full-thread saves
+              // (exported via threadRuntime.export) don't carry the queue, and
+              // we don't want them to clobber queued-message state persisted
+              // via POST /threads/:id/queued.
+              if (body.threadData) {
+                try {
+                  const existing = JSON.parse(thread.threadData);
+                  if (existing.queuedMessages !== undefined) {
+                    const incoming = JSON.parse(newThreadData);
+                    if (incoming.queuedMessages === undefined) {
+                      incoming.queuedMessages = existing.queuedMessages;
+                      newThreadData = JSON.stringify(incoming);
+                    }
+                  }
+                } catch {
+                  // Invalid JSON in either side — fall back to raw body blob.
+                }
+              }
+              await updateThreadData(
+                threadId,
+                newThreadData,
+                body.title ?? thread.title,
+                body.preview ?? thread.preview,
+                body.messageCount || thread.messageCount,
+              );
+              return { ok: true };
+            });
           }
 
           // POST /threads/:id/queued — debounced writes from the client

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -449,9 +449,13 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
         }
       }
 
-      // If some accounts failed but others succeeded, add warning header
+      // If some accounts failed but others succeeded, add warning header.
+      // HTTP headers must be ByteString (code points <= 255), so strip any
+      // UTF-8 that might land in an error message (em dashes, smart quotes,
+      // etc. from Google error responses). Otherwise the whole handler 500s.
       if (errors.length > 0) {
-        setResponseHeader(event, "X-Account-Errors", JSON.stringify(errors));
+        const safe = JSON.stringify(errors).replace(/[^\x20-\x7e]/g, "?");
+        setResponseHeader(event, "X-Account-Errors", safe);
       }
 
       // Encode next page token for the frontend

--- a/templates/mail/server/lib/google-api.ts
+++ b/templates/mail/server/lib/google-api.ts
@@ -269,7 +269,7 @@ export async function googleFetch(
   const remaining = isInCooldown(accessToken);
   if (remaining > 0) {
     throw new Error(
-      `Google API error (429): Rate limit cooldown — retry in ${Math.ceil(remaining / 1000)}s`,
+      `Google API error (429): Rate limit cooldown, retry in ${Math.ceil(remaining / 1000)}s`,
     );
   }
 
@@ -480,15 +480,18 @@ export function gmailListHistory(
     maxResults?: number;
   },
 ) {
-  const queryParams: Record<string, string | number | undefined> = {
-    startHistoryId: params.startHistoryId,
-    labelId: params.labelId,
-    maxResults: params.maxResults,
-  };
-  if (params.historyTypes?.length) {
-    queryParams.historyTypes = params.historyTypes.join(",");
+  // Gmail's users.history.list expects `historyTypes` as repeated query
+  // params (e.g. ...&historyTypes=messageAdded&historyTypes=labelAdded),
+  // not a single comma-joined value — the API returns 400 "Invalid value"
+  // otherwise. URLSearchParams.append handles repetition.
+  const sp = new URLSearchParams();
+  sp.set("startHistoryId", params.startHistoryId);
+  if (params.labelId) sp.set("labelId", params.labelId);
+  if (params.maxResults !== undefined) {
+    sp.set("maxResults", String(params.maxResults));
   }
-  return googleFetch(`${GMAIL_BASE}/history${qs(queryParams)}`, accessToken);
+  for (const t of params.historyTypes || []) sp.append("historyTypes", t);
+  return googleFetch(`${GMAIL_BASE}/history?${sp.toString()}`, accessToken);
 }
 
 export function gmailWatch(
@@ -546,7 +549,7 @@ export async function gmailBatchGetMessages(
   const remaining = isInCooldown(accessToken);
   if (remaining > 0) {
     throw new Error(
-      `Google API error (429): Rate limit cooldown — retry in ${Math.ceil(remaining / 1000)}s`,
+      `Google API error (429): Rate limit cooldown, retry in ${Math.ceil(remaining / 1000)}s`,
     );
   }
 

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -1,6 +1,7 @@
 import {
   createOAuth2Client,
   gmailGetProfile,
+  gmailGetMessage,
   gmailListMessages,
   gmailBatchGetMessages,
   gmailListHistory,
@@ -582,15 +583,34 @@ async function hydrateAccountInbox(
     "metadata",
   );
 
-  // Partial batch failures would leave gaps in the inbox window while we
-  // still cache `historyId` — those messages then never appear in history
-  // deltas (deltas only surface events since the cached id) and silently
-  // vanish from the UI until the next full rehydrate. Fail the whole
-  // hydrate instead; the caller retries, which is cheaper than serving a
-  // wrong list indefinitely.
-  if (batchResults.some((r) => !r.data)) {
+  // Gmail's batch endpoint will return fewer sub-responses than sub-requests
+  // when it rate-limits mid-batch (or on transient transport issues). Refill
+  // any gaps with individual gets so we don't cache an incomplete inbox and
+  // then silently drop those messages from every subsequent delta.
+  const missing = batchResults.filter((r) => !r.data).map((r) => r.id);
+  if (missing.length > 0) {
+    const refills = await Promise.all(
+      missing.map(async (id) => {
+        try {
+          const data = await gmailGetMessage(accessToken, id, "metadata");
+          return { id, data };
+        } catch {
+          return { id, data: null as any };
+        }
+      }),
+    );
+    const byId = new Map(refills.map((r) => [r.id, r.data]));
+    for (const r of batchResults) {
+      if (!r.data && byId.has(r.id)) r.data = byId.get(r.id);
+    }
+  }
+
+  // If refill still couldn't cover everything, abort rather than cache a
+  // partial window (gaps never show up in history deltas). Caller retries.
+  const stillMissing = batchResults.filter((r) => !r.data).length;
+  if (stillMissing > 0) {
     throw new Error(
-      `Batch message fetch returned incomplete results (${batchResults.filter((r) => !r.data).length}/${batchResults.length} missing) — aborting hydrate to avoid caching an incomplete inbox`,
+      `Batch message fetch incomplete: ${stillMissing}/${batchResults.length} missing after refill; aborting hydrate`,
     );
   }
 

--- a/templates/mail/server/routes/api/gmail/push.post.ts
+++ b/templates/mail/server/routes/api/gmail/push.post.ts
@@ -55,31 +55,29 @@ async function verifyPubSubToken(authHeader: string): Promise<JWTPayload> {
 }
 
 export default defineEventHandler(async (event: H3Event) => {
-  // Fail closed when watches are enabled. If GMAIL_WATCH_TOPIC is set we are
-  // actively subscribing for push notifications, so the endpoint MUST verify
-  // incoming payloads — otherwise any public caller can post forged
-  // historyId bumps and force the server into garbage-hydrate loops. OIDC
-  // verification is keyed off GMAIL_PUSH_AUDIENCE; both must be configured
-  // together. Without GMAIL_WATCH_TOPIC (watches disabled) we accept
-  // unauthenticated pushes as a no-op pathway for local/dev testing.
-  const watchesEnabled = !!process.env.GMAIL_WATCH_TOPIC;
+  // The push endpoint is registered as a public path so Google's Pub/Sub
+  // can reach it without a user session. That's only safe when OIDC
+  // verification is active — otherwise any caller who knows an email
+  // address could bump historyId and force cache invalidation + Gmail
+  // rehydrate loops on the server. So:
+  //
+  //   - GMAIL_PUSH_AUDIENCE set   → verify every request; reject on failure.
+  //   - GMAIL_PUSH_AUDIENCE unset → the endpoint is disabled. Return 503 so
+  //     a misconfigured deployment (watches running via GMAIL_WATCH_TOPIC
+  //     with no audience) surfaces in Pub/Sub's delivery metrics, and so
+  //     anonymous callers can't trigger processing.
   const audience = process.env.GMAIL_PUSH_AUDIENCE;
-  if (watchesEnabled && !audience) {
-    console.error(
-      "[gmail-push] GMAIL_WATCH_TOPIC set but GMAIL_PUSH_AUDIENCE missing — rejecting to avoid unauthenticated push processing",
-    );
+  if (!audience) {
     setResponseStatus(event, 503);
-    return { ok: false, error: "push auth not configured" };
+    return { ok: false, error: "push endpoint disabled" };
   }
-  if (audience) {
-    const authHeader = getHeader(event, "authorization") || "";
-    try {
-      await verifyPubSubToken(authHeader);
-    } catch (err: any) {
-      console.warn(`[gmail-push] OIDC verify failed: ${err.message}`);
-      setResponseStatus(event, 401);
-      return { ok: false, error: "unauthorized" };
-    }
+  const authHeader = getHeader(event, "authorization") || "";
+  try {
+    await verifyPubSubToken(authHeader);
+  } catch (err: any) {
+    console.warn(`[gmail-push] OIDC verify failed: ${err.message}`);
+    setResponseStatus(event, 401);
+    return { ok: false, error: "unauthorized" };
   }
 
   let body: any;


### PR DESCRIPTION
## Summary

Addresses Builder's review comments on #242.

### 🔴 Thread-data lock memory leak (`chat-threads/store.ts`)
The cleanup handler compared against `next.finally(...)`, which returns a new promise — the identity check never matched, so entries accumulated forever. Now we store `next` itself in the map and attach the cleanup as a side effect so the later comparison actually matches.

### 🔴 Mutex didn't cover PUT /threads/:id (`agent-chat-plugin.ts`)
The frontend's periodic full-thread saves bypassed the lock and could still clobber `onRunComplete`'s assistant-message append. Wrap the PUT handler's full read-modify-write in `withThreadDataLock`.

### 🟡 Anonymous cache invalidation via `/api/gmail/push`
`/api/gmail/push` is in `publicPaths` so Google Pub/Sub can reach it. When `GMAIL_PUSH_AUDIENCE` was unset the handler still processed payloads and called `bumpHistoryWatermark` + `invalidateListCacheForOwner` — anyone who knew an email address could trigger Gmail rehydrates. Now:
- `GMAIL_PUSH_AUDIENCE` unset → endpoint returns 503 and does nothing.
- `GMAIL_PUSH_AUDIENCE` set → OIDC verification mandatory (already required `GMAIL_PUSH_SIGNER_EMAIL`).

## Test plan
- [ ] CI green
- [ ] Spot-check Builder doesn't re-raise
- [ ] Manual: PUT a thread while an agent run is completing → no lost messages