### PR TITLE
feat(observability): add userId tracking across observability components

### DIFF
--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1177,7 +1177,7 @@ export function createProductionAgentHandler(
               loopOpts: agentLoopOpts,
               runId,
               threadId: threadId ?? null,
-              userId: ownerEmail,
+              userId: ownerEmail || "local@localhost",
               config: obsConfig,
             });
           }

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1177,6 +1177,7 @@ export function createProductionAgentHandler(
               loopOpts: agentLoopOpts,
               runId,
               threadId: threadId ?? null,
+              userId: ownerEmail,
               config: obsConfig,
             });
           }

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -33,9 +33,17 @@ function adaptSqlForSqlite(sql: string): string {
   return sql.replace(/ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS/gi, "ADD COLUMN");
 }
 
-function isDuplicateColumnError(err: unknown): boolean {
+/**
+ * True when an error from `ALTER TABLE ... ADD COLUMN` indicates the
+ * column already existed. Recognizes both SQLite ("duplicate column
+ * name") and Postgres ("column ... already exists" — exact text varies
+ * by error code 42701, but the substring is stable). Exported so other
+ * idempotent column-upgrade loops in the codebase don't reinvent this
+ * regex with subtly different shapes.
+ */
+export function isDuplicateColumnError(err: unknown): boolean {
   const msg = (err as Error | undefined)?.message ?? "";
-  return /duplicate column name/i.test(msg);
+  return /duplicate column name/i.test(msg) || /already exists/i.test(msg);
 }
 
 /**

--- a/packages/core/src/db/migrations.ts
+++ b/packages/core/src/db/migrations.ts
@@ -43,7 +43,9 @@ function adaptSqlForSqlite(sql: string): string {
  */
 export function isDuplicateColumnError(err: unknown): boolean {
   const msg = (err as Error | undefined)?.message ?? "";
-  return /duplicate column name/i.test(msg) || /already exists/i.test(msg);
+  return (
+    /duplicate column name/i.test(msg) || /column .* already exists/i.test(msg)
+  );
 }
 
 /**

--- a/packages/core/src/observability/evals.ts
+++ b/packages/core/src/observability/evals.ts
@@ -476,11 +476,7 @@ export async function evaluateRun(
   opts?: { sampleRate?: number },
 ): Promise<EvalResult[]> {
   const results = await runAutomatedEvals(runId);
-  let userId = results[0]?.userId ?? null;
-  if (userId == null) {
-    const summary = await getTraceSummary(runId);
-    userId = summary?.userId ?? null;
-  }
+  const userId = results[0]?.userId ?? null;
 
   const sampleRate = opts?.sampleRate ?? 0;
   if (sampleRate > 0 && Math.random() < sampleRate) {

--- a/packages/core/src/observability/evals.ts
+++ b/packages/core/src/observability/evals.ts
@@ -16,25 +16,39 @@ const LATENCY_BASELINE_PER_TOOL_MS = 10_000;
 const COST_BASELINE_PER_TOOL_CX100 = 50;
 const LLM_JUDGE_TIMEOUT_MS = 30_000;
 
-function makeEvalResult(
-  runId: string,
-  threadId: string | null,
-  evalType: EvalResult["evalType"],
-  criteria: string,
-  score: number,
-  reasoning: string | null = null,
-  metadata: Record<string, unknown> | null = null,
-): EvalResult {
+interface MakeEvalResultOpts {
+  runId: string;
+  threadId: string | null;
+  userId: string | null;
+  evalType: EvalResult["evalType"];
+  criteria: string;
+  score: number;
+  reasoning?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+function makeEvalResult(opts: MakeEvalResultOpts): EvalResult {
   return {
     id: crypto.randomUUID(),
-    runId,
-    threadId,
-    evalType,
-    criteria,
-    score: Math.max(0, Math.min(1, score)),
-    reasoning,
-    metadata,
+    runId: opts.runId,
+    threadId: opts.threadId,
+    userId: opts.userId,
+    evalType: opts.evalType,
+    criteria: opts.criteria,
+    score: Math.max(0, Math.min(1, opts.score)),
+    reasoning: opts.reasoning ?? null,
+    metadata: opts.metadata ?? null,
     createdAt: Date.now(),
+  };
+}
+
+/** Lift the (runId, threadId, userId) triple off a TraceSummary —
+ *  every automated scorer pulls these together. */
+function fromSummary(summary: TraceSummary) {
+  return {
+    runId: summary.runId,
+    threadId: summary.threadId,
+    userId: summary.userId,
   };
 }
 
@@ -43,19 +57,17 @@ function makeEvalResult(
 function scoreToolSuccessRate(summary: TraceSummary): EvalResult {
   const total = summary.toolCalls;
   const score = total > 0 ? summary.successfulTools / total : 1.0;
-  return makeEvalResult(
-    summary.runId,
-    summary.threadId,
-    "automated",
-    "tool_success_rate",
+  return makeEvalResult({
+    ...fromSummary(summary),
+    evalType: "automated",
+    criteria: "tool_success_rate",
     score,
-    null,
-    {
+    metadata: {
       totalTools: total,
       successfulTools: summary.successfulTools,
       failedTools: summary.failedTools,
     },
-  );
+  });
 }
 
 function scoreStepEfficiency(summary: TraceSummary): EvalResult {
@@ -67,15 +79,13 @@ function scoreStepEfficiency(summary: TraceSummary): EvalResult {
       : summary.llmCalls > 0
         ? Math.min(1, summary.toolCalls / summary.llmCalls)
         : 1.0;
-  return makeEvalResult(
-    summary.runId,
-    summary.threadId,
-    "automated",
-    "step_efficiency",
+  return makeEvalResult({
+    ...fromSummary(summary),
+    evalType: "automated",
+    criteria: "step_efficiency",
     score,
-    null,
-    { llmCalls: summary.llmCalls, toolCalls: summary.toolCalls },
-  );
+    metadata: { llmCalls: summary.llmCalls, toolCalls: summary.toolCalls },
+  });
 }
 
 function scoreLatency(summary: TraceSummary): EvalResult {
@@ -84,15 +94,13 @@ function scoreLatency(summary: TraceSummary): EvalResult {
     summary.toolCalls * LATENCY_BASELINE_PER_TOOL_MS,
   );
   const score = Math.max(0, 1 - summary.totalDurationMs / expectedMs);
-  return makeEvalResult(
-    summary.runId,
-    summary.threadId,
-    "automated",
-    "latency_score",
+  return makeEvalResult({
+    ...fromSummary(summary),
+    evalType: "automated",
+    criteria: "latency_score",
     score,
-    null,
-    { actualMs: summary.totalDurationMs, expectedMs },
-  );
+    metadata: { actualMs: summary.totalDurationMs, expectedMs },
+  });
 }
 
 function scoreCostEfficiency(summary: TraceSummary): EvalResult {
@@ -101,15 +109,13 @@ function scoreCostEfficiency(summary: TraceSummary): EvalResult {
     summary.toolCalls * COST_BASELINE_PER_TOOL_CX100,
   );
   const score = Math.max(0, 1 - summary.totalCostCentsX100 / expectedCx100);
-  return makeEvalResult(
-    summary.runId,
-    summary.threadId,
-    "automated",
-    "cost_efficiency",
+  return makeEvalResult({
+    ...fromSummary(summary),
+    evalType: "automated",
+    criteria: "cost_efficiency",
     score,
-    null,
-    { actualCx100: summary.totalCostCentsX100, expectedCx100 },
-  );
+    metadata: { actualCx100: summary.totalCostCentsX100, expectedCx100 },
+  });
 }
 
 function scoreErrorRecovery(
@@ -125,15 +131,13 @@ function scoreErrorRecovery(
   } else {
     score = 0;
   }
-  return makeEvalResult(
-    summary.runId,
-    summary.threadId,
-    "automated",
-    "error_recovery",
+  return makeEvalResult({
+    ...fromSummary(summary),
+    evalType: "automated",
+    criteria: "error_recovery",
     score,
-    null,
-    { hadErrors, runStatus },
-  );
+    metadata: { hadErrors, runStatus },
+  });
 }
 
 export async function runAutomatedEvals(runId: string): Promise<EvalResult[]> {
@@ -220,7 +224,7 @@ Evaluate the conversation and respond with ONLY a JSON object (no markdown, no e
 export async function runLlmJudgeEval(
   runId: string,
   criteria: EvalCriteria,
-  opts?: { engine?: AgentEngine; model?: string },
+  opts?: { engine?: AgentEngine; model?: string; userId?: string | null },
 ): Promise<EvalResult | null> {
   try {
     const [events, run] = await Promise.all([
@@ -282,15 +286,16 @@ export async function runLlmJudgeEval(
     const normalizedScore =
       max > min ? (parsed.score - min) / (max - min) : parsed.score;
 
-    const result = makeEvalResult(
+    const result = makeEvalResult({
       runId,
-      run?.threadId ?? null,
-      "llm_judge",
-      criteria.name,
-      normalizedScore,
-      parsed.reasoning,
-      { model, rawScore: parsed.score, scoreRange: { min, max } },
-    );
+      threadId: run?.threadId ?? null,
+      userId: opts?.userId ?? null,
+      evalType: "llm_judge",
+      criteria: criteria.name,
+      score: normalizedScore,
+      reasoning: parsed.reasoning,
+      metadata: { model, rawScore: parsed.score, scoreRange: { min, max } },
+    });
 
     insertEvalResult(result).catch(() => {});
     return result;
@@ -430,14 +435,19 @@ async function evaluateTestCase(
     // Dataset evals use a synthetic runId since there's no real run
     const syntheticRunId = `dataset:${datasetId}:${crypto.randomUUID()}`;
 
-    const result = makeEvalResult(
-      syntheticRunId,
-      null,
-      "llm_judge",
-      criteria.name,
-      normalizedScore,
-      parsed.reasoning,
-      {
+    // Dataset evals are administrative — there's no per-user runId, so
+    // we leave userId null. Per-user reads filter null rows out, which
+    // is the right default; admins can fetch dataset evals via the
+    // unfiltered call path.
+    const result = makeEvalResult({
+      runId: syntheticRunId,
+      threadId: null,
+      userId: null,
+      evalType: "llm_judge",
+      criteria: criteria.name,
+      score: normalizedScore,
+      reasoning: parsed.reasoning,
+      metadata: {
         datasetId,
         model,
         testCaseInput: testCase.input,
@@ -446,7 +456,7 @@ async function evaluateTestCase(
         rawScore: parsed.score,
         scoreRange: { min, max },
       },
-    );
+    });
 
     insertEvalResult(result).catch(() => {});
     return result;
@@ -462,6 +472,11 @@ export async function evaluateRun(
   opts?: { sampleRate?: number },
 ): Promise<EvalResult[]> {
   const results = await runAutomatedEvals(runId);
+  // The automated scorers already stamped each result with the same
+  // userId pulled from the trace summary. Reusing it here avoids a
+  // redundant `getTraceSummary` lookup on every turn (the LLM-judge
+  // path is sample-gated; the lookup wasn't).
+  const userId = results[0]?.userId ?? null;
 
   const sampleRate = opts?.sampleRate ?? 0;
   if (sampleRate > 0 && Math.random() < sampleRate) {
@@ -479,7 +494,7 @@ export async function evaluateRun(
     ];
 
     const judgeResults = await Promise.all(
-      defaultCriteria.map((c) => runLlmJudgeEval(runId, c)),
+      defaultCriteria.map((c) => runLlmJudgeEval(runId, c, { userId })),
     );
 
     for (const r of judgeResults) {

--- a/packages/core/src/observability/evals.ts
+++ b/packages/core/src/observability/evals.ts
@@ -44,7 +44,11 @@ function makeEvalResult(opts: MakeEvalResultOpts): EvalResult {
 
 /** Lift the (runId, threadId, userId) triple off a TraceSummary —
  *  every automated scorer pulls these together. */
-function fromSummary(summary: TraceSummary) {
+function fromSummary(summary: TraceSummary): {
+  runId: string;
+  threadId: string | null;
+  userId: string | null;
+} {
   return {
     runId: summary.runId,
     threadId: summary.threadId,
@@ -472,11 +476,11 @@ export async function evaluateRun(
   opts?: { sampleRate?: number },
 ): Promise<EvalResult[]> {
   const results = await runAutomatedEvals(runId);
-  // The automated scorers already stamped each result with the same
-  // userId pulled from the trace summary. Reusing it here avoids a
-  // redundant `getTraceSummary` lookup on every turn (the LLM-judge
-  // path is sample-gated; the lookup wasn't).
-  const userId = results[0]?.userId ?? null;
+  let userId = results[0]?.userId ?? null;
+  if (userId == null) {
+    const summary = await getTraceSummary(runId);
+    userId = summary?.userId ?? null;
+  }
 
   const sampleRate = opts?.sampleRate ?? 0;
   if (sampleRate > 0 && Math.random() < sampleRate) {

--- a/packages/core/src/observability/feedback.ts
+++ b/packages/core/src/observability/feedback.ts
@@ -289,6 +289,7 @@ function computeRetryScore(userMessages: string[]): number {
 
 export async function computeSatisfactionScore(
   threadId: string,
+  opts: { userId?: string | null } = {},
 ): Promise<SatisfactionScore> {
   const messages = await getThreadMessages(threadId);
   const userMessages = messages
@@ -314,6 +315,7 @@ export async function computeSatisfactionScore(
   const score: SatisfactionScore = {
     id: `sat-${threadId}`,
     threadId,
+    userId: opts.userId ?? null,
     frustrationScore: Math.round(frustrationScore * 100) / 100,
     rephrasingScore: Math.round(rephrasingScore * 100) / 100,
     abandonmentScore: Math.round(abandonmentScore * 100) / 100,

--- a/packages/core/src/observability/routes.ts
+++ b/packages/core/src/observability/routes.ts
@@ -101,11 +101,14 @@ export function createObservabilityHandler() {
       }
     }
 
+    // Every read endpoint passes `userId: owner` to the store. Omitting
+    // it returns rows from every user — load-bearing.
+
     // GET / — overview stats
     if (method === "GET" && parts.length === 0) {
       const q = getQuery(event);
       const sinceMs = parseSince(q);
-      return getObservabilityOverview(sinceMs);
+      return getObservabilityOverview(sinceMs, { userId: owner });
     }
 
     // GET /traces — list trace summaries
@@ -114,6 +117,7 @@ export function createObservabilityHandler() {
       return getTraceSummaries({
         sinceMs: parseSince(q),
         limit: parseLimit(q),
+        userId: owner,
       });
     }
 
@@ -124,15 +128,19 @@ export function createObservabilityHandler() {
       parts[0] === "traces" &&
       parts[2] === "evals"
     ) {
-      return getEvalsForRun(decodeURIComponent(parts[1]));
+      return getEvalsForRun(decodeURIComponent(parts[1]), { userId: owner });
     }
 
-    // GET /traces/:runId — trace detail (summary + spans)
+    // GET /traces/:runId — trace detail (summary + spans). Looking up by
+    // runId opens an IDOR vector if we don't ALSO scope to the owner —
+    // a user who knows or guesses another user's runId would otherwise
+    // get back the trace. The `userId: owner` filter on both lookups
+    // returns 404 instead.
     if (method === "GET" && parts.length === 2 && parts[0] === "traces") {
       const runId = decodeURIComponent(parts[1]);
       const [summary, spans] = await Promise.all([
-        getTraceSummary(runId),
-        getTraceSpansForRun(runId),
+        getTraceSummary(runId, { userId: owner }),
+        getTraceSpansForRun(runId, { userId: owner }),
       ]);
       if (!summary) {
         setResponseStatus(event, 404);
@@ -149,7 +157,7 @@ export function createObservabilityHandler() {
       parts[1] === "stats"
     ) {
       const q = getQuery(event);
-      return getFeedbackStats(parseSince(q));
+      return getFeedbackStats(parseSince(q), { userId: owner });
     }
 
     // POST /feedback — submit feedback
@@ -188,11 +196,13 @@ export function createObservabilityHandler() {
         userId: owner,
         createdAt: Date.now(),
       });
-      // Fire-and-forget: recompute satisfaction score for the thread
+      // Fire-and-forget: recompute satisfaction score for the thread.
       if (body.threadId) {
         import("./feedback.js")
           .then(({ computeSatisfactionScore }) =>
-            computeSatisfactionScore(String(body.threadId)).catch(() => {}),
+            computeSatisfactionScore(String(body.threadId), {
+              userId: owner,
+            }).catch(() => {}),
           )
           .catch(() => {});
       }
@@ -205,13 +215,17 @@ export function createObservabilityHandler() {
       return getFeedback({
         sinceMs: parseSince(q),
         limit: parseLimit(q),
+        userId: owner,
       });
     }
 
     // GET /satisfaction — satisfaction scores
     if (method === "GET" && parts.length === 1 && parts[0] === "satisfaction") {
       const q = getQuery(event);
-      return getSatisfactionScores({ sinceMs: parseSince(q) });
+      return getSatisfactionScores({
+        sinceMs: parseSince(q),
+        userId: owner,
+      });
     }
 
     // GET /evals/stats — eval stats
@@ -222,7 +236,7 @@ export function createObservabilityHandler() {
       parts[1] === "stats"
     ) {
       const q = getQuery(event);
-      return getEvalStats(parseSince(q));
+      return getEvalStats(parseSince(q), { userId: owner });
     }
 
     // POST /experiments — create experiment

--- a/packages/core/src/observability/routes.ts
+++ b/packages/core/src/observability/routes.ts
@@ -272,6 +272,11 @@ export function createObservabilityHandler() {
       return { id };
     }
 
+    // Experiments are platform-wide A/B test configurations — they assign
+    // variants across all users, so reads are NOT per-user scoped. Writes
+    // are gated by authentication above (only authenticated users or
+    // local-dev can reach this point).
+
     // GET /experiments — list experiments
     if (method === "GET" && parts.length === 1 && parts[0] === "experiments") {
       return listExperiments();

--- a/packages/core/src/observability/store.spec.ts
+++ b/packages/core/src/observability/store.spec.ts
@@ -206,7 +206,7 @@ describe("observability store: per-user isolation", () => {
         createdAt: 1,
       });
       const call = execCalls.find((c) =>
-        /INSERT (OR REPLACE )?INTO agent_trace_summaries/.test(c.sql),
+        /INSERT\s+(OR REPLACE\s+)?INTO agent_trace_summaries/.test(c.sql),
       );
       expect(call).toBeDefined();
       expect(call!.sql).toMatch(/\buser_id\b/);
@@ -226,9 +226,7 @@ describe("observability store: per-user isolation", () => {
         metadata: null,
         createdAt: 1,
       });
-      const call = execCalls.find((c) =>
-        /INSERT INTO agent_evals/.test(c.sql),
-      );
+      const call = execCalls.find((c) => /INSERT INTO agent_evals/.test(c.sql));
       expect(call).toBeDefined();
       expect(call!.sql).toMatch(/\buser_id\b/);
       expect(call!.args).toContain("alice");

--- a/packages/core/src/observability/store.spec.ts
+++ b/packages/core/src/observability/store.spec.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Capture every SQL string + bound args the store sends to the DB so we
+// can assert that user-scoped reads include `user_id = ?` and that the
+// owner identifier reaches the binding. We don't simulate real SQL
+// execution — the goal here is to verify that the data-isolation
+// contract is upheld at the query-construction layer.
+interface ExecCall {
+  sql: string;
+  args: any[];
+}
+
+const execCalls: ExecCall[] = [];
+
+function createCapturingDb() {
+  return {
+    execute: vi.fn(async (sql: string | { sql: string; args?: any[] }) => {
+      const rawSql = typeof sql === "string" ? sql : sql.sql;
+      const args = typeof sql === "string" ? [] : (sql.args ?? []);
+      execCalls.push({ sql: rawSql, args });
+      // Most calls just need to "succeed" with empty rows. SELECTs in this
+      // store return an array shape; provide one to keep the mappers happy.
+      return { rows: [], rowsAffected: 0 };
+    }),
+  };
+}
+
+const mockDb = createCapturingDb();
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => mockDb,
+  isPostgres: () => false,
+  intType: () => "INTEGER",
+}));
+
+// Pull the store after the mock is wired so it picks up the capturing db.
+const {
+  getTraceSummaries,
+  getTraceSummary,
+  getTraceSpansForRun,
+  getFeedback,
+  getFeedbackStats,
+  getSatisfactionScores,
+  getEvalsForRun,
+  getEvalStats,
+  getObservabilityOverview,
+  insertTraceSpan,
+  insertEvalResult,
+  insertFeedback,
+  upsertTraceSummary,
+  upsertSatisfactionScore,
+} = await import("./store.js");
+
+function lastSelect(): ExecCall {
+  // Skip CREATE/ALTER/INDEX init calls; return the most recent SELECT.
+  const selects = execCalls.filter((c) => /^\s*SELECT\b/i.test(c.sql));
+  if (selects.length === 0) throw new Error("no SELECT was executed");
+  return selects[selects.length - 1];
+}
+
+describe("observability store: per-user isolation", () => {
+  beforeEach(() => {
+    execCalls.length = 0;
+    vi.clearAllMocks();
+  });
+
+  describe("read filtering", () => {
+    it("getTraceSummaries adds user_id filter when userId is provided", async () => {
+      await getTraceSummaries({ sinceMs: 1000, limit: 50, userId: "alice" });
+      const call = lastSelect();
+      expect(call.sql).toMatch(/WHERE created_at >= \? AND user_id = \?/);
+      expect(call.args).toEqual([1000, "alice", 50]);
+    });
+
+    it("getTraceSummaries omits user_id filter when userId is undefined", async () => {
+      // Internal callers (background reports, admin tools) can pass no
+      // filter to read across all users. The omission must produce a
+      // SELECT without a `user_id =` clause — load-bearing for any
+      // future callers that intentionally want unfiltered reads.
+      await getTraceSummaries({ sinceMs: 1000, limit: 50 });
+      const call = lastSelect();
+      expect(call.sql).not.toMatch(/user_id/);
+      expect(call.args).toEqual([1000, 50]);
+    });
+
+    it("getTraceSummary scopes by user_id (prevents IDOR by runId)", async () => {
+      await getTraceSummary("run-from-other-user", { userId: "alice" });
+      const call = lastSelect();
+      expect(call.sql).toMatch(/WHERE run_id = \? AND user_id = \?/);
+      expect(call.args).toEqual(["run-from-other-user", "alice"]);
+    });
+
+    it("getTraceSpansForRun scopes by user_id (prevents IDOR)", async () => {
+      await getTraceSpansForRun("run-x", { userId: "alice" });
+      const call = lastSelect();
+      expect(call.sql).toMatch(/WHERE run_id = \? AND user_id = \?/);
+      expect(call.args).toEqual(["run-x", "alice"]);
+    });
+
+    it("getFeedback adds user_id filter when userId is provided", async () => {
+      await getFeedback({ sinceMs: 500, limit: 20, userId: "bob" });
+      const call = lastSelect();
+      expect(call.sql).toMatch(/user_id = \?/);
+      expect(call.args).toEqual([500, "bob", 20]);
+    });
+
+    it("getFeedbackStats scopes aggregations to userId", async () => {
+      await getFeedbackStats(2000, { userId: "carol" });
+      const call = lastSelect();
+      expect(call.sql).toMatch(/WHERE created_at >= \? AND user_id = \?/);
+      expect(call.args).toEqual([2000, "carol"]);
+    });
+
+    it("getSatisfactionScores adds user_id filter when userId is provided", async () => {
+      await getSatisfactionScores({ sinceMs: 100, userId: "dave" });
+      const call = lastSelect();
+      expect(call.sql).toMatch(/user_id = \?/);
+      expect(call.args).toEqual([100, "dave", 100]);
+    });
+
+    it("getEvalsForRun scopes by user_id (prevents IDOR)", async () => {
+      await getEvalsForRun("run-x", { userId: "alice" });
+      const call = lastSelect();
+      expect(call.sql).toMatch(/WHERE run_id = \? AND user_id = \?/);
+      expect(call.args).toEqual(["run-x", "alice"]);
+    });
+
+    it("getEvalStats applies user_id to BOTH sub-queries", async () => {
+      await getEvalStats(3000, { userId: "alice" });
+      // getEvalStats fires two SELECTs (totals + per-criteria); both must
+      // carry the user filter, otherwise the per-criteria breakdown leaks
+      // other users' eval data while only the totals are scoped.
+      const selects = execCalls.filter((c) => /^\s*SELECT\b/i.test(c.sql));
+      expect(selects.length).toBe(2);
+      for (const s of selects) {
+        expect(s.sql).toMatch(/user_id = \?/);
+        expect(s.args).toEqual([3000, "alice"]);
+      }
+    });
+
+    it("getObservabilityOverview applies user_id to ALL four sub-queries", async () => {
+      await getObservabilityOverview(4000, { userId: "alice" });
+      const selects = execCalls.filter((c) => /^\s*SELECT\b/i.test(c.sql));
+      expect(selects.length).toBe(4);
+      for (const s of selects) {
+        expect(s.sql).toMatch(/AND user_id = \?/);
+        expect(s.args).toEqual([4000, "alice"]);
+      }
+    });
+
+    it("getObservabilityOverview without userId leaves all four sub-queries unfiltered", async () => {
+      await getObservabilityOverview(4000);
+      const selects = execCalls.filter((c) => /^\s*SELECT\b/i.test(c.sql));
+      expect(selects.length).toBe(4);
+      for (const s of selects) {
+        expect(s.sql).not.toMatch(/user_id/);
+        expect(s.args).toEqual([4000]);
+      }
+    });
+  });
+
+  describe("write capture", () => {
+    it("insertTraceSpan persists user_id alongside the span", async () => {
+      await insertTraceSpan({
+        id: "s1",
+        runId: "r1",
+        threadId: "t1",
+        userId: "alice",
+        parentSpanId: null,
+        spanType: "agent_run",
+        name: "n",
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        costCentsX100: 0,
+        durationMs: 0,
+        status: "success",
+        errorMessage: null,
+        metadata: null,
+        createdAt: 1,
+      });
+      const call = execCalls.find((c) =>
+        /INSERT INTO agent_trace_spans/.test(c.sql),
+      );
+      expect(call).toBeDefined();
+      expect(call!.sql).toMatch(/\buser_id\b/);
+      expect(call!.args).toContain("alice");
+    });
+
+    it("upsertTraceSummary persists user_id (covers SQLite REPLACE branch)", async () => {
+      await upsertTraceSummary({
+        runId: "r1",
+        threadId: "t1",
+        userId: "alice",
+        totalSpans: 1,
+        llmCalls: 1,
+        toolCalls: 0,
+        successfulTools: 0,
+        failedTools: 0,
+        totalDurationMs: 0,
+        totalCostCentsX100: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        model: "m",
+        createdAt: 1,
+      });
+      const call = execCalls.find((c) =>
+        /INSERT (OR REPLACE )?INTO agent_trace_summaries/.test(c.sql),
+      );
+      expect(call).toBeDefined();
+      expect(call!.sql).toMatch(/\buser_id\b/);
+      expect(call!.args).toContain("alice");
+    });
+
+    it("insertEvalResult persists user_id", async () => {
+      await insertEvalResult({
+        id: "e1",
+        runId: "r1",
+        threadId: "t1",
+        userId: "alice",
+        evalType: "automated",
+        criteria: "c",
+        score: 0.5,
+        reasoning: null,
+        metadata: null,
+        createdAt: 1,
+      });
+      const call = execCalls.find((c) =>
+        /INSERT INTO agent_evals/.test(c.sql),
+      );
+      expect(call).toBeDefined();
+      expect(call!.sql).toMatch(/\buser_id\b/);
+      expect(call!.args).toContain("alice");
+    });
+
+    it("upsertSatisfactionScore persists user_id", async () => {
+      await upsertSatisfactionScore({
+        id: "sat-t1",
+        threadId: "t1",
+        userId: "alice",
+        frustrationScore: 0,
+        rephrasingScore: 0,
+        abandonmentScore: 0,
+        sentimentScore: 0,
+        lengthTrendScore: 0,
+        computedAt: 1,
+      });
+      const call = execCalls.find((c) =>
+        /INSERT (OR REPLACE )?INTO agent_satisfaction_scores/.test(c.sql),
+      );
+      expect(call).toBeDefined();
+      expect(call!.sql).toMatch(/\buser_id\b/);
+      expect(call!.args).toContain("alice");
+    });
+
+    it("insertFeedback already wrote user_id (regression guard)", async () => {
+      await insertFeedback({
+        id: "f1",
+        runId: null,
+        threadId: "t1",
+        messageSeq: null,
+        feedbackType: "thumbs_up",
+        value: "",
+        userId: "alice",
+        createdAt: 1,
+      });
+      const call = execCalls.find((c) =>
+        /INSERT INTO agent_feedback/.test(c.sql),
+      );
+      expect(call).toBeDefined();
+      expect(call!.args).toContain("alice");
+    });
+  });
+});

--- a/packages/core/src/observability/store.ts
+++ b/packages/core/src/observability/store.ts
@@ -38,6 +38,7 @@ const USER_SCOPED_TABLES = [
   "agent_trace_summaries",
   "agent_satisfaction_scores",
   "agent_evals",
+  "agent_feedback",
 ] as const;
 
 /**
@@ -50,7 +51,7 @@ function withUserFilter(
   baseArgs: any[],
   userId: string | undefined,
 ): { where: string; args: any[] } {
-  if (!userId) return { where: baseWhere, args: baseArgs };
+  if (userId == null) return { where: baseWhere, args: baseArgs };
   return {
     where: `${baseWhere} AND user_id = ?`,
     args: [...baseArgs, userId],
@@ -202,9 +203,7 @@ export async function ensureObservabilityTables(): Promise<void> {
       // (from db/migrations.ts) recognizes both shapes.
       for (const table of USER_SCOPED_TABLES) {
         try {
-          await client.execute(
-            `ALTER TABLE ${table} ADD COLUMN user_id TEXT`,
-          );
+          await client.execute(`ALTER TABLE ${table} ADD COLUMN user_id TEXT`);
         } catch (err) {
           if (isDuplicateColumnError(err)) continue;
           throw err;
@@ -320,12 +319,23 @@ export async function upsertTraceSummary(summary: TraceSummary): Promise<void> {
     });
   } else {
     await client.execute({
-      sql: `INSERT OR REPLACE INTO agent_trace_summaries
+      sql: `INSERT INTO agent_trace_summaries
         (run_id, thread_id, user_id, total_spans, llm_calls, tool_calls,
          successful_tools, failed_tools, total_duration_ms,
          total_cost_cents_x100, total_input_tokens, total_output_tokens,
          model, created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (run_id) DO UPDATE SET
+          total_spans = EXCLUDED.total_spans,
+          llm_calls = EXCLUDED.llm_calls,
+          tool_calls = EXCLUDED.tool_calls,
+          successful_tools = EXCLUDED.successful_tools,
+          failed_tools = EXCLUDED.failed_tools,
+          total_duration_ms = EXCLUDED.total_duration_ms,
+          total_cost_cents_x100 = EXCLUDED.total_cost_cents_x100,
+          total_input_tokens = EXCLUDED.total_input_tokens,
+          total_output_tokens = EXCLUDED.total_output_tokens,
+          model = EXCLUDED.model`,
       args: [
         summary.runId,
         summary.threadId,
@@ -945,24 +955,24 @@ export async function getObservabilityOverview(
           COALESCE(SUM(successful_tools), 0) as success_tools,
           COALESCE(SUM(tool_calls), 0) as total_tools
           FROM agent_trace_summaries WHERE ${created.where}`,
-        args: [...created.args],
+        args: created.args,
       }),
       client.execute({
         sql: `SELECT COALESCE(AVG(frustration_score), 0) as avg_frustration
           FROM agent_satisfaction_scores WHERE ${computed.where}`,
-        args: [...computed.args],
+        args: computed.args,
       }),
       client.execute({
         sql: `SELECT
           COALESCE(SUM(CASE WHEN feedback_type = 'thumbs_up' THEN 1 ELSE 0 END), 0) as up,
           COALESCE(SUM(CASE WHEN feedback_type IN ('thumbs_up', 'thumbs_down') THEN 1 ELSE 0 END), 0) as total
           FROM agent_feedback WHERE ${created.where}`,
-        args: [...created.args],
+        args: created.args,
       }),
       client.execute({
         sql: `SELECT COALESCE(AVG(score), 0) as avg_score
           FROM agent_evals WHERE ${created.where}`,
-        args: [...created.args],
+        args: created.args,
       }),
     ]);
 

--- a/packages/core/src/observability/store.ts
+++ b/packages/core/src/observability/store.ts
@@ -539,10 +539,17 @@ export async function upsertSatisfactionScore(
     });
   } else {
     await client.execute({
-      sql: `INSERT OR REPLACE INTO agent_satisfaction_scores
+      sql: `INSERT INTO agent_satisfaction_scores
         (id, thread_id, user_id, frustration_score, rephrasing_score,
          abandonment_score, sentiment_score, length_trend_score, computed_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (id) DO UPDATE SET
+          frustration_score = EXCLUDED.frustration_score,
+          rephrasing_score = EXCLUDED.rephrasing_score,
+          abandonment_score = EXCLUDED.abandonment_score,
+          sentiment_score = EXCLUDED.sentiment_score,
+          length_trend_score = EXCLUDED.length_trend_score,
+          computed_at = EXCLUDED.computed_at`,
       args: [
         score.id,
         score.threadId,

--- a/packages/core/src/observability/store.ts
+++ b/packages/core/src/observability/store.ts
@@ -7,6 +7,7 @@
  * rather than Drizzle ORM (which is for template-level schemas).
  */
 import { getDbExec, intType, isPostgres } from "../db/client.js";
+import { isDuplicateColumnError } from "../db/migrations.js";
 import type {
   TraceSpan,
   TraceSummary,
@@ -28,6 +29,34 @@ function safeJsonParse<T>(value: unknown, fallback: T): T {
   }
 }
 
+// Tables whose rows are owned by an end user — drives the boot-time
+// user_id ALTER loop and the per-user composite indexes below. Every
+// new user-owned observability table must be added here so the upgrade
+// path and the per-user query plan stay in sync.
+const USER_SCOPED_TABLES = [
+  "agent_trace_spans",
+  "agent_trace_summaries",
+  "agent_satisfaction_scores",
+  "agent_evals",
+] as const;
+
+/**
+ * Append an `AND user_id = ?` clause when a userId filter is requested.
+ * Returns the fully-bound WHERE clause + args ready to splice into the
+ * caller's SQL. Centralizes the pattern so tests can assert one shape.
+ */
+function withUserFilter(
+  baseWhere: string,
+  baseArgs: any[],
+  userId: string | undefined,
+): { where: string; args: any[] } {
+  if (!userId) return { where: baseWhere, args: baseArgs };
+  return {
+    where: `${baseWhere} AND user_id = ?`,
+    args: [...baseArgs, userId],
+  };
+}
+
 let _initPromise: Promise<void> | undefined;
 
 export async function ensureObservabilityTables(): Promise<void> {
@@ -40,6 +69,7 @@ export async function ensureObservabilityTables(): Promise<void> {
           id TEXT PRIMARY KEY,
           run_id TEXT NOT NULL,
           thread_id TEXT,
+          user_id TEXT,
           parent_span_id TEXT,
           span_type TEXT NOT NULL,
           name TEXT NOT NULL,
@@ -60,6 +90,7 @@ export async function ensureObservabilityTables(): Promise<void> {
         CREATE TABLE IF NOT EXISTS agent_trace_summaries (
           run_id TEXT PRIMARY KEY,
           thread_id TEXT,
+          user_id TEXT,
           total_spans ${intType()} NOT NULL DEFAULT 0,
           llm_calls ${intType()} NOT NULL DEFAULT 0,
           tool_calls ${intType()} NOT NULL DEFAULT 0,
@@ -91,6 +122,7 @@ export async function ensureObservabilityTables(): Promise<void> {
         CREATE TABLE IF NOT EXISTS agent_satisfaction_scores (
           id TEXT PRIMARY KEY,
           thread_id TEXT NOT NULL,
+          user_id TEXT,
           frustration_score REAL NOT NULL DEFAULT 0,
           rephrasing_score REAL NOT NULL DEFAULT 0,
           abandonment_score REAL NOT NULL DEFAULT 0,
@@ -105,6 +137,7 @@ export async function ensureObservabilityTables(): Promise<void> {
           id TEXT PRIMARY KEY,
           run_id TEXT NOT NULL,
           thread_id TEXT,
+          user_id TEXT,
           eval_type TEXT NOT NULL,
           criteria TEXT NOT NULL,
           score REAL NOT NULL DEFAULT 0,
@@ -163,17 +196,37 @@ export async function ensureObservabilityTables(): Promise<void> {
         )
       `);
 
+      // Idempotent column upgrades for DBs created before per-user
+      // isolation. SQLite has no `ADD COLUMN IF NOT EXISTS`; Postgres
+      // surfaces "column ... already exists". `isDuplicateColumnError`
+      // (from db/migrations.ts) recognizes both shapes.
+      for (const table of USER_SCOPED_TABLES) {
+        try {
+          await client.execute(
+            `ALTER TABLE ${table} ADD COLUMN user_id TEXT`,
+          );
+        } catch (err) {
+          if (isDuplicateColumnError(err)) continue;
+          throw err;
+        }
+      }
+
       // Indexes for common query patterns
       const indexes = [
         `CREATE INDEX IF NOT EXISTS idx_trace_spans_run ON agent_trace_spans (run_id)`,
         `CREATE INDEX IF NOT EXISTS idx_trace_spans_thread ON agent_trace_spans (thread_id)`,
         `CREATE INDEX IF NOT EXISTS idx_trace_spans_created ON agent_trace_spans (created_at)`,
         `CREATE INDEX IF NOT EXISTS idx_trace_summaries_created ON agent_trace_summaries (created_at)`,
+        `CREATE INDEX IF NOT EXISTS idx_trace_summaries_user ON agent_trace_summaries (user_id, created_at)`,
+        `CREATE INDEX IF NOT EXISTS idx_trace_spans_user ON agent_trace_spans (user_id)`,
         `CREATE INDEX IF NOT EXISTS idx_feedback_thread ON agent_feedback (thread_id)`,
         `CREATE INDEX IF NOT EXISTS idx_feedback_created ON agent_feedback (created_at)`,
+        `CREATE INDEX IF NOT EXISTS idx_feedback_user ON agent_feedback (user_id, created_at)`,
         `CREATE INDEX IF NOT EXISTS idx_satisfaction_thread ON agent_satisfaction_scores (thread_id)`,
+        `CREATE INDEX IF NOT EXISTS idx_satisfaction_user ON agent_satisfaction_scores (user_id, computed_at)`,
         `CREATE INDEX IF NOT EXISTS idx_evals_run ON agent_evals (run_id)`,
         `CREATE INDEX IF NOT EXISTS idx_evals_created ON agent_evals (created_at)`,
+        `CREATE INDEX IF NOT EXISTS idx_evals_user ON agent_evals (user_id, created_at)`,
         `CREATE INDEX IF NOT EXISTS idx_experiment_results_exp ON agent_experiment_results (experiment_id)`,
       ];
       for (const sql of indexes) {
@@ -198,14 +251,15 @@ export async function insertTraceSpan(span: TraceSpan): Promise<void> {
   const client = getDbExec();
   await client.execute({
     sql: `INSERT INTO agent_trace_spans
-      (id, run_id, thread_id, parent_span_id, span_type, name,
+      (id, run_id, thread_id, user_id, parent_span_id, span_type, name,
        input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
        cost_cents_x100, duration_ms, status, error_message, metadata, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       span.id,
       span.runId,
       span.threadId,
+      span.userId,
       span.parentSpanId,
       span.spanType,
       span.name,
@@ -226,14 +280,16 @@ export async function insertTraceSpan(span: TraceSpan): Promise<void> {
 export async function upsertTraceSummary(summary: TraceSummary): Promise<void> {
   await ensureObservabilityTables();
   const client = getDbExec();
+  // user_id is intentionally NOT updated on conflict — once a run's
+  // owner is recorded it shouldn't change under us.
   if (isPostgres()) {
     await client.execute({
       sql: `INSERT INTO agent_trace_summaries
-        (run_id, thread_id, total_spans, llm_calls, tool_calls,
+        (run_id, thread_id, user_id, total_spans, llm_calls, tool_calls,
          successful_tools, failed_tools, total_duration_ms,
          total_cost_cents_x100, total_input_tokens, total_output_tokens,
          model, created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT (run_id) DO UPDATE SET
           total_spans = EXCLUDED.total_spans,
           llm_calls = EXCLUDED.llm_calls,
@@ -248,6 +304,7 @@ export async function upsertTraceSummary(summary: TraceSummary): Promise<void> {
       args: [
         summary.runId,
         summary.threadId,
+        summary.userId,
         summary.totalSpans,
         summary.llmCalls,
         summary.toolCalls,
@@ -264,14 +321,15 @@ export async function upsertTraceSummary(summary: TraceSummary): Promise<void> {
   } else {
     await client.execute({
       sql: `INSERT OR REPLACE INTO agent_trace_summaries
-        (run_id, thread_id, total_spans, llm_calls, tool_calls,
+        (run_id, thread_id, user_id, total_spans, llm_calls, tool_calls,
          successful_tools, failed_tools, total_duration_ms,
          total_cost_cents_x100, total_input_tokens, total_output_tokens,
          model, created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       args: [
         summary.runId,
         summary.threadId,
+        summary.userId,
         summary.totalSpans,
         summary.llmCalls,
         summary.toolCalls,
@@ -288,12 +346,16 @@ export async function upsertTraceSummary(summary: TraceSummary): Promise<void> {
   }
 }
 
-export async function getTraceSpansForRun(runId: string): Promise<TraceSpan[]> {
+export async function getTraceSpansForRun(
+  runId: string,
+  opts: { userId?: string } = {},
+): Promise<TraceSpan[]> {
   await ensureObservabilityTables();
   const client = getDbExec();
+  const { where, args } = withUserFilter("run_id = ?", [runId], opts.userId);
   const { rows } = await client.execute({
-    sql: `SELECT * FROM agent_trace_spans WHERE run_id = ? ORDER BY created_at ASC`,
-    args: [runId],
+    sql: `SELECT * FROM agent_trace_spans WHERE ${where} ORDER BY created_at ASC`,
+    args,
   });
   return (rows as any[]).map(rowToTraceSpan);
 }
@@ -301,29 +363,37 @@ export async function getTraceSpansForRun(runId: string): Promise<TraceSpan[]> {
 export async function getTraceSummaries(opts: {
   sinceMs?: number;
   limit?: number;
+  userId?: string;
 }): Promise<TraceSummary[]> {
   await ensureObservabilityTables();
   const client = getDbExec();
   const sinceMs = opts.sinceMs ?? 0;
   const limit = opts.limit ?? 100;
+  const { where, args } = withUserFilter(
+    "created_at >= ?",
+    [sinceMs],
+    opts.userId,
+  );
   const { rows } = await client.execute({
     sql: `SELECT * FROM agent_trace_summaries
-      WHERE created_at >= ?
+      WHERE ${where}
       ORDER BY created_at DESC
       LIMIT ?`,
-    args: [sinceMs, limit],
+    args: [...args, limit],
   });
   return (rows as any[]).map(rowToTraceSummary);
 }
 
 export async function getTraceSummary(
   runId: string,
+  opts: { userId?: string } = {},
 ): Promise<TraceSummary | null> {
   await ensureObservabilityTables();
   const client = getDbExec();
+  const { where, args } = withUserFilter("run_id = ?", [runId], opts.userId);
   const { rows } = await client.execute({
-    sql: `SELECT * FROM agent_trace_summaries WHERE run_id = ?`,
-    args: [runId],
+    sql: `SELECT * FROM agent_trace_summaries WHERE ${where}`,
+    args,
   });
   if (rows.length === 0) return null;
   return rowToTraceSummary(rows[0] as any);
@@ -356,6 +426,7 @@ export async function getFeedback(opts: {
   sinceMs?: number;
   limit?: number;
   feedbackType?: string;
+  userId?: string;
 }): Promise<FeedbackEntry[]> {
   await ensureObservabilityTables();
   const client = getDbExec();
@@ -373,6 +444,10 @@ export async function getFeedback(opts: {
     conditions.push("feedback_type = ?");
     args.push(opts.feedbackType);
   }
+  if (opts.userId) {
+    conditions.push("user_id = ?");
+    args.push(opts.userId);
+  }
   const where =
     conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
   const limit = opts.limit ?? 100;
@@ -383,7 +458,10 @@ export async function getFeedback(opts: {
   return (rows as any[]).map(rowToFeedback);
 }
 
-export async function getFeedbackStats(sinceMs: number): Promise<{
+export async function getFeedbackStats(
+  sinceMs: number,
+  opts: { userId?: string } = {},
+): Promise<{
   total: number;
   thumbsUp: number;
   thumbsDown: number;
@@ -391,11 +469,16 @@ export async function getFeedbackStats(sinceMs: number): Promise<{
 }> {
   await ensureObservabilityTables();
   const client = getDbExec();
+  const { where, args } = withUserFilter(
+    "created_at >= ?",
+    [sinceMs],
+    opts.userId,
+  );
   const { rows } = await client.execute({
     sql: `SELECT feedback_type, value, COUNT(*) as cnt
-      FROM agent_feedback WHERE created_at >= ?
+      FROM agent_feedback WHERE ${where}
       GROUP BY feedback_type, value`,
-    args: [sinceMs],
+    args,
   });
   let total = 0;
   let thumbsUp = 0;
@@ -422,9 +505,9 @@ export async function upsertSatisfactionScore(
   if (isPostgres()) {
     await client.execute({
       sql: `INSERT INTO agent_satisfaction_scores
-        (id, thread_id, frustration_score, rephrasing_score,
+        (id, thread_id, user_id, frustration_score, rephrasing_score,
          abandonment_score, sentiment_score, length_trend_score, computed_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT (id) DO UPDATE SET
           frustration_score = EXCLUDED.frustration_score,
           rephrasing_score = EXCLUDED.rephrasing_score,
@@ -435,6 +518,7 @@ export async function upsertSatisfactionScore(
       args: [
         score.id,
         score.threadId,
+        score.userId,
         score.frustrationScore,
         score.rephrasingScore,
         score.abandonmentScore,
@@ -446,12 +530,13 @@ export async function upsertSatisfactionScore(
   } else {
     await client.execute({
       sql: `INSERT OR REPLACE INTO agent_satisfaction_scores
-        (id, thread_id, frustration_score, rephrasing_score,
+        (id, thread_id, user_id, frustration_score, rephrasing_score,
          abandonment_score, sentiment_score, length_trend_score, computed_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       args: [
         score.id,
         score.threadId,
+        score.userId,
         score.frustrationScore,
         score.rephrasingScore,
         score.abandonmentScore,
@@ -467,6 +552,7 @@ export async function getSatisfactionScores(opts: {
   sinceMs?: number;
   limit?: number;
   minFrustration?: number;
+  userId?: string;
 }): Promise<SatisfactionScore[]> {
   await ensureObservabilityTables();
   const client = getDbExec();
@@ -479,6 +565,10 @@ export async function getSatisfactionScores(opts: {
   if (opts.minFrustration != null) {
     conditions.push("frustration_score >= ?");
     args.push(opts.minFrustration);
+  }
+  if (opts.userId) {
+    conditions.push("user_id = ?");
+    args.push(opts.userId);
   }
   const where =
     conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
@@ -497,12 +587,13 @@ export async function insertEvalResult(result: EvalResult): Promise<void> {
   const client = getDbExec();
   await client.execute({
     sql: `INSERT INTO agent_evals
-      (id, run_id, thread_id, eval_type, criteria, score, reasoning, metadata, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      (id, run_id, thread_id, user_id, eval_type, criteria, score, reasoning, metadata, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       result.id,
       result.runId,
       result.threadId,
+      result.userId,
       result.evalType,
       result.criteria,
       result.score,
@@ -513,35 +604,47 @@ export async function insertEvalResult(result: EvalResult): Promise<void> {
   });
 }
 
-export async function getEvalsForRun(runId: string): Promise<EvalResult[]> {
+export async function getEvalsForRun(
+  runId: string,
+  opts: { userId?: string } = {},
+): Promise<EvalResult[]> {
   await ensureObservabilityTables();
   const client = getDbExec();
+  const { where, args } = withUserFilter("run_id = ?", [runId], opts.userId);
   const { rows } = await client.execute({
-    sql: `SELECT * FROM agent_evals WHERE run_id = ? ORDER BY created_at ASC`,
-    args: [runId],
+    sql: `SELECT * FROM agent_evals WHERE ${where} ORDER BY created_at ASC`,
+    args,
   });
   return (rows as any[]).map(rowToEval);
 }
 
-export async function getEvalStats(sinceMs: number): Promise<{
+export async function getEvalStats(
+  sinceMs: number,
+  opts: { userId?: string } = {},
+): Promise<{
   totalEvals: number;
   avgScore: number;
   byCriteria: Array<{ criteria: string; avgScore: number; count: number }>;
 }> {
   await ensureObservabilityTables();
   const client = getDbExec();
+  const { where, args } = withUserFilter(
+    "created_at >= ?",
+    [sinceMs],
+    opts.userId,
+  );
   const { rows: totalRows } = await client.execute({
     sql: `SELECT COUNT(*) as cnt, AVG(score) as avg_score
-      FROM agent_evals WHERE created_at >= ?`,
-    args: [sinceMs],
+      FROM agent_evals WHERE ${where}`,
+    args,
   });
   const t = (totalRows[0] ?? {}) as Record<string, number | null>;
 
   const { rows: criteriaRows } = await client.execute({
     sql: `SELECT criteria, AVG(score) as avg_score, COUNT(*) as cnt
-      FROM agent_evals WHERE created_at >= ?
+      FROM agent_evals WHERE ${where}
       GROUP BY criteria ORDER BY cnt DESC`,
-    args: [sinceMs],
+    args,
   });
 
   return {
@@ -810,7 +913,10 @@ export async function getExperimentResults(
 
 // ─── Aggregate queries for dashboard ─────────────────────────────────
 
-export async function getObservabilityOverview(sinceMs: number): Promise<{
+export async function getObservabilityOverview(
+  sinceMs: number,
+  opts: { userId?: string } = {},
+): Promise<{
   totalRuns: number;
   totalCostCents: number;
   avgDurationMs: number;
@@ -822,6 +928,13 @@ export async function getObservabilityOverview(sinceMs: number): Promise<{
   await ensureObservabilityTables();
   const client = getDbExec();
 
+  // Three of the four sub-queries time-key on `created_at`; satisfaction
+  // uses `computed_at`. Each gets its own `withUserFilter` invocation so
+  // the args array isn't aliased across calls (some drivers mutate args
+  // for prepared-statement caching).
+  const created = withUserFilter("created_at >= ?", [sinceMs], opts.userId);
+  const computed = withUserFilter("computed_at >= ?", [sinceMs], opts.userId);
+
   const [tracesResult, satisfactionResult, feedbackResult, evalsResult] =
     await Promise.all([
       client.execute({
@@ -831,25 +944,25 @@ export async function getObservabilityOverview(sinceMs: number): Promise<{
           COALESCE(AVG(total_duration_ms), 0) as avg_duration,
           COALESCE(SUM(successful_tools), 0) as success_tools,
           COALESCE(SUM(tool_calls), 0) as total_tools
-          FROM agent_trace_summaries WHERE created_at >= ?`,
-        args: [sinceMs],
+          FROM agent_trace_summaries WHERE ${created.where}`,
+        args: [...created.args],
       }),
       client.execute({
         sql: `SELECT COALESCE(AVG(frustration_score), 0) as avg_frustration
-          FROM agent_satisfaction_scores WHERE computed_at >= ?`,
-        args: [sinceMs],
+          FROM agent_satisfaction_scores WHERE ${computed.where}`,
+        args: [...computed.args],
       }),
       client.execute({
         sql: `SELECT
           COALESCE(SUM(CASE WHEN feedback_type = 'thumbs_up' THEN 1 ELSE 0 END), 0) as up,
           COALESCE(SUM(CASE WHEN feedback_type IN ('thumbs_up', 'thumbs_down') THEN 1 ELSE 0 END), 0) as total
-          FROM agent_feedback WHERE created_at >= ?`,
-        args: [sinceMs],
+          FROM agent_feedback WHERE ${created.where}`,
+        args: [...created.args],
       }),
       client.execute({
         sql: `SELECT COALESCE(AVG(score), 0) as avg_score
-          FROM agent_evals WHERE created_at >= ?`,
-        args: [sinceMs],
+          FROM agent_evals WHERE ${created.where}`,
+        args: [...created.args],
       }),
     ]);
 
@@ -881,6 +994,7 @@ function rowToTraceSpan(row: Record<string, any>): TraceSpan {
     id: String(row.id),
     runId: String(row.run_id),
     threadId: row.thread_id ? String(row.thread_id) : null,
+    userId: row.user_id ? String(row.user_id) : null,
     parentSpanId: row.parent_span_id ? String(row.parent_span_id) : null,
     spanType: row.span_type as TraceSpan["spanType"],
     name: String(row.name),
@@ -901,6 +1015,7 @@ function rowToTraceSummary(row: Record<string, any>): TraceSummary {
   return {
     runId: String(row.run_id),
     threadId: row.thread_id ? String(row.thread_id) : null,
+    userId: row.user_id ? String(row.user_id) : null,
     totalSpans: Number(row.total_spans ?? 0),
     llmCalls: Number(row.llm_calls ?? 0),
     toolCalls: Number(row.tool_calls ?? 0),
@@ -932,6 +1047,7 @@ function rowToSatisfaction(row: Record<string, any>): SatisfactionScore {
   return {
     id: String(row.id),
     threadId: String(row.thread_id),
+    userId: row.user_id ? String(row.user_id) : null,
     frustrationScore: Number(row.frustration_score ?? 0),
     rephrasingScore: Number(row.rephrasing_score ?? 0),
     abandonmentScore: Number(row.abandonment_score ?? 0),
@@ -946,6 +1062,7 @@ function rowToEval(row: Record<string, any>): EvalResult {
     id: String(row.id),
     runId: String(row.run_id),
     threadId: row.thread_id ? String(row.thread_id) : null,
+    userId: row.user_id ? String(row.user_id) : null,
     evalType: row.eval_type as EvalResult["evalType"],
     criteria: String(row.criteria),
     score: Number(row.score ?? 0),

--- a/packages/core/src/observability/traces.ts
+++ b/packages/core/src/observability/traces.ts
@@ -46,9 +46,14 @@ export async function instrumentAgentLoop(opts: {
   };
   runId: string;
   threadId: string | null;
+  /** Owner of this run; persisted on every span + summary so dashboard
+   *  reads can filter to a single user. Null for unauthenticated callers
+   *  (background tasks, etc.) — those rows aren't returned by per-user
+   *  reads. */
+  userId: string | null;
   config: ObservabilityConfig;
 }): Promise<AgentLoopUsage> {
-  const { runAgentLoop, loopOpts, runId, threadId, config } = opts;
+  const { runAgentLoop, loopOpts, runId, threadId, userId, config } = opts;
   const runStart = Date.now();
   const parentSpanId = spanId();
 
@@ -104,6 +109,7 @@ export async function instrumentAgentLoop(opts: {
           id: pending?.spanId ?? spanId(),
           runId,
           threadId,
+          userId,
           parentSpanId,
           spanType: "tool_call",
           name: event.tool,
@@ -160,6 +166,7 @@ export async function instrumentAgentLoop(opts: {
         id: spanId(),
         runId,
         threadId,
+        userId,
         parentSpanId,
         spanType: "llm_call",
         name: usage.model,
@@ -181,6 +188,7 @@ export async function instrumentAgentLoop(opts: {
       id: parentSpanId,
       runId,
       threadId,
+      userId,
       parentSpanId: null,
       spanType: "agent_run",
       name: "agent_run",
@@ -200,6 +208,7 @@ export async function instrumentAgentLoop(opts: {
     const summary: TraceSummary = {
       runId,
       threadId,
+      userId,
       totalSpans: spans.length,
       llmCalls: llmCallCount,
       toolCalls: toolCallCount,

--- a/packages/core/src/observability/types.ts
+++ b/packages/core/src/observability/types.ts
@@ -15,6 +15,10 @@ export interface TraceSpan {
   id: string;
   runId: string;
   threadId: string | null;
+  /** Owner of the run that produced this span. Null for legacy rows
+   *  written before per-user isolation; null also means "no auth context"
+   *  (background tasks, etc.) and is filtered out of per-user reads. */
+  userId: string | null;
   parentSpanId: string | null;
   spanType: SpanType;
   name: string;
@@ -33,6 +37,8 @@ export interface TraceSpan {
 export interface TraceSummary {
   runId: string;
   threadId: string | null;
+  /** See `TraceSpan.userId`. */
+  userId: string | null;
   totalSpans: number;
   llmCalls: number;
   toolCalls: number;
@@ -64,6 +70,9 @@ export interface FeedbackEntry {
 export interface SatisfactionScore {
   id: string;
   threadId: string;
+  /** Owner of the thread the score was computed for. Same null semantics
+   *  as `TraceSpan.userId`. */
+  userId: string | null;
   frustrationScore: number;
   rephrasingScore: number;
   abandonmentScore: number;
@@ -80,6 +89,9 @@ export interface EvalResult {
   id: string;
   runId: string;
   threadId: string | null;
+  /** Owner of the run being evaluated. Same null semantics as
+   *  `TraceSpan.userId`. */
+  userId: string | null;
   evalType: EvalType;
   criteria: string;
   score: number;


### PR DESCRIPTION
## Summary

  Closes a multi-tenant data-isolation gap in the observability subsystem introduced in #288. Every read endpoint and every observability table except
   `agent_feedback` had no per-user scoping, meaning any authenticated user could read every other user's traces, spans, evals, and satisfaction
  scores. This PR adds end-to-end `user_id` ownership across all four tables and all read paths.

  ## Problem

  PR #288 (https://github.com/BuilderIO/agent-native/pull/288) wired the observability subsystem but only captured `user_id` on feedback inserts. The
  remaining tables — `agent_trace_spans`, `agent_trace_summaries`, `agent_satisfaction_scores`, `agent_evals` — stored no owner, and every read
  endpoint queried them without filtering. On a multi-tenant deployment this allowed any authenticated user to read any other user's data, including
  IDOR via guessable `runId` values.

  ## Solution

  Add a `user_id TEXT` column to all four tables, stamp it on every insert/upsert, and thread an optional `userId` parameter through every read
  function so callers can scope results to a single owner. All HTTP read endpoints pass the authenticated `owner` into the store. Run-id-keyed lookups
   (`getTraceSummary`, `getTraceSpansForRun`, `getEvalsForRun`) now require the `userId` to match, so guessing another user's `runId` returns a 404
  instead of their data.

  ## Key Changes

  - **Schema** (`observability/store.ts`): Adds `user_id TEXT` to `agent_trace_spans`, `agent_trace_summaries`, `agent_satisfaction_scores`,
  `agent_evals`. A boot-time `ALTER TABLE` loop applies the column to existing databases idempotently (SQLite + Postgres). New composite indexes added
   on `(user_id, created_at)` for all four tables.
  - **`isDuplicateColumnError`** (`db/migrations.ts`): Extended to recognize Postgres `"already exists"` error text in addition to SQLite's
  `"duplicate column name"`. Exported so the new ALTER loop and any future idempotent upgrade paths can share it.
  - **Types** (`observability/types.ts`): `userId: string | null` added to `TraceSpan`, `TraceSummary`, `SatisfactionScore`, and `EvalResult`.
  - **`withUserFilter` helper** (`observability/store.ts`): Centralizes the `AND user_id = ?` clause injection so all read functions use one
  consistent shape, and tests can assert against a single pattern.
  - **`evals.ts`**: `makeEvalResult` refactored from 8 positional parameters to an options object. New `fromSummary(summary)` helper lifts `(runId,
  threadId, userId)` off a `TraceSummary`. `evaluateRun` reads `userId` from `results[0]?.userId` instead of a redundant `getTraceSummary` call.
  Dataset evals write `null` userId (administrative, not per-user).
  - **`traces.ts`**: `instrumentAgentLoop` accepts and stamps `userId` on every span and summary.
  - **`feedback.ts`**: `computeSatisfactionScore` accepts `{ userId }` and stamps the score.
  - **`routes.ts`**: Every read endpoint passes `userId: owner`; post-feedback satisfaction recomputation threads owner through.
  - **`production-agent.ts`**: One-line change — passes `ownerEmail` to `instrumentAgentLoop`.
  - **`observability/store.spec.ts`** (new): 16 isolation tests covering read filtering, IDOR-safe runId-keyed reads, multi-subquery aggregates
  (`getEvalStats`, `getObservabilityOverview`), and insert/upsert persistence.

  ## Backward compatibility

  Existing rows with `user_id = NULL` are silently excluded from per-user reads. In `AUTH_MODE=local`, `resolveOwner` returns `local@localhost` so
  single-user dev behavior is unchanged.