### PR TITLE
fix(core): auto-create org edge cases — invites, race, refetch semantics

### DIFF
--- a/packages/core/src/client/org/hooks.ts
+++ b/packages/core/src/client/org/hooks.ts
@@ -62,11 +62,15 @@ export function useOrgInvitations() {
   });
 }
 
-// NOTE: the onSuccess handlers below `await` invalidateQueries so that
-// `mutation.isPending` stays true until the refetch completes. Without the
-// await, isPending flips false the instant the HTTP response lands, opening
-// a window where a submit button can re-enable, the user can fire another
-// mutation, and two mutations race to overwrite active-org-id last.
+// NOTE: the onSuccess handlers below `await refetchQueries` so that
+// `mutation.isPending` stays true until the dependent queries have
+// actually refetched. We use refetchQueries (not invalidateQueries)
+// for unambiguous semantics: refetchQueries returns a promise that
+// resolves only when the network refetch settles, so awaiting it
+// guarantees `isPending` covers the full read-after-write window.
+// Without that, a submit button can re-enable the moment the HTTP
+// mutation response lands but before stale UI data is refreshed,
+// opening a window where two mutations race to overwrite active-org-id.
 
 export function useCreateOrg() {
   const qc = useQueryClient();
@@ -78,8 +82,8 @@ export function useCreateOrg() {
       }),
     onSuccess: async () => {
       await Promise.all([
-        qc.invalidateQueries({ queryKey: ["org-me"] }),
-        qc.invalidateQueries({ queryKey: ["org-members"] }),
+        qc.refetchQueries({ queryKey: ["org-me"] }),
+        qc.refetchQueries({ queryKey: ["org-members"] }),
       ]);
     },
   });
@@ -95,8 +99,8 @@ export function useInviteMember() {
       }),
     onSuccess: async () => {
       await Promise.all([
-        qc.invalidateQueries({ queryKey: ["org-members"] }),
-        qc.invalidateQueries({ queryKey: ["org-invitations"] }),
+        qc.refetchQueries({ queryKey: ["org-members"] }),
+        qc.refetchQueries({ queryKey: ["org-invitations"] }),
       ]);
     },
   });
@@ -110,7 +114,9 @@ export function useAcceptInvitation() {
         method: "POST",
       }),
     onSuccess: async () => {
-      // Joining/switching orgs changes all org-scoped data — clear caches.
+      // Joining/switching orgs changes all org-scoped data. invalidate
+      // (not refetch) here because we don't know which keys are mounted —
+      // invalidate marks them stale and the active ones refetch.
       await qc.invalidateQueries();
     },
   });
@@ -124,7 +130,7 @@ export function useRemoveMember() {
         method: "DELETE",
       }),
     onSuccess: async () => {
-      await qc.invalidateQueries({ queryKey: ["org-members"] });
+      await qc.refetchQueries({ queryKey: ["org-members"] });
     },
   });
 }

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -200,6 +200,14 @@ async function tryCreateDefaultOrg(
 
     return { email, orgId, orgName, role: "owner" };
   } catch {
+    // Org / member insert failed AFTER we won the claim. Drop the claim
+    // so a future request from this user can retry auto-create —
+    // otherwise the claim row would permanently block provisioning and
+    // the user would be stuck on RequireActiveOrg without any recovery
+    // path short of manual creation.
+    await exec
+      .execute({ sql: `DELETE FROM settings WHERE key = ?`, args: [claimKey] })
+      .catch(() => {});
     return null;
   }
 }

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -2,6 +2,7 @@ import type { H3Event } from "h3";
 import { getSession } from "../server/auth.js";
 import { getUserSetting } from "../settings/user-settings.js";
 import { getDbExec } from "../db/client.js";
+import { getSetting } from "../settings/store.js";
 import type { OrgContext, OrgRole } from "./types.js";
 
 const EMPTY_CONTEXT: OrgContext = {
@@ -118,10 +119,41 @@ function defaultOrgName(
 }
 
 /**
+ * Check whether the user has a pending invitation. If so, auto-create
+ * MUST be skipped — otherwise we'd provision a personal org for them
+ * before they ever see the inviter's org in the RequireActiveOrg
+ * accept-invite pane, and they'd never join the team that invited them.
+ */
+async function hasPendingInvitation(
+  exec: ReturnType<typeof getDbExec>,
+  email: string,
+): Promise<boolean> {
+  try {
+    const { rows } = await exec.execute({
+      sql: `SELECT 1 FROM org_invitations WHERE LOWER(email) = ? AND status = 'pending' LIMIT 1`,
+      args: [email.toLowerCase()],
+    });
+    return rows.length > 0;
+  } catch {
+    // If we can't tell, err on the side of NOT auto-creating — the
+    // RequireActiveOrg client guard will surface the situation.
+    return true;
+  }
+}
+
+/**
  * Attempt to provision a default org + owner membership for a user with
- * zero memberships. Re-queries before inserting to catch a concurrent
- * request that already created one, and returns the existing org in that
- * case. Returns null on any failure so the caller can fall back to the
+ * zero memberships.
+ *
+ * Race protection: claims the user's auto-create slot via an atomic
+ * INSERT into the framework `settings` table (PRIMARY KEY (key) — so
+ * concurrent inserts for the same key throw uniqueness violations on
+ * both SQLite and Postgres). Only the request that wins the claim
+ * proceeds to create the org; losers bail. By the time a losing
+ * request retries on a subsequent navigation, the winner's org is in
+ * `org_members` and the auto-create branch is skipped entirely.
+ *
+ * Returns null on any failure so the caller can fall back to the
  * empty-context / client-guard path.
  */
 async function tryCreateDefaultOrg(
@@ -129,25 +161,30 @@ async function tryCreateDefaultOrg(
   email: string,
   session: { name?: string } | null,
 ): Promise<OrgContext | null> {
-  try {
-    const existing = await exec.execute({
-      sql: `SELECT m.org_id AS "orgId", m.role AS role, o.name AS "orgName"
-            FROM org_members m
-            INNER JOIN organizations o ON m.org_id = o.id
-            WHERE LOWER(m.email) = ?
-            LIMIT 1`,
-      args: [email.toLowerCase()],
-    });
-    if (existing.rows.length > 0) {
-      const r = existing.rows[0] as any;
-      return {
-        email,
-        orgId: String(r.orgId ?? r.org_id),
-        orgName: String(r.orgName ?? r.org_name),
-        role: String(r.role) as OrgRole,
-      };
-    }
+  // Skip auto-create if there's a pending invite — the user should join
+  // the inviter's org via the RequireActiveOrg accept-invite pane, not
+  // be silently dropped into a personal workspace they didn't ask for.
+  if (await hasPendingInvitation(exec, email)) return null;
 
+  // Make sure the framework `settings` table exists before we use it as
+  // a claim primitive. getSetting() ensures the table on first call.
+  await getSetting("__init").catch(() => null);
+
+  const claimKey = `u:${email.toLowerCase()}:auto-create-claim`;
+  try {
+    await exec.execute({
+      sql: `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)`,
+      args: [claimKey, JSON.stringify({ at: Date.now() }), Date.now()],
+    });
+  } catch {
+    // INSERT failed → another request already claimed this user's
+    // auto-create slot. Bail; their request will create the org and a
+    // future getOrgContext call from this user will see non-empty
+    // memberships and skip the auto-create branch.
+    return null;
+  }
+
+  try {
     const orgId = nanoid();
     const orgName = defaultOrgName(email, session);
     const now = Date.now();


### PR DESCRIPTION
## Summary

Three post-merge review items on the auto-create-default-org flow.

- **Pending-invite check**: `getOrgContext` now skips auto-create if `org_invitations` has a pending row for the user's email. Previously a user invited to "Acme Corp" would have a personal "Their's workspace" provisioned on first authenticated load, hiding the invite from `RequireActiveOrg`'s accept pane and stranding them in a workspace they didn't ask for.
- **Cross-process race**: replaces the best-effort re-query with an atomic claim via the framework `settings` table. `INSERT INTO settings (key, ...)` uses the table's `PRIMARY KEY (key)` constraint to serialize across processes (works on both SQLite and Postgres). Concurrent first-load requests for the same user fail their second insert and bail; the winner creates the org. Subsequent requests find non-empty memberships and skip auto-create entirely.
- **Refetch semantics**: org mutation hooks switch `await invalidateQueries(...)` → `await refetchQueries(...)` for unambiguous behavior. `refetchQueries` returns a promise that resolves only when the refetch settles, so `mutation.isPending` reliably covers the read-after-write window — no dependence on TanStack v5 invalidate timing nuances. `useAcceptInvitation` keeps invalidate (it clears all queries, not a known set).
- **Self-heal on claim-held-but-create-failed**: if the claim INSERT succeeds but the org / org_members inserts then fail (DB hiccup, migration race), delete the claim row so a future request can retry instead of permanently stranding the user on RequireActiveOrg.


## Test plan

- [ ] Invite alice@example.com → alice signs up, lands on app with `AUTO_CREATE_DEFAULT_ORG=1` → sees the invite in `RequireActiveOrg`, no personal org auto-created.
- [ ] Plain signup with no pending invite → personal workspace appears as before.
- [ ] Multi-tab simulation (two parallel requests on first load) → exactly one default org in `organizations` after the dust settles.
- [ ] Mutation race: rapid create+accept clicks → submit button stays disabled through the full settle window.