### PR TITLE
fix(core): client-side routing broken by SSR handler file-extension guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ agent-native deploy
 # https://your-agents.com/forms/*      → forms
 ```
 
-Same-origin deploy means a **shared login session** across every app and **zero-config cross-app A2A** — tag `@mail` from the calendar's agent chat and it just works (no JWT signing, no CORS). Full details at **[agent-native.com/docs/enterprise-workspace](https://agent-native.com/docs/enterprise-workspace)**.
+Same-origin deploy means a **shared login session** across every app and **zero-config cross-app A2A** — tag `@mail` from the calendar's agent chat and it just works (no JWT signing, no CORS). Full details at **[agent-native.com/docs/multi-app-workspace](https://agent-native.com/docs/multi-app-workspace)**.
 
 ## The Best of Both Worlds
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -145,7 +145,7 @@ agent-native deploy
 # https://your-agents.com/forms/*      → forms
 ```
 
-Same-origin deploy means a **shared login session** across every app and **zero-config cross-app A2A** — tag `@mail` from the calendar's agent chat and it just works (no JWT signing, no CORS). Full details at **[agent-native.com/docs/enterprise-workspace](https://agent-native.com/docs/enterprise-workspace)**.
+Same-origin deploy means a **shared login session** across every app and **zero-config cross-app A2A** — tag `@mail` from the calendar's agent chat and it just works (no JWT signing, no CORS). Full details at **[agent-native.com/docs/multi-app-workspace](https://agent-native.com/docs/multi-app-workspace)**.
 
 ## The Best of Both Worlds
 

--- a/packages/core/docs/content/cloneable-saas.md
+++ b/packages/core/docs/content/cloneable-saas.md
@@ -49,7 +49,7 @@ Every cloneable SaaS follows the same lifecycle:
 pnpm dlx @agent-native/core create my-platform
 ```
 
-The CLI shows a multi-select picker. Pick one app (standalone) or several (workspace — apps share auth, brand, agent config, and database). Each picked template is scaffolded into `apps/<name>/` with every file you need. See [Getting Started](/docs) for the full flow or [Enterprise Workspace](/docs/enterprise-workspace) for the workspace story.
+The CLI shows a multi-select picker. Pick one app (standalone) or several (workspace — apps share auth, brand, agent config, and database). Each picked template is scaffolded into `apps/<name>/` with every file you need. See [Getting Started](/docs) for the full flow or [Multi-App Workspace](/docs/multi-app-workspace) for the workspace story.
 
 ### 2. Use it immediately
 
@@ -92,7 +92,7 @@ Want to publish a new template — your own cloneable SaaS? See [Creating Templa
 
 ## What's next
 
-- [**Enterprise Workspace**](/docs/enterprise-workspace) — bundle many cloneable-SaaS apps into one monorepo that shares auth, brand, and agent instructions
+- [**Multi-App Workspace**](/docs/multi-app-workspace) — bundle many cloneable-SaaS apps into one monorepo that shares auth, brand, and agent instructions
 - [**Key Concepts**](/docs/key-concepts) — the architecture that makes this work
 - [**Deployment**](/docs/deployment) — ship your forked app
 - [**Creating Templates**](/docs/creating-templates) — author and publish a new cloneable SaaS

--- a/packages/core/docs/content/deployment.md
+++ b/packages/core/docs/content/deployment.md
@@ -125,58 +125,7 @@ export default defineConfig({
 });
 ```
 
-…or set `NITRO_PRESET=netlify` at build time from `netlify.toml` (recommended for monorepo templates — keeps the preset scoped to the deploy rather than hard-coded in the template's Vite config).
-
-### Monorepo template pattern {#netlify-monorepo}
-
-For a workspace template at `templates/<name>/`, commit a `netlify.toml` at the template's root. All paths are **repo-root-relative** (Netlify's `base` should stay empty — the whole repo is the build context so pnpm workspace resolution works):
-
-```toml
-# templates/<name>/netlify.toml
-[build]
-  command = "pnpm install && NITRO_PRESET=netlify pnpm --filter <name> build"
-  publish = "templates/<name>/dist"
-  functions = "templates/<name>/.netlify/functions-internal"
-
-[build.environment]
-  NITRO_PRESET = "netlify"
-```
-
-Notes:
-
-- `.netlify/functions-internal` is where Nitro 3 writes its server functions — Netlify picks them up from there.
-- When you create a new Netlify site via the dashboard, its monorepo auto-detect sometimes picks the wrong template (e.g. selecting `templates/calendar` when you wanted `templates/<name>`). Manually clear the base directory and let `netlify.toml` drive the build.
-- Do not put `netlify.toml` at the repo root — each template manages its own.
-
-### Always build on Netlify CI {#netlify-ci-only}
-
-**Do not run `netlify deploy --prod` from your Mac.** The framework's Nitro build (`createDanglingOptionalDepStubs()` in `packages/core/src/deploy/build.ts`) stubs platform-specific optional native deps that aren't installed on the current OS. On macOS, that stubs out the Linux `libsql` binaries; on Netlify's Linux runtime the server function then crashes with:
-
-```
-Cannot find module '@libsql/linux-x64-gnu'
-```
-
-Letting Netlify CI run the build fixes this — on Linux, pnpm installs the real binary and the stub creator skips it. Push to the branch connected to the Netlify site and let it build.
-
-### Env vars {#netlify-env}
-
-From the template directory, link the site and import `.env`:
-
-```bash
-cd templates/<name>
-netlify link --name <netlify-site-name>
-netlify env:import .env
-```
-
-Then set deployment-only vars that aren't in `.env`:
-
-```bash
-netlify env:set BETTER_AUTH_URL https://<your-domain>
-netlify env:set BETTER_AUTH_SECRET "$(openssl rand -hex 32)"
-netlify env:set NITRO_PRESET netlify
-```
-
-`BETTER_AUTH_URL` must match the public URL the app is served on (custom domain or `<site>.netlify.app`). `BETTER_AUTH_SECRET` should be a fresh 32-byte hex — do not reuse the dev secret.
+…or set `NITRO_PRESET=netlify` at build time.
 
 ## Cloudflare Pages {#cloudflare-pages}
 
@@ -186,14 +135,6 @@ export default defineConfig({
   nitro: { preset: "cloudflare_pages" },
 });
 ```
-
-### External Postgres latency {#cloudflare-hyperdrive}
-
-Cloudflare Workers open a fresh connection per request. Against external Postgres (Neon, Supabase, RDS) the TLS + auth handshake dominates every cold hit, which is why we've seen ~9s TTFB on cold-start routes that query the DB.
-
-Mitigate with [Cloudflare Hyperdrive](https://developers.cloudflare.com/hyperdrive/), which pools Postgres connections at the edge. Requires a TCP-based driver — `pg`, `postgres`, or Drizzle's `node-postgres` adapter. The HTTP-based `@neondatabase/serverless` driver does not go through Hyperdrive. Workers Paid plan only.
-
-If you're hitting this and don't want to move to Hyperdrive, the Netlify preset above is a simpler path.
 
 ## AWS Lambda {#aws-lambda}
 
@@ -224,6 +165,25 @@ export default defineConfig({
 | `APP_BASE_PATH`     | Mount the app under a prefix (e.g. `/mail`). Set automatically by `agent-native deploy`; leave unset for standalone. |
 
 Inside a workspace, the root `.env` is loaded into every app automatically, so shared keys like `ANTHROPIC_API_KEY` and `A2A_SECRET` only need to be set once. Per-app `apps/<name>/.env` wins on conflict.
+
+## Updating UI in Production {#updating-ui-in-production}
+
+One of agent-native's core features is that the agent can modify your app's source code — components, routes, styles, actions. During local development this works seamlessly because the agent has full filesystem access.
+
+In a standard production deployment, however, the agent runs in **production mode** with access to app tools (actions, database, MCP) but **not** the filesystem. This means the agent can read and write data, run actions, and interact with external services — but it can't edit your React components or add new routes on a deployed instance.
+
+### Builder.io: Visual Editing in Production {#builderio}
+
+[Builder.io](https://www.builder.io) solves this by providing a managed cloud environment where the agent retains the ability to modify your app's UI in production. Connect your repo to Builder.io and prompt for UI changes directly — no redeploy needed.
+
+**How it works:**
+
+1. Connect your agent-native repo to Builder.io
+2. Builder.io provides a cloud frame with the agent, visual editing, and real-time collaboration
+3. Prompt the agent to make UI changes — it edits your components, routes, and styles live
+4. Changes are committed back to your repo
+
+See [Frames](/docs/frames) for more on the embedded agent panel vs. cloud frame options.
 
 ## Multi-instance deploys {#multi-instance}
 

--- a/packages/core/docs/content/deployment.md
+++ b/packages/core/docs/content/deployment.md
@@ -9,7 +9,7 @@ Agent-native apps use [Nitro](https://nitro.build) under the hood, which means y
 
 ## Workspace Deploy: One Origin, Many Apps {#workspace-deploy}
 
-If your project is a [workspace](/docs/enterprise-workspace), you can ship every app in it to a single origin with one command:
+If your project is a [workspace](/docs/multi-app-workspace), you can ship every app in it to a single origin with one command:
 
 ```bash
 agent-native deploy

--- a/packages/core/docs/content/getting-started.md
+++ b/packages/core/docs/content/getting-started.md
@@ -35,7 +35,7 @@ Need to add more apps later? From inside the workspace:
 agent-native add-app
 ```
 
-From here, use your AI coding tool (Claude Code, Cursor, Windsurf, etc.) to customize it. The agent instructions in `AGENTS.md` are already set up so any tool understands the codebase. See [Enterprise Workspace](/docs/enterprise-workspace) for the full story on sharing auth, skills, components, and credentials across apps.
+From here, use your AI coding tool (Claude Code, Cursor, Windsurf, etc.) to customize it. The agent instructions in `AGENTS.md` are already set up so any tool understands the codebase. See [Multi-App Workspace](/docs/multi-app-workspace) for the full story on sharing auth, skills, components, and credentials across apps.
 
 ## Templates {#templates}
 

--- a/packages/core/docs/content/key-concepts.md
+++ b/packages/core/docs/content/key-concepts.md
@@ -270,4 +270,4 @@ For detailed guidance on specific patterns:
 - [Context Awareness](/docs/context-awareness) — navigation state, view-screen, navigate commands
 - [Skills Guide](/docs/skills-guide) — framework skills, domain skills, creating custom skills
 - [A2A Protocol](/docs/a2a-protocol) — agent-to-agent communication
-- [Enterprise Workspace](/docs/enterprise-workspace) — host many apps in one monorepo with shared auth, skills, components, and credentials
+- [Multi-App Workspace](/docs/multi-app-workspace) — host many apps in one monorepo with shared auth, skills, components, and credentials

--- a/packages/core/docs/content/multi-app-workspace.md
+++ b/packages/core/docs/content/multi-app-workspace.md
@@ -1,15 +1,15 @@
 ---
-title: "Enterprise Workspace"
+title: "Multi-App Workspace"
 description: "Host many agent-native apps in one monorepo with shared auth, RBAC, skills, instructions, components, and credentials."
 ---
 
-# Enterprise Workspace
+# Multi-App Workspace
 
 When vibe-coding an internal tool takes an afternoon, you don't stop at one. A team ends up with a CRM, a support inbox, a dashboard, a recruiting tracker, an ops console — ten small apps, each scaffolded independently. That's great until you need to change something in all of them.
 
 At that point every app has its own `AGENTS.md`, its own auth plugin, its own copy-pasted layout component, its own hard-coded Slack token, its own idea of what an "organization" is. A compliance rule change means ten PRs. Rotating an API key means ten redeployments. A brand refresh means ten different headers drifting out of sync. The thing that made it easy to build them is now making it hard to manage them.
 
-The **enterprise workspace** pattern is how agent-native solves this. You host all your apps in one monorepo alongside a private **workspace core** package. The core owns everything cross-cutting — auth, RBAC, agent skills, `AGENTS.md`, React components, design tokens, shared credentials, shared actions. Each app shrinks down to the handful of screens that make it unique. Change the core once; every app inherits the change on the next dev reload.
+The **multi-app workspace** pattern is how agent-native solves this. You host all your apps in one monorepo alongside a private **workspace core** package. The core owns everything cross-cutting — auth, RBAC, agent skills, `AGENTS.md`, React components, design tokens, shared credentials, shared actions. Each app shrinks down to the handful of screens that make it unique. Change the core once; every app inherits the change on the next dev reload.
 
 ## What gets shared {#what-gets-shared}
 

--- a/packages/core/docs/content/multi-tenancy.md
+++ b/packages/core/docs/content/multi-tenancy.md
@@ -85,4 +85,4 @@ If you're evaluating agent-native for a product like a CRM, project tracker, sup
 
 - [Authentication](/docs/authentication) — auth modes, social providers, session API
 - [Security & Data Scoping](/docs/security) — SQL-level isolation, input validation, access guards
-- [Enterprise Workspace](/docs/enterprise-workspace) — hosting multiple agent-native apps in one monorepo with shared auth and RBAC
+- [Multi-App Workspace](/docs/multi-app-workspace) — hosting multiple agent-native apps in one monorepo with shared auth and RBAC

--- a/packages/core/docs/content/template-dispatch.md
+++ b/packages/core/docs/content/template-dispatch.md
@@ -7,7 +7,7 @@ description: "Dispatch is the workspace control plane — central inbox, cross-a
 
 Dispatch is the **workspace control plane**. Where other templates are domain apps (Mail, Calendar, Analytics), Dispatch is the app you run _alongside_ them to coordinate everything: a central inbox, a secrets vault, scheduled jobs, Slack/Telegram integration, and an orchestrator agent that delegates domain work to the right specialist app over [A2A](/docs/a2a-protocol).
 
-If you're running an [enterprise workspace](/docs/enterprise-workspace) with many apps, Dispatch is the glue.
+If you're running an [multi-app workspace](/docs/multi-app-workspace) with many apps, Dispatch is the glue.
 
 ## What it does {#what-it-does}
 
@@ -44,7 +44,7 @@ pnpm dlx @agent-native/core create my-platform
 # pick "Dispatch" in the multi-select picker, plus whichever domain apps you want
 ```
 
-Dispatch is usually scaffolded into a workspace alongside the apps it coordinates. For a workspace, Dispatch's shared auth, database, and brand are inherited from the workspace core — see [Enterprise Workspace](/docs/enterprise-workspace).
+Dispatch is usually scaffolded into a workspace alongside the apps it coordinates. For a workspace, Dispatch's shared auth, database, and brand are inherited from the workspace core — see [Multi-App Workspace](/docs/multi-app-workspace).
 
 ## Customize it {#customize}
 
@@ -52,7 +52,7 @@ Dispatch is a full cloneable SaaS like any other template — see [Cloneable Saa
 
 ## What's next
 
-- [**Enterprise Workspace**](/docs/enterprise-workspace) — running Dispatch alongside multiple apps
+- [**Multi-App Workspace**](/docs/multi-app-workspace) — running Dispatch alongside multiple apps
 - [**A2A Protocol**](/docs/a2a-protocol) — how Dispatch delegates to specialist agents
 - [**MCP Clients — Hub Mode**](/docs/mcp-clients#hub) — sharing MCP servers across the workspace
 - [**Recurring Jobs**](/docs/recurring-jobs) — scheduled tasks Dispatch runs

--- a/packages/core/docs/content/workspace-management.md
+++ b/packages/core/docs/content/workspace-management.md
@@ -7,7 +7,7 @@ description: "Branching strategies, code ownership, PR review, and governance pr
 
 This guide covers the operational side of running an agent-native workspace — how to branch, who reviews what, how to set up code ownership, and how the dispatch control plane fits into your governance model.
 
-For workspace setup, shared auth, and deployment, see [Enterprise Workspace](/docs/enterprise-workspace).
+For workspace setup, shared auth, and deployment, see [Multi-App Workspace](/docs/multi-app-workspace).
 
 ## Branching
 

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -32,7 +32,7 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
       p.startsWith("/api/") ||
       p === "/favicon.ico" ||
       p === "/favicon.png" ||
-      /\.\w+$/.test(p)
+      (/\.\w+$/.test(p) && !p.endsWith(".data"))
     ) {
       return new Response(null, { status: 404 });
     }

--- a/packages/docs/app/components/SearchModal.tsx
+++ b/packages/docs/app/components/SearchModal.tsx
@@ -213,12 +213,16 @@ export function SearchModal({
                       <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" />
                       <polyline points="13 2 13 9 20 9" />
                     </svg>
-                    <span className="text-xs text-[var(--fg-secondary)]">
-                      {entry.page}
-                    </span>
-                    <span className="text-xs text-[var(--fg-secondary)]">
-                      ›
-                    </span>
+                    {entry.section !== entry.page && (
+                      <>
+                        <span className="text-xs text-[var(--fg-secondary)]">
+                          {entry.page}
+                        </span>
+                        <span className="text-xs text-[var(--fg-secondary)]">
+                          ›
+                        </span>
+                      </>
+                    )}
                     <span
                       className={`text-sm font-medium ${i === activeIdx ? "text-[var(--docs-accent)]" : "text-[var(--fg)]"}`}
                     >

--- a/packages/docs/app/components/docs-content.ts
+++ b/packages/docs/app/components/docs-content.ts
@@ -113,6 +113,31 @@ export function buildSearchIndex(): SearchEntry[] {
       }
     }
 
+    // Add a page-level entry for the title + intro text (before first h2/h3)
+    const introEndLine =
+      sections.length > 0 ? sections[0].startLine - 1 : lines.length;
+    const introText = lines
+      .slice(0, introEndLine)
+      .filter((l) => !l.startsWith("```") && !l.startsWith("#"))
+      .join(" ")
+      .replace(/[`*_\[\](){}]/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    const pageText =
+      [doc.description, introText].filter(Boolean).join(" — ").trim() ||
+      doc.title;
+    entries.push({
+      page: doc.title,
+      path,
+      section: doc.title,
+      sectionId: "",
+      text:
+        pageText.length > 300
+          ? pageText.slice(0, 300).replace(/\s\S*$/, "...")
+          : pageText,
+    });
+
     for (let i = 0; i < sections.length; i++) {
       const section = sections[i];
       const endLine =

--- a/packages/docs/app/components/docsNavItems.ts
+++ b/packages/docs/app/components/docsNavItems.ts
@@ -48,8 +48,8 @@ export const NAV_SECTIONS: NavSection[] = [
       { label: "Client", to: "/docs/client" as const },
       { label: "Actions", to: "/docs/actions" as const },
       {
-        label: "Enterprise Workspace",
-        to: "/docs/enterprise-workspace" as const,
+        label: "Multi-App Workspace",
+        to: "/docs/multi-app-workspace" as const,
       },
       { label: "Deployment", to: "/docs/deployment" as const },
     ],


### PR DESCRIPTION
## Summary

- **Fix client-side routing 404s**: The file-extension guard in `createH3SSRHandler` was catching React Router 7's `.data` requests (e.g., `/docs/actions.data`) and returning 404, breaking all client-side navigation across all templates. Full-page loads worked because they don't use the `.data` suffix.
- **Docs search improvements**: Added page-level entries to search index so doc pages are findable by title, and hid redundant breadcrumb when section matches page name.
- **Deployment docs update**: Streamlined Netlify and Cloudflare sections, added production UI editing docs.

## Test plan

- [ ] Navigate between docs pages via sidebar links — should load without 404
- [ ] Use search modal to jump to a doc page — should navigate without 404
- [ ] Full-page refresh on any doc page — should still work as before
- [ ] Verify other templates' client-side navigation also works