### PR TITLE
fix: dedupe @tanstack/react-query to fix docs site crash

### DIFF
--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -649,6 +649,7 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
         "react",
         "react-dom",
         "react-dom/client",
+        "@tanstack/react-query",
         "@radix-ui/react-select",
         "@radix-ui/react-popover",
         "@radix-ui/react-tooltip",


### PR DESCRIPTION
## Summary
- Adds `@tanstack/react-query` to Vite's `resolve.dedupe` list in the framework's `defineConfig`
- Fixes the production crash on agent-native.com ("No QueryClient set, use QueryClientProvider to set one")
- Root cause: pnpm installed two copies of react-query (one via core's devDeps at v5.96.2/React 18, one via docs at v5.99.2/React 19). The `QueryClientProvider` in docs used one module instance while core's components (`ScreenRefreshBoundary`, `ResourcesPanel`) read context from the other — different module = different React context = crash

## Test plan
- [ ] Deploy docs site and verify agent-native.com loads without errors
- [ ] Verify no "No QueryClient set" errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)