### PR TITLE
fix: restore SSR for docs site

### DIFF
--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -9,13 +9,9 @@ import {
   useRouteError,
   useLocation,
 } from "react-router";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  AgentSidebar,
-  ClientOnly,
-  DefaultSpinner,
-} from "@agent-native/core/client";
+import { AgentSidebar } from "@agent-native/core/client";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 
@@ -127,41 +123,45 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
-function AppContent() {
+export default function Root() {
   const [queryClient] = useState(
     () =>
       new QueryClient({
         defaultOptions: { queries: { staleTime: 30_000, retry: 1 } },
       }),
   );
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const content = (
+    <>
+      <Header />
+      <Outlet />
+      <Footer />
+    </>
+  );
 
   return (
     <QueryClientProvider client={queryClient}>
-      <AgentSidebar
-        position="right"
-        defaultOpen={false}
-        sidebarWidth={400}
-        emptyStateText="Ask me anything about Agent-Native"
-        suggestions={[
-          "How do I get started with Agent-Native?",
-          "How do actions work?",
-          "Explain the polling sync model",
-          "How do I deploy to production?",
-        ]}
-      >
-        <Header />
-        <Outlet />
-        <Footer />
-      </AgentSidebar>
+      {mounted ? (
+        <AgentSidebar
+          position="right"
+          defaultOpen={false}
+          sidebarWidth={400}
+          emptyStateText="Ask me anything about Agent-Native"
+          suggestions={[
+            "How do I get started with Agent-Native?",
+            "How do actions work?",
+            "Explain the polling sync model",
+            "How do I deploy to production?",
+          ]}
+        >
+          {content}
+        </AgentSidebar>
+      ) : (
+        content
+      )}
     </QueryClientProvider>
-  );
-}
-
-export default function Root() {
-  return (
-    <ClientOnly fallback={<DefaultSpinner />}>
-      <AppContent />
-    </ClientOnly>
   );
 }
 


### PR DESCRIPTION
## Summary
- The recent AgentSidebar addition (`6e312ae9`) wrapped all page content in `<ClientOnly>`, causing the server to render only a loading spinner instead of actual content
- Restructured so page content (Header, route Outlet, Footer) renders server-side for SEO, while AgentSidebar mounts as a client-only progressive enhancement after hydration
- Before this PR, crawlers and users with slow JS saw only a spinner; now they get the full rendered page

## Test plan
- [ ] Verify `curl https://agent-native.com` returns actual HTML content (Header, hero, Footer) instead of just a spinner
- [ ] Verify the AgentSidebar still appears and functions after client-side hydration
- [ ] Verify no hydration mismatch warnings in console
- [ ] Check Netlify deploy preview SSR output