### PR TITLE
fix(core): TTL claim recovery, narrower invite race, case-insensitive…

### DIFF
--- a/packages/core/src/client/org/hooks.ts
+++ b/packages/core/src/client/org/hooks.ts
@@ -62,15 +62,22 @@ export function useOrgInvitations() {
   });
 }
 
-// NOTE: the onSuccess handlers below `await refetchQueries` so that
-// `mutation.isPending` stays true until the dependent queries have
-// actually refetched. We use refetchQueries (not invalidateQueries)
-// for unambiguous semantics: refetchQueries returns a promise that
-// resolves only when the network refetch settles, so awaiting it
-// guarantees `isPending` covers the full read-after-write window.
-// Without that, a submit button can re-enable the moment the HTTP
-// mutation response lands but before stale UI data is refreshed,
-// opening a window where two mutations race to overwrite active-org-id.
+// NOTE: the onSuccess handlers below `await invalidateQueries`. In
+// TanStack Query v5, invalidateQueries:
+//   1. Marks every matching query as stale, so the next mount of an
+//      INACTIVE query (e.g. the org-members table on a settings page
+//      the user hasn't visited yet) refetches immediately instead of
+//      serving 30-second-stale cached data.
+//   2. Triggers a refetch of every ACTIVE query that matches.
+//   3. Returns a promise that resolves once those refetches settle.
+//
+// `await`ing therefore keeps `mutation.isPending` true through the
+// full read-after-write window — closing the create-org / accept-
+// invite race where a button could re-enable mid-refetch. We
+// previously tried refetchQueries here for "unambiguous semantics",
+// but that variant doesn't mark inactive queries stale, leaving them
+// to serve stale data on next mount. invalidateQueries is the right
+// primitive — it just needed an `await`.
 
 export function useCreateOrg() {
   const qc = useQueryClient();
@@ -82,8 +89,8 @@ export function useCreateOrg() {
       }),
     onSuccess: async () => {
       await Promise.all([
-        qc.refetchQueries({ queryKey: ["org-me"] }),
-        qc.refetchQueries({ queryKey: ["org-members"] }),
+        qc.invalidateQueries({ queryKey: ["org-me"] }),
+        qc.invalidateQueries({ queryKey: ["org-members"] }),
       ]);
     },
   });
@@ -99,8 +106,8 @@ export function useInviteMember() {
       }),
     onSuccess: async () => {
       await Promise.all([
-        qc.refetchQueries({ queryKey: ["org-members"] }),
-        qc.refetchQueries({ queryKey: ["org-invitations"] }),
+        qc.invalidateQueries({ queryKey: ["org-members"] }),
+        qc.invalidateQueries({ queryKey: ["org-invitations"] }),
       ]);
     },
   });
@@ -114,9 +121,9 @@ export function useAcceptInvitation() {
         method: "POST",
       }),
     onSuccess: async () => {
-      // Joining/switching orgs changes all org-scoped data. invalidate
-      // (not refetch) here because we don't know which keys are mounted —
-      // invalidate marks them stale and the active ones refetch.
+      // Joining/switching orgs changes all org-scoped data — invalidate
+      // every cached query (no key filter) so each one refetches or is
+      // marked stale for the next mount.
       await qc.invalidateQueries();
     },
   });
@@ -130,7 +137,7 @@ export function useRemoveMember() {
         method: "DELETE",
       }),
     onSuccess: async () => {
-      await qc.refetchQueries({ queryKey: ["org-members"] });
+      await qc.invalidateQueries({ queryKey: ["org-members"] });
     },
   });
 }

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -225,26 +225,24 @@ async function acquireClaim(
     });
     return true;
   } catch {
-    // Conflict — someone else's claim is in the row. If it's stale, take
-    // it over; otherwise yield.
-    const existing = (await getSetting(claimKey).catch(() => null)) as {
-      at?: number;
-    } | null;
-    const at = typeof existing?.at === "number" ? existing.at : 0;
-    if (now - at < CLAIM_TTL_MS) return false;
-
-    await exec
-      .execute({ sql: `DELETE FROM settings WHERE key = ?`, args: [claimKey] })
-      .catch(() => {});
-    try {
-      await exec.execute({
-        sql: `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)`,
-        args: [claimKey, JSON.stringify({ at: now }), now],
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    // Conflict — someone else's claim is already in the row. If it's
+    // stale (older than CLAIM_TTL_MS) we take it over.
+    //
+    // CRITICAL: this MUST be a single atomic UPDATE guarded on
+    // `updated_at <= staleThreshold`. A read-then-DELETE-then-INSERT
+    // sequence lets two concurrent reclaimers each observe the stale
+    // timestamp, delete each other's fresh claim, and both think they
+    // won — duplicating org creation. The conditional UPDATE matches
+    // each stale row at most once: only the first writer sees
+    // rowsAffected === 1; the row's updated_at is now `now`, so any
+    // subsequent UPDATE no longer satisfies `updated_at <= staleThreshold`
+    // and matches zero rows.
+    const staleThreshold = now - CLAIM_TTL_MS;
+    const result = (await exec.execute({
+      sql: `UPDATE settings SET value = ?, updated_at = ? WHERE key = ? AND updated_at <= ?`,
+      args: [JSON.stringify({ at: now }), now, claimKey, staleThreshold],
+    })) as { rowsAffected?: number };
+    return (result.rowsAffected ?? 0) > 0;
   }
 }
 

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -141,6 +141,13 @@ async function hasPendingInvitation(
   }
 }
 
+/** Stale-claim threshold. A claim row this old is treated as abandoned
+ *  (process crashed, DELETE failed, etc.) and a new caller may take it
+ *  over. Long enough that two genuine concurrent first-loads don't
+ *  trample each other (those settle in milliseconds), short enough that
+ *  a stuck user recovers on their next navigation. */
+const CLAIM_TTL_MS = 5 * 60 * 1000;
+
 /**
  * Attempt to provision a default org + owner membership for a user with
  * zero memberships.
@@ -153,6 +160,11 @@ async function hasPendingInvitation(
  * request retries on a subsequent navigation, the winner's org is in
  * `org_members` and the auto-create branch is skipped entirely.
  *
+ * Stuck-state recovery: a stale claim (held longer than CLAIM_TTL_MS)
+ * is reclaimed automatically. So even if the DELETE on the failure
+ * path fails (network blip, DB error), the user isn't stranded — the
+ * next request after the TTL elapses retries cleanly.
+ *
  * Returns null on any failure so the caller can fall back to the
  * empty-context / client-guard path.
  */
@@ -161,26 +173,20 @@ async function tryCreateDefaultOrg(
   email: string,
   session: { name?: string } | null,
 ): Promise<OrgContext | null> {
-  // Skip auto-create if there's a pending invite — the user should join
-  // the inviter's org via the RequireActiveOrg accept-invite pane, not
-  // be silently dropped into a personal workspace they didn't ask for.
-  if (await hasPendingInvitation(exec, email)) return null;
-
   // Make sure the framework `settings` table exists before we use it as
   // a claim primitive. getSetting() ensures the table on first call.
   await getSetting("__init").catch(() => null);
 
   const claimKey = `u:${email.toLowerCase()}:auto-create-claim`;
-  try {
-    await exec.execute({
-      sql: `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)`,
-      args: [claimKey, JSON.stringify({ at: Date.now() }), Date.now()],
-    });
-  } catch {
-    // INSERT failed → another request already claimed this user's
-    // auto-create slot. Bail; their request will create the org and a
-    // future getOrgContext call from this user will see non-empty
-    // memberships and skip the auto-create branch.
+
+  if (!(await acquireClaim(exec, claimKey))) return null;
+
+  // Pending-invite check happens INSIDE the claim so the window where a
+  // newly-arrived invitation can be missed is narrowed to a single SQL
+  // round-trip. (A still-narrower window would require a transaction
+  // spanning org_invitations and settings — out of scope.)
+  if (await hasPendingInvitation(exec, email)) {
+    await releaseClaim(exec, claimKey);
     return null;
   }
 
@@ -202,14 +208,54 @@ async function tryCreateDefaultOrg(
 
     return { email, orgId, orgName, role: "owner" };
   } catch {
-    // Org / member insert failed AFTER we won the claim. Drop the claim
-    // so a future request from this user can retry auto-create —
-    // otherwise the claim row would permanently block provisioning and
-    // the user would be stuck on RequireActiveOrg without any recovery
-    // path short of manual creation.
+    await releaseClaim(exec, claimKey);
+    return null;
+  }
+}
+
+async function acquireClaim(
+  exec: ReturnType<typeof getDbExec>,
+  claimKey: string,
+): Promise<boolean> {
+  const now = Date.now();
+  try {
+    await exec.execute({
+      sql: `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)`,
+      args: [claimKey, JSON.stringify({ at: now }), now],
+    });
+    return true;
+  } catch {
+    // Conflict — someone else's claim is in the row. If it's stale, take
+    // it over; otherwise yield.
+    const existing = (await getSetting(claimKey).catch(() => null)) as {
+      at?: number;
+    } | null;
+    const at = typeof existing?.at === "number" ? existing.at : 0;
+    if (now - at < CLAIM_TTL_MS) return false;
+
     await exec
       .execute({ sql: `DELETE FROM settings WHERE key = ?`, args: [claimKey] })
       .catch(() => {});
-    return null;
+    try {
+      await exec.execute({
+        sql: `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)`,
+        args: [claimKey, JSON.stringify({ at: now }), now],
+      });
+      return true;
+    } catch {
+      return false;
+    }
   }
+}
+
+async function releaseClaim(
+  exec: ReturnType<typeof getDbExec>,
+  claimKey: string,
+): Promise<void> {
+  // Best-effort. If this fails (transient network/DB error), the
+  // CLAIM_TTL_MS-based takeover in acquireClaim recovers automatically
+  // on a future request — no permanent stuck state.
+  await exec
+    .execute({ sql: `DELETE FROM settings WHERE key = ?`, args: [claimKey] })
+    .catch(() => {});
 }

--- a/packages/core/src/org/handlers.ts
+++ b/packages/core/src/org/handlers.ts
@@ -88,11 +88,15 @@ export const getMyOrgHandler = defineEventHandler(async (event: H3Event) => {
   }));
 
   const invitesRes = await e.execute({
+    // Case-insensitive match: invitations are stored with whatever case
+    // the inviter typed, but the session email may be normalized
+    // differently by the auth provider. LOWER(both sides) keeps these
+    // discoverable and matches getOrgContext.hasPendingInvitation.
     sql: `SELECT i.id AS id, i.org_id AS "orgId", o.name AS "orgName", i.invited_by AS "invitedBy"
           FROM org_invitations i
           INNER JOIN organizations o ON i.org_id = o.id
-          WHERE i.email = ? AND i.status = 'pending'`,
-    args: [ctx.email],
+          WHERE LOWER(i.email) = ? AND i.status = 'pending'`,
+    args: [ctx.email.toLowerCase()],
   });
   const pendingInvitations = invitesRes.rows.map((r: any) => ({
     id: String(r.id),
@@ -278,9 +282,11 @@ export const acceptInvitationHandler = defineEventHandler(
     const e = await exec();
 
     const invRes = await e.execute({
+      // Case-insensitive on email — see comment on the analogous
+      // pending-invitations query in getMyOrgHandler.
       sql: `SELECT id, org_id AS "orgId" FROM org_invitations
-            WHERE id = ? AND email = ? AND status = 'pending' LIMIT 1`,
-      args: [invitationId, email],
+            WHERE id = ? AND LOWER(email) = ? AND status = 'pending' LIMIT 1`,
+      args: [invitationId, email.toLowerCase()],
     });
     if (invRes.rows.length === 0) {
       throw createError({


### PR DESCRIPTION
## Summary

Follow-ups from review on the previously-merged auto-create-default-org work (#294). Each item is a hardening of a specific edge case the prior pass left open.

- **Self-healing claim with TTL.** `acquireClaim` / `releaseClaim` helpers replace the inline INSERT. On collision, the existing claim's `at` timestamp is checked; if older than `CLAIM_TTL_MS` (5 min), it's treated as abandoned and reclaimed. Means a release-DELETE that fails (network blip, DB error, process crash mid-create) no longer permanently strands the user — the next request after the TTL elapses retries cleanly. The fast-path DELETE on org-insert failure stays as a best-effort speedup; the TTL is the correctness guarantee.
- **Pending-invite check moved inside the claim hold.** Previously the window between `hasPendingInvitation()` and the claim INSERT was unprotected — an invite landing in that gap would be missed and the user would get a personal org alongside the invite. The check now happens after the claim is held, so the window collapses to a single SQL round-trip.
- **Case-insensitive email matching** in `getMyOrgHandler` (pending invitations list) and `acceptInvitationHandler` (lookup by email). Both used exact-case matching, so an invitation stored as `Alice@Example.com` wouldn't be discoverable for a session email of `alice@example.com` — the user would land at `RequireActiveOrg` with no visible invite, accept the auto-create instead, and orphan the invitation. Brings them in line with `hasPendingInvitation` in `context.ts` and `accept-pending.ts` which already lower both sides.
- **Revert refetchQueries → invalidateQueries** in the org mutation hooks. The earlier switch was based on a wrong claim that `invalidateQueries` doesn't await refetches; in 