### PR TITLE
core: bump to 0.7.8

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -231,17 +231,27 @@ export async function getClientForAccount(
   const all = await listOAuthAccounts("google");
   const account = all.find((a) => a.accountId === accountId);
   if (!account) return null;
+  return getClientFromAccount(account);
+}
 
+/**
+ * Same as getClientForAccount but takes a pre-fetched account object to
+ * avoid re-calling listOAuthAccounts. Use this inside loops that already
+ * have the accounts list loaded (watch renewal, bootstrap).
+ */
+export async function getClientFromAccount(
+  account: Awaited<ReturnType<typeof listOAuthAccounts>>[number],
+): Promise<{ accessToken: string; email: string } | null> {
   const tokens = account.tokens as unknown as GoogleTokens;
   if (!tokens) return null;
 
-  const ownerForRefresh = account.owner ?? accountId;
+  const ownerForRefresh = account.owner ?? account.accountId;
   const accessToken = await getValidAccessToken(
-    accountId,
+    account.accountId,
     tokens,
     ownerForRefresh,
   );
-  return { accessToken, email: accountId };
+  return { accessToken, email: account.accountId };
 }
 
 /**

--- a/templates/mail/server/plugins/auth.ts
+++ b/templates/mail/server/plugins/auth.ts
@@ -8,5 +8,7 @@ export default createAuthPlugin({
   // Gmail Pub/Sub push notifications POST here from Google's servers — no
   // user session. The handler itself verifies the OIDC token when
   // GMAIL_PUSH_AUDIENCE is configured.
-  publicPaths: ["/api/gmail/push"],
+  // Cloud Scheduler POSTs to /api/gmail/watch/renew every 6h for watch
+  // lifecycle; same OIDC-verification pattern.
+  publicPaths: ["/api/gmail/push", "/api/gmail/watch/renew"],
 });

--- a/templates/mail/server/routes/api/gmail/watch/renew.post.ts
+++ b/templates/mail/server/routes/api/gmail/watch/renew.post.ts
@@ -7,7 +7,7 @@ import {
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 import { listOAuthAccounts } from "@agent-native/core/oauth-tokens";
 import {
-  getClientForAccount,
+  getClientFromAccount,
   startWatch,
 } from "../../../../lib/google-auth.js";
 
@@ -29,6 +29,7 @@ const GOOGLE_ISSUERS = ["https://accounts.google.com", "accounts.google.com"];
 async function verifyCallerToken(
   authHeader: string,
   audience: string,
+  expectedSigner: string,
 ): Promise<JWTPayload> {
   if (!authHeader.startsWith("Bearer ")) {
     throw new Error("missing bearer token");
@@ -41,26 +42,28 @@ async function verifyCallerToken(
   if (payload.email_verified !== true) {
     throw new Error("email_verified claim is not true");
   }
-  const expectedSigner = process.env.GMAIL_PUSH_SIGNER_EMAIL;
-  if (!expectedSigner) {
-    throw new Error("GMAIL_PUSH_SIGNER_EMAIL not configured");
-  }
   if (payload.email !== expectedSigner) {
+    // Log the caller's claimed email — service-account identities aren't
+    // sensitive, and this is invaluable when debugging misconfig vs attack.
     throw new Error(`unexpected signer: ${payload.email}`);
   }
   return payload;
 }
 
 export default defineEventHandler(async (event: H3Event) => {
+  // Treat missing config as 503 "service unavailable", not 401. These are
+  // operator errors, not caller errors — surfacing them as auth failures
+  // pollutes the push/renew auth-error metric and misleads on-call.
   const audience = process.env.GMAIL_WATCH_RENEW_AUDIENCE;
-  if (!audience) {
+  const expectedSigner = process.env.GMAIL_PUSH_SIGNER_EMAIL;
+  if (!audience || !expectedSigner) {
     setResponseStatus(event, 503);
     return { ok: false, error: "renew endpoint disabled" };
   }
 
   const authHeader = getHeader(event, "authorization") || "";
   try {
-    await verifyCallerToken(authHeader, audience);
+    await verifyCallerToken(authHeader, audience, expectedSigner);
   } catch (err: any) {
     console.warn(`[gmail-watch-renew] OIDC verify failed: ${err.message}`);
     setResponseStatus(event, 401);
@@ -71,6 +74,8 @@ export default defineEventHandler(async (event: H3Event) => {
     return { ok: true, skipped: "GMAIL_WATCH_TOPIC not set" };
   }
 
+  // Load the full account list once and reuse it in the loop; calling
+  // getClientForAccount(accountId) would re-scan oauth_tokens per account.
   const accounts = await listOAuthAccounts("google");
   let succeeded = 0;
   let failed = 0;
@@ -78,7 +83,7 @@ export default defineEventHandler(async (event: H3Event) => {
 
   for (const acc of accounts) {
     try {
-      const client = await getClientForAccount(acc.accountId);
+      const client = await getClientFromAccount(acc);
       if (!client) {
         failed += 1;
         errors.push(`${acc.accountId}: no valid token`);

--- a/templates/mail/server/routes/api/gmail/watch/renew.post.ts
+++ b/templates/mail/server/routes/api/gmail/watch/renew.post.ts
@@ -1,0 +1,113 @@
+import {
+  defineEventHandler,
+  getHeader,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
+import { listOAuthAccounts } from "@agent-native/core/oauth-tokens";
+import {
+  getClientForAccount,
+  startWatch,
+} from "../../../../lib/google-auth.js";
+
+// Gmail watches expire after 7 days, so something has to call watch() on a
+// schedule. The in-process setInterval in mail-jobs.ts is unreliable on
+// serverless hosts where function instances don't stay warm long enough to
+// see the 12h tick. Instead, Cloud Scheduler POSTs to this endpoint every
+// ~6 hours with an OIDC token signed by the same service account we use
+// for Pub/Sub pushes (gmail-push-signer), so we can reuse the same signer
+// check. The audience is per-URL — set GMAIL_WATCH_RENEW_AUDIENCE to this
+// endpoint's full URL.
+
+const GOOGLE_JWKS = createRemoteJWKSet(
+  new URL("https://www.googleapis.com/oauth2/v3/certs"),
+);
+
+const GOOGLE_ISSUERS = ["https://accounts.google.com", "accounts.google.com"];
+
+async function verifyCallerToken(
+  authHeader: string,
+  audience: string,
+): Promise<JWTPayload> {
+  if (!authHeader.startsWith("Bearer ")) {
+    throw new Error("missing bearer token");
+  }
+  const token = authHeader.slice(7);
+  const { payload } = await jwtVerify(token, GOOGLE_JWKS, {
+    issuer: GOOGLE_ISSUERS,
+    audience,
+  });
+  if (payload.email_verified !== true) {
+    throw new Error("email_verified claim is not true");
+  }
+  const expectedSigner = process.env.GMAIL_PUSH_SIGNER_EMAIL;
+  if (!expectedSigner) {
+    throw new Error("GMAIL_PUSH_SIGNER_EMAIL not configured");
+  }
+  if (payload.email !== expectedSigner) {
+    throw new Error(`unexpected signer: ${payload.email}`);
+  }
+  return payload;
+}
+
+export default defineEventHandler(async (event: H3Event) => {
+  const audience = process.env.GMAIL_WATCH_RENEW_AUDIENCE;
+  if (!audience) {
+    setResponseStatus(event, 503);
+    return { ok: false, error: "renew endpoint disabled" };
+  }
+
+  const authHeader = getHeader(event, "authorization") || "";
+  try {
+    await verifyCallerToken(authHeader, audience);
+  } catch (err: any) {
+    console.warn(`[gmail-watch-renew] OIDC verify failed: ${err.message}`);
+    setResponseStatus(event, 401);
+    return { ok: false, error: "unauthorized" };
+  }
+
+  if (!process.env.GMAIL_WATCH_TOPIC) {
+    return { ok: true, skipped: "GMAIL_WATCH_TOPIC not set" };
+  }
+
+  const accounts = await listOAuthAccounts("google");
+  let succeeded = 0;
+  let failed = 0;
+  const errors: string[] = [];
+
+  for (const acc of accounts) {
+    try {
+      const client = await getClientForAccount(acc.accountId);
+      if (!client) {
+        failed += 1;
+        errors.push(`${acc.accountId}: no valid token`);
+        continue;
+      }
+      const res = await startWatch(client.accessToken);
+      if (res) {
+        succeeded += 1;
+      } else {
+        failed += 1;
+        errors.push(`${acc.accountId}: startWatch returned null`);
+      }
+    } catch (err: any) {
+      failed += 1;
+      errors.push(`${acc.accountId}: ${err.message}`);
+    }
+  }
+
+  console.log(
+    `[gmail-watch-renew] ${succeeded}/${accounts.length} ok, ${failed} failed`,
+  );
+
+  return {
+    ok: true,
+    total: accounts.length,
+    succeeded,
+    failed,
+    // Cap error list — scheduler treats any 2xx as success, body is just for
+    // human inspection in the scheduler UI or logs.
+    errors: errors.slice(0, 20),
+  };
+});


### PR DESCRIPTION
## Summary
- Bump `@agent-native/core` from 0.7.7 → 0.7.8
- Test PR to validate the auto-publish.yml fix from #244

## Test plan
- [ ] On merge, `auto-publish.yml` triggers on the push to main
- [ ] Publish step succeeds (no more `ENEEDAUTH`) via OIDC trusted publishing
- [ ] 0.7.8 appears on npm: https://www.npmjs.com/package/@agent-native/core