### PR TITLE
fix(core): allowlist *.agent-native.com in Builder OAuth redirect

### DIFF
--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -1013,10 +1013,10 @@ export function TiptapComposer({
             {execMode && onExecModeChange && (
               <ModeSelector mode={execMode} onChange={onExecModeChange} />
             )}
-            {extraActionButton}
             {voiceEnabled && (
               <VoiceButton voice={voice} isMac={isMac} disabled={disabled} />
             )}
+            {extraActionButton}
             <button
               type="button"
               onClick={submitComposer}

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -40,7 +40,12 @@ function isAllowedBrowserReturnUrl(urlString: string): boolean {
       hostname === "[::1]";
     const isBuilderDomain =
       hostname === "builder.io" || hostname.endsWith(".builder.io");
-    return isAllowedProtocol && (isLocalhost || isBuilderDomain);
+    const isAgentNativeDomain =
+      hostname === "agent-native.com" || hostname.endsWith(".agent-native.com");
+    return (
+      isAllowedProtocol &&
+      (isLocalhost || isBuilderDomain || isAgentNativeDomain)
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- Adds `*.agent-native.com` to the allowed redirect URL domains in the framework's `isAllowedBrowserReturnUrl` (builder-browser.ts)
- **Companion change needed in builder-internal**: same allowlist update in `CLIAuthPage.tsx` `isAllowedRedirectUrl` — without it, Builder's cli-auth falls back to `http://localhost:10110/auth` for any non-localhost/non-builder.io redirect URL, breaking all deployed agent-native apps

## Root cause

Builder's `CLIAuthPage.tsx` validates the `redirect_url` param against an allowlist (localhost + *.builder.io only). Deployed agent-native apps on `*.agent-native.com` fail this check, so `redirectUrl` is set to null and the hardcoded fallback `http://localhost:10110/auth` is used — which gives ERR_CONNECTION_REFUSED.

## Test plan

- [ ] Deploy a Clips app to *.agent-native.com and click "Connect Builder.io" — should redirect back to the app's callback URL instead of localhost
- [ ] Verify localhost dev flow still works
- [ ] Verify builder.io-hosted flows still work


🤖 Generated with [Claude Code](https://claude.com/claude-code)