### PR TITLE
fix(csrf): sign CSRF state token on Builder OAuth callback

### DIFF
--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -64,7 +64,7 @@ import {
  * to sign in again. Pinning the secret to `.env.local` on first boot
  * removes that footgun.
  */
-export function resolveAuthSecret(): string {
+function resolveAuthSecret(): string {
   if (process.env.BETTER_AUTH_SECRET) return process.env.BETTER_AUTH_SECRET;
 
   // Only persist on a real filesystem (not edge / workers). If fs writes
@@ -132,6 +132,11 @@ function appendEnvLocalSecret(envLocalPath: string, secret: string): void {
   } else {
     fs.writeFileSync(envLocalPath, header + line, { mode: 0o600 });
   }
+}
+
+/** Read-only accessor for the resolved auth secret. */
+export function getAuthSecret(): string {
+  return resolveAuthSecret();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -64,7 +64,7 @@ import {
  * to sign in again. Pinning the secret to `.env.local` on first boot
  * removes that footgun.
  */
-function resolveAuthSecret(): string {
+export function resolveAuthSecret(): string {
   if (process.env.BETTER_AUTH_SECRET) return process.env.BETTER_AUTH_SECRET;
 
   // Only persist on a real filesystem (not edge / workers). If fs writes

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  buildBuilderCliAuthUrl,
+  BUILDER_CALLBACK_PATH,
+  BUILDER_STATE_PARAM,
+  signBuilderCallbackState,
+  verifyBuilderCallbackState,
+} from "./builder-browser.js";
+
+describe("Builder callback CSRF state", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Pin the secret so signed tokens are stable across calls and the
+    // .env.local autogeneration in resolveAuthSecret never fires.
+    process.env.BETTER_AUTH_SECRET = "test-secret-9f2a7c";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.useRealTimers();
+  });
+
+  describe("signBuilderCallbackState / verifyBuilderCallbackState", () => {
+    it("verifies a fresh, well-formed token bound to the same email", () => {
+      const token = signBuilderCallbackState("alice@example.com");
+      expect(verifyBuilderCallbackState(token, "alice@example.com")).toBe(true);
+    });
+
+    it("produces a 4-segment dotted token (nonce.email.ts.mac)", () => {
+      const token = signBuilderCallbackState("alice@example.com");
+      expect(token.split(".")).toHaveLength(4);
+    });
+
+    it("yields different tokens on repeat calls (nonce randomness)", () => {
+      const a = signBuilderCallbackState("alice@example.com");
+      const b = signBuilderCallbackState("alice@example.com");
+      expect(a).not.toBe(b);
+    });
+
+    it("rejects an empty / null / non-string token", () => {
+      expect(verifyBuilderCallbackState(null, "alice@example.com")).toBe(false);
+      expect(verifyBuilderCallbackState(undefined, "alice@example.com")).toBe(
+        false,
+      );
+      expect(verifyBuilderCallbackState("", "alice@example.com")).toBe(false);
+    });
+
+    it("rejects a malformed token (wrong segment count)", () => {
+      expect(
+        verifyBuilderCallbackState("only.three.segments", "alice@example.com"),
+      ).toBe(false);
+      expect(
+        verifyBuilderCallbackState(
+          "five.segments.are.too.many",
+          "alice@example.com",
+        ),
+      ).toBe(false);
+    });
+
+    it("rejects a token whose MAC was tampered with", () => {
+      const token = signBuilderCallbackState("alice@example.com");
+      const parts = token.split(".");
+      parts[3] = parts[3].slice(0, -1) + (parts[3].endsWith("A") ? "B" : "A");
+      const tampered = parts.join(".");
+      expect(verifyBuilderCallbackState(tampered, "alice@example.com")).toBe(
+        false,
+      );
+    });
+
+    it("rejects a token signed for a different email (cross-session replay)", () => {
+      const aliceToken = signBuilderCallbackState("alice@example.com");
+      expect(verifyBuilderCallbackState(aliceToken, "bob@example.com")).toBe(
+        false,
+      );
+    });
+
+    it("rejects a token whose embedded email was swapped post-sign", () => {
+      // Forge attempt: keep the MAC but swap the encoded email field.
+      const token = signBuilderCallbackState("alice@example.com");
+      const [nonce, _emailEncoded, ts, mac] = token.split(".");
+      const swappedEmail = Buffer.from("bob@example.com", "utf8").toString(
+        "base64url",
+      );
+      const forged = `${nonce}.${swappedEmail}.${ts}.${mac}`;
+      expect(verifyBuilderCallbackState(forged, "bob@example.com")).toBe(false);
+    });
+
+    it("rejects a token signed with a different secret (cross-deploy replay)", () => {
+      const token = signBuilderCallbackState("alice@example.com");
+      process.env.BETTER_AUTH_SECRET = "rotated-secret";
+      expect(verifyBuilderCallbackState(token, "alice@example.com")).toBe(
+        false,
+      );
+    });
+
+    it("rejects an expired token (older than 10 min)", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-24T12:00:00.000Z"));
+      const token = signBuilderCallbackState("alice@example.com");
+      // 11 minutes later — past the 10-min TTL.
+      vi.setSystemTime(new Date("2026-04-24T12:11:00.000Z"));
+      expect(verifyBuilderCallbackState(token, "alice@example.com")).toBe(
+        false,
+      );
+    });
+
+    it("accepts a token within the TTL window", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-24T12:00:00.000Z"));
+      const token = signBuilderCallbackState("alice@example.com");
+      // 9 minutes later — still inside the 10-min TTL.
+      vi.setSystemTime(new Date("2026-04-24T12:09:00.000Z"));
+      expect(verifyBuilderCallbackState(token, "alice@example.com")).toBe(true);
+    });
+
+    it("rejects a token whose timestamp is far in the future", () => {
+      const token = signBuilderCallbackState("alice@example.com");
+      const [nonce, email, _ts, mac] = token.split(".");
+      // Pretend the token was minted an hour from now — an attacker
+      // trying to give a leaked state arbitrary lifetime.
+      const futureTs = Date.now() + 60 * 60 * 1000;
+      const forged = `${nonce}.${email}.${futureTs}.${mac}`;
+      expect(verifyBuilderCallbackState(forged, "alice@example.com")).toBe(
+        false,
+      );
+    });
+
+    it("rejects a token with a non-numeric timestamp", () => {
+      const token = signBuilderCallbackState("alice@example.com");
+      const [nonce, email, _ts, mac] = token.split(".");
+      const forged = `${nonce}.${email}.notanumber.${mac}`;
+      expect(verifyBuilderCallbackState(forged, "alice@example.com")).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("buildBuilderCliAuthUrl", () => {
+    it("embeds the state token inside the redirect_url query string", () => {
+      const state = signBuilderCallbackState("alice@example.com");
+      const cliAuthUrl = buildBuilderCliAuthUrl(
+        "https://alice.agent-native.com",
+        state,
+      );
+      const parsed = new URL(cliAuthUrl);
+      const redirectUrl = parsed.searchParams.get("redirect_url");
+      expect(redirectUrl).toBeTruthy();
+      const parsedRedirect = new URL(redirectUrl!);
+      expect(parsedRedirect.pathname).toBe(BUILDER_CALLBACK_PATH);
+      expect(parsedRedirect.searchParams.get(BUILDER_STATE_PARAM)).toBe(state);
+    });
+
+    it("survives Builder appending p-key / api-key to redirect_url verbatim", () => {
+      const state = signBuilderCallbackState("alice@example.com");
+      const cliAuthUrl = buildBuilderCliAuthUrl(
+        "https://alice.agent-native.com",
+        state,
+      );
+      // Simulate Builder's CLIAuthPage: parse redirect_url, append params.
+      const redirectUrl = new URL(cliAuthUrl).searchParams.get("redirect_url")!;
+      const finalUrl = new URL(redirectUrl);
+      finalUrl.searchParams.set("p-key", "bpk-test-private-key");
+      finalUrl.searchParams.set("api-key", "test-api-key");
+      finalUrl.searchParams.set("user-id", "user-123");
+      finalUrl.searchParams.set("org-name", "Acme");
+      finalUrl.searchParams.set("kind", "team");
+      // The state must still be there alongside Builder's appended params.
+      expect(finalUrl.searchParams.get(BUILDER_STATE_PARAM)).toBe(state);
+      expect(finalUrl.searchParams.get("p-key")).toBe("bpk-test-private-key");
+      expect(
+        verifyBuilderCallbackState(
+          finalUrl.searchParams.get(BUILDER_STATE_PARAM),
+          "alice@example.com",
+        ),
+      ).toBe(true);
+    });
+
+    it("omits the state param when no state is provided", () => {
+      const cliAuthUrl = buildBuilderCliAuthUrl(
+        "https://alice.agent-native.com",
+      );
+      const redirectUrl = new URL(cliAuthUrl).searchParams.get("redirect_url")!;
+      expect(new URL(redirectUrl).searchParams.has(BUILDER_STATE_PARAM)).toBe(
+        false,
+      );
+    });
+
+    it("normalizes a trailing slash in the origin", () => {
+      const cliAuthUrl = buildBuilderCliAuthUrl(
+        "https://alice.agent-native.com/",
+      );
+      const redirectUrl = new URL(cliAuthUrl).searchParams.get("redirect_url")!;
+      expect(redirectUrl).toBe(
+        "https://alice.agent-native.com/_agent-native/builder/callback",
+      );
+    });
+  });
+});

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -17,7 +17,10 @@ describe("Builder callback CSRF state", () => {
   });
 
   afterEach(() => {
-    process.env = { ...originalEnv };
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) delete process.env[key];
+    }
+    Object.assign(process.env, originalEnv);
     vi.useRealTimers();
   });
 
@@ -133,6 +136,30 @@ describe("Builder callback CSRF state", () => {
       expect(verifyBuilderCallbackState(forged, "alice@example.com")).toBe(
         false,
       );
+    });
+
+    it("handles emails with special characters (plus addressing, subdomains)", () => {
+      const emails = [
+        "user+tag@example.com",
+        "bob@subdomain.example.co.uk",
+        "name@xn--e1afmapc.xn--p1ai",
+      ];
+      for (const email of emails) {
+        const token = signBuilderCallbackState(email);
+        expect(verifyBuilderCallbackState(token, email)).toBe(true);
+      }
+    });
+
+    it("rejects a token when session email differs only by case", () => {
+      const token = signBuilderCallbackState("Alice@Example.com");
+      expect(verifyBuilderCallbackState(token, "alice@example.com")).toBe(
+        false,
+      );
+    });
+
+    it("works with the AUTH_MODE=local bypass email", () => {
+      const token = signBuilderCallbackState("local@localhost");
+      expect(verifyBuilderCallbackState(token, "local@localhost")).toBe(true);
     });
   });
 

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -1,10 +1,26 @@
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import type { H3Event } from "h3";
+import { resolveAuthSecret } from "./better-auth-instance.js";
 import { getOrigin } from "./google-oauth.js";
 
 const DEFAULT_BUILDER_APP_HOST = "https://builder.io";
 const DEFAULT_BUILDER_API_HOST = "https://api.builder.io";
 const BUILDER_BROWSER_HOST = "agent-native-browser";
 const BUILDER_BROWSER_CLIENT_ID = "Agent Native Browser";
+
+export const BUILDER_CALLBACK_PATH = "/_agent-native/builder/callback";
+
+/**
+ * Query-param name carrying the signed CSRF state on the connect→callback
+ * round-trip. Builder's cli-auth flow doesn't echo a top-level `state`
+ * parameter, but it preserves the path/query of `redirect_url` verbatim
+ * when redirecting back. We embed `state=…` inside the redirect_url query
+ * string at connect time, and the callback handler reads it back from its
+ * own URL after Builder appends `p-key`, `api-key`, etc.
+ */
+export const BUILDER_STATE_PARAM = "state";
+
+const BUILDER_STATE_TTL_MS = 10 * 60 * 1000;
 
 export interface BuilderBrowserStatus {
   configured: boolean;
@@ -26,6 +42,66 @@ export interface BrowserConnectionArgs {
   proxyOrigin?: string;
   proxyDefaultOrigin?: string;
   proxyDestination?: string;
+}
+
+function macForParts(nonce: string, emailEncoded: string, ts: number): string {
+  return createHmac("sha256", resolveAuthSecret())
+    .update(`${nonce}.${emailEncoded}.${ts}`)
+    .digest("base64url");
+}
+
+/**
+ * Mint a signed CSRF state token bound to the current session's email
+ * and a fresh nonce. Round-trips through Builder's cli-auth flow inside
+ * the redirect_url query string and is verified on the callback before
+ * any keys are written.
+ *
+ * Why bind to email: it's the only stable, universally-available
+ * identity field across all auth modes (Better Auth, BYOA, AUTH_MODE=local).
+ * Binding to the session token instead would put the cookie value in a
+ * URL that may end up in server logs / browser history.
+ */
+export function signBuilderCallbackState(sessionEmail: string): string {
+  const nonce = randomBytes(16).toString("base64url");
+  const ts = Date.now();
+  const emailEncoded = Buffer.from(sessionEmail, "utf8").toString("base64url");
+  const mac = macForParts(nonce, emailEncoded, ts);
+  return `${nonce}.${emailEncoded}.${ts}.${mac}`;
+}
+
+/**
+ * Verify a state token produced by `signBuilderCallbackState`. Returns
+ * false on any malformed, forged, expired, or cross-session token.
+ */
+export function verifyBuilderCallbackState(
+  token: string | null | undefined,
+  sessionEmail: string,
+): boolean {
+  if (typeof token !== "string" || token.length === 0) return false;
+  const parts = token.split(".");
+  if (parts.length !== 4) return false;
+  const [nonce, emailEncoded, tsStr, mac] = parts;
+  if (!nonce || !emailEncoded || !tsStr || !mac) return false;
+
+  let boundEmail: string;
+  try {
+    boundEmail = Buffer.from(emailEncoded, "base64url").toString("utf8");
+  } catch {
+    return false;
+  }
+  if (boundEmail !== sessionEmail) return false;
+
+  const ts = Number(tsStr);
+  if (!Number.isFinite(ts)) return false;
+  // Reject expired AND far-future timestamps — a clock-skew attacker
+  // (or a bug that mints states with `ts` in the future) shouldn't get
+  // an arbitrarily-long-lived token.
+  if (Math.abs(Date.now() - ts) > BUILDER_STATE_TTL_MS) return false;
+
+  const expected = Buffer.from(macForParts(nonce, emailEncoded, ts));
+  const candidate = Buffer.from(mac);
+  if (expected.length !== candidate.length) return false;
+  return timingSafeEqual(expected, candidate);
 }
 
 function isAllowedBrowserReturnUrl(urlString: string): boolean {
@@ -72,17 +148,48 @@ export function getBuilderApiHost(): string {
   );
 }
 
-export function getBuilderBrowserConnectUrl(origin: string): string {
+/**
+ * Build the Builder cli-auth URL for the connect popup. When a signed
+ * `state` token is supplied it is embedded inside the `redirect_url`
+ * query string so it survives Builder's redirect verbatim — Builder
+ * preserves the redirect_url's existing query when appending p-key /
+ * api-key / etc., so we don't depend on Builder echoing a top-level
+ * `state` parameter (it doesn't).
+ *
+ * The user-facing connect entry point is `/_agent-native/builder/connect`
+ * (a server-side 302). Status / chat-card responses surface that path
+ * rather than the cli-auth URL directly, so the 302 handler can mint a
+ * fresh state bound to the current session on every click.
+ */
+export function buildBuilderCliAuthUrl(
+  origin: string,
+  state: string | null = null,
+): string {
   const normalizedOrigin = normalizeOrigin(origin);
-  const callbackUrl = `${normalizedOrigin}/_agent-native/builder/callback`;
+  const callbackUrl = new URL(BUILDER_CALLBACK_PATH, normalizedOrigin);
+  if (state) {
+    callbackUrl.searchParams.set(BUILDER_STATE_PARAM, state);
+  }
   const url = new URL("/cli-auth", getBuilderAppHost());
   url.searchParams.set("response_type", "code");
   url.searchParams.set("host", BUILDER_BROWSER_HOST);
   url.searchParams.set("client_id", BUILDER_BROWSER_CLIENT_ID);
-  url.searchParams.set("redirect_url", callbackUrl);
+  url.searchParams.set("redirect_url", callbackUrl.toString());
   url.searchParams.set("preview_url", normalizedOrigin);
   url.searchParams.set("framework", "agent-native");
   return url.toString();
+}
+
+/**
+ * The URL surfaced to clients (chat card, settings panels, status
+ * endpoint) as `connectUrl`. Pointing every entry point at our local 302
+ * means the cli-auth URL — and the CSRF state token bound to the current
+ * session — are minted server-side at click time, instead of being baked
+ * into a status response that may be cached or rendered for a different
+ * session.
+ */
+export function getBuilderBrowserConnectUrl(origin: string): string {
+  return `${normalizeOrigin(origin)}/_agent-native/builder/connect`;
 }
 
 export function getBuilderBrowserStatus(origin: string): BuilderBrowserStatus {

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -1,6 +1,6 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import type { H3Event } from "h3";
-import { resolveAuthSecret } from "./better-auth-instance.js";
+import { getAuthSecret } from "./better-auth-instance.js";
 import { getOrigin } from "./google-oauth.js";
 
 const DEFAULT_BUILDER_APP_HOST = "https://builder.io";
@@ -12,13 +12,13 @@ export const BUILDER_CALLBACK_PATH = "/_agent-native/builder/callback";
 
 /**
  * Query-param name carrying the signed CSRF state on the connect→callback
- * round-trip. Builder's cli-auth flow doesn't echo a top-level `state`
- * parameter, but it preserves the path/query of `redirect_url` verbatim
- * when redirecting back. We embed `state=…` inside the redirect_url query
- * string at connect time, and the callback handler reads it back from its
- * own URL after Builder appends `p-key`, `api-key`, etc.
+ * round-trip. Prefixed with `_an_` to avoid collisions if Builder ever
+ * adds standard OAuth `state` support to cli-auth. Builder preserves
+ * the path/query of `redirect_url` verbatim when redirecting back, so
+ * we embed `_an_state=…` inside the redirect_url query string at
+ * connect time and read it back on the callback.
  */
-export const BUILDER_STATE_PARAM = "state";
+export const BUILDER_STATE_PARAM = "_an_state";
 
 const BUILDER_STATE_TTL_MS = 10 * 60 * 1000;
 
@@ -45,7 +45,7 @@ export interface BrowserConnectionArgs {
 }
 
 function macForParts(nonce: string, emailEncoded: string, ts: number): string {
-  return createHmac("sha256", resolveAuthSecret())
+  return createHmac("sha256", `builder-csrf:${getAuthSecret()}`)
     .update(`${nonce}.${emailEncoded}.${ts}`)
     .digest("base64url");
 }

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -14,11 +14,15 @@ import type { EnvKeyConfig } from "./create-server.js";
 import { readBody } from "./h3-helpers.js";
 import {
   BUILDER_ENV_KEYS,
+  BUILDER_STATE_PARAM,
+  buildBuilderCliAuthUrl,
   createBuilderBrowserCallbackPage,
   getBuilderBrowserStatusForEvent,
   getBuilderCallbackEnvVars,
   resolveSafePreviewUrl,
   runBuilderAgent,
+  signBuilderCallbackState,
+  verifyBuilderCallbackState,
 } from "./builder-browser.js";
 import {
   getState,
@@ -271,13 +275,22 @@ export function createCoreRoutesPlugin(
     // Lightweight 302 to the Builder CLI-auth URL. Lets clients do
     // `window.open('/_agent-native/builder/connect', '_blank')` synchronously
     // inside a click handler, avoiding the popup-blocker downgrade that
-    // happens when an await sits before window.open.
+    // happens when an await sits before window.open. We mint a signed
+    // CSRF state here and embed it in the callback URL we hand to
+    // Builder; the callback handler verifies it before accepting any
+    // keys. See `signBuilderCallbackState` for the threat model.
     getH3App(nitroApp).use(
       `${P}/builder/connect`,
-      defineEventHandler((event) => {
-        const status = getBuilderBrowserStatusForEvent(event);
+      defineEventHandler(async (event) => {
+        const session = await getSession(event).catch(() => null);
+        if (!session?.email) {
+          setResponseStatus(event, 401);
+          return { error: "Authentication required" };
+        }
+        const state = signBuilderCallbackState(session.email);
+        const cliAuthUrl = buildBuilderCliAuthUrl(getOrigin(event), state);
         setResponseStatus(event, 302);
-        setResponseHeader(event, "Location", status.connectUrl);
+        setResponseHeader(event, "Location", cliAuthUrl);
         return "";
       }),
     );
@@ -353,12 +366,9 @@ export function createCoreRoutesPlugin(
           return { error: "Method not allowed" };
         }
 
-        // Require a signed-in session before we accept Builder credentials
-        // into the server's .env / process.env. Without this, a logged-in
-        // user visiting an attacker-crafted URL would silently swap the
-        // workspace's Builder account with the attacker's. In AUTH_MODE=local
-        // the session is always `local@localhost`, so this is a no-op in
-        // local dev; it matters in hosted / multi-tenant deploys.
+        // Session blocks anonymous callers; the signed state below blocks
+        // CSRF (session cookies are SameSite=None;Secure for the iframe
+        // editor, so they ride along on attacker-crafted top-level links).
         const session = await getSession(event).catch(() => null);
         if (!session?.email) {
           setResponseStatus(event, 401);
@@ -369,6 +379,16 @@ export function createCoreRoutesPlugin(
           `${event.url?.pathname || "/"}${event.url?.search || ""}`,
           getOrigin(event),
         );
+
+        const state = requestUrl.searchParams.get(BUILDER_STATE_PARAM);
+        if (!verifyBuilderCallbackState(state, session.email)) {
+          setResponseStatus(event, 403);
+          return {
+            error:
+              "Invalid or expired connect token. Restart the Builder connect flow from Settings.",
+          };
+        }
+
         const privateKey = requestUrl.searchParams.get("p-key");
         const publicKey = requestUrl.searchParams.get("api-key");
 


### PR DESCRIPTION
## Summary

  - The `/_agent-native/builder/callback` endpoint was vulnerable to CSRF even after the session check added in #292, because session cookies are
  `SameSite=None; Secure` (required for the Builder editor iframe) and ride along on attacker-crafted top-level links.
  - This PR closes that gap with an HMAC-signed state token (`nonce.email.timestamp.mac`) minted at connect time, bound to the session email, and
  verified before any keys are written to `.env` / `process.env` / `persisted-env-vars`.
  - The state is embedded inside the `redirect_url` query string (not as a top-level `state` param), so Builder's cli-auth flow preserves it verbatim
  when appending `p-key` / `api-key` — no Builder-side change required.
  - 17 new unit tests cover forge attempts, MAC tampering, cross-session replay, embedded-email swap, secret rotation, expiry, far-future timestamps,
  malformed input, and the `redirect_url` round-trip through Builder's `searchParams.set`.

  ## Why

  **Session-only check is not sufficient.** Browsers attach `SameSite=None; Secure` cookies on any cross-site top-level navigation. A logged-in victim
   clicking an attacker-crafted callback URL (`/_agent-native/builder/callback?p-key=attacker-key&...`) passes the session check, and the attacker's
  keys get written to the victim's workspace, routing every subsequent LLM call through the attacker's Builder gateway.

  **Threat model by deployment context:**

  | Context | Risk before this PR | Risk after |
  |---|---|---|
  | Local dev (`localhost`) | Negligible (browsers block cross-site → localhost) | Negligible |
  | Electron desktop app | Low (callbacks originate inside the OAuth popup webview) | Low |
  | Hosted / multi-tenant (`*.agent-native.com`) | **Real** — a crafted link from any origin exploits the iframe-required `SameSite=None` cookie |
  **Blocked** |

  **Why email-binding instead of session-token binding:** the session email is stable across all auth modes (Better Auth, BYOA, `AUTH_MODE=local`) and
   doesn't put a cookie value in a URL that may appear in server logs or browser history.

  **Why embed state in `redirect_url` instead of a top-level `state` param:** Builder's `CLIAuthPage` parses `redirect_url` via `new URL(...)` and
  uses `searchParams.set` to append its own keys (`p-key`, `api-key`, etc.), which preserves pre-existing query params verbatim. Builder does not echo
   a top-level `state` param on redirect.