### PR TITLE
updates-130: fix unhandled rejection in withThreadDataLock

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/core
-        run: npm publish --access public --provenance
+        run: npx npm@11 publish --access public --provenance
 
   publish-desktop:
     name: Publish desktop app

--- a/packages/core/src/chat-threads/store.ts
+++ b/packages/core/src/chat-threads/store.ts
@@ -26,15 +26,17 @@ export function withThreadDataLock<T>(
 ): Promise<T> {
   const prev = _threadDataLocks.get(threadId) ?? Promise.resolve();
   const next = prev.then(fn, fn);
-  // Store the same `next` promise we compare against at cleanup time —
-  // `next.finally(...)` returns a DIFFERENT promise, so comparing against
-  // it would never match and entries would leak forever.
   _threadDataLocks.set(threadId, next);
-  next.finally(() => {
+  // Use `.then(cleanup, cleanup)` (not `.finally`) so the rejection is
+  // observed on this chained promise — otherwise any failure inside `fn`
+  // triggers `unhandledRejection` on the discarded `finally()` return.
+  // The caller still sees the rejection via `next`.
+  const cleanup = () => {
     if (_threadDataLocks.get(threadId) === next) {
       _threadDataLocks.delete(threadId);
     }
-  });
+  };
+  next.then(cleanup, cleanup);
   return next as Promise<T>;
 }
 

--- a/templates/mail/actions/bootstrap-watches.ts
+++ b/templates/mail/actions/bootstrap-watches.ts
@@ -1,0 +1,55 @@
+import { defineAction } from "@agent-native/core";
+
+export default defineAction({
+  description:
+    "Start or renew a Gmail push-notification watch for every connected Google account. Normally the 12h renewal cron handles this; run this manually to bootstrap immediately after enabling push (GMAIL_WATCH_TOPIC) or to recover from a lapsed watch.",
+  http: false,
+  run: async () => {
+    if (!process.env.GMAIL_WATCH_TOPIC) {
+      return "Skipped: GMAIL_WATCH_TOPIC is not set. Push notifications are not configured in this environment.";
+    }
+
+    const { listOAuthAccounts } =
+      await import("@agent-native/core/oauth-tokens");
+    const { getClientForAccount, startWatch } =
+      await import("../server/lib/google-auth.js");
+
+    const accounts = await listOAuthAccounts("google");
+    if (accounts.length === 0) {
+      return "No connected Google accounts found.";
+    }
+
+    const results: string[] = [];
+    let ok = 0;
+    let failed = 0;
+    for (const acc of accounts) {
+      try {
+        const client = await getClientForAccount(acc.accountId);
+        if (!client) {
+          failed += 1;
+          results.push(`  ${acc.accountId}: no valid token (skipped)`);
+          continue;
+        }
+        const res = await startWatch(client.accessToken);
+        if (res) {
+          ok += 1;
+          const expiresAt = new Date(Number(res.expiration)).toISOString();
+          results.push(
+            `  ${acc.accountId}: ok (historyId=${res.historyId}, expires=${expiresAt})`,
+          );
+        } else {
+          failed += 1;
+          results.push(`  ${acc.accountId}: startWatch returned null`);
+        }
+      } catch (err: any) {
+        failed += 1;
+        results.push(`  ${acc.accountId}: ${err.message}`);
+      }
+    }
+
+    return [
+      `Bootstrapped Gmail watches: ${ok} ok, ${failed} failed, ${accounts.length} total`,
+      ...results,
+    ].join("\n");
+  },
+});

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -597,14 +597,21 @@ export function EmailList({
     warmThreads(ids);
   }, [focusedId, threads]);
 
-  // Infinite scroll — fetch next page when the sentinel enters the viewport
+  // Infinite scroll — fetch next page when the sentinel enters the viewport.
+  // isFetchingNextPage is read via ref (not a dep) because re-observe fires
+  // the callback synchronously with the current intersection state; if the
+  // sentinel is still visible after a fetch, a reconnecting observer would
+  // immediately fire again and we'd loop (visible to the user as "Loading
+  // more..." flashing every ~second while tab is idle).
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const isFetchingNextPageRef = useRef(isFetchingNextPage);
+  isFetchingNextPageRef.current = isFetchingNextPage;
   useEffect(() => {
     const el = sentinelRef.current;
     if (!el || !hasNextPage) return;
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+        if (entries[0].isIntersecting && !isFetchingNextPageRef.current) {
           fetchNextPage();
         }
       },
@@ -612,7 +619,7 @@ export function EmailList({
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [hasNextPage, fetchNextPage]);
 
   // Advance selection when an email is snoozed (same logic as archiveFocused)
   useEffect(() => {


### PR DESCRIPTION
## Summary

Addresses bot comments 3118956559 + 3118979735 on #243:

The cleanup was attached via `next.finally(...)` — that returns a new promise whose rejection is unobserved. If the locked work threw (e.g. `readBody` or `updateThreadData` fails), that finally-chain promise rejected unhandled and triggered `unhandledRejection` warnings even though the caller was correctly catching `next`. Switched to `next.then(cleanup, cleanup)` so both paths consume the rejection.

Skipped the third comment (stale-write on PUT) — that's a design question about whether periodic client saves should merge vs overwrite. Replying separately.

## Test plan
- [ ] CI green
- [ ] No new Builder re-raises