### PR TITLE
fix(core): honor user-selected LLM model, extraContext, and native template actions in dev

### DIFF
--- a/packages/core/src/agent/engine/index.ts
+++ b/packages/core/src/agent/engine/index.ts
@@ -22,6 +22,7 @@ export {
   getAgentEngineEntry,
   listAgentEngines,
   resolveEngine,
+  getStoredModelForEngine,
   detectEngineFromEnv,
   isAgentEngineSettingConfigured,
   isStoredEngineUsable,

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -120,6 +120,89 @@ describe("AgentEngine registry", () => {
     expect(resolved).toBe(fakeAnthropicEngine);
   });
 
+  describe("getStoredModelForEngine", () => {
+    beforeEach(() => {
+      vi.resetModules();
+    });
+
+    it("returns the stored model when the stored engine name matches", async () => {
+      vi.doMock("../../settings/store.js", () => ({
+        getSetting: vi.fn().mockResolvedValue({
+          engine: "ai-sdk:openrouter",
+          model: "google/gemini-2.5-flash",
+        }),
+      }));
+      const { getStoredModelForEngine } = await import("./registry.js");
+
+      const result = await getStoredModelForEngine("ai-sdk:openrouter");
+      expect(result).toBe("google/gemini-2.5-flash");
+    });
+
+    it("returns undefined when the stored engine doesn't match", async () => {
+      // Don't apply a Claude model string to an OpenRouter engine.
+      vi.doMock("../../settings/store.js", () => ({
+        getSetting: vi.fn().mockResolvedValue({
+          engine: "anthropic",
+          model: "claude-sonnet-4-6",
+        }),
+      }));
+      const { getStoredModelForEngine } = await import("./registry.js");
+
+      expect(
+        await getStoredModelForEngine("ai-sdk:openrouter"),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined when no model is stored", async () => {
+      vi.doMock("../../settings/store.js", () => ({
+        getSetting: vi.fn().mockResolvedValue({ engine: "ai-sdk:openrouter" }),
+      }));
+      const { getStoredModelForEngine } = await import("./registry.js");
+
+      expect(
+        await getStoredModelForEngine("ai-sdk:openrouter"),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for an empty-string model", async () => {
+      vi.doMock("../../settings/store.js", () => ({
+        getSetting: vi
+          .fn()
+          .mockResolvedValue({ engine: "ai-sdk:openrouter", model: "" }),
+      }));
+      const { getStoredModelForEngine } = await import("./registry.js");
+
+      expect(
+        await getStoredModelForEngine("ai-sdk:openrouter"),
+      ).toBeUndefined();
+    });
+
+    it("swallows settings-store errors", async () => {
+      vi.doMock("../../settings/store.js", () => ({
+        getSetting: vi
+          .fn()
+          .mockRejectedValue(new Error("settings table not ready")),
+      }));
+      const { getStoredModelForEngine } = await import("./registry.js");
+
+      expect(
+        await getStoredModelForEngine("ai-sdk:openrouter"),
+      ).toBeUndefined();
+    });
+
+    it("accepts an engine instance and uses its .name", async () => {
+      vi.doMock("../../settings/store.js", () => ({
+        getSetting: vi
+          .fn()
+          .mockResolvedValue({ engine: "ai-sdk:openai", model: "gpt-4o" }),
+      }));
+      const { getStoredModelForEngine } = await import("./registry.js");
+
+      const fakeEngine = { name: "ai-sdk:openai" } as any;
+      expect(await getStoredModelForEngine(fakeEngine)).toBe("gpt-4o");
+    });
+  });
+
   it("resolveEngine uses env AGENT_ENGINE when set", async () => {
     const { registerAgentEngine, resolveEngine } =
       await import("./registry.js");

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -219,3 +219,36 @@ export async function resolveEngine(
   }
   return anthropicEntry.create({ apiKey });
 }
+
+/**
+ * Read the user-selected model for an engine from the `agent-engine` setting.
+ *
+ * The settings UI writes `{engine, model}` via the `set-agent-engine` action,
+ * but `resolveEngine` only uses the stored engine (the model is a separate
+ * per-request concern). Call this helper alongside `resolveEngine` to honor
+ * the user's model choice without requiring a process restart.
+ *
+ * Returns the stored model only when the stored engine name matches `engine`
+ * — otherwise returns `undefined` to avoid applying an Anthropic model string
+ * to, say, an OpenRouter engine.
+ */
+export async function getStoredModelForEngine(
+  engine: AgentEngine | string,
+): Promise<string | undefined> {
+  const engineName = typeof engine === "string" ? engine : engine.name;
+  try {
+    const stored = await getSetting("agent-engine");
+    if (
+      stored &&
+      typeof stored.engine === "string" &&
+      stored.engine === engineName &&
+      typeof stored.model === "string" &&
+      stored.model.length > 0
+    ) {
+      return stored.model;
+    }
+  } catch {
+    // Settings store not ready (fresh install, migration pending) — skip.
+  }
+  return undefined;
+}

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -17,7 +17,11 @@ import type {
   EngineMessage,
   EngineContentPart,
 } from "./engine/types.js";
-import { resolveEngine, registerBuiltinEngines } from "./engine/index.js";
+import {
+  resolveEngine,
+  registerBuiltinEngines,
+  getStoredModelForEngine,
+} from "./engine/index.js";
 import { PROVIDER_TO_ENV } from "./engine/provider-env-vars.js";
 import { readAppState } from "../application-state/script-helpers.js";
 import {
@@ -584,7 +588,16 @@ export function createProductionAgentHandler(
       });
     }
 
-    const model = requestModel ?? configuredModel ?? engine.defaultModel;
+    // Honor the model the user picked in the settings UI (written via
+    // `set-agent-engine`), but only when the caller hasn't overridden it for
+    // this request or at plugin construction time. Read per-request so a
+    // dropdown change in the UI takes effect without a server restart. Skip
+    // the DB read entirely when a higher-precedence value is set.
+    const model =
+      requestModel ??
+      configuredModel ??
+      (await getStoredModelForEngine(engine)) ??
+      engine.defaultModel;
 
     options.onEngineResolved?.(engine, model);
 

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1193,6 +1193,10 @@ export interface AgentChatPluginOptions {
    * Return `null` or an empty string to skip. The string you return is
    * appended verbatim, so wrap it in your own XML tags (e.g.
    * `<data-dictionary>…</data-dictionary>`) to keep the prompt scannable.
+   *
+   * Called on every request in every prompt variant (lean, lazy, full).
+   * Templates that want to suppress it in a particular mode should return
+   * `null` from the callback based on their own logic.
    */
   extraContext?: (
     event: any,
@@ -2927,17 +2931,29 @@ export function createAgentChatPlugin(
       // DB round-trips and tokens that minimal/voice apps don't need.
       const leanBasePrompt = (options?.systemPrompt ?? "") + prodActionsPrompt;
 
+      // Per-request preamble shared by both prod and dev handlers. Resolves
+      // owner + user API key (stashed on the closure so downstream tools can
+      // reach them) and the template-authored `extraContext`. `extraContext`
+      // runs in every prompt variant (lean, lazy, full) — if a template
+      // defined it, they opted in; framework-provided content is what the
+      // token-saving modes strip.
+      const prepareRun = async (event: any) => {
+        _currentRequestOrigin = getOrigin(event);
+        const owner = await getOwnerFromEvent(event);
+        _currentRunOwner = owner;
+        const { getOwnerActiveApiKey } =
+          await import("../agent/production-agent.js");
+        _currentRunUserApiKey = await getOwnerActiveApiKey(owner);
+        const extra = await resolveExtraContext(event, owner);
+        return { owner, extra };
+      };
+
       const prodHandler = createProductionAgentHandler({
         actions: prodActions,
         systemPrompt: async (event: any) => {
-          _currentRequestOrigin = getOrigin(event);
-          const owner = await getOwnerFromEvent(event);
-          _currentRunOwner = owner;
-          const { getOwnerActiveApiKey } =
-            await import("../agent/production-agent.js");
-          _currentRunUserApiKey = await getOwnerActiveApiKey(owner);
+          const { owner, extra } = await prepareRun(event);
           if (leanPrompt) {
-            _currentRunSystemPrompt = leanBasePrompt;
+            _currentRunSystemPrompt = leanBasePrompt + extra;
             return _currentRunSystemPrompt;
           }
           const resources = await loadResourcesForPrompt(owner, lazyContext);
@@ -2946,9 +2962,6 @@ export function createAgentChatPlugin(
           const schemaBlock = lazyContext
             ? ""
             : await buildSchemaBlock(owner, false);
-          const extra = lazyContext
-            ? ""
-            : await resolveExtraContext(event, owner);
           _currentRunSystemPrompt =
             basePrompt + resources + schemaBlock + extra;
           return _currentRunSystemPrompt;
@@ -3022,23 +3035,15 @@ export function createAgentChatPlugin(
         devHandler = createProductionAgentHandler({
           actions: devActions,
           systemPrompt: async (event: any) => {
-            _currentRequestOrigin = getOrigin(event);
-            const owner = await getOwnerFromEvent(event);
-            _currentRunOwner = owner;
-            const { getOwnerActiveApiKey } =
-              await import("../agent/production-agent.js");
-            _currentRunUserApiKey = await getOwnerActiveApiKey(owner);
+            const { owner, extra } = await prepareRun(event);
             if (leanPrompt) {
-              _currentRunSystemPrompt = leanBasePrompt;
+              _currentRunSystemPrompt = leanBasePrompt + extra;
               return _currentRunSystemPrompt;
             }
             const resources = await loadResourcesForPrompt(owner, lazyContext);
             const schemaBlock = lazyContext
               ? ""
               : await buildSchemaBlock(owner, true);
-            const extra = lazyContext
-              ? ""
-              : await resolveExtraContext(event, owner);
             _currentRunSystemPrompt =
               devPrompt + resources + schemaBlock + extra;
             return _currentRunSystemPrompt;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1233,6 +1233,26 @@ export interface AgentChatPluginOptions {
    * Ignored when `leanPrompt` is set (lean mode is even more minimal).
    */
   lazyContext?: boolean;
+  /**
+   * In dev mode, register the template's actions as native tools the agent
+   * can call directly with structured JSON args — skipping the default
+   * `shell(command="pnpm action <name> ...")` indirection.
+   *
+   * The default dev behavior shells out because it "mirrors how Claude Code
+   * works locally" and reduces empty-object tool calls for templates with
+   * simple string args. But templates whose actions take structured data
+   * (objects, arrays, nested JSON) can't round-trip those cleanly through
+   * the CLI parser — stringified JSON on the way in, loss of type fidelity
+   * on the way out.
+   *
+   * Set to `true` to get the same tool surface in dev that production uses.
+   * `leanPrompt: true` implies this already (lean mode has no shell-usage
+   * guidance, so actions must be native). Set this flag without
+   * `leanPrompt` when you want native actions AND the full system prompt.
+   *
+   * Defaults to `false`.
+   */
+  nativeActionsInDev?: boolean;
 }
 
 /**
@@ -2541,16 +2561,22 @@ export function createAgentChatPlugin(
           (lazyContext
             ? PROD_FRAMEWORK_PROMPT_COMPACT
             : PROD_FRAMEWORK_PROMPT)) + prodActionsPrompt;
-      const devPrompt =
-        (options?.devSystemPrompt
-          ? options.devSystemPrompt +
-            (options?.systemPrompt ??
-              (lazyContext
-                ? PROD_FRAMEWORK_PROMPT_COMPACT
-                : PROD_FRAMEWORK_PROMPT))
-          : lazyContext
-            ? DEV_FRAMEWORK_PROMPT_COMPACT
-            : DEV_FRAMEWORK_PROMPT) + devActionsPrompt;
+      // When template actions are registered as native tools in dev (via
+      // `nativeActionsInDev` or `leanPrompt`), the dev prompt's "invoke
+      // template actions via shell" guidance is wrong — use the prod prompt
+      // + tool-format action list instead, same as production.
+      const devNative = options?.nativeActionsInDev === true || leanPrompt;
+      const devPrompt = devNative
+        ? prodPrompt
+        : (options?.devSystemPrompt
+            ? options.devSystemPrompt +
+              (options?.systemPrompt ??
+                (lazyContext
+                  ? PROD_FRAMEWORK_PROMPT_COMPACT
+                  : PROD_FRAMEWORK_PROMPT))
+            : lazyContext
+              ? DEV_FRAMEWORK_PROMPT_COMPACT
+              : DEV_FRAMEWORK_PROMPT) + devActionsPrompt;
       // Keep legacy names for the composition below
       const basePrompt = prodPrompt;
       const devPrefix = options?.devSystemPrompt ?? DEFAULT_DEV_PROMPT;
@@ -3003,10 +3029,11 @@ export function createAgentChatPlugin(
         // how Claude Code works locally and dramatically reduces the rate of
         // degenerate empty-object tool calls. The CLI syntax for each action is
         // listed in the dev system prompt's "Available Actions" section.
-        // In lean mode, expose the template's actions directly as native tools
-        // instead of routing through shell — the lean system prompt has no
-        // shell-usage guidance, so shell-based action invocation would break.
-        const devActions = leanPrompt
+        // In lean mode — or when `nativeActionsInDev` is set — expose the
+        // template's actions as native tools instead of routing through shell.
+        // Templates with structured-arg actions (objects/arrays) need this to
+        // avoid round-tripping JSON through the CLI parser.
+        const devActions = devNative
           ? prodActions
           : {
               ...resourceScripts,
@@ -3025,8 +3052,8 @@ export function createAgentChatPlugin(
               ...(await createDevScriptRegistry()),
             };
         // Keep dev action dict in sync with runtime MCP additions. When
-        // leanPrompt is true, devActions === prodActions so the prod listener
-        // already covers it.
+        // native-actions mode is on (lean or `nativeActionsInDev`), devActions
+        // === prodActions so the prod listener already covers it.
         if (devActions !== prodActions) {
           mcpManager.onChange(() => {
             syncMcpActionEntries(mcpManager, devActions);


### PR DESCRIPTION
## Summary

Three framework gaps surface when a template grounds the agent with an `extraContext` callback + a user-picked model in dev mode:

1. The Settings UI writes `{engine, model}` to the `agent-engine` setting, but `resolveEngine` reads only `stored.engine` — the user's model choice is silently discarded and the engine's hardcoded default (e.g. `anthropic/claude-sonnet-4.6` on OpenRouter) is always used.
2. `extraContext` is silently skipped in `leanPrompt` mode and the default `lazyContext` mode, so template-authored grounding evaporates as soon as either token-saving switch is on.
3. Template actions are only native tools in dev when `leanPrompt: true`, which also strips the full system prompt. Templates with structured JSON args have no clean option — the CLI parser mangles objects/arrays.

## What's in this PR

- **Model**: new `getStoredModelForEngine` helper; `createProductionAgentHandler` threads `storedModel` into its per-request fallback chain (no restart needed, no cross-provider leaks).
- **extraContext**: runs in every prompt variant. Template-authored = opt-in; token-saving modes strip framework content, not template content.
- **`nativeActionsInDev`** new option: native tools in dev without lean-mode prompt stripping. Dev prompt switches to prod + tool-format action list when on.

## Test plan

- [x] 6 new unit tests for `getStoredModelForEngine` (matching engine, cross-provider guard, empty/missing model, store errors, string vs instance input)
- [x] `pnpm test` — 414/414 pass (pre-existing `dist/catalog.json` failure unrelated)
- [x] `pnpm exec tsc --noEmit` clean on touched files
- [x] Manual E2E against a template using all three: Settings dropdown takes effect live, `extraContext` fires every turn, structured-arg actions round-trip as native tools
- [ ] CI checks