### PR TITLE
fix(core): lean-mode agents use web-request instead of template action tools

### DIFF
--- a/.agents/skills/automations/SKILL.md
+++ b/.agents/skills/automations/SKILL.md
@@ -24,8 +24,8 @@ Event triggers can optionally include a `condition` -- a natural-language string
 ## How It Works
 
 1. User asks the agent to create an automation (or uses the settings UI).
-2. Agent calls `list-automation-events` to discover available events.
-3. Agent calls `define-automation` to write a `jobs/<name>.md` resource.
+2. Agent calls `manage-automations` with `action=list-events` to discover available events.
+3. Agent calls `manage-automations` with `action=define` to write a `jobs/<name>.md` resource.
 4. The trigger dispatcher subscribes to the event on the bus.
 5. When the event fires, the dispatcher loads all matching triggers, evaluates conditions via Haiku, and dispatches matching ones.
 6. In `agentic` mode, the dispatcher runs a full `runAgentLoop` with the automation body as the prompt and the event payload as context.
@@ -71,15 +71,18 @@ Use the web-request tool with ${keys.SLACK_WEBHOOK}.
 
 ## Agent Tools
 
-| Tool                      | Purpose                                                          |
-| ------------------------- | ---------------------------------------------------------------- |
-| `define-automation`       | Create a new automation (name, trigger type, event, condition, body) |
-| `list-automation-events`  | Discover all registered events with descriptions and payload schemas |
-| `list-automations`        | List all automations with status, filter by domain or enabled    |
-| `update-automation`       | Update an existing automation (enabled, condition, body)         |
-| `delete-automation`       | Delete an automation (always confirm with user first)            |
-| `fire-test-event`         | Emit a `test.event.fired` event to validate automations          |
-| `web-request`             | Outbound HTTP with `${keys.NAME}` substitution                   |
+All automation operations are accessed through a single `manage-automations` tool with an `action` parameter:
+
+| Action        | Purpose                                                              |
+| ------------- | -------------------------------------------------------------------- |
+| `list-events` | Discover all registered events with descriptions and payload schemas |
+| `list`        | List all automations with status, filter by domain or enabled        |
+| `define`      | Create a new automation (name, trigger type, event, condition, body)  |
+| `update`      | Update an existing automation (enabled, condition, body)             |
+| `delete`      | Delete an automation (always confirm with user first)                |
+| `fire-test`   | Emit a `test.event.fired` event to validate automations              |
+
+Additional tool: `web-request` — outbound HTTP with `${keys.NAME}` substitution.
 
 ## The Event Bus
 
@@ -113,7 +116,7 @@ emit("calendar.booking.created", {
 
 | Event                     | Source              |
 | ------------------------- | ------------------- |
-| `test.event.fired`        | Manual / fire-test-event tool |
+| `test.event.fired`        | Manual / manage-automations action=fire-test |
 | `agent.turn.completed`    | Agent chat          |
 | `calendar.*`              | Calendar integration |
 | `clip.*`                  | Clips integration   |
@@ -157,9 +160,9 @@ User: "When someone books a meeting with a @builder.io email, message me in Slac
 
 Agent flow:
 
-1. Calls `list-automation-events` to find `calendar.booking.created`.
+1. Calls `manage-automations` with `action=list-events` to find `calendar.booking.created`.
 2. Confirms the plan with the user.
-3. Calls `define-automation`:
+3. Calls `manage-automations` with `action=define`:
    - `name`: `slack-on-builder-booking`
    - `trigger_type`: `event`
    - `event`: `calendar.booking.created`

--- a/.agents/skills/recurring-jobs/SKILL.md
+++ b/.agents/skills/recurring-jobs/SKILL.md
@@ -15,17 +15,17 @@ Recurring jobs are scheduled tasks the agent executes automatically on a cron sc
 ## How It Works
 
 1. User asks for something recurring via the agent chat
-2. Agent uses `create-job` tool to write a job file at `jobs/<name>.md`
+2. Agent uses `manage-jobs` tool (action: "create") to write a job file at `jobs/<name>.md`
 3. A scheduler polls every 60 seconds, finds due jobs, and executes them via `runAgentLoop`
 4. Job results are saved as chat threads
 
-## Job Tools (built in)
+## Job Tool (built in)
 
-| Tool         | Purpose                                                    |
-| ------------ | ---------------------------------------------------------- |
-| `create-job` | Create a recurring job (name, cron schedule, instructions) |
-| `list-jobs`  | List all jobs and their status                             |
-| `update-job` | Update schedule, instructions, or toggle enabled           |
+| Tool          | Action     | Purpose                                                    |
+| ------------- | ---------- | ---------------------------------------------------------- |
+| `manage-jobs` | `create`   | Create a recurring job (name, cron schedule, instructions) |
+| `manage-jobs` | `list`     | List all jobs and their status                             |
+| `manage-jobs` | `update`   | Update schedule, instructions, or toggle enabled           |
 
 ## Key Files
 
@@ -33,7 +33,7 @@ Recurring jobs are scheduled tasks the agent executes automatically on a cron sc
 | ------------------------------------- | -------------------------------------------------------- |
 | `packages/core/src/jobs/cron.ts`      | Cron parsing (`nextOccurrence`, `isValidCron`, `describeCron`) |
 | `packages/core/src/jobs/scheduler.ts` | Job execution engine (`processRecurringJobs`)            |
-| `packages/core/src/jobs/tools.ts`     | Agent tools (`create-job`, `list-jobs`, `update-job`)    |
+| `packages/core/src/jobs/tools.ts`     | Agent tool (`manage-jobs` with create/list/update actions) |
 
 ## Related Skills
 

--- a/packages/core/docs/content/automations.md
+++ b/packages/core/docs/content/automations.md
@@ -85,15 +85,15 @@ Integrations register events at module load time. The bus validates payloads aga
 
 ### Built-in events {#built-in-events}
 
-| Event                  | Source                          |
-| ---------------------- | ------------------------------- |
-| `test.event.fired`     | Manual / `fire-test-event` tool |
-| `agent.turn.completed` | Agent chat                      |
-| `calendar.*`           | Calendar integration            |
-| `clip.*`               | Clips integration               |
-| `mail.*`               | Mail integration                |
+| Event                  | Source                                         |
+| ---------------------- | ---------------------------------------------- |
+| `test.event.fired`     | Manual / `manage-automations` action=fire-test |
+| `agent.turn.completed` | Agent chat                                     |
+| `calendar.*`           | Calendar integration                           |
+| `clip.*`               | Clips integration                              |
+| `mail.*`               | Mail integration                               |
 
-Call `list-automation-events` from the agent to see all registered events with descriptions and payload schemas for the current template.
+Call `manage-automations` with `action=list-events` from the agent to see all registered events with descriptions and payload schemas for the current template.
 
 ### Emitting custom events {#emitting-events}
 
@@ -183,15 +183,18 @@ Keys are ad-hoc secrets created by users or the agent for automation use (e.g. `
 
 ## Agent tools {#agent-tools}
 
-| Tool                     | Purpose                                                              |
-| ------------------------ | -------------------------------------------------------------------- |
-| `define-automation`      | Create a new automation (name, trigger type, event, condition, body) |
-| `list-automation-events` | Discover all registered events with descriptions and payload schemas |
-| `list-automations`       | List all automations with status; filter by domain or enabled        |
-| `update-automation`      | Update an existing automation (enabled, condition, body)             |
-| `delete-automation`      | Delete an automation (always confirms with user first)               |
-| `fire-test-event`        | Emit a `test.event.fired` event to validate automations              |
-| `web-request`            | Outbound HTTP with `${keys.NAME}` substitution                       |
+All automation operations are accessed through a single `manage-automations` tool with an `action` parameter:
+
+| Action        | Purpose                                                              |
+| ------------- | -------------------------------------------------------------------- |
+| `list-events` | Discover all registered events with descriptions and payload schemas |
+| `list`        | List all automations with status; filter by domain or enabled        |
+| `define`      | Create a new automation (name, trigger type, event, condition, body) |
+| `update`      | Update an existing automation (enabled, condition, body)             |
+| `delete`      | Delete an automation (always confirms with user first)               |
+| `fire-test`   | Emit a `test.event.fired` event to validate automations              |
+
+Additional tool: `web-request` — outbound HTTP with `${keys.NAME}` substitution.
 
 ## API endpoints {#api}
 
@@ -220,9 +223,9 @@ Keys are ad-hoc secrets created by users or the agent for automation use (e.g. `
 
 **Agent flow:**
 
-1. Calls `list-automation-events` — finds `calendar.booking.created`.
+1. Calls `manage-automations` with `action=list-events` — finds `calendar.booking.created`.
 2. Confirms the plan with the user.
-3. Calls `define-automation`:
+3. Calls `manage-automations` with `action=define`:
    - `name`: `slack-on-builder-booking`
    - `trigger_type`: `event`
    - `event`: `calendar.booking.created`

--- a/packages/core/docs/content/progress.md
+++ b/packages/core/docs/content/progress.md
@@ -41,7 +41,7 @@ Separate concern from [notifications](/docs/notifications): notifications fire o
 | `failed`    | Error terminal              |
 | `cancelled` | User interrupted            |
 
-Terminal statuses set `completed_at`. The UI tray shows only `running` rows; completed rows stay in the database for `list-runs` queries.
+Terminal statuses set `completed_at`. The UI tray shows only `running` rows; completed rows stay in the database for `manage-progress --action=list` queries.
 
 ## API {#api}
 
@@ -123,22 +123,22 @@ export function HeaderBar() {
 
 Inline header widget — mount it next to the notifications bell. Shows a spinner icon + count badge when runs are active; click opens a dropdown with one live percent bar per run. Hides the trigger entirely when no active runs. Polls `/_agent-native/runs?active=true` every `pollMs` (default 3 s). Uses shadcn semantic tokens, adapts to light and dark themes.
 
-## Agent tools {#agent-tools}
+## Agent tool {#agent-tool}
 
-Four native tools are registered in every template:
+A single `manage-progress` tool is registered in every template. The `action` parameter selects the operation:
 
-| Tool                  | Purpose                                                         |
-| --------------------- | --------------------------------------------------------------- |
-| `start-run`           | Call at the top of a long task. Returns a runId.                |
-| `update-run-progress` | Call periodically during the task with `percent` and/or `step`. |
-| `complete-run`        | Terminal — one of `succeeded`, `failed`, `cancelled`.           |
-| `list-runs`           | Inspect recent runs (filter by `active=true`).                  |
+| Action     | Purpose                                                         |
+| ---------- | --------------------------------------------------------------- |
+| `start`    | Call at the top of a long task. Returns a runId.                |
+| `update`   | Call periodically during the task with `percent` and/or `step`. |
+| `complete` | Terminal — one of `succeeded`, `failed`, `cancelled`.           |
+| `list`     | Inspect recent runs (filter by `active=true`).                  |
 
 ### When to start a run {#when-to-start}
 
 - Use for anything > ~5 seconds. A spinner with no context feels frozen.
 - Update at natural checkpoints, not every iteration. Every 5–10% is plenty.
-- **Always** call `complete-run`, including in error paths. An orphan `running` row is worse than no row.
+- **Always** call `manage-progress --action=complete`, including in error paths. An orphan `running` row is worse than no row.
 - Pair with `notify` on completion so the user sees the outcome when they're not actively watching the tray.
 
 ## Event bus {#event-bus}
@@ -171,6 +171,6 @@ Notify me that run {{runId}} has been running for a long time.
 
 ## What's next
 
-- [**Notifications**](/docs/notifications) — pair with `complete-run` to tell the user when work finishes
+- [**Notifications**](/docs/notifications) — pair with `manage-progress --action=complete` to tell the user when work finishes
 - [**Automations**](/docs/automations) — watchdog slow runs via `run.progress.updated`
 - [**Client**](/docs/client) — `useDbSync` for real-time cache invalidation

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -296,7 +296,7 @@ Keep the skill concise (under 500 lines) and actionable.`,
       message: `Create a recurring job: ${trimmed}`,
       context: `The user wants to create a recurring job. Their description: "${trimmed}"
 
-Use the create-job tool to create this. You need to:
+Use the manage-jobs tool with action "create" to create this. You need to:
 1. Derive a hyphen-case name from the description
 2. Convert the schedule to a cron expression (e.g., "every weekday at 9am" → "0 9 * * 1-5")
 3. Write clear, self-contained instructions for what the agent should do each time the job runs
@@ -491,7 +491,7 @@ The result should be a reusable agent profile, not a one-off task response.`,
         sendToAgentChat({
           message:
             "Help me create a new automation. Ask me what I want to automate.",
-          context: `The user wants to create a new automation. Scope: personal. Use define-automation to create it. Ask clarifying questions if needed about what event to trigger on, conditions, and what actions to take.`,
+          context: `The user wants to create a new automation. Scope: personal. Use manage-automations with action=define to create it. Ask clarifying questions if needed about what event to trigger on, conditions, and what actions to take.`,
           submit: true,
         });
         onCreated?.();

--- a/packages/core/src/client/settings/AutomationsSection.tsx
+++ b/packages/core/src/client/settings/AutomationsSection.tsx
@@ -254,7 +254,7 @@ export function AutomationsSection() {
       );
       sendToAgentChat({
         message: newPrompt.trim(),
-        context: `The user wants to create a new automation. Scope: ${newScope}. Use define-automation to create it. Ask clarifying questions if needed about what event to trigger on, conditions, and what actions to take.`,
+        context: `The user wants to create a new automation. Scope: ${newScope}. Use manage-automations with action=define to create it. Ask clarifying questions if needed about what event to trigger on, conditions, and what actions to take.`,
         submit: true,
       });
       setNewPrompt("");

--- a/packages/core/src/jobs/tools.ts
+++ b/packages/core/src/jobs/tools.ts
@@ -7,7 +7,6 @@ import {
 } from "./scheduler.js";
 import {
   resourcePut,
-  resourceGet,
   resourceGetByPath,
   resourceList,
   SHARED_OWNER,
@@ -20,233 +19,206 @@ function getOwner(): string {
   return getRequestUserEmail() || "local@localhost";
 }
 
+async function runCreate(args: Record<string, any>): Promise<string> {
+  const { name, schedule, instructions, scope, runAs } = args;
+
+  if (!name || !schedule || !instructions) {
+    return JSON.stringify({
+      error: "name, schedule, and instructions are required",
+    });
+  }
+
+  if (!isValidCron(schedule)) {
+    return JSON.stringify({
+      error: `Invalid cron expression: "${schedule}". Use 5 fields: minute hour day-of-month month day-of-week.`,
+    });
+  }
+
+  const owner = scope === "personal" ? getOwner() : SHARED_OWNER;
+  const path = `jobs/${name}.md`;
+  const now = new Date();
+  const next = nextOccurrence(schedule, now);
+
+  const meta: JobFrontmatter = {
+    schedule,
+    enabled: true,
+    createdBy: getOwner(),
+    orgId: getRequestOrgId() || undefined,
+    runAs: runAs === "shared" ? "shared" : "creator",
+    nextRun: next.toISOString(),
+  };
+
+  const content = buildJobContent(meta, instructions);
+  await resourcePut(owner, path, content);
+
+  return JSON.stringify({
+    created: true,
+    name,
+    path,
+    schedule,
+    scheduleDescription: describeCron(schedule),
+    nextRun: next.toISOString(),
+    scope: scope || "shared",
+  });
+}
+
+async function runList(args: Record<string, any>): Promise<string> {
+  const owner = getOwner();
+  // Fetch only current user's and shared jobs (not other users')
+  const [personal, shared] = await Promise.all([
+    resourceList(owner, "jobs/"),
+    resourceList(SHARED_OWNER, "jobs/"),
+  ]);
+  let resources = [...personal, ...shared];
+  if (args.scope === "personal") resources = personal;
+  else if (args.scope === "shared") resources = shared;
+  const metas = resources.filter(
+    (r) => r.path.endsWith(".md") && !r.path.endsWith(".keep"),
+  );
+  const jobs = await Promise.all(
+    metas.map(async (r) => {
+      const full = await resourceGetByPath(r.owner, r.path);
+      const { meta } = parseJobFrontmatter(full?.content || "");
+      return {
+        name: r.path.replace(/^jobs\//, "").replace(/\.md$/, ""),
+        path: r.path,
+        scope: r.owner === SHARED_OWNER ? "shared" : "personal",
+        schedule: meta.schedule,
+        scheduleDescription: meta.schedule ? describeCron(meta.schedule) : "",
+        enabled: meta.enabled,
+        lastRun: meta.lastRun || null,
+        lastStatus: meta.lastStatus || null,
+        lastError: meta.lastError || null,
+        nextRun: meta.nextRun || null,
+      };
+    }),
+  );
+
+  if (jobs.length === 0) {
+    return "No recurring jobs configured. Use manage-jobs with action 'create' to create one.";
+  }
+
+  return JSON.stringify(jobs, null, 2);
+}
+
+async function runUpdate(args: Record<string, any>): Promise<string> {
+  const { name, schedule, instructions, enabled, scope, runAs } = args;
+  const path = `jobs/${name}.md`;
+
+  // Try to find the resource
+  let resource = await resourceGetByPath(SHARED_OWNER, path);
+  if (!resource && scope !== "shared") {
+    resource = await resourceGetByPath(getOwner(), path);
+  }
+
+  if (!resource) {
+    return JSON.stringify({ error: `Job "${name}" not found` });
+  }
+
+  const { meta, body } = parseJobFrontmatter(resource.content);
+
+  if (schedule) {
+    if (!isValidCron(schedule)) {
+      return JSON.stringify({
+        error: `Invalid cron expression: "${schedule}"`,
+      });
+    }
+    meta.schedule = schedule;
+    meta.nextRun = nextOccurrence(schedule).toISOString();
+  }
+
+  if (enabled !== undefined) {
+    meta.enabled = enabled === "true";
+  }
+
+  if (runAs === "creator" || runAs === "shared") {
+    meta.runAs = runAs;
+  }
+
+  const newBody = instructions || body;
+  const content = buildJobContent(meta, newBody);
+  await resourcePut(resource.owner, resource.path, content);
+
+  return JSON.stringify({
+    updated: true,
+    name,
+    schedule: meta.schedule,
+    scheduleDescription: describeCron(meta.schedule),
+    enabled: meta.enabled,
+    nextRun: meta.nextRun,
+  });
+}
+
 export function createJobTools(): Record<string, ActionEntry> {
   return {
-    "create-job": {
+    "manage-jobs": {
       tool: {
-        description:
-          "Create a recurring job that runs on a cron schedule. The job instructions describe what the agent should do each time it runs. The schedule uses standard 5-field cron format (minute hour day-of-month month day-of-week). Common patterns: '0 9 * * *' (daily 9am), '0 9 * * 1-5' (weekdays 9am), '0 * * * *' (every hour), '0 9 * * 1' (Mondays 9am), '*/30 * * * *' (every 30 min).",
+        description: `Manage recurring jobs that run on a cron schedule.
+
+Actions:
+- "create": Create a new recurring job. Requires name, schedule, and instructions.
+- "list": List all recurring jobs and their status (schedule, enabled, last run, next run).
+- "update": Update a job's schedule, instructions, or enabled state. Requires name.
+
+Cron format is 5 fields: minute hour day-of-month month day-of-week. Common patterns: '0 9 * * *' (daily 9am), '0 9 * * 1-5' (weekdays 9am), '0 * * * *' (every hour), '0 9 * * 1' (Mondays 9am), '*/30 * * * *' (every 30 min).`,
         parameters: {
           type: "object",
           properties: {
+            action: {
+              type: "string",
+              description: "The action to perform.",
+              enum: ["create", "list", "update"],
+            },
             name: {
               type: "string",
               description:
-                "Job name (hyphen-case, e.g. 'daily-scorecard-check'). Used as the filename.",
+                "Job name (hyphen-case, e.g. 'daily-scorecard-check'). Required for create and update.",
             },
             schedule: {
               type: "string",
               description:
-                "Cron expression (5 fields: minute hour day-of-month month day-of-week). Examples: '0 9 * * 1-5' (weekdays 9am), '0 */2 * * *' (every 2 hours).",
+                "Cron expression (5 fields: minute hour day-of-month month day-of-week). Required for create, optional for update.",
             },
             instructions: {
               type: "string",
               description:
-                "What the agent should do when this job runs. Be specific — include which actions to call and what to do with the results.",
-            },
-            scope: {
-              type: "string",
-              description:
-                "personal (only your jobs) or shared (team jobs). Default: shared.",
-              enum: ["personal", "shared"],
-            },
-            runAs: {
-              type: "string",
-              description:
-                "Who shared jobs execute as: creator or shared. Default: creator.",
-              enum: ["creator", "shared"],
-            },
-          },
-          required: ["name", "schedule", "instructions"],
-        },
-      },
-      run: async (args) => {
-        const { name, schedule, instructions, scope, runAs } = args;
-
-        if (!name || !schedule || !instructions) {
-          return JSON.stringify({
-            error: "name, schedule, and instructions are required",
-          });
-        }
-
-        if (!isValidCron(schedule)) {
-          return JSON.stringify({
-            error: `Invalid cron expression: "${schedule}". Use 5 fields: minute hour day-of-month month day-of-week.`,
-          });
-        }
-
-        const owner = scope === "personal" ? getOwner() : SHARED_OWNER;
-        const path = `jobs/${name}.md`;
-        const now = new Date();
-        const next = nextOccurrence(schedule, now);
-
-        const meta: JobFrontmatter = {
-          schedule,
-          enabled: true,
-          createdBy: getOwner(),
-          orgId: getRequestOrgId() || undefined,
-          runAs: runAs === "shared" ? "shared" : "creator",
-          nextRun: next.toISOString(),
-        };
-
-        const content = buildJobContent(meta, instructions);
-        await resourcePut(owner, path, content);
-
-        return JSON.stringify({
-          created: true,
-          name,
-          path,
-          schedule,
-          scheduleDescription: describeCron(schedule),
-          nextRun: next.toISOString(),
-          scope: scope || "shared",
-        });
-      },
-    },
-
-    "list-jobs": {
-      tool: {
-        description:
-          "List all recurring jobs and their status (schedule, enabled, last run, last status, next run).",
-        parameters: {
-          type: "object",
-          properties: {
-            scope: {
-              type: "string",
-              description:
-                "Filter by scope: personal, shared, or all. Default: all.",
-              enum: ["personal", "shared", "all"],
-            },
-          },
-        },
-      },
-      run: async (args) => {
-        const owner = getOwner();
-        // Fetch only current user's and shared jobs (not other users')
-        const [personal, shared] = await Promise.all([
-          resourceList(owner, "jobs/"),
-          resourceList(SHARED_OWNER, "jobs/"),
-        ]);
-        let resources = [...personal, ...shared];
-        if (args.scope === "personal") resources = personal;
-        else if (args.scope === "shared") resources = shared;
-        const metas = resources.filter(
-          (r) => r.path.endsWith(".md") && !r.path.endsWith(".keep"),
-        );
-        const jobs = await Promise.all(
-          metas.map(async (r) => {
-            const full = await resourceGetByPath(r.owner, r.path);
-            const { meta } = parseJobFrontmatter(full?.content || "");
-            return {
-              name: r.path.replace(/^jobs\//, "").replace(/\.md$/, ""),
-              path: r.path,
-              scope: r.owner === SHARED_OWNER ? "shared" : "personal",
-              schedule: meta.schedule,
-              scheduleDescription: meta.schedule
-                ? describeCron(meta.schedule)
-                : "",
-              enabled: meta.enabled,
-              lastRun: meta.lastRun || null,
-              lastStatus: meta.lastStatus || null,
-              lastError: meta.lastError || null,
-              nextRun: meta.nextRun || null,
-            };
-          }),
-        );
-
-        if (jobs.length === 0) {
-          return "No recurring jobs configured. Use create-job to create one.";
-        }
-
-        return JSON.stringify(jobs, null, 2);
-      },
-    },
-
-    "update-job": {
-      tool: {
-        description:
-          "Update a recurring job's schedule, instructions, or enabled state.",
-        parameters: {
-          type: "object",
-          properties: {
-            name: {
-              type: "string",
-              description: "Job name (e.g. 'daily-scorecard-check')",
-            },
-            schedule: {
-              type: "string",
-              description: "New cron expression (optional)",
-            },
-            instructions: {
-              type: "string",
-              description: "New job instructions (optional)",
+                "What the agent should do when this job runs. Be specific — include which actions to call and what to do with the results. Required for create, optional for update.",
             },
             enabled: {
               type: "string",
-              description: "Enable or disable: 'true' or 'false' (optional)",
+              description:
+                "Enable or disable a job: 'true' or 'false'. Only used with update.",
               enum: ["true", "false"],
             },
             scope: {
               type: "string",
               description:
-                "Which scope to search: personal, shared, or all. Default: all.",
+                "For create: personal or shared (default: shared). For list: personal, shared, or all (default: all). For update: which scope to search (default: all).",
               enum: ["personal", "shared", "all"],
             },
             runAs: {
               type: "string",
-              description: "Update execution principal to creator or shared.",
+              description:
+                "Who shared jobs execute as: creator or shared. Default: creator. Used with create and update.",
               enum: ["creator", "shared"],
             },
           },
-          required: ["name"],
+          required: ["action"],
         },
       },
       run: async (args) => {
-        const { name, schedule, instructions, enabled, scope, runAs } = args;
-        const path = `jobs/${name}.md`;
-
-        // Try to find the resource
-        let resource = await resourceGetByPath(SHARED_OWNER, path);
-        if (!resource && scope !== "shared") {
-          resource = await resourceGetByPath(getOwner(), path);
-        }
-
-        if (!resource) {
-          return JSON.stringify({ error: `Job "${name}" not found` });
-        }
-
-        const { meta, body } = parseJobFrontmatter(resource.content);
-
-        if (schedule) {
-          if (!isValidCron(schedule)) {
+        switch (args.action) {
+          case "create":
+            return runCreate(args);
+          case "list":
+            return runList(args);
+          case "update":
+            return runUpdate(args);
+          default:
             return JSON.stringify({
-              error: `Invalid cron expression: "${schedule}"`,
+              error: `Unknown action "${args.action}". Use "create", "list", or "update".`,
             });
-          }
-          meta.schedule = schedule;
-          meta.nextRun = nextOccurrence(schedule).toISOString();
         }
-
-        if (enabled !== undefined) {
-          meta.enabled = enabled === "true";
-        }
-
-        if (runAs === "creator" || runAs === "shared") {
-          meta.runAs = runAs;
-        }
-
-        const newBody = instructions || body;
-        const content = buildJobContent(meta, newBody);
-        await resourcePut(resource.owner, resource.path, content);
-
-        return JSON.stringify({
-          updated: true,
-          name,
-          schedule: meta.schedule,
-          scheduleDescription: describeCron(meta.schedule),
-          enabled: meta.enabled,
-          nextRun: meta.nextRun,
-        });
       },
     },
   };

--- a/packages/core/src/notifications/actions.ts
+++ b/packages/core/src/notifications/actions.ts
@@ -2,8 +2,8 @@
  * Framework-level agent actions for the notifications primitive.
  *
  * Registered as native tools (not template actions) so they're available in
- * every template. The agent uses `notify` to surface progress, completions,
- * and alerts to the user through the in-app inbox and any registered channels.
+ * every template. Consolidated into a single `manage-notifications` tool with
+ * an `action` parameter that dispatches to the correct implementation.
  */
 
 import type { ActionEntry } from "../agent/production-agent.js";
@@ -14,120 +14,132 @@ export function createNotificationToolEntries(
   getCurrentUser: () => string,
 ): Record<string, ActionEntry> {
   return {
-    notify: {
+    "manage-notifications": {
       tool: {
-        description:
-          "Send a notification to the user. Always persisted to the in-app inbox so the bell + toast surface shows it. Registered channels (webhook, Slack, etc.) also run. Use `info` for FYI, `warning` for things the user should look at, `critical` for things that need immediate attention.",
+        description: [
+          "Manage user notifications. Available actions:",
+          "",
+          '• action="send" — Send a notification to the user. Persisted to the in-app inbox so the bell + toast surface shows it. Registered channels (webhook, Slack, etc.) also run.',
+          "  Required: severity, title. Optional: body, metadataJson, channels.",
+          "",
+          '• action="list" — List recent notifications for the current user. Useful when the user asks about prior alerts.',
+          "  Optional: unreadOnly (boolean), limit (number, default 20, max 200).",
+        ].join("\n"),
         parameters: {
           type: "object" as const,
           properties: {
+            action: {
+              type: "string",
+              enum: ["send", "list"],
+              description: "The notification action to perform.",
+            },
             severity: {
               type: "string",
               enum: ["info", "warning", "critical"],
               description:
-                "Severity level — drives styling and per-severity channel routing.",
+                '(send) Severity level — drives styling and per-severity channel routing. Use "info" for FYI, "warning" for things the user should look at, "critical" for things that need immediate attention.',
             },
             title: {
               type: "string",
-              description: "Short, human-readable headline (≤100 chars).",
+              description:
+                "(send) Short, human-readable headline (≤100 chars).",
             },
             body: {
               type: "string",
-              description: "Optional longer description.",
+              description: "(send) Optional longer description.",
             },
             metadataJson: {
               type: "string",
               description:
-                'Optional JSON metadata (URLs, entity ids, etc.). Example: \'{"threadId":"abc","link":"/inbox/abc"}\'.',
+                '(send) Optional JSON metadata (URLs, entity ids, etc.). Example: \'{"threadId":"abc","link":"/inbox/abc"}\'.',
             },
             channels: {
               type: "string",
               description:
-                'Optional comma-separated channel allowlist (e.g. "inbox,webhook"). Omit to run all registered channels.',
+                '(send) Optional comma-separated channel allowlist (e.g. "inbox,webhook"). Omit to run all registered channels.',
             },
-          },
-          required: ["severity", "title"],
-        },
-      },
-      run: async (args: Record<string, string>) => {
-        const owner = getCurrentUser();
-        if (!args.severity || !args.title) {
-          return "Error: --severity and --title are required.";
-        }
-        const severity = args.severity as NotificationSeverity;
-        if (!["info", "warning", "critical"].includes(severity)) {
-          return `Error: severity must be info, warning, or critical (got "${severity}").`;
-        }
-
-        let metadata: Record<string, unknown> | undefined;
-        if (args.metadataJson) {
-          try {
-            metadata = JSON.parse(args.metadataJson);
-          } catch {
-            return "Error: metadataJson must be valid JSON.";
-          }
-        }
-
-        const channels = args.channels
-          ? args.channels
-              .split(",")
-              .map((s) => s.trim())
-              .filter(Boolean)
-          : undefined;
-
-        const stored = await notify(
-          {
-            severity,
-            title: args.title,
-            body: args.body || undefined,
-            metadata,
-            channels,
-          },
-          { owner },
-        );
-        return stored
-          ? `Notification sent (id: ${stored.id})`
-          : "Notification dispatched to channels (not persisted).";
-      },
-    },
-
-    "list-notifications": {
-      tool: {
-        description:
-          "List recent notifications for the current user. Useful when the user asks about prior alerts.",
-        parameters: {
-          type: "object" as const,
-          properties: {
             unreadOnly: {
               type: "boolean",
-              description: "When true, only include unread notifications.",
+              description:
+                "(list) When true, only include unread notifications.",
             },
             limit: {
               type: "number",
-              description: "Max rows to return (default 20, max 200).",
+              description: "(list) Max rows to return (default 20, max 200).",
             },
           },
+          required: ["action"],
         },
       },
       run: async (args: Record<string, unknown>) => {
         const owner = getCurrentUser();
-        const rows = await listNotifications(owner, {
-          unreadOnly: args.unreadOnly === true || args.unreadOnly === "true",
-          limit: Math.min(Number(args.limit ?? 20), 200),
-        });
-        if (rows.length === 0) {
-          return args.unreadOnly
-            ? "No unread notifications."
-            : "No notifications.";
+        const action = args.action as string;
+
+        switch (action) {
+          case "send": {
+            if (!args.severity || !args.title) {
+              return "Error: severity and title are required for action=send.";
+            }
+            const severity = args.severity as NotificationSeverity;
+            if (!["info", "warning", "critical"].includes(severity)) {
+              return `Error: severity must be info, warning, or critical (got "${severity}").`;
+            }
+
+            let metadata: Record<string, unknown> | undefined;
+            if (args.metadataJson) {
+              try {
+                metadata = JSON.parse(args.metadataJson as string);
+              } catch {
+                return "Error: metadataJson must be valid JSON.";
+              }
+            }
+
+            const channels =
+              typeof args.channels === "string"
+                ? args.channels
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean)
+                : undefined;
+
+            const stored = await notify(
+              {
+                severity,
+                title: args.title as string,
+                body: (args.body as string) || undefined,
+                metadata,
+                channels,
+              },
+              { owner },
+            );
+            return stored
+              ? `Notification sent (id: ${stored.id})`
+              : "Notification dispatched to channels (not persisted).";
+          }
+
+          case "list": {
+            const rows = await listNotifications(owner, {
+              unreadOnly:
+                args.unreadOnly === true || args.unreadOnly === "true",
+              limit: Math.min(Number(args.limit ?? 20), 200),
+            });
+            if (rows.length === 0) {
+              return args.unreadOnly
+                ? "No unread notifications."
+                : "No notifications.";
+            }
+            const unreadCount = await countUnread(owner);
+            const lines = rows.map(
+              (n) =>
+                `[${n.readAt ? " " : "•"}] (${n.severity}) ${n.title}${n.body ? ` — ${n.body}` : ""} · ${n.createdAt}`,
+            );
+            return `${unreadCount} unread\n\n${lines.join("\n")}`;
+          }
+
+          default:
+            return `Error: unknown action "${action}". Must be one of: send, list.`;
         }
-        const unreadCount = await countUnread(owner);
-        const lines = rows.map(
-          (n) =>
-            `[${n.readAt ? " " : "•"}] (${n.severity}) ${n.title}${n.body ? ` — ${n.body}` : ""} · ${n.createdAt}`,
-        );
-        return `${unreadCount} unread\n\n${lines.join("\n")}`;
       },
-      readOnly: true,
     },
   };
 }

--- a/packages/core/src/progress/actions.ts
+++ b/packages/core/src/progress/actions.ts
@@ -2,6 +2,9 @@
  * Framework-level agent tools for the progress primitive. Registered as
  * native tools so every template exposes them. Use from long agent loops
  * to communicate status to the user while work is still in-flight.
+ *
+ * All operations are consolidated into a single `manage-progress` tool
+ * with an `action` discriminator.
  */
 
 import type { ActionEntry } from "../agent/production-agent.js";
@@ -16,165 +19,142 @@ export function createProgressToolEntries(
   getCurrentUser: () => string,
 ): Record<string, ActionEntry> {
   return {
-    "start-run": {
+    "manage-progress": {
       tool: {
-        description:
-          "Mark the start of a long-running task the user should be able to watch. Returns a runId — pass it to `update-run-progress` and `complete-run`. Call this at the top of any task that will take more than a few seconds.",
+        description: `Manage long-running task progress visible to the user. Use this whenever a task will take more than a few seconds so the user can watch status in the runs tray.
+
+Actions:
+• "start" — Begin tracking a new task. Returns a runId to pass to subsequent calls. Params: title (required), step (optional initial step text), metadataJson (optional JSON string with link/thread/artifact info).
+• "update" — Report progress on a running task. Call frequently during long loops. Params: runId (required), percent (optional 0–100), step (optional current step text). Omitted fields stay unchanged.
+• "complete" — Mark a task as finished. Params: runId (required), status (required: "succeeded" | "failed" | "cancelled"), step (optional final step text). Pairs well with \`notify\` to tell the user the outcome.
+• "list" — List the user's recent runs. Use when the user asks "what is still running" or "what did you do earlier". Params: active (optional boolean, filter to in-progress only), limit (optional number, default 20, max 200).`,
         parameters: {
           type: "object" as const,
           properties: {
+            action: {
+              type: "string",
+              enum: ["start", "update", "complete", "list"],
+              description:
+                'The operation to perform: "start" a new run, "update" progress, "complete" a run, or "list" recent runs.',
+            },
             title: {
               type: "string",
               description:
-                'Short human-readable title, e.g. "Triage 128 unread emails".',
+                '[start] Short human-readable title, e.g. "Triage 128 unread emails".',
             },
             step: {
               type: "string",
-              description: 'Initial step description, e.g. "Fetching inbox".',
+              description:
+                '[start/update/complete] Step description, e.g. "Fetching inbox" or "Drafting reply 23/100".',
             },
             metadataJson: {
               type: "string",
               description:
-                "Optional JSON metadata: link, thread id, artifact path, etc.",
+                "[start] Optional JSON metadata: link, thread id, artifact path, etc.",
             },
-          },
-          required: ["title"],
-        },
-      },
-      run: async (args: Record<string, string>) => {
-        const owner = getCurrentUser();
-        if (!args.title) return "Error: --title is required.";
-        let metadata: Record<string, unknown> | undefined;
-        if (args.metadataJson) {
-          try {
-            metadata = JSON.parse(args.metadataJson);
-          } catch {
-            return "Error: metadataJson must be valid JSON.";
-          }
-        }
-        const run = await startRun({
-          owner,
-          title: args.title,
-          step: args.step || undefined,
-          metadata,
-        });
-        return `Run started. runId=${run.id}`;
-      },
-    },
-
-    "update-run-progress": {
-      tool: {
-        description:
-          "Update a running task with progress. Call frequently during long loops so the user can watch status in the runs tray. Any omitted field stays unchanged.",
-        parameters: {
-          type: "object" as const,
-          properties: {
             runId: {
               type: "string",
-              description: "The id returned by `start-run`.",
+              description:
+                '[update/complete] The id returned by a "start" action.',
             },
             percent: {
               type: "number",
               description:
-                "Progress 0–100. Omit if the task has no known upper bound.",
-            },
-            step: {
-              type: "string",
-              description: 'Current step, e.g. "Drafting reply 23/100".',
-            },
-          },
-          required: ["runId"],
-        },
-      },
-      run: async (args: Record<string, unknown>) => {
-        const owner = getCurrentUser();
-        const runId = String(args.runId ?? "");
-        if (!runId) return "Error: --runId is required.";
-        const percent = args.percent == null ? undefined : Number(args.percent);
-        const run = await updateRunProgress(runId, owner, {
-          percent,
-          step: args.step ? String(args.step) : undefined,
-        });
-        if (!run) return `Error: run ${runId} not found.`;
-        return `Run updated (percent=${run.percent ?? "?"}, step=${run.step ?? ""}).`;
-      },
-    },
-
-    "complete-run": {
-      tool: {
-        description:
-          "Mark a task as finished. Use `succeeded` for a clean finish, `failed` when something went wrong, `cancelled` when the user interrupted. Pairs well with `notify` to tell the user the outcome.",
-        parameters: {
-          type: "object" as const,
-          properties: {
-            runId: {
-              type: "string",
-              description: "The id returned by `start-run`.",
+                "[update] Progress 0–100. Omit if the task has no known upper bound.",
             },
             status: {
               type: "string",
               enum: ["succeeded", "failed", "cancelled"],
-              description: "Terminal status.",
+              description: "[complete] Terminal status for the run.",
             },
-            step: {
-              type: "string",
-              description: "Optional final step text.",
-            },
-          },
-          required: ["runId", "status"],
-        },
-      },
-      run: async (args: Record<string, string>) => {
-        const owner = getCurrentUser();
-        if (!args.runId || !args.status) {
-          return "Error: --runId and --status are required.";
-        }
-        const run = await completeRun(
-          args.runId,
-          owner,
-          args.status as "succeeded" | "failed" | "cancelled",
-          args.step ? { step: args.step } : undefined,
-        );
-        if (!run) return `Error: run ${args.runId} not found.`;
-        return `Run ${run.id} completed with status=${run.status}.`;
-      },
-    },
-
-    "list-runs": {
-      tool: {
-        description:
-          "List the user's recent runs. Use when the user asks 'what is still running' or 'what did you do earlier'.",
-        parameters: {
-          type: "object" as const,
-          properties: {
             active: {
               type: "boolean",
-              description: "When true, only return runs still in progress.",
+              description:
+                "[list] When true, only return runs still in progress.",
             },
             limit: {
               type: "number",
-              description: "Max rows (default 20, max 200).",
+              description: "[list] Max rows (default 20, max 200).",
             },
           },
+          required: ["action"],
         },
       },
       run: async (args: Record<string, unknown>) => {
         const owner = getCurrentUser();
-        const rows = await listRuns(owner, {
-          activeOnly: args.active === true || args.active === "true",
-          limit: Math.min(Number(args.limit ?? 20), 200),
-        });
-        if (rows.length === 0) {
-          return args.active ? "No active runs." : "No runs.";
+        const action = String(args.action ?? "");
+
+        switch (action) {
+          case "start": {
+            const title = args.title ? String(args.title) : "";
+            if (!title) return "Error: title is required for the start action.";
+            let metadata: Record<string, unknown> | undefined;
+            if (args.metadataJson) {
+              try {
+                metadata = JSON.parse(String(args.metadataJson));
+              } catch {
+                return "Error: metadataJson must be valid JSON.";
+              }
+            }
+            const run = await startRun({
+              owner,
+              title,
+              step: args.step ? String(args.step) : undefined,
+              metadata,
+            });
+            return `Run started. runId=${run.id}`;
+          }
+
+          case "update": {
+            const runId = String(args.runId ?? "");
+            if (!runId)
+              return "Error: runId is required for the update action.";
+            const percent =
+              args.percent == null ? undefined : Number(args.percent);
+            const run = await updateRunProgress(runId, owner, {
+              percent,
+              step: args.step ? String(args.step) : undefined,
+            });
+            if (!run) return `Error: run ${runId} not found.`;
+            return `Run updated (percent=${run.percent ?? "?"}, step=${run.step ?? ""}).`;
+          }
+
+          case "complete": {
+            const runId = String(args.runId ?? "");
+            const status = String(args.status ?? "");
+            if (!runId || !status) {
+              return "Error: runId and status are required for the complete action.";
+            }
+            const run = await completeRun(
+              runId,
+              owner,
+              status as "succeeded" | "failed" | "cancelled",
+              args.step ? { step: String(args.step) } : undefined,
+            );
+            if (!run) return `Error: run ${runId} not found.`;
+            return `Run ${run.id} completed with status=${run.status}.`;
+          }
+
+          case "list": {
+            const rows = await listRuns(owner, {
+              activeOnly: args.active === true || args.active === "true",
+              limit: Math.min(Number(args.limit ?? 20), 200),
+            });
+            if (rows.length === 0) {
+              return args.active ? "No active runs." : "No runs.";
+            }
+            return rows
+              .map(
+                (r) =>
+                  `[${r.status}] ${r.title}${r.percent != null ? ` · ${r.percent}%` : ""}${r.step ? ` — ${r.step}` : ""} · ${r.startedAt}`,
+              )
+              .join("\n");
+          }
+
+          default:
+            return `Error: unknown action "${action}". Use one of: start, update, complete, list.`;
         }
-        return rows
-          .map(
-            (r) =>
-              `[${r.status}] ${r.title}${r.percent != null ? ` · ${r.percent}%` : ""}${r.step ? ` — ${r.step}` : ""} · ${r.startedAt}`,
-          )
-          .join("\n");
       },
-      readOnly: true,
     },
   };
 }

--- a/packages/core/src/progress/routes.ts
+++ b/packages/core/src/progress/routes.ts
@@ -7,7 +7,7 @@
  *   GET    /_agent-native/runs/:id
  *   DELETE /_agent-native/runs/:id
  *
- * Writes happen through the `update-run-progress` agent tool, not HTTP —
+ * Writes happen through the `manage-progress` agent tool, not HTTP —
  * the agent is the canonical writer, the UI only reads. (We can add write
  * routes later if a non-agent producer needs them.)
  */

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1888,9 +1888,9 @@ ${lines.join("\n")}`;
 
   return `\n\n## Available Actions
 
-**Use these actions directly as tool calls. Do NOT use \`web-request\`, \`db-schema\`, \`db-query\`, \`search-files\`, or \`shell\` — these actions already connect to the correct database and services. Never call action HTTP endpoints via \`web-request\`; use the action tool directly.**
+**ALWAYS use these actions as direct tool calls for any task they can accomplish.** These are your primary tools — they handle database access, validation, and business logic internally. Do NOT replicate their work with lower-level tools like \`web-request\`, \`db-query\`, \`db-schema\`, or \`shell\`. In particular, never call \`/_agent-native/actions/\` endpoints via \`web-request\` — the action IS a tool in your tool list; call it directly.
 
-**For external data sources (BigQuery, HubSpot, Jira, GA4, etc.), use the data-source-specific action below — NOT \`db-query\`.** \`db-query\` only reaches the app's own internal database. If the user asks about tables not in the app schema, pick the matching action here.
+Other tools (\`web-request\`, \`db-query\`, \`save-memory\`, etc.) are available for tasks that fall outside these actions — use them freely for those cases.
 
 Parameter notation: \`name*\` = required, \`name?\` = optional. Always pass the tool's parameters as a JSON object to the tool_use call — never via shell or string-concatenated CLI flags.
 
@@ -2943,28 +2943,7 @@ export function createAgentChatPlugin(
         jobTools = createJobTools();
       } catch {}
 
-      // Lean mode: only expose template actions + a minimal set of framework
-      // tools. Voice-first / minimal apps opted into `leanPrompt` precisely
-      // because they don't need the full framework surface. Exposing 30+
-      // undocumented framework tools (web-request, db-query, call-agent, etc.)
-      // alongside the 10-20 template actions confuses the model — it reaches
-      // for `web-request` to hit action HTTP endpoints instead of calling the
-      // native tool directly.
-      const leanActions = leanPrompt
-        ? {
-            ...templateScripts,
-            ...(resourceScripts["save-memory"]
-              ? { "save-memory": resourceScripts["save-memory"] }
-              : {}),
-            ...(resourceScripts["delete-memory"]
-              ? { "delete-memory": resourceScripts["delete-memory"] }
-              : {}),
-            ...notificationTools,
-            ...mcpActionEntries,
-          }
-        : null;
-
-      const prodActions = leanActions ?? {
+      const prodActions = {
         ...templateScripts,
         ...resourceScripts,
         ...docsScripts,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1888,7 +1888,7 @@ ${lines.join("\n")}`;
 
   return `\n\n## Available Actions
 
-**Use these actions directly to accomplish tasks. Do NOT use \`db-schema\`, \`search-files\`, or \`shell\` to explore the app — these actions already connect to the correct database and services.**
+**Use these actions directly as tool calls. Do NOT use \`web-request\`, \`db-schema\`, \`db-query\`, \`search-files\`, or \`shell\` — these actions already connect to the correct database and services. Never call action HTTP endpoints via \`web-request\`; use the action tool directly.**
 
 **For external data sources (BigQuery, HubSpot, Jira, GA4, etc.), use the data-source-specific action below — NOT \`db-query\`.** \`db-query\` only reaches the app's own internal database. If the user asks about tables not in the app schema, pick the matching action here.
 
@@ -2943,7 +2943,28 @@ export function createAgentChatPlugin(
         jobTools = createJobTools();
       } catch {}
 
-      const prodActions = {
+      // Lean mode: only expose template actions + a minimal set of framework
+      // tools. Voice-first / minimal apps opted into `leanPrompt` precisely
+      // because they don't need the full framework surface. Exposing 30+
+      // undocumented framework tools (web-request, db-query, call-agent, etc.)
+      // alongside the 10-20 template actions confuses the model — it reaches
+      // for `web-request` to hit action HTTP endpoints instead of calling the
+      // native tool directly.
+      const leanActions = leanPrompt
+        ? {
+            ...templateScripts,
+            ...(resourceScripts["save-memory"]
+              ? { "save-memory": resourceScripts["save-memory"] }
+              : {}),
+            ...(resourceScripts["delete-memory"]
+              ? { "delete-memory": resourceScripts["delete-memory"] }
+              : {}),
+            ...notificationTools,
+            ...mcpActionEntries,
+          }
+        : null;
+
+      const prodActions = leanActions ?? {
         ...templateScripts,
         ...resourceScripts,
         ...docsScripts,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -529,109 +529,105 @@ async function createResourceScriptEntries(): Promise<
       import("../scripts/resources/delete-memory.js"),
     ]);
 
+    // Wrap each CLI runner so it captures stdout and converts args properly
+    const listEntry = wrapCliScript(
+      {
+        description: "",
+        parameters: { type: "object" as const, properties: {} },
+      },
+      list.default,
+      { readOnly: true },
+    );
+    const readEntry = wrapCliScript(
+      {
+        description: "",
+        parameters: { type: "object" as const, properties: {} },
+      },
+      read.default,
+      { readOnly: true },
+    );
+    const writeEntry = wrapCliScript(
+      {
+        description: "",
+        parameters: { type: "object" as const, properties: {} },
+      },
+      write.default,
+    );
+    const deleteEntry = wrapCliScript(
+      {
+        description: "",
+        parameters: { type: "object" as const, properties: {} },
+      },
+      del.default,
+    );
+
     return {
-      "resource-list": wrapCliScript(
-        {
+      resources: {
+        tool: {
           description:
-            "List resources (persistent files/notes). Returns file paths, sizes, and metadata.",
+            'Manage persistent resources (files/notes). Actions: "list" (browse), "read" (get contents), "write" (create/update), "delete" (remove).',
           parameters: {
             type: "object",
             properties: {
-              prefix: {
+              action: {
                 type: "string",
-                description: "Filter by path prefix (e.g. 'notes/')",
+                description: "The operation to perform",
+                enum: ["list", "read", "write", "delete"],
               },
-              scope: {
-                type: "string",
-                description:
-                  "Which resources to list: personal, shared, or all (default: all)",
-                enum: ["personal", "shared", "all"],
-              },
-              format: {
-                type: "string",
-                description: 'Output format: "json" or "text" (default: text)',
-                enum: ["json", "text"],
-              },
-            },
-          },
-        },
-        list.default,
-      ),
-      "resource-read": wrapCliScript(
-        {
-          description: "Read a resource by path. Returns the file contents.",
-          parameters: {
-            type: "object",
-            properties: {
               path: {
                 type: "string",
                 description:
-                  "Resource path (e.g. 'LEARNINGS.md', 'notes/ideas.md')",
-              },
-              scope: {
-                type: "string",
-                description:
-                  "personal or shared (default: personal, falls back to shared)",
-                enum: ["personal", "shared"],
-              },
-            },
-            required: ["path"],
-          },
-        },
-        read.default,
-      ),
-      "resource-write": wrapCliScript(
-        {
-          description:
-            "Write or update a resource. Creates the resource if it doesn't exist.",
-          parameters: {
-            type: "object",
-            properties: {
-              path: {
-                type: "string",
-                description:
-                  "Resource path (e.g. 'LEARNINGS.md', 'notes/ideas.md')",
+                  "Resource path (e.g. 'LEARNINGS.md', 'notes/ideas.md'). Required for read/write/delete.",
               },
               content: {
                 type: "string",
-                description: "The content to write",
+                description: "Content to write. Required for write.",
               },
               scope: {
                 type: "string",
-                description: "personal or shared (default: personal)",
-                enum: ["personal", "shared"],
+                description:
+                  "personal, shared, or all (default varies by action)",
+                enum: ["personal", "shared", "all"],
+              },
+              prefix: {
+                type: "string",
+                description:
+                  "Filter by path prefix when listing (e.g. 'notes/')",
               },
               mime: {
                 type: "string",
-                description: "MIME type (default: inferred from extension)",
+                description:
+                  "MIME type for write (default: inferred from extension)",
+              },
+              format: {
+                type: "string",
+                description:
+                  'Output format for list: "json" or "text" (default: text)',
+                enum: ["json", "text"],
               },
             },
-            required: ["path", "content"],
+            required: ["action"],
           },
         },
-        write.default,
-      ),
-      "resource-delete": wrapCliScript(
-        {
-          description: "Delete a resource by path.",
-          parameters: {
-            type: "object",
-            properties: {
-              path: {
-                type: "string",
-                description: "Resource path to delete",
-              },
-              scope: {
-                type: "string",
-                description: "personal or shared (default: personal)",
-                enum: ["personal", "shared"],
-              },
-            },
-            required: ["path"],
-          },
+        run: async (args: Record<string, string>) => {
+          const { action: a, ...rest } = args;
+          if (a === "list") return listEntry.run(rest);
+          if (a === "read") {
+            if (!rest.path) return "Error: path is required for read";
+            return readEntry.run(rest);
+          }
+          if (a === "write") {
+            if (!rest.path || !rest.content)
+              return "Error: path and content are required for write";
+            return writeEntry.run(rest);
+          }
+          if (a === "delete") {
+            if (!rest.path) return "Error: path is required for delete";
+            return deleteEntry.run(rest);
+          }
+          return `Error: unknown action "${a}". Use: list, read, write, delete`;
         },
-        del.default,
-      ),
+      },
       "save-memory": wrapCliScript(
         {
           description:
@@ -1344,9 +1340,9 @@ Sub-agents have access to all template tools but **cannot spawn sub-agents thems
 
 You can create recurring jobs that run on a cron schedule. Jobs are resource files under \`jobs/\`.
 
-- \`create-job\` — Create a new recurring job with a cron schedule and instructions
-- \`list-jobs\` — List all recurring jobs and their status
-- \`update-job\` — Update a job's schedule, instructions, or toggle enabled/disabled
+- \`manage-jobs\` (action: "create") — Create a new recurring job with a cron schedule and instructions
+- \`manage-jobs\` (action: "list") — List all recurring jobs and their status
+- \`manage-jobs\` (action: "update") — Update a job's schedule, instructions, or toggle enabled/disabled
 - Delete a job with \`resource-delete --path jobs/<name>.md\`
 
 Convert natural language to 5-field cron format:
@@ -1442,7 +1438,7 @@ Resources can be personal (per-user) or shared (team-wide). By default, resource
 
 When the user gives instructions that should apply to all users/sessions, update the shared "AGENTS.md" resource.
 
-**Resources are NOT an agent scratchpad.** Never use \`resource-write\` to store executable scripts, task plans, retry notes, or work-in-progress files you're writing to yourself. Specifically, do NOT create resources under \`scripts/\` or \`tasks/\` unless the user explicitly asked for a file at that path, or a tool (like \`create-job\` or \`spawn-task\`) writes there as part of its contract. If you can't complete a task with the tools you have, say so — don't improvise by leaving behind \`FINAL-*.md\`, \`EXECUTE-NOW-*.js\`, or similar artifacts. Resources are visible to the user in the workspace sidebar; every file you write is something they'll see and have to clean up.
+**Resources are NOT an agent scratchpad.** Never use \`resource-write\` to store executable scripts, task plans, retry notes, or work-in-progress files you're writing to yourself. Specifically, do NOT create resources under \`scripts/\` or \`tasks/\` unless the user explicitly asked for a file at that path, or a tool (like \`manage-jobs\` or \`spawn-task\`) writes there as part of its contract. If you can't complete a task with the tools you have, say so — don't improvise by leaving behind \`FINAL-*.md\`, \`EXECUTE-NOW-*.js\`, or similar artifacts. Resources are visible to the user in the workspace sidebar; every file you write is something they'll see and have to clean up.
 
 ### Navigation Rule
 
@@ -1512,9 +1508,9 @@ Sub-agents have access to all template tools but **cannot spawn sub-agents thems
 
 You can create recurring jobs that run on a cron schedule. Jobs are resource files under \`jobs/\`. Each job has a cron schedule and instructions that the agent executes automatically.
 
-- \`create-job\` — Create a new recurring job with a cron schedule and instructions
-- \`list-jobs\` — List all recurring jobs and their status (schedule, last run, next run, errors)
-- \`update-job\` — Update a job's schedule, instructions, or toggle enabled/disabled
+- \`manage-jobs\` (action: "create") — Create a new recurring job with a cron schedule and instructions
+- \`manage-jobs\` (action: "list") — List all recurring jobs and their status (schedule, last run, next run, errors)
+- \`manage-jobs\` (action: "update") — Update a job's schedule, instructions, or toggle enabled/disabled
 - Delete a job with \`resource-delete --path jobs/<name>.md\`
 
 When the user asks for something recurring ("every morning", "daily at 9am", "weekly on Mondays"), create a job. Convert natural language to 5-field cron format:
@@ -2936,7 +2932,7 @@ export function createAgentChatPlugin(
       });
 
       // Hook into the run lifecycle to set/clear the send reference.
-      // Job management tools (create-job, list-jobs, update-job)
+      // Job management tool (manage-jobs)
       let jobTools: Record<string, ActionEntry> = {};
       try {
         const { createJobTools } = await import("../jobs/tools.js");

--- a/packages/core/src/templates/default/.agents/skills/progress/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/progress/SKILL.md
@@ -22,25 +22,27 @@ Separate concern from `notifications`:
 
 Common pattern: on completion, emit a `notify()` so the user sees the outcome when they're not actively watching the tray.
 
-## Available Tools
+## Tool
 
-| Tool | Purpose |
+All progress operations go through a single `manage-progress` tool with an `action` parameter:
+
+| Action | Purpose |
 |---|---|
-| `start-run` | Mark the start of a long task. Returns a runId. |
-| `update-run-progress` | Update percent and/or current step. Call frequently. |
-| `complete-run` | Mark terminal status: `succeeded`, `failed`, `cancelled`. |
-| `list-runs` | List recent runs (all or `--active=true`). |
+| `start` | Mark the start of a long task. Returns a runId. |
+| `update` | Update percent and/or current step. Call frequently. |
+| `complete` | Mark terminal status: `succeeded`, `failed`, `cancelled`. |
+| `list` | List recent runs (all or `--active=true`). |
 
 ## Canonical Flow
 
 ```
-start-run --title "Triage 128 unread emails" --step "Fetching inbox"
+manage-progress --action=start --title "Triage 128 unread emails" --step "Fetching inbox"
   → runId=abc
 
-update-run-progress --runId=abc --percent=25 --step="Classifying 32/128"
-update-run-progress --runId=abc --percent=75 --step="Drafting replies 97/128"
+manage-progress --action=update --runId=abc --percent=25 --step="Classifying 32/128"
+manage-progress --action=update --runId=abc --percent=75 --step="Drafting replies 97/128"
 
-complete-run --runId=abc --status=succeeded
+manage-progress --action=complete --runId=abc --status=succeeded
 notify --severity=info --title="Triage done" --body="12 archived, 6 drafts ready to review"
 ```
 
@@ -48,9 +50,9 @@ notify --severity=info --title="Triage done" --body="12 archived, 6 drafts ready
 
 - **Start a run for anything > ~5 seconds.** Users want feedback; a spinner with no context feels frozen.
 - **Update at natural checkpoints**, not every iteration. Every 5–10% is enough for most UIs.
-- **Always call `complete-run`** at the end — including the error path. An orphaned `running` row is worse than no row.
+- **Always call `manage-progress --action=complete`** at the end — including the error path. An orphaned `running` row is worse than no row.
 - **Pair with `notify`** on completion. The tray tells users what's *running*; notifications tell them what *finished*.
-- **Use `metadataJson`** on `start-run` to pass a link back to the produced artifact (thread id, document path), so the UI can deep-link from the runs tray.
+- **Use `metadataJson`** on `manage-progress --action=start` to pass a link back to the produced artifact (thread id, document path), so the UI can deep-link from the runs tray.
 
 ## Runs API
 

--- a/packages/core/src/triggers/actions.ts
+++ b/packages/core/src/triggers/actions.ts
@@ -4,15 +4,16 @@
  * These are registered as native tools (not template actions) so they're
  * available in every template. The agent uses them to create, list, and
  * manage automations from chat.
+ *
+ * All six operations are consolidated into a single `manage-automations` tool
+ * with an `action` discriminator to keep the tool registry compact.
  */
 
-import { randomUUID } from "node:crypto";
 import type { ActionEntry } from "../agent/production-agent.js";
 import { listEvents } from "../event-bus/index.js";
 import {
   resourceListAllOwners,
   resourcePut,
-  resourceGet,
   resourceDelete,
   resourceGetByPath,
 } from "../resources/store.js";
@@ -20,118 +21,224 @@ import { parseTriggerFrontmatter, buildTriggerContent } from "./dispatcher.js";
 import { refreshEventSubscriptions } from "./dispatcher.js";
 import type { TriggerFrontmatter } from "./types.js";
 
+/* ------------------------------------------------------------------ */
+/*  Individual action handlers                                        */
+/* ------------------------------------------------------------------ */
+
+async function handleListEvents(): Promise<string> {
+  const events = listEvents();
+  if (events.length === 0) {
+    return "No events registered yet. Events are registered by integrations (mail, calendar, clips, etc.).";
+  }
+  const lines = events.map((e) => {
+    let schemaStr = "";
+    try {
+      const s = e.payloadSchema as any;
+      if (s?._zod?.def?.shape) {
+        const fields = Object.keys(s._zod.def.shape);
+        schemaStr = ` Fields: ${fields.join(", ")}`;
+      }
+    } catch {
+      // ignore
+    }
+    const example = e.example
+      ? `\n  Example: ${JSON.stringify(e.example)}`
+      : "";
+    return `- **${e.name}**: ${e.description}${schemaStr}${example}`;
+  });
+  return lines.join("\n");
+}
+
+async function handleList(args: Record<string, string>): Promise<string> {
+  const resources = await resourceListAllOwners("jobs/");
+  const triggers = resources
+    .filter((r) => r.path.endsWith(".md"))
+    .map((r) => {
+      const { meta, body } = parseTriggerFrontmatter(r.content);
+      const name = r.path.replace(/^jobs\//, "").replace(/\.md$/, "");
+      return { name, meta, body, owner: r.owner, id: r.id };
+    })
+    .filter((t) => {
+      if (args.domain && t.meta.domain !== args.domain) return false;
+      if (args.enabled_only === "true" && !t.meta.enabled) return false;
+      return true;
+    });
+
+  if (triggers.length === 0) return "No automations found.";
+
+  const lines = triggers.map((t) => {
+    const type =
+      t.meta.triggerType === "event"
+        ? `on ${t.meta.event || "?"}`
+        : `cron: ${t.meta.schedule}`;
+    const status = t.meta.enabled ? "enabled" : "disabled";
+    const lastStatus = t.meta.lastStatus ? ` (last: ${t.meta.lastStatus})` : "";
+    const condition = t.meta.condition
+      ? `\n  Condition: "${t.meta.condition}"`
+      : "";
+    const domain = t.meta.domain ? ` [${t.meta.domain}]` : "";
+    return `- **${t.name}**${domain}: ${type} → ${t.meta.mode} (${status}${lastStatus})${condition}\n  Body: ${t.body.slice(0, 100)}${t.body.length > 100 ? "..." : ""}`;
+  });
+  return lines.join("\n\n");
+}
+
+async function handleDefine(
+  args: Record<string, string>,
+  getCurrentUser: () => string,
+): Promise<string> {
+  const owner = getCurrentUser();
+  const name = (args.name || "").replace(/[^a-z0-9-]/g, "-");
+  if (!name) return "Error: name is required (lowercase, hyphens).";
+
+  const path = `jobs/${name}.md`;
+
+  // Check if it already exists
+  const existing = await resourceGetByPath(owner, path);
+  if (existing) {
+    return `Error: An automation named "${name}" already exists. Use a different name or delete the existing one first.`;
+  }
+
+  const triggerType = args.trigger_type === "schedule" ? "schedule" : "event";
+  const meta: TriggerFrontmatter = {
+    schedule: args.schedule || "",
+    enabled: true,
+    triggerType,
+    event: args.event || undefined,
+    condition: args.condition || undefined,
+    mode: args.mode === "deterministic" ? "deterministic" : "agentic",
+    domain: args.domain || undefined,
+    createdBy: owner,
+    runAs: "creator",
+  };
+
+  const content = buildTriggerContent(meta, args.body || "");
+  await resourcePut(owner, path, content);
+
+  // Refresh event subscriptions so the new trigger is active immediately
+  await refreshEventSubscriptions();
+
+  const summary =
+    triggerType === "event"
+      ? `on ${meta.event || "?"}${meta.condition ? ` when "${meta.condition}"` : ""}`
+      : `on schedule "${meta.schedule}"`;
+
+  return `Automation "${name}" created. Fires ${summary} in ${meta.mode} mode.`;
+}
+
+async function handleUpdate(
+  args: Record<string, string>,
+  getCurrentUser: () => string,
+): Promise<string> {
+  const owner = getCurrentUser();
+  const name = args.name;
+  const path = `jobs/${name}.md`;
+
+  const resource = await resourceGetByPath(owner, path);
+  if (!resource) {
+    return `Automation "${name}" not found (or you don't own it).`;
+  }
+
+  const { meta, body } = parseTriggerFrontmatter(resource.content);
+
+  if (args.enabled !== undefined) {
+    meta.enabled = args.enabled !== "false";
+  }
+  if (args.condition !== undefined) {
+    meta.condition = args.condition || undefined;
+  }
+  const newBody = args.body ?? body;
+
+  await resourcePut(
+    resource.owner,
+    resource.path,
+    buildTriggerContent(meta, newBody),
+  );
+  await refreshEventSubscriptions();
+
+  return `Automation "${name}" updated.`;
+}
+
+async function handleDelete(
+  args: Record<string, string>,
+  getCurrentUser: () => string,
+): Promise<string> {
+  const owner = getCurrentUser();
+  const path = `jobs/${args.name}.md`;
+
+  const resource = await resourceGetByPath(owner, path);
+  if (!resource) return `Automation "${args.name}" not found.`;
+
+  await resourceDelete(resource.id);
+  return `Automation "${args.name}" deleted.`;
+}
+
+async function handleFireTest(args: Record<string, string>): Promise<string> {
+  // Dynamic import to avoid circular dependency at module load time
+  const { emit } = await import("../event-bus/index.js");
+
+  let data: Record<string, unknown> = {};
+  if (args.data) {
+    try {
+      data = JSON.parse(args.data);
+    } catch {
+      return "Error: invalid JSON in data parameter.";
+    }
+  }
+
+  emit("test.event.fired", { data });
+  return `Test event fired with payload: ${JSON.stringify({ data })}. Any automations subscribed to "test.event.fired" will be evaluated.`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Consolidated tool entry                                           */
+/* ------------------------------------------------------------------ */
+
+const VALID_ACTIONS = [
+  "list-events",
+  "list",
+  "define",
+  "update",
+  "delete",
+  "fire-test",
+] as const;
+
 export function createAutomationToolEntries(
   getCurrentUser: () => string,
 ): Record<string, ActionEntry> {
   return {
-    "list-automation-events": {
+    "manage-automations": {
       tool: {
-        description:
-          "List all registered event types that automations can subscribe to. Returns event names, descriptions, and payload schemas. Call this BEFORE defining an automation to discover available events.",
-        parameters: { type: "object" as const, properties: {} },
-      },
-      run: async () => {
-        const events = listEvents();
-        if (events.length === 0) {
-          return "No events registered yet. Events are registered by integrations (mail, calendar, clips, etc.).";
-        }
-        const lines = events.map((e) => {
-          let schemaStr = "";
-          try {
-            const s = e.payloadSchema as any;
-            if (s?._zod?.def?.shape) {
-              const fields = Object.keys(s._zod.def.shape);
-              schemaStr = ` Fields: ${fields.join(", ")}`;
-            }
-          } catch {
-            // ignore
-          }
-          const example = e.example
-            ? `\n  Example: ${JSON.stringify(e.example)}`
-            : "";
-          return `- **${e.name}**: ${e.description}${schemaStr}${example}`;
-        });
-        return lines.join("\n");
-      },
-      readOnly: true,
-    },
+        description: `Manage automations (event-triggered and scheduled tasks). Use the "action" parameter to choose an operation:
 
-    "list-automations": {
-      tool: {
-        description:
-          "List all automations (triggers). Shows name, event, condition, mode, status, and domain.",
+- **list-events**: List all registered event types that automations can subscribe to. Returns event names, descriptions, and payload schemas. Call this BEFORE defining an automation to discover available events.
+- **list**: List all automations (triggers). Shows name, event, condition, mode, status, and domain. Optional params: domain, enabled_only.
+- **define**: Create a new automation. IMPORTANT: Always confirm with the user before calling — show them a summary of what will be created. Required params: name, trigger_type, body. Optional: event, schedule, condition, mode, domain.
+- **update**: Update an existing automation's settings (enabled, condition, body, etc.). Required param: name. Optional: enabled, condition, body.
+- **delete**: Delete an automation. Always confirm with the user first. Required param: name.
+- **fire-test**: Fire a test event to validate automations. Emits a test.event.fired event. Optional param: data (JSON string).`,
         parameters: {
           type: "object" as const,
           properties: {
-            domain: {
+            action: {
               type: "string",
               description:
-                "Filter by domain (mail, calendar, clips, etc.). Omit for all.",
+                "The operation to perform: list-events, list, define, update, delete, or fire-test.",
+              enum: [...VALID_ACTIONS],
             },
-            enabled_only: {
-              type: "string",
-              description: '"true" to show only enabled automations.',
-            },
-          },
-        },
-      },
-      run: async (args: Record<string, string>) => {
-        const resources = await resourceListAllOwners("jobs/");
-        const triggers = resources
-          .filter((r) => r.path.endsWith(".md"))
-          .map((r) => {
-            const { meta, body } = parseTriggerFrontmatter(r.content);
-            const name = r.path.replace(/^jobs\//, "").replace(/\.md$/, "");
-            return { name, meta, body, owner: r.owner, id: r.id };
-          })
-          .filter((t) => {
-            if (args.domain && t.meta.domain !== args.domain) return false;
-            if (args.enabled_only === "true" && !t.meta.enabled) return false;
-            return true;
-          });
-
-        if (triggers.length === 0) return "No automations found.";
-
-        const lines = triggers.map((t) => {
-          const type =
-            t.meta.triggerType === "event"
-              ? `on ${t.meta.event || "?"}`
-              : `cron: ${t.meta.schedule}`;
-          const status = t.meta.enabled ? "enabled" : "disabled";
-          const lastStatus = t.meta.lastStatus
-            ? ` (last: ${t.meta.lastStatus})`
-            : "";
-          const condition = t.meta.condition
-            ? `\n  Condition: "${t.meta.condition}"`
-            : "";
-          const domain = t.meta.domain ? ` [${t.meta.domain}]` : "";
-          return `- **${t.name}**${domain}: ${type} → ${t.meta.mode} (${status}${lastStatus})${condition}\n  Body: ${t.body.slice(0, 100)}${t.body.length > 100 ? "..." : ""}`;
-        });
-        return lines.join("\n\n");
-      },
-      readOnly: true,
-    },
-
-    "define-automation": {
-      tool: {
-        description: `Create a new automation. The automation is stored as a markdown resource and fires when the specified event occurs and the condition (if any) matches. IMPORTANT: Always confirm with the user before calling this — show them a summary of what will be created.`,
-        parameters: {
-          type: "object" as const,
-          properties: {
             name: {
               type: "string",
               description:
-                "Slug name for the automation (lowercase, hyphens). Example: slack-on-builder-booking",
+                "Slug name for the automation (lowercase, hyphens). Used by define, update, and delete.",
             },
             trigger_type: {
               type: "string",
-              description: '"event" or "schedule".',
+              description: '"event" or "schedule". Required for define.',
               enum: ["event", "schedule"],
             },
             event: {
               type: "string",
               description:
-                "For event triggers: the event name to subscribe to. Call list-automation-events first to see available events.",
+                "For event triggers: the event name to subscribe to. Call with action=list-events first to see available events.",
             },
             schedule: {
               type: "string",
@@ -141,186 +248,62 @@ export function createAutomationToolEntries(
             condition: {
               type: "string",
               description:
-                'Natural-language condition. Example: "attendee email ends with @builder.io". Leave empty for unconditional.',
+                'Natural-language condition. Example: "attendee email ends with @builder.io". Leave empty for unconditional. Used by define and update.',
             },
             mode: {
               type: "string",
               description:
-                '"agentic" (full agent loop, can use tools) or "deterministic" (fixed actions only).',
+                '"agentic" (full agent loop, can use tools) or "deterministic" (fixed actions only). Used by define.',
               enum: ["agentic", "deterministic"],
             },
             domain: {
               type: "string",
               description:
-                "Domain tag for grouping (mail, calendar, clips, etc.).",
+                "Domain tag for grouping (mail, calendar, clips, etc.). Used by define and list.",
             },
             body: {
               type: "string",
               description:
-                "The natural-language instructions for what to do when the automation fires. This becomes the agent's prompt in agentic mode.",
-            },
-          },
-          required: ["name", "trigger_type", "body"],
-        },
-      },
-      run: async (args: Record<string, string>) => {
-        const owner = getCurrentUser();
-        const name = (args.name || "").replace(/[^a-z0-9-]/g, "-");
-        if (!name) return "Error: name is required (lowercase, hyphens).";
-
-        const path = `jobs/${name}.md`;
-
-        // Check if it already exists
-        const existing = await resourceGetByPath(owner, path);
-        if (existing) {
-          return `Error: An automation named "${name}" already exists. Use a different name or delete the existing one first.`;
-        }
-
-        const triggerType =
-          args.trigger_type === "schedule" ? "schedule" : "event";
-        const meta: TriggerFrontmatter = {
-          schedule: args.schedule || "",
-          enabled: true,
-          triggerType,
-          event: args.event || undefined,
-          condition: args.condition || undefined,
-          mode: args.mode === "deterministic" ? "deterministic" : "agentic",
-          domain: args.domain || undefined,
-          createdBy: owner,
-          runAs: "creator",
-        };
-
-        const content = buildTriggerContent(meta, args.body || "");
-        await resourcePut(owner, path, content);
-
-        // Refresh event subscriptions so the new trigger is active immediately
-        await refreshEventSubscriptions();
-
-        const summary =
-          triggerType === "event"
-            ? `on ${meta.event || "?"}${meta.condition ? ` when "${meta.condition}"` : ""}`
-            : `on schedule "${meta.schedule}"`;
-
-        return `Automation "${name}" created. Fires ${summary} in ${meta.mode} mode.`;
-      },
-    },
-
-    "update-automation": {
-      tool: {
-        description:
-          "Update an existing automation's settings (enabled, condition, body, etc.).",
-        parameters: {
-          type: "object" as const,
-          properties: {
-            name: {
-              type: "string",
-              description: "Name of the automation to update.",
+                "The natural-language instructions for what to do when the automation fires. This becomes the agent's prompt in agentic mode. Used by define and update.",
             },
             enabled: {
               type: "string",
-              description: '"true" or "false" to enable/disable.',
+              description:
+                '"true" or "false" to enable/disable. Used by update.',
             },
-            condition: {
+            enabled_only: {
               type: "string",
               description:
-                "New natural-language condition (or empty to clear).",
+                '"true" to show only enabled automations. Used by list.',
             },
-            body: {
-              type: "string",
-              description: "New automation body/instructions.",
-            },
-          },
-          required: ["name"],
-        },
-      },
-      run: async (args: Record<string, string>) => {
-        const owner = getCurrentUser();
-        const name = args.name;
-        const path = `jobs/${name}.md`;
-
-        const resource = await resourceGetByPath(owner, path);
-        if (!resource) {
-          return `Automation "${name}" not found (or you don't own it).`;
-        }
-
-        const { meta, body } = parseTriggerFrontmatter(resource.content);
-
-        if (args.enabled !== undefined) {
-          meta.enabled = args.enabled !== "false";
-        }
-        if (args.condition !== undefined) {
-          meta.condition = args.condition || undefined;
-        }
-        const newBody = args.body ?? body;
-
-        await resourcePut(
-          resource.owner,
-          resource.path,
-          buildTriggerContent(meta, newBody),
-        );
-        await refreshEventSubscriptions();
-
-        return `Automation "${name}" updated.`;
-      },
-    },
-
-    "delete-automation": {
-      tool: {
-        description:
-          "Delete an automation. Always confirm with the user first.",
-        parameters: {
-          type: "object" as const,
-          properties: {
-            name: {
-              type: "string",
-              description: "Name of the automation to delete.",
-            },
-          },
-          required: ["name"],
-        },
-      },
-      run: async (args: Record<string, string>) => {
-        const owner = getCurrentUser();
-        const path = `jobs/${args.name}.md`;
-
-        const resource = await resourceGetByPath(owner, path);
-        if (!resource) return `Automation "${args.name}" not found.`;
-
-        await resourceDelete(resource.id);
-        return `Automation "${args.name}" deleted.`;
-      },
-    },
-
-    "fire-test-event": {
-      tool: {
-        description:
-          "Fire a test event to validate automations. Emits a test.event.fired event with the provided data.",
-        parameters: {
-          type: "object" as const,
-          properties: {
             data: {
               type: "string",
               description:
-                'JSON data to include as the event payload. Example: \'{"email": "test@example.com"}\'.',
+                'JSON data to include as the test event payload. Used by fire-test. Example: \'{"email": "test@example.com"}\'.',
             },
           },
+          required: ["action"],
         },
       },
       run: async (args: Record<string, string>) => {
-        // Dynamic import to avoid circular dependency at module load time
-        const { emit } = await import("../event-bus/index.js");
+        const action = args.action;
 
-        let data: Record<string, unknown> = {};
-        if (args.data) {
-          try {
-            data = JSON.parse(args.data);
-          } catch {
-            return "Error: invalid JSON in data parameter.";
-          }
+        switch (action) {
+          case "list-events":
+            return handleListEvents();
+          case "list":
+            return handleList(args);
+          case "define":
+            return handleDefine(args, getCurrentUser);
+          case "update":
+            return handleUpdate(args, getCurrentUser);
+          case "delete":
+            return handleDelete(args, getCurrentUser);
+          case "fire-test":
+            return handleFireTest(args);
+          default:
+            return `Error: unknown action "${action}". Valid actions: ${VALID_ACTIONS.join(", ")}.`;
         }
-
-        emit("test.event.fired", { data });
-        return `Test event fired with payload: ${JSON.stringify({ data })}. Any automations subscribed to "test.event.fired" will be evaluated.`;
       },
     },
   };


### PR DESCRIPTION
## Summary

- **Prompt fix:** In `leanPrompt` mode (macros), the agent was using `web-request` to POST to `/_agent-native/actions/` endpoints instead of calling `log-meal`, `log-exercise`, etc. as direct tool_use calls. Strengthened the Available Actions prompt to explicitly direct the agent to always prefer template actions over lower-level framework tools.

- **Tool consolidation:** Reduced framework tools from ~35 to ~20 by consolidating related tools behind single tools with an `action` parameter:
  - `resources` (was 4: resource-list/read/write/delete → 1)
  - `manage-automations` (was 6 → 1)
  - `manage-jobs` (was 3 → 1)
  - `manage-progress` (was 4 → 1)
  - `manage-notifications` (was 2 → 1)

Total tool count for macros: **~39** (down from **~54**)

## Test plan

- [x] `pnpm run prep` passes (build, typecheck, lint, test)
- [x] All GitHub Actions CI checks pass
- [ ] Verify macros app calls log-meal directly (not via web-request)
- [ ] Verify other templates still work with consolidated tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)