### PR TITLE
ci: Neon preview-branch workflow for per-PR DB isolation

### DIFF
--- a/.github/workflows/neon-preview-branches.yml
+++ b/.github/workflows/neon-preview-branches.yml
@@ -63,27 +63,31 @@ jobs:
           branch_name: preview/pr-${{ github.event.number }}
           api_key: ${{ secrets.NEON_API_KEY }}
 
-      - name: Set NETLIFY_DATABASE_URL for deploy previews
+      - name: Set preview DB URLs on Netlify site
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NEON_DB_URL: ${{ steps.neon.outputs.db_url_pooled }}
+          NEON_DB_URL_POOLED: ${{ steps.neon.outputs.db_url_pooled }}
+          NEON_DB_URL_UNPOOLED: ${{ steps.neon.outputs.db_url }}
         run: |
-          # Set the branch DB URL as NETLIFY_DATABASE_URL in the deploy-preview context.
-          # Netlify's auto-deploy will pick this up via the shell expansion in netlify.toml.
-          curl -s -X POST \
-            -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
-            -H "Content-Type: application/json" \
-            "https://api.netlify.com/api/v1/accounts/${{ secrets.NETLIFY_ACCOUNT_ID }}/env?site_id=${{ matrix.netlify_site }}" \
-            -d '[{"key":"NETLIFY_DATABASE_URL","scopes":["builds","functions","runtime"],"values":[{"value":"'"$NEON_DB_URL"'","context":"deploy-preview"}]}]' \
-            || echo "Env var may already exist, trying PATCH..."
+          SITE="${{ matrix.netlify_site }}"
+          ACCT="${{ secrets.NETLIFY_ACCOUNT_ID }}"
+          BASE="https://api.netlify.com/api/v1/accounts/$ACCT/env"
+          AUTH="Authorization: Bearer $NETLIFY_AUTH_TOKEN"
 
-          # If it already exists, update the deploy-preview value
-          curl -s -X PATCH \
-            -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
-            -H "Content-Type: application/json" \
-            "https://api.netlify.com/api/v1/accounts/${{ secrets.NETLIFY_ACCOUNT_ID }}/env/NETLIFY_DATABASE_URL?site_id=${{ matrix.netlify_site }}" \
-            -d '{"value":"'"$NEON_DB_URL"'","context":"deploy-preview"}' \
-            || true
+          for pair in "NETLIFY_DATABASE_URL:$NEON_DB_URL_POOLED" "NETLIFY_DATABASE_URL_UNPOOLED:$NEON_DB_URL_UNPOOLED"; do
+            KEY="${pair%%:*}"
+            VAL="${pair#*:}"
+            # Try POST (create); if it already exists, PATCH (update)
+            curl -s -X POST -H "$AUTH" -H "Content-Type: application/json" \
+              "$BASE?site_id=$SITE" \
+              -d '[{"key":"'"$KEY"'","scopes":["builds","functions","runtime"],"values":[{"value":"'"$VAL"'","context":"deploy-preview"}]}]' \
+              -o /dev/null -w '' \
+              || curl -s -X PATCH -H "$AUTH" -H "Content-Type: application/json" \
+                "$BASE/$KEY?site_id=$SITE" \
+                -d '{"value":"'"$VAL"'","context":"deploy-preview"}' \
+                -o /dev/null -w '' \
+              || true
+          done
 
   delete-branches:
     if: github.event.action == 'closed'
@@ -127,11 +131,15 @@ jobs:
           branch: preview/pr-${{ github.event.number }}
           api_key: ${{ secrets.NEON_API_KEY }}
 
-      - name: Remove NETLIFY_DATABASE_URL override
+      - name: Remove preview DB URL overrides
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         run: |
-          curl -s -X DELETE \
-            -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
-            "https://api.netlify.com/api/v1/accounts/${{ secrets.NETLIFY_ACCOUNT_ID }}/env/NETLIFY_DATABASE_URL?site_id=${{ matrix.netlify_site }}" \
-            || true
+          SITE="${{ matrix.netlify_site }}"
+          ACCT="${{ secrets.NETLIFY_ACCOUNT_ID }}"
+          AUTH="Authorization: Bearer $NETLIFY_AUTH_TOKEN"
+          for KEY in NETLIFY_DATABASE_URL NETLIFY_DATABASE_URL_UNPOOLED; do
+            curl -s -X DELETE -H "$AUTH" \
+              "https://api.netlify.com/api/v1/accounts/$ACCT/env/$KEY?site_id=$SITE" \
+              || true
+          done

--- a/.github/workflows/neon-preview-branches.yml
+++ b/.github/workflows/neon-preview-branches.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Set NETLIFY_DATABASE_URL for deploy previews
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NEON_DB_URL: ${{ steps.neon.outputs.db_url_pooled }}
         run: |
           # Set the branch DB URL as NETLIFY_DATABASE_URL in the deploy-preview context.
           # Netlify's auto-deploy will pick this up via the shell expansion in netlify.toml.
@@ -73,7 +74,7 @@ jobs:
             -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
             -H "Content-Type: application/json" \
             "https://api.netlify.com/api/v1/accounts/${{ secrets.NETLIFY_ACCOUNT_ID }}/env?site_id=${{ matrix.netlify_site }}" \
-            -d '[{"key":"NETLIFY_DATABASE_URL","scopes":["builds","functions","runtime"],"values":[{"value":"${{ steps.neon.outputs.db_url_with_pooler }}","context":"deploy-preview"}]}]' \
+            -d '[{"key":"NETLIFY_DATABASE_URL","scopes":["builds","functions","runtime"],"values":[{"value":"'"$NEON_DB_URL"'","context":"deploy-preview"}]}]' \
             || echo "Env var may already exist, trying PATCH..."
 
           # If it already exists, update the deploy-preview value
@@ -81,7 +82,7 @@ jobs:
             -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
             -H "Content-Type: application/json" \
             "https://api.netlify.com/api/v1/accounts/${{ secrets.NETLIFY_ACCOUNT_ID }}/env/NETLIFY_DATABASE_URL?site_id=${{ matrix.netlify_site }}" \
-            -d '{"value":"${{ steps.neon.outputs.db_url_with_pooler }}","context":"deploy-preview"}' \
+            -d '{"value":"'"$NEON_DB_URL"'","context":"deploy-preview"}' \
             || true
 
   delete-branches:

--- a/.github/workflows/neon-preview-branches.yml
+++ b/.github/workflows/neon-preview-branches.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   create-branches:
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -90,7 +90,7 @@ jobs:
           done
 
   delete-branches:
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/neon-preview-branches.yml
+++ b/.github/workflows/neon-preview-branches.yml
@@ -1,0 +1,136 @@
+name: Neon Preview Branches
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Map each Netlify site to its Neon project. When a PR opens, we create a
+# Neon branch per project and inject NETLIFY_DATABASE_URL into the Netlify
+# site's deploy-preview context. Netlify's auto-deploy picks it up via the
+# shell expansion in each template's netlify.toml:
+#   export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL}
+#
+# On PR close we delete the branches and remove the env overrides.
+
+env:
+  NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+
+jobs:
+  create-branches:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - template: analytics
+            neon_project: dry-shadow-75673589
+            netlify_site: ba983662-dac4-478d-a481-5079e67e4d33
+          - template: calendar
+            neon_project: super-fire-75593365
+            netlify_site: 954fe53b-052e-4401-aac2-2e973e498af8
+          - template: clips
+            neon_project: aged-glitter-95425960
+            netlify_site: 7e3f4fee-258d-4d16-9aaf-154a714e87e2
+          - template: content
+            neon_project: quiet-heart-51077706
+            netlify_site: 5c2198f5-bee4-41c3-8a6d-4869f400eec2
+          - template: forms
+            neon_project: curly-glade-91979555
+            netlify_site: aa0b2020-9983-4d6c-8fb0-65462f960fc4
+          - template: issues
+            neon_project: crimson-wave-50288362
+            netlify_site: 76b94d46-f566-43cd-bddd-01123137ab9a
+          - template: mail
+            neon_project: patient-cake-44789837
+            netlify_site: dee98bb0-6143-4205-8c04-afe7bf83d5b5
+          - template: slides
+            neon_project: hidden-thunder-16834477
+            netlify_site: fd5deb5b-5539-47e1-830c-e5fb5e105efd
+          - template: videos
+            neon_project: soft-pine-75308618
+            netlify_site: 3f0c2cd2-06cd-4ab8-bfb4-c199430d1dac
+    steps:
+      - name: Create Neon branch
+        uses: neondatabase/create-branch-action@v6
+        id: neon
+        with:
+          project_id: ${{ matrix.neon_project }}
+          branch_name: preview/pr-${{ github.event.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
+      - name: Set NETLIFY_DATABASE_URL for deploy previews
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        run: |
+          # Set the branch DB URL as NETLIFY_DATABASE_URL in the deploy-preview context.
+          # Netlify's auto-deploy will pick this up via the shell expansion in netlify.toml.
+          curl -s -X POST \
+            -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.netlify.com/api/v1/accounts/${{ secrets.NETLIFY_ACCOUNT_ID }}/env?site_id=${{ matrix.netlify_site }}" \
+            -d '[{"key":"NETLIFY_DATABASE_URL","scopes":["builds","functions","runtime"],"values":[{"value":"${{ steps.neon.outputs.db_url_with_pooler }}","context":"deploy-preview"}]}]' \
+            || echo "Env var may already exist, trying PATCH..."
+
+          # If it already exists, update the deploy-preview value
+          curl -s -X PATCH \
+            -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.netlify.com/api/v1/accounts/${{ secrets.NETLIFY_ACCOUNT_ID }}/env/NETLIFY_DATABASE_URL?site_id=${{ matrix.netlify_site }}" \
+            -d '{"value":"${{ steps.neon.outputs.db_url_with_pooler }}","context":"deploy-preview"}' \
+            || true
+
+  delete-branches:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - template: analytics
+            neon_project: dry-shadow-75673589
+            netlify_site: ba983662-dac4-478d-a481-5079e67e4d33
+          - template: calendar
+            neon_project: super-fire-75593365
+            netlify_site: 954fe53b-052e-4401-aac2-2e973e498af8
+          - template: clips
+            neon_project: aged-glitter-95425960
+            netlify_site: 7e3f4fee-258d-4d16-9aaf-154a714e87e2
+          - template: content
+            neon_project: quiet-heart-51077706
+            netlify_site: 5c2198f5-bee4-41c3-8a6d-4869f400eec2
+          - template: forms
+            neon_project: curly-glade-91979555
+            netlify_site: aa0b2020-9983-4d6c-8fb0-65462f960fc4
+          - template: issues
+            neon_project: crimson-wave-50288362
+            netlify_site: 76b94d46-f566-43cd-bddd-01123137ab9a
+          - template: mail
+            neon_project: patient-cake-44789837
+            netlify_site: dee98bb0-6143-4205-8c04-afe7bf83d5b5
+          - template: slides
+            neon_project: hidden-thunder-16834477
+            netlify_site: fd5deb5b-5539-47e1-830c-e5fb5e105efd
+          - template: videos
+            neon_project: soft-pine-75308618
+            netlify_site: 3f0c2cd2-06cd-4ab8-bfb4-c199430d1dac
+    steps:
+      - name: Delete Neon branch
+        uses: neondatabase/delete-branch-action@v4
+        with:
+          project_id: ${{ matrix.neon_project }}
+          branch: preview/pr-${{ github.event.number }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+
+      - name: Remove NETLIFY_DATABASE_URL override
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        run: |
+          curl -s -X DELETE \
+            -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+            "https://api.netlify.com/api/v1/accounts/${{ secrets.NETLIFY_ACCOUNT_ID }}/env/NETLIFY_DATABASE_URL?site_id=${{ matrix.netlify_site }}" \
+            || true

--- a/docs/neon-netlify-integration.md
+++ b/docs/neon-netlify-integration.md
@@ -1,113 +1,62 @@
-# Neon ↔ Netlify integration — per-deploy DB branches
+# Neon preview branches — per-PR database isolation
 
-Each hosted template runs `drizzle-kit push --force` during its Netlify build
-(see every `templates/*/netlify.toml`). Without deploy-context-aware DB URLs,
-that means **preview deploys mutate the prod database** — a fresh PR with a
-schema change will `ALTER` prod before the PR is even reviewed.
+Preview deploys share the prod `DATABASE_URL` by default, so any server
+cold-start that touches the database writes to prod. To isolate preview
+deploys, we use Neon's copy-on-write branching via GitHub Actions.
 
-The Netlify↔Neon extension solves this. On every deploy it creates a
-copy-on-write Neon branch from the prod branch, injects the branch's
-connection string as `NETLIFY_DATABASE_URL` into that deploy's env, and
-deletes the branch when the deploy is cleaned up. Production deploys on
-`main` keep using the prod branch.
+## How it works
 
-## What's already done (config)
+1. **PR opened/updated** — `.github/workflows/neon-preview-branches.yml`
+   creates a Neon branch (`preview/pr-<number>`) for each hosted template's
+   Neon project, then sets `NETLIFY_DATABASE_URL` on the corresponding
+   Netlify site's deploy-preview context.
 
-Every template's `netlify.toml` build command now starts with:
+2. **Netlify auto-deploys** — each template's `netlify.toml` build command
+   starts with `export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL}`.
+   When `NETLIFY_DATABASE_URL` is set (preview), the build and runtime use
+   the branch DB. When unset (prod), they fall through to the real
+   `DATABASE_URL`.
 
-```
-export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && ...
-```
+3. **PR closed** — the workflow deletes the Neon branches and removes the
+   `NETLIFY_DATABASE_URL` env overrides.
 
-That's the whole mapping. If the Netlify↔Neon extension is installed and the
-site is linked, Netlify injects `NETLIFY_DATABASE_URL` per deploy context
-(prod branch for prod, preview branch for previews) and the shell expansion
-overrides `DATABASE_URL` with it before `pnpm install`, `drizzle-kit push`,
-and the Nitro build all read it. If the extension is not installed, the
-fallback leaves the existing `DATABASE_URL` untouched.
+`@agent-native/core` stays provider-agnostic — it only reads `DATABASE_URL`.
+The Neon/Netlify specifics live in the workflow and each template's
+`netlify.toml`.
 
-`@agent-native/core` stays provider-agnostic — it only ever reads
-`DATABASE_URL`. The Netlify-specific convention lives in each template's
-`netlify.toml`, not in framework code.
+## Required GitHub secrets
 
-## What has to be done in the Netlify UI (one-time per team + per site)
+| Secret                | Where to get it                              |
+| --------------------- | -------------------------------------------- |
+| `NEON_API_KEY`        | Neon dashboard → Account → API Keys          |
+| `NETLIFY_AUTH_TOKEN`  | Netlify User Settings → Personal Access Token|
+| `NETLIFY_ACCOUNT_ID`  | Netlify team settings → Team ID              |
 
-### 1. Install the Neon extension (team-wide, once)
+## Site ↔ Neon project mapping
 
-1. <https://app.netlify.com/teams/steve-sewell/extensions>
-2. Search **Neon** → **Install**
-3. Authorize against the existing Neon account (the one that owns
-   `agent-native-*` Neon projects)
+Defined in the workflow's matrix. Update it when adding a new hosted template.
 
-Confirm with `cd /tmp && netlify db status` — it should print
-`Neon extension: installed on team`.
+| Template  | Neon project ID            | Netlify site ID                      |
+| --------- | -------------------------- | ------------------------------------ |
+| analytics | dry-shadow-75673589        | ba983662-dac4-478d-a481-5079e67e4d33 |
+| calendar  | super-fire-75593365        | 954fe53b-052e-4401-aac2-2e973e498af8 |
+| clips     | aged-glitter-95425960      | 7e3f4fee-258d-4d16-9aaf-154a714e87e2 |
+| content   | quiet-heart-51077706       | 5c2198f5-bee4-41c3-8a6d-4869f400eec2 |
+| forms     | curly-glade-91979555       | aa0b2020-9983-4d6c-8fb0-65462f960fc4 |
+| issues    | crimson-wave-50288362      | 76b94d46-f566-43cd-bddd-01123137ab9a |
+| mail      | patient-cake-44789837      | dee98bb0-6143-4205-8c04-afe7bf83d5b5 |
+| slides    | hidden-thunder-16834477    | fd5deb5b-5539-47e1-830c-e5fb5e105efd |
+| videos    | soft-pine-75308618         | 3f0c2cd2-06cd-4ab8-bfb4-c199430d1dac |
 
-### 2. Per-site: claim the existing Neon project and enable branching
+## Schema changes
 
-For each of the 8 sites below, from the Netlify site dashboard:
+`drizzle-kit push` is **not** run in any build (removed after it caused
+production data loss — see PR #252). Schema evolution uses `runMigrations`
+in each template's `server/plugins/db.ts` — additive SQL only
+(`CREATE TABLE IF NOT EXISTS`, `ALTER TABLE ADD COLUMN IF NOT EXISTS`).
 
-1. **Project configuration → Database** (or **Extensions → Neon**)
-2. **Connect existing Neon project** → pick the matching project (names will
-   line up: `agent-native-forms` site ↔ `agent-native-forms` Neon project,
-   etc.)
-3. Set the **production branch** to `main` (or whatever the Neon prod branch
-   is called for that project — usually `main`).
-4. Enable **Create a branch per deploy preview**. Leave branch-naming and
-   TTL at defaults.
+## Follow-ups
 
-After step 4 Netlify writes `NETLIFY_DATABASE_URL` and
-`NETLIFY_DATABASE_URL_UNPOOLED` into every deploy's env. Preview deploys get
-a per-deploy branch URL; prod deploys get the prod-branch URL.
-
-### 3. Do NOT remove the existing `DATABASE_URL`
-
-Leave the existing `DATABASE_URL` env var in place as a belt-and-suspenders
-fallback for any tooling that still reads it directly (drizzle CLI outside
-the build, local `pnpm action`, etc.). `NETLIFY_DATABASE_URL` wins when
-present, so the integration still takes over on Netlify deploys.
-
-## Sites to configure
-
-| Template  | Netlify site           | Neon project           |
-| --------- | ---------------------- | ---------------------- |
-| forms     | agent-native-forms     | agent-native-forms     |
-| calendar  | agent-native-calendar  | agent-native-calendar  |
-| clips     | agent-native-clips     | agent-native-clips     |
-| content   | agent-native-content   | agent-native-content   |
-| slides    | agent-native-slides    | agent-native-slides    |
-| videos    | agent-native-videos    | agent-native-videos    |
-| analytics | agent-native-analytics | agent-native-analytics |
-| mail      | agent-native-mail      | agent-native-mail      |
-
-(Add `scheduling`, `issues`, `recruiting`, `dispatch`, `macros` if/when they
-start using Neon. Today they either use SQLite locally or haven't shipped.)
-
-## Verification
-
-After enabling on one site (pilot with `forms` or `videos` — small data):
-
-1. Open a throwaway PR that adds a no-op column: e.g. add
-   `test_column text` to a table, commit, push.
-2. Wait for the Netlify preview deploy to finish building.
-3. Inspect the deploy's function env — `NETLIFY_DATABASE_URL` should be set
-   to a branch-specific URL (it'll contain a branch identifier, not `main`).
-4. Connect to the prod Neon branch directly (via Neon console) and confirm
-   `test_column` is **not** present — the preview build pushed it to the
-   preview branch, not prod.
-5. Close the PR without merging. Netlify tears down the preview deploy; Neon
-   deletes the branch. Prod is untouched throughout.
-
-Once verified on the pilot, roll out to the remaining sites.
-
-## Follow-ups (not done yet)
-
-- **Committed migrations for prod.** `drizzle-kit push --force` on `main`
-  still auto-approves destructive statements. Once we have a first rename or
-  drop to ship, move the prod branch's build to `drizzle-kit migrate` against
-  generated migration files and leave `push` only for previews. Until then,
-  follow the additive-only schema rule in `CLAUDE.md`.
-- **Preview-only actions.** Actions that mutate data (e.g. `delete-form`,
-  `publish-recording`) run against whatever branch the deploy points at.
-  That's fine — a preview branch is disposable. But if we ever add actions
-  that reach outside the DB (send email, charge a card, post to Slack),
-  they need their own preview-vs-prod gating.
+- **Preview-only actions.** Actions that reach outside the DB (send email,
+  charge a card, post to Slack) need their own preview-vs-prod gating so
+  preview deploys don't trigger real-world side effects.

--- a/docs/neon-netlify-integration.md
+++ b/docs/neon-netlify-integration.md
@@ -26,27 +26,27 @@ The Neon/Netlify specifics live in the workflow and each template's
 
 ## Required GitHub secrets
 
-| Secret                | Where to get it                              |
-| --------------------- | -------------------------------------------- |
-| `NEON_API_KEY`        | Neon dashboard → Account → API Keys          |
-| `NETLIFY_AUTH_TOKEN`  | Netlify User Settings → Personal Access Token|
-| `NETLIFY_ACCOUNT_ID`  | Netlify team settings → Team ID              |
+| Secret               | Where to get it                               |
+| -------------------- | --------------------------------------------- |
+| `NEON_API_KEY`       | Neon dashboard → Account → API Keys           |
+| `NETLIFY_AUTH_TOKEN` | Netlify User Settings → Personal Access Token |
+| `NETLIFY_ACCOUNT_ID` | Netlify team settings → Team ID               |
 
 ## Site ↔ Neon project mapping
 
 Defined in the workflow's matrix. Update it when adding a new hosted template.
 
-| Template  | Neon project ID            | Netlify site ID                      |
-| --------- | -------------------------- | ------------------------------------ |
-| analytics | dry-shadow-75673589        | ba983662-dac4-478d-a481-5079e67e4d33 |
-| calendar  | super-fire-75593365        | 954fe53b-052e-4401-aac2-2e973e498af8 |
-| clips     | aged-glitter-95425960      | 7e3f4fee-258d-4d16-9aaf-154a714e87e2 |
-| content   | quiet-heart-51077706       | 5c2198f5-bee4-41c3-8a6d-4869f400eec2 |
-| forms     | curly-glade-91979555       | aa0b2020-9983-4d6c-8fb0-65462f960fc4 |
-| issues    | crimson-wave-50288362      | 76b94d46-f566-43cd-bddd-01123137ab9a |
-| mail      | patient-cake-44789837      | dee98bb0-6143-4205-8c04-afe7bf83d5b5 |
-| slides    | hidden-thunder-16834477    | fd5deb5b-5539-47e1-830c-e5fb5e105efd |
-| videos    | soft-pine-75308618         | 3f0c2cd2-06cd-4ab8-bfb4-c199430d1dac |
+| Template  | Neon project ID         | Netlify site ID                      |
+| --------- | ----------------------- | ------------------------------------ |
+| analytics | dry-shadow-75673589     | ba983662-dac4-478d-a481-5079e67e4d33 |
+| calendar  | super-fire-75593365     | 954fe53b-052e-4401-aac2-2e973e498af8 |
+| clips     | aged-glitter-95425960   | 7e3f4fee-258d-4d16-9aaf-154a714e87e2 |
+| content   | quiet-heart-51077706    | 5c2198f5-bee4-41c3-8a6d-4869f400eec2 |
+| forms     | curly-glade-91979555    | aa0b2020-9983-4d6c-8fb0-65462f960fc4 |
+| issues    | crimson-wave-50288362   | 76b94d46-f566-43cd-bddd-01123137ab9a |
+| mail      | patient-cake-44789837   | dee98bb0-6143-4205-8c04-afe7bf83d5b5 |
+| slides    | hidden-thunder-16834477 | fd5deb5b-5539-47e1-830c-e5fb5e105efd |
+| videos    | soft-pine-75308618      | 3f0c2cd2-06cd-4ab8-bfb4-c199430d1dac |
 
 ## Schema changes
 

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -87,6 +87,38 @@ export async function retrySqliteBusy<T>(
   return undefined as unknown as T; // caller handles undefined (e.g. PRAGMA setup)
 }
 
+/**
+ * Retry a DDL statement (CREATE TABLE, CREATE INDEX) once when it fails due
+ * to a Postgres pg_catalog race.
+ *
+ * Postgres's `IF NOT EXISTS` check is NOT atomic with the `pg_type` /
+ * `pg_class` catalog insert. When multiple processes boot concurrently and
+ * issue the same CREATE, both can pass the existence check and one fails
+ * with code 23505 on `pg_type_typname_nsp_index` or similar. The table does
+ * end up created by the winner, so rerunning the same `IF NOT EXISTS`
+ * statement is a safe no-op.
+ */
+export async function retryOnDdlRace<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (e: any) {
+    if (!isPgCatalogRace(e)) throw e;
+    return await fn();
+  }
+}
+
+function isPgCatalogRace(e: any): boolean {
+  if (e?.code !== "23505") return false;
+  const constraint = String(e?.constraint_name ?? e?.constraint ?? "");
+  const detail = String(e?.detail ?? "");
+  return (
+    constraint.startsWith("pg_type") ||
+    constraint.startsWith("pg_class") ||
+    detail.includes("pg_type") ||
+    detail.includes("pg_class")
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Dialect detection
 // ---------------------------------------------------------------------------

--- a/packages/core/src/integrations/config-store.ts
+++ b/packages/core/src/integrations/config-store.ts
@@ -1,4 +1,9 @@
-import { getDbExec, isPostgres, intType } from "../db/client.js";
+import {
+  getDbExec,
+  isPostgres,
+  intType,
+  retryOnDdlRace,
+} from "../db/client.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -6,17 +11,23 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
-        CREATE TABLE IF NOT EXISTS integration_configs (
-          platform TEXT NOT NULL,
-          config_key TEXT NOT NULL,
-          config_data TEXT NOT NULL,
-          owner TEXT,
-          updated_at ${intType()} NOT NULL,
-          PRIMARY KEY (platform, config_key)
-        )
-      `);
-    })();
+      await retryOnDdlRace(() =>
+        client.execute(`
+          CREATE TABLE IF NOT EXISTS integration_configs (
+            platform TEXT NOT NULL,
+            config_key TEXT NOT NULL,
+            config_data TEXT NOT NULL,
+            owner TEXT,
+            updated_at ${intType()} NOT NULL,
+            PRIMARY KEY (platform, config_key)
+          )
+        `),
+      );
+    })().catch((err) => {
+      // Don't cache the rejection — let the next caller retry a fresh init.
+      _initPromise = undefined;
+      throw err;
+    });
   }
   return _initPromise;
 }

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -1,4 +1,10 @@
-import { getDbExec, isPostgres, intType, type DbExec } from "../db/client.js";
+import {
+  getDbExec,
+  isPostgres,
+  intType,
+  retryOnDdlRace,
+  type DbExec,
+} from "../db/client.js";
 import { emitResourceChange, emitResourceDelete } from "./emitter.js";
 import type { StoreWriteOptions } from "../settings/store.js";
 import crypto from "crypto";
@@ -178,26 +184,32 @@ Add people you frequently interact with so the agent can resolve names like "ema
 
 async function ensureTable(): Promise<void> {
   if (!_initPromise) {
-    _initPromise = _doEnsureTable();
+    _initPromise = _doEnsureTable().catch((err) => {
+      // Don't cache the rejection — let the next caller retry a fresh init.
+      _initPromise = undefined;
+      throw err;
+    });
   }
   return _initPromise;
 }
 
 async function _doEnsureTable(): Promise<void> {
   const client = getDbExec();
-  await client.execute(`
-    CREATE TABLE IF NOT EXISTS resources (
-      id TEXT PRIMARY KEY,
-      path TEXT NOT NULL,
-      owner TEXT NOT NULL,
-      content TEXT NOT NULL DEFAULT '',
-      mime_type TEXT NOT NULL DEFAULT 'text/markdown',
-      size ${intType()} NOT NULL DEFAULT 0,
-      created_at ${intType()} NOT NULL,
-      updated_at ${intType()} NOT NULL,
-      UNIQUE(path, owner)
-    )
-  `);
+  await retryOnDdlRace(() =>
+    client.execute(`
+      CREATE TABLE IF NOT EXISTS resources (
+        id TEXT PRIMARY KEY,
+        path TEXT NOT NULL,
+        owner TEXT NOT NULL,
+        content TEXT NOT NULL DEFAULT '',
+        mime_type TEXT NOT NULL DEFAULT 'text/markdown',
+        size ${intType()} NOT NULL DEFAULT 0,
+        created_at ${intType()} NOT NULL,
+        updated_at ${intType()} NOT NULL,
+        UNIQUE(path, owner)
+      )
+    `),
+  );
 
   // Seed default shared resources if they don't exist (INSERT OR IGNORE to avoid race conditions)
   const now = Date.now();

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -269,6 +269,7 @@ describe("server/auth", () => {
         isPostgres: () => false,
         isLocalDatabase: () => true,
         intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
       }));
 
       const authModule = await import("./auth.js");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -34,6 +34,7 @@ import {
   isPostgres,
   intType,
   isLocalDatabase,
+  retryOnDdlRace,
 } from "../db/client.js";
 import { getBetterAuth, getBetterAuthSync } from "./better-auth-instance.js";
 import type { BetterAuthConfig } from "./better-auth-instance.js";
@@ -229,21 +230,47 @@ async function ensureSessionTable(): Promise<void> {
   if (!_sessionInitPromise) {
     _sessionInitPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
-        CREATE TABLE IF NOT EXISTS sessions (
-          token TEXT PRIMARY KEY,
-          email TEXT,
-          created_at ${intType()} NOT NULL
-        )
-      `);
+      await retryOnDdlRace(() =>
+        client.execute(`
+          CREATE TABLE IF NOT EXISTS sessions (
+            token TEXT PRIMARY KEY,
+            email TEXT,
+            created_at ${intType()} NOT NULL
+          )
+        `),
+      );
       try {
         await client.execute(`ALTER TABLE sessions ADD COLUMN email TEXT`);
       } catch {
         // Column already exists
       }
-    })();
+    })().catch((err) => {
+      // Don't cache the rejection — let the next caller retry a fresh init.
+      _sessionInitPromise = undefined;
+      throw err;
+    });
   }
   return _sessionInitPromise;
+}
+
+/**
+ * Re-run any `sessions`-table op once if Postgres reports the relation is
+ * missing. Covers the case where a prior `ensureSessionTable()` resolved but
+ * the table wasn't actually present (e.g. a race where the CREATE was dropped
+ * on a reused pool connection, or a cached resolved promise from a prior
+ * DB URL). Forces a fresh init, then retries the caller's op.
+ */
+async function retryIfSessionsMissing<T>(op: () => Promise<T>): Promise<T> {
+  try {
+    return await op();
+  } catch (e: any) {
+    if (e?.code !== "42P01") throw e;
+    const msg = String(e?.message ?? "");
+    if (!msg.includes("sessions")) throw e;
+    _sessionInitPromise = undefined;
+    await ensureSessionTable();
+    return await op();
+  }
 }
 
 /**
@@ -253,22 +280,26 @@ async function ensureSessionTable(): Promise<void> {
 export async function addSession(token: string, email?: string): Promise<void> {
   await ensureSessionTable();
   const client = getDbExec();
-  await client.execute({
-    sql: isPostgres()
-      ? `INSERT INTO sessions (token, email, created_at) VALUES (?, ?, ?) ON CONFLICT (token) DO UPDATE SET email=EXCLUDED.email, created_at=EXCLUDED.created_at`
-      : `INSERT OR REPLACE INTO sessions (token, email, created_at) VALUES (?, ?, ?)`,
-    args: [token, email ?? null, Date.now()],
-  });
+  await retryIfSessionsMissing(() =>
+    client.execute({
+      sql: isPostgres()
+        ? `INSERT INTO sessions (token, email, created_at) VALUES (?, ?, ?) ON CONFLICT (token) DO UPDATE SET email=EXCLUDED.email, created_at=EXCLUDED.created_at`
+        : `INSERT OR REPLACE INTO sessions (token, email, created_at) VALUES (?, ?, ?)`,
+      args: [token, email ?? null, Date.now()],
+    }),
+  );
 }
 
 /** Remove a session from the legacy sessions table. */
 export async function removeSession(token: string): Promise<void> {
   await ensureSessionTable();
   const client = getDbExec();
-  await client.execute({
-    sql: `DELETE FROM sessions WHERE token = ?`,
-    args: [token],
-  });
+  await retryIfSessionsMissing(() =>
+    client.execute({
+      sql: `DELETE FROM sessions WHERE token = ?`,
+      args: [token],
+    }),
+  );
 }
 
 /**
@@ -278,10 +309,12 @@ export async function removeSession(token: string): Promise<void> {
 export async function getSessionEmail(token: string): Promise<string | null> {
   await ensureSessionTable();
   const client = getDbExec();
-  const { rows } = await client.execute({
-    sql: `SELECT email, created_at FROM sessions WHERE token = ?`,
-    args: [token],
-  });
+  const { rows } = await retryIfSessionsMissing(() =>
+    client.execute({
+      sql: `SELECT email, created_at FROM sessions WHERE token = ?`,
+      args: [token],
+    }),
+  );
   if (rows.length === 0) return null;
   const createdAt = rows[0].created_at as number;
   if (Date.now() - createdAt > sessionMaxAge * 1000) {

--- a/templates/mail/server/plugins/db.ts
+++ b/templates/mail/server/plugins/db.ts
@@ -15,15 +15,15 @@ export default runMigrations([
   },
   {
     version: 2,
-    sql: `ALTER TABLE scheduled_jobs ADD COLUMN account_email TEXT`,
+    sql: `ALTER TABLE scheduled_jobs ADD COLUMN IF NOT EXISTS account_email TEXT`,
   },
   {
     version: 3,
-    sql: `ALTER TABLE scheduled_jobs ADD COLUMN owner_email TEXT`,
+    sql: `ALTER TABLE scheduled_jobs ADD COLUMN IF NOT EXISTS owner_email TEXT`,
   },
   {
     version: 4,
-    sql: `ALTER TABLE scheduled_jobs ADD COLUMN thread_id TEXT`,
+    sql: `ALTER TABLE scheduled_jobs ADD COLUMN IF NOT EXISTS thread_id TEXT`,
   },
   {
     version: 5,


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/neon-preview-branches.yml` — on PR open/sync, creates a Neon copy-on-write branch per hosted template and injects `NETLIFY_DATABASE_URL` into the Netlify site's deploy-preview context. On PR close, cleans up branches and env overrides.
- Replaces the deprecated Netlify↔Neon extension approach with `neondatabase/create-branch-action@v6` + `neondatabase/delete-branch-action@v4`.
- Rewrote `docs/neon-netlify-integration.md` to document the GitHub Actions approach, required secrets, and site↔project mapping.

## Required setup (one-time)

Add these GitHub secrets to the repo:
- `NEON_API_KEY` — from Neon dashboard → Account → API Keys
- `NETLIFY_AUTH_TOKEN` — from Netlify User Settings → Personal Access Token
- `NETLIFY_ACCOUNT_ID` — team ID (`5b76fed9fdd72a2f79e1c586`)

## How it works

Each template's `netlify.toml` already has `export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL}`. The workflow sets `NETLIFY_DATABASE_URL` for the deploy-preview context only — prod deploys are unaffected.

## Test plan

- [ ] Add the three GitHub secrets
- [ ] Open a test PR and verify Neon branches are created (check Actions log)
- [ ] Verify preview deploy uses the branch DB (check function env in Netlify deploy log)
- [ ] Close the test PR and verify branches are deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)