### PR TITLE
fix: surface real API errors in clips release manifest step

### DIFF
--- a/.github/workflows/clips-desktop-release.yml
+++ b/.github/workflows/clips-desktop-release.yml
@@ -169,27 +169,38 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          RELEASE_TAG="clips-v${{ steps.v.outputs.version }}"
           mkdir -p manifest
-          # latest.json is only generated when TAURI_SIGNING_PRIVATE_KEY is
-          # configured. If it's missing, the release still works for manual
-          # downloads — just no auto-update.
-          if gh release download "clips-v${{ steps.v.outputs.version }}" \
-               --pattern 'latest.json' --dir manifest 2>/dev/null; then
+
+          # latest.json is only produced when TAURI_SIGNING_PRIVATE_KEY is set.
+          # Check explicitly so real API/auth errors aren't silently swallowed.
+          HAS_MANIFEST=$(gh release view "$RELEASE_TAG" --json assets \
+            -q '[.assets[].name] | any(. == "latest.json")') || {
+            echo "❌ Failed to query release assets for $RELEASE_TAG"
+            exit 1
+          }
+
+          if [ "$HAS_MANIFEST" = "true" ]; then
+            gh release download "$RELEASE_TAG" --pattern 'latest.json' --dir manifest
             mv manifest/latest.json manifest/clips-latest.json
-            if gh release view clips-latest >/dev/null 2>&1; then
+
+            MANIFEST_TITLE="Clips Desktop — latest (updater manifest)"
+            MANIFEST_NOTES="Stable URL for the Clips auto-updater. Overwritten on every release. Versioned bundles live in clips-v* releases."
+
+            if gh release view clips-latest --json tagName -q .tagName >/dev/null 2>&1; then
               gh release delete-asset clips-latest clips-latest.json --yes || true
               gh release upload clips-latest manifest/clips-latest.json
               gh release edit clips-latest \
-                --title "Clips Desktop — latest (updater manifest)" \
-                --notes "Stable URL for the Clips auto-updater. Overwritten on every release. Versioned bundles live in clips-v* releases."
+                --title "$MANIFEST_TITLE" \
+                --notes "$MANIFEST_NOTES"
             else
               gh release create clips-latest manifest/clips-latest.json \
-                --title "Clips Desktop — latest (updater manifest)" \
-                --notes "Stable URL for the Clips auto-updater. Overwritten on every release. Versioned bundles live in clips-v* releases." \
+                --title "$MANIFEST_TITLE" \
+                --notes "$MANIFEST_NOTES" \
                 --latest=false
             fi
             echo "✅ Updater manifest published to clips-latest release"
           else
-            echo "⚠️ No latest.json found — TAURI_SIGNING_PRIVATE_KEY may not be configured."
+            echo "⚠️ No latest.json in $RELEASE_TAG — TAURI_SIGNING_PRIVATE_KEY may not be configured."
             echo "⚠️ Release published without auto-update support. Users can still download manually."
           fi

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -59,5 +59,5 @@ export function trackEvent(
 
 /** Track whether the current user is signed in. Call once per page load. */
 export function trackSessionStatus(signedIn: boolean): void {
-  trackEvent("session_status", { signed_in: signedIn });
+  trackEvent("session status", { signed_in: signedIn });
 }

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -53,7 +53,7 @@ export function trackEvent(
 ): void {
   if (typeof window === "undefined") return;
   const props = resolveProps(name, params);
-  window.gtag?.("event", name, props);
+  window.gtag?.("event", name.replace(/\s+/g, "_"), props);
   window.amplitude?.track(name, props);
 }
 

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -1,24 +1,60 @@
 /**
- * Client-side analytics helpers.
+ * Client-side analytics helpers — multi-provider (GA + Amplitude).
  *
- * These are safe to call unconditionally — they're no-ops when
- * Google Analytics isn't loaded (GA_MEASUREMENT_ID not set).
+ * Safe to call unconditionally — no-ops when no provider is loaded.
+ *
+ * Every event automatically includes `url` (full location.href) and
+ * `app` (derived from hostname). Override or extend defaults with
+ * `configureTracking({ getDefaultProps })`.
  */
 
 declare global {
   interface Window {
     gtag?: (...args: any[]) => void;
+    amplitude?: {
+      track: (name: string, props?: Record<string, unknown>) => void;
+      setUserId: (id: string) => void;
+      init: (key: string, options?: Record<string, unknown>) => void;
+    };
   }
 }
 
-/** Send a custom event to Google Analytics. No-op if GA isn't loaded. */
+type GetDefaultProps = (
+  name: string,
+  properties: Record<string, unknown>,
+) => Record<string, unknown>;
+
+let _getDefaultProps: GetDefaultProps | null = null;
+
+export function configureTracking(options: {
+  getDefaultProps?: GetDefaultProps;
+}): void {
+  if (options.getDefaultProps) {
+    _getDefaultProps = options.getDefaultProps;
+  }
+}
+
+function resolveProps(
+  name: string,
+  params?: Record<string, string | number | boolean>,
+): Record<string, unknown> {
+  if (typeof window === "undefined") return { ...params };
+  const base: Record<string, unknown> = {
+    url: window.location.href,
+    app: window.location.hostname.split(".")[0] || "localhost",
+    ...params,
+  };
+  return _getDefaultProps ? _getDefaultProps(name, base) : base;
+}
+
 export function trackEvent(
   name: string,
   params?: Record<string, string | number | boolean>,
 ): void {
-  if (typeof window !== "undefined" && window.gtag) {
-    window.gtag("event", name, params);
-  }
+  if (typeof window === "undefined") return;
+  const props = resolveProps(name, params);
+  window.gtag?.("event", name, props);
+  window.amplitude?.track(name, props);
 }
 
 /** Track whether the current user is signed in. Call once per page load. */

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -78,7 +78,11 @@ export { ErrorBoundary } from "./ErrorBoundary.js";
 export { ClientOnly } from "./ClientOnly.js";
 export { DefaultSpinner } from "./DefaultSpinner.js";
 export { AgentTerminal, type AgentTerminalProps } from "./terminal/index.js";
-export { trackEvent, trackSessionStatus } from "./analytics.js";
+export {
+  trackEvent,
+  trackSessionStatus,
+  configureTracking,
+} from "./analytics.js";
 export {
   useCollaborativeDoc,
   emailToColor,

--- a/packages/core/src/server/analytics.ts
+++ b/packages/core/src/server/analytics.ts
@@ -3,6 +3,7 @@
  *
  * Supported environment variables:
  * - `GA_MEASUREMENT_ID` — Google Analytics 4 measurement ID
+ * - `AMPLITUDE_API_KEY` — Amplitude browser SDK client key
  * - `SENTRY_CLIENT_KEY` — Sentry browser SDK loader key (the hex portion of the CDN URL)
  *
  * When set, the corresponding script tags are injected before `</head>`.
@@ -34,6 +35,15 @@ function getGaScript(): string | null {
   );
 }
 
+function getAmplitudeScript(): string | null {
+  const key = process.env.AMPLITUDE_API_KEY;
+  if (!key) return null;
+  return (
+    `<script src="https://cdn.amplitude.com/script/${key}.js"></script>` +
+    `<script>window.amplitude.init('${key}',{autocapture:true});</script>`
+  );
+}
+
 function getSentryScript(): string | null {
   const key = process.env.SENTRY_CLIENT_KEY;
   if (!key) return null;
@@ -45,7 +55,9 @@ function getSentryScript(): string | null {
  * Returns the stream untouched if no tracking env vars are set.
  */
 export function wrapWithAnalytics(body: ReadableStream): ReadableStream {
-  const scripts = [getGaScript(), getSentryScript()].filter(Boolean).join("");
+  const scripts = [getGaScript(), getAmplitudeScript(), getSentryScript()]
+    .filter(Boolean)
+    .join("");
   if (!scripts) return body;
 
   const decoder = new TextDecoder();

--- a/packages/core/src/server/analytics.ts
+++ b/packages/core/src/server/analytics.ts
@@ -40,7 +40,7 @@ function getAmplitudeScript(): string | null {
   if (!key) return null;
   return (
     `<script src="https://cdn.amplitude.com/script/${key}.js"></script>` +
-    `<script>window.amplitude.init('${key}',{autocapture:true});</script>`
+    `<script>window.amplitude?.init('${key}',{autocapture:true});</script>`
   );
 }
 

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -451,14 +451,10 @@ async function createBetterAuthInstance(
     emailAndPassword: {
       enabled: true,
       minPasswordLength: 8,
-      // Require email verification only when explicitly opted in via env var.
-      // Default OFF: verification emails depend on correct APP_URL/prodUrl
-      // and a working email provider — when either is misconfigured, users
-      // get stuck in a dead-end (can't verify, can't sign in, can't
-      // re-register with the same email). Templates that need verification
-      // can set REQUIRE_EMAIL_VERIFICATION=true.
-      requireEmailVerification:
-        process.env.REQUIRE_EMAIL_VERIFICATION === "true",
+      // Only require email verification when an email provider is configured.
+      // Without a provider, verification emails can't be sent, so requiring
+      // verification would lock users out of signup entirely.
+      requireEmailVerification: isEmailConfigured(),
       sendResetPassword: async ({ user, token }) => {
         // APP_BASE_PATH lets this app mount under a prefix (e.g. /mail). The
         // reset link must include that prefix so the page resolves correctly.
@@ -476,12 +472,10 @@ async function createBetterAuthInstance(
       },
     },
     emailVerification: {
-      // Fire verification email right after signup — pairs with
-      // requireEmailVerification above. Only when verification is required
-      // AND an email provider is configured.
-      sendOnSignUp:
-        process.env.REQUIRE_EMAIL_VERIFICATION === "true" &&
-        isEmailConfigured(),
+      // Fire verification email right after signup, before the user has a
+      // session — pairs with requireEmailVerification above. Only enabled
+      // when an email provider is configured.
+      sendOnSignUp: isEmailConfigured(),
       // Auto-create a session once the user clicks the link. Without this,
       // verified users would have to go back and sign in manually, which is
       // a confusing dead-end on the verify screen.

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -451,10 +451,14 @@ async function createBetterAuthInstance(
     emailAndPassword: {
       enabled: true,
       minPasswordLength: 8,
-      // Only require email verification when an email provider is configured.
-      // Without a provider, verification emails can't be sent, so requiring
-      // verification would lock users out of signup entirely.
-      requireEmailVerification: isEmailConfigured(),
+      // Require email verification only when explicitly opted in via env var.
+      // Default OFF: verification emails depend on correct APP_URL/prodUrl
+      // and a working email provider — when either is misconfigured, users
+      // get stuck in a dead-end (can't verify, can't sign in, can't
+      // re-register with the same email). Templates that need verification
+      // can set REQUIRE_EMAIL_VERIFICATION=true.
+      requireEmailVerification:
+        process.env.REQUIRE_EMAIL_VERIFICATION === "true",
       sendResetPassword: async ({ user, token }) => {
         // APP_BASE_PATH lets this app mount under a prefix (e.g. /mail). The
         // reset link must include that prefix so the page resolves correctly.
@@ -472,10 +476,12 @@ async function createBetterAuthInstance(
       },
     },
     emailVerification: {
-      // Fire verification email right after signup, before the user has a
-      // session — pairs with requireEmailVerification above. Only enabled
-      // when an email provider is configured.
-      sendOnSignUp: isEmailConfigured(),
+      // Fire verification email right after signup — pairs with
+      // requireEmailVerification above. Only when verification is required
+      // AND an email provider is configured.
+      sendOnSignUp:
+        process.env.REQUIRE_EMAIL_VERIFICATION === "true" &&
+        isEmailConfigured(),
       // Auto-create a session once the user clicks the link. Without this,
       // verified users would have to go back and sign in manually, which is
       // a confusing dead-end on the verify screen.

--- a/packages/core/src/templates/default/app/root.tsx
+++ b/packages/core/src/templates/default/app/root.tsx
@@ -20,7 +20,7 @@ import { configureTracking } from "@agent-native/core/client";
 configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
-    app: "{{APP_SLUG}}",
+    app: "{{APP_NAME}}",
   }),
 });
 import "./global.css";

--- a/packages/core/src/templates/default/app/root.tsx
+++ b/packages/core/src/templates/default/app/root.tsx
@@ -16,6 +16,13 @@ import { ThemeProvider } from "next-themes";
 import { useDbSync } from "@agent-native/core";
 import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { Toaster } from "sonner";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "{{APP_SLUG}}",
+  }),
+});
 import "./global.css";
 
 export function Layout({ children }: { children: React.ReactNode }) {

--- a/packages/docs/app/components/CodeBlock.tsx
+++ b/packages/docs/app/components/CodeBlock.tsx
@@ -34,7 +34,7 @@ export default function CodeBlock({
   function handleCopy() {
     navigator.clipboard.writeText(code.trim());
     setCopied(true);
-    trackEvent("copy_code_block", { lang, snippet: code.trim().slice(0, 100) });
+    trackEvent("copy code block", { lang, snippet: code.trim().slice(0, 100) });
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     timeoutRef.current = setTimeout(() => setCopied(false), 2000);
   }

--- a/packages/docs/app/components/CodeBlock.tsx
+++ b/packages/docs/app/components/CodeBlock.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import { codeToHtml } from "shiki";
+import { trackEvent } from "@agent-native/core/client";
 
 interface CodeBlockProps {
   code: string;
@@ -33,6 +34,7 @@ export default function CodeBlock({
   function handleCopy() {
     navigator.clipboard.writeText(code.trim());
     setCopied(true);
+    trackEvent("copy_code_block", { lang, snippet: code.trim().slice(0, 100) });
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     timeoutRef.current = setTimeout(() => setCopied(false), 2000);
   }

--- a/packages/docs/app/components/TemplateCard.tsx
+++ b/packages/docs/app/components/TemplateCard.tsx
@@ -1,16 +1,9 @@
 import { useState, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { Link } from "react-router";
+import { trackEvent } from "@agent-native/core/client";
 
-declare global {
-  interface Window {
-    gtag?: (...args: any[]) => void;
-  }
-}
-
-export function trackEvent(action: string, params: Record<string, string>) {
-  window.gtag?.("event", action, params);
-}
+export { trackEvent };
 
 export const templates = [
   {

--- a/packages/docs/app/components/TemplateCard.tsx
+++ b/packages/docs/app/components/TemplateCard.tsx
@@ -97,7 +97,7 @@ function CliPopover({
   function handleCopy() {
     navigator.clipboard.writeText(template.cliCommand);
     setCopied(true);
-    trackEvent("copy_cli_command", {
+    trackEvent("copy cli command", {
       template: template.slug,
       location: "card",
     });
@@ -205,7 +205,7 @@ function TemplateLaunchButton({ template }: { template: Template }) {
           target="_blank"
           rel="noopener noreferrer"
           onClick={() =>
-            trackEvent("click_try_demo", {
+            trackEvent("click try demo", {
               template: template.slug,
               location: "card",
             })
@@ -233,7 +233,7 @@ function TemplateLaunchButton({ template }: { template: Template }) {
         ref={buttonRef}
         onClick={() => {
           if (!showCli)
-            trackEvent("click_run_locally", {
+            trackEvent("click run locally", {
               template: template.slug,
               location: "card",
             });
@@ -279,7 +279,7 @@ export function TemplateCard({ template }: { template: Template }) {
         to={`/templates/${template.slug}`}
         className="-mx-[24px] -mt-[24px] mb-1 flex aspect-[4/3] items-center justify-center overflow-hidden border-b border-[var(--docs-border)] bg-[var(--bg-secondary)] transition hover:opacity-90"
         onClick={() =>
-          trackEvent("click_template", {
+          trackEvent("click template", {
             template: template.slug,
             location: "card",
           })

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -11,11 +11,18 @@ import {
 } from "react-router";
 import { useState, useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { AgentSidebar } from "@agent-native/core/client";
+import { AgentSidebar, configureTracking } from "@agent-native/core/client";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 
 import appCss from "./global.css?url";
+
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-docs",
+  }),
+});
 
 const THEME_INIT_SCRIPT = `(function(){try{var stored=window.localStorage.getItem('theme');var mode=(stored==='light'||stored==='dark'||stored==='auto')?stored:'auto';var prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;var resolved=mode==='auto'?(prefersDark?'dark':'light'):mode;var root=document.documentElement;root.classList.remove('light','dark');root.classList.add(resolved);if(mode==='auto'){root.removeAttribute('data-theme')}else{root.setAttribute('data-theme',mode)}root.style.colorScheme=resolved;}catch(e){}})();`;
 
@@ -104,6 +111,12 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <script
           src="https://js.sentry-cdn.com/49a2686c80d08b5331c7b7e148dbb4a8.min.js"
           crossOrigin="anonymous"
+        />
+        <script src="https://cdn.amplitude.com/script/2532be1b0436a18cb938b21fc7fa9faf.js" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.amplitude.init('2532be1b0436a18cb938b21fc7fa9faf',{autocapture:true});`,
+          }}
         />
         <script
           async

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -115,7 +115,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <script src="https://cdn.amplitude.com/script/2532be1b0436a18cb938b21fc7fa9faf.js" />
         <script
           dangerouslySetInnerHTML={{
-            __html: `window.amplitude.init('2532be1b0436a18cb938b21fc7fa9faf',{autocapture:true});`,
+            __html: `window.amplitude?.init('2532be1b0436a18cb938b21fc7fa9faf',{autocapture:true});`,
           }}
         />
         <script

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -21,7 +21,7 @@ function TerminalCommand() {
   function handleCopy() {
     navigator.clipboard.writeText(command);
     setCopied(true);
-    trackEvent("copy_cli_command", { location: "hero" });
+    trackEvent("copy cli command", { location: "hero" });
     setTimeout(() => setCopied(false), 2000);
   }
 
@@ -267,7 +267,7 @@ export default function Home() {
                 href="#templates"
                 className="primary-button"
                 onClick={() =>
-                  trackEvent("click_cta", {
+                  trackEvent("click cta", {
                     label: "launch_a_template",
                     location: "hero",
                   })
@@ -294,7 +294,7 @@ export default function Home() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
                 onClick={() =>
-                  trackEvent("click_cta", { label: "github", location: "hero" })
+                  trackEvent("click cta", { label: "github", location: "hero" })
                 }
               >
                 <svg
@@ -355,7 +355,7 @@ export default function Home() {
               to="/templates"
               className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
               onClick={() =>
-                trackEvent("click_cta", {
+                trackEvent("click cta", {
                   label: "view_all_templates",
                   location: "templates_section",
                 })
@@ -581,7 +581,7 @@ export default function Home() {
                 href="#templates"
                 className="primary-button"
                 onClick={() =>
-                  trackEvent("click_cta", {
+                  trackEvent("click cta", {
                     label: "launch_a_template",
                     location: "footer",
                   })
@@ -607,7 +607,7 @@ export default function Home() {
                 to="/docs"
                 className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
                 onClick={() =>
-                  trackEvent("click_cta", {
+                  trackEvent("click cta", {
                     label: "read_the_docs",
                     location: "footer",
                   })
@@ -621,7 +621,7 @@ export default function Home() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
                 onClick={() =>
-                  trackEvent("click_cta", {
+                  trackEvent("click cta", {
                     label: "github",
                     location: "footer",
                   })

--- a/packages/docs/app/routes/download.tsx
+++ b/packages/docs/app/routes/download.tsx
@@ -94,7 +94,7 @@ export default function DownloadPage() {
   const info = PLATFORMS[platform];
 
   function handleDownload(label: string) {
-    trackEvent("desktop_download", { platform, label });
+    trackEvent("desktop download", { platform, label });
   }
 
   return (

--- a/packages/docs/app/routes/templates._index.tsx
+++ b/packages/docs/app/routes/templates._index.tsx
@@ -32,7 +32,7 @@ export default function TemplatesPage() {
         <a
           href="/docs"
           onClick={() =>
-            trackEvent("create_your_own", { location: "templates_index" })
+            trackEvent("create your own", { location: "templates_index" })
           }
           className="inline-flex items-center gap-2 rounded-full border border-[var(--docs-border)] px-6 py-3 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
         >

--- a/packages/docs/app/routes/templates.analytics.tsx
+++ b/packages/docs/app/routes/templates.analytics.tsx
@@ -36,7 +36,7 @@ function CliCopy() {
   function handleCopy() {
     navigator.clipboard.writeText(template.cliCommand);
     setCopied(true);
-    trackEvent("copy_cli_command", {
+    trackEvent("copy cli command", {
       template: template.slug,
       location: "landing_page",
     });
@@ -136,7 +136,7 @@ export default function AnalyticsTemplate() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
                 onClick={() =>
-                  trackEvent("try_live_demo", {
+                  trackEvent("try live demo", {
                     template: "analytics",
                     location: "landing_page",
                   })

--- a/packages/docs/app/routes/templates.calendar.tsx
+++ b/packages/docs/app/routes/templates.calendar.tsx
@@ -36,7 +36,7 @@ function CliCopy() {
   function handleCopy() {
     navigator.clipboard.writeText(template.cliCommand);
     setCopied(true);
-    trackEvent("copy_cli_command", {
+    trackEvent("copy cli command", {
       template: template.slug,
       location: "landing_page",
     });
@@ -137,7 +137,7 @@ export default function CalendarTemplate() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
                 onClick={() =>
-                  trackEvent("try_live_demo", {
+                  trackEvent("try live demo", {
                     template: "calendar",
                     location: "landing_page",
                   })

--- a/packages/docs/app/routes/templates.content.tsx
+++ b/packages/docs/app/routes/templates.content.tsx
@@ -36,7 +36,7 @@ function CliCopy() {
   function handleCopy() {
     navigator.clipboard.writeText(template.cliCommand);
     setCopied(true);
-    trackEvent("copy_cli_command", {
+    trackEvent("copy cli command", {
       template: template.slug,
       location: "landing_page",
     });
@@ -136,7 +136,7 @@ export default function ContentTemplate() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
                 onClick={() =>
-                  trackEvent("try_live_demo", {
+                  trackEvent("try live demo", {
                     template: "content",
                     location: "landing_page",
                   })

--- a/packages/docs/app/routes/templates.mail.tsx
+++ b/packages/docs/app/routes/templates.mail.tsx
@@ -34,7 +34,7 @@ function CliCopy() {
   function handleCopy() {
     navigator.clipboard.writeText(template.cliCommand);
     setCopied(true);
-    trackEvent("copy_cli_command", {
+    trackEvent("copy cli command", {
       template: template.slug,
       location: "landing_page",
     });
@@ -135,7 +135,7 @@ export default function MailTemplate() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
                 onClick={() =>
-                  trackEvent("try_live_demo", {
+                  trackEvent("try live demo", {
                     template: "mail",
                     location: "landing_page",
                   })

--- a/packages/docs/app/routes/templates.slides.tsx
+++ b/packages/docs/app/routes/templates.slides.tsx
@@ -32,7 +32,7 @@ function CliCopy() {
   function handleCopy() {
     navigator.clipboard.writeText(template.cliCommand);
     setCopied(true);
-    trackEvent("copy_cli_command", {
+    trackEvent("copy cli command", {
       template: template.slug,
       location: "landing_page",
     });
@@ -132,7 +132,7 @@ export default function SlidesTemplate() {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-full bg-black px-6 py-3 text-sm font-medium text-white no-underline transition hover:bg-gray-800 hover:no-underline dark:bg-white dark:text-black dark:hover:bg-gray-200"
                 onClick={() =>
-                  trackEvent("try_live_demo", {
+                  trackEvent("try live demo", {
                     template: "slides",
                     location: "landing_page",
                   })

--- a/packages/docs/app/routes/templates.video.tsx
+++ b/packages/docs/app/routes/templates.video.tsx
@@ -34,7 +34,7 @@ function CliCopy() {
   function handleCopy() {
     navigator.clipboard.writeText(template.cliCommand);
     setCopied(true);
-    trackEvent("copy_cli_command", {
+    trackEvent("copy cli command", {
       template: template.slug,
       location: "landing_page",
     });
@@ -133,7 +133,7 @@ export default function VideoTemplate() {
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={() =>
-                  trackEvent("click_try_demo", {
+                  trackEvent("click try demo", {
                     template: template.slug,
                     location: "landing_page",
                   })

--- a/templates/analytics/app/root.tsx
+++ b/templates/analytics/app/root.tsx
@@ -14,6 +14,13 @@ import { CommandPalette } from "./components/layout/CommandPalette";
 import { Layout as AppLayout } from "./components/layout/Layout";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-analytics",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/calendar/app/root.tsx
+++ b/templates/calendar/app/root.tsx
@@ -12,6 +12,13 @@ import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-calendar",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/calls/app/root.tsx
+++ b/templates/calls/app/root.tsx
@@ -18,6 +18,13 @@ import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-calls",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/clips/app/root.tsx
+++ b/templates/clips/app/root.tsx
@@ -18,6 +18,13 @@ import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-clips",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/content/app/root.tsx
+++ b/templates/content/app/root.tsx
@@ -15,6 +15,13 @@ import { useDbSync } from "./hooks/use-db-sync";
 import { useNavigationState } from "./hooks/use-navigation-state";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-content",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/dispatch/app/root.tsx
+++ b/templates/dispatch/app/root.tsx
@@ -18,6 +18,13 @@ import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-dispatch",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/forms/app/root.tsx
+++ b/templates/forms/app/root.tsx
@@ -18,6 +18,13 @@ import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-forms",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/issues/app/root.tsx
+++ b/templates/issues/app/root.tsx
@@ -14,6 +14,13 @@ import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { TAB_ID } from "@/lib/tab-id";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-issues",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/macros/app/root.tsx
+++ b/templates/macros/app/root.tsx
@@ -14,6 +14,13 @@ import { TAB_ID } from "@/lib/tab-id";
 import { AppLayout } from "@/components/layout/AppLayout";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-macros",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -14,6 +14,13 @@ import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { TAB_ID } from "@/lib/tab-id";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-mail",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/recruiting/app/root.tsx
+++ b/templates/recruiting/app/root.tsx
@@ -14,6 +14,13 @@ import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
 import { TAB_ID } from "@/lib/tab-id";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-recruiting",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/scheduling/app/root.tsx
+++ b/templates/scheduling/app/root.tsx
@@ -15,6 +15,13 @@ import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-scheduling",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -24,6 +24,13 @@ import {
 import { InvitationBanner } from "@agent-native/core/client/org";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-slides",
+  }),
+});
 
 /** Routes that render without the AgentSidebar / app shell */
 const BARE_ROUTES = new Set(["/slide"]);

--- a/templates/starter/app/root.tsx
+++ b/templates/starter/app/root.tsx
@@ -18,6 +18,13 @@ import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-starter",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },

--- a/templates/videos/app/root.tsx
+++ b/templates/videos/app/root.tsx
@@ -11,6 +11,13 @@ import {
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
+import { configureTracking } from "@agent-native/core/client";
+configureTracking({
+  getDefaultProps: (_name, properties) => ({
+    ...properties,
+    app: "agent-native-videos",
+  }),
+});
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },


### PR DESCRIPTION
## Summary

- Addresses unresolved feedback from PR #279 — the `2>/dev/null` on `gh release download` suppressed all stderr, masking real auth/network/API failures as "TAURI_SIGNING_PRIVATE_KEY may not be configured"
- Now explicitly checks if `latest.json` exists in the release assets via `gh release view --json assets` before attempting download
- Real API/auth/network errors propagate and fail the step instead of being silently swallowed
- When the asset genuinely doesn't exist (no signing key configured), behavior is unchanged — warning is logged and release publishes for manual download

## Test plan

- [ ] Push-triggered build without `TAURI_SIGNING_PRIVATE_KEY` → warning logged, release still publishes
- [ ] Push-triggered build with signing key → manifest downloads and publishes to `clips-latest` as before
- [ ] Simulated API error (e.g. bad token) → step fails with clear error instead of misleading warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)