### PR TITLE
feat(core): notifications primitive + agent run progress

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,8 @@
     "./tracking": "./dist/tracking/index.js",
     "./notifications": "./dist/notifications/index.js",
     "./client/notifications": "./dist/client/notifications/index.js",
+    "./progress": "./dist/progress/index.js",
+    "./client/progress": "./dist/client/progress/index.js",
     "./triggers": "./dist/triggers/index.js",
     "./terminal": "./dist/client/terminal/index.js",
     "./terminal/server": "./dist/terminal/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,8 @@
     "./mcp": "./dist/mcp/index.js",
     "./mcp-client": "./dist/mcp-client/index.js",
     "./tracking": "./dist/tracking/index.js",
+    "./notifications": "./dist/notifications/index.js",
+    "./client/notifications": "./dist/client/notifications/index.js",
     "./triggers": "./dist/triggers/index.js",
     "./terminal": "./dist/client/terminal/index.js",
     "./terminal/server": "./dist/terminal/index.js",

--- a/packages/core/src/client/notifications/NotificationsBell.tsx
+++ b/packages/core/src/client/notifications/NotificationsBell.tsx
@@ -1,0 +1,226 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { IconBell, IconBellRinging, IconLoader2 } from "@tabler/icons-react";
+
+interface NotificationDto {
+  id: string;
+  owner: string;
+  severity: "info" | "warning" | "critical";
+  title: string;
+  body?: string;
+  metadata?: Record<string, unknown>;
+  deliveredChannels: string[];
+  createdAt: string;
+  readAt: string | null;
+}
+
+interface NotificationsBellProps {
+  /** Poll interval in ms. Set to 0 to disable polling. Default: 10000. */
+  pollMs?: number;
+  /** Optional className for the outer container. */
+  className?: string;
+}
+
+const POLL_MS_DEFAULT = 10_000;
+
+/**
+ * Header-bar bell that shows the unread-notification count and a dropdown of
+ * recent entries. Polling keeps it in sync (the framework poll loop already
+ * bumps a version counter so notifications ride on that signal, but we poll
+ * the count endpoint directly so the bell updates even outside an app-state
+ * change).
+ */
+export function NotificationsBell({
+  pollMs = POLL_MS_DEFAULT,
+  className,
+}: NotificationsBellProps) {
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<NotificationDto[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  const refreshCount = useCallback(async () => {
+    try {
+      const res = await fetch("/_agent-native/notifications/count");
+      if (!res.ok) return;
+      const data = (await res.json()) as { count: number };
+      setUnreadCount(data.count);
+    } catch {
+      // best-effort
+    }
+  }, []);
+
+  const loadItems = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/_agent-native/notifications?limit=20");
+      if (!res.ok) return;
+      const rows = (await res.json()) as NotificationDto[];
+      setItems(rows);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshCount();
+    if (pollMs <= 0) return;
+    const id = window.setInterval(refreshCount, pollMs);
+    return () => window.clearInterval(id);
+  }, [pollMs, refreshCount]);
+
+  useEffect(() => {
+    if (!open) return;
+    loadItems();
+  }, [open, loadItems]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  const markRead = async (id: string) => {
+    try {
+      await fetch(`/_agent-native/notifications/${id}/read`, {
+        method: "POST",
+      });
+      setItems((prev) =>
+        prev
+          ? prev.map((n) =>
+              n.id === id ? { ...n, readAt: new Date().toISOString() } : n,
+            )
+          : prev,
+      );
+      refreshCount();
+    } catch {
+      // best-effort
+    }
+  };
+
+  const markAllRead = async () => {
+    try {
+      await fetch(`/_agent-native/notifications/read-all`, { method: "POST" });
+      setItems((prev) =>
+        prev
+          ? prev.map((n) =>
+              n.readAt ? n : { ...n, readAt: new Date().toISOString() },
+            )
+          : prev,
+      );
+      setUnreadCount(0);
+    } catch {
+      // best-effort
+    }
+  };
+
+  const hasUnread = unreadCount > 0;
+  const Icon = hasUnread ? IconBellRinging : IconBell;
+
+  return (
+    <div
+      ref={menuRef}
+      className={
+        "an-notifications-bell relative inline-flex" +
+        (className ? ` ${className}` : "")
+      }
+    >
+      <button
+        type="button"
+        aria-label={
+          hasUnread ? `${unreadCount} unread notifications` : "Notifications"
+        }
+        onClick={() => setOpen((v) => !v)}
+        className="an-notifications-bell__trigger relative inline-flex h-8 w-8 items-center justify-center rounded-md hover:bg-black/5"
+      >
+        <Icon size={18} aria-hidden />
+        {hasUnread ? (
+          <span
+            aria-hidden
+            className="an-notifications-bell__badge absolute -right-0.5 -top-0.5 rounded-full bg-red-500 px-1 text-[10px] leading-[14px] text-white"
+          >
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        ) : null}
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="an-notifications-bell__menu absolute right-0 top-full z-50 mt-2 w-80 rounded-md border border-black/10 bg-white shadow-lg"
+        >
+          <div className="flex items-center justify-between border-b border-black/10 px-3 py-2 text-sm font-medium">
+            <span>Notifications</span>
+            {hasUnread ? (
+              <button
+                type="button"
+                onClick={markAllRead}
+                className="text-xs text-blue-600 hover:underline"
+              >
+                Mark all read
+              </button>
+            ) : null}
+          </div>
+          <div className="max-h-96 overflow-y-auto">
+            {loading && items === null ? (
+              <div className="flex items-center gap-2 p-4 text-sm text-black/60">
+                <IconLoader2 size={14} className="animate-spin" /> Loading…
+              </div>
+            ) : items && items.length > 0 ? (
+              items.map((n) => (
+                <button
+                  type="button"
+                  key={n.id}
+                  onClick={() => (n.readAt ? undefined : markRead(n.id))}
+                  className={
+                    "flex w-full flex-col items-start gap-0.5 border-b border-black/5 px-3 py-2 text-left last:border-b-0 hover:bg-black/5 " +
+                    (n.readAt ? "opacity-60" : "")
+                  }
+                >
+                  <div className="flex w-full items-center justify-between gap-2">
+                    <span className="truncate text-sm font-medium">
+                      {n.title}
+                    </span>
+                    <SeverityBadge severity={n.severity} />
+                  </div>
+                  {n.body ? (
+                    <span className="line-clamp-2 text-xs text-black/70">
+                      {n.body}
+                    </span>
+                  ) : null}
+                  <span className="text-[10px] text-black/50">
+                    {new Date(n.createdAt).toLocaleString()}
+                  </span>
+                </button>
+              ))
+            ) : (
+              <div className="p-4 text-sm text-black/60">No notifications.</div>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SeverityBadge({
+  severity,
+}: {
+  severity: NotificationDto["severity"];
+}) {
+  const color =
+    severity === "critical"
+      ? "bg-red-100 text-red-800"
+      : severity === "warning"
+        ? "bg-amber-100 text-amber-800"
+        : "bg-slate-100 text-slate-700";
+  return (
+    <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${color}`}>
+      {severity}
+    </span>
+  );
+}

--- a/packages/core/src/client/notifications/index.ts
+++ b/packages/core/src/client/notifications/index.ts
@@ -1,0 +1,1 @@
+export { NotificationsBell } from "./NotificationsBell.js";

--- a/packages/core/src/client/progress/RunsTray.tsx
+++ b/packages/core/src/client/progress/RunsTray.tsx
@@ -1,0 +1,123 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { IconLoader2, IconCheck, IconX, IconClock } from "@tabler/icons-react";
+
+interface AgentRunDto {
+  id: string;
+  owner: string;
+  title: string;
+  step?: string;
+  percent: number | null;
+  status: "running" | "succeeded" | "failed" | "cancelled";
+  metadata?: Record<string, unknown>;
+  startedAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+interface RunsTrayProps {
+  /** Poll interval in ms. 0 disables. Default 3000 (active runs need tight feedback). */
+  pollMs?: number;
+  /** Max runs to show. Default 5. */
+  limit?: number;
+  /** Only show when at least one run is active. Default true. */
+  hideWhenIdle?: boolean;
+  className?: string;
+}
+
+/**
+ * Floating tray that lists the user's active agent runs with live progress.
+ * Polls `/_agent-native/runs?active=true` so it only loads what's in-flight.
+ */
+export function RunsTray({
+  pollMs = 3000,
+  limit = 5,
+  hideWhenIdle = true,
+  className,
+}: RunsTrayProps) {
+  const [runs, setRuns] = useState<AgentRunDto[]>([]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(`/_agent-native/runs?active=true&limit=${limit}`);
+      if (!res.ok) return;
+      const rows = (await res.json()) as AgentRunDto[];
+      setRuns(rows);
+    } catch {
+      // best-effort
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    refresh();
+    if (pollMs <= 0) return;
+    const id = window.setInterval(refresh, pollMs);
+    return () => window.clearInterval(id);
+  }, [pollMs, refresh]);
+
+  if (runs.length === 0 && hideWhenIdle) return null;
+
+  return (
+    <div
+      className={
+        "an-runs-tray fixed bottom-4 right-4 z-50 w-72 rounded-md border border-black/10 bg-white shadow-lg" +
+        (className ? ` ${className}` : "")
+      }
+    >
+      <div className="border-b border-black/10 px-3 py-2 text-sm font-medium">
+        {runs.length === 0
+          ? "No active runs"
+          : `${runs.length} active run${runs.length > 1 ? "s" : ""}`}
+      </div>
+      <div className="divide-y divide-black/5">
+        {runs.map((r) => (
+          <RunRow key={r.id} run={r} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RunRow({ run }: { run: AgentRunDto }) {
+  return (
+    <div className="flex flex-col gap-1 px-3 py-2 text-sm">
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate font-medium">{run.title}</span>
+        <StatusGlyph status={run.status} />
+      </div>
+      {run.step ? (
+        <span className="truncate text-xs text-black/60">{run.step}</span>
+      ) : null}
+      {run.percent != null ? (
+        <div className="mt-0.5 h-1 w-full overflow-hidden rounded bg-black/5">
+          <div
+            className="h-full bg-blue-500 transition-all"
+            style={{ width: `${run.percent}%` }}
+          />
+        </div>
+      ) : (
+        <div className="mt-0.5 h-1 w-full overflow-hidden rounded bg-black/5">
+          <div className="h-full w-1/3 animate-pulse bg-blue-300" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusGlyph({ status }: { status: AgentRunDto["status"] }) {
+  if (status === "running") {
+    return (
+      <IconLoader2
+        size={14}
+        className="animate-spin text-blue-600"
+        aria-hidden
+      />
+    );
+  }
+  if (status === "succeeded") {
+    return <IconCheck size={14} className="text-green-600" aria-hidden />;
+  }
+  if (status === "failed") {
+    return <IconX size={14} className="text-red-600" aria-hidden />;
+  }
+  return <IconClock size={14} className="text-slate-500" aria-hidden />;
+}

--- a/packages/core/src/client/progress/index.ts
+++ b/packages/core/src/client/progress/index.ts
@@ -1,0 +1,1 @@
+export { RunsTray } from "./RunsTray.js";

--- a/packages/core/src/notifications/actions.ts
+++ b/packages/core/src/notifications/actions.ts
@@ -1,0 +1,133 @@
+/**
+ * Framework-level agent actions for the notifications primitive.
+ *
+ * Registered as native tools (not template actions) so they're available in
+ * every template. The agent uses `notify` to surface progress, completions,
+ * and alerts to the user through the in-app inbox and any registered channels.
+ */
+
+import type { ActionEntry } from "../agent/production-agent.js";
+import { notify, listNotifications, countUnread } from "./registry.js";
+import type { NotificationSeverity } from "./types.js";
+
+export function createNotificationToolEntries(
+  getCurrentUser: () => string,
+): Record<string, ActionEntry> {
+  return {
+    notify: {
+      tool: {
+        description:
+          "Send a notification to the user. Always persisted to the in-app inbox so the bell + toast surface shows it. Registered channels (webhook, Slack, etc.) also run. Use `info` for FYI, `warning` for things the user should look at, `critical` for things that need immediate attention.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            severity: {
+              type: "string",
+              enum: ["info", "warning", "critical"],
+              description:
+                "Severity level — drives styling and per-severity channel routing.",
+            },
+            title: {
+              type: "string",
+              description: "Short, human-readable headline (≤100 chars).",
+            },
+            body: {
+              type: "string",
+              description: "Optional longer description.",
+            },
+            metadataJson: {
+              type: "string",
+              description:
+                'Optional JSON metadata (URLs, entity ids, etc.). Example: \'{"threadId":"abc","link":"/inbox/abc"}\'.',
+            },
+            channels: {
+              type: "string",
+              description:
+                'Optional comma-separated channel allowlist (e.g. "inbox,webhook"). Omit to run all registered channels.',
+            },
+          },
+          required: ["severity", "title"],
+        },
+      },
+      run: async (args: Record<string, string>) => {
+        const owner = getCurrentUser();
+        if (!args.severity || !args.title) {
+          return "Error: --severity and --title are required.";
+        }
+        const severity = args.severity as NotificationSeverity;
+        if (!["info", "warning", "critical"].includes(severity)) {
+          return `Error: severity must be info, warning, or critical (got "${severity}").`;
+        }
+
+        let metadata: Record<string, unknown> | undefined;
+        if (args.metadataJson) {
+          try {
+            metadata = JSON.parse(args.metadataJson);
+          } catch {
+            return "Error: metadataJson must be valid JSON.";
+          }
+        }
+
+        const channels = args.channels
+          ? args.channels
+              .split(",")
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : undefined;
+
+        const stored = await notify(
+          {
+            severity,
+            title: args.title,
+            body: args.body || undefined,
+            metadata,
+            channels,
+          },
+          { owner },
+        );
+        return stored
+          ? `Notification sent (id: ${stored.id})`
+          : "Notification dispatched to channels (not persisted).";
+      },
+    },
+
+    "list-notifications": {
+      tool: {
+        description:
+          "List recent notifications for the current user. Useful when the user asks about prior alerts.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            unreadOnly: {
+              type: "boolean",
+              description: "When true, only include unread notifications.",
+            },
+            limit: {
+              type: "number",
+              description: "Max rows to return (default 20, max 200).",
+            },
+          },
+        },
+      },
+      run: async (args: Record<string, unknown>) => {
+        const owner = getCurrentUser();
+        const rows = await listNotifications(owner, {
+          unreadOnly: args.unreadOnly === true || args.unreadOnly === "true",
+          limit: Math.min(Number(args.limit ?? 20), 200),
+        });
+        if (rows.length === 0) {
+          return args.unreadOnly
+            ? "No unread notifications."
+            : "No notifications.";
+        }
+        const unreadCount = await countUnread(owner);
+        const lines = rows.map(
+          (n) =>
+            `[${n.readAt ? " " : "•"}] (${n.severity}) ${n.title}${n.body ? ` — ${n.body}` : ""} · ${n.createdAt}`,
+        );
+        return `${unreadCount} unread\n\n${lines.join("\n")}`;
+      },
+      readOnly: true,
+    },
+  };
+}

--- a/packages/core/src/notifications/channels.ts
+++ b/packages/core/src/notifications/channels.ts
@@ -1,0 +1,87 @@
+/**
+ * Built-in notification channels.
+ *
+ * Set environment variables to auto-register the webhook channel at startup.
+ * Extra channels can be registered at any time via
+ * `registerNotificationChannel()` from a server plugin.
+ *
+ * NOTIFICATIONS_WEBHOOK_URL  → POST notifications as JSON to this URL.
+ *                              Supports `${keys.NAME}` substitution — the raw
+ *                              value never enters the agent context.
+ * NOTIFICATIONS_WEBHOOK_AUTH → optional `Authorization` header value (also
+ *                              supports `${keys.NAME}`).
+ */
+
+import { registerNotificationChannel } from "./registry.js";
+import type { NotificationChannel } from "./types.js";
+import {
+  resolveKeyReferences,
+  validateUrlAllowlist,
+  getKeyAllowlist,
+} from "../secrets/substitution.js";
+
+let _registered = false;
+
+export function registerBuiltinNotificationChannels(): void {
+  if (_registered) return;
+  _registered = true;
+
+  const url = process.env.NOTIFICATIONS_WEBHOOK_URL;
+  if (url) {
+    registerNotificationChannel(createWebhookChannel(url));
+  }
+}
+
+function createWebhookChannel(urlTemplate: string): NotificationChannel {
+  const authTemplate = process.env.NOTIFICATIONS_WEBHOOK_AUTH;
+  return {
+    name: "webhook",
+    async deliver(input, meta) {
+      // Resolve `${keys.NAME}` references against the owner's user-scope
+      // secrets. Missing keys throw — the error surfaces in logs and the
+      // channel is marked un-delivered, but other channels still run.
+      const { resolved: url } = await resolveKeyReferences(
+        urlTemplate,
+        "user",
+        meta.owner,
+      );
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (authTemplate) {
+        const { resolved: auth } = await resolveKeyReferences(
+          authTemplate,
+          "user",
+          meta.owner,
+        );
+        headers.Authorization = auth;
+      }
+
+      // If the user set an allowlist on a referenced key, enforce it here.
+      // Origin-level check — same rule the automations fetch-tool uses.
+      for (const match of urlTemplate.matchAll(
+        /\$\{keys\.([A-Za-z0-9_-]+)\}/g,
+      )) {
+        const allowlist = await getKeyAllowlist(match[1], "user", meta.owner);
+        if (!validateUrlAllowlist(url, allowlist)) {
+          throw new Error(
+            `[notifications] webhook URL ${new URL(url).origin} is not in the allowlist for key "${match[1]}"`,
+          );
+        }
+      }
+
+      await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          severity: input.severity,
+          title: input.title,
+          body: input.body,
+          metadata: input.metadata,
+          owner: meta.owner,
+          emittedAt: new Date().toISOString(),
+        }),
+      });
+    },
+  };
+}

--- a/packages/core/src/notifications/index.ts
+++ b/packages/core/src/notifications/index.ts
@@ -1,0 +1,21 @@
+export type {
+  Notification,
+  NotificationSeverity,
+  NotificationInput,
+  NotificationMeta,
+  NotificationChannel,
+} from "./types.js";
+
+export {
+  notify,
+  registerNotificationChannel,
+  unregisterNotificationChannel,
+  listNotificationChannels,
+  listNotifications,
+  countUnread,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification,
+} from "./registry.js";
+
+export { registerBuiltinNotificationChannels } from "./channels.js";

--- a/packages/core/src/notifications/notifications.spec.ts
+++ b/packages/core/src/notifications/notifications.spec.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockInsertNotification = vi.fn();
+const mockEmit = vi.fn();
+
+vi.mock("./store.js", () => ({
+  insertNotification: (...args: unknown[]) => mockInsertNotification(...args),
+}));
+
+vi.mock("../event-bus/bus.js", () => ({
+  emit: (...args: unknown[]) => mockEmit(...args),
+}));
+
+import {
+  notify,
+  registerNotificationChannel,
+  unregisterNotificationChannel,
+  listNotificationChannels,
+  __resetNotificationChannels,
+} from "./registry.js";
+
+describe("notifications registry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetNotificationChannels();
+    mockInsertNotification.mockResolvedValue({
+      id: "n-1",
+      owner: "boni@local",
+      severity: "info",
+      title: "Hi",
+      body: undefined,
+      metadata: undefined,
+      deliveredChannels: ["inbox"],
+      createdAt: "2026-04-22T16:00:00.000Z",
+      readAt: null,
+    });
+  });
+
+  describe("notify()", () => {
+    it("persists an inbox row by default and emits notification.sent", async () => {
+      const stored = await notify(
+        { severity: "info", title: "Booking confirmed" },
+        { owner: "boni@local" },
+      );
+
+      expect(mockInsertNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "boni@local",
+          severity: "info",
+          title: "Booking confirmed",
+        }),
+      );
+      expect(stored?.id).toBe("n-1");
+      expect(mockEmit).toHaveBeenCalledWith(
+        "notification.sent",
+        expect.objectContaining({
+          notificationId: "n-1",
+          severity: "info",
+          deliveredChannels: ["inbox"],
+        }),
+        { owner: "boni@local" },
+      );
+    });
+
+    it("requires meta.owner", async () => {
+      await expect(
+        notify({ severity: "info", title: "x" }, { owner: "" }),
+      ).rejects.toThrow(/owner is required/);
+    });
+
+    it("fans out to registered channels in addition to the inbox row", async () => {
+      const deliver = vi.fn();
+      registerNotificationChannel({ name: "slack", deliver });
+
+      await notify(
+        { severity: "warning", title: "Disk low" },
+        { owner: "boni@local" },
+      );
+
+      expect(deliver).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: "warning", title: "Disk low" }),
+        { owner: "boni@local" },
+      );
+      expect(mockInsertNotification).toHaveBeenCalledTimes(1);
+    });
+
+    it("channel throws — other channels still run and inbox still persists", async () => {
+      const badDeliver = vi.fn(() => {
+        throw new Error("slack is down");
+      });
+      const goodDeliver = vi.fn();
+      registerNotificationChannel({ name: "slack", deliver: badDeliver });
+      registerNotificationChannel({ name: "pager", deliver: goodDeliver });
+
+      await notify(
+        { severity: "critical", title: "DB offline" },
+        { owner: "boni@local" },
+      );
+
+      expect(badDeliver).toHaveBeenCalled();
+      expect(goodDeliver).toHaveBeenCalled();
+      expect(mockInsertNotification).toHaveBeenCalled();
+    });
+
+    it("explicit channels allowlist scopes delivery and excludes inbox when omitted", async () => {
+      const deliverSlack = vi.fn();
+      const deliverPager = vi.fn();
+      registerNotificationChannel({ name: "slack", deliver: deliverSlack });
+      registerNotificationChannel({ name: "pager", deliver: deliverPager });
+
+      await notify(
+        { severity: "info", title: "Test", channels: ["slack"] },
+        { owner: "boni@local" },
+      );
+
+      expect(deliverSlack).toHaveBeenCalled();
+      expect(deliverPager).not.toHaveBeenCalled();
+      expect(mockInsertNotification).not.toHaveBeenCalled();
+    });
+
+    it("channels=['inbox'] persists but skips custom channels", async () => {
+      const deliverSlack = vi.fn();
+      registerNotificationChannel({ name: "slack", deliver: deliverSlack });
+
+      await notify(
+        { severity: "info", title: "Test", channels: ["inbox"] },
+        { owner: "boni@local" },
+      );
+
+      expect(mockInsertNotification).toHaveBeenCalled();
+      expect(deliverSlack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("channel registration", () => {
+    it("requires a name", () => {
+      expect(() =>
+        registerNotificationChannel({
+          name: "",
+          deliver: () => undefined,
+        }),
+      ).toThrow(/name is required/);
+    });
+
+    it("requires deliver to be a function", () => {
+      expect(() =>
+        registerNotificationChannel({
+          name: "bad",
+          deliver: "nope" as unknown as NotificationChannel["deliver"],
+        }),
+      ).toThrow(/must be a function/);
+    });
+
+    it("listNotificationChannels reflects registered channels", () => {
+      registerNotificationChannel({ name: "a", deliver: () => undefined });
+      registerNotificationChannel({ name: "b", deliver: () => undefined });
+      expect(listNotificationChannels().sort()).toEqual(["a", "b"]);
+      unregisterNotificationChannel("a");
+      expect(listNotificationChannels()).toEqual(["b"]);
+    });
+  });
+});
+
+// Re-import the type inline so the cast above compiles without circularity.
+type NotificationChannel = {
+  name: string;
+  deliver: (...args: unknown[]) => unknown;
+};

--- a/packages/core/src/notifications/registry.ts
+++ b/packages/core/src/notifications/registry.ts
@@ -1,0 +1,139 @@
+import type {
+  NotificationChannel,
+  NotificationInput,
+  NotificationMeta,
+  Notification,
+} from "./types.js";
+import { insertNotification } from "./store.js";
+import { emit as emitBusEvent } from "../event-bus/bus.js";
+
+const REGISTRY_KEY = Symbol.for("@agent-native/core/notifications.registry");
+interface GlobalWithRegistry {
+  [REGISTRY_KEY]?: Map<string, NotificationChannel>;
+}
+
+function getRegistry(): Map<string, NotificationChannel> {
+  const g = globalThis as unknown as GlobalWithRegistry;
+  if (!g[REGISTRY_KEY]) g[REGISTRY_KEY] = new Map();
+  return g[REGISTRY_KEY];
+}
+
+export function registerNotificationChannel(
+  channel: NotificationChannel,
+): void {
+  if (!channel?.name) {
+    throw new Error("registerNotificationChannel: channel.name is required");
+  }
+  if (typeof channel.deliver !== "function") {
+    throw new Error(
+      "registerNotificationChannel: channel.deliver must be a function",
+    );
+  }
+  getRegistry().set(channel.name, channel);
+}
+
+export function unregisterNotificationChannel(name: string): boolean {
+  return getRegistry().delete(name);
+}
+
+export function listNotificationChannels(): string[] {
+  return Array.from(getRegistry().keys());
+}
+
+/**
+ * Deliver a notification.
+ *
+ * The `inbox` channel always persists a row that drives the in-app UI
+ * (bell + toast). Additional channels (webhook, custom) run in parallel,
+ * best-effort. Returns the stored Notification when `inbox` ran, otherwise
+ * `undefined`.
+ *
+ * Also emits `notification.sent` on the event bus so automations can react
+ * to notifications (e.g. "when a critical notification fires, also page me").
+ */
+export async function notify(
+  input: NotificationInput,
+  meta: NotificationMeta,
+): Promise<Notification | undefined> {
+  if (!meta?.owner) {
+    throw new Error("notify: meta.owner is required");
+  }
+  const channels = selectChannels(input.channels);
+
+  // The inbox channel is always included unless explicitly excluded.
+  const runInbox = !input.channels || input.channels.includes("inbox");
+  const delivered: string[] = [];
+  let stored: Notification | undefined;
+
+  if (runInbox) {
+    try {
+      stored = await insertNotification({
+        owner: meta.owner,
+        severity: input.severity,
+        title: input.title,
+        body: input.body,
+        metadata: input.metadata,
+        deliveredChannels: channels.map((c) => c.name).concat("inbox"),
+      });
+      delivered.push("inbox");
+    } catch (err) {
+      console.error("[notifications] inbox persist failed:", err);
+    }
+  }
+
+  // Fan out to registered channels (best-effort).
+  for (const channel of channels) {
+    try {
+      const result = channel.deliver(input, meta);
+      if (result && typeof (result as Promise<void>).catch === "function") {
+        (result as Promise<void>).catch((err) => {
+          console.error(
+            `[notifications] channel "${channel.name}" rejected:`,
+            err,
+          );
+        });
+      }
+      delivered.push(channel.name);
+    } catch (err) {
+      console.error(`[notifications] channel "${channel.name}" threw:`, err);
+    }
+  }
+
+  try {
+    emitBusEvent(
+      "notification.sent",
+      {
+        notificationId: stored?.id,
+        severity: input.severity,
+        title: input.title,
+        body: input.body,
+        deliveredChannels: delivered,
+      },
+      { owner: meta.owner },
+    );
+  } catch {
+    // best-effort
+  }
+
+  return stored;
+}
+
+function selectChannels(allowlist?: string[]): NotificationChannel[] {
+  const registry = getRegistry();
+  const all = Array.from(registry.values());
+  if (!allowlist) return all;
+  return all.filter((c) => allowlist.includes(c.name));
+}
+
+/** Test helper — drops all registered channels. */
+export function __resetNotificationChannels(): void {
+  getRegistry().clear();
+}
+
+export {
+  listNotifications,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification,
+  countUnread,
+} from "./store.js";

--- a/packages/core/src/notifications/routes.ts
+++ b/packages/core/src/notifications/routes.ts
@@ -1,0 +1,89 @@
+/**
+ * H3 event handlers for the notifications inbox.
+ *
+ * Mounted under `/_agent-native/notifications/*` by `core-routes-plugin`.
+ *
+ *   GET  /_agent-native/notifications?unread=true&limit=50&before=ISO
+ *                                                   — list for the session owner
+ *   GET  /_agent-native/notifications/count         — unread count
+ *   POST /_agent-native/notifications/:id/read      — mark as read
+ *   POST /_agent-native/notifications/read-all      — mark all read
+ *   DELETE /_agent-native/notifications/:id         — delete
+ */
+
+import {
+  defineEventHandler,
+  getMethod,
+  getQuery,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+import { getSession } from "../server/auth.js";
+import {
+  listNotifications,
+  countUnread,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification,
+} from "./store.js";
+
+async function resolveOwner(event: H3Event): Promise<string> {
+  const session = await getSession(event).catch(() => null);
+  return session?.email || "local@localhost";
+}
+
+export function createNotificationsHandler() {
+  return defineEventHandler(async (event: H3Event) => {
+    const method = getMethod(event);
+    const pathname = (event.url?.pathname || "")
+      .replace(/^\/+/, "")
+      .replace(/\/+$/, "");
+    const parts = pathname ? pathname.split("/") : [];
+    const owner = await resolveOwner(event);
+
+    // GET /  — list
+    if (method === "GET" && parts.length === 0) {
+      const q = getQuery(event);
+      return listNotifications(owner, {
+        unreadOnly: q.unread === "true" || q.unread === "1",
+        limit: q.limit ? Math.min(Number(q.limit) || 50, 200) : 50,
+        before: typeof q.before === "string" ? q.before : undefined,
+      });
+    }
+
+    // GET /count
+    if (method === "GET" && parts.length === 1 && parts[0] === "count") {
+      const count = await countUnread(owner);
+      return { count };
+    }
+
+    // POST /read-all
+    if (method === "POST" && parts.length === 1 && parts[0] === "read-all") {
+      const updated = await markAllNotificationsRead(owner);
+      return { updated };
+    }
+
+    // POST /:id/read
+    if (method === "POST" && parts.length === 2 && parts[1] === "read") {
+      const ok = await markNotificationRead(parts[0], owner);
+      if (!ok) {
+        setResponseStatus(event, 404);
+        return { error: "Not found or already read" };
+      }
+      return { ok: true };
+    }
+
+    // DELETE /:id
+    if (method === "DELETE" && parts.length === 1) {
+      const ok = await deleteNotification(parts[0], owner);
+      if (!ok) {
+        setResponseStatus(event, 404);
+        return { error: "Not found" };
+      }
+      return { ok: true };
+    }
+
+    setResponseStatus(event, 404);
+    return { error: "Not found" };
+  });
+}

--- a/packages/core/src/notifications/store.ts
+++ b/packages/core/src/notifications/store.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from "node:crypto";
+import { getDbExec, intType, isPostgres } from "../db/client.js";
+import type { Notification, NotificationSeverity } from "./types.js";
+
+let _initPromise: Promise<void> | undefined;
+
+async function ensureTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const client = getDbExec();
+      await client.execute(`
+        CREATE TABLE IF NOT EXISTS notifications (
+          id TEXT PRIMARY KEY,
+          owner TEXT NOT NULL,
+          severity TEXT NOT NULL,
+          title TEXT NOT NULL,
+          body TEXT,
+          metadata TEXT,
+          delivered_channels TEXT NOT NULL DEFAULT '[]',
+          created_at ${intType()} NOT NULL,
+          read_at ${intType()}
+        )
+      `);
+      await client.execute(
+        `CREATE INDEX IF NOT EXISTS idx_notifications_owner_unread ON notifications (owner, read_at)`,
+      );
+    })();
+  }
+  return _initPromise;
+}
+
+function parseRow(row: Record<string, unknown>): Notification {
+  return {
+    id: String(row.id),
+    owner: String(row.owner),
+    severity: String(row.severity) as NotificationSeverity,
+    title: String(row.title),
+    body: row.body == null ? undefined : String(row.body),
+    metadata: row.metadata
+      ? (JSON.parse(String(row.metadata)) as Record<string, unknown>)
+      : undefined,
+    deliveredChannels: JSON.parse(
+      String(row.delivered_channels ?? "[]"),
+    ) as string[],
+    createdAt: new Date(Number(row.created_at)).toISOString(),
+    readAt:
+      row.read_at == null ? null : new Date(Number(row.read_at)).toISOString(),
+  };
+}
+
+export interface InsertNotificationInput {
+  owner: string;
+  severity: NotificationSeverity;
+  title: string;
+  body?: string;
+  metadata?: Record<string, unknown>;
+  deliveredChannels?: string[];
+}
+
+export async function insertNotification(
+  input: InsertNotificationInput,
+): Promise<Notification> {
+  await ensureTable();
+  const client = getDbExec();
+  const id = randomUUID();
+  const createdAt = Date.now();
+  await client.execute({
+    sql: `INSERT INTO notifications
+      (id, owner, severity, title, body, metadata, delivered_channels, created_at, read_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+    args: [
+      id,
+      input.owner,
+      input.severity,
+      input.title,
+      input.body ?? null,
+      input.metadata ? JSON.stringify(input.metadata) : null,
+      JSON.stringify(input.deliveredChannels ?? []),
+      createdAt,
+    ],
+  });
+  return {
+    id,
+    owner: input.owner,
+    severity: input.severity,
+    title: input.title,
+    body: input.body,
+    metadata: input.metadata,
+    deliveredChannels: input.deliveredChannels ?? [],
+    createdAt: new Date(createdAt).toISOString(),
+    readAt: null,
+  };
+}
+
+export interface ListNotificationsOptions {
+  /** When true, only return unread (read_at IS NULL). */
+  unreadOnly?: boolean;
+  /** Max rows to return. Default 50. */
+  limit?: number;
+  /** ISO timestamp cursor — returns rows with created_at < cursor. */
+  before?: string;
+}
+
+export async function listNotifications(
+  owner: string,
+  options: ListNotificationsOptions = {},
+): Promise<Notification[]> {
+  await ensureTable();
+  const client = getDbExec();
+  const limit = Math.min(options.limit ?? 50, 200);
+  const args: Array<string | number> = [owner];
+  let where = `owner = ?`;
+  if (options.unreadOnly) where += ` AND read_at IS NULL`;
+  if (options.before) {
+    where += ` AND created_at < ?`;
+    args.push(new Date(options.before).getTime());
+  }
+  args.push(limit);
+  const { rows } = await client.execute({
+    sql: `SELECT * FROM notifications WHERE ${where} ORDER BY created_at DESC LIMIT ?`,
+    args,
+  });
+  return rows.map((r) => parseRow(r as Record<string, unknown>));
+}
+
+export async function countUnread(owner: string): Promise<number> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT COUNT(*) as c FROM notifications WHERE owner = ? AND read_at IS NULL`,
+    args: [owner],
+  });
+  return Number(rows[0]?.c ?? 0);
+}
+
+export async function markNotificationRead(
+  id: string,
+  owner: string,
+): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const sql = isPostgres()
+    ? `UPDATE notifications SET read_at = ? WHERE id = ? AND owner = ? AND read_at IS NULL`
+    : `UPDATE notifications SET read_at = ? WHERE id = ? AND owner = ? AND read_at IS NULL`;
+  const res = await client.execute({ sql, args: [now, id, owner] });
+  return (res as unknown as { rowsAffected?: number }).rowsAffected !== 0;
+}
+
+export async function markAllNotificationsRead(owner: string): Promise<number> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const res = await client.execute({
+    sql: `UPDATE notifications SET read_at = ? WHERE owner = ? AND read_at IS NULL`,
+    args: [now, owner],
+  });
+  return (res as unknown as { rowsAffected?: number }).rowsAffected ?? 0;
+}
+
+export async function deleteNotification(
+  id: string,
+  owner: string,
+): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const res = await client.execute({
+    sql: `DELETE FROM notifications WHERE id = ? AND owner = ?`,
+    args: [id, owner],
+  });
+  return (res as unknown as { rowsAffected?: number }).rowsAffected !== 0;
+}

--- a/packages/core/src/notifications/types.ts
+++ b/packages/core/src/notifications/types.ts
@@ -1,0 +1,48 @@
+export type NotificationSeverity = "info" | "warning" | "critical";
+
+export interface Notification {
+  id: string;
+  owner: string;
+  severity: NotificationSeverity;
+  title: string;
+  body?: string;
+  /** Arbitrary JSON metadata — URLs, entity ids, the agent turn that produced it. */
+  metadata?: Record<string, unknown>;
+  /** ISO timestamp */
+  createdAt: string;
+  /** ISO timestamp — null while unread */
+  readAt: string | null;
+  /** Channels that delivered (or attempted delivery of) this notification. */
+  deliveredChannels: string[];
+}
+
+export interface NotificationInput {
+  severity: NotificationSeverity;
+  title: string;
+  body?: string;
+  metadata?: Record<string, unknown>;
+  /**
+   * Explicit channel allowlist for this emission. When omitted, every
+   * registered channel runs. Use to scope a single `notify()` call to a
+   * subset (e.g. `["inbox"]` to skip webhooks).
+   */
+  channels?: string[];
+}
+
+export interface NotificationMeta {
+  /** Owner email — scopes the notification in the inbox. */
+  owner: string;
+}
+
+export interface NotificationChannel {
+  /** Unique channel name, e.g. `"inbox"`, `"webhook"`, `"slack"`. */
+  name: string;
+  /**
+   * Deliver the notification. Must be best-effort — throwing will be logged
+   * but will not block other channels from running.
+   */
+  deliver(
+    input: NotificationInput,
+    meta: NotificationMeta,
+  ): void | Promise<void>;
+}

--- a/packages/core/src/progress/actions.ts
+++ b/packages/core/src/progress/actions.ts
@@ -1,0 +1,185 @@
+/**
+ * Framework-level agent tools for the progress primitive. Registered as
+ * native tools so every template exposes them. Use from long agent loops
+ * to communicate status to the user while work is still in-flight.
+ */
+
+import type { ActionEntry } from "../agent/production-agent.js";
+import {
+  startRun,
+  updateRunProgress,
+  completeRun,
+  listRuns,
+} from "./registry.js";
+import type { ProgressStatus } from "./types.js";
+
+export function createProgressToolEntries(
+  getCurrentUser: () => string,
+): Record<string, ActionEntry> {
+  return {
+    "start-run": {
+      tool: {
+        description:
+          "Mark the start of a long-running task the user should be able to watch. Returns a runId — pass it to `update-run-progress` and `complete-run`. Call this at the top of any task that will take more than a few seconds.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            title: {
+              type: "string",
+              description:
+                'Short human-readable title, e.g. "Triage 128 unread emails".',
+            },
+            step: {
+              type: "string",
+              description: 'Initial step description, e.g. "Fetching inbox".',
+            },
+            metadataJson: {
+              type: "string",
+              description:
+                "Optional JSON metadata: link, thread id, artifact path, etc.",
+            },
+          },
+          required: ["title"],
+        },
+      },
+      run: async (args: Record<string, string>) => {
+        const owner = getCurrentUser();
+        if (!args.title) return "Error: --title is required.";
+        let metadata: Record<string, unknown> | undefined;
+        if (args.metadataJson) {
+          try {
+            metadata = JSON.parse(args.metadataJson);
+          } catch {
+            return "Error: metadataJson must be valid JSON.";
+          }
+        }
+        const run = await startRun({
+          owner,
+          title: args.title,
+          step: args.step || undefined,
+          metadata,
+        });
+        return `Run started. runId=${run.id}`;
+      },
+    },
+
+    "update-run-progress": {
+      tool: {
+        description:
+          "Update a running task with progress. Call frequently during long loops so the user can watch status in the runs tray. Any omitted field stays unchanged.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            runId: {
+              type: "string",
+              description: "The id returned by `start-run`.",
+            },
+            percent: {
+              type: "number",
+              description:
+                "Progress 0–100. Omit if the task has no known upper bound.",
+            },
+            step: {
+              type: "string",
+              description: 'Current step, e.g. "Drafting reply 23/100".',
+            },
+          },
+          required: ["runId"],
+        },
+      },
+      run: async (args: Record<string, unknown>) => {
+        const owner = getCurrentUser();
+        const runId = String(args.runId ?? "");
+        if (!runId) return "Error: --runId is required.";
+        const percent = args.percent == null ? undefined : Number(args.percent);
+        const run = await updateRunProgress(runId, owner, {
+          percent,
+          step: args.step ? String(args.step) : undefined,
+        });
+        if (!run) return `Error: run ${runId} not found.`;
+        return `Run updated (percent=${run.percent ?? "?"}, step=${run.step ?? ""}).`;
+      },
+    },
+
+    "complete-run": {
+      tool: {
+        description:
+          "Mark a task as finished. Use `succeeded` for a clean finish, `failed` when something went wrong, `cancelled` when the user interrupted. Pairs well with `notify` to tell the user the outcome.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            runId: {
+              type: "string",
+              description: "The id returned by `start-run`.",
+            },
+            status: {
+              type: "string",
+              enum: ["succeeded", "failed", "cancelled"],
+              description: "Terminal status.",
+            },
+            step: {
+              type: "string",
+              description: "Optional final step text.",
+            },
+          },
+          required: ["runId", "status"],
+        },
+      },
+      run: async (args: Record<string, string>) => {
+        const owner = getCurrentUser();
+        if (!args.runId || !args.status) {
+          return "Error: --runId and --status are required.";
+        }
+        const status = args.status as ProgressStatus;
+        if (!["succeeded", "failed", "cancelled"].includes(status)) {
+          return `Error: status must be succeeded, failed, or cancelled (got "${status}").`;
+        }
+        const run = await completeRun(
+          args.runId,
+          owner,
+          status as "succeeded" | "failed" | "cancelled",
+          args.step ? { step: args.step } : undefined,
+        );
+        if (!run) return `Error: run ${args.runId} not found.`;
+        return `Run ${run.id} completed with status=${run.status}.`;
+      },
+    },
+
+    "list-runs": {
+      tool: {
+        description:
+          "List the user's recent runs. Use when the user asks 'what is still running' or 'what did you do earlier'.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            active: {
+              type: "boolean",
+              description: "When true, only return runs still in progress.",
+            },
+            limit: {
+              type: "number",
+              description: "Max rows (default 20, max 200).",
+            },
+          },
+        },
+      },
+      run: async (args: Record<string, unknown>) => {
+        const owner = getCurrentUser();
+        const rows = await listRuns(owner, {
+          activeOnly: args.active === true || args.active === "true",
+          limit: Math.min(Number(args.limit ?? 20), 200),
+        });
+        if (rows.length === 0) {
+          return args.active ? "No active runs." : "No runs.";
+        }
+        return rows
+          .map(
+            (r) =>
+              `[${r.status}] ${r.title}${r.percent != null ? ` · ${r.percent}%` : ""}${r.step ? ` — ${r.step}` : ""} · ${r.startedAt}`,
+          )
+          .join("\n");
+      },
+      readOnly: true,
+    },
+  };
+}

--- a/packages/core/src/progress/index.ts
+++ b/packages/core/src/progress/index.ts
@@ -1,0 +1,16 @@
+export type {
+  AgentRun,
+  ProgressStatus,
+  StartRunInput,
+  UpdateProgressInput,
+  ListRunsOptions,
+} from "./types.js";
+
+export {
+  startRun,
+  updateRunProgress,
+  completeRun,
+  getRun,
+  listRuns,
+  deleteRun,
+} from "./registry.js";

--- a/packages/core/src/progress/progress.spec.ts
+++ b/packages/core/src/progress/progress.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockInsertRun = vi.fn();
+const mockUpdateRun = vi.fn();
+const mockEmit = vi.fn();
+
+vi.mock("./store.js", () => ({
+  insertRun: (...args: unknown[]) => mockInsertRun(...args),
+  updateRun: (...args: unknown[]) => mockUpdateRun(...args),
+  getRun: vi.fn(),
+  listRuns: vi.fn(),
+  deleteRun: vi.fn(),
+}));
+
+vi.mock("../event-bus/bus.js", () => ({
+  emit: (...args: unknown[]) => mockEmit(...args),
+}));
+
+import { startRun, updateRunProgress, completeRun } from "./registry.js";
+
+function stubRun(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "r-1",
+    owner: "boni@local",
+    title: "Test run",
+    step: undefined,
+    percent: null,
+    status: "running",
+    metadata: undefined,
+    startedAt: "2026-04-22T00:00:00.000Z",
+    updatedAt: "2026-04-22T00:00:00.000Z",
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+describe("progress registry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("startRun inserts and emits run.progress.started", async () => {
+    mockInsertRun.mockResolvedValue(stubRun({ title: "Triage inbox" }));
+
+    const run = await startRun({ owner: "boni@local", title: "Triage inbox" });
+
+    expect(mockInsertRun).toHaveBeenCalledWith({
+      owner: "boni@local",
+      title: "Triage inbox",
+    });
+    expect(run.id).toBe("r-1");
+    expect(mockEmit).toHaveBeenCalledWith(
+      "run.progress.started",
+      expect.objectContaining({
+        runId: "r-1",
+        title: "Triage inbox",
+      }),
+      { owner: "boni@local" },
+    );
+  });
+
+  it("updateRunProgress emits run.progress.updated with new state", async () => {
+    mockUpdateRun.mockResolvedValue(
+      stubRun({ percent: 42, step: "Drafting 23/100" }),
+    );
+
+    const run = await updateRunProgress("r-1", "boni@local", {
+      percent: 42,
+      step: "Drafting 23/100",
+    });
+
+    expect(mockUpdateRun).toHaveBeenCalledWith("r-1", "boni@local", {
+      percent: 42,
+      step: "Drafting 23/100",
+    });
+    expect(run?.percent).toBe(42);
+    expect(mockEmit).toHaveBeenCalledWith(
+      "run.progress.updated",
+      expect.objectContaining({
+        runId: "r-1",
+        percent: 42,
+        step: "Drafting 23/100",
+      }),
+      { owner: "boni@local" },
+    );
+  });
+
+  it("updateRunProgress returns null when the run does not exist", async () => {
+    mockUpdateRun.mockResolvedValue(null);
+    const run = await updateRunProgress("missing", "boni@local", {
+      percent: 50,
+    });
+    expect(run).toBeNull();
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it("completeRun sets percent=100 on success and passes status through", async () => {
+    mockUpdateRun.mockResolvedValue(
+      stubRun({ percent: 100, status: "succeeded", completedAt: "x" }),
+    );
+
+    const run = await completeRun("r-1", "boni@local", "succeeded");
+
+    expect(mockUpdateRun).toHaveBeenCalledWith(
+      "r-1",
+      "boni@local",
+      expect.objectContaining({ status: "succeeded", percent: 100 }),
+    );
+    expect(run?.status).toBe("succeeded");
+    expect(mockEmit).toHaveBeenCalledWith(
+      "run.progress.updated",
+      expect.objectContaining({ runId: "r-1", status: "succeeded" }),
+      { owner: "boni@local" },
+    );
+  });
+
+  it("completeRun with failed does not force percent to 100", async () => {
+    mockUpdateRun.mockResolvedValue(stubRun({ status: "failed" }));
+
+    await completeRun("r-1", "boni@local", "failed");
+
+    expect(mockUpdateRun).toHaveBeenCalledWith(
+      "r-1",
+      "boni@local",
+      expect.not.objectContaining({ percent: 100 }),
+    );
+  });
+});

--- a/packages/core/src/progress/registry.ts
+++ b/packages/core/src/progress/registry.ts
@@ -1,0 +1,73 @@
+import { emit as emitBusEvent } from "../event-bus/bus.js";
+import { insertRun, updateRun, getRun, listRuns, deleteRun } from "./store.js";
+import type { AgentRun, StartRunInput, UpdateProgressInput } from "./types.js";
+
+/**
+ * Start a new run. Emits `run.progress.started` on the event bus so
+ * automations can react (e.g. pinning the row in a UI tray).
+ */
+export async function startRun(input: StartRunInput): Promise<AgentRun> {
+  const run = await insertRun(input);
+  try {
+    emitBusEvent(
+      "run.progress.started",
+      {
+        runId: run.id,
+        title: run.title,
+        step: run.step,
+      },
+      { owner: run.owner },
+    );
+  } catch {
+    // best-effort
+  }
+  return run;
+}
+
+/**
+ * Update a run in-flight. Emits `run.progress.updated`. Caller supplies
+ * partial fields — any omitted field stays unchanged.
+ */
+export async function updateRunProgress(
+  id: string,
+  owner: string,
+  input: UpdateProgressInput,
+): Promise<AgentRun | null> {
+  const run = await updateRun(id, owner, input);
+  if (!run) return null;
+  try {
+    emitBusEvent(
+      "run.progress.updated",
+      {
+        runId: run.id,
+        percent: run.percent,
+        step: run.step,
+        status: run.status,
+      },
+      { owner: run.owner },
+    );
+  } catch {
+    // best-effort
+  }
+  return run;
+}
+
+/**
+ * Finalize a run with a terminal status. Convenience wrapper around
+ * `updateRunProgress` that ensures `completed_at` is set.
+ */
+export async function completeRun(
+  id: string,
+  owner: string,
+  status: "succeeded" | "failed" | "cancelled",
+  extras?: { step?: string; metadata?: Record<string, unknown> },
+): Promise<AgentRun | null> {
+  return updateRunProgress(id, owner, {
+    status,
+    percent: status === "succeeded" ? 100 : undefined,
+    step: extras?.step,
+    metadata: extras?.metadata,
+  });
+}
+
+export { getRun, listRuns, deleteRun };

--- a/packages/core/src/progress/routes.ts
+++ b/packages/core/src/progress/routes.ts
@@ -1,0 +1,71 @@
+/**
+ * H3 event handlers for the agent-runs progress primitive.
+ *
+ * Mounted under `/_agent-native/runs/*` by `core-routes-plugin`.
+ *
+ *   GET    /_agent-native/runs?active=true&limit=50
+ *   GET    /_agent-native/runs/:id
+ *   DELETE /_agent-native/runs/:id
+ *
+ * Writes happen through the `update-run-progress` agent tool, not HTTP —
+ * the agent is the canonical writer, the UI only reads. (We can add write
+ * routes later if a non-agent producer needs them.)
+ */
+
+import {
+  defineEventHandler,
+  getMethod,
+  getQuery,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+import { getSession } from "../server/auth.js";
+import { listRuns, getRun, deleteRun } from "./store.js";
+
+async function resolveOwner(event: H3Event): Promise<string> {
+  const session = await getSession(event).catch(() => null);
+  return session?.email || "local@localhost";
+}
+
+export function createProgressHandler() {
+  return defineEventHandler(async (event: H3Event) => {
+    const method = getMethod(event);
+    const pathname = (event.url?.pathname || "")
+      .replace(/^\/+/, "")
+      .replace(/\/+$/, "");
+    const parts = pathname ? pathname.split("/") : [];
+    const owner = await resolveOwner(event);
+
+    // GET /  — list
+    if (method === "GET" && parts.length === 0) {
+      const q = getQuery(event);
+      return listRuns(owner, {
+        activeOnly: q.active === "true" || q.active === "1",
+        limit: q.limit ? Math.min(Number(q.limit) || 50, 200) : 50,
+      });
+    }
+
+    // GET /:id
+    if (method === "GET" && parts.length === 1) {
+      const row = await getRun(parts[0], owner);
+      if (!row) {
+        setResponseStatus(event, 404);
+        return { error: "Not found" };
+      }
+      return row;
+    }
+
+    // DELETE /:id
+    if (method === "DELETE" && parts.length === 1) {
+      const ok = await deleteRun(parts[0], owner);
+      if (!ok) {
+        setResponseStatus(event, 404);
+        return { error: "Not found" };
+      }
+      return { ok: true };
+    }
+
+    setResponseStatus(event, 404);
+    return { error: "Not found" };
+  });
+}

--- a/packages/core/src/progress/store.ts
+++ b/packages/core/src/progress/store.ts
@@ -1,0 +1,181 @@
+import { randomUUID } from "node:crypto";
+import { getDbExec, intType } from "../db/client.js";
+import type {
+  AgentRun,
+  ListRunsOptions,
+  ProgressStatus,
+  StartRunInput,
+  UpdateProgressInput,
+} from "./types.js";
+
+let _initPromise: Promise<void> | undefined;
+
+async function ensureTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const client = getDbExec();
+      await client.execute(`
+        CREATE TABLE IF NOT EXISTS agent_runs (
+          id TEXT PRIMARY KEY,
+          owner TEXT NOT NULL,
+          title TEXT NOT NULL,
+          step TEXT,
+          percent ${intType()},
+          status TEXT NOT NULL DEFAULT 'running',
+          metadata TEXT,
+          started_at ${intType()} NOT NULL,
+          updated_at ${intType()} NOT NULL,
+          completed_at ${intType()}
+        )
+      `);
+      await client.execute(
+        `CREATE INDEX IF NOT EXISTS idx_agent_runs_owner_status ON agent_runs (owner, status, started_at)`,
+      );
+    })();
+  }
+  return _initPromise;
+}
+
+function parseRow(row: Record<string, unknown>): AgentRun {
+  const percent = row.percent;
+  return {
+    id: String(row.id),
+    owner: String(row.owner),
+    title: String(row.title),
+    step: row.step == null ? undefined : String(row.step),
+    percent: percent == null ? null : Number(percent),
+    status: String(row.status) as ProgressStatus,
+    metadata: row.metadata
+      ? (JSON.parse(String(row.metadata)) as Record<string, unknown>)
+      : undefined,
+    startedAt: new Date(Number(row.started_at)).toISOString(),
+    updatedAt: new Date(Number(row.updated_at)).toISOString(),
+    completedAt:
+      row.completed_at == null
+        ? null
+        : new Date(Number(row.completed_at)).toISOString(),
+  };
+}
+
+export async function insertRun(input: StartRunInput): Promise<AgentRun> {
+  await ensureTable();
+  const client = getDbExec();
+  const id = input.id ?? randomUUID();
+  const now = Date.now();
+  await client.execute({
+    sql: `INSERT INTO agent_runs
+      (id, owner, title, step, percent, status, metadata, started_at, updated_at, completed_at)
+      VALUES (?, ?, ?, ?, NULL, 'running', ?, ?, ?, NULL)`,
+    args: [
+      id,
+      input.owner,
+      input.title,
+      input.step ?? null,
+      input.metadata ? JSON.stringify(input.metadata) : null,
+      now,
+      now,
+    ],
+  });
+  return {
+    id,
+    owner: input.owner,
+    title: input.title,
+    step: input.step,
+    percent: null,
+    status: "running",
+    metadata: input.metadata,
+    startedAt: new Date(now).toISOString(),
+    updatedAt: new Date(now).toISOString(),
+    completedAt: null,
+  };
+}
+
+export async function getRun(
+  id: string,
+  owner: string,
+): Promise<AgentRun | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT * FROM agent_runs WHERE id = ? AND owner = ?`,
+    args: [id, owner],
+  });
+  if (rows.length === 0) return null;
+  return parseRow(rows[0] as Record<string, unknown>);
+}
+
+export async function updateRun(
+  id: string,
+  owner: string,
+  input: UpdateProgressInput,
+): Promise<AgentRun | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const sets: string[] = ["updated_at = ?"];
+  const args: Array<string | number | null> = [now];
+
+  if (Object.prototype.hasOwnProperty.call(input, "percent")) {
+    sets.push("percent = ?");
+    args.push(input.percent == null ? null : clampPercent(input.percent));
+  }
+  if (input.step !== undefined) {
+    sets.push("step = ?");
+    args.push(input.step);
+  }
+  if (input.metadata !== undefined) {
+    sets.push("metadata = ?");
+    args.push(JSON.stringify(input.metadata));
+  }
+  if (input.status !== undefined) {
+    sets.push("status = ?");
+    args.push(input.status);
+    if (input.status !== "running") {
+      sets.push("completed_at = ?");
+      args.push(now);
+    }
+  }
+  args.push(id, owner);
+
+  const res = await client.execute({
+    sql: `UPDATE agent_runs SET ${sets.join(", ")} WHERE id = ? AND owner = ?`,
+    args,
+  });
+  if ((res as unknown as { rowsAffected?: number }).rowsAffected === 0) {
+    return null;
+  }
+  return getRun(id, owner);
+}
+
+function clampPercent(n: number): number {
+  if (Number.isNaN(n)) return 0;
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+export async function listRuns(
+  owner: string,
+  options: ListRunsOptions = {},
+): Promise<AgentRun[]> {
+  await ensureTable();
+  const client = getDbExec();
+  const limit = Math.min(options.limit ?? 50, 200);
+  let where = `owner = ?`;
+  const args: Array<string | number> = [owner];
+  if (options.activeOnly) where += ` AND status = 'running'`;
+  args.push(limit);
+  const { rows } = await client.execute({
+    sql: `SELECT * FROM agent_runs WHERE ${where} ORDER BY started_at DESC LIMIT ?`,
+    args,
+  });
+  return rows.map((r) => parseRow(r as Record<string, unknown>));
+}
+
+export async function deleteRun(id: string, owner: string): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const res = await client.execute({
+    sql: `DELETE FROM agent_runs WHERE id = ? AND owner = ?`,
+    args: [id, owner],
+  });
+  return (res as unknown as { rowsAffected?: number }).rowsAffected !== 0;
+}

--- a/packages/core/src/progress/types.ts
+++ b/packages/core/src/progress/types.ts
@@ -1,0 +1,51 @@
+export type ProgressStatus = "running" | "succeeded" | "failed" | "cancelled";
+
+/**
+ * A long-running agent task the UI can track. Separate from "notifications":
+ * notifications fire once ("X happened"), progress is continuous state
+ * ("X is 45% done"). Both primitives may interop — completed runs commonly
+ * emit a notification.
+ */
+export interface AgentRun {
+  id: string;
+  owner: string;
+  /** Human-readable title, e.g. "Triage 128 unread emails". */
+  title: string;
+  /** Optional free-text current step ("Fetching 23/100", "Drafting replies"). */
+  step?: string;
+  /** 0–100. `null` when the task has no known upper bound. */
+  percent: number | null;
+  status: ProgressStatus;
+  /** Optional deeper context: link, thread id, artifact path, etc. */
+  metadata?: Record<string, unknown>;
+  /** ISO timestamp — when the run was started. */
+  startedAt: string;
+  /** ISO timestamp — latest update. */
+  updatedAt: string;
+  /** ISO timestamp — when the run reached a terminal status. */
+  completedAt: string | null;
+}
+
+export interface StartRunInput {
+  /** Client-provided id — optional; server generates a UUID when omitted. */
+  id?: string;
+  owner: string;
+  title: string;
+  step?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UpdateProgressInput {
+  percent?: number | null;
+  step?: string;
+  metadata?: Record<string, unknown>;
+  /** Optional terminal status — sets completedAt when `succeeded|failed|cancelled`. */
+  status?: ProgressStatus;
+}
+
+export interface ListRunsOptions {
+  /** When true, only return runs with status = "running". */
+  activeOnly?: boolean;
+  /** Max rows. Default 50. */
+  limit?: number;
+}

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1995,6 +1995,12 @@ export function createAgentChatPlugin(
         await import("../triggers/actions.js");
       automationTools = createAutomationToolEntries(() => _currentRunOwner);
     } catch {}
+    let notificationTools: Record<string, ActionEntry> = {};
+    try {
+      const { createNotificationToolEntries } =
+        await import("../notifications/actions.js");
+      notificationTools = createNotificationToolEntries(() => _currentRunOwner);
+    } catch {}
     let fetchTool: Record<string, ActionEntry> = {};
     try {
       const { createFetchToolEntry } = await import("../tools/fetch-tool.js");
@@ -2031,6 +2037,7 @@ export function createAgentChatPlugin(
           ...chatScripts,
           ...callAgentScript,
           ...automationTools,
+          ...notificationTools,
           ...fetchTool,
           ...browserTools,
           ...devScriptsForA2A,
@@ -2046,6 +2053,7 @@ export function createAgentChatPlugin(
           ...chatScripts,
           ...callAgentScript,
           ...automationTools,
+          ...notificationTools,
           ...fetchTool,
           ...browserTools,
           ...devScriptsForA2A,
@@ -3602,6 +3610,7 @@ export function createAgentChatPlugin(
           ...chatScripts,
           ...jobTools,
           ...automationTools,
+          ...notificationTools,
           ...fetchTool,
         }),
         getSystemPrompt: async (owner: string) => {
@@ -3639,6 +3648,7 @@ export function createAgentChatPlugin(
           ...chatScripts,
           ...jobTools,
           ...automationTools,
+          ...notificationTools,
           ...fetchTool,
         }),
         getSystemPrompt: async (owner: string) => {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2001,6 +2001,12 @@ export function createAgentChatPlugin(
         await import("../notifications/actions.js");
       notificationTools = createNotificationToolEntries(() => _currentRunOwner);
     } catch {}
+    let progressTools: Record<string, ActionEntry> = {};
+    try {
+      const { createProgressToolEntries } =
+        await import("../progress/actions.js");
+      progressTools = createProgressToolEntries(() => _currentRunOwner);
+    } catch {}
     let fetchTool: Record<string, ActionEntry> = {};
     try {
       const { createFetchToolEntry } = await import("../tools/fetch-tool.js");
@@ -2038,6 +2044,7 @@ export function createAgentChatPlugin(
           ...callAgentScript,
           ...automationTools,
           ...notificationTools,
+          ...progressTools,
           ...fetchTool,
           ...browserTools,
           ...devScriptsForA2A,
@@ -2054,6 +2061,7 @@ export function createAgentChatPlugin(
           ...callAgentScript,
           ...automationTools,
           ...notificationTools,
+          ...progressTools,
           ...fetchTool,
           ...browserTools,
           ...devScriptsForA2A,
@@ -3611,6 +3619,7 @@ export function createAgentChatPlugin(
           ...jobTools,
           ...automationTools,
           ...notificationTools,
+          ...progressTools,
           ...fetchTool,
         }),
         getSystemPrompt: async (owner: string) => {
@@ -3649,6 +3658,7 @@ export function createAgentChatPlugin(
           ...jobTools,
           ...automationTools,
           ...notificationTools,
+          ...progressTools,
           ...fetchTool,
         }),
         getSystemPrompt: async (owner: string) => {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -48,6 +48,8 @@ import {
 } from "../secrets/routes.js";
 import { registerFrameworkSecrets } from "../secrets/register-framework-secrets.js";
 import { registerBuiltinProviders } from "../tracking/providers.js";
+import { registerBuiltinNotificationChannels } from "../notifications/channels.js";
+import { createNotificationsHandler } from "../notifications/routes.js";
 import { createTranscribeVoiceHandler } from "./transcribe-voice.js";
 
 /**
@@ -106,6 +108,7 @@ export function createCoreRoutesPlugin(
     // already registered the same key win.
     registerFrameworkSecrets();
     registerBuiltinProviders();
+    registerBuiltinNotificationChannels();
 
     const P = FRAMEWORK_ROUTE_PREFIX;
 
@@ -619,6 +622,14 @@ export function createCoreRoutesPlugin(
         return { error: "Not found" };
       }),
     );
+
+    // ─── Notifications inbox ──────────────────────────────────────────
+    // GET    /_agent-native/notifications[?unread&limit&before]
+    // GET    /_agent-native/notifications/count
+    // POST   /_agent-native/notifications/:id/read
+    // POST   /_agent-native/notifications/read-all
+    // DELETE /_agent-native/notifications/:id
+    getH3App(nitroApp).use(`${P}/notifications`, createNotificationsHandler());
 
     // ─── Automations API ──────────────────────────────────────────────
     // GET  /_agent-native/automations — list all automations (parsed triggers)

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -50,6 +50,7 @@ import { registerFrameworkSecrets } from "../secrets/register-framework-secrets.
 import { registerBuiltinProviders } from "../tracking/providers.js";
 import { registerBuiltinNotificationChannels } from "../notifications/channels.js";
 import { createNotificationsHandler } from "../notifications/routes.js";
+import { createProgressHandler } from "../progress/routes.js";
 import { createTranscribeVoiceHandler } from "./transcribe-voice.js";
 
 /**
@@ -630,6 +631,12 @@ export function createCoreRoutesPlugin(
     // POST   /_agent-native/notifications/read-all
     // DELETE /_agent-native/notifications/:id
     getH3App(nitroApp).use(`${P}/notifications`, createNotificationsHandler());
+
+    // ─── Agent run progress ───────────────────────────────────────────
+    // GET    /_agent-native/runs[?active&limit]
+    // GET    /_agent-native/runs/:id
+    // DELETE /_agent-native/runs/:id
+    getH3App(nitroApp).use(`${P}/runs`, createProgressHandler());
 
     // ─── Automations API ──────────────────────────────────────────────
     // GET  /_agent-native/automations — list all automations (parsed triggers)

--- a/packages/core/src/templates/default/.agents/skills/notifications/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/notifications/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: notifications
+description: >-
+  In-app notifications primitive with pluggable server-side channels. Use when
+  the agent needs to surface progress, alerts, or completions to the user —
+  both in-app (bell + toast) and out-of-band (webhook, Slack, custom).
+---
+
+# Notifications
+
+## Overview
+
+`notify()` is the framework's "tell the user something" primitive. Every call persists a row to the in-app inbox (drives the bell + toast UI) and fans out to any registered server-side channels (webhook, Slack, custom). Channels follow the same pluggable-provider pattern as the `tracking` module — register at startup, `notify()` fans out, errors are isolated.
+
+Use this for: *agent progress milestones, automation triggers firing, background job completions, critical errors worth interrupting the user.* Don't use it for chat replies — those already show up in the conversation.
+
+## Available Tools
+
+| Tool | Purpose |
+|---|---|
+| `notify` | Send a notification (severity + title + optional body/metadata/channels) |
+| `list-notifications` | Show recent notifications for the current user |
+
+## Sending a Notification
+
+```
+notify --severity info --title "Booking confirmed" --body "Jane at 3pm"
+```
+
+Severities:
+
+| Severity | When to use |
+|---|---|
+| `info` | FYI / progress / confirmation — doesn't need action |
+| `warning` | Something the user should look at soon |
+| `critical` | Needs immediate attention — channels should be noisier |
+
+Optional args:
+- `--metadataJson` — arbitrary JSON context (`{"threadId":"abc","link":"/inbox/abc"}`)
+- `--channels` — comma-separated allowlist (`"inbox"`, `"inbox,webhook"`). Omit to run every registered channel.
+
+## Delivery Model
+
+```
+  notify(input, { owner })
+        │
+        ▼
+  ┌───────────────────────────┐
+  │ inbox (always, unless     │  INSERT into `notifications` table →
+  │ explicitly excluded)      │  UI polls → bell unread count + toast
+  └───────────────────────────┘
+        │
+        ▼  (fan-out, best-effort)
+  ┌───────────────────────────┐
+  │ registered channels       │  webhook, Slack, custom…
+  └───────────────────────────┘
+        │
+        ▼
+  event-bus: `notification.sent`   ← automations can chain off this
+```
+
+Each channel is called once per `notify()`. A channel that throws logs the error but does not prevent other channels or the inbox row from running.
+
+## Built-in Channels
+
+| Channel | How it delivers | Requires |
+|---|---|---|
+| `inbox` | INSERT into `notifications` table — drives all in-app UI | (nothing — always present) |
+| `webhook` | POSTs JSON to `NOTIFICATIONS_WEBHOOK_URL` with optional `NOTIFICATIONS_WEBHOOK_AUTH`; both support `${keys.NAME}` substitution and URL allowlists from the ad-hoc keys system | Env var set |
+
+The webhook channel auto-registers at startup when `NOTIFICATIONS_WEBHOOK_URL` is set. Any user who has set up an ad-hoc key (e.g. `SLACK_WEBHOOK`) can use `${keys.SLACK_WEBHOOK}` in the env template — the raw value is resolved server-side at dispatch, never enters the model's context.
+
+## Registering a Custom Channel
+
+Import from `@agent-native/core/notifications` in a server plugin:
+
+```ts
+// server/plugins/notifications-slack.ts
+import { registerNotificationChannel } from "@agent-native/core/notifications";
+
+export default () => {
+  registerNotificationChannel({
+    name: "slack-ops",
+    async deliver(input, meta) {
+      await fetch(process.env.OPS_SLACK_WEBHOOK!, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text: `*${input.severity.toUpperCase()}* — ${input.title}\n${input.body ?? ""}`,
+          owner: meta.owner,
+        }),
+      });
+    },
+  });
+};
+```
+
+Rules:
+- `name` must be unique — re-registering the same name replaces the prior channel.
+- `deliver()` should be best-effort; throwing logs the error but does not block other channels.
+- Do NOT call `notify()` from inside a channel — it will recurse.
+
+## Notifications API
+
+Mounted at `/_agent-native/notifications/*` by `core-routes-plugin`:
+
+| Method | Route | Body |
+|---|---|---|
+| `GET`    | `/_agent-native/notifications?unread=true&limit=50&before=<iso>` | — |
+| `GET`    | `/_agent-native/notifications/count` | — |
+| `POST`   | `/_agent-native/notifications/:id/read` | — |
+| `POST`   | `/_agent-native/notifications/read-all` | — |
+| `DELETE` | `/_agent-native/notifications/:id` | — |
+
+All routes are scoped to the session owner.
+
+## UI Surface
+
+The framework ships a `<NotificationsBell />` component at `@agent-native/core/client/notifications`:
+
+```tsx
+import { NotificationsBell } from "@agent-native/core/client/notifications";
+
+export function HeaderBar() {
+  return (
+    <div className="flex items-center gap-2">
+      {/* … */}
+      <NotificationsBell pollMs={10_000} />
+    </div>
+  );
+}
+```
+
+Templates can drop it into the header bar. It polls `/count` every `pollMs` (default 10s) and lazy-loads the full list when the dropdown opens.
+
+## Event Bus Integration
+
+Every `notify()` also emits `notification.sent` on the event bus:
+
+```json
+{
+  "notificationId": "n-123",
+  "severity": "critical",
+  "title": "DB offline",
+  "body": "Primary dropped connections",
+  "deliveredChannels": ["inbox", "webhook"]
+}
+```
+
+This lets automations (PR #255) react to notifications — e.g. *"when a critical notification fires, also page on-call."*
+
+## Related Skills
+
+- `automations` — event-triggered automations can call `notify` in their agentic body.
+- `secrets` — the webhook channel reuses `${keys.NAME}` substitution and URL allowlists.
+- `tracking` — analytics events; separate concern — do not route tracking through notifications or vice versa.

--- a/packages/core/src/templates/default/.agents/skills/progress/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/progress/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: progress
+description: >-
+  Report live progress from long-running agent tasks. Use when a task takes
+  more than a few seconds, so the user can watch status in the runs tray
+  instead of staring at a spinner.
+---
+
+# Progress
+
+## Overview
+
+`agent_runs` is the framework's "what is the agent doing right now" primitive. The agent starts a run at the top of a long task, updates it as work proceeds, and completes it with a terminal status. The UI renders active runs in a floating tray — percent bar, current step, spinner/check/X — so the user has live visibility into work that would otherwise be opaque.
+
+Separate concern from `notifications`:
+
+| | Notifications | Progress |
+|---|---|---|
+| Shape | One-shot event — "X happened" | Continuous state — "X is 45% done" |
+| UI surface | Bell + toast | Runs tray with percent bar |
+| Lifecycle | Dismissable (read/unread) | Running → terminal (succeeded/failed/cancelled) |
+
+Common pattern: on completion, emit a `notify()` so the user sees the outcome when they're not actively watching the tray.
+
+## Available Tools
+
+| Tool | Purpose |
+|---|---|
+| `start-run` | Mark the start of a long task. Returns a runId. |
+| `update-run-progress` | Update percent and/or current step. Call frequently. |
+| `complete-run` | Mark terminal status: `succeeded`, `failed`, `cancelled`. |
+| `list-runs` | List recent runs (all or `--active=true`). |
+
+## Canonical Flow
+
+```
+start-run --title "Triage 128 unread emails" --step "Fetching inbox"
+  → runId=abc
+
+update-run-progress --runId=abc --percent=25 --step="Classifying 32/128"
+update-run-progress --runId=abc --percent=75 --step="Drafting replies 97/128"
+
+complete-run --runId=abc --status=succeeded
+notify --severity=info --title="Triage done" --body="12 archived, 6 drafts ready to review"
+```
+
+## Best Practices
+
+- **Start a run for anything > ~5 seconds.** Users want feedback; a spinner with no context feels frozen.
+- **Update at natural checkpoints**, not every iteration. Every 5–10% is enough for most UIs.
+- **Always call `complete-run`** at the end — including the error path. An orphaned `running` row is worse than no row.
+- **Pair with `notify`** on completion. The tray tells users what's *running*; notifications tell them what *finished*.
+- **Use `metadataJson`** on `start-run` to pass a link back to the produced artifact (thread id, document path), so the UI can deep-link from the runs tray.
+
+## Runs API
+
+Mounted at `/_agent-native/runs/*` by `core-routes-plugin`. **Read-only** over HTTP — writes flow through the agent tools:
+
+| Method | Route |
+|---|---|
+| `GET`    | `/_agent-native/runs?active=true&limit=50` |
+| `GET`    | `/_agent-native/runs/:id` |
+| `DELETE` | `/_agent-native/runs/:id` |
+
+## UI Surface
+
+Ships as `<RunsTray />` at `@agent-native/core/client/progress`:
+
+```tsx
+import { RunsTray } from "@agent-native/core/client/progress";
+
+export function AppShell() {
+  return (
+    <>
+      {/* … */}
+      <RunsTray pollMs={3000} />
+    </>
+  );
+}
+```
+
+Floats at the bottom-right. Hides when no active runs. Polls `active=true` every `pollMs` (default 3s — active runs need tight feedback).
+
+## Event Bus Integration
+
+Two events emit on the bus so automations (PR #255) can react:
+
+- `run.progress.started` — `{ runId, title, step? }`
+- `run.progress.updated` — `{ runId, percent, step, status }`
+
+Example automation: *"when a run takes longer than 5 minutes, notify me."*
+
+## Related Skills
+
+- `notifications` — fire one when a run finishes so the user sees the outcome.
+- `automations` — subscribe to `run.progress.updated` to build watchdogs on slow runs.
+- `delegate-to-agent` — if you're delegating a long task, start a run on the delegator side so the caller has visibility.

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -95,6 +95,7 @@ Skills in `.agents/skills/` provide detailed guidance for each architectural rul
 | `frontend-design`     | Before building or restyling any UI component, page, or layout  |
 | `agent-engines`       | Before switching LLM providers or registering a custom engine   |
 | `notifications`       | Before surfacing alerts/progress to the user or adding channels |
+| `progress`            | Before running any task that takes more than a few seconds      |
 
 ## When Adding Features
 

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -84,16 +84,17 @@ You do NOT get auto-injected screen state. **Call `pnpm action view-screen` at t
 
 Skills in `.agents/skills/` provide detailed guidance for each architectural rule. Read them before making changes.
 
-| Skill                 | When to read                                                   |
-| --------------------- | -------------------------------------------------------------- |
-| `storing-data`        | Before storing or reading any app state                        |
-| `delegate-to-agent`   | Before adding LLM calls or AI delegation                       |
-| `actions`             | Before creating or modifying actions                           |
-| `real-time-sync`      | Before wiring up real-time UI sync                             |
-| `self-modifying-code` | Before editing source, components, or styles                   |
-| `capture-learnings`   | Before recording user preferences or corrections               |
-| `frontend-design`     | Before building or restyling any UI component, page, or layout |
-| `agent-engines`       | Before switching LLM providers or registering a custom engine  |
+| Skill                 | When to read                                                    |
+| --------------------- | --------------------------------------------------------------- |
+| `storing-data`        | Before storing or reading any app state                         |
+| `delegate-to-agent`   | Before adding LLM calls or AI delegation                        |
+| `actions`             | Before creating or modifying actions                            |
+| `real-time-sync`      | Before wiring up real-time UI sync                              |
+| `self-modifying-code` | Before editing source, components, or styles                    |
+| `capture-learnings`   | Before recording user preferences or corrections                |
+| `frontend-design`     | Before building or restyling any UI component, page, or layout  |
+| `agent-engines`       | Before switching LLM providers or registering a custom engine   |
+| `notifications`       | Before surfacing alerts/progress to the user or adding channels |
 
 ## When Adding Features
 


### PR DESCRIPTION
## Summary

Adds two new core primitives on top of the tracking/automations infrastructure from #255 + #257:

- **Notifications** — `notify()` with pluggable channels (mirrors `tracking`'s provider pattern). Persists to a new `notifications` table that drives the in-app bell + toast UI; `webhook` channel auto-registers when `NOTIFICATIONS_WEBHOOK_URL` is set and reuses `\${keys.NAME}` substitution + URL allowlists from #255. `notify` + `list-notifications` agent tools registered framework-level. Emits `notification.sent` on the event bus so automations can chain off it. Ships `<NotificationsBell />` at `@agent-native/core/client/notifications`.
- **Progress** — `agent_runs` table + `start-run` / `update-run-progress` / `complete-run` / `list-runs` agent tools so long tasks can report live status instead of hiding behind a spinner. Ships `<RunsTray />` at `@agent-native/core/client/progress` — floating bottom-right tray with percent bar + current step, hides when idle. Emits `run.progress.started` / `run.progress.updated` so automations like *"notify me when a run > 5min"* can be wired.

Separate concerns on purpose: notifications fire once (\"X happened\"), progress is continuous state (\"X is 45% done\"). Common pattern is to pair them — `complete-run` followed by `notify(..., severity: \"info\")`. Documented in both skill files.

Committed as two logical commits for clearer review.

Drafted for feedback first — happy to iterate on scope, channel shape, or UI placement before finalizing.

## Test plan

- [x] `pnpm --filter @agent-native/core test` — 9 notifications specs + 5 progress specs pass (registry fan-out, error isolation, emit payloads)
- [x] `pnpm --filter @agent-native/core run typecheck` — no new errors (pre-existing React 19 + drizzle-kit errors unchanged)
- [x] `pnpm --filter @agent-native/core exec prettier --check` on touched files
- [ ] Manual: `notify` tool call renders in the bell, mark-read + mark-all-read flows
- [ ] Manual: `start-run` / `update-run-progress` / `complete-run` cycle shows in `<RunsTray />` with live percent
- [ ] Manual: register a custom `slack` notification channel from a server plugin, verify fan-out runs alongside the inbox row
- [ ] Manual: set `NOTIFICATIONS_WEBHOOK_URL` + an ad-hoc key, verify the webhook channel auto-registers and resolves `\${keys.NAME}` server-side

## Follow-ups (not in this PR)

- `sound` notification channel (no default tone bikeshed yet)
- Per-severity user preferences (info → toast only; critical → toast + sound + browser popup)
- Browser Notification API integration (permission flow + service-worker)
- Agent-chat-plugin auto-creates a run for each turn so every long agent response is trackable without the agent having to call `start-run` manually