### PR TITLE
feat(core): public AgentEngine API + integration spec

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,7 @@
     "./terminal/server": "./dist/terminal/index.js",
     "./tailwind": "./dist/tailwind.preset.js",
     "./styles/agent-native.css": "./dist/styles/agent-native.css",
+    "./agent/engine": "./dist/agent/engine/index.js",
     "./tsconfig.base.json": "./tsconfig.base.json"
   },
   "files": [

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -17,6 +17,7 @@ import type {
   EngineCapabilities,
   EngineStreamOptions,
   EngineEvent,
+  EngineContentPart,
 } from "./types.js";
 import {
   engineToolsToAISDK,
@@ -250,6 +251,8 @@ class AISDKEngine implements AgentEngine {
       }
     }
 
+    let assistantContent: EngineContentPart[] = [];
+
     try {
       const result = streamText({
         model: providerModel,
@@ -262,27 +265,29 @@ class AISDKEngine implements AgentEngine {
           : {}),
         abortSignal: opts.abortSignal,
         onStepFinish: (step: any) => {
-          (opts as any)[AISDK_ASSISTANT_CONTENT_KEY] =
-            aiSdkStepToAssistantContent(step);
+          assistantContent = aiSdkStepToAssistantContent(step);
         },
         ...(Object.keys(providerOpts).length > 0
           ? { providerOptions: providerOpts }
           : {}),
       });
 
-      let hasEmittedStop = false;
+      // Buffer the terminal stop so assistant-content can be emitted just
+      // before it, regardless of where `finish` arrives in the stream.
+      let bufferedStop: EngineEvent | undefined;
 
       for await (const part of result.fullStream) {
-        const events = aiSdkPartToEngineEvents(part);
-        for (const event of events) {
-          yield event;
-          if (event.type === "stop") hasEmittedStop = true;
+        for (const event of aiSdkPartToEngineEvents(part)) {
+          if (event.type === "stop") {
+            bufferedStop = event;
+          } else {
+            yield event;
+          }
         }
       }
 
-      if (!hasEmittedStop) {
-        yield { type: "stop", reason: "end_turn" };
-      }
+      yield { type: "assistant-content", parts: assistantContent };
+      yield bufferedStop ?? { type: "stop", reason: "end_turn" };
     } catch (err: any) {
       yield {
         type: "stop",
@@ -320,12 +325,6 @@ class AISDKEngine implements AgentEngine {
     return this.provider === "openai" ? provider.chat(model) : provider(model);
   }
 }
-
-// ---------------------------------------------------------------------------
-// Symbol for assistant content pass-through
-// ---------------------------------------------------------------------------
-
-export const AISDK_ASSISTANT_CONTENT_KEY = Symbol("aiSdkAssistantContent");
 
 // ---------------------------------------------------------------------------
 // Factory functions

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -13,7 +13,6 @@ import type {
   EngineCapabilities,
   EngineStreamOptions,
   EngineEvent,
-  EngineContentPart,
 } from "./types.js";
 import {
   engineToolsToAnthropic,
@@ -145,6 +144,8 @@ class AnthropicEngine implements AgentEngine {
         };
       }
 
+      yield { type: "assistant-content", parts: assistantContent };
+
       // Emit stop reason
       const stopReason = finalMessage.stop_reason ?? "end_turn";
       yield {
@@ -156,11 +157,6 @@ class AnthropicEngine implements AgentEngine {
               ? "max_tokens"
               : "end_turn",
       };
-
-      // Store the final assistant content for the caller via a side channel.
-      // runAgentLoop reads this via the assistantContentRef passed in opts.
-      // We attach it as a non-enumerable symbol property.
-      (opts as any)[ASSISTANT_CONTENT_KEY] = assistantContent;
     } catch (err: any) {
       yield {
         type: "stop",
@@ -171,12 +167,6 @@ class AnthropicEngine implements AgentEngine {
     }
   }
 }
-
-/**
- * Symbol used by AnthropicEngine to return the final assistant content blocks
- * back to runAgentLoop without changing the EngineEvent stream shape.
- */
-export const ASSISTANT_CONTENT_KEY = Symbol("assistantContent");
 
 /**
  * Create an AnthropicEngine instance.

--- a/packages/core/src/agent/engine/translate-ai-sdk.integration.spec.ts
+++ b/packages/core/src/agent/engine/translate-ai-sdk.integration.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * Integration test for the AI SDK translator.
+ *
+ * Unlike translate-ai-sdk.spec.ts — which tests the translator against
+ * synthetic TextStreamPart objects in isolation — this spec drives real
+ * `streamText` with `MockLanguageModelV3` from `ai/test`. It exercises the
+ * full pipeline: mock LM parts → streamText transformation → our translator.
+ *
+ * This is our insurance against AI SDK minor-version drift: if Vercel changes
+ * the fullStream event shapes subtly between v6 patches, these tests fail
+ * loudly, unlike the unit specs which would happily keep passing against
+ * stale fixtures.
+ */
+import { describe, it, expect } from "vitest";
+import { streamText } from "ai";
+import { MockLanguageModelV3, convertArrayToReadableStream } from "ai/test";
+import { aiSdkPartToEngineEvents } from "./translate-ai-sdk.js";
+import type { EngineEvent } from "./types.js";
+
+function mockModel(parts: any[]) {
+  return new MockLanguageModelV3({
+    doStream: async () => ({ stream: convertArrayToReadableStream(parts) }),
+  });
+}
+
+async function collect(result: {
+  fullStream: AsyncIterable<unknown>;
+}): Promise<EngineEvent[]> {
+  const events: EngineEvent[] = [];
+  for await (const part of result.fullStream) {
+    for (const e of aiSdkPartToEngineEvents(part)) events.push(e);
+  }
+  return events;
+}
+
+/** Build a LanguageModelV3Usage with the common fields set. */
+function usage(
+  input: number,
+  output: number,
+  extra: { cacheRead?: number; reasoning?: number } = {},
+) {
+  return {
+    inputTokens: {
+      total: input,
+      noCache: input - (extra.cacheRead ?? 0),
+      cacheRead: extra.cacheRead,
+      cacheWrite: undefined,
+    },
+    outputTokens: {
+      total: output,
+      text: output - (extra.reasoning ?? 0),
+      reasoning: extra.reasoning,
+    },
+  };
+}
+
+/** Build a finish stream-part. */
+function finish(
+  reason:
+    | "stop"
+    | "tool-calls"
+    | "length"
+    | "content-filter"
+    | "error"
+    | "other",
+  u: ReturnType<typeof usage>,
+) {
+  return {
+    type: "finish" as const,
+    usage: u,
+    finishReason: { unified: reason, raw: reason },
+  };
+}
+
+describe("translate-ai-sdk integration (streamText + MockLanguageModelV3)", () => {
+  it("translates a plain text response into text-delta + usage + stop", async () => {
+    const model = mockModel([
+      { type: "stream-start", warnings: [] },
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: "hello" },
+      { type: "text-delta", id: "t1", delta: " world" },
+      { type: "text-end", id: "t1" },
+      finish("stop", usage(5, 2)),
+    ]);
+
+    const events = await collect(streamText({ model, prompt: "hi" }));
+
+    const deltas = events.filter((e) => e.type === "text-delta");
+    expect(deltas.map((e: any) => e.text).join("")).toBe("hello world");
+    expect(events.find((e) => e.type === "usage")).toMatchObject({
+      inputTokens: 5,
+      outputTokens: 2,
+    });
+    expect(events.find((e) => e.type === "stop")).toMatchObject({
+      reason: "end_turn",
+    });
+  });
+
+  it("maps finishReason 'tool-calls' to tool_use stop and emits a tool-call event", async () => {
+    const model = mockModel([
+      { type: "stream-start", warnings: [] },
+      { type: "tool-input-start", id: "tc1", toolName: "get_weather" },
+      { type: "tool-input-delta", id: "tc1", delta: '{"city":"' },
+      { type: "tool-input-delta", id: "tc1", delta: 'Paris"}' },
+      { type: "tool-input-end", id: "tc1" },
+      {
+        type: "tool-call",
+        toolCallId: "tc1",
+        toolName: "get_weather",
+        input: '{"city":"Paris"}',
+      },
+      finish("tool-calls", usage(8, 4)),
+    ]);
+
+    const events = await collect(streamText({ model, prompt: "weather" }));
+
+    expect(events.find((e) => e.type === "tool-call")).toMatchObject({
+      id: "tc1",
+      name: "get_weather",
+      input: { city: "Paris" },
+    });
+    expect(events.find((e) => e.type === "stop")).toMatchObject({
+      reason: "tool_use",
+    });
+  });
+
+  it("surfaces cacheRead tokens via cacheReadTokens on the usage event", async () => {
+    const model = mockModel([
+      { type: "stream-start", warnings: [] },
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: "ok" },
+      { type: "text-end", id: "t1" },
+      finish("stop", usage(100, 1, { cacheRead: 60 })),
+    ]);
+
+    const events = await collect(streamText({ model, prompt: "hi" }));
+    expect(events.find((e) => e.type === "usage")).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 1,
+      cacheReadTokens: 60,
+    });
+  });
+
+  it("emits a thinking-delta event for reasoning-delta parts", async () => {
+    const model = mockModel([
+      { type: "stream-start", warnings: [] },
+      { type: "reasoning-start", id: "r1" },
+      { type: "reasoning-delta", id: "r1", delta: "let me think" },
+      { type: "reasoning-end", id: "r1" },
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: "the answer is 42" },
+      { type: "text-end", id: "t1" },
+      finish("stop", usage(5, 10, { reasoning: 4 })),
+    ]);
+
+    const events = await collect(streamText({ model, prompt: "q" }));
+    const thinking = events.filter((e) => e.type === "thinking-delta");
+    expect(thinking.map((e: any) => e.text).join("")).toBe("let me think");
+  });
+
+  it("maps a stream-level error into a stop-with-error event", async () => {
+    const model = mockModel([
+      { type: "stream-start", warnings: [] },
+      { type: "error", error: new Error("upstream blew up") },
+    ]);
+
+    const events = await collect(streamText({ model, prompt: "boom" }));
+    const stop = events.find((e) => e.type === "stop");
+    expect(stop).toMatchObject({ reason: "error" });
+    if (stop?.type === "stop") {
+      expect(stop.error).toContain("upstream blew up");
+    }
+  });
+});

--- a/packages/core/src/agent/engine/types.ts
+++ b/packages/core/src/agent/engine/types.ts
@@ -103,6 +103,12 @@ export type EngineEvent =
       reasoningTokens?: number;
     }
   | {
+      /** Final assistant content for the turn. Engines MUST emit this
+       *  exactly once, immediately before the terminal `stop` event. */
+      type: "assistant-content";
+      parts: EngineContentPart[];
+    }
+  | {
       type: "stop";
       reason:
         | "end_turn"

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -18,7 +18,6 @@ import type {
   EngineContentPart,
 } from "./engine/types.js";
 import { resolveEngine, registerBuiltinEngines } from "./engine/index.js";
-import { ASSISTANT_CONTENT_KEY } from "./engine/anthropic-engine.js";
 import { readAppState } from "../application-state/script-helpers.js";
 import {
   startRun,
@@ -311,6 +310,8 @@ export async function runAgentLoop(opts: {
             // them as a collapsible "reasoning" section in the UI.
           } else if (event.type === "tool-call") {
             hasToolCalls = true;
+          } else if (event.type === "assistant-content") {
+            assistantContent = event.parts;
           } else if (event.type === "usage") {
             usage.inputTokens += event.inputTokens;
             usage.outputTokens += event.outputTokens;
@@ -319,19 +320,6 @@ export async function runAgentLoop(opts: {
           } else if (event.type === "stop" && event.reason === "error") {
             throw new Error(event.error ?? "Engine stream error");
           }
-        }
-
-        // Retrieve the assistant content blocks stored by the engine.
-        // AnthropicEngine sets streamOpts[ASSISTANT_CONTENT_KEY] after streaming.
-        assistantContent = (streamOpts as any)[ASSISTANT_CONTENT_KEY];
-
-        // If engine didn't populate assistant content (e.g. AI SDK engine),
-        // rebuild it from the messages state we tracked via tool-call events.
-        // The AI SDK engine stores it under AISDK_ASSISTANT_CONTENT_KEY.
-        if (!assistantContent) {
-          const { AISDK_ASSISTANT_CONTENT_KEY } =
-            await import("./engine/ai-sdk-engine.js");
-          assistantContent = (streamOpts as any)[AISDK_ASSISTANT_CONTENT_KEY];
         }
 
         break;

--- a/packages/core/src/templates/default/.agents/skills/agent-engines/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/agent-engines/SKILL.md
@@ -88,11 +88,17 @@ These features are silently ignored when a non-Anthropic engine is active (capab
 
 ## Registering a Custom Engine
 
-Register custom engines in a server plugin at startup:
+Register custom engines in a server plugin at startup. Import from the
+`@agent-native/core/agent/engine` subpath:
 
 ```ts
 // server/plugins/my-engine.ts
-import { registerAgentEngine } from "@agent-native/core/server";
+import {
+  registerAgentEngine,
+  type AgentEngine,
+  type EngineEvent,
+  type EngineStreamOptions,
+} from "@agent-native/core/agent/engine";
 
 registerAgentEngine({
   name: "my-engine",
@@ -108,11 +114,37 @@ registerAgentEngine({
   defaultModel: "my-model-v1",
   supportedModels: ["my-model-v1", "my-model-v2"],
   requiredEnvVars: ["MY_ENGINE_API_KEY"],
-  create: (config) => new MyEngine(config),
+  create: (config): AgentEngine => ({
+    name: "my-engine",
+    label: "My Custom Engine",
+    defaultModel: "my-model-v1",
+    supportedModels: ["my-model-v1", "my-model-v2"],
+    capabilities: {
+      /* same shape as above */
+    } as any,
+    async *stream(opts: EngineStreamOptions): AsyncIterable<EngineEvent> {
+      // yield text-delta / thinking-delta / tool-call / usage events
+      // as they arrive, then:
+      yield { type: "assistant-content", parts: /* final content parts */ [] };
+      yield { type: "stop", reason: "end_turn" };
+    },
+  }),
 });
 ```
 
-After registering, the engine appears in `list-agent-engines` output and can be selected via `set-agent-engine`.
+### Engine stream contract
+
+Every engine's `stream(opts)` MUST emit, in order:
+
+1. Zero or more `text-delta`, `thinking-delta`, `tool-call`, and `usage`
+   events as they arrive from the model.
+2. Exactly one `{ type: "assistant-content", parts }` event with the
+   structured content for the turn. `runAgentLoop` reads this to
+   reconstruct the assistant message for the next turn.
+3. Exactly one terminal `{ type: "stop", reason }` event.
+
+After registering, the engine appears in `list-agent-engines` output and can
+be selected via `set-agent-engine`.
 
 ## Env Vars Reference
 


### PR DESCRIPTION
Base: main (stacked on #245) · Head: gossterrible:feat/public-engine-api  

## Problem

I was trying to register a third-party `AgentEngine` and ran into two issues.

First, the import doesn't work. The `agent-engines` skill says to use `import { registerAgentEngine } from "@agent-native/core/server"`, but that symbol isn't exported there. The actual export lives in `packages/core/src/agent/engine/index.ts`, which isn't listed in `package.json#exports` — so there's no public subpath. The only way to reach it is to patch the installed tarball.

Second, once the engine is wired up, `runAgentLoop` can't read its output. It pulls the final assistant content through two private `Symbol`s (`ASSISTANT_CONTENT_KEY`, `AISDK_ASSISTANT_CONTENT_KEY`) that the two built-in engines set on the caller's options object. It checks each one in sequence. A third-party engine either reuses an internal symbol or patches the loop.

This PR fixes both and updates the skill so its example works.

## Changes

### `core: replace engine symbol side-channel with assistant-content event`
- New `EngineEvent` variant: `{ type: "assistant-content"; parts: EngineContentPart[] }`
- Engines emit it immediately before their terminal `stop`
- `runAgentLoop` reads from the event stream; both `Symbol` exports deleted

### `feat(core): expose agent/engine subpath + integration spec`
- Add `"./agent/engine": "./dist/agent/engine/index.js"` to core's `exports`
- New `translate-ai-sdk.integration.spec.ts` drives real `streamText` + `MockLanguageModelV3` (5 scenarios: text deltas, tool-call round-trip, `cacheReadTokens`, reasoning, error)
- `agent-engines/SKILL.md` rewritten to use the new subpath and document the stream contract — the previous example had a broken import

## Test plan

- `pnpm fmt:check` ✅
- `pnpm test` ✅ 376/376 (+5)
- `pnpm typecheck` ✅ bit-identical to base
- `pnpm build` ✅ same pass pattern as base

## Impact

- **Breaking (pre-1.0):** two internal `Symbol` exports deleted. No consumers outside the four files touched here.
- **Additive:** new subpath export, new `EngineEvent` variant, integration spec.