### PR TITLE
fix(core): Sentry client-side tracking + postinstall append fix

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -513,16 +513,18 @@ async function scaffoldRequiredPackages(
       try {
         const rootPkg = JSON.parse(fs.readFileSync(rootPkgPath, "utf-8"));
         rootPkg.scripts = rootPkg.scripts ?? {};
-        if (!rootPkg.scripts.postinstall) {
-          const filters = [...needed]
-            .map((n) => `pnpm --filter ./packages/${n} build`)
-            .join(" && ");
-          rootPkg.scripts.postinstall = filters;
-          fs.writeFileSync(
-            rootPkgPath,
-            JSON.stringify(rootPkg, null, 2) + "\n",
-          );
+        const builds = [...needed]
+          .map((n) => `pnpm --filter ./packages/${n} build`)
+          .join(" && ");
+        const existing = rootPkg.scripts.postinstall;
+        if (existing) {
+          if (!existing.includes(builds)) {
+            rootPkg.scripts.postinstall = `${existing} && ${builds}`;
+          }
+        } else {
+          rootPkg.scripts.postinstall = builds;
         }
+        fs.writeFileSync(rootPkgPath, JSON.stringify(rootPkg, null, 2) + "\n");
       } catch {}
     }
   }

--- a/packages/core/src/server/analytics.ts
+++ b/packages/core/src/server/analytics.ts
@@ -1,8 +1,11 @@
 /**
- * Opt-in Google Analytics injection for SSR streams.
+ * Opt-in analytics & error-tracking injection for SSR streams.
  *
- * When the `GA_MEASUREMENT_ID` environment variable is set, this module
- * injects GA script tags into the HTML response before `</head>`.
+ * Supported environment variables:
+ * - `GA_MEASUREMENT_ID` — Google Analytics 4 measurement ID
+ * - `SENTRY_CLIENT_KEY` — Sentry browser SDK loader key (the hex portion of the CDN URL)
+ *
+ * When set, the corresponding script tags are injected before `</head>`.
  * When not set, the stream passes through untouched (zero overhead).
  *
  * Usage in entry.server.tsx:
@@ -31,13 +34,19 @@ function getGaScript(): string | null {
   );
 }
 
+function getSentryScript(): string | null {
+  const key = process.env.SENTRY_CLIENT_KEY;
+  if (!key) return null;
+  return `<script src="https://js.sentry-cdn.com/${key}.min.js" crossorigin="anonymous"></script>`;
+}
+
 /**
- * Wrap an SSR ReadableStream to inject Google Analytics scripts before `</head>`.
- * Returns the stream untouched if `GA_MEASUREMENT_ID` is not set.
+ * Wrap an SSR ReadableStream to inject analytics/error-tracking scripts before `</head>`.
+ * Returns the stream untouched if no tracking env vars are set.
  */
 export function wrapWithAnalytics(body: ReadableStream): ReadableStream {
-  const gaScript = getGaScript();
-  if (!gaScript) return body;
+  const scripts = [getGaScript(), getSentryScript()].filter(Boolean).join("");
+  if (!scripts) return body;
 
   const decoder = new TextDecoder();
   const encoder = new TextEncoder();
@@ -54,7 +63,7 @@ export function wrapWithAnalytics(body: ReadableStream): ReadableStream {
         const headCloseIdx = text.indexOf("</head>");
         if (headCloseIdx !== -1) {
           const modified =
-            text.slice(0, headCloseIdx) + gaScript + text.slice(headCloseIdx);
+            text.slice(0, headCloseIdx) + scripts + text.slice(headCloseIdx);
           controller.enqueue(encoder.encode(modified));
           injected = true;
         } else {

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -102,6 +102,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
         />
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <script
+          src="https://js.sentry-cdn.com/49a2686c80d08b5331c7b7e148dbb4a8.min.js"
+          crossOrigin="anonymous"
+        />
+        <script
           async
           src="https://www.googletagmanager.com/gtag/js?id=G-ESF7FYXGN9"
         />


### PR DESCRIPTION
## Summary

- **Sentry client-side tracking**: Add `SENTRY_CLIENT_KEY` env var support to the SSR analytics wrapper (`wrapWithAnalytics`), injecting the Sentry browser SDK loader alongside Google Analytics. Also add the loader directly to the docs site.
- **Postinstall append fix** (from PR #277 review): `scaffoldRequiredPackages` now appends build commands to an existing `postinstall` script instead of silently skipping — fixes `add-app` into workspaces that already have a postinstall (Husky, codegen, etc.).

## Test plan

- [ ] Verify `SENTRY_CLIENT_KEY` injects Sentry loader script in SSR HTML when set
- [ ] Verify no injection when env var is unset (zero overhead)
- [ ] Verify docs site loads Sentry loader in `<head>`
- [ ] Verify `agent-native add-app` appends to existing postinstall script instead of skipping