### PR TITLE
feat: auto-release desktop apps on merge to main

### DIFF
--- a/.github/workflows/clips-desktop-release.yml
+++ b/.github/workflows/clips-desktop-release.yml
@@ -73,13 +73,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Auto-bump patch version (push trigger only)
+      - name: Auto-bump version (push trigger only)
         if: github.event_name == 'push'
         working-directory: ${{ env.TAURI_APP_PATH }}
         shell: bash
         run: |
           CURRENT=$(node -p "require('./package.json').version")
-          NEXT=$(node -e "const [ma,mi,pa]=process.argv[1].split('.').map(Number); console.log(ma+'.'+mi+'.'+(pa+1))" "$CURRENT")
+          # Use major.minor from package.json + run_number as patch for
+          # guaranteed uniqueness without committing version bumps back.
+          NEXT=$(node -e "const [ma,mi]=process.argv[1].split('.'); console.log(ma+'.'+mi+'.${{ github.run_number }}')" "$CURRENT")
           npm version "$NEXT" --no-git-tag-version
           node -e "
             const fs = require('fs');

--- a/.github/workflows/clips-desktop-release.yml
+++ b/.github/workflows/clips-desktop-release.yml
@@ -7,6 +7,11 @@ name: Clips Desktop Release
 # which is what `endpoints` in tauri.conf.json points at.
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'templates/clips/desktop/**'
+      - 'packages/shared-app-config/**'
   workflow_dispatch:
     inputs:
       version:
@@ -68,7 +73,25 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Bump version
+      - name: Auto-bump patch version (push trigger only)
+        if: github.event_name == 'push'
+        working-directory: ${{ env.TAURI_APP_PATH }}
+        shell: bash
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          NEXT=$(node -e "const [ma,mi,pa]=process.argv[1].split('.').map(Number); console.log(ma+'.'+mi+'.'+(pa+1))" "$CURRENT")
+          npm version "$NEXT" --no-git-tag-version
+          node -e "
+            const fs = require('fs');
+            const tc = JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json','utf8'));
+            tc.version = '$NEXT';
+            fs.writeFileSync('src-tauri/tauri.conf.json', JSON.stringify(tc, null, 2) + '\n');
+            const cargo = fs.readFileSync('src-tauri/Cargo.toml','utf8');
+            fs.writeFileSync('src-tauri/Cargo.toml', cargo.replace(/^version = \".*\"/m, 'version = \"$NEXT\"'));
+          "
+          echo "Auto-bumped version: $CURRENT → $NEXT"
+
+      - name: Bump version (manual)
         if: inputs.version != ''
         working-directory: ${{ env.TAURI_APP_PATH }}
         shell: bash
@@ -132,7 +155,7 @@ jobs:
         id: v
         run: echo "version=${{ needs.build-tauri.outputs.app-version }}" >> "$GITHUB_OUTPUT"
 
-      - name: Mark versioned release as latest
+      - name: Mark versioned release as published
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -140,34 +163,31 @@ jobs:
             --draft=false \
             --latest=false
 
-      - name: Download latest.json from versioned release
+      - name: Download and publish updater manifest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p manifest
-          gh release download "clips-v${{ steps.v.outputs.version }}" \
-            --pattern 'latest.json' \
-            --dir manifest
-
-      # The updater endpoint in tauri.conf.json expects a file named
-      # `clips-latest.json` at a stable URL. We host it on the long-lived
-      # `clips-latest` release — overwriting its asset on every build.
-      - name: Rename manifest
-        run: mv manifest/latest.json manifest/clips-latest.json
-
-      - name: Publish / refresh clips-latest pointer release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh release view clips-latest >/dev/null 2>&1; then
-            gh release delete-asset clips-latest clips-latest.json --yes || true
-            gh release upload clips-latest manifest/clips-latest.json
-            gh release edit clips-latest \
-              --title "Clips Desktop — latest (updater manifest)" \
-              --notes "Stable URL for the Clips auto-updater. Overwritten on every release. Versioned bundles live in clips-v* releases."
+          # latest.json is only generated when TAURI_SIGNING_PRIVATE_KEY is
+          # configured. If it's missing, the release still works for manual
+          # downloads — just no auto-update.
+          if gh release download "clips-v${{ steps.v.outputs.version }}" \
+               --pattern 'latest.json' --dir manifest 2>/dev/null; then
+            mv manifest/latest.json manifest/clips-latest.json
+            if gh release view clips-latest >/dev/null 2>&1; then
+              gh release delete-asset clips-latest clips-latest.json --yes || true
+              gh release upload clips-latest manifest/clips-latest.json
+              gh release edit clips-latest \
+                --title "Clips Desktop — latest (updater manifest)" \
+                --notes "Stable URL for the Clips auto-updater. Overwritten on every release. Versioned bundles live in clips-v* releases."
+            else
+              gh release create clips-latest manifest/clips-latest.json \
+                --title "Clips Desktop — latest (updater manifest)" \
+                --notes "Stable URL for the Clips auto-updater. Overwritten on every release. Versioned bundles live in clips-v* releases." \
+                --latest=false
+            fi
+            echo "✅ Updater manifest published to clips-latest release"
           else
-            gh release create clips-latest manifest/clips-latest.json \
-              --title "Clips Desktop — latest (updater manifest)" \
-              --notes "Stable URL for the Clips auto-updater. Overwritten on every release. Versioned bundles live in clips-v* releases." \
-              --latest=false
+            echo "⚠️ No latest.json found — TAURI_SIGNING_PRIVATE_KEY may not be configured."
+            echo "⚠️ Release published without auto-update support. Users can still download manually."
           fi

--- a/.github/workflows/clips-desktop-release.yml
+++ b/.github/workflows/clips-desktop-release.yml
@@ -10,8 +10,8 @@ on:
   push:
     branches: [main]
     paths:
-      - 'templates/clips/desktop/**'
-      - 'packages/shared-app-config/**'
+      - "templates/clips/desktop/**"
+      - "packages/shared-app-config/**"
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -16,8 +16,34 @@ on:
 permissions:
   contents: write
 
+env:
+  # Deterministic version for auto-triggered builds: base version from
+  # package.json + run number ensures uniqueness without committing back.
+  AUTO_VERSION_SUFFIX: ${{ github.run_number }}
+
 jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: v
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            BASE=$(node -p "require('./packages/desktop-app/package.json').version")
+            echo "version=${BASE}+${AUTO_VERSION_SUFFIX}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(node -p "require('./packages/desktop-app/package.json').version")" >> "$GITHUB_OUTPUT"
+          fi
+
   build-mac:
+    needs: resolve-version
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,22 +58,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Auto-bump patch version (push trigger only)
-        if: github.event_name == 'push'
+      - name: Set version
         working-directory: packages/desktop-app
-        shell: bash
-        run: |
-          CURRENT=$(node -p "require('./package.json').version")
-          NEXT=$(node -e "const [ma,mi,pa]=process.argv[1].split('.').map(Number); console.log(ma+'.'+mi+'.'+(pa+1))" "$CURRENT")
-          npm version "$NEXT" --no-git-tag-version
-          echo "Auto-bumped version: $CURRENT → $NEXT"
-
-      - name: Bump version (manual)
-        if: inputs.version != ''
-        working-directory: packages/desktop-app
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: npm version "$RELEASE_VERSION" --no-git-tag-version
+        run: npm version "${{ needs.resolve-version.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Import signing certificate
         env:
@@ -72,6 +85,7 @@ jobs:
         run: pnpm build && npx electron-builder --mac --config --publish always
 
   build-windows:
+    needs: resolve-version
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -86,22 +100,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Auto-bump patch version (push trigger only)
-        if: github.event_name == 'push'
+      - name: Set version
         working-directory: packages/desktop-app
-        shell: bash
-        run: |
-          CURRENT=$(node -p "require('./package.json').version")
-          NEXT=$(node -e "const [ma,mi,pa]=process.argv[1].split('.').map(Number); console.log(ma+'.'+mi+'.'+(pa+1))" "$CURRENT")
-          npm version "$NEXT" --no-git-tag-version
-          echo "Auto-bumped version: $CURRENT → $NEXT"
-
-      - name: Bump version (manual)
-        if: inputs.version != ''
-        working-directory: packages/desktop-app
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: npm version "$RELEASE_VERSION" --no-git-tag-version
+        run: npm version "${{ needs.resolve-version.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Build and publish
         working-directory: packages/desktop-app
@@ -110,6 +111,7 @@ jobs:
         run: pnpm build && npx electron-builder --win --config --publish always
 
   build-linux:
+    needs: resolve-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -124,22 +126,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Auto-bump patch version (push trigger only)
-        if: github.event_name == 'push'
+      - name: Set version
         working-directory: packages/desktop-app
-        shell: bash
-        run: |
-          CURRENT=$(node -p "require('./package.json').version")
-          NEXT=$(node -e "const [ma,mi,pa]=process.argv[1].split('.').map(Number); console.log(ma+'.'+mi+'.'+(pa+1))" "$CURRENT")
-          npm version "$NEXT" --no-git-tag-version
-          echo "Auto-bumped version: $CURRENT → $NEXT"
-
-      - name: Bump version (manual)
-        if: inputs.version != ''
-        working-directory: packages/desktop-app
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
-        run: npm version "$RELEASE_VERSION" --no-git-tag-version
+        run: npm version "${{ needs.resolve-version.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Build and publish
         working-directory: packages/desktop-app
@@ -148,21 +137,10 @@ jobs:
         run: pnpm build && npx electron-builder --linux --config --publish always
 
   publish-release:
-    needs: [build-mac, build-windows, build-linux]
+    needs: [resolve-version, build-mac, build-windows, build-linux]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Get version
-        id: version
-        run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=$(node -p "require('./packages/desktop-app/package.json').version")" >> $GITHUB_OUTPUT
-          fi
-
       - name: Publish draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "v${{ steps.version.outputs.version }}" --draft=false --latest
+        run: gh release edit "v${{ needs.resolve-version.outputs.version }}" --draft=false --latest -R ${{ github.repository }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,6 +1,11 @@
 name: Desktop App Release
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/desktop-app/**'
+      - 'packages/shared-app-config/**'
   workflow_dispatch:
     inputs:
       version:
@@ -27,7 +32,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Bump version
+      - name: Auto-bump patch version (push trigger only)
+        if: github.event_name == 'push'
+        working-directory: packages/desktop-app
+        shell: bash
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          NEXT=$(node -e "const [ma,mi,pa]=process.argv[1].split('.').map(Number); console.log(ma+'.'+mi+'.'+(pa+1))" "$CURRENT")
+          npm version "$NEXT" --no-git-tag-version
+          echo "Auto-bumped version: $CURRENT → $NEXT"
+
+      - name: Bump version (manual)
         if: inputs.version != ''
         working-directory: packages/desktop-app
         env:
@@ -71,7 +86,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Bump version
+      - name: Auto-bump patch version (push trigger only)
+        if: github.event_name == 'push'
+        working-directory: packages/desktop-app
+        shell: bash
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          NEXT=$(node -e "const [ma,mi,pa]=process.argv[1].split('.').map(Number); console.log(ma+'.'+mi+'.'+(pa+1))" "$CURRENT")
+          npm version "$NEXT" --no-git-tag-version
+          echo "Auto-bumped version: $CURRENT → $NEXT"
+
+      - name: Bump version (manual)
         if: inputs.version != ''
         working-directory: packages/desktop-app
         env:
@@ -99,7 +124,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Bump version
+      - name: Auto-bump patch version (push trigger only)
+        if: github.event_name == 'push'
+        working-directory: packages/desktop-app
+        shell: bash
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          NEXT=$(node -e "const [ma,mi,pa]=process.argv[1].split('.').map(Number); console.log(ma+'.'+mi+'.'+(pa+1))" "$CURRENT")
+          npm version "$NEXT" --no-git-tag-version
+          echo "Auto-bumped version: $CURRENT → $NEXT"
+
+      - name: Bump version (manual)
         if: inputs.version != ''
         working-directory: packages/desktop-app
         env:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/desktop-app/**'
-      - 'packages/shared-app-config/**'
+      - "packages/desktop-app/**"
+      - "packages/shared-app-config/**"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary

- **Auto-trigger on code changes**: Both desktop release workflows now fire on push to main when their code paths change, not just on manual dispatch
  - Clips Tauri: `templates/clips/desktop/**` or `packages/shared-app-config/**`
  - Electron: `packages/desktop-app/**` or `packages/shared-app-config/**`
- **Auto patch-bump**: Push-triggered builds automatically increment the patch version so each release gets a unique tag
- **Resilient publish**: The Clips `publish-release` step no longer fails when `latest.json` is missing (happens when `TAURI_SIGNING_PRIVATE_KEY` isn't configured) — it publishes the release for manual download and logs a warning

## Test plan

- [ ] Merge a change to `templates/clips/desktop/` → Clips Desktop Release triggers automatically
- [ ] Merge a change to `packages/desktop-app/` → Desktop App Release triggers automatically  
- [ ] Manual `workflow_dispatch` with explicit version still works
- [ ] Push-triggered build auto-bumps patch version in the release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)