### PR TITLE
core: upgrade Vercel AI SDK to v6

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -115,15 +115,15 @@
     "tiptap-markdown": "^0.9.0",
     "y-protocols": "^1.0.7",
     "yjs": "^13.6.30",
-    "zod": "^3.24.0"
+    "zod": "^3.25.76"
   },
   "peerDependencies": {
-    "@ai-sdk/anthropic": ">=1",
-    "@ai-sdk/cohere": ">=1",
-    "@ai-sdk/google": ">=1",
-    "@ai-sdk/groq": ">=1",
-    "@ai-sdk/mistral": ">=1",
-    "@ai-sdk/openai": ">=1",
+    "@ai-sdk/anthropic": ">=3",
+    "@ai-sdk/cohere": ">=3",
+    "@ai-sdk/google": ">=3",
+    "@ai-sdk/groq": ">=3",
+    "@ai-sdk/mistral": ">=3",
+    "@ai-sdk/openai": ">=3",
     "@assistant-ui/react": ">=0.12",
     "@assistant-ui/react-markdown": ">=0.12",
     "@supabase/supabase-js": ">=2",
@@ -133,10 +133,10 @@
     "@xterm/addon-fit": ">=0.10",
     "@xterm/addon-web-links": ">=0.11",
     "@xterm/xterm": ">=5",
-    "ai": ">=4",
+    "ai": ">=6",
+    "ai-sdk-ollama": ">=3",
     "convex": ">=1",
     "node-pty": ">=1",
-    "ollama-ai-provider": ">=1",
     "postgres": ">=3",
     "react": ">=18",
     "react-dom": ">=18",
@@ -169,7 +169,7 @@
     "@ai-sdk/cohere": {
       "optional": true
     },
-    "ollama-ai-provider": {
+    "ai-sdk-ollama": {
       "optional": true
     },
     "@tabler/icons-react": {
@@ -219,10 +219,10 @@
     }
   },
   "devDependencies": {
-    "@ai-sdk/anthropic": "^1.2.12",
-    "@ai-sdk/google": "^1.2.22",
-    "@ai-sdk/groq": "^1.2.9",
-    "@ai-sdk/openai": "^1.3.24",
+    "@ai-sdk/anthropic": "^3.0.71",
+    "@ai-sdk/google": "^3.0.64",
+    "@ai-sdk/groq": "^3.0.35",
+    "@ai-sdk/openai": "^3.0.53",
     "@assistant-ui/react": "^0.12.19",
     "@assistant-ui/react-markdown": "^0.12.6",
     "@react-router/dev": "^7.13.1",
@@ -240,7 +240,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0",
-    "ai": "^4.3.19",
+    "ai": "^6.0.168",
     "autoprefixer": "^10.4.21",
     "express": "^5.2.1",
     "firebase-admin": "^13.0.0",

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -154,7 +154,18 @@ const PROVIDER_PACKAGES: Record<AISDKProvider, string> = {
   groq: "@ai-sdk/groq",
   mistral: "@ai-sdk/mistral",
   cohere: "@ai-sdk/cohere",
-  ollama: "ollama-ai-provider",
+  ollama: "ai-sdk-ollama",
+};
+
+/** Factory export name per provider (not all follow `create<Provider>`). */
+const PROVIDER_FACTORIES: Record<AISDKProvider, string> = {
+  anthropic: "createAnthropic",
+  openai: "createOpenAI",
+  google: "createGoogleGenerativeAI",
+  groq: "createGroq",
+  mistral: "createMistral",
+  cohere: "createCohere",
+  ollama: "createOllama",
 };
 
 // ---------------------------------------------------------------------------
@@ -232,7 +243,6 @@ class AISDKEngine implements AgentEngine {
         };
       }
       if (anthropicOpts.cacheControl) {
-        // AI SDK v5 supports cache_control via system message providerOptions
         providerOpts.anthropic = {
           ...((providerOpts.anthropic as object) ?? {}),
           cacheControl: anthropicOpts.cacheControl,
@@ -246,34 +256,27 @@ class AISDKEngine implements AgentEngine {
         system: opts.systemPrompt,
         messages,
         tools: aiSdkTools,
-        maxTokens: opts.maxTokens ?? 16384,
+        maxOutputTokens: opts.maxOutputTokens ?? 16384,
         ...(opts.temperature !== undefined
           ? { temperature: opts.temperature }
           : {}),
         abortSignal: opts.abortSignal,
-        // One step only — runAgentLoop drives the loop
-        maxSteps: 1,
-        // Collect tool calls but don't auto-execute them
-        experimental_toolCallStreaming: false,
+        onStepFinish: (step: any) => {
+          (opts as any)[AISDK_ASSISTANT_CONTENT_KEY] =
+            aiSdkStepToAssistantContent(step);
+        },
         ...(Object.keys(providerOpts).length > 0
           ? { providerOptions: providerOpts }
           : {}),
       });
 
       let hasEmittedStop = false;
-      let assistantContent: any[] = [];
 
       for await (const part of result.fullStream) {
         const events = aiSdkPartToEngineEvents(part);
         for (const event of events) {
           yield event;
           if (event.type === "stop") hasEmittedStop = true;
-        }
-
-        // Capture step finish for assistant content reconstruction
-        if (part.type === "step-finish") {
-          assistantContent = aiSdkStepToAssistantContent(part);
-          (opts as any)[AISDK_ASSISTANT_CONTENT_KEY] = assistantContent;
         }
       }
 
@@ -301,11 +304,10 @@ class AISDKEngine implements AgentEngine {
       );
     }
 
-    const createFnName = `create${capitalize(this.provider)}`;
-    const createFn = providerModule[createFnName] ?? providerModule.default;
-
+    const fnName = PROVIDER_FACTORIES[this.provider];
+    const createFn = providerModule[fnName] ?? providerModule.default;
     if (typeof createFn !== "function") {
-      throw new Error(`Could not find provider factory in "${pkg}"`);
+      throw new Error(`"${pkg}" does not export ${fnName} or default`);
     }
 
     const config: Record<string, unknown> = {};
@@ -313,7 +315,9 @@ class AISDKEngine implements AgentEngine {
     if (this.baseUrl) config.baseURL = this.baseUrl;
 
     const provider = createFn(config);
-    return provider(model);
+    // @ai-sdk/openai@3 defaults to the Responses API; force Chat Completions
+    // so OpenAI-compatible gateways (OpenRouter, Groq, Together, …) work too.
+    return this.provider === "openai" ? provider.chat(model) : provider(model);
   }
 }
 

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -97,7 +97,7 @@ class AnthropicEngine implements AgentEngine {
 
     const requestParams: any = {
       model: opts.model,
-      max_tokens: opts.maxTokens ?? 16384,
+      max_tokens: opts.maxOutputTokens ?? 16384,
       system: systemBlocks,
       tools: cachedTools.length > 0 ? cachedTools : undefined,
       messages,

--- a/packages/core/src/agent/engine/translate-ai-sdk.spec.ts
+++ b/packages/core/src/agent/engine/translate-ai-sdk.spec.ts
@@ -3,11 +3,12 @@ import {
   engineToolsToAISDK,
   engineMessagesToAISDK,
   aiSdkPartToEngineEvents,
+  aiSdkStepToAssistantContent,
 } from "./translate-ai-sdk.js";
 import type { EngineTool, EngineMessage } from "./types.js";
 
 describe("engineToolsToAISDK", () => {
-  it("converts tools to AI SDK format (plain JSON Schema)", () => {
+  it("converts tools to AI SDK v6 format (plain JSON Schema)", () => {
     const tools: EngineTool[] = [
       {
         name: "search",
@@ -23,10 +24,10 @@ describe("engineToolsToAISDK", () => {
     const result = engineToolsToAISDK(tools);
     expect(result).toHaveProperty("search");
     expect(result.search.description).toBe("Search for something");
-    expect(result.search.parameters.properties).toHaveProperty("q");
+    expect(result.search.inputSchema.properties).toHaveProperty("q");
   });
 
-  it("wraps parameters with jsonSchema() when provided", () => {
+  it("wraps inputSchema with jsonSchema() when provided", () => {
     const tools: EngineTool[] = [
       {
         name: "greet",
@@ -39,7 +40,6 @@ describe("engineToolsToAISDK", () => {
       },
     ];
 
-    // Simulate the AI SDK's jsonSchema() helper (wraps raw schema with marker)
     const wrapped: Record<string, unknown>[] = [];
     const mockJsonSchema = (schema: Record<string, unknown>) => {
       wrapped.push(schema);
@@ -48,8 +48,8 @@ describe("engineToolsToAISDK", () => {
 
     const result = engineToolsToAISDK(tools, mockJsonSchema);
     expect(wrapped).toHaveLength(1);
-    expect(result.greet.parameters).toHaveProperty("_aiSdkWrapped", true);
-    expect(result.greet.parameters.properties).toHaveProperty("name");
+    expect(result.greet.inputSchema).toHaveProperty("_aiSdkWrapped", true);
+    expect(result.greet.inputSchema.properties).toHaveProperty("name");
   });
 });
 
@@ -61,14 +61,13 @@ describe("engineMessagesToAISDK", () => {
     const result = engineMessagesToAISDK(messages);
     expect(result).toHaveLength(1);
     expect(result[0].role).toBe("user");
-    // Single text part may be coerced to string
     const content = result[0].content;
     const text =
       typeof content === "string" ? content : (content as any)?.[0]?.text;
     expect(text).toBe("Hi");
   });
 
-  it("converts assistant message with tool-call", () => {
+  it("converts assistant message with tool-call (v6 input field)", () => {
     const messages: EngineMessage[] = [
       {
         role: "assistant",
@@ -89,59 +88,249 @@ describe("engineMessagesToAISDK", () => {
     expect(tc).toBeDefined();
     expect(tc.toolCallId).toBe("tc-1");
     expect(tc.toolName).toBe("search");
-    expect(tc.args).toEqual({ q: "test" });
+    expect(tc.input).toEqual({ q: "test" });
+  });
+
+  it("emits tool-results as a dedicated role:tool message (v6)", () => {
+    const messages: EngineMessage[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-1",
+            toolName: "search",
+            content: "42",
+          },
+        ],
+      },
+    ];
+    const result = engineMessagesToAISDK(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("tool");
+    const tr = (result[0].content as any[]).find(
+      (p: any) => p.type === "tool-result",
+    );
+    expect(tr).toBeDefined();
+    expect(tr.toolCallId).toBe("tc-1");
+    expect(tr.toolName).toBe("search");
+    expect(tr.output).toEqual({ type: "text", value: "42" });
+  });
+
+  it("splits mixed user content into tool then user messages", () => {
+    const messages: EngineMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "follow-up question" },
+          {
+            type: "tool-result",
+            toolCallId: "tc-1",
+            toolName: "search",
+            content: "42",
+          },
+        ],
+      },
+    ];
+    const result = engineMessagesToAISDK(messages);
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe("tool");
+    expect(result[1].role).toBe("user");
+  });
+
+  it("flags tool-result errors via output.type === 'error-text'", () => {
+    const messages: EngineMessage[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc-1",
+            toolName: "search",
+            content: "boom",
+            isError: true,
+          },
+        ],
+      },
+    ];
+    const result = engineMessagesToAISDK(messages);
+    expect(result[0].role).toBe("tool");
+    const tr = (result[0].content as any[]).find(
+      (p: any) => p.type === "tool-result",
+    );
+    expect(tr.output).toEqual({ type: "error-text", value: "boom" });
+  });
+
+  it("round-trips an Anthropic thinking signature through providerOptions", () => {
+    const messages: EngineMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            text: "reasoning about the problem",
+            signature: "sig-abc",
+          },
+        ],
+      },
+    ];
+    const result = engineMessagesToAISDK(messages);
+    const reasoning = (result[0].content as any[]).find(
+      (p: any) => p.type === "reasoning",
+    );
+    expect(reasoning).toBeDefined();
+    expect(reasoning.text).toBe("reasoning about the problem");
+    expect(reasoning.providerOptions?.anthropic?.signature).toBe("sig-abc");
   });
 });
 
-describe("aiSdkPartToEngineEvents", () => {
-  it("converts text-delta to text-delta event", () => {
+describe("aiSdkPartToEngineEvents (v6 stream protocol)", () => {
+  it("emits text-delta from v6 text-delta part (uses `text` field)", () => {
     const events = aiSdkPartToEngineEvents({
       type: "text-delta",
-      textDelta: "hello",
+      id: "t-1",
+      text: "hello",
     });
-    expect(events).toHaveLength(1);
-    expect(events[0]).toEqual({ type: "text-delta", text: "hello" });
+    expect(events).toEqual([{ type: "text-delta", text: "hello" }]);
   });
 
-  it("converts reasoning to thinking-delta event", () => {
+  it("absorbs text-start / text-end lifecycle parts", () => {
+    expect(aiSdkPartToEngineEvents({ type: "text-start", id: "t-1" })).toEqual(
+      [],
+    );
+    expect(aiSdkPartToEngineEvents({ type: "text-end", id: "t-1" })).toEqual(
+      [],
+    );
+  });
+
+  it("emits thinking-delta from reasoning-delta part", () => {
     const events = aiSdkPartToEngineEvents({
-      type: "reasoning",
-      textDelta: "I'm thinking...",
-    });
-    expect(events).toHaveLength(1);
-    expect(events[0]).toEqual({
-      type: "thinking-delta",
+      type: "reasoning-delta",
+      id: "r-1",
       text: "I'm thinking...",
     });
+    expect(events).toEqual([
+      { type: "thinking-delta", text: "I'm thinking..." },
+    ]);
   });
 
-  it("converts tool-call to tool-call event", () => {
+  it("absorbs reasoning-start / reasoning-end and tool-input-* lifecycle parts", () => {
+    for (const type of [
+      "reasoning-start",
+      "reasoning-end",
+      "tool-input-start",
+      "tool-input-delta",
+      "tool-input-end",
+    ]) {
+      expect(aiSdkPartToEngineEvents({ type, id: "x", delta: "y" })).toEqual(
+        [],
+      );
+    }
+  });
+
+  it("converts tool-call to tool-call event (v6 input field)", () => {
     const events = aiSdkPartToEngineEvents({
       type: "tool-call",
       toolCallId: "tc-1",
       toolName: "search",
-      args: { q: "test" },
-    });
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
-      type: "tool-call",
-      id: "tc-1",
-      name: "search",
       input: { q: "test" },
     });
+    expect(events).toEqual([
+      {
+        type: "tool-call",
+        id: "tc-1",
+        name: "search",
+        input: { q: "test" },
+      },
+    ]);
   });
 
-  it("converts finish event to stop event", () => {
+  it("converts finish event with totalUsage to usage + stop events", () => {
     const events = aiSdkPartToEngineEvents({
       type: "finish",
       finishReason: "stop",
-      usage: { promptTokens: 10, completionTokens: 5 },
+      totalUsage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      },
     });
-    const stopEvent = events.find((e) => e.type === "stop");
-    expect(stopEvent).toBeDefined();
-    if (stopEvent?.type === "stop") {
-      expect(stopEvent.reason).toBe("end_turn");
-    }
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      type: "usage",
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+    expect(events[1]).toEqual({ type: "stop", reason: "end_turn" });
+  });
+
+  it("maps finishReason 'tool-calls' to tool_use stop", () => {
+    const events = aiSdkPartToEngineEvents({
+      type: "finish",
+      finishReason: "tool-calls",
+      totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    });
+    const stop = events.find((e) => e.type === "stop");
+    expect(stop).toBeDefined();
+    if (stop?.type === "stop") expect(stop.reason).toBe("tool_use");
+  });
+
+  it("maps finishReason 'length' to max_tokens stop", () => {
+    const events = aiSdkPartToEngineEvents({
+      type: "finish",
+      finishReason: "length",
+    });
+    const stop = events.find((e) => e.type === "stop");
+    if (stop?.type === "stop") expect(stop.reason).toBe("max_tokens");
+  });
+
+  it("unpacks cacheReadTokens from v6 inputTokenDetails", () => {
+    const events = aiSdkPartToEngineEvents({
+      type: "finish-step",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        totalTokens: 120,
+        inputTokenDetails: {
+          cacheReadTokens: 50,
+          cacheWriteTokens: 10,
+          noCacheTokens: 40,
+        },
+      },
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "usage",
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 50,
+      cacheWriteTokens: 10,
+    });
+  });
+
+  it("falls back to deprecated cachedInputTokens on pre-v6 usage shapes", () => {
+    const events = aiSdkPartToEngineEvents({
+      type: "finish-step",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 20,
+        cachedInputTokens: 25,
+      },
+    });
+    expect(events[0]).toMatchObject({
+      type: "usage",
+      cacheReadTokens: 25,
+    });
+  });
+
+  it("finish-step emits usage only, no stop (stop waits for finish)", () => {
+    const events = aiSdkPartToEngineEvents({
+      type: "finish-step",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      finishReason: "stop",
+    });
+    expect(events.some((e) => e.type === "stop")).toBe(false);
+    expect(events.some((e) => e.type === "usage")).toBe(true);
   });
 
   it("converts error part to stop-with-error event", () => {
@@ -151,21 +340,60 @@ describe("aiSdkPartToEngineEvents", () => {
     });
     expect(events).toHaveLength(1);
     const stop = events[0];
+    expect(stop.type).toBe("stop");
     if (stop.type === "stop") {
       expect(stop.reason).toBe("error");
-      expect((stop as any).error).toContain("some stream error");
+      expect(stop.error).toContain("some stream error");
     }
   });
 
-  it("converts tool_calls finish reason to tool_use stop", () => {
-    const events = aiSdkPartToEngineEvents({
-      type: "finish",
-      finishReason: "tool-calls",
-      usage: { promptTokens: 10, completionTokens: 5 },
-    });
-    const stopEvent = events.find((e) => e.type === "stop");
-    if (stopEvent?.type === "stop") {
-      expect(stopEvent.reason).toBe("tool_use");
+  it("silently absorbs unknown or non-engine-facing part types", () => {
+    for (const type of [
+      "start",
+      "start-step",
+      "source",
+      "file",
+      "raw",
+      "abort",
+      "zzz-unknown",
+    ]) {
+      expect(aiSdkPartToEngineEvents({ type })).toEqual([]);
     }
+  });
+});
+
+describe("aiSdkStepToAssistantContent", () => {
+  it("reconstructs content from v6 step.content array", () => {
+    const parts = aiSdkStepToAssistantContent({
+      content: [
+        { type: "text", text: "hello" },
+        {
+          type: "tool-call",
+          toolCallId: "tc-1",
+          toolName: "search",
+          input: { q: "test" },
+        },
+        {
+          type: "reasoning",
+          text: "thinking...",
+          providerMetadata: { anthropic: { signature: "sig-1" } },
+        },
+      ],
+    });
+    expect(parts).toEqual([
+      { type: "text", text: "hello" },
+      {
+        type: "tool-call",
+        id: "tc-1",
+        name: "search",
+        input: { q: "test" },
+      },
+      { type: "thinking", text: "thinking...", signature: "sig-1" },
+    ]);
+  });
+
+  it("returns an empty array for a malformed step with no content", () => {
+    expect(aiSdkStepToAssistantContent({})).toEqual([]);
+    expect(aiSdkStepToAssistantContent(null)).toEqual([]);
   });
 });

--- a/packages/core/src/agent/engine/translate-ai-sdk.ts
+++ b/packages/core/src/agent/engine/translate-ai-sdk.ts
@@ -1,22 +1,30 @@
 /**
  * Translation helpers between AgentEngine normalized types and
- * Vercel AI SDK (ai package) types.
+ * Vercel AI SDK (`ai` package, v6+) types.
+ *
+ * The framework keeps a provider-neutral content/event model (see ./types.ts).
+ * These helpers convert in both directions against the v6 `TextStreamPart` and
+ * `ModelMessage` shapes.
  */
 
-import type { EngineTool, EngineMessage, EngineContentPart } from "./types.js";
+import type {
+  EngineTool,
+  EngineMessage,
+  EngineContentPart,
+  EngineEvent,
+} from "./types.js";
 
 // ---------------------------------------------------------------------------
-// EngineTool → AI SDK CoreTool shape
+// EngineTool → AI SDK tool definition
 // ---------------------------------------------------------------------------
 
 /**
- * Convert EngineTool[] to the `tools` Record<string, CoreTool> shape
- * that AI SDK's streamText expects.
+ * Convert EngineTool[] into the record shape that AI SDK's `streamText` expects
+ * under the `tools` option.
  *
- * AI SDK v4 requires tool parameters to be Zod schemas or jsonSchema()-wrapped
- * objects. Pass the `jsonSchema` helper from the `ai` package to produce a
- * compatible schema wrapper; fall back to the raw JSON Schema object when the
- * helper is not available (older AI SDK or tests).
+ * Pass the `jsonSchema` helper from the `ai` package when available so the
+ * schema is wrapped in the SDK's runtime validator; fall back to the raw JSON
+ * Schema object otherwise (mostly for unit tests that don't import `ai`).
  */
 export function engineToolsToAISDK(
   tools: EngineTool[],
@@ -31,43 +39,65 @@ export function engineToolsToAISDK(
     };
     result[tool.name] = {
       description: tool.description,
-      parameters: jsonSchema ? jsonSchema(rawSchema) : rawSchema,
+      inputSchema: jsonSchema ? jsonSchema(rawSchema) : rawSchema,
     };
   }
   return result;
 }
 
 // ---------------------------------------------------------------------------
-// EngineMessage → AI SDK CoreMessage
+// EngineMessage → AI SDK ModelMessage
 // ---------------------------------------------------------------------------
 
-export function engineMessageToAISDK(msg: EngineMessage): any {
+/**
+ * Convert a single EngineMessage into **one or more** AI SDK ModelMessages.
+ *
+ * v6 puts tool-results in a dedicated `role: "tool"` message rather than
+ * embedding them in user content. When an EngineMessage's user content mixes
+ * text/images with tool-results, we emit the tool-result parts first as a
+ * `{role: "tool"}` message, followed by the remaining text/image parts as a
+ * `{role: "user"}` message.
+ */
+export function engineMessageToAISDK(msg: EngineMessage): any[] {
+  // EngineMessage is `user | assistant` — both branches return below.
   if (msg.role === "user") {
-    const content: any[] = [];
+    const userParts: any[] = [];
+    const toolResultParts: any[] = [];
     for (const part of msg.content) {
       if (part.type === "text") {
-        content.push({ type: "text", text: part.text });
+        userParts.push({ type: "text", text: part.text });
       } else if (part.type === "image") {
-        content.push({
+        userParts.push({
           type: "image",
           image: `data:${part.mediaType};base64,${part.data}`,
+          mediaType: part.mediaType,
         });
       } else if (part.type === "tool-result") {
-        content.push({
+        toolResultParts.push({
           type: "tool-result",
           toolCallId: part.toolCallId,
-          result: part.content,
-          isError: part.isError,
+          toolName: part.toolName ?? "",
+          output: part.isError
+            ? { type: "error-text", value: part.content }
+            : { type: "text", value: part.content },
         });
       }
     }
-    return {
-      role: "user",
-      content:
-        content.length === 1 && content[0].type === "text"
-          ? content[0].text
-          : content,
-    };
+
+    const out: any[] = [];
+    if (toolResultParts.length > 0) {
+      out.push({ role: "tool", content: toolResultParts });
+    }
+    if (userParts.length > 0) {
+      out.push({
+        role: "user",
+        content:
+          userParts.length === 1 && userParts[0].type === "text"
+            ? userParts[0].text
+            : userParts,
+      });
+    }
+    return out;
   }
 
   if (msg.role === "assistant") {
@@ -80,114 +110,195 @@ export function engineMessageToAISDK(msg: EngineMessage): any {
           type: "tool-call",
           toolCallId: part.id,
           toolName: part.name,
-          args: part.input,
+          input: part.input,
         });
       } else if (part.type === "thinking") {
-        // AI SDK 5+ supports reasoning content parts
-        content.push({ type: "reasoning", text: part.text });
+        const reasoning: Record<string, unknown> = {
+          type: "reasoning",
+          text: part.text,
+        };
+        if (part.signature) {
+          // Round-trip the Anthropic extended-thinking signature through
+          // providerOptions so the model can continue its chain of thought.
+          reasoning.providerOptions = {
+            anthropic: { signature: part.signature },
+          };
+        }
+        content.push(reasoning);
       }
     }
-    return {
-      role: "assistant",
-      content:
-        content.length === 1 && content[0].type === "text"
-          ? content[0].text
-          : content,
-    };
+    return [
+      {
+        role: "assistant",
+        content:
+          content.length === 1 && content[0].type === "text"
+            ? content[0].text
+            : content,
+      },
+    ];
   }
 
-  // Exhaustive — EngineMessage only has "user" | "assistant" roles
-  return { role: (msg as any).role, content: "" };
+  throw new Error(`unknown EngineMessage role: ${(msg as any).role}`);
 }
 
 export function engineMessagesToAISDK(messages: EngineMessage[]): any[] {
-  return messages.map(engineMessageToAISDK);
+  return messages.flatMap(engineMessageToAISDK);
 }
 
 // ---------------------------------------------------------------------------
-// AI SDK stream part → EngineEvent
+// AI SDK TextStreamPart → EngineEvent
 // ---------------------------------------------------------------------------
 
-export function aiSdkPartToEngineEvents(
-  part: any,
-): import("./types.js").EngineEvent[] {
-  const events: import("./types.js").EngineEvent[] = [];
+/**
+ * Translate a single part from AI SDK's `result.fullStream` into the flat
+ * sequence of EngineEvent items the framework works with.
+ *
+ * v6 emits lifecycle events (`text-start` / `text-delta` / `text-end`,
+ * `reasoning-start` / `reasoning-delta` / `reasoning-end`, `tool-input-*`).
+ * We absorb the boundary events and forward only the deltas plus the terminal
+ * `tool-call`, `finish-step`, and `finish` parts.
+ */
+export function aiSdkPartToEngineEvents(part: any): EngineEvent[] {
+  const events: EngineEvent[] = [];
 
-  if (part.type === "text-delta") {
-    events.push({ type: "text-delta", text: part.textDelta ?? "" });
-  } else if (part.type === "reasoning") {
-    events.push({
-      type: "thinking-delta",
-      text: part.textDelta ?? part.text ?? "",
-    });
-  } else if (part.type === "tool-call") {
-    events.push({
-      type: "tool-call",
-      id: part.toolCallId,
-      name: part.toolName,
-      input: part.args,
-    });
-  } else if (part.type === "error") {
-    // AI SDK emits { type: "error", error: Error } when streaming fails
-    const errMsg =
-      (part.error instanceof Error ? part.error.message : String(part.error)) ??
-      "Unknown stream error";
-    events.push({ type: "stop", reason: "error", error: errMsg } as any);
-  } else if (part.type === "finish") {
-    // Usage info may arrive on the finish step
-    if (part.usage) {
+  switch (part?.type) {
+    case "text-delta":
+      if (part.text) events.push({ type: "text-delta", text: part.text });
+      break;
+    case "text-start":
+    case "text-end":
+      break;
+
+    case "reasoning-delta":
+      if (part.text) events.push({ type: "thinking-delta", text: part.text });
+      break;
+    case "reasoning-start":
+    case "reasoning-end":
+      break;
+
+    case "tool-input-start":
+    case "tool-input-delta":
+    case "tool-input-end":
+      // Ignored: the terminal `tool-call` part carries the full input.
+      break;
+
+    case "tool-call":
       events.push({
-        type: "usage",
-        inputTokens: part.usage.promptTokens ?? 0,
-        outputTokens: part.usage.completionTokens ?? 0,
-        cacheReadTokens: (part.usage as any).cacheReadTokens ?? 0,
-        cacheWriteTokens: (part.usage as any).cacheWriteTokens ?? 0,
+        type: "tool-call",
+        id: part.toolCallId,
+        name: part.toolName,
+        input: part.input ?? {},
       });
+      break;
+
+    case "tool-result":
+    case "tool-error":
+      // Only fired when the SDK itself executes a tool. Our runAgentLoop
+      // dispatches tools on the outside, so these don't appear in our flow.
+      break;
+
+    case "error": {
+      const errMsg =
+        part.error instanceof Error
+          ? part.error.message
+          : typeof part.error === "string"
+            ? part.error
+            : JSON.stringify(part.error);
+      events.push({ type: "stop", reason: "error", error: errMsg });
+      break;
     }
-    const reason = part.finishReason;
-    events.push({
-      type: "stop",
-      reason:
-        reason === "tool-calls"
-          ? "tool_use"
-          : reason === "length"
-            ? "max_tokens"
-            : "end_turn",
-    });
+
+    case "finish-step":
+      if (part.usage) {
+        events.push(usageEventFromLanguageModelUsage(part.usage));
+      }
+      break;
+
+    case "finish":
+      if (part.totalUsage) {
+        events.push(usageEventFromLanguageModelUsage(part.totalUsage));
+      }
+      events.push({
+        type: "stop",
+        reason: finishReasonToStopReason(part.finishReason),
+      });
+      break;
+
+    case "start":
+    case "start-step":
+    case "source":
+    case "file":
+    case "abort":
+    case "raw":
+    default:
+      break;
   }
 
   return events;
 }
 
+function finishReasonToStopReason(
+  reason: unknown,
+): "end_turn" | "tool_use" | "max_tokens" | "stop_sequence" | "error" {
+  switch (reason) {
+    case "tool-calls":
+      return "tool_use";
+    case "length":
+      return "max_tokens";
+    case "content-filter":
+    case "error":
+      return "error";
+    default:
+      // Maps "stop", "other", "unknown", and anything we don't recognise.
+      return "end_turn";
+  }
+}
+
+function usageEventFromLanguageModelUsage(usage: any): EngineEvent {
+  // v6 exposes cache/reasoning tokens via detail objects; older providers
+  // put them at the top level (deprecated but still read as a fallback).
+  return {
+    type: "usage",
+    inputTokens: usage.inputTokens ?? 0,
+    outputTokens: usage.outputTokens ?? 0,
+    totalTokens: usage.totalTokens,
+    cacheReadTokens:
+      usage.inputTokenDetails?.cacheReadTokens ?? usage.cachedInputTokens ?? 0,
+    cacheWriteTokens: usage.inputTokenDetails?.cacheWriteTokens ?? 0,
+    reasoningTokens:
+      usage.outputTokenDetails?.reasoningTokens ?? usage.reasoningTokens,
+  };
+}
+
 // ---------------------------------------------------------------------------
-// AI SDK step result → EngineContentPart[] (assistant content for messages)
+// AI SDK StepResult → EngineContentPart[] (assistant content reconstruction)
 // ---------------------------------------------------------------------------
 
+/**
+ * Reconstruct the assistant message content from an AI SDK v6 `StepResult`.
+ * `step.content` is the canonical structured form — iterate it.
+ */
 export function aiSdkStepToAssistantContent(step: any): EngineContentPart[] {
   const parts: EngineContentPart[] = [];
-
-  if (typeof step.text === "string" && step.text) {
-    parts.push({ type: "text", text: step.text });
-  }
-
-  if (Array.isArray(step.toolCalls)) {
-    for (const tc of step.toolCalls) {
+  for (const part of step?.content ?? []) {
+    if (part.type === "text" && part.text) {
+      parts.push({ type: "text", text: part.text });
+    } else if (part.type === "reasoning") {
+      const signature = part.providerMetadata?.anthropic?.signature;
+      const thinking: EngineContentPart = {
+        type: "thinking",
+        text: part.text ?? "",
+      };
+      if (typeof signature === "string") thinking.signature = signature;
+      parts.push(thinking);
+    } else if (part.type === "tool-call") {
       parts.push({
         type: "tool-call",
-        id: tc.toolCallId,
-        name: tc.toolName,
-        input: tc.args,
+        id: part.toolCallId,
+        name: part.toolName,
+        input: part.input,
       });
     }
   }
-
-  if (Array.isArray(step.reasoning)) {
-    for (const r of step.reasoning) {
-      if (r.type === "text") {
-        parts.push({ type: "thinking", text: r.text });
-      }
-    }
-  }
-
   return parts;
 }

--- a/packages/core/src/agent/engine/types.ts
+++ b/packages/core/src/agent/engine/types.ts
@@ -61,6 +61,8 @@ export interface EngineToolCallPart {
 export interface EngineToolResultPart {
   type: "tool-result";
   toolCallId: string;
+  /** Required by AI SDK v6+ ModelMessage. */
+  toolName?: string;
   content: string;
   isError?: boolean;
 }
@@ -97,6 +99,8 @@ export type EngineEvent =
       outputTokens: number;
       cacheReadTokens?: number;
       cacheWriteTokens?: number;
+      totalTokens?: number;
+      reasoningTokens?: number;
     }
   | {
       type: "stop";
@@ -136,7 +140,7 @@ export interface EngineStreamOptions {
   messages: EngineMessage[];
   tools: EngineTool[];
   abortSignal: AbortSignal;
-  maxTokens?: number;
+  maxOutputTokens?: number;
   temperature?: number;
   /**
    * Provider-specific options passed opaquely.

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -382,6 +382,7 @@ export async function runAgentLoop(opts: {
           return {
             type: "tool-result" as const,
             toolCallId: toolCall.id,
+            toolName: toolCall.name,
             content: result,
             isError: true,
           };
@@ -429,6 +430,7 @@ export async function runAgentLoop(opts: {
         return {
           type: "tool-result" as const,
           toolCallId: toolCall.id,
+          toolName: toolCall.name,
           content: result,
           ...(isError ? { isError } : {}),
         };
@@ -445,7 +447,8 @@ export async function runAgentLoop(opts: {
 export function createProductionAgentHandler(
   options: ProductionAgentOptions,
 ): H3EventHandler {
-  const model = options.model ?? "claude-sonnet-4-6";
+  // Undefined = let each engine pick its own defaultModel at request time.
+  const configuredModel = options.model;
 
   // Resolve actions — prefer `actions`, fall back to deprecated `scripts`
   const resolvedActions = options.actions ?? options.scripts ?? {};
@@ -516,13 +519,15 @@ export function createProductionAgentHandler(
       engine = await resolveEngine({
         engineOption: options.engine,
         apiKey: effectiveApiKey,
-        model,
+        model: configuredModel,
       });
     } catch {
       engine = await resolveEngine({
         apiKey: effectiveApiKey,
       });
     }
+
+    const model = configuredModel ?? engine.defaultModel;
 
     // Check for API key before starting a run (only for anthropic engine)
     if (engine.name === "anthropic" && !effectiveApiKey) {

--- a/packages/pinpoint/package.json
+++ b/packages/pinpoint/package.json
@@ -52,7 +52,7 @@
     "bippy": "^0.5.32",
     "element-source": "^0.0.3",
     "solid-js": "^1.9.10",
-    "zod": "^3.23.0"
+    "zod": "^3.25.76"
   },
   "peerDependencies": {
     "react": ">=18.0.0"

--- a/packages/scheduling/package.json
+++ b/packages/scheduling/package.json
@@ -51,7 +51,7 @@
     "date-fns": "^4.1.0",
     "nanoid": "^4.0.2",
     "rrule": "^2.8.1",
-    "zod": "^3.24.0"
+    "zod": "^3.25.76"
   },
   "peerDependencies": {
     "@agent-native/core": ">=0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,10 +87,10 @@ importers:
   packages/core:
     dependencies:
       '@ai-sdk/cohere':
-        specifier: '>=1'
+        specifier: '>=3'
         version: 3.0.30(zod@3.25.76)
       '@ai-sdk/mistral':
-        specifier: '>=1'
+        specifier: '>=3'
         version: 3.0.30(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: '>=0.81.0'
@@ -149,6 +149,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.22.2
         version: 3.22.2
+      ai-sdk-ollama:
+        specifier: '>=3'
+        version: 3.8.3(ai@6.0.168(zod@3.25.76))(zod@3.25.76)
       better-auth:
         specifier: ^1.6.0
         version: 1.6.0(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(pg@8.20.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(solid-js@1.9.12)(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.12.2)(happy-dom@20.8.9)(jsdom@28.1.0(@noble/hashes@2.0.1)(canvas@3.2.3))(lightningcss@1.32.0)(terser@5.46.1))
@@ -191,9 +194,6 @@ importers:
       nitro:
         specifier: 3.0.260311-beta
         version: 3.0.260311-beta(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.15.15)(better-sqlite3@12.8.0)(chokidar@4.0.3)(dotenv@17.4.0)(drizzle-orm@0.45.2(@libsql/client@0.15.15)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(kysely@0.28.15)(pg@8.20.0)(postgres@3.4.9))(giget@3.2.0)(ioredis@5.10.1)(jiti@2.6.1)(lru-cache@11.2.7)(miniflare@4.20260405.0)(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
-      ollama-ai-provider:
-        specifier: '>=1'
-        version: 1.2.0(zod@3.25.76)
       p-limit:
         specifier: ^7.3.0
         version: 7.3.0
@@ -228,21 +228,21 @@ importers:
         specifier: ^13.6.30
         version: 13.6.30
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
       '@ai-sdk/anthropic':
-        specifier: ^1.2.12
-        version: 1.2.12(zod@3.25.76)
+        specifier: ^3.0.71
+        version: 3.0.71(zod@3.25.76)
       '@ai-sdk/google':
-        specifier: ^1.2.22
-        version: 1.2.22(zod@3.25.76)
+        specifier: ^3.0.64
+        version: 3.0.64(zod@3.25.76)
       '@ai-sdk/groq':
-        specifier: ^1.2.9
-        version: 1.2.9(zod@3.25.76)
+        specifier: ^3.0.35
+        version: 3.0.35(zod@3.25.76)
       '@ai-sdk/openai':
-        specifier: ^1.3.24
-        version: 1.3.24(zod@3.25.76)
+        specifier: ^3.0.53
+        version: 3.0.53(zod@3.25.76)
       '@assistant-ui/react':
         specifier: ^0.12.19
         version: 0.12.22(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -289,8 +289,8 @@ importers:
         specifier: ^5.5.0
         version: 5.5.0
       ai:
-        specifier: ^4.3.19
-        version: 4.3.19(react@18.3.1)(zod@3.25.76)
+        specifier: ^6.0.168
+        version: 6.0.168(zod@3.25.76)
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
@@ -578,7 +578,7 @@ importers:
         specifier: ^1.9.10
         version: 1.9.12
       zod:
-        specifier: ^3.23.0
+        specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
       '@modelcontextprotocol/sdk':
@@ -633,7 +633,7 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
       '@agent-native/core':
@@ -3968,11 +3968,11 @@ packages:
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
 
-  '@ai-sdk/anthropic@1.2.12':
-    resolution: {integrity: sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==}
+  '@ai-sdk/anthropic@3.0.71':
+    resolution: {integrity: sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/cohere@3.0.30':
     resolution: {integrity: sha512-j3fe/6lUUkHPD/51OgMXN9UD7p1QSQEAlroIinmb3MhJ1s+O0MnqdRa30IM7dRHafNp0FQ9X4YpobY85iMknUQ==}
@@ -3980,17 +3980,23 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@1.2.22':
-    resolution: {integrity: sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==}
+  '@ai-sdk/gateway@3.0.104':
+    resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/groq@1.2.9':
-    resolution: {integrity: sha512-7MoDaxm8yWtiRbD1LipYZG0kBl+Xe0sv/EeyxnHnGPZappXdlgtdOgTZVjjXkT3nWP30jjZi9A45zoVrBMb3Xg==}
+  '@ai-sdk/google@3.0.64':
+    resolution: {integrity: sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/groq@3.0.35':
+    resolution: {integrity: sha512-LXoPwSKaqXst9LyLN2J7gK8n7RldQLbP2zsnBYxXcOsXKrtceksqtbsmGXujvab2TM9FisquAw/ZG2hTbD5vnQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/mistral@3.0.30':
     resolution: {integrity: sha512-+j4IXRSk9E661cFSafmIr+XHOzwjFagawwzMOlSqwL6U4Sq4PCFLDF+oHbX5NUqNjUL7FD1zi/9lBIfa41pUvw==}
@@ -3998,17 +4004,11 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@1.3.24':
-    resolution: {integrity: sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==}
+  '@ai-sdk/openai@3.0.53':
+    resolution: {integrity: sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      zod: ^3.0.0
-
-  '@ai-sdk/provider-utils@2.2.8':
-    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/provider-utils@4.0.23':
     resolution: {integrity: sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==}
@@ -4016,29 +4016,9 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@1.1.3':
-    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
-    engines: {node: '>=18'}
-
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
-
-  '@ai-sdk/react@1.2.12':
-    resolution: {integrity: sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      zod:
-        optional: true
-
-  '@ai-sdk/ui-utils@1.2.11':
-    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -9378,6 +9358,10 @@ packages:
     peerDependencies:
       react: '>= 16.8.0'
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react-swc@4.3.0':
     resolution: {integrity: sha512-mOkXCII839dHyAt/gpoSlm28JIVDwhZ6tnG6wJxUy2bmOx7UaPjvOyIDf3SFv5s7Eo7HVaq6kRcu6YMEzt5Z7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -9472,15 +9456,17 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
-  ai@4.3.19:
-    resolution: {integrity: sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==}
+  ai-sdk-ollama@3.8.3:
+    resolution: {integrity: sha512-KId/S++eb0CgTPFTtHzCGCrO73kXZLK+hyyZx5k8LVqU2XOEHYKVbIwDiQ+hm3okHjnsGehn4zR4QNm14SUM3Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      ai: ^6.0.154
+
+  ai@6.0.168:
+    resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      react:
-        optional: true
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -9954,10 +9940,6 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
-
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -12084,16 +12066,15 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsondiffpatch@0.6.0:
-    resolution: {integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonrepair@3.14.0:
+    resolution: {integrity: sha512-tWPGKMZf/8UPim+fcW2EfcQ/d/7aKUrP6IECz9G3Tu6Q5dX0orSleqJ9z6sSw7qrQkjF8/Edo4DvsWBZ8H+HNg==}
+    hasBin: true
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -13127,14 +13108,8 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
-  ollama-ai-provider@1.2.0:
-    resolution: {integrity: sha512-jTNFruwe3O/ruJeppI/quoOUxG7NA6blG3ZyQj3lei4+NnJo7bi3eIRWqlVpRlu/mbzbFXeJSBuYQWF6pzGKww==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
+  ollama@0.6.3:
+    resolution: {integrity: sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==}
 
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -13261,9 +13236,6 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-
-  partial-json@0.1.7:
-    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
@@ -14119,9 +14091,6 @@ packages:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
 
-  secure-json-parse@2.7.0:
-    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
-
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -14494,11 +14463,6 @@ packages:
     peerDependencies:
       react: '>=17.0'
 
-  swr@2.4.1:
-    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -14574,10 +14538,6 @@ packages:
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
-
-  throttleit@2.1.0:
-    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
-    engines: {node: '>=18'}
 
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
@@ -15531,10 +15491,10 @@ snapshots:
 
   '@acemir/cssom@0.9.31': {}
 
-  '@ai-sdk/anthropic@1.2.12(zod@3.25.76)':
+  '@ai-sdk/anthropic@3.0.71(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/cohere@3.0.30(zod@3.25.76)':
@@ -15543,16 +15503,23 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/google@1.2.22(zod@3.25.76)':
+  '@ai-sdk/gateway@3.0.104(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      '@vercel/oidc': 3.2.0
       zod: 3.25.76
 
-  '@ai-sdk/groq@1.2.9(zod@3.25.76)':
+  '@ai-sdk/google@3.0.64(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/groq@3.0.35(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/mistral@3.0.30(zod@3.25.76)':
@@ -15561,17 +15528,10 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/openai@1.3.24(zod@3.25.76)':
+  '@ai-sdk/openai@3.0.53(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      zod: 3.25.76
-
-  '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.11
-      secure-json-parse: 2.7.0
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.23(zod@3.25.76)':
@@ -15581,30 +15541,9 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
-  '@ai-sdk/provider@1.1.3':
-    dependencies:
-      json-schema: 0.4.0
-
   '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
-
-  '@ai-sdk/react@1.2.12(react@18.3.1)(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
-      react: 18.3.1
-      swr: 2.4.1(react@18.3.1)
-      throttleit: 2.1.0
-    optionalDependencies:
-      zod: 3.25.76
-
-  '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -21614,6 +21553,8 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.3.1
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react-swc@4.3.0(vite@5.4.21(@types/node@24.12.2)(lightningcss@1.32.0)(sass@1.51.0)(terser@5.46.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -21757,17 +21698,23 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@4.3.19(react@18.3.1)(zod@3.25.76):
+  ai-sdk-ollama@3.8.3(ai@6.0.168(zod@3.25.76))(zod@3.25.76):
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      '@ai-sdk/react': 1.2.12(react@18.3.1)(zod@3.25.76)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
+      ai: 6.0.168(zod@3.25.76)
+      jsonrepair: 3.14.0
+      ollama: 0.6.3
+    transitivePeerDependencies:
+      - zod
+
+  ai@6.0.168(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.104(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.23(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
-      jsondiffpatch: 0.6.0
       zod: 3.25.76
-    optionalDependencies:
-      react: 18.3.1
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -22351,8 +22298,6 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -24871,12 +24816,6 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsondiffpatch@0.6.0:
-    dependencies:
-      '@types/diff-match-patch': 1.0.36
-      chalk: 5.6.2
-      diff-match-patch: 1.0.5
-
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -24886,6 +24825,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonrepair@3.14.0: {}
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -26332,13 +26273,9 @@ snapshots:
 
   ohash@2.0.11: {}
 
-  ollama-ai-provider@1.2.0(zod@3.25.76):
+  ollama@0.6.3:
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
-      partial-json: 0.1.7
-    optionalDependencies:
-      zod: 3.25.76
+      whatwg-fetch: 3.6.20
 
   on-finished@2.3.0:
     dependencies:
@@ -26484,8 +26421,6 @@ snapshots:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
-
-  partial-json@0.1.7: {}
 
   path-data-parser@0.1.0: {}
 
@@ -27651,8 +27586,6 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
-  secure-json-parse@2.7.0: {}
-
   secure-json-parse@4.1.0: {}
 
   semver-compare@1.0.0:
@@ -28072,12 +28005,6 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  swr@2.4.1(react@18.3.1):
-    dependencies:
-      dequal: 2.0.3
-      react: 18.3.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
-
   symbol-tree@3.2.4: {}
 
   tailwind-merge@2.6.1: {}
@@ -28176,8 +28103,6 @@ snapshots:
   three@0.176.0: {}
 
   throat@5.0.0: {}
-
-  throttleit@2.1.0: {}
 
   tiny-async-pool@1.3.0:
     dependencies:


### PR DESCRIPTION
## What

Migrates `@agent-native/core`'s `ai-sdk:*` engines from AI SDK v4 to v6.

All changes are confined to `packages/core/src/agent/engine/` plus two small contract fixes in `production-agent.ts`. Template code is untouched — every template continues to work unchanged against the upgraded core.

## Why

v4 is two majors behind stable (released 2024). Several `ai-sdk:*` engines were latently broken against v4: OpenAI-compatible gateways (OpenRouter, Groq, LM Studio, Ollama-compat) couldn't be used because the provider factory lookup was wrong (`createOpenai` vs `createOpenAI`) and the default OpenAI invocation hits the Responses API (which those gateways don't speak). The upgrade unblocks them and removes the pressure for downstream templates to patch or fork the core.

## What changed

### Dep bumps (`chore:` commit)

| package                  | was       | is          |
| ------------------------ | --------- | ----------- |
| `ai`                     | `^4.3.19` | `^6.0.168`  |
| `@ai-sdk/anthropic`      | `^1.2.12` | `^3.0.71`   |
| `@ai-sdk/google`         | `^1.2.22` | `^3.0.64`   |
| `@ai-sdk/groq`           | `^1.2.9`  | `^3.0.35`   |
| `@ai-sdk/openai`         | `^1.3.24` | `^3.0.53`   |
| `@ai-sdk/cohere`/`mistral` peer | `>=1` | `>=3`       |
| `ollama-ai-provider`     | `>=1`     | `ai-sdk-ollama >= 3` (original has no v6-compatible release) |
| `zod`                    | `^3.24.0` | `^3.25.76` (AI SDK v6 peer: `^3.25.76 \|\| ^4.1.8`) |

### Engine migration (`core:` commit)

v6 reshapes three surfaces that core's engine layer touches:

- **Stream protocol** now uses per-block lifecycle events: `text-start` / `text-delta` / `text-end`, `reasoning-*`, `tool-input-*`. `tool-call` parts carry `input` instead of `args`; `finish` emits `totalUsage`; `LanguageModelUsage` exposes cache + reasoning tokens via `inputTokenDetails` / `outputTokenDetails`.
- **ModelMessage schema**: tool-results now belong in a dedicated `role: "tool"` message with `toolName` required and an `output: { type, value }` envelope.
- **`streamText` options**: `maxTokens` → `maxOutputTokens`; `maxSteps` and `experimental_toolCallStreaming` removed; the `finish-step` stream part no longer carries content (use `onStepFinish` instead).

Changes:

- `translate-ai-sdk.ts` rewritten against v6 `TextStreamPart` + `ModelMessage`. `engineMessageToAISDK` returns `ModelMessage[]` and splits mixed user content into a `role:"tool"` + `role:"user"` pair.
- `ai-sdk-engine.ts`:
  - drops `maxSteps` + `experimental_toolCallStreaming`
  - uses `onStepFinish` to capture assistant content (v6's `finish-step` is metadata-only)
  - `PROVIDER_FACTORIES` map makes the factory export name explicit per provider (fixes `createOpenAI`/`createGoogleGenerativeAI` which the old `capitalize()` heuristic silently resolved to `undefined`)
  - for `openai`, invokes `provider.chat(model)` so OpenAI-compatible gateways work (v6's callable form defaults to Responses API)
- `types.ts`:
  - `EngineStreamOptions.maxTokens` → `maxOutputTokens`
  - `EngineEvent` usage variant extended additively with `totalTokens`/`reasoningTokens`
  - `EngineToolResultPart.toolName?` added
- `anthropic-engine.ts`: one-line `opts.maxTokens` → `opts.maxOutputTokens` rename to match the engine contract; the native `@anthropic-ai/sdk` path is unchanged.

### Contract fixes (`core:` commit)

- `createProductionAgentHandler` no longer hardcodes `"claude-sonnet-4-6"` as the fallback model. When `options.model` is unset, it now resolves the engine first and uses `engine.defaultModel`, so each provider picks its own sensible default.
- `runAgentLoop` now includes `toolName` on the `EngineToolResultPart` entries it constructs after dispatching a tool (v6's `ToolModelMessage` schema requires it).

## Test plan

- [x] `pnpm fmt:check` — clean
- [x] `pnpm test` — core 371/371 passing (was 370; added v6 translator specs). Engine-layer specs up from 24 to 37 to cover v6 stream-part shapes, tool-result splitting, Anthropic signature round-trip, and `cacheReadTokens` via `inputTokenDetails`.
- [x] `pnpm typecheck` — no new errors vs `main` (output is bit-identical)
- [x] `pnpm build` — all 21 non-core packages/templates succeed on both branches
- [x] End-to-end smoke: templated (mail) app linked against this core, chat works through OpenRouter (Gemini via Chat Completions), tool calls round-trip, streaming deltas + stop reasons correct, usage telemetry populated. Also verified tool-result message splitting doesn't break the multi-turn loop.

## Impact on templates

**Zero template code changes required.** Grepped all 15 templates:

- No direct imports from `ai`, `@ai-sdk/*`, or `ollama-ai-provider`.
- No calls to `registerAgentEngine`, no references to `EngineStreamOptions`/`EngineTool`/`EngineEvent`, no `maxTokens` on engine options.
- One template (`recruiting`) calls `@anthropic-ai/sdk` directly for a domain-specific resume filter — that's Anthropic's native SDK, not the AI SDK, and it's unaffected.
- Zod pins already compatible: 11 templates on `^3.25.76`, 4 on `^4.3.6`. Both satisfy v6's `^3.25.76 || ^4.1.8` peer.

The engine abstraction absorbs the entire SDK churn — this is the payoff of the layering from #187.

## Migration notes for downstream consumers

- Run `pnpm up ai @ai-sdk/*` in your template. If you use the ollama engine, swap `ollama-ai-provider` for `ai-sdk-ollama`.
- `EngineStreamOptions.maxTokens` is now `maxOutputTokens`. This is framework-internal and unlikely to surface in template code.
- If you passed a custom default model to `createProductionAgentHandler`, it still takes precedence. Omitting it now falls back to `engine.defaultModel` instead of `claude-sonnet-4-6` — better for non-Anthropic engines.

## Follow-ups (out of scope)

- Evaluate adopting v6's `ToolLoopAgent` in place of the custom `runAgentLoop`.
- Evaluate DevTools integration for the agent debug panel.
- Evaluate `needsApproval` mapping to the framework's action-approval flow.