### PR TITLE
fix(core): case-insensitive email matching across remaining org handlers

### DIFF
--- a/packages/core/src/org/handlers.ts
+++ b/packages/core/src/org/handlers.ts
@@ -194,10 +194,13 @@ export const createInvitationHandler = defineEventHandler(
     // Existing rows in org_members / org_invitations may have any case
     // (writes haven't been normalized historically). Compare with LOWER
     // on both sides so an "alice@..." invite check correctly recognizes
-    // an existing "Alice@..." membership.
+    // an existing "Alice@..." membership. `email` is already lowercased
+    // at parse time above, but call .toLowerCase() explicitly here so
+    // the contract at the SQL boundary matches every other handler in
+    // this file.
     const existingMember = await e.execute({
       sql: `SELECT 1 FROM org_members WHERE org_id = ? AND LOWER(email) = ? LIMIT 1`,
-      args: [ctx.orgId, email],
+      args: [ctx.orgId, email.toLowerCase()],
     });
     if (existingMember.rows.length > 0) {
       throw createError({
@@ -208,7 +211,7 @@ export const createInvitationHandler = defineEventHandler(
 
     const existingInvite = await e.execute({
       sql: `SELECT 1 FROM org_invitations WHERE org_id = ? AND LOWER(email) = ? AND status = 'pending' LIMIT 1`,
-      args: [ctx.orgId, email],
+      args: [ctx.orgId, email.toLowerCase()],
     });
     if (existingInvite.rows.length > 0) {
       throw createError({
@@ -360,17 +363,20 @@ export const removeMemberHandler = defineEventHandler(
       throw createError({ statusCode: 400, message: "Email is required" });
     }
 
-    if (memberEmail === ctx.email && ctx.role === "owner") {
+    // memberEmail comes from the URL path verbatim; org_members may
+    // hold the row with any case. LOWER both sides for the lookup AND
+    // the DELETE so removal works regardless of how either side cased
+    // it. The self-removal guard ALSO compares case-insensitively —
+    // otherwise an owner whose email was stored as Alice@... could
+    // remove themselves via the lowercase URL alice@..., bypassing the
+    // guard and leaving the org ownerless.
+    const memberEmailLower = memberEmail.toLowerCase();
+    if (memberEmailLower === ctx.email.toLowerCase() && ctx.role === "owner") {
       throw createError({
         statusCode: 400,
         message: "Organization owner cannot remove themselves",
       });
     }
-
-    // memberEmail comes from the URL path verbatim; org_members may
-    // hold the row with any case. LOWER both sides for the lookup AND
-    // the DELETE so removal works regardless of how either side cased it.
-    const memberEmailLower = memberEmail.toLowerCase();
     const e = await exec();
     const target = await e.execute({
       sql: `SELECT role FROM org_members WHERE org_id = ? AND LOWER(email) = ? LIMIT 1`,

--- a/packages/core/src/org/handlers.ts
+++ b/packages/core/src/org/handlers.ts
@@ -378,11 +378,19 @@ export const removeMemberHandler = defineEventHandler(
       });
     }
     const e = await exec();
-    const target = await e.execute({
-      sql: `SELECT role FROM org_members WHERE org_id = ? AND LOWER(email) = ? LIMIT 1`,
+    // Look specifically for an OWNER row matching this email rather
+    // than just "any matching row". Duplicate-case rows are possible
+    // (e.g. legacy data with both "Alice@..." and "alice@..." in
+    // org_members), and the prior `SELECT role ... LIMIT 1` could
+    // return the non-owner duplicate, pass the role check, and then
+    // the case-insensitive DELETE below would remove BOTH rows —
+    // including the owner — leaving the org ownerless. Querying for
+    // the owner row directly closes that case-mismatch attack.
+    const ownerCheck = await e.execute({
+      sql: `SELECT 1 FROM org_members WHERE org_id = ? AND LOWER(email) = ? AND role = 'owner' LIMIT 1`,
       args: [ctx.orgId, memberEmailLower],
     });
-    if ((target.rows[0] as any)?.role === "owner") {
+    if (ownerCheck.rows.length > 0) {
       throw createError({
         statusCode: 403,
         message: "Cannot remove the organization owner",

--- a/packages/core/src/org/handlers.ts
+++ b/packages/core/src/org/handlers.ts
@@ -191,8 +191,12 @@ export const createInvitationHandler = defineEventHandler(
 
     const e = await exec();
 
+    // Existing rows in org_members / org_invitations may have any case
+    // (writes haven't been normalized historically). Compare with LOWER
+    // on both sides so an "alice@..." invite check correctly recognizes
+    // an existing "Alice@..." membership.
     const existingMember = await e.execute({
-      sql: `SELECT 1 FROM org_members WHERE org_id = ? AND email = ? LIMIT 1`,
+      sql: `SELECT 1 FROM org_members WHERE org_id = ? AND LOWER(email) = ? LIMIT 1`,
       args: [ctx.orgId, email],
     });
     if (existingMember.rows.length > 0) {
@@ -203,7 +207,7 @@ export const createInvitationHandler = defineEventHandler(
     }
 
     const existingInvite = await e.execute({
-      sql: `SELECT 1 FROM org_invitations WHERE org_id = ? AND email = ? AND status = 'pending' LIMIT 1`,
+      sql: `SELECT 1 FROM org_invitations WHERE org_id = ? AND LOWER(email) = ? AND status = 'pending' LIMIT 1`,
       args: [ctx.orgId, email],
     });
     if (existingInvite.rows.length > 0) {
@@ -298,8 +302,8 @@ export const acceptInvitationHandler = defineEventHandler(
     const invOrgId = String(inv.orgId ?? inv.org_id);
 
     const existingMembership = await e.execute({
-      sql: `SELECT role FROM org_members WHERE org_id = ? AND email = ? LIMIT 1`,
-      args: [invOrgId, email],
+      sql: `SELECT role FROM org_members WHERE org_id = ? AND LOWER(email) = ? LIMIT 1`,
+      args: [invOrgId, email.toLowerCase()],
     });
 
     const orgRes = await e.execute({
@@ -363,10 +367,14 @@ export const removeMemberHandler = defineEventHandler(
       });
     }
 
+    // memberEmail comes from the URL path verbatim; org_members may
+    // hold the row with any case. LOWER both sides for the lookup AND
+    // the DELETE so removal works regardless of how either side cased it.
+    const memberEmailLower = memberEmail.toLowerCase();
     const e = await exec();
     const target = await e.execute({
-      sql: `SELECT role FROM org_members WHERE org_id = ? AND email = ? LIMIT 1`,
-      args: [ctx.orgId, memberEmail],
+      sql: `SELECT role FROM org_members WHERE org_id = ? AND LOWER(email) = ? LIMIT 1`,
+      args: [ctx.orgId, memberEmailLower],
     });
     if ((target.rows[0] as any)?.role === "owner") {
       throw createError({
@@ -376,8 +384,8 @@ export const removeMemberHandler = defineEventHandler(
     }
 
     await e.execute({
-      sql: `DELETE FROM org_members WHERE org_id = ? AND email = ?`,
-      args: [ctx.orgId, memberEmail],
+      sql: `DELETE FROM org_members WHERE org_id = ? AND LOWER(email) = ?`,
+      args: [ctx.orgId, memberEmailLower],
     });
 
     return { success: true };
@@ -402,8 +410,8 @@ export const switchOrgHandler = defineEventHandler(async (event: H3Event) => {
     sql: `SELECT m.role AS role, o.name AS "orgName"
           FROM org_members m
           INNER JOIN organizations o ON m.org_id = o.id
-          WHERE m.org_id = ? AND m.email = ? LIMIT 1`,
-    args: [orgId, email],
+          WHERE m.org_id = ? AND LOWER(m.email) = ? LIMIT 1`,
+    args: [orgId, email.toLowerCase()],
   });
 
   if (membership.rows.length === 0) {


### PR DESCRIPTION
## Summary

Sweep of org handlers that still did exact-case email comparisons after the auto-create work (#296) only normalized the read paths it touched directly. Existing rows in `org_members` and `org_invitations` carry whatever case each historical write produced, so any read using exact case can miss a real match. Concrete failure modes the gap allows:

- **`createInvitationHandler`** — re-invite an already-member if the membership row was stored mixed-case; "no pending invite" check misses an existing pending one.
- **`acceptInvitationHandler` membership check** — misses a pre-existing membership and re-INSERTs the user, creating a duplicate `org_members` row.
- **`removeMemberHandler`** — silently fails to remove a mixed-case member; both the role lookup and the DELETE compared exact case.
- **`switchOrgHandler`** — rejects a legitimate switch with "you are not a member" when session email casing differs from the stored membership row.

All read sites now `LOWER(email) = ?` with lowercased args. Writes unchanged in this PR — read normalization is enough to make matching robust regardless of historical write casing; normalizing writes is a separate (data-touching) follow-up.

## Test plan

- [ ] Manually insert a membership row with `Alice@Example.com`. As `alice@example.com`, hit `/switch` for that org → succeeds (was 403 before).
- [ ] Invite `bob@example.com` to two orgs sequentially as `Bob@Example.com` member of one — second invite is correctly rejected as already-member.
- [ ] Remove a mixed-case-stored member via the lowercase URL — the row is deleted (was silent no-op before).
- [ ] Accept an invite for a user who's already a mixed-case member — no duplicate row inserted.