### PR TITLE
feat(core): notifications + progress primitives

### DIFF
--- a/packages/core/docs/content/notifications.md
+++ b/packages/core/docs/content/notifications.md
@@ -1,0 +1,199 @@
+---
+title: "Notifications"
+description: "In-app notifications with pluggable channels — inbox, webhook, or custom"
+---
+
+# Notifications
+
+One function, many destinations. Call `notify()` from any server-side code — an action, an automation, a plugin — and the event lands in the user's in-app inbox and fans out to every registered channel. Ships with a bell-and-dropdown UI component that the host template drops into its header.
+
+```ts
+import { notify } from "@agent-native/core/notifications";
+
+await notify(
+  { severity: "info", title: "Booking confirmed", body: "Jane at 3pm" },
+  { owner: "steve@builder.io" },
+);
+```
+
+## Severities {#severities}
+
+| Severity   | Use for                                 |
+| ---------- | --------------------------------------- |
+| `info`     | Confirmations, progress milestones, FYI |
+| `warning`  | Something the user should look at soon  |
+| `critical` | Needs immediate attention               |
+
+Severity drives the badge styling in the dropdown and is passed through to channels so they can branch on urgency.
+
+## Built-in channels {#channels}
+
+| Channel   | Delivery                                                  | Requires                                            |
+| --------- | --------------------------------------------------------- | --------------------------------------------------- |
+| `inbox`   | Persists to the `notifications` table; drives the bell UI | Always on — part of the primitive.                  |
+| `webhook` | POST JSON to a configured URL                             | `NOTIFICATIONS_WEBHOOK_URL` env var set at startup. |
+
+The webhook channel resolves `${keys.NAME}` references in both the URL and `NOTIFICATIONS_WEBHOOK_AUTH` against the owner's ad-hoc [secrets](/docs/security), so the raw value never enters the agent's context. Per-key URL allowlists are enforced — same rule the automations `web-request` tool uses.
+
+## API {#api}
+
+### `notify(input, meta)` {#notify}
+
+Deliver a notification. Always persists to the inbox unless explicitly excluded; additional registered channels run in parallel, best-effort.
+
+```ts
+await notify(
+  {
+    severity: "critical",
+    title: "Database offline",
+    body: "Primary dropped connections",
+    metadata: { runbookUrl: "https://runbooks/db-offline" },
+    channels: ["inbox", "webhook"], // optional allowlist; omit to run all
+  },
+  { owner: "ops@company.com" },
+);
+```
+
+`meta.owner` is required — scopes the notification so only that user sees it in the bell.
+
+### `registerNotificationChannel(channel)` {#register}
+
+Register a custom channel from any server plugin.
+
+```ts
+import { registerNotificationChannel } from "@agent-native/core/notifications";
+
+registerNotificationChannel({
+  name: "slack-ops",
+  async deliver(input, meta) {
+    await fetch(process.env.OPS_SLACK_WEBHOOK!, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: `*${input.severity.toUpperCase()}* — ${input.title}\n${input.body ?? ""}`,
+        owner: meta.owner,
+      }),
+    });
+  },
+});
+```
+
+Channel names are unique — re-registering replaces the prior channel. `deliver()` is best-effort; throwing logs the error but does not block other channels or the inbox row.
+
+### Listing and reading {#read}
+
+```ts
+import {
+  listNotifications,
+  countUnread,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification,
+} from "@agent-native/core/notifications";
+
+const rows = await listNotifications("steve@builder.io", {
+  unreadOnly: true,
+  limit: 50,
+});
+const unread = await countUnread("steve@builder.io");
+await markNotificationRead(rows[0].id, "steve@builder.io");
+await markAllNotificationsRead("steve@builder.io");
+await deleteNotification(rows[0].id, "steve@builder.io");
+```
+
+Each function is owner-scoped — no cross-user reads, no cross-user writes.
+
+## The NotificationChannel interface {#channel-interface}
+
+```ts
+interface NotificationChannel {
+  name: string;
+  deliver(
+    input: NotificationInput,
+    meta: NotificationMeta,
+  ): void | Promise<void>;
+}
+
+interface NotificationInput {
+  severity: "info" | "warning" | "critical";
+  title: string;
+  body?: string;
+  metadata?: Record<string, unknown>;
+  channels?: string[];
+}
+
+interface NotificationMeta {
+  owner: string;
+}
+```
+
+## HTTP API {#http}
+
+Mounted at `/_agent-native/notifications/*` by the core-routes plugin. All routes are scoped to the authenticated session's email.
+
+| Method   | Path                                                |
+| -------- | --------------------------------------------------- |
+| `GET`    | `/_agent-native/notifications?unread=true&limit=50` |
+| `GET`    | `/_agent-native/notifications/count`                |
+| `POST`   | `/_agent-native/notifications/:id/read`             |
+| `POST`   | `/_agent-native/notifications/read-all`             |
+| `DELETE` | `/_agent-native/notifications/:id`                  |
+
+## UI component {#ui}
+
+```tsx
+import { NotificationsBell } from "@agent-native/core/client/notifications";
+
+export function HeaderBar() {
+  return (
+    <header className="flex items-center gap-2">
+      {/* … */}
+      <NotificationsBell browserNotifications />
+    </header>
+  );
+}
+```
+
+Bell icon with unread badge. Clicking opens a dropdown of recent notifications. Uses shadcn semantic tokens, adapts to the host template's light/dark theme.
+
+Pass `browserNotifications` to also fire system `new Notification(...)` popups for every new unread item — useful when the user's tab is in the background. The dropdown renders an "Enable" prompt until the user grants permission; duplicates are prevented per-id via the Notification `tag` field.
+
+## Agent tools {#agent-tools}
+
+Two native tools are registered in every template:
+
+| Tool                 | Purpose                                              |
+| -------------------- | ---------------------------------------------------- |
+| `notify`             | Send a notification from an agent turn or automation |
+| `list-notifications` | Show recent notifications to the agent for context   |
+
+Automations (see [Automations](/docs/automations)) can call `notify` in their body — this is the canonical pattern for turning an external event into a user-visible alert.
+
+## Event bus {#event-bus}
+
+Every successful delivery emits `notification.sent` on the [event bus](/docs/automations#event-bus):
+
+```json
+{
+  "notificationId": "n-123",
+  "severity": "critical",
+  "title": "DB offline",
+  "body": "Primary dropped connections",
+  "deliveredChannels": ["inbox", "webhook"]
+}
+```
+
+Automations can chain off this — e.g. _"if a critical notification fires, also page on-call."_
+
+## How it works {#internals}
+
+- **Owner scoping** — every row has an `owner` column; every query filters on it; every route uses the authenticated session's email. Users never see each other's notifications.
+- **Poll integration** — every mutation calls `recordChange()` so templates using [`useDbSync`](/docs/client) auto-invalidate without any extra wiring.
+- **Best-effort fan-out** — channel errors are caught and logged; one failing channel does not block others or the inbox write.
+- **Fire-and-forget** — `notify()` returns after the inbox write completes; custom channels run in the background.
+
+## What's next
+
+- [**Automations**](/docs/automations) — the most common caller of `notify()`
+- [**Secrets**](/docs/security) — the `${keys.NAME}` substitution that powers the webhook channel
+- [**Server plugins**](/docs/server) — where custom channels are registered at startup

--- a/packages/core/docs/content/progress.md
+++ b/packages/core/docs/content/progress.md
@@ -1,0 +1,176 @@
+---
+title: "Progress"
+description: "Live progress signal for long-running agent tasks — start, update, complete"
+---
+
+# Progress
+
+Long agent tasks shouldn't hide behind a spinner. `progress_runs` gives the agent a way to announce _"I'm working on this, I'm 45% done, here's the current step"_ — which the UI renders as a floating runs tray with a percent bar.
+
+```ts
+import {
+  startRun,
+  updateRunProgress,
+  completeRun,
+} from "@agent-native/core/progress";
+
+const run = await startRun({
+  owner: "steve@builder.io",
+  title: "Triage 128 unread emails",
+  step: "Fetching inbox",
+});
+
+for (let i = 1; i <= total; i++) {
+  await updateRunProgress(run.id, run.owner, {
+    percent: Math.round((i / total) * 100),
+    step: `Classifying ${i}/${total}`,
+  });
+}
+
+await completeRun(run.id, run.owner, "succeeded");
+```
+
+Separate concern from [notifications](/docs/notifications): notifications fire once (_"X happened"_), progress is continuous state (_"X is 45% done"_). The two compose — `completeRun` followed by `notify(..., severity: "info")` tells the user when the work finishes even if they weren't watching the tray.
+
+## The lifecycle {#lifecycle}
+
+| Status      | Transition                  |
+| ----------- | --------------------------- |
+| `running`   | Initial — set by `startRun` |
+| `succeeded` | Happy-path terminal         |
+| `failed`    | Error terminal              |
+| `cancelled` | User interrupted            |
+
+Terminal statuses set `completed_at`. The UI tray shows only `running` rows; completed rows stay in the database for `list-runs` queries.
+
+## API {#api}
+
+### `startRun(input)` {#start}
+
+Create a run. Returns the full `AgentRun` with a generated id.
+
+```ts
+const run = await startRun({
+  owner: "steve@builder.io",
+  title: "Ingest 1M rows",
+  step: "Opening CSV",
+  metadata: { jobId: "abc123", artifactPath: "s3://..." },
+});
+```
+
+Emits `run.progress.started` on the event bus.
+
+### `updateRunProgress(id, owner, input)` {#update}
+
+Patch any field of a running run. Any omitted field stays unchanged.
+
+```ts
+await updateRunProgress(run.id, run.owner, {
+  percent: 75,
+  step: "Writing to target DB",
+});
+```
+
+Emits `run.progress.updated` on the event bus. Returns the updated `AgentRun`, or `null` if the run doesn't exist or isn't owned by the caller.
+
+### `completeRun(id, owner, status, extras?)` {#complete}
+
+Transition to a terminal status. `succeeded` implicitly sets `percent=100`.
+
+```ts
+await completeRun(run.id, run.owner, "succeeded", {
+  step: "All 1M rows ingested",
+  metadata: { totalDurationMs: 98_123 },
+});
+```
+
+Also emits `run.progress.updated` with the terminal status.
+
+### Listing {#list}
+
+```ts
+import { listRuns, getRun, deleteRun } from "@agent-native/core/progress";
+
+const active = await listRuns("steve@builder.io", { activeOnly: true });
+const run = await getRun("run-id", "steve@builder.io");
+await deleteRun("run-id", "steve@builder.io");
+```
+
+## HTTP API {#http}
+
+Mounted at `/_agent-native/runs/*` by the core-routes plugin. **Read-only over HTTP** — writes go through the agent tools since the agent is the canonical writer. All routes are owner-scoped.
+
+| Method   | Path                              |
+| -------- | --------------------------------- |
+| `GET`    | `/_agent-native/runs?active=true` |
+| `GET`    | `/_agent-native/runs/:id`         |
+| `DELETE` | `/_agent-native/runs/:id`         |
+
+## UI component {#ui}
+
+```tsx
+import { RunsTray } from "@agent-native/core/client/progress";
+
+export function HeaderBar() {
+  return (
+    <header className="flex items-center gap-2">
+      {/* … */}
+      <RunsTray />
+    </header>
+  );
+}
+```
+
+Inline header widget — mount it next to the notifications bell. Shows a spinner icon + count badge when runs are active; click opens a dropdown with one live percent bar per run. Hides the trigger entirely when no active runs. Polls `/_agent-native/runs?active=true` every `pollMs` (default 3 s). Uses shadcn semantic tokens, adapts to light and dark themes.
+
+## Agent tools {#agent-tools}
+
+Four native tools are registered in every template:
+
+| Tool                  | Purpose                                                         |
+| --------------------- | --------------------------------------------------------------- |
+| `start-run`           | Call at the top of a long task. Returns a runId.                |
+| `update-run-progress` | Call periodically during the task with `percent` and/or `step`. |
+| `complete-run`        | Terminal — one of `succeeded`, `failed`, `cancelled`.           |
+| `list-runs`           | Inspect recent runs (filter by `active=true`).                  |
+
+### When to start a run {#when-to-start}
+
+- Use for anything > ~5 seconds. A spinner with no context feels frozen.
+- Update at natural checkpoints, not every iteration. Every 5–10% is plenty.
+- **Always** call `complete-run`, including in error paths. An orphan `running` row is worse than no row.
+- Pair with `notify` on completion so the user sees the outcome when they're not actively watching the tray.
+
+## Event bus {#event-bus}
+
+Two events emit on the [event bus](/docs/automations#event-bus):
+
+| Event                  | Payload                            |
+| ---------------------- | ---------------------------------- |
+| `run.progress.started` | `{ runId, title, step? }`          |
+| `run.progress.updated` | `{ runId, percent, step, status }` |
+
+[Automations](/docs/automations) can subscribe to these — for example, _"if a run takes longer than 5 minutes, notify me"_:
+
+```yaml
+---
+triggerType: event
+event: run.progress.updated
+condition: "status is running and (now - started) > 5 minutes"
+mode: agentic
+---
+Notify me that run {{runId}} has been running for a long time.
+```
+
+## How it works {#internals}
+
+- **Owner scoping** — every row has an `owner` column; every query filters on it. Users see only their own runs.
+- **Poll integration** — every mutation calls `recordChange()` so templates using [`useDbSync`](/docs/client) auto-invalidate without any extra wiring.
+- **Table name** — the framework also has an `agent_runs` table for internal agent-chat turn lifecycle tracking. The progress primitive uses `progress_runs` to keep the two concerns separate.
+- **Percent clamping** — values are clamped to `[0, 100]` and rounded to an integer on write.
+
+## What's next
+
+- [**Notifications**](/docs/notifications) — pair with `complete-run` to tell the user when work finishes
+- [**Automations**](/docs/automations) — watchdog slow runs via `run.progress.updated`
+- [**Client**](/docs/client) — `useDbSync` for real-time cache invalidation

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,8 @@
     "./tracking": "./dist/tracking/index.js",
     "./notifications": "./dist/notifications/index.js",
     "./client/notifications": "./dist/client/notifications/index.js",
+    "./progress": "./dist/progress/index.js",
+    "./client/progress": "./dist/client/progress/index.js",
     "./triggers": "./dist/triggers/index.js",
     "./terminal": "./dist/client/terminal/index.js",
     "./terminal/server": "./dist/terminal/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,8 @@
     "./mcp": "./dist/mcp/index.js",
     "./mcp-client": "./dist/mcp-client/index.js",
     "./tracking": "./dist/tracking/index.js",
+    "./notifications": "./dist/notifications/index.js",
+    "./client/notifications": "./dist/client/notifications/index.js",
     "./triggers": "./dist/triggers/index.js",
     "./terminal": "./dist/client/terminal/index.js",
     "./terminal/server": "./dist/terminal/index.js",

--- a/packages/core/src/client/notifications/NotificationsBell.tsx
+++ b/packages/core/src/client/notifications/NotificationsBell.tsx
@@ -80,12 +80,16 @@ export function NotificationsBell({
         if (!res.ok) return;
         const rows = (await res.json()) as NotificationDto[];
         setUnreadCount(rows.length);
-        const isFirst = seenIdsRef.current === null;
-        const seen = isFirst ? new Set<string>() : seenIdsRef.current!;
+        // First run: treat everything as already seen so we don't pop
+        // retroactively on page load. After that, rebuild from the current
+        // unread list so ids for read/archived rows drop out — keeps the
+        // set bounded to the unread fetch limit (~20).
+        const prev = seenIdsRef.current;
+        const seen = new Set<string>();
         for (const n of rows) {
-          if (seen.has(n.id)) continue;
+          const alreadySeen = prev?.has(n.id) ?? true;
           seen.add(n.id);
-          if (isFirst) continue;
+          if (alreadySeen) continue;
           if (!SUPPORTS_NOTIFICATION) continue;
           if (Notification.permission !== "granted") continue;
           try {
@@ -95,7 +99,7 @@ export function NotificationsBell({
             // claims to be granted — silent no-op.
           }
         }
-        if (isFirst) seenIdsRef.current = seen;
+        seenIdsRef.current = seen;
       } catch {
         // best-effort
       }
@@ -263,7 +267,9 @@ export function NotificationsBell({
                 </button>
               ))
             ) : (
-              <div className="p-4 text-sm text-black/60">No notifications.</div>
+              <div className="p-4 text-sm text-muted-foreground">
+                No notifications.
+              </div>
             )}
           </div>
         </div>

--- a/packages/core/src/client/notifications/NotificationsBell.tsx
+++ b/packages/core/src/client/notifications/NotificationsBell.tsx
@@ -1,0 +1,291 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { IconBell, IconBellRinging, IconLoader2 } from "@tabler/icons-react";
+import { usePausingInterval } from "../use-pausing-interval.js";
+import type {
+  Notification as NotificationDto,
+  NotificationSeverity,
+} from "../../notifications/types.js";
+
+interface NotificationsBellProps {
+  /** Poll interval in ms. Set to 0 to disable polling. Default: 10000. */
+  pollMs?: number;
+  /** Optional className for the outer container. */
+  className?: string;
+  /**
+   * When true, fires a system-level `new Notification(...)` popup for each
+   * new unread notification — handy when the tab is in the background.
+   * Renders an "Enable browser notifications" prompt in the dropdown until
+   * the user grants permission. Silently no-ops on denied or unsupported.
+   */
+  browserNotifications?: boolean;
+}
+
+const POLL_MS_DEFAULT = 10_000;
+const SUPPORTS_NOTIFICATION =
+  typeof window !== "undefined" && "Notification" in window;
+
+/**
+ * Header-bar bell that shows the unread-notification count and a dropdown of
+ * recent entries. Polling keeps it in sync (the framework poll loop already
+ * bumps a version counter so notifications ride on that signal, but we poll
+ * the count endpoint directly so the bell updates even outside an app-state
+ * change).
+ */
+export function NotificationsBell({
+  pollMs = POLL_MS_DEFAULT,
+  className,
+  browserNotifications = false,
+}: NotificationsBellProps) {
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<NotificationDto[] | null>(null);
+  // Init to "default" unconditionally so server and client render the same
+  // HTML — reading Notification.permission at init would diverge between SSR
+  // ("denied", no API) and hydration ("default"/"granted"), causing a mismatch
+  // in templates that mount the bell outside a ClientOnly boundary. We sync
+  // to the real value in a useEffect below.
+  const [permission, setPermission] =
+    useState<NotificationPermission>("default");
+
+  useEffect(() => {
+    if (SUPPORTS_NOTIFICATION) setPermission(Notification.permission);
+  }, []);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  // Ids already popped as browser notifications. Seeded on first run so
+  // existing unread don't pop retroactively on page load.
+  const seenIdsRef = useRef<Set<string> | null>(null);
+
+  const loadItems = useCallback(async () => {
+    try {
+      const res = await fetch("/_agent-native/notifications?limit=20");
+      if (!res.ok) return;
+      const rows = (await res.json()) as NotificationDto[];
+      setItems(rows);
+    } catch {
+      // best-effort
+    }
+  }, []);
+
+  // One polling callback used by both paths. When browserNotifications is on
+  // we fetch the unread list (source of truth for both the badge count AND
+  // the popup loop — no second /count request), and pop Notification() for
+  // any new ids. When off, we fetch just /count. The unread-list branch also
+  // opts out of visibility pause so popups still fire for backgrounded tabs.
+  const refresh = useCallback(async () => {
+    if (browserNotifications) {
+      try {
+        const res = await fetch(
+          "/_agent-native/notifications?unread=true&limit=20",
+        );
+        if (!res.ok) return;
+        const rows = (await res.json()) as NotificationDto[];
+        setUnreadCount(rows.length);
+        const isFirst = seenIdsRef.current === null;
+        const seen = isFirst ? new Set<string>() : seenIdsRef.current!;
+        for (const n of rows) {
+          if (seen.has(n.id)) continue;
+          seen.add(n.id);
+          if (isFirst) continue;
+          if (!SUPPORTS_NOTIFICATION) continue;
+          if (Notification.permission !== "granted") continue;
+          try {
+            new Notification(n.title, { body: n.body, tag: n.id });
+          } catch {
+            // Safari / restricted contexts may throw even when permission
+            // claims to be granted — silent no-op.
+          }
+        }
+        if (isFirst) seenIdsRef.current = seen;
+      } catch {
+        // best-effort
+      }
+      return;
+    }
+    try {
+      const res = await fetch("/_agent-native/notifications/count");
+      if (!res.ok) return;
+      const data = (await res.json()) as { count: number };
+      setUnreadCount(data.count);
+    } catch {
+      // best-effort
+    }
+  }, [browserNotifications]);
+
+  usePausingInterval(
+    refresh,
+    pollMs,
+    /* pauseWhenHidden */ !browserNotifications,
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    loadItems();
+  }, [open, loadItems]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  const markRead = async (id: string) => {
+    try {
+      await fetch(`/_agent-native/notifications/${id}/read`, {
+        method: "POST",
+      });
+      setItems((prev) =>
+        prev
+          ? prev.map((n) =>
+              n.id === id ? { ...n, readAt: new Date().toISOString() } : n,
+            )
+          : prev,
+      );
+      refresh();
+    } catch {
+      // best-effort
+    }
+  };
+
+  const markAllRead = async () => {
+    try {
+      await fetch(`/_agent-native/notifications/read-all`, { method: "POST" });
+      setItems((prev) =>
+        prev
+          ? prev.map((n) =>
+              n.readAt ? n : { ...n, readAt: new Date().toISOString() },
+            )
+          : prev,
+      );
+      setUnreadCount(0);
+    } catch {
+      // best-effort
+    }
+  };
+
+  const hasUnread = unreadCount > 0;
+  const Icon = hasUnread ? IconBellRinging : IconBell;
+
+  return (
+    <div
+      ref={menuRef}
+      className={
+        "an-notifications-bell relative inline-flex" +
+        (className ? ` ${className}` : "")
+      }
+    >
+      <button
+        type="button"
+        aria-label={
+          hasUnread ? `${unreadCount} unread notifications` : "Notifications"
+        }
+        onClick={() => setOpen((v) => !v)}
+        className="an-notifications-bell__trigger relative inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/40 hover:text-foreground"
+      >
+        <Icon size={18} aria-hidden />
+        {hasUnread ? (
+          <span
+            aria-hidden
+            className="an-notifications-bell__badge absolute -right-0.5 -top-0.5 rounded-full bg-destructive px-1 text-[10px] leading-[14px] font-medium text-destructive-foreground"
+          >
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        ) : null}
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="an-notifications-bell__menu absolute right-0 top-full z-50 mt-2 w-80 rounded-md border border-border bg-popover text-popover-foreground shadow-lg"
+        >
+          <div className="flex items-center justify-between border-b border-border px-3 py-2 text-sm font-medium">
+            <span>Notifications</span>
+            {hasUnread ? (
+              <button
+                type="button"
+                onClick={markAllRead}
+                className="text-xs text-primary hover:underline"
+              >
+                Mark all read
+              </button>
+            ) : null}
+          </div>
+          {browserNotifications &&
+          SUPPORTS_NOTIFICATION &&
+          permission === "default" ? (
+            <div className="flex items-center justify-between gap-2 border-b border-border bg-accent/40 px-3 py-2 text-xs text-foreground">
+              <span>Get a system popup for new notifications.</span>
+              <button
+                type="button"
+                onClick={async () => {
+                  const result = await Notification.requestPermission();
+                  setPermission(result);
+                }}
+                className="shrink-0 rounded bg-primary px-2 py-0.5 font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Enable
+              </button>
+            </div>
+          ) : null}
+          <div className="max-h-96 overflow-y-auto">
+            {items === null ? (
+              <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+                <IconLoader2 size={14} className="animate-spin" /> Loading…
+              </div>
+            ) : items.length > 0 ? (
+              items.map((n) => (
+                <button
+                  type="button"
+                  key={n.id}
+                  onClick={() => (n.readAt ? undefined : markRead(n.id))}
+                  className={
+                    "flex w-full flex-col items-start gap-0.5 border-b border-border px-3 py-2 text-left last:border-b-0 hover:bg-accent/40 " +
+                    (n.readAt ? "opacity-60" : "")
+                  }
+                >
+                  <div className="flex w-full items-center justify-between gap-2">
+                    <span className="truncate text-sm font-medium text-foreground">
+                      {n.title}
+                    </span>
+                    <SeverityBadge severity={n.severity} />
+                  </div>
+                  {n.body ? (
+                    <span className="line-clamp-2 text-xs text-muted-foreground">
+                      {n.body}
+                    </span>
+                  ) : null}
+                  <span className="text-[10px] text-muted-foreground/70">
+                    {new Date(n.createdAt).toLocaleString()}
+                  </span>
+                </button>
+              ))
+            ) : (
+              <div className="p-4 text-sm text-black/60">No notifications.</div>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// Severity color pairs — use /20 opacity backdrops that work against both
+// light and dark theme backgrounds; text uses 700/300 so it stays readable
+// in each mode (the `dark:` prefix is one of the few places where explicit
+// variants are necessary since these are brand-color tokens, not semantic).
+function SeverityBadge({ severity }: { severity: NotificationSeverity }) {
+  const color =
+    severity === "critical"
+      ? "bg-red-500/20 text-red-700 dark:text-red-300"
+      : severity === "warning"
+        ? "bg-amber-500/20 text-amber-700 dark:text-amber-300"
+        : "bg-muted text-muted-foreground";
+  return (
+    <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${color}`}>
+      {severity}
+    </span>
+  );
+}

--- a/packages/core/src/client/notifications/index.ts
+++ b/packages/core/src/client/notifications/index.ts
@@ -1,0 +1,1 @@
+export { NotificationsBell } from "./NotificationsBell.js";

--- a/packages/core/src/client/progress/RunsTray.tsx
+++ b/packages/core/src/client/progress/RunsTray.tsx
@@ -1,0 +1,166 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { IconLoader2, IconCheck, IconX, IconClock } from "@tabler/icons-react";
+import { usePausingInterval } from "../use-pausing-interval.js";
+import type { AgentRun, ProgressStatus } from "../../progress/types.js";
+
+type AgentRunDto = AgentRun;
+
+interface RunsTrayProps {
+  /** Poll interval in ms. 0 disables. Default 3000. */
+  pollMs?: number;
+  /** Max runs to show in the dropdown. Default 5. */
+  limit?: number;
+  /** Hide the trigger entirely when no active runs. Default true. */
+  hideWhenIdle?: boolean;
+  className?: string;
+}
+
+/**
+ * Header-bar progress indicator. Shows a spinner icon with a count badge
+ * when runs are active; opens a dropdown with live progress bars for each.
+ * Same inline-header pattern as <NotificationsBell /> — drop it into the
+ * header, no floating overlay over the main content.
+ */
+export function RunsTray({
+  pollMs = 3000,
+  limit = 5,
+  hideWhenIdle = true,
+  className,
+}: RunsTrayProps) {
+  const [runs, setRuns] = useState<AgentRunDto[]>([]);
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(`/_agent-native/runs?active=true&limit=${limit}`);
+      if (!res.ok) return;
+      const rows = (await res.json()) as AgentRunDto[];
+      setRuns(rows);
+    } catch {
+      // best-effort
+    }
+  }, [limit]);
+
+  usePausingInterval(refresh, pollMs);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  // Close the dropdown when the last active run finishes.
+  useEffect(() => {
+    if (runs.length === 0 && open) setOpen(false);
+  }, [runs.length, open]);
+
+  const hasRuns = runs.length > 0;
+  if (!hasRuns && hideWhenIdle) return null;
+
+  return (
+    <div
+      ref={menuRef}
+      className={
+        "an-runs-tray relative inline-flex" + (className ? ` ${className}` : "")
+      }
+    >
+      <button
+        type="button"
+        aria-label={
+          hasRuns
+            ? `${runs.length} active run${runs.length > 1 ? "s" : ""}`
+            : "No active runs"
+        }
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="an-runs-tray__trigger relative inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/40 hover:text-foreground"
+      >
+        <IconLoader2
+          size={18}
+          className={hasRuns ? "animate-spin text-primary" : ""}
+          aria-hidden
+        />
+        {hasRuns ? (
+          <span
+            aria-hidden
+            className="an-runs-tray__badge absolute -right-0.5 -top-0.5 rounded-full bg-primary px-1 text-[10px] leading-[14px] font-medium text-primary-foreground"
+          >
+            {runs.length > 9 ? "9+" : runs.length}
+          </span>
+        ) : null}
+      </button>
+      {open && hasRuns ? (
+        <div
+          role="menu"
+          className="an-runs-tray__menu absolute right-0 top-full z-50 mt-2 w-80 rounded-md border border-border bg-popover text-popover-foreground shadow-lg"
+        >
+          <div className="border-b border-border px-3 py-2 text-sm font-medium">
+            {runs.length} active run{runs.length > 1 ? "s" : ""}
+          </div>
+          <div className="max-h-96 divide-y divide-border overflow-y-auto">
+            {runs.map((r) => (
+              <RunRow key={r.id} run={r} />
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function RunRow({ run }: { run: AgentRunDto }) {
+  return (
+    <div className="flex flex-col gap-1 px-3 py-2 text-sm">
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate font-medium text-foreground">
+          {run.title}
+        </span>
+        <StatusGlyph status={run.status} />
+      </div>
+      {run.step ? (
+        <span className="truncate text-xs text-muted-foreground">
+          {run.step}
+        </span>
+      ) : null}
+      {run.percent != null ? (
+        <div className="mt-0.5 h-1 w-full overflow-hidden rounded bg-muted">
+          <div
+            className="h-full bg-primary transition-all"
+            style={{ width: `${run.percent}%` }}
+          />
+        </div>
+      ) : (
+        <div className="mt-0.5 h-1 w-full overflow-hidden rounded bg-muted">
+          <div className="h-full w-1/3 animate-pulse bg-primary/60" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// dark: variants only where there's no semantic token for the colour
+// (e.g. success green isn't in shadcn's default palette).
+const STATUS_GLYPHS: Record<
+  ProgressStatus,
+  { Icon: typeof IconLoader2; className: string }
+> = {
+  running: { Icon: IconLoader2, className: "text-primary" },
+  succeeded: {
+    Icon: IconCheck,
+    className: "text-green-600 dark:text-green-400",
+  },
+  failed: { Icon: IconX, className: "text-destructive" },
+  cancelled: { Icon: IconClock, className: "text-muted-foreground" },
+};
+
+function StatusGlyph({ status }: { status: ProgressStatus }) {
+  const { Icon, className } = STATUS_GLYPHS[status];
+  const spinClass = status === "running" ? " animate-spin" : "";
+  return <Icon size={14} className={`${className}${spinClass}`} aria-hidden />;
+}

--- a/packages/core/src/client/progress/index.ts
+++ b/packages/core/src/client/progress/index.ts
@@ -1,0 +1,1 @@
+export { RunsTray } from "./RunsTray.js";

--- a/packages/core/src/client/use-pausing-interval.ts
+++ b/packages/core/src/client/use-pausing-interval.ts
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+
+/**
+ * Runs `callback` on an interval, pausing when the tab becomes hidden and
+ * resuming (with an immediate re-run) when the tab becomes visible again.
+ * Fires `callback` once immediately on mount (if the tab is visible).
+ *
+ * Pass `pollMs=0` to disable. Pass `pauseWhenHidden=false` to keep the
+ * interval running even when the tab is hidden — the bell's browser-
+ * notification popup loop uses that to still reach backgrounded tabs.
+ */
+export function usePausingInterval(
+  callback: () => void | Promise<void>,
+  pollMs: number,
+  pauseWhenHidden: boolean = true,
+): void {
+  useEffect(() => {
+    if (pollMs <= 0) return;
+    let id: ReturnType<typeof setInterval> | null = null;
+    const start = () => {
+      if (id == null) id = setInterval(callback, pollMs);
+    };
+    const stop = () => {
+      if (id != null) {
+        clearInterval(id);
+        id = null;
+      }
+    };
+
+    callback();
+
+    if (!pauseWhenHidden) {
+      start();
+      return () => stop();
+    }
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        callback();
+        start();
+      }
+    };
+    if (!document.hidden) start();
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [callback, pollMs, pauseWhenHidden]);
+}

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -56,6 +56,25 @@ export function getDatabaseAuthToken(): string | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// Safe JSON column parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a JSON-serialized column value defensively. A malformed row — from a
+ * hand-edit, dirty migration, or a misbehaving agent that wrote raw SQL —
+ * must not break an entire list endpoint. Callers supply a fallback for the
+ * malformed path; null/undefined values also fall back.
+ */
+export function safeJsonParse<T>(value: unknown, fallback: T): T {
+  if (value == null) return fallback;
+  try {
+    return JSON.parse(String(value)) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // SQLite retry helper
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -138,6 +138,29 @@ function isPgCatalogRace(e: any): boolean {
   );
 }
 
+/**
+ * True when `e` is a UNIQUE / PRIMARY KEY constraint violation from any
+ * supported driver (Postgres 23505, SQLite SQLITE_CONSTRAINT_PRIMARYKEY /
+ * _UNIQUE, D1). Used by stores that accept caller-provided ids and want to
+ * surface a clean "already exists" error instead of the raw SQL text.
+ */
+export function isUniqueViolation(e: any): boolean {
+  if (e?.code === "23505") return true;
+  const code = String(e?.code ?? "");
+  if (
+    code === "SQLITE_CONSTRAINT_PRIMARYKEY" ||
+    code === "SQLITE_CONSTRAINT_UNIQUE"
+  ) {
+    return true;
+  }
+  const msg = String(e?.message ?? "").toLowerCase();
+  return (
+    msg.includes("unique constraint") ||
+    msg.includes("primary key constraint") ||
+    msg.includes("duplicate key")
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Dialect detection
 // ---------------------------------------------------------------------------

--- a/packages/core/src/notifications/actions.ts
+++ b/packages/core/src/notifications/actions.ts
@@ -1,0 +1,133 @@
+/**
+ * Framework-level agent actions for the notifications primitive.
+ *
+ * Registered as native tools (not template actions) so they're available in
+ * every template. The agent uses `notify` to surface progress, completions,
+ * and alerts to the user through the in-app inbox and any registered channels.
+ */
+
+import type { ActionEntry } from "../agent/production-agent.js";
+import { notify, listNotifications, countUnread } from "./registry.js";
+import type { NotificationSeverity } from "./types.js";
+
+export function createNotificationToolEntries(
+  getCurrentUser: () => string,
+): Record<string, ActionEntry> {
+  return {
+    notify: {
+      tool: {
+        description:
+          "Send a notification to the user. Always persisted to the in-app inbox so the bell + toast surface shows it. Registered channels (webhook, Slack, etc.) also run. Use `info` for FYI, `warning` for things the user should look at, `critical` for things that need immediate attention.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            severity: {
+              type: "string",
+              enum: ["info", "warning", "critical"],
+              description:
+                "Severity level — drives styling and per-severity channel routing.",
+            },
+            title: {
+              type: "string",
+              description: "Short, human-readable headline (≤100 chars).",
+            },
+            body: {
+              type: "string",
+              description: "Optional longer description.",
+            },
+            metadataJson: {
+              type: "string",
+              description:
+                'Optional JSON metadata (URLs, entity ids, etc.). Example: \'{"threadId":"abc","link":"/inbox/abc"}\'.',
+            },
+            channels: {
+              type: "string",
+              description:
+                'Optional comma-separated channel allowlist (e.g. "inbox,webhook"). Omit to run all registered channels.',
+            },
+          },
+          required: ["severity", "title"],
+        },
+      },
+      run: async (args: Record<string, string>) => {
+        const owner = getCurrentUser();
+        if (!args.severity || !args.title) {
+          return "Error: --severity and --title are required.";
+        }
+        const severity = args.severity as NotificationSeverity;
+        if (!["info", "warning", "critical"].includes(severity)) {
+          return `Error: severity must be info, warning, or critical (got "${severity}").`;
+        }
+
+        let metadata: Record<string, unknown> | undefined;
+        if (args.metadataJson) {
+          try {
+            metadata = JSON.parse(args.metadataJson);
+          } catch {
+            return "Error: metadataJson must be valid JSON.";
+          }
+        }
+
+        const channels = args.channels
+          ? args.channels
+              .split(",")
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : undefined;
+
+        const stored = await notify(
+          {
+            severity,
+            title: args.title,
+            body: args.body || undefined,
+            metadata,
+            channels,
+          },
+          { owner },
+        );
+        return stored
+          ? `Notification sent (id: ${stored.id})`
+          : "Notification dispatched to channels (not persisted).";
+      },
+    },
+
+    "list-notifications": {
+      tool: {
+        description:
+          "List recent notifications for the current user. Useful when the user asks about prior alerts.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            unreadOnly: {
+              type: "boolean",
+              description: "When true, only include unread notifications.",
+            },
+            limit: {
+              type: "number",
+              description: "Max rows to return (default 20, max 200).",
+            },
+          },
+        },
+      },
+      run: async (args: Record<string, unknown>) => {
+        const owner = getCurrentUser();
+        const rows = await listNotifications(owner, {
+          unreadOnly: args.unreadOnly === true || args.unreadOnly === "true",
+          limit: Math.min(Number(args.limit ?? 20), 200),
+        });
+        if (rows.length === 0) {
+          return args.unreadOnly
+            ? "No unread notifications."
+            : "No notifications.";
+        }
+        const unreadCount = await countUnread(owner);
+        const lines = rows.map(
+          (n) =>
+            `[${n.readAt ? " " : "•"}] (${n.severity}) ${n.title}${n.body ? ` — ${n.body}` : ""} · ${n.createdAt}`,
+        );
+        return `${unreadCount} unread\n\n${lines.join("\n")}`;
+      },
+      readOnly: true,
+    },
+  };
+}

--- a/packages/core/src/notifications/channels.ts
+++ b/packages/core/src/notifications/channels.ts
@@ -1,0 +1,95 @@
+/**
+ * Built-in notification channels.
+ *
+ * Set environment variables to auto-register the webhook channel at startup.
+ * Extra channels can be registered at any time via
+ * `registerNotificationChannel()` from a server plugin.
+ *
+ * NOTIFICATIONS_WEBHOOK_URL  → POST notifications as JSON to this URL.
+ *                              Supports `${keys.NAME}` substitution — the raw
+ *                              value never enters the agent context.
+ * NOTIFICATIONS_WEBHOOK_AUTH → optional `Authorization` header value (also
+ *                              supports `${keys.NAME}`).
+ */
+
+import { registerNotificationChannel } from "./registry.js";
+import type { NotificationChannel } from "./types.js";
+import {
+  resolveKeyReferences,
+  validateUrlAllowlist,
+  getKeyAllowlist,
+} from "../secrets/substitution.js";
+
+let _registered = false;
+
+export function registerBuiltinNotificationChannels(): void {
+  if (_registered) return;
+  _registered = true;
+
+  const url = process.env.NOTIFICATIONS_WEBHOOK_URL;
+  if (url) {
+    registerNotificationChannel(createWebhookChannel(url));
+  }
+}
+
+function createWebhookChannel(urlTemplate: string): NotificationChannel {
+  const authTemplate = process.env.NOTIFICATIONS_WEBHOOK_AUTH;
+  return {
+    name: "webhook",
+    async deliver(input, meta) {
+      // Resolve `${keys.NAME}` references against the owner's user-scope
+      // secrets. Missing keys throw — the error surfaces in logs and the
+      // channel is marked un-delivered, but other channels still run.
+      const { resolved: url } = await resolveKeyReferences(
+        urlTemplate,
+        "user",
+        meta.owner,
+      );
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (authTemplate) {
+        const { resolved: auth } = await resolveKeyReferences(
+          authTemplate,
+          "user",
+          meta.owner,
+        );
+        headers.Authorization = auth;
+      }
+
+      // If the user set an allowlist on a referenced key, enforce it here —
+      // origin-level check, same rule the automations fetch-tool applies.
+      const keyNames = Array.from(
+        new Set(
+          Array.from(
+            urlTemplate.matchAll(/\$\{keys\.([A-Za-z0-9_-]+)\}/g),
+            (m) => m[1],
+          ),
+        ),
+      );
+      const allowlists = await Promise.all(
+        keyNames.map((name) => getKeyAllowlist(name, "user", meta.owner)),
+      );
+      keyNames.forEach((name, i) => {
+        if (!validateUrlAllowlist(url, allowlists[i])) {
+          throw new Error(
+            `[notifications] webhook URL ${new URL(url).origin} is not in the allowlist for key "${name}"`,
+          );
+        }
+      });
+
+      await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          severity: input.severity,
+          title: input.title,
+          body: input.body,
+          metadata: input.metadata,
+          owner: meta.owner,
+          emittedAt: new Date().toISOString(),
+        }),
+      });
+    },
+  };
+}

--- a/packages/core/src/notifications/channels.ts
+++ b/packages/core/src/notifications/channels.ts
@@ -78,7 +78,7 @@ function createWebhookChannel(urlTemplate: string): NotificationChannel {
         }
       });
 
-      await fetch(url, {
+      const res = await fetch(url, {
         method: "POST",
         headers,
         body: JSON.stringify({
@@ -90,6 +90,38 @@ function createWebhookChannel(urlTemplate: string): NotificationChannel {
           emittedAt: new Date().toISOString(),
         }),
       });
+      if (!res.ok) {
+        throw new Error(
+          `[notifications] webhook ${new URL(url).origin} returned ${res.status}${
+            (await readErrorSnippet(res)) || ""
+          }`,
+        );
+      }
     },
   };
+}
+
+/**
+ * Read up to ~1 KB from the body for error context. Streams chunks so a
+ * misbehaving endpoint returning a large error page doesn't pin that whole
+ * payload in memory per failed webhook.
+ */
+async function readErrorSnippet(res: Response): Promise<string> {
+  const reader = res.body?.getReader();
+  if (!reader) return "";
+  const decoder = new TextDecoder();
+  const MAX = 1024;
+  let buf = "";
+  try {
+    while (buf.length < MAX) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+    }
+    reader.cancel().catch(() => {});
+  } catch {
+    return "";
+  }
+  if (!buf) return "";
+  return `: ${buf.slice(0, 200)}`;
 }

--- a/packages/core/src/notifications/index.ts
+++ b/packages/core/src/notifications/index.ts
@@ -1,0 +1,21 @@
+export type {
+  Notification,
+  NotificationSeverity,
+  NotificationInput,
+  NotificationMeta,
+  NotificationChannel,
+} from "./types.js";
+
+export {
+  notify,
+  registerNotificationChannel,
+  unregisterNotificationChannel,
+  listNotificationChannels,
+  listNotifications,
+  countUnread,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification,
+} from "./registry.js";
+
+export { registerBuiltinNotificationChannels } from "./channels.js";

--- a/packages/core/src/notifications/notifications.spec.ts
+++ b/packages/core/src/notifications/notifications.spec.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockInsertNotification = vi.fn();
+const mockEmit = vi.fn();
+
+vi.mock("./store.js", () => ({
+  insertNotification: (...args: unknown[]) => mockInsertNotification(...args),
+}));
+
+vi.mock("../event-bus/bus.js", () => ({
+  emit: (...args: unknown[]) => mockEmit(...args),
+}));
+
+import {
+  notify,
+  registerNotificationChannel,
+  unregisterNotificationChannel,
+  listNotificationChannels,
+  __resetNotificationChannels,
+} from "./registry.js";
+
+describe("notifications registry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetNotificationChannels();
+    mockInsertNotification.mockResolvedValue({
+      id: "n-1",
+      owner: "boni@local",
+      severity: "info",
+      title: "Hi",
+      body: undefined,
+      metadata: undefined,
+      deliveredChannels: ["inbox"],
+      createdAt: "2026-04-22T16:00:00.000Z",
+      readAt: null,
+    });
+  });
+
+  describe("notify()", () => {
+    it("persists an inbox row by default and emits notification.sent", async () => {
+      const stored = await notify(
+        { severity: "info", title: "Booking confirmed" },
+        { owner: "boni@local" },
+      );
+
+      expect(mockInsertNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "boni@local",
+          severity: "info",
+          title: "Booking confirmed",
+        }),
+      );
+      expect(stored?.id).toBe("n-1");
+      expect(mockEmit).toHaveBeenCalledWith(
+        "notification.sent",
+        expect.objectContaining({
+          notificationId: "n-1",
+          severity: "info",
+          deliveredChannels: ["inbox"],
+        }),
+        { owner: "boni@local" },
+      );
+    });
+
+    it("requires meta.owner", async () => {
+      await expect(
+        notify({ severity: "info", title: "x" }, { owner: "" }),
+      ).rejects.toThrow(/owner is required/);
+    });
+
+    it("fans out to registered channels in addition to the inbox row", async () => {
+      const deliver = vi.fn();
+      registerNotificationChannel({ name: "slack", deliver });
+
+      await notify(
+        { severity: "warning", title: "Disk low" },
+        { owner: "boni@local" },
+      );
+
+      expect(deliver).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: "warning", title: "Disk low" }),
+        { owner: "boni@local" },
+      );
+      expect(mockInsertNotification).toHaveBeenCalledTimes(1);
+    });
+
+    it("channel throws — other channels still run and inbox still persists", async () => {
+      const badDeliver = vi.fn(() => {
+        throw new Error("slack is down");
+      });
+      const goodDeliver = vi.fn();
+      registerNotificationChannel({ name: "slack", deliver: badDeliver });
+      registerNotificationChannel({ name: "pager", deliver: goodDeliver });
+
+      await notify(
+        { severity: "critical", title: "DB offline" },
+        { owner: "boni@local" },
+      );
+
+      expect(badDeliver).toHaveBeenCalled();
+      expect(goodDeliver).toHaveBeenCalled();
+      expect(mockInsertNotification).toHaveBeenCalled();
+    });
+
+    it("explicit channels allowlist scopes delivery and excludes inbox when omitted", async () => {
+      const deliverSlack = vi.fn();
+      const deliverPager = vi.fn();
+      registerNotificationChannel({ name: "slack", deliver: deliverSlack });
+      registerNotificationChannel({ name: "pager", deliver: deliverPager });
+
+      await notify(
+        { severity: "info", title: "Test", channels: ["slack"] },
+        { owner: "boni@local" },
+      );
+
+      expect(deliverSlack).toHaveBeenCalled();
+      expect(deliverPager).not.toHaveBeenCalled();
+      expect(mockInsertNotification).not.toHaveBeenCalled();
+    });
+
+    it("channels=['inbox'] persists but skips custom channels", async () => {
+      const deliverSlack = vi.fn();
+      registerNotificationChannel({ name: "slack", deliver: deliverSlack });
+
+      await notify(
+        { severity: "info", title: "Test", channels: ["inbox"] },
+        { owner: "boni@local" },
+      );
+
+      expect(mockInsertNotification).toHaveBeenCalled();
+      expect(deliverSlack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("channel registration", () => {
+    it("requires a name", () => {
+      expect(() =>
+        registerNotificationChannel({
+          name: "",
+          deliver: () => undefined,
+        }),
+      ).toThrow(/name is required/);
+    });
+
+    it("requires deliver to be a function", () => {
+      expect(() =>
+        registerNotificationChannel({
+          name: "bad",
+          deliver: "nope" as unknown as NotificationChannel["deliver"],
+        }),
+      ).toThrow(/must be a function/);
+    });
+
+    it("listNotificationChannels reflects registered channels", () => {
+      registerNotificationChannel({ name: "a", deliver: () => undefined });
+      registerNotificationChannel({ name: "b", deliver: () => undefined });
+      expect(listNotificationChannels().sort()).toEqual(["a", "b"]);
+      unregisterNotificationChannel("a");
+      expect(listNotificationChannels()).toEqual(["b"]);
+    });
+  });
+});
+
+// Re-import the type inline so the cast above compiles without circularity.
+type NotificationChannel = {
+  name: string;
+  deliver: (...args: unknown[]) => unknown;
+};

--- a/packages/core/src/notifications/notifications.spec.ts
+++ b/packages/core/src/notifications/notifications.spec.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockInsertNotification = vi.fn();
+const mockUpdateDeliveredChannels = vi.fn();
 const mockEmit = vi.fn();
 
 vi.mock("./store.js", () => ({
   insertNotification: (...args: unknown[]) => mockInsertNotification(...args),
+  updateDeliveredChannels: (...args: unknown[]) =>
+    mockUpdateDeliveredChannels(...args),
 }));
 
 vi.mock("../event-bus/bus.js", () => ({
@@ -100,6 +103,54 @@ describe("notifications registry", () => {
       expect(badDeliver).toHaveBeenCalled();
       expect(goodDeliver).toHaveBeenCalled();
       expect(mockInsertNotification).toHaveBeenCalled();
+    });
+
+    it("failed channels are excluded from deliveredChannels on the emit event", async () => {
+      registerNotificationChannel({
+        name: "slack",
+        deliver: () => {
+          throw new Error("slack is down");
+        },
+      });
+      registerNotificationChannel({
+        name: "pager",
+        deliver: async () => {},
+      });
+
+      await notify(
+        { severity: "critical", title: "DB offline" },
+        { owner: "boni@local" },
+      );
+
+      const eventCall = mockEmit.mock.calls.find(
+        ([name]) => name === "notification.sent",
+      );
+      expect(eventCall).toBeDefined();
+      const [, payload] = eventCall!;
+      expect(payload.deliveredChannels).toEqual(
+        expect.arrayContaining(["inbox", "pager"]),
+      );
+      expect(payload.deliveredChannels).not.toContain("slack");
+      expect(mockUpdateDeliveredChannels).toHaveBeenCalledWith(
+        "n-1",
+        expect.arrayContaining(["inbox", "pager"]),
+      );
+    });
+
+    it("truncates overlong titles + bodies", async () => {
+      const longTitle = "x".repeat(150);
+      const longBody = "y".repeat(3000);
+
+      await notify(
+        { severity: "info", title: longTitle, body: longBody },
+        { owner: "boni@local" },
+      );
+
+      const call = mockInsertNotification.mock.calls[0][0];
+      expect(call.title.length).toBeLessThanOrEqual(100);
+      expect(call.title.endsWith("…")).toBe(true);
+      expect(call.body.length).toBeLessThanOrEqual(2000);
+      expect(call.body.endsWith("…")).toBe(true);
     });
 
     it("explicit channels allowlist scopes delivery and excludes inbox when omitted", async () => {

--- a/packages/core/src/notifications/registry.ts
+++ b/packages/core/src/notifications/registry.ts
@@ -1,0 +1,168 @@
+import { z } from "zod";
+import {
+  NOTIFICATION_SEVERITIES,
+  type NotificationChannel,
+  type NotificationInput,
+  type NotificationMeta,
+  type Notification,
+} from "./types.js";
+import { insertNotification } from "./store.js";
+import { emit as emitBusEvent } from "../event-bus/bus.js";
+import { registerEvent } from "../event-bus/registry.js";
+import type { EventDefinition } from "../event-bus/types.js";
+
+registerEvent({
+  name: "notification.sent",
+  description:
+    "Fires after notify() delivers to at least one channel. Automations can chain off this — e.g. fan critical notifications to Slack.",
+  payloadSchema: z.object({
+    notificationId: z.string().optional(),
+    severity: z.enum(NOTIFICATION_SEVERITIES),
+    title: z.string(),
+    body: z.string().optional(),
+    deliveredChannels: z.array(z.string()),
+  }) as unknown as EventDefinition["payloadSchema"],
+  example: {
+    notificationId: "ntf_abc",
+    severity: "critical",
+    title: "Payment failed",
+    body: "Card ending 4242 declined",
+    deliveredChannels: ["inbox", "webhook"],
+  },
+});
+
+const REGISTRY_KEY = Symbol.for("@agent-native/core/notifications.registry");
+interface GlobalWithRegistry {
+  [REGISTRY_KEY]?: Map<string, NotificationChannel>;
+}
+
+function getRegistry(): Map<string, NotificationChannel> {
+  const g = globalThis as unknown as GlobalWithRegistry;
+  if (!g[REGISTRY_KEY]) g[REGISTRY_KEY] = new Map();
+  return g[REGISTRY_KEY];
+}
+
+export function registerNotificationChannel(
+  channel: NotificationChannel,
+): void {
+  if (!channel?.name) {
+    throw new Error("registerNotificationChannel: channel.name is required");
+  }
+  if (typeof channel.deliver !== "function") {
+    throw new Error(
+      "registerNotificationChannel: channel.deliver must be a function",
+    );
+  }
+  getRegistry().set(channel.name, channel);
+}
+
+export function unregisterNotificationChannel(name: string): boolean {
+  return getRegistry().delete(name);
+}
+
+export function listNotificationChannels(): string[] {
+  return Array.from(getRegistry().keys());
+}
+
+/**
+ * Deliver a notification.
+ *
+ * The `inbox` channel always persists a row that drives the in-app UI
+ * (bell + toast). Additional channels (webhook, custom) run in parallel,
+ * best-effort. Returns the stored Notification when `inbox` ran, otherwise
+ * `undefined`.
+ *
+ * Also emits `notification.sent` on the event bus so automations can react
+ * to notifications (e.g. "when a critical notification fires, also page me").
+ */
+export async function notify(
+  input: NotificationInput,
+  meta: NotificationMeta,
+): Promise<Notification | undefined> {
+  if (!meta?.owner) {
+    throw new Error("notify: meta.owner is required");
+  }
+  const channels = selectChannels(input.channels);
+
+  // The inbox channel is always included unless explicitly excluded.
+  const runInbox = !input.channels || input.channels.includes("inbox");
+  const delivered: string[] = [];
+  let stored: Notification | undefined;
+
+  if (runInbox) {
+    try {
+      stored = await insertNotification({
+        owner: meta.owner,
+        severity: input.severity,
+        title: input.title,
+        body: input.body,
+        metadata: input.metadata,
+        deliveredChannels: channels.map((c) => c.name).concat("inbox"),
+      });
+      delivered.push("inbox");
+    } catch (err) {
+      console.error("[notifications] inbox persist failed:", err);
+    }
+  }
+
+  // Fan out to registered channels (best-effort).
+  for (const channel of channels) {
+    try {
+      const result = channel.deliver(input, meta);
+      if (result && typeof (result as Promise<void>).catch === "function") {
+        (result as Promise<void>).catch((err) => {
+          console.error(
+            `[notifications] channel "${channel.name}" rejected:`,
+            err,
+          );
+        });
+      }
+      delivered.push(channel.name);
+    } catch (err) {
+      console.error(`[notifications] channel "${channel.name}" threw:`, err);
+    }
+  }
+
+  // Only emit when at least one channel delivered — an emission with an
+  // empty delivery list (and likely a null notificationId) would mislead
+  // any automation chaining off this event.
+  if (delivered.length > 0) {
+    try {
+      emitBusEvent(
+        "notification.sent",
+        {
+          notificationId: stored?.id,
+          severity: input.severity,
+          title: input.title,
+          body: input.body,
+          deliveredChannels: delivered,
+        },
+        { owner: meta.owner },
+      );
+    } catch {
+      // best-effort
+    }
+  }
+
+  return stored;
+}
+
+function selectChannels(allowlist?: string[]): NotificationChannel[] {
+  const registry = getRegistry();
+  const all = Array.from(registry.values());
+  if (!allowlist) return all;
+  return all.filter((c) => allowlist.includes(c.name));
+}
+
+/** Test helper — drops all registered channels. */
+export function __resetNotificationChannels(): void {
+  getRegistry().clear();
+}
+
+export {
+  listNotifications,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification,
+  countUnread,
+} from "./store.js";

--- a/packages/core/src/notifications/registry.ts
+++ b/packages/core/src/notifications/registry.ts
@@ -6,10 +6,11 @@ import {
   type NotificationMeta,
   type Notification,
 } from "./types.js";
-import { insertNotification } from "./store.js";
+import { insertNotification, updateDeliveredChannels } from "./store.js";
 import { emit as emitBusEvent } from "../event-bus/bus.js";
 import { registerEvent } from "../event-bus/registry.js";
 import type { EventDefinition } from "../event-bus/types.js";
+import { truncate } from "../shared/truncate.js";
 
 registerEvent({
   name: "notification.sent",
@@ -75,6 +76,9 @@ export function listNotificationChannels(): string[] {
  * Also emits `notification.sent` on the event bus so automations can react
  * to notifications (e.g. "when a critical notification fires, also page me").
  */
+const MAX_TITLE_LEN = 100;
+const MAX_BODY_LEN = 2000;
+
 export async function notify(
   input: NotificationInput,
   meta: NotificationMeta,
@@ -82,6 +86,11 @@ export async function notify(
   if (!meta?.owner) {
     throw new Error("notify: meta.owner is required");
   }
+  input = {
+    ...input,
+    title: truncate(input.title, MAX_TITLE_LEN),
+    body: truncate(input.body, MAX_BODY_LEN),
+  };
   const channels = selectChannels(input.channels);
 
   // The inbox channel is always included unless explicitly excluded.
@@ -91,13 +100,15 @@ export async function notify(
 
   if (runInbox) {
     try {
+      // Stored with just "inbox" first; the real delivered list is written
+      // after fan-out so a failing webhook doesn't claim it was delivered.
       stored = await insertNotification({
         owner: meta.owner,
         severity: input.severity,
         title: input.title,
         body: input.body,
         metadata: input.metadata,
-        deliveredChannels: channels.map((c) => c.name).concat("inbox"),
+        deliveredChannels: ["inbox"],
       });
       delivered.push("inbox");
     } catch (err) {
@@ -105,21 +116,31 @@ export async function notify(
     }
   }
 
-  // Fan out to registered channels (best-effort).
-  for (const channel of channels) {
+  // Await every channel so a 500-ing webhook doesn't end up in `delivered`.
+  const results = await Promise.allSettled(
+    channels.map(async (channel) => {
+      await channel.deliver(input, meta);
+      return channel.name;
+    }),
+  );
+  results.forEach((r, i) => {
+    if (r.status === "fulfilled") {
+      delivered.push(r.value);
+    } else {
+      console.error(
+        `[notifications] channel "${channels[i].name}" failed:`,
+        r.reason,
+      );
+    }
+  });
+
+  const hasExtraChannel = delivered.some((c) => c !== "inbox");
+  if (stored && hasExtraChannel) {
     try {
-      const result = channel.deliver(input, meta);
-      if (result && typeof (result as Promise<void>).catch === "function") {
-        (result as Promise<void>).catch((err) => {
-          console.error(
-            `[notifications] channel "${channel.name}" rejected:`,
-            err,
-          );
-        });
-      }
-      delivered.push(channel.name);
+      await updateDeliveredChannels(stored.id, delivered);
+      stored = { ...stored, deliveredChannels: delivered };
     } catch (err) {
-      console.error(`[notifications] channel "${channel.name}" threw:`, err);
+      console.error("[notifications] delivered-channel update failed:", err);
     }
   }
 

--- a/packages/core/src/notifications/routes.ts
+++ b/packages/core/src/notifications/routes.ts
@@ -1,0 +1,89 @@
+/**
+ * H3 event handlers for the notifications inbox.
+ *
+ * Mounted under `/_agent-native/notifications/*` by `core-routes-plugin`.
+ *
+ *   GET  /_agent-native/notifications?unread=true&limit=50&before=ISO
+ *                                                   — list for the session owner
+ *   GET  /_agent-native/notifications/count         — unread count
+ *   POST /_agent-native/notifications/:id/read      — mark as read
+ *   POST /_agent-native/notifications/read-all      — mark all read
+ *   DELETE /_agent-native/notifications/:id         — delete
+ */
+
+import {
+  defineEventHandler,
+  getMethod,
+  getQuery,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+import { getSession } from "../server/auth.js";
+import {
+  listNotifications,
+  countUnread,
+  markNotificationRead,
+  markAllNotificationsRead,
+  deleteNotification,
+} from "./store.js";
+
+async function resolveOwner(event: H3Event): Promise<string> {
+  const session = await getSession(event).catch(() => null);
+  return session?.email || "local@localhost";
+}
+
+export function createNotificationsHandler() {
+  return defineEventHandler(async (event: H3Event) => {
+    const method = getMethod(event);
+    const pathname = (event.url?.pathname || "")
+      .replace(/^\/+/, "")
+      .replace(/\/+$/, "");
+    const parts = pathname ? pathname.split("/") : [];
+    const owner = await resolveOwner(event);
+
+    // GET /  — list
+    if (method === "GET" && parts.length === 0) {
+      const q = getQuery(event);
+      return listNotifications(owner, {
+        unreadOnly: q.unread === "true" || q.unread === "1",
+        limit: q.limit ? Math.min(Number(q.limit) || 50, 200) : 50,
+        before: typeof q.before === "string" ? q.before : undefined,
+      });
+    }
+
+    // GET /count
+    if (method === "GET" && parts.length === 1 && parts[0] === "count") {
+      const count = await countUnread(owner);
+      return { count };
+    }
+
+    // POST /read-all
+    if (method === "POST" && parts.length === 1 && parts[0] === "read-all") {
+      const updated = await markAllNotificationsRead(owner);
+      return { updated };
+    }
+
+    // POST /:id/read
+    if (method === "POST" && parts.length === 2 && parts[1] === "read") {
+      const ok = await markNotificationRead(parts[0], owner);
+      if (!ok) {
+        setResponseStatus(event, 404);
+        return { error: "Not found or already read" };
+      }
+      return { ok: true };
+    }
+
+    // DELETE /:id
+    if (method === "DELETE" && parts.length === 1) {
+      const ok = await deleteNotification(parts[0], owner);
+      if (!ok) {
+        setResponseStatus(event, 404);
+        return { error: "Not found" };
+      }
+      return { ok: true };
+    }
+
+    setResponseStatus(event, 404);
+    return { error: "Not found" };
+  });
+}

--- a/packages/core/src/notifications/store.ts
+++ b/packages/core/src/notifications/store.ts
@@ -1,0 +1,196 @@
+import { randomUUID } from "node:crypto";
+import {
+  getDbExec,
+  intType,
+  retryOnDdlRace,
+  safeJsonParse,
+} from "../db/client.js";
+import { recordChange } from "../server/poll.js";
+import type { Notification, NotificationSeverity } from "./types.js";
+
+function bumpPoll(owner: string): void {
+  recordChange({ source: "notifications", type: "change", key: owner });
+}
+
+let _initPromise: Promise<void> | undefined;
+
+async function ensureTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const client = getDbExec();
+      await retryOnDdlRace(() =>
+        client.execute(`
+          CREATE TABLE IF NOT EXISTS notifications (
+            id TEXT PRIMARY KEY,
+            owner TEXT NOT NULL,
+            severity TEXT NOT NULL,
+            title TEXT NOT NULL,
+            body TEXT,
+            metadata TEXT,
+            delivered_channels TEXT NOT NULL DEFAULT '[]',
+            created_at ${intType()} NOT NULL,
+            read_at ${intType()}
+          )
+        `),
+      );
+      await retryOnDdlRace(() =>
+        client.execute(
+          `CREATE INDEX IF NOT EXISTS idx_notifications_owner_unread ON notifications (owner, read_at)`,
+        ),
+      );
+    })();
+  }
+  return _initPromise;
+}
+
+function parseRow(row: Record<string, unknown>): Notification {
+  return {
+    id: String(row.id),
+    owner: String(row.owner),
+    severity: String(row.severity) as NotificationSeverity,
+    title: String(row.title),
+    body: row.body == null ? undefined : String(row.body),
+    metadata: row.metadata
+      ? safeJsonParse<Record<string, unknown> | undefined>(
+          row.metadata,
+          undefined,
+        )
+      : undefined,
+    deliveredChannels: safeJsonParse<string[]>(row.delivered_channels, []),
+    createdAt: new Date(Number(row.created_at)).toISOString(),
+    readAt:
+      row.read_at == null ? null : new Date(Number(row.read_at)).toISOString(),
+  };
+}
+
+export interface InsertNotificationInput {
+  owner: string;
+  severity: NotificationSeverity;
+  title: string;
+  body?: string;
+  metadata?: Record<string, unknown>;
+  deliveredChannels?: string[];
+}
+
+export async function insertNotification(
+  input: InsertNotificationInput,
+): Promise<Notification> {
+  await ensureTable();
+  const client = getDbExec();
+  const id = randomUUID();
+  const createdAt = Date.now();
+  await client.execute({
+    sql: `INSERT INTO notifications
+      (id, owner, severity, title, body, metadata, delivered_channels, created_at, read_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+    args: [
+      id,
+      input.owner,
+      input.severity,
+      input.title,
+      input.body ?? null,
+      input.metadata ? JSON.stringify(input.metadata) : null,
+      JSON.stringify(input.deliveredChannels ?? []),
+      createdAt,
+    ],
+  });
+  bumpPoll(input.owner);
+  return {
+    id,
+    owner: input.owner,
+    severity: input.severity,
+    title: input.title,
+    body: input.body,
+    metadata: input.metadata,
+    deliveredChannels: input.deliveredChannels ?? [],
+    createdAt: new Date(createdAt).toISOString(),
+    readAt: null,
+  };
+}
+
+export interface ListNotificationsOptions {
+  /** When true, only return unread (read_at IS NULL). */
+  unreadOnly?: boolean;
+  /** Max rows to return. Default 50. */
+  limit?: number;
+  /** ISO timestamp cursor — returns rows with created_at < cursor. */
+  before?: string;
+}
+
+export async function listNotifications(
+  owner: string,
+  options: ListNotificationsOptions = {},
+): Promise<Notification[]> {
+  await ensureTable();
+  const client = getDbExec();
+  const limit = Math.min(options.limit ?? 50, 200);
+  const args: Array<string | number> = [owner];
+  let where = `owner = ?`;
+  if (options.unreadOnly) where += ` AND read_at IS NULL`;
+  if (options.before) {
+    where += ` AND created_at < ?`;
+    args.push(new Date(options.before).getTime());
+  }
+  args.push(limit);
+  const { rows } = await client.execute({
+    sql: `SELECT * FROM notifications WHERE ${where} ORDER BY created_at DESC LIMIT ?`,
+    args,
+  });
+  return rows.map((r) => parseRow(r as Record<string, unknown>));
+}
+
+export async function countUnread(owner: string): Promise<number> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT COUNT(*) as c FROM notifications WHERE owner = ? AND read_at IS NULL`,
+    args: [owner],
+  });
+  return Number(rows[0]?.c ?? 0);
+}
+
+export async function markNotificationRead(
+  id: string,
+  owner: string,
+): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const res = await client.execute({
+    sql: `UPDATE notifications SET read_at = ? WHERE id = ? AND owner = ? AND read_at IS NULL`,
+    args: [now, id, owner],
+  });
+  const updated =
+    (res as unknown as { rowsAffected?: number }).rowsAffected !== 0;
+  if (updated) bumpPoll(owner);
+  return updated;
+}
+
+export async function markAllNotificationsRead(owner: string): Promise<number> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const res = await client.execute({
+    sql: `UPDATE notifications SET read_at = ? WHERE owner = ? AND read_at IS NULL`,
+    args: [now, owner],
+  });
+  const count = (res as unknown as { rowsAffected?: number }).rowsAffected ?? 0;
+  if (count > 0) bumpPoll(owner);
+  return count;
+}
+
+export async function deleteNotification(
+  id: string,
+  owner: string,
+): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const res = await client.execute({
+    sql: `DELETE FROM notifications WHERE id = ? AND owner = ?`,
+    args: [id, owner],
+  });
+  const deleted =
+    (res as unknown as { rowsAffected?: number }).rowsAffected !== 0;
+  if (deleted) bumpPoll(owner);
+  return deleted;
+}

--- a/packages/core/src/notifications/store.ts
+++ b/packages/core/src/notifications/store.ts
@@ -38,7 +38,13 @@ async function ensureTable(): Promise<void> {
           `CREATE INDEX IF NOT EXISTS idx_notifications_owner_unread ON notifications (owner, read_at)`,
         ),
       );
-    })();
+    })().catch((err) => {
+      // Reset on failure so a transient DB outage doesn't poison the cached
+      // promise and reject every future insert/list call for the lifetime of
+      // the process.
+      _initPromise = undefined;
+      throw err;
+    });
   }
   return _initPromise;
 }
@@ -106,6 +112,18 @@ export async function insertNotification(
     createdAt: new Date(createdAt).toISOString(),
     readAt: null,
   };
+}
+
+export async function updateDeliveredChannels(
+  id: string,
+  channels: string[],
+): Promise<void> {
+  await ensureTable();
+  const client = getDbExec();
+  await client.execute({
+    sql: `UPDATE notifications SET delivered_channels = ? WHERE id = ?`,
+    args: [JSON.stringify(channels), id],
+  });
 }
 
 export interface ListNotificationsOptions {

--- a/packages/core/src/notifications/types.ts
+++ b/packages/core/src/notifications/types.ts
@@ -1,0 +1,49 @@
+export const NOTIFICATION_SEVERITIES = ["info", "warning", "critical"] as const;
+export type NotificationSeverity = (typeof NOTIFICATION_SEVERITIES)[number];
+
+export interface Notification {
+  id: string;
+  owner: string;
+  severity: NotificationSeverity;
+  title: string;
+  body?: string;
+  /** Arbitrary JSON metadata — URLs, entity ids, the agent turn that produced it. */
+  metadata?: Record<string, unknown>;
+  /** ISO timestamp */
+  createdAt: string;
+  /** ISO timestamp — null while unread */
+  readAt: string | null;
+  /** Channels that delivered (or attempted delivery of) this notification. */
+  deliveredChannels: string[];
+}
+
+export interface NotificationInput {
+  severity: NotificationSeverity;
+  title: string;
+  body?: string;
+  metadata?: Record<string, unknown>;
+  /**
+   * Explicit channel allowlist for this emission. When omitted, every
+   * registered channel runs. Use to scope a single `notify()` call to a
+   * subset (e.g. `["inbox"]` to skip webhooks).
+   */
+  channels?: string[];
+}
+
+export interface NotificationMeta {
+  /** Owner email — scopes the notification in the inbox. */
+  owner: string;
+}
+
+export interface NotificationChannel {
+  /** Unique channel name, e.g. `"inbox"`, `"webhook"`, `"slack"`. */
+  name: string;
+  /**
+   * Deliver the notification. Must be best-effort — throwing will be logged
+   * but will not block other channels from running.
+   */
+  deliver(
+    input: NotificationInput,
+    meta: NotificationMeta,
+  ): void | Promise<void>;
+}

--- a/packages/core/src/progress/actions.ts
+++ b/packages/core/src/progress/actions.ts
@@ -1,0 +1,180 @@
+/**
+ * Framework-level agent tools for the progress primitive. Registered as
+ * native tools so every template exposes them. Use from long agent loops
+ * to communicate status to the user while work is still in-flight.
+ */
+
+import type { ActionEntry } from "../agent/production-agent.js";
+import {
+  startRun,
+  updateRunProgress,
+  completeRun,
+  listRuns,
+} from "./registry.js";
+
+export function createProgressToolEntries(
+  getCurrentUser: () => string,
+): Record<string, ActionEntry> {
+  return {
+    "start-run": {
+      tool: {
+        description:
+          "Mark the start of a long-running task the user should be able to watch. Returns a runId — pass it to `update-run-progress` and `complete-run`. Call this at the top of any task that will take more than a few seconds.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            title: {
+              type: "string",
+              description:
+                'Short human-readable title, e.g. "Triage 128 unread emails".',
+            },
+            step: {
+              type: "string",
+              description: 'Initial step description, e.g. "Fetching inbox".',
+            },
+            metadataJson: {
+              type: "string",
+              description:
+                "Optional JSON metadata: link, thread id, artifact path, etc.",
+            },
+          },
+          required: ["title"],
+        },
+      },
+      run: async (args: Record<string, string>) => {
+        const owner = getCurrentUser();
+        if (!args.title) return "Error: --title is required.";
+        let metadata: Record<string, unknown> | undefined;
+        if (args.metadataJson) {
+          try {
+            metadata = JSON.parse(args.metadataJson);
+          } catch {
+            return "Error: metadataJson must be valid JSON.";
+          }
+        }
+        const run = await startRun({
+          owner,
+          title: args.title,
+          step: args.step || undefined,
+          metadata,
+        });
+        return `Run started. runId=${run.id}`;
+      },
+    },
+
+    "update-run-progress": {
+      tool: {
+        description:
+          "Update a running task with progress. Call frequently during long loops so the user can watch status in the runs tray. Any omitted field stays unchanged.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            runId: {
+              type: "string",
+              description: "The id returned by `start-run`.",
+            },
+            percent: {
+              type: "number",
+              description:
+                "Progress 0–100. Omit if the task has no known upper bound.",
+            },
+            step: {
+              type: "string",
+              description: 'Current step, e.g. "Drafting reply 23/100".',
+            },
+          },
+          required: ["runId"],
+        },
+      },
+      run: async (args: Record<string, unknown>) => {
+        const owner = getCurrentUser();
+        const runId = String(args.runId ?? "");
+        if (!runId) return "Error: --runId is required.";
+        const percent = args.percent == null ? undefined : Number(args.percent);
+        const run = await updateRunProgress(runId, owner, {
+          percent,
+          step: args.step ? String(args.step) : undefined,
+        });
+        if (!run) return `Error: run ${runId} not found.`;
+        return `Run updated (percent=${run.percent ?? "?"}, step=${run.step ?? ""}).`;
+      },
+    },
+
+    "complete-run": {
+      tool: {
+        description:
+          "Mark a task as finished. Use `succeeded` for a clean finish, `failed` when something went wrong, `cancelled` when the user interrupted. Pairs well with `notify` to tell the user the outcome.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            runId: {
+              type: "string",
+              description: "The id returned by `start-run`.",
+            },
+            status: {
+              type: "string",
+              enum: ["succeeded", "failed", "cancelled"],
+              description: "Terminal status.",
+            },
+            step: {
+              type: "string",
+              description: "Optional final step text.",
+            },
+          },
+          required: ["runId", "status"],
+        },
+      },
+      run: async (args: Record<string, string>) => {
+        const owner = getCurrentUser();
+        if (!args.runId || !args.status) {
+          return "Error: --runId and --status are required.";
+        }
+        const run = await completeRun(
+          args.runId,
+          owner,
+          args.status as "succeeded" | "failed" | "cancelled",
+          args.step ? { step: args.step } : undefined,
+        );
+        if (!run) return `Error: run ${args.runId} not found.`;
+        return `Run ${run.id} completed with status=${run.status}.`;
+      },
+    },
+
+    "list-runs": {
+      tool: {
+        description:
+          "List the user's recent runs. Use when the user asks 'what is still running' or 'what did you do earlier'.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            active: {
+              type: "boolean",
+              description: "When true, only return runs still in progress.",
+            },
+            limit: {
+              type: "number",
+              description: "Max rows (default 20, max 200).",
+            },
+          },
+        },
+      },
+      run: async (args: Record<string, unknown>) => {
+        const owner = getCurrentUser();
+        const rows = await listRuns(owner, {
+          activeOnly: args.active === true || args.active === "true",
+          limit: Math.min(Number(args.limit ?? 20), 200),
+        });
+        if (rows.length === 0) {
+          return args.active ? "No active runs." : "No runs.";
+        }
+        return rows
+          .map(
+            (r) =>
+              `[${r.status}] ${r.title}${r.percent != null ? ` · ${r.percent}%` : ""}${r.step ? ` — ${r.step}` : ""} · ${r.startedAt}`,
+          )
+          .join("\n");
+      },
+      readOnly: true,
+    },
+  };
+}

--- a/packages/core/src/progress/index.ts
+++ b/packages/core/src/progress/index.ts
@@ -1,0 +1,16 @@
+export type {
+  AgentRun,
+  ProgressStatus,
+  StartRunInput,
+  UpdateProgressInput,
+  ListRunsOptions,
+} from "./types.js";
+
+export {
+  startRun,
+  updateRunProgress,
+  completeRun,
+  getRun,
+  listRuns,
+  deleteRun,
+} from "./registry.js";

--- a/packages/core/src/progress/progress.spec.ts
+++ b/packages/core/src/progress/progress.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockInsertRun = vi.fn();
+const mockUpdateRun = vi.fn();
+const mockEmit = vi.fn();
+
+vi.mock("./store.js", () => ({
+  insertRun: (...args: unknown[]) => mockInsertRun(...args),
+  updateRun: (...args: unknown[]) => mockUpdateRun(...args),
+  getRun: vi.fn(),
+  listRuns: vi.fn(),
+  deleteRun: vi.fn(),
+}));
+
+vi.mock("../event-bus/bus.js", () => ({
+  emit: (...args: unknown[]) => mockEmit(...args),
+}));
+
+import { startRun, updateRunProgress, completeRun } from "./registry.js";
+
+function stubRun(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "r-1",
+    owner: "boni@local",
+    title: "Test run",
+    step: undefined,
+    percent: null,
+    status: "running",
+    metadata: undefined,
+    startedAt: "2026-04-22T00:00:00.000Z",
+    updatedAt: "2026-04-22T00:00:00.000Z",
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+describe("progress registry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("startRun inserts and emits run.progress.started", async () => {
+    mockInsertRun.mockResolvedValue(stubRun({ title: "Triage inbox" }));
+
+    const run = await startRun({ owner: "boni@local", title: "Triage inbox" });
+
+    expect(mockInsertRun).toHaveBeenCalledWith({
+      owner: "boni@local",
+      title: "Triage inbox",
+    });
+    expect(run.id).toBe("r-1");
+    expect(mockEmit).toHaveBeenCalledWith(
+      "run.progress.started",
+      expect.objectContaining({
+        runId: "r-1",
+        title: "Triage inbox",
+      }),
+      { owner: "boni@local" },
+    );
+  });
+
+  it("updateRunProgress emits run.progress.updated with new state", async () => {
+    mockUpdateRun.mockResolvedValue(
+      stubRun({ percent: 42, step: "Drafting 23/100" }),
+    );
+
+    const run = await updateRunProgress("r-1", "boni@local", {
+      percent: 42,
+      step: "Drafting 23/100",
+    });
+
+    expect(mockUpdateRun).toHaveBeenCalledWith("r-1", "boni@local", {
+      percent: 42,
+      step: "Drafting 23/100",
+    });
+    expect(run?.percent).toBe(42);
+    expect(mockEmit).toHaveBeenCalledWith(
+      "run.progress.updated",
+      expect.objectContaining({
+        runId: "r-1",
+        percent: 42,
+        step: "Drafting 23/100",
+      }),
+      { owner: "boni@local" },
+    );
+  });
+
+  it("updateRunProgress returns null when the run does not exist", async () => {
+    mockUpdateRun.mockResolvedValue(null);
+    const run = await updateRunProgress("missing", "boni@local", {
+      percent: 50,
+    });
+    expect(run).toBeNull();
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it("completeRun sets percent=100 on success and passes status through", async () => {
+    mockUpdateRun.mockResolvedValue(
+      stubRun({ percent: 100, status: "succeeded", completedAt: "x" }),
+    );
+
+    const run = await completeRun("r-1", "boni@local", "succeeded");
+
+    expect(mockUpdateRun).toHaveBeenCalledWith(
+      "r-1",
+      "boni@local",
+      expect.objectContaining({ status: "succeeded", percent: 100 }),
+    );
+    expect(run?.status).toBe("succeeded");
+    expect(mockEmit).toHaveBeenCalledWith(
+      "run.progress.updated",
+      expect.objectContaining({ runId: "r-1", status: "succeeded" }),
+      { owner: "boni@local" },
+    );
+  });
+
+  it("completeRun with failed does not force percent to 100", async () => {
+    mockUpdateRun.mockResolvedValue(stubRun({ status: "failed" }));
+
+    await completeRun("r-1", "boni@local", "failed");
+
+    expect(mockUpdateRun).toHaveBeenCalledWith(
+      "r-1",
+      "boni@local",
+      expect.not.objectContaining({ percent: 100 }),
+    );
+  });
+});

--- a/packages/core/src/progress/registry.ts
+++ b/packages/core/src/progress/registry.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+import { emit as emitBusEvent } from "../event-bus/bus.js";
+import { registerEvent } from "../event-bus/registry.js";
+import type { EventDefinition } from "../event-bus/types.js";
+import { insertRun, updateRun, getRun, listRuns, deleteRun } from "./store.js";
+import {
+  PROGRESS_STATUSES,
+  type AgentRun,
+  type StartRunInput,
+  type UpdateProgressInput,
+} from "./types.js";
+
+registerEvent({
+  name: "run.progress.started",
+  description:
+    "Fires when a long-running agent task begins. Pair with run.progress.updated to build watchdogs for stuck work.",
+  payloadSchema: z.object({
+    runId: z.string(),
+    title: z.string(),
+    step: z.string().optional(),
+  }) as unknown as EventDefinition["payloadSchema"],
+  example: {
+    runId: "run_abc",
+    title: "Triage 128 unread emails",
+    step: "Fetching inbox",
+  },
+});
+
+registerEvent({
+  name: "run.progress.updated",
+  description:
+    "Fires on every progress update or terminal transition. Subscribe to watch for slow runs (status=running and elapsed > N) or fan terminal status to a notification.",
+  payloadSchema: z.object({
+    runId: z.string(),
+    percent: z.number().nullable(),
+    step: z.string().optional(),
+    status: z.enum(PROGRESS_STATUSES),
+  }) as unknown as EventDefinition["payloadSchema"],
+  example: {
+    runId: "run_abc",
+    percent: 45,
+    step: "Classifying 56/128",
+    status: "running",
+  },
+});
+
+/**
+ * Start a new run. Emits `run.progress.started` on the event bus so
+ * automations can react (e.g. pinning the row in a UI tray).
+ */
+export async function startRun(input: StartRunInput): Promise<AgentRun> {
+  const run = await insertRun(input);
+  try {
+    emitBusEvent(
+      "run.progress.started",
+      {
+        runId: run.id,
+        title: run.title,
+        step: run.step,
+      },
+      { owner: run.owner },
+    );
+  } catch {
+    // best-effort
+  }
+  return run;
+}
+
+/**
+ * Update a run in-flight. Emits `run.progress.updated`. Caller supplies
+ * partial fields — any omitted field stays unchanged.
+ */
+export async function updateRunProgress(
+  id: string,
+  owner: string,
+  input: UpdateProgressInput,
+): Promise<AgentRun | null> {
+  const run = await updateRun(id, owner, input);
+  if (!run) return null;
+  try {
+    emitBusEvent(
+      "run.progress.updated",
+      {
+        runId: run.id,
+        percent: run.percent,
+        step: run.step,
+        status: run.status,
+      },
+      { owner: run.owner },
+    );
+  } catch {
+    // best-effort
+  }
+  return run;
+}
+
+/**
+ * Finalize a run with a terminal status. Convenience wrapper around
+ * `updateRunProgress` that ensures `completed_at` is set.
+ */
+export async function completeRun(
+  id: string,
+  owner: string,
+  status: "succeeded" | "failed" | "cancelled",
+  extras?: { step?: string; metadata?: Record<string, unknown> },
+): Promise<AgentRun | null> {
+  return updateRunProgress(id, owner, {
+    status,
+    percent: status === "succeeded" ? 100 : undefined,
+    step: extras?.step,
+    metadata: extras?.metadata,
+  });
+}
+
+export { getRun, listRuns, deleteRun };

--- a/packages/core/src/progress/registry.ts
+++ b/packages/core/src/progress/registry.ts
@@ -9,6 +9,7 @@ import {
   type StartRunInput,
   type UpdateProgressInput,
 } from "./types.js";
+import { truncate } from "../shared/truncate.js";
 
 registerEvent({
   name: "run.progress.started",
@@ -44,12 +45,19 @@ registerEvent({
   },
 });
 
+const MAX_TITLE_LEN = 100;
+const MAX_STEP_LEN = 200;
+
 /**
  * Start a new run. Emits `run.progress.started` on the event bus so
  * automations can react (e.g. pinning the row in a UI tray).
  */
 export async function startRun(input: StartRunInput): Promise<AgentRun> {
-  const run = await insertRun(input);
+  const run = await insertRun({
+    ...input,
+    title: truncate(input.title, MAX_TITLE_LEN),
+    step: truncate(input.step, MAX_STEP_LEN),
+  });
   try {
     emitBusEvent(
       "run.progress.started",
@@ -75,7 +83,10 @@ export async function updateRunProgress(
   owner: string,
   input: UpdateProgressInput,
 ): Promise<AgentRun | null> {
-  const run = await updateRun(id, owner, input);
+  const run = await updateRun(id, owner, {
+    ...input,
+    step: truncate(input.step, MAX_STEP_LEN),
+  });
   if (!run) return null;
   try {
     emitBusEvent(

--- a/packages/core/src/progress/routes.ts
+++ b/packages/core/src/progress/routes.ts
@@ -1,0 +1,71 @@
+/**
+ * H3 event handlers for the agent-runs progress primitive.
+ *
+ * Mounted under `/_agent-native/runs/*` by `core-routes-plugin`.
+ *
+ *   GET    /_agent-native/runs?active=true&limit=50
+ *   GET    /_agent-native/runs/:id
+ *   DELETE /_agent-native/runs/:id
+ *
+ * Writes happen through the `update-run-progress` agent tool, not HTTP —
+ * the agent is the canonical writer, the UI only reads. (We can add write
+ * routes later if a non-agent producer needs them.)
+ */
+
+import {
+  defineEventHandler,
+  getMethod,
+  getQuery,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+import { getSession } from "../server/auth.js";
+import { listRuns, getRun, deleteRun } from "./store.js";
+
+async function resolveOwner(event: H3Event): Promise<string> {
+  const session = await getSession(event).catch(() => null);
+  return session?.email || "local@localhost";
+}
+
+export function createProgressHandler() {
+  return defineEventHandler(async (event: H3Event) => {
+    const method = getMethod(event);
+    const pathname = (event.url?.pathname || "")
+      .replace(/^\/+/, "")
+      .replace(/\/+$/, "");
+    const parts = pathname ? pathname.split("/") : [];
+    const owner = await resolveOwner(event);
+
+    // GET /  — list
+    if (method === "GET" && parts.length === 0) {
+      const q = getQuery(event);
+      return listRuns(owner, {
+        activeOnly: q.active === "true" || q.active === "1",
+        limit: q.limit ? Math.min(Number(q.limit) || 50, 200) : 50,
+      });
+    }
+
+    // GET /:id
+    if (method === "GET" && parts.length === 1) {
+      const row = await getRun(parts[0], owner);
+      if (!row) {
+        setResponseStatus(event, 404);
+        return { error: "Not found" };
+      }
+      return row;
+    }
+
+    // DELETE /:id
+    if (method === "DELETE" && parts.length === 1) {
+      const ok = await deleteRun(parts[0], owner);
+      if (!ok) {
+        setResponseStatus(event, 404);
+        return { error: "Not found" };
+      }
+      return { ok: true };
+    }
+
+    setResponseStatus(event, 404);
+    return { error: "Not found" };
+  });
+}

--- a/packages/core/src/progress/store.ts
+++ b/packages/core/src/progress/store.ts
@@ -1,0 +1,208 @@
+import { randomUUID } from "node:crypto";
+import {
+  getDbExec,
+  intType,
+  retryOnDdlRace,
+  safeJsonParse,
+} from "../db/client.js";
+import { recordChange } from "../server/poll.js";
+
+function bumpPoll(owner: string): void {
+  recordChange({ source: "runs", type: "change", key: owner });
+}
+import type {
+  AgentRun,
+  ListRunsOptions,
+  ProgressStatus,
+  StartRunInput,
+  UpdateProgressInput,
+} from "./types.js";
+
+let _initPromise: Promise<void> | undefined;
+
+async function ensureTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const client = getDbExec();
+      await retryOnDdlRace(() =>
+        client.execute(`
+          CREATE TABLE IF NOT EXISTS progress_runs (
+            id TEXT PRIMARY KEY,
+            owner TEXT NOT NULL,
+            title TEXT NOT NULL,
+            step TEXT,
+            percent ${intType()},
+            status TEXT NOT NULL DEFAULT 'running',
+            metadata TEXT,
+            started_at ${intType()} NOT NULL,
+            updated_at ${intType()} NOT NULL,
+            completed_at ${intType()}
+          )
+        `),
+      );
+      await retryOnDdlRace(() =>
+        client.execute(
+          `CREATE INDEX IF NOT EXISTS idx_progress_runs_owner_status ON progress_runs (owner, status, started_at)`,
+        ),
+      );
+      // NOTE: table name is `progress_runs` (not `agent_runs`) to avoid
+      // colliding with core's existing agent/run-store.ts which uses
+      // `agent_runs` for agent-chat turn lifecycle tracking. These are
+      // separate concerns — progress = user-facing task status, agent_runs =
+      // internal chat turn bookkeeping.
+    })();
+  }
+  return _initPromise;
+}
+
+function parseRow(row: Record<string, unknown>): AgentRun {
+  const percent = row.percent;
+  return {
+    id: String(row.id),
+    owner: String(row.owner),
+    title: String(row.title),
+    step: row.step == null ? undefined : String(row.step),
+    percent: percent == null ? null : Number(percent),
+    status: String(row.status) as ProgressStatus,
+    metadata: row.metadata
+      ? safeJsonParse<Record<string, unknown> | undefined>(
+          row.metadata,
+          undefined,
+        )
+      : undefined,
+    startedAt: new Date(Number(row.started_at)).toISOString(),
+    updatedAt: new Date(Number(row.updated_at)).toISOString(),
+    completedAt:
+      row.completed_at == null
+        ? null
+        : new Date(Number(row.completed_at)).toISOString(),
+  };
+}
+
+export async function insertRun(input: StartRunInput): Promise<AgentRun> {
+  await ensureTable();
+  const client = getDbExec();
+  const id = input.id ?? randomUUID();
+  const now = Date.now();
+  await client.execute({
+    sql: `INSERT INTO progress_runs
+      (id, owner, title, step, percent, status, metadata, started_at, updated_at, completed_at)
+      VALUES (?, ?, ?, ?, NULL, 'running', ?, ?, ?, NULL)`,
+    args: [
+      id,
+      input.owner,
+      input.title,
+      input.step ?? null,
+      input.metadata ? JSON.stringify(input.metadata) : null,
+      now,
+      now,
+    ],
+  });
+  bumpPoll(input.owner);
+  return {
+    id,
+    owner: input.owner,
+    title: input.title,
+    step: input.step,
+    percent: null,
+    status: "running",
+    metadata: input.metadata,
+    startedAt: new Date(now).toISOString(),
+    updatedAt: new Date(now).toISOString(),
+    completedAt: null,
+  };
+}
+
+export async function getRun(
+  id: string,
+  owner: string,
+): Promise<AgentRun | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT * FROM progress_runs WHERE id = ? AND owner = ?`,
+    args: [id, owner],
+  });
+  if (rows.length === 0) return null;
+  return parseRow(rows[0] as Record<string, unknown>);
+}
+
+export async function updateRun(
+  id: string,
+  owner: string,
+  input: UpdateProgressInput,
+): Promise<AgentRun | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const sets: string[] = ["updated_at = ?"];
+  const args: Array<string | number | null> = [now];
+
+  if (Object.prototype.hasOwnProperty.call(input, "percent")) {
+    sets.push("percent = ?");
+    args.push(input.percent == null ? null : clampPercent(input.percent));
+  }
+  if (input.step !== undefined) {
+    sets.push("step = ?");
+    args.push(input.step);
+  }
+  if (input.metadata !== undefined) {
+    sets.push("metadata = ?");
+    args.push(JSON.stringify(input.metadata));
+  }
+  if (input.status !== undefined) {
+    sets.push("status = ?");
+    args.push(input.status);
+    if (input.status !== "running") {
+      sets.push("completed_at = ?");
+      args.push(now);
+    }
+  }
+  args.push(id, owner);
+
+  const res = await client.execute({
+    sql: `UPDATE progress_runs SET ${sets.join(", ")} WHERE id = ? AND owner = ?`,
+    args,
+  });
+  if ((res as unknown as { rowsAffected?: number }).rowsAffected === 0) {
+    return null;
+  }
+  bumpPoll(owner);
+  return getRun(id, owner);
+}
+
+function clampPercent(n: number): number {
+  if (Number.isNaN(n)) return 0;
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+export async function listRuns(
+  owner: string,
+  options: ListRunsOptions = {},
+): Promise<AgentRun[]> {
+  await ensureTable();
+  const client = getDbExec();
+  const limit = Math.min(options.limit ?? 50, 200);
+  let where = `owner = ?`;
+  const args: Array<string | number> = [owner];
+  if (options.activeOnly) where += ` AND status = 'running'`;
+  args.push(limit);
+  const { rows } = await client.execute({
+    sql: `SELECT * FROM progress_runs WHERE ${where} ORDER BY started_at DESC LIMIT ?`,
+    args,
+  });
+  return rows.map((r) => parseRow(r as Record<string, unknown>));
+}
+
+export async function deleteRun(id: string, owner: string): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const res = await client.execute({
+    sql: `DELETE FROM progress_runs WHERE id = ? AND owner = ?`,
+    args: [id, owner],
+  });
+  const deleted =
+    (res as unknown as { rowsAffected?: number }).rowsAffected !== 0;
+  if (deleted) bumpPoll(owner);
+  return deleted;
+}

--- a/packages/core/src/progress/store.ts
+++ b/packages/core/src/progress/store.ts
@@ -2,14 +2,11 @@ import { randomUUID } from "node:crypto";
 import {
   getDbExec,
   intType,
+  isUniqueViolation,
   retryOnDdlRace,
   safeJsonParse,
 } from "../db/client.js";
 import { recordChange } from "../server/poll.js";
-
-function bumpPoll(owner: string): void {
-  recordChange({ source: "runs", type: "change", key: owner });
-}
 import type {
   AgentRun,
   ListRunsOptions,
@@ -17,6 +14,10 @@ import type {
   StartRunInput,
   UpdateProgressInput,
 } from "./types.js";
+
+function bumpPoll(owner: string): void {
+  recordChange({ source: "runs", type: "change", key: owner });
+}
 
 let _initPromise: Promise<void> | undefined;
 
@@ -50,7 +51,13 @@ async function ensureTable(): Promise<void> {
       // `agent_runs` for agent-chat turn lifecycle tracking. These are
       // separate concerns — progress = user-facing task status, agent_runs =
       // internal chat turn bookkeeping.
-    })();
+    })().catch((err) => {
+      // Reset on failure so a transient DB outage doesn't poison the cached
+      // promise and reject every future insert/update call for the lifetime
+      // of the process.
+      _initPromise = undefined;
+      throw err;
+    });
   }
   return _initPromise;
 }
@@ -84,20 +91,29 @@ export async function insertRun(input: StartRunInput): Promise<AgentRun> {
   const client = getDbExec();
   const id = input.id ?? randomUUID();
   const now = Date.now();
-  await client.execute({
-    sql: `INSERT INTO progress_runs
-      (id, owner, title, step, percent, status, metadata, started_at, updated_at, completed_at)
-      VALUES (?, ?, ?, ?, NULL, 'running', ?, ?, ?, NULL)`,
-    args: [
-      id,
-      input.owner,
-      input.title,
-      input.step ?? null,
-      input.metadata ? JSON.stringify(input.metadata) : null,
-      now,
-      now,
-    ],
-  });
+  try {
+    await client.execute({
+      sql: `INSERT INTO progress_runs
+        (id, owner, title, step, percent, status, metadata, started_at, updated_at, completed_at)
+        VALUES (?, ?, ?, ?, NULL, 'running', ?, ?, ?, NULL)`,
+      args: [
+        id,
+        input.owner,
+        input.title,
+        input.step ?? null,
+        input.metadata ? JSON.stringify(input.metadata) : null,
+        now,
+        now,
+      ],
+    });
+  } catch (err) {
+    if (input.id && isUniqueViolation(err)) {
+      throw new Error(
+        `insertRun: run id "${input.id}" already exists for this owner`,
+      );
+    }
+    throw err;
+  }
   bumpPoll(input.owner);
   return {
     id,
@@ -134,41 +150,54 @@ export async function updateRun(
 ): Promise<AgentRun | null> {
   await ensureTable();
   const client = getDbExec();
+  // Read current row first so we can return a consistent snapshot of this
+  // caller's update (avoids the UPDATE→SELECT race where a concurrent writer
+  // could have their change reflected in the returned value).
+  const current = await getRun(id, owner);
+  if (!current) return null;
+
   const now = Date.now();
   const sets: string[] = ["updated_at = ?"];
   const args: Array<string | number | null> = [now];
+  const next: AgentRun = {
+    ...current,
+    updatedAt: new Date(now).toISOString(),
+  };
 
   if (Object.prototype.hasOwnProperty.call(input, "percent")) {
+    const percent = input.percent == null ? null : clampPercent(input.percent);
     sets.push("percent = ?");
-    args.push(input.percent == null ? null : clampPercent(input.percent));
+    args.push(percent);
+    next.percent = percent;
   }
   if (input.step !== undefined) {
     sets.push("step = ?");
     args.push(input.step);
+    next.step = input.step;
   }
   if (input.metadata !== undefined) {
     sets.push("metadata = ?");
     args.push(JSON.stringify(input.metadata));
+    next.metadata = input.metadata;
   }
   if (input.status !== undefined) {
     sets.push("status = ?");
     args.push(input.status);
+    next.status = input.status;
     if (input.status !== "running") {
       sets.push("completed_at = ?");
       args.push(now);
+      next.completedAt = new Date(now).toISOString();
     }
   }
   args.push(id, owner);
 
-  const res = await client.execute({
+  await client.execute({
     sql: `UPDATE progress_runs SET ${sets.join(", ")} WHERE id = ? AND owner = ?`,
     args,
   });
-  if ((res as unknown as { rowsAffected?: number }).rowsAffected === 0) {
-    return null;
-  }
   bumpPoll(owner);
-  return getRun(id, owner);
+  return next;
 }
 
 function clampPercent(n: number): number {

--- a/packages/core/src/progress/types.ts
+++ b/packages/core/src/progress/types.ts
@@ -1,0 +1,57 @@
+export const PROGRESS_STATUSES = [
+  "running",
+  "succeeded",
+  "failed",
+  "cancelled",
+] as const;
+export type ProgressStatus = (typeof PROGRESS_STATUSES)[number];
+
+/**
+ * A long-running agent task the UI can track. Separate from "notifications":
+ * notifications fire once ("X happened"), progress is continuous state
+ * ("X is 45% done"). Both primitives may interop — completed runs commonly
+ * emit a notification.
+ */
+export interface AgentRun {
+  id: string;
+  owner: string;
+  /** Human-readable title, e.g. "Triage 128 unread emails". */
+  title: string;
+  /** Optional free-text current step ("Fetching 23/100", "Drafting replies"). */
+  step?: string;
+  /** 0–100. `null` when the task has no known upper bound. */
+  percent: number | null;
+  status: ProgressStatus;
+  /** Optional deeper context: link, thread id, artifact path, etc. */
+  metadata?: Record<string, unknown>;
+  /** ISO timestamp — when the run was started. */
+  startedAt: string;
+  /** ISO timestamp — latest update. */
+  updatedAt: string;
+  /** ISO timestamp — when the run reached a terminal status. */
+  completedAt: string | null;
+}
+
+export interface StartRunInput {
+  /** Client-provided id — optional; server generates a UUID when omitted. */
+  id?: string;
+  owner: string;
+  title: string;
+  step?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UpdateProgressInput {
+  percent?: number | null;
+  step?: string;
+  metadata?: Record<string, unknown>;
+  /** Optional terminal status — sets completedAt when `succeeded|failed|cancelled`. */
+  status?: ProgressStatus;
+}
+
+export interface ListRunsOptions {
+  /** When true, only return runs with status = "running". */
+  activeOnly?: boolean;
+  /** Max rows. Default 50. */
+  limit?: number;
+}

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1998,6 +1998,14 @@ export function createAgentChatPlugin(
           await import("../triggers/actions.js");
         automationTools = createAutomationToolEntries(() => _currentRunOwner);
       } catch {}
+      let notificationTools: Record<string, ActionEntry> = {};
+      try {
+        const { createNotificationToolEntries } =
+          await import("../notifications/actions.js");
+        notificationTools = createNotificationToolEntries(
+          () => _currentRunOwner,
+        );
+      } catch {}
       let fetchTool: Record<string, ActionEntry> = {};
       try {
         const { createFetchToolEntry } = await import("../tools/fetch-tool.js");
@@ -2034,6 +2042,7 @@ export function createAgentChatPlugin(
             ...chatScripts,
             ...callAgentScript,
             ...automationTools,
+            ...notificationTools,
             ...fetchTool,
             ...browserTools,
             ...devScriptsForA2A,
@@ -2049,6 +2058,7 @@ export function createAgentChatPlugin(
             ...chatScripts,
             ...callAgentScript,
             ...automationTools,
+            ...notificationTools,
             ...fetchTool,
             ...browserTools,
             ...devScriptsForA2A,
@@ -2577,6 +2587,7 @@ export function createAgentChatPlugin(
         ...teamTools,
         ...jobTools,
         ...automationTools,
+        ...notificationTools,
         ...fetchTool,
         ...browserTools,
         ...mcpActionEntries,
@@ -2682,6 +2693,7 @@ export function createAgentChatPlugin(
               ...teamTools,
               ...jobTools,
               ...automationTools,
+              ...notificationTools,
               ...fetchTool,
               ...browserTools,
               ...mcpActionEntries,
@@ -3772,6 +3784,7 @@ export function createAgentChatPlugin(
             ...chatScripts,
             ...jobTools,
             ...automationTools,
+            ...notificationTools,
             ...fetchTool,
           }),
           getSystemPrompt: async (owner: string) => {
@@ -3809,6 +3822,7 @@ export function createAgentChatPlugin(
             ...chatScripts,
             ...jobTools,
             ...automationTools,
+            ...notificationTools,
             ...fetchTool,
           }),
           getSystemPrompt: async (owner: string) => {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2006,6 +2006,12 @@ export function createAgentChatPlugin(
           () => _currentRunOwner,
         );
       } catch {}
+      let progressTools: Record<string, ActionEntry> = {};
+      try {
+        const { createProgressToolEntries } =
+          await import("../progress/actions.js");
+        progressTools = createProgressToolEntries(() => _currentRunOwner);
+      } catch {}
       let fetchTool: Record<string, ActionEntry> = {};
       try {
         const { createFetchToolEntry } = await import("../tools/fetch-tool.js");
@@ -2043,6 +2049,7 @@ export function createAgentChatPlugin(
             ...callAgentScript,
             ...automationTools,
             ...notificationTools,
+            ...progressTools,
             ...fetchTool,
             ...browserTools,
             ...devScriptsForA2A,
@@ -2059,6 +2066,7 @@ export function createAgentChatPlugin(
             ...callAgentScript,
             ...automationTools,
             ...notificationTools,
+            ...progressTools,
             ...fetchTool,
             ...browserTools,
             ...devScriptsForA2A,
@@ -2588,6 +2596,7 @@ export function createAgentChatPlugin(
         ...jobTools,
         ...automationTools,
         ...notificationTools,
+        ...progressTools,
         ...fetchTool,
         ...browserTools,
         ...mcpActionEntries,
@@ -2694,6 +2703,7 @@ export function createAgentChatPlugin(
               ...jobTools,
               ...automationTools,
               ...notificationTools,
+              ...progressTools,
               ...fetchTool,
               ...browserTools,
               ...mcpActionEntries,
@@ -3785,6 +3795,7 @@ export function createAgentChatPlugin(
             ...jobTools,
             ...automationTools,
             ...notificationTools,
+            ...progressTools,
             ...fetchTool,
           }),
           getSystemPrompt: async (owner: string) => {
@@ -3823,6 +3834,7 @@ export function createAgentChatPlugin(
             ...jobTools,
             ...automationTools,
             ...notificationTools,
+            ...progressTools,
             ...fetchTool,
           }),
           getSystemPrompt: async (owner: string) => {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -48,6 +48,8 @@ import {
 } from "../secrets/routes.js";
 import { registerFrameworkSecrets } from "../secrets/register-framework-secrets.js";
 import { registerBuiltinProviders } from "../tracking/providers.js";
+import { registerBuiltinNotificationChannels } from "../notifications/channels.js";
+import { createNotificationsHandler } from "../notifications/routes.js";
 import { createTranscribeVoiceHandler } from "./transcribe-voice.js";
 
 /**
@@ -106,6 +108,7 @@ export function createCoreRoutesPlugin(
     // already registered the same key win.
     registerFrameworkSecrets();
     registerBuiltinProviders();
+    registerBuiltinNotificationChannels();
 
     const P = FRAMEWORK_ROUTE_PREFIX;
 
@@ -619,6 +622,14 @@ export function createCoreRoutesPlugin(
         return { error: "Not found" };
       }),
     );
+
+    // ─── Notifications inbox ──────────────────────────────────────────
+    // GET    /_agent-native/notifications[?unread&limit&before]
+    // GET    /_agent-native/notifications/count
+    // POST   /_agent-native/notifications/:id/read
+    // POST   /_agent-native/notifications/read-all
+    // DELETE /_agent-native/notifications/:id
+    getH3App(nitroApp).use(`${P}/notifications`, createNotificationsHandler());
 
     // ─── Automations API ──────────────────────────────────────────────
     // GET  /_agent-native/automations — list all automations (parsed triggers)

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -50,6 +50,7 @@ import { registerFrameworkSecrets } from "../secrets/register-framework-secrets.
 import { registerBuiltinProviders } from "../tracking/providers.js";
 import { registerBuiltinNotificationChannels } from "../notifications/channels.js";
 import { createNotificationsHandler } from "../notifications/routes.js";
+import { createProgressHandler } from "../progress/routes.js";
 import { createTranscribeVoiceHandler } from "./transcribe-voice.js";
 
 /**
@@ -630,6 +631,12 @@ export function createCoreRoutesPlugin(
     // POST   /_agent-native/notifications/read-all
     // DELETE /_agent-native/notifications/:id
     getH3App(nitroApp).use(`${P}/notifications`, createNotificationsHandler());
+
+    // ─── Agent run progress ───────────────────────────────────────────
+    // GET    /_agent-native/runs[?active&limit]
+    // GET    /_agent-native/runs/:id
+    // DELETE /_agent-native/runs/:id
+    getH3App(nitroApp).use(`${P}/runs`, createProgressHandler());
 
     // ─── Automations API ──────────────────────────────────────────────
     // GET  /_agent-native/automations — list all automations (parsed triggers)

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -5,3 +5,4 @@ export {
   type AgentChatResponse,
 } from "./agent-chat.js";
 export { agentEnv, type EnvVar } from "./agent-env.js";
+export { truncate } from "./truncate.js";

--- a/packages/core/src/shared/truncate.ts
+++ b/packages/core/src/shared/truncate.ts
@@ -1,0 +1,13 @@
+/**
+ * Truncate `s` to at most `max` characters, appending an ellipsis when a
+ * cut is made. Returns the original reference unchanged when no truncation
+ * is needed so identity-sensitive callers (React props, memo keys) don't
+ * see a new allocation on every call.
+ */
+export function truncate<S extends string | undefined | null>(
+  s: S,
+  max: number,
+): S {
+  if (s == null) return s;
+  return (s.length > max ? s.slice(0, max - 1) + "…" : s) as S;
+}

--- a/packages/core/src/templates/default/.agents/skills/notifications/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/notifications/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: notifications
+description: >-
+  In-app notifications primitive with pluggable server-side channels. Use when
+  the agent needs to surface progress, alerts, or completions to the user —
+  both in-app (bell + toast) and out-of-band (webhook, Slack, custom).
+---
+
+# Notifications
+
+`notify()` is the framework's "tell the user something" primitive. Every call persists a row to the inbox (drives the bell UI) and fans out to any registered server-side channels. Channels follow the same pluggable-provider pattern as `tracking` — register at startup, `notify()` fans out, errors are isolated.
+
+Use for: *agent progress milestones, automation triggers firing, background job completions, critical errors*. Don't use for chat replies — those go through the conversation.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `notify` | Send a notification (severity + title + optional body/metadata/channels) |
+| `list-notifications` | Show recent notifications for the current user |
+
+## Sending
+
+```
+notify --severity info --title "Booking confirmed" --body "Jane at 3pm"
+```
+
+| Severity | When |
+|---|---|
+| `info` | FYI / progress / confirmation |
+| `warning` | Something to look at soon |
+| `critical` | Needs immediate attention |
+
+Optional: `--metadataJson '{"threadId":"abc"}'`, `--channels inbox,webhook` (omit to run all registered).
+
+## Delivery
+
+`notify()` always inserts into the `notifications` table (unless `channels` explicitly excludes `inbox`), then fans out to every registered channel in parallel (best-effort; a failing channel doesn't block others). Finally it emits `notification.sent` on the event bus so automations can chain — e.g. *"when a critical notification fires, also page on-call."*
+
+## Built-in Channels
+
+| Channel | How | Requires |
+|---|---|---|
+| `inbox` | INSERT → drives bell UI | (always on) |
+| `webhook` | POST JSON to `NOTIFICATIONS_WEBHOOK_URL` (+ optional `NOTIFICATIONS_WEBHOOK_AUTH`); both support `${keys.NAME}` + URL allowlists from the ad-hoc-keys system | env var set |
+
+The webhook channel resolves `${keys.NAME}` server-side — the raw value never enters the agent context.
+
+## Registering a Custom Channel
+
+```ts
+// server/plugins/notifications-slack.ts
+import { registerNotificationChannel } from "@agent-native/core/notifications";
+
+export default () => {
+  registerNotificationChannel({
+    name: "slack-ops",
+    async deliver(input, meta) {
+      await fetch(process.env.OPS_SLACK_WEBHOOK!, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: `*${input.severity}* — ${input.title}`, owner: meta.owner }),
+      });
+    },
+  });
+};
+```
+
+Names are unique — re-registering replaces. `deliver()` must be best-effort; a thrown error is logged and ignored. Do NOT call `notify()` from inside a channel (recursion).
+
+## HTTP API
+
+Mounted at `/_agent-native/notifications/*` by `core-routes-plugin`, all session-scoped:
+
+- `GET    /notifications?unread=true&limit=50&before=<iso>`
+- `GET    /notifications/count`
+- `POST   /notifications/:id/read`
+- `POST   /notifications/read-all`
+- `DELETE /notifications/:id`
+
+## UI
+
+```tsx
+import { NotificationsBell } from "@agent-native/core/client/notifications";
+
+<NotificationsBell browserNotifications />
+```
+
+Bell icon + unread badge + lazy-loaded dropdown. Pass `browserNotifications` to also fire system `new Notification(...)` popups for items that arrive after mount (dedups by id, renders an "Enable" prompt until permission is granted, silently no-ops on denied / unsupported). Styled with shadcn tokens — adapts to the host theme.
+
+## Related
+
+- `automations` — event-triggered bodies can call `notify`.
+- `secrets` — `${keys.NAME}` substitution + URL allowlists powering the webhook channel.
+- `tracking` — analytics; separate concern, don't route through notifications.

--- a/packages/core/src/templates/default/.agents/skills/progress/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/progress/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: progress
+description: >-
+  Report live progress from long-running agent tasks. Use when a task takes
+  more than a few seconds, so the user can watch status in the runs tray
+  instead of staring at a spinner.
+---
+
+# Progress
+
+## Overview
+
+`progress_runs` is the framework's "what is the agent doing right now" primitive. The agent starts a run at the top of a long task, updates it as work proceeds, and completes it with a terminal status. The UI renders active runs in a header-bar widget with a percent bar, current step, and spinner/check/X — live visibility into work that would otherwise be opaque.
+
+Separate concern from `notifications`:
+
+| | Notifications | Progress |
+|---|---|---|
+| Shape | One-shot event — "X happened" | Continuous state — "X is 45% done" |
+| UI surface | Bell + toast | Runs tray with percent bar |
+| Lifecycle | Dismissable (read/unread) | Running → terminal (succeeded/failed/cancelled) |
+
+Common pattern: on completion, emit a `notify()` so the user sees the outcome when they're not actively watching the tray.
+
+## Available Tools
+
+| Tool | Purpose |
+|---|---|
+| `start-run` | Mark the start of a long task. Returns a runId. |
+| `update-run-progress` | Update percent and/or current step. Call frequently. |
+| `complete-run` | Mark terminal status: `succeeded`, `failed`, `cancelled`. |
+| `list-runs` | List recent runs (all or `--active=true`). |
+
+## Canonical Flow
+
+```
+start-run --title "Triage 128 unread emails" --step "Fetching inbox"
+  → runId=abc
+
+update-run-progress --runId=abc --percent=25 --step="Classifying 32/128"
+update-run-progress --runId=abc --percent=75 --step="Drafting replies 97/128"
+
+complete-run --runId=abc --status=succeeded
+notify --severity=info --title="Triage done" --body="12 archived, 6 drafts ready to review"
+```
+
+## Best Practices
+
+- **Start a run for anything > ~5 seconds.** Users want feedback; a spinner with no context feels frozen.
+- **Update at natural checkpoints**, not every iteration. Every 5–10% is enough for most UIs.
+- **Always call `complete-run`** at the end — including the error path. An orphaned `running` row is worse than no row.
+- **Pair with `notify`** on completion. The tray tells users what's *running*; notifications tell them what *finished*.
+- **Use `metadataJson`** on `start-run` to pass a link back to the produced artifact (thread id, document path), so the UI can deep-link from the runs tray.
+
+## Runs API
+
+Mounted at `/_agent-native/runs/*` by `core-routes-plugin`. **Read-only** over HTTP — writes flow through the agent tools:
+
+| Method | Route |
+|---|---|
+| `GET`    | `/_agent-native/runs?active=true&limit=50` |
+| `GET`    | `/_agent-native/runs/:id` |
+| `DELETE` | `/_agent-native/runs/:id` |
+
+## UI Surface
+
+Ships as `<RunsTray />` at `@agent-native/core/client/progress`:
+
+```tsx
+import { RunsTray } from "@agent-native/core/client/progress";
+
+export function HeaderBar() {
+  return (
+    <header className="flex items-center gap-2">
+      {/* … */}
+      <RunsTray />
+    </header>
+  );
+}
+```
+
+Inline header widget — mount next to the notifications bell. Shows a spinner icon + count badge when runs are active; click opens a dropdown with a live percent bar per run. Hides the trigger entirely when no active runs. Polls `active=true` every `pollMs` (default 3s).
+
+## Event Bus Integration
+
+Two events emit on the bus so automations can react:
+
+- `run.progress.started` — `{ runId, title, step? }`
+- `run.progress.updated` — `{ runId, percent, step, status }`
+
+Example automation: *"when a run takes longer than 5 minutes, notify me."*
+
+## Related Skills
+
+- `notifications` — fire one when a run finishes so the user sees the outcome.
+- `automations` — subscribe to `run.progress.updated` to build watchdogs on slow runs.
+- `delegate-to-agent` — if you're delegating a long task, start a run on the delegator side so the caller has visibility.

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -95,6 +95,7 @@ Skills in `.agents/skills/` provide detailed guidance for each architectural rul
 | `frontend-design`     | Before building or restyling any UI component, page, or layout  |
 | `agent-engines`       | Before switching LLM providers or registering a custom engine   |
 | `notifications`       | Before surfacing alerts/progress to the user or adding channels |
+| `progress`            | Before running any task that takes more than a few seconds      |
 
 ## When Adding Features
 

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -84,16 +84,17 @@ You do NOT get auto-injected screen state. **Call `pnpm action view-screen` at t
 
 Skills in `.agents/skills/` provide detailed guidance for each architectural rule. Read them before making changes.
 
-| Skill                 | When to read                                                   |
-| --------------------- | -------------------------------------------------------------- |
-| `storing-data`        | Before storing or reading any app state                        |
-| `delegate-to-agent`   | Before adding LLM calls or AI delegation                       |
-| `actions`             | Before creating or modifying actions                           |
-| `real-time-sync`      | Before wiring up real-time UI sync                             |
-| `self-modifying-code` | Before editing source, components, or styles                   |
-| `capture-learnings`   | Before recording user preferences or corrections               |
-| `frontend-design`     | Before building or restyling any UI component, page, or layout |
-| `agent-engines`       | Before switching LLM providers or registering a custom engine  |
+| Skill                 | When to read                                                    |
+| --------------------- | --------------------------------------------------------------- |
+| `storing-data`        | Before storing or reading any app state                         |
+| `delegate-to-agent`   | Before adding LLM calls or AI delegation                        |
+| `actions`             | Before creating or modifying actions                            |
+| `real-time-sync`      | Before wiring up real-time UI sync                              |
+| `self-modifying-code` | Before editing source, components, or styles                    |
+| `capture-learnings`   | Before recording user preferences or corrections                |
+| `frontend-design`     | Before building or restyling any UI component, page, or layout  |
+| `agent-engines`       | Before switching LLM providers or registering a custom engine   |
+| `notifications`       | Before surfacing alerts/progress to the user or adding channels |
 
 ## When Adding Features
 


### PR DESCRIPTION
## Summary

- **Notifications** — new `notify()` send-and-store API at `@agent-native/core/notifications`. Every call persists to a `notifications` table (drives a `<NotificationsBell />` with unread badge, dropdown, and optional `browserNotifications` system popups) and fans out to pluggable server-side channels: `inbox` built-in, `webhook` auto-registers from `NOTIFICATIONS_WEBHOOK_URL` (reuses the secrets module's `${keys.NAME}` substitution + URL allowlists), plus custom channels via `registerNotificationChannel()`. Agent tools: `notify`, `list-notifications`.
- **Progress** — new `progress_runs` primitive at `@agent-native/core/progress` for long agent tasks to report live progress with a `running` → `succeeded`/`failed`/`cancelled` lifecycle. Renders in a `<RunsTray />` inline header widget (spinner trigger + count badge + per-run percent bar in a dropdown). Agent tools: `start-run`, `update-run-progress`, `complete-run`, `list-runs`.
- **Event-bus integration** — both primitives emit `notification.sent` / `run.progress.started` / `run.progress.updated` with declared Zod payload schemas, so they're discoverable via the agent's `list-automation-events` tool and validated on emit. Automations can chain off them, e.g. *"when a run has been running > 5 minutes, notify me"*.
- **Docs** — `packages/core/docs/content/notifications.md` and `progress.md` matching the `tracking.md` layout.

### Why

Long agent tasks used to hide behind spinners and async completions had no user-facing surface outside of chat. These two primitives give the agent a first-class way to say *"I'm working on this — here's where I'm at"* and *"this thing happened, see it in the bell"*. Both compose with the existing automations system: an event triggers an automation, the automation body calls `notify()` or starts a run, and the user sees it without needing a chat session open. The webhook channel + pluggable channel registry also fix a gap for out-of-band delivery (Slack, email, whatever the template wires up).

## Test plan

- [x] `pnpm test` — 393/393 core specs pass (notifications + progress spec files included)
- [x] End-to-end in a template app: real `notify()`, `startRun()`, `updateRunProgress()`, `completeRun()` calls produce zero `"[event-bus] Emitting unregistered event"` warnings and malformed payloads are dropped with Zod validation errors
- [x] `<NotificationsBell />` polls, shows unread count, dedupes by id, fires browser popups when `browserNotifications` is set; pauses polling on tab-hidden by default via shared `usePausingInterval` hook
- [x] `<RunsTray />` mounts inline next to the bell; hides when no active runs; auto-closes dropdown when the last run completes
- [x] Webhook channel substitutes `${keys.NAME}` server-side and respects per-key URL allowlists
- [x] Agent's `list-automation-events` tool surfaces the three new events with descriptions, field names, and example payloads
- [x] `pnpm fmt:check` + `pnpm guard:no-drizzle-push` pass

## Notes

- Table name is `progress_runs` (not `agent_runs`) to avoid colliding with core's existing `agent/run-store.ts` table used for chat-turn lifecycle tracking.
- `shadcn` semantic tokens throughout both React components — adapts to light + dark themes.
- Only local retention policy: completed runs + notifications accumulate in the DB. Flag for follow-up: a configurable retention TTL so old rows don't grow unbounded.