### PR TITLE
ci: address PR #247 feedback on auto-publish.yml

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -59,7 +59,13 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           git add package.json
           git commit -m "chore: bump @agent-native/core to v${VERSION}"
-          git tag "v${VERSION}"
+          # Idempotent tag creation — matches the pattern in publish-core so
+          # a retried job after a partial push doesn't fail on a tag conflict.
+          if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists locally, skipping"
+          else
+            git tag "v${VERSION}"
+          fi
           git push origin HEAD:main --tags
 
   dispatch-dev-publish:
@@ -191,6 +197,10 @@ jobs:
     name: Publish desktop app
     needs: detect-changes
     if: needs.detect-changes.outputs.desktop-changed == 'true'
+    # electron-builder --publish always creates/updates a GitHub release.
+    # Needed because the workflow-level permissions: {} resets defaults.
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:
@@ -241,6 +251,9 @@ jobs:
     name: Publish desktop release
     needs: [detect-changes, publish-desktop]
     if: needs.detect-changes.outputs.desktop-changed == 'true'
+    # gh release edit requires contents:write; workflow default is {}.
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Restore `contents: write` on `publish-desktop` and `publish-desktop-release` (workflow-level `permissions: {}` was stripping their `GITHUB_TOKEN` scopes, which would break the next desktop bump mid-publish)
- Make `dispatch-bump` tag creation idempotent, matching the pattern in `publish-core` so a retried job after a partial push doesn't fail on a tag conflict

## Declined from the review
- Re-adding `release: [published]` trigger — removed intentionally in the consolidation; nothing in the repo consumes release events
- Adding `fetch-tags: true` on `publish-core` — reviewer incorrect; `fetch-depth: 0` already fetches all tags per the checkout@v4 docs

## Test plan
- [ ] Next core version bump via workflow_dispatch lands on main and publishes cleanly
- [ ] If a desktop package.json bump ships, electron-builder creates/updates the release without 403s