### PR TITLE
feat(core): add ai-sdk:openrouter built-in engine

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -129,6 +129,7 @@
     "@ai-sdk/groq": ">=3",
     "@ai-sdk/mistral": ">=3",
     "@ai-sdk/openai": ">=3",
+    "@openrouter/ai-sdk-provider": ">=2",
     "@assistant-ui/react": ">=0.12",
     "@assistant-ui/react-markdown": ">=0.12",
     "@supabase/supabase-js": ">=2",
@@ -161,6 +162,9 @@
       "optional": true
     },
     "@ai-sdk/openai": {
+      "optional": true
+    },
+    "@openrouter/ai-sdk-provider": {
       "optional": true
     },
     "@ai-sdk/google": {

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -33,6 +33,7 @@ import {
 export type AISDKProvider =
   | "anthropic"
   | "openai"
+  | "openrouter"
   | "google"
   | "groq"
   | "mistral"
@@ -50,6 +51,13 @@ const PROVIDER_CAPABILITIES: Record<AISDKProvider, EngineCapabilities> = {
   openai: {
     thinking: false,
     promptCaching: false,
+    vision: true,
+    computerUse: false,
+    parallelToolCalls: true,
+  },
+  openrouter: {
+    thinking: true,
+    promptCaching: true,
     vision: true,
     computerUse: false,
     parallelToolCalls: true,
@@ -94,6 +102,7 @@ const PROVIDER_CAPABILITIES: Record<AISDKProvider, EngineCapabilities> = {
 const PROVIDER_DEFAULT_MODELS: Record<AISDKProvider, string> = {
   anthropic: "claude-sonnet-4-6",
   openai: "gpt-4o",
+  openrouter: "anthropic/claude-sonnet-4.5",
   google: "gemini-2.0-flash",
   groq: "llama-3.3-70b-versatile",
   mistral: "mistral-large-latest",
@@ -118,6 +127,16 @@ const PROVIDER_SUPPORTED_MODELS: Record<AISDKProvider, readonly string[]> = {
     "o3",
     "o3-mini",
   ],
+  openrouter: [
+    "anthropic/claude-sonnet-4.5",
+    "anthropic/claude-opus-4.1",
+    "anthropic/claude-3.5-haiku",
+    "openai/gpt-4o",
+    "openai/o3",
+    "google/gemini-2.5-pro",
+    "google/gemini-2.5-flash",
+    "meta-llama/llama-3.3-70b-instruct",
+  ],
   google: [
     "gemini-2.0-flash",
     "gemini-2.0-pro",
@@ -141,6 +160,7 @@ const PROVIDER_SUPPORTED_MODELS: Record<AISDKProvider, readonly string[]> = {
 const PROVIDER_ENV_VARS: Record<AISDKProvider, string[]> = {
   anthropic: ["ANTHROPIC_API_KEY"],
   openai: ["OPENAI_API_KEY"],
+  openrouter: ["OPENROUTER_API_KEY"],
   google: ["GOOGLE_GENERATIVE_AI_API_KEY"],
   groq: ["GROQ_API_KEY"],
   mistral: ["MISTRAL_API_KEY"],
@@ -151,6 +171,7 @@ const PROVIDER_ENV_VARS: Record<AISDKProvider, string[]> = {
 const PROVIDER_PACKAGES: Record<AISDKProvider, string> = {
   anthropic: "@ai-sdk/anthropic",
   openai: "@ai-sdk/openai",
+  openrouter: "@openrouter/ai-sdk-provider",
   google: "@ai-sdk/google",
   groq: "@ai-sdk/groq",
   mistral: "@ai-sdk/mistral",
@@ -162,6 +183,7 @@ const PROVIDER_PACKAGES: Record<AISDKProvider, string> = {
 const PROVIDER_FACTORIES: Record<AISDKProvider, string> = {
   anthropic: "createAnthropic",
   openai: "createOpenAI",
+  openrouter: "createOpenRouter",
   google: "createGoogleGenerativeAI",
   groq: "createGroq",
   mistral: "createMistral",
@@ -173,6 +195,20 @@ const PROVIDER_FACTORIES: Record<AISDKProvider, string> = {
 // AISDKEngine implementation
 // ---------------------------------------------------------------------------
 
+/** Config accepted by every `ai-sdk:*` engine. */
+export interface AISDKEngineConfig {
+  /** Override the provider's default model (also becomes the engine's defaultModel). */
+  model?: string;
+  /** API key — falls back to the provider-specific env var if omitted. */
+  apiKey?: string;
+  /** Override the provider base URL (useful for proxies or OpenAI-compatible gateways). */
+  baseUrl?: string;
+  /** OpenRouter: `X-OpenRouter-Title` header for dashboard attribution. */
+  appName?: string;
+  /** OpenRouter: `HTTP-Referer` header for dashboard attribution. */
+  appUrl?: string;
+}
+
 class AISDKEngine implements AgentEngine {
   readonly name: string;
   readonly label: string;
@@ -183,18 +219,20 @@ class AISDKEngine implements AgentEngine {
   private readonly provider: AISDKProvider;
   private readonly apiKey?: string;
   private readonly baseUrl?: string;
+  private readonly appName?: string;
+  private readonly appUrl?: string;
 
-  constructor(provider: AISDKProvider, config: Record<string, unknown>) {
+  constructor(provider: AISDKProvider, config: AISDKEngineConfig) {
     this.provider = provider;
     this.name = `ai-sdk:${provider}`;
     this.label = `${capitalize(provider)} (AI SDK)`;
-    this.defaultModel =
-      (config.model as string | undefined) ?? PROVIDER_DEFAULT_MODELS[provider];
+    this.defaultModel = config.model ?? PROVIDER_DEFAULT_MODELS[provider];
     this.supportedModels = PROVIDER_SUPPORTED_MODELS[provider];
     this.capabilities = PROVIDER_CAPABILITIES[provider];
-    this.apiKey =
-      (config.apiKey as string | undefined) ?? getProviderApiKey(provider);
-    this.baseUrl = config.baseUrl as string | undefined;
+    this.apiKey = config.apiKey ?? getProviderApiKey(provider);
+    this.baseUrl = config.baseUrl;
+    this.appName = config.appName;
+    this.appUrl = config.appUrl;
   }
 
   async *stream(opts: EngineStreamOptions): AsyncIterable<EngineEvent> {
@@ -318,6 +356,11 @@ class AISDKEngine implements AgentEngine {
     const config: Record<string, unknown> = {};
     if (this.apiKey) config.apiKey = this.apiKey;
     if (this.baseUrl) config.baseURL = this.baseUrl;
+    // Scoped to openrouter — other providers' factories may reject unknown keys.
+    if (this.provider === "openrouter") {
+      if (this.appName) config.appName = this.appName;
+      if (this.appUrl) config.appUrl = this.appUrl;
+    }
 
     const provider = createFn(config);
     // @ai-sdk/openai@3 defaults to the Responses API; force Chat Completions
@@ -334,7 +377,7 @@ export function createAISDKEngine(
   provider: AISDKProvider,
   config: Record<string, unknown> = {},
 ): AgentEngine {
-  return new AISDKEngine(provider, config);
+  return new AISDKEngine(provider, config as AISDKEngineConfig);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/agent/engine/builtin.ts
+++ b/packages/core/src/agent/engine/builtin.ts
@@ -49,6 +49,7 @@ export function registerBuiltinEngines(): void {
   const aiSdkProviders: AISDKProvider[] = [
     "anthropic",
     "openai",
+    "openrouter",
     "google",
     "groq",
     "mistral",
@@ -59,6 +60,7 @@ export function registerBuiltinEngines(): void {
   const providerLabels: Record<AISDKProvider, string> = {
     anthropic: "Claude via AI SDK",
     openai: "OpenAI (AI SDK)",
+    openrouter: "OpenRouter (AI SDK)",
     google: "Google Gemini (AI SDK)",
     groq: "Groq (AI SDK)",
     mistral: "Mistral (AI SDK)",
@@ -70,6 +72,8 @@ export function registerBuiltinEngines(): void {
     anthropic:
       "Claude models through the Vercel AI SDK. Supports thinking and caching via AI SDK providerOptions.",
     openai: "OpenAI GPT models via the Vercel AI SDK. Requires OPENAI_API_KEY.",
+    openrouter:
+      "300+ models from Anthropic, OpenAI, Google, Meta, and more routed through a single endpoint. Use model IDs like 'anthropic/claude-sonnet-4.5' or 'openai/gpt-4o'. Requires OPENROUTER_API_KEY.",
     google:
       "Google Gemini models via the Vercel AI SDK. Requires GOOGLE_GENERATIVE_AI_API_KEY.",
     groq: "Groq LPU inference via the Vercel AI SDK. Requires GROQ_API_KEY.",

--- a/packages/core/src/agent/engine/openrouter-engine.spec.ts
+++ b/packages/core/src/agent/engine/openrouter-engine.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("OpenRouter builtin engine", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("registers ai-sdk:openrouter with expected metadata", async () => {
+    const { registerBuiltinEngines } = await import("./builtin.js");
+    const { getAgentEngineEntry } = await import("./registry.js");
+
+    registerBuiltinEngines();
+
+    const entry = getAgentEngineEntry("ai-sdk:openrouter");
+    expect(entry).toBeDefined();
+    expect(entry?.label).toContain("OpenRouter");
+    expect(entry?.requiredEnvVars).toEqual(["OPENROUTER_API_KEY"]);
+    expect(entry?.defaultModel).toMatch(/\//); // vendor/model form
+    expect(entry?.supportedModels).toEqual(
+      expect.arrayContaining(["anthropic/claude-sonnet-4.5"]),
+    );
+    expect(entry?.installPackage).toContain("@openrouter/ai-sdk-provider");
+  });
+
+  it("stream wires apiKey + appName + appUrl into createOpenRouter and resolves the model via provider(model)", async () => {
+    const streamText = vi.fn().mockImplementation(() => ({
+      fullStream: (async function* () {
+        yield {
+          type: "finish",
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      })(),
+    }));
+    const jsonSchema = vi.fn((s: unknown) => s);
+    vi.doMock("ai", () => ({ streamText, jsonSchema }));
+
+    const chatModel = {
+      __isModel: true,
+      modelId: "anthropic/claude-sonnet-4.5",
+    };
+    // `@openrouter/ai-sdk-provider`'s returned provider is callable AND has .chat().
+    const providerCallable = vi.fn().mockReturnValue(chatModel);
+    const openrouter: any = Object.assign(providerCallable, {
+      chat: vi.fn().mockReturnValue(chatModel),
+    });
+    const createOpenRouter = vi.fn().mockReturnValue(openrouter);
+    vi.doMock("@openrouter/ai-sdk-provider", () => ({ createOpenRouter }));
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("openrouter", {
+      apiKey: "or-test-key",
+      appName: "My App",
+      appUrl: "https://myapp.example",
+    });
+
+    const events: any[] = [];
+    for await (const e of engine.stream({
+      model: "anthropic/claude-sonnet-4.5",
+      systemPrompt: "",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      tools: [],
+      abortSignal: new AbortController().signal,
+    } as any)) {
+      events.push(e);
+    }
+
+    expect(createOpenRouter).toHaveBeenCalledWith({
+      apiKey: "or-test-key",
+      appName: "My App",
+      appUrl: "https://myapp.example",
+    });
+    expect(providerCallable).toHaveBeenCalledWith(
+      "anthropic/claude-sonnet-4.5",
+    );
+    expect(streamText).toHaveBeenCalled();
+
+    const stop = events.find((e) => e.type === "stop");
+    expect(stop).toBeDefined();
+    expect(stop.reason).not.toBe("error");
+  });
+
+  it("falls back to OPENROUTER_API_KEY env var when apiKey not in config", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "env-or-key");
+
+    const streamText = vi.fn().mockReturnValue({
+      fullStream: (async function* () {
+        yield { type: "finish", finishReason: "stop", usage: {} };
+      })(),
+    });
+    vi.doMock("ai", () => ({ streamText, jsonSchema: (s: unknown) => s }));
+
+    const chat = vi.fn().mockReturnValue({});
+    const openrouter: any = Object.assign(vi.fn().mockReturnValue({}), {
+      chat,
+    });
+    const createOpenRouter = vi.fn().mockReturnValue(openrouter);
+    vi.doMock("@openrouter/ai-sdk-provider", () => ({ createOpenRouter }));
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("openrouter", {});
+
+    for await (const _ of engine.stream({
+      model: "anthropic/claude-sonnet-4.5",
+      systemPrompt: "",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      tools: [],
+      abortSignal: new AbortController().signal,
+    } as any)) {
+      void _;
+    }
+
+    expect(createOpenRouter).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: "env-or-key" }),
+    );
+  });
+});

--- a/packages/core/src/templates/default/.agents/skills/agent-engines/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/agent-engines/SKILL.md
@@ -59,6 +59,7 @@ Returns `{ ok, latencyMs, response, capabilities }`. If `ok: false`, the error m
 | `anthropic` | Anthropic Claude SDK | `ANTHROPIC_API_KEY` |
 | `ai-sdk:anthropic` | Claude via Vercel AI SDK | `ANTHROPIC_API_KEY` |
 | `ai-sdk:openai` | OpenAI via Vercel AI SDK | `OPENAI_API_KEY` |
+| `ai-sdk:openrouter` | 300+ models (Anthropic, OpenAI, Google, Meta, …) routed through OpenRouter | `OPENROUTER_API_KEY` |
 | `ai-sdk:google` | Google Gemini via Vercel AI SDK | `GOOGLE_GENERATIVE_AI_API_KEY` |
 | `ai-sdk:groq` | Groq LPU via Vercel AI SDK | `GROQ_API_KEY` |
 | `ai-sdk:mistral` | Mistral via Vercel AI SDK | `MISTRAL_API_KEY` |
@@ -85,6 +86,28 @@ When using the `anthropic` engine (or `ai-sdk:anthropic`):
 - **Extended thinking** can be enabled via `providerOptions.anthropic.thinking` — the agent reasons longer before responding.
 
 These features are silently ignored when a non-Anthropic engine is active (capability-gated, no breakage).
+
+## Using OpenRouter
+
+`ai-sdk:openrouter` gives access to 300+ models from many providers through a single API. Model IDs use the `vendor/model` form:
+
+```
+set-agent-engine --engine "ai-sdk:openrouter" --model "anthropic/claude-sonnet-4.5"
+set-agent-engine --engine "ai-sdk:openrouter" --model "openai/gpt-4o"
+set-agent-engine --engine "ai-sdk:openrouter" --model "google/gemini-2.5-pro"
+```
+
+Any `vendor/model` string from [openrouter.ai/models](https://openrouter.ai/models) works — the `supportedModels` list in the registry is a UI hint, not an allow-list.
+
+**App attribution** (optional): pass `appName` / `appUrl` in the engine config to set the `X-OpenRouter-Title` / `HTTP-Referer` headers — useful to see your app on the OpenRouter dashboard and leaderboards:
+
+```ts
+createAISDKEngine("openrouter", {
+  apiKey: process.env.OPENROUTER_API_KEY,
+  appName: "My App",
+  appUrl: "https://myapp.example",
+});
+```
 
 ## Registering a Custom Engine
 
@@ -152,6 +175,7 @@ be selected via `set-agent-engine`.
 |---|---|
 | `ANTHROPIC_API_KEY` | Required for `anthropic` and `ai-sdk:anthropic` engines |
 | `OPENAI_API_KEY` | Required for `ai-sdk:openai` |
+| `OPENROUTER_API_KEY` | Required for `ai-sdk:openrouter` |
 | `GOOGLE_GENERATIVE_AI_API_KEY` | Required for `ai-sdk:google` |
 | `GROQ_API_KEY` | Required for `ai-sdk:groq` |
 | `MISTRAL_API_KEY` | Required for `ai-sdk:mistral` |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@neondatabase/serverless':
         specifier: ^1.1.0
         version: 1.1.0
+      '@openrouter/ai-sdk-provider':
+        specifier: '>=2'
+        version: 2.8.0(ai@6.0.168(zod@3.25.76))(zod@3.25.76)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
@@ -6477,6 +6480,13 @@ packages:
   '@npmcli/fs@4.0.0':
     resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@openrouter/ai-sdk-provider@2.8.0':
+    resolution: {integrity: sha512-oDDW/0KMqz4suHVloB9sNv0YyKLGNYf1FTevXH6adDkid5dsmbbcYuiEsbIhpZSZtHa6o5AVjK1jEAfePOLxww==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ai: ^6.0.0
+      zod: ^3.25.0 || ^4.0.0
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -17802,6 +17812,11 @@ snapshots:
   '@npmcli/fs@4.0.0':
     dependencies:
       semver: 7.7.4
+
+  '@openrouter/ai-sdk-provider@2.8.0(ai@6.0.168(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      ai: 6.0.168(zod@3.25.76)
+      zod: 3.25.76
 
   '@opentelemetry/api@1.9.0': {}
 


### PR DESCRIPTION
## Summary

- Adds `ai-sdk:openrouter` as a first-class built-in AI SDK engine so OpenRouter appears in `list-agent-engines` / `set-agent-engine` and uses `OPENROUTER_API_KEY` directly, instead of having to piggyback on `ai-sdk:openai` with a custom `baseUrl`.
- Uses `@openrouter/ai-sdk-provider` (maintained by the OpenRouter team, listed in the AI SDK docs' community-providers section) as an optional peer dependency — same treatment as `ai-sdk-ollama`, so core installs don't pull it.
- Engine config accepts optional `appName` / `appUrl`, forwarded to `createOpenRouter`. OpenRouter maps these to `X-OpenRouter-Title` / `HTTP-Referer` for dashboard attribution.
- `agent-engines` skill updated with the new engine row, env var entry, and a "Using OpenRouter" section that documents the `vendor/model` ID convention.

## Test plan

- [x] `list-agent-engines` includes `ai-sdk:openrouter` with `OPENROUTER_API_KEY` as the required env var
- [x] `set-agent-engine --engine "ai-sdk:openrouter" --model "anthropic/claude-sonnet-4.5"` then a real agent turn completes without errors
- [x] `pnpm --filter @agent-native/core test` — engine tests pass