### PR TITLE
fix(core): hide plan/act mode toggle in production

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -131,6 +131,7 @@
     "shiki": "^4.0.2",
     "tailwind-merge": "^3.5.0",
     "tiptap-markdown": "^0.9.0",
+    "tw-animate-css": "1.4.0",
     "y-protocols": "^1.0.7",
     "yjs": "^13.6.30",
     "zod": "^4.3.6"

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -321,7 +321,7 @@ class AISDKEngine implements AgentEngine {
     const pkg = PROVIDER_PACKAGES[this.provider];
     let providerModule: any;
     try {
-      providerModule = await import(/* @vite-ignore */ pkg);
+      providerModule = await importProviderPackage(this.provider);
     } catch {
       throw new Error(
         `Provider package "${pkg}" is not installed. Run: pnpm add ai ${pkg}`,
@@ -364,6 +364,29 @@ export function createAISDKEngine(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// Static string-literal imports so bundlers (Nitro/Rollup/Vercel) can analyze
+// and include provider packages. A variable-based `import(pkg)` gets skipped.
+async function importProviderPackage(provider: AISDKProvider): Promise<any> {
+  switch (provider) {
+    case "anthropic":
+      return import("@ai-sdk/anthropic");
+    case "openai":
+      return import("@ai-sdk/openai");
+    case "openrouter":
+      return import("@openrouter/ai-sdk-provider");
+    case "google":
+      return import("@ai-sdk/google");
+    case "groq":
+      return import("@ai-sdk/groq");
+    case "mistral":
+      return import("@ai-sdk/mistral");
+    case "cohere":
+      return import("@ai-sdk/cohere");
+    case "ollama":
+      return import("ai-sdk-ollama");
+  }
+}
 
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1058,8 +1058,8 @@ export function AgentPanel({
             emptyStateText={emptyStateText}
             suggestions={suggestions}
             onSwitchToCli={() => switchMode("cli")}
-            execMode={execMode}
-            onExecModeChange={switchExecMode}
+            execMode={isDevMode ? execMode : undefined}
+            onExecModeChange={isDevMode ? switchExecMode : undefined}
             storageKey={storageKey}
           />
         )}

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -969,15 +969,15 @@ function AssistantMessage() {
       </div>
       {/* Action bar — only show after message is complete */}
       {isComplete && (
-        <div className="mt-1 flex items-center gap-0.5 opacity-0 group-hover:opacity-100">
+        <div className="mt-1 flex items-center justify-between">
           <button
             onClick={handleCopy}
-            className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+            className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground/70 hover:bg-accent hover:text-foreground"
           >
             {copied ? (
-              <IconCheck className="h-3 w-3" />
+              <IconCheck className="h-3.5 w-3.5" />
             ) : (
-              <IconCopy className="h-3 w-3" />
+              <IconCopy className="h-3.5 w-3.5" />
             )}
           </button>
           <React.Suspense fallback={null}>

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -657,6 +657,7 @@ export function MultiTabAssistantChat({
       }
 
       const isPlanMode = (() => {
+        if (!props.execMode) return false;
         try {
           return localStorage.getItem(execModeKey) === "plan";
         } catch {

--- a/packages/core/src/client/components/ui/popover.tsx
+++ b/packages/core/src/client/components/ui/popover.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+
+import { cn } from "../../utils.js";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent };

--- a/packages/core/src/client/composer/ComposerPlusMenu.tsx
+++ b/packages/core/src/client/composer/ComposerPlusMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import {
   IconPlus,
   IconUpload,
@@ -10,9 +10,13 @@ import {
   IconCheck,
   IconArrowLeft,
 } from "@tabler/icons-react";
-import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { ComposerPrimitive } from "@assistant-ui/react";
 import { cn } from "../utils.js";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "../components/ui/popover.js";
 import { sendToAgentChat } from "../agent-chat.js";
 import { useOrg } from "../org/hooks.js";
 import {
@@ -262,8 +266,8 @@ The job will run automatically on the schedule. Make the instructions specific â
         />
       </ComposerPrimitive.AddAttachment>
 
-      <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
-        <PopoverPrimitive.Trigger asChild>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
           <button
             type="button"
             className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 disabled:opacity-30 disabled:cursor-not-allowed"
@@ -271,245 +275,243 @@ The job will run automatically on the schedule. Make the instructions specific â
           >
             <IconPlus className="h-4 w-4" />
           </button>
-        </PopoverPrimitive.Trigger>
-        <PopoverPrimitive.Portal>
-          <PopoverPrimitive.Content
-            side="top"
-            align="start"
-            sideOffset={8}
-            className="w-[260px] rounded-lg border border-border bg-popover shadow-lg z-50 animate-in fade-in-0 zoom-in-95"
-            style={{ fontSize: 13, lineHeight: "normal" }}
-            onOpenAutoFocus={(e) => e.preventDefault()}
-          >
-            {view === "menu" && (
-              <div className="py-1">
-                {menuItems.map((item) => (
-                  <button
-                    key={item.label}
-                    onClick={item.action}
-                    className="flex w-full items-center gap-2.5 px-3 py-2 text-left hover:bg-accent/50"
-                  >
-                    <span className="text-muted-foreground">{item.icon}</span>
-                    <div className="min-w-0">
-                      <div className="text-[12px] font-medium text-foreground">
-                        {item.label}
-                      </div>
-                      <div className="text-[10px] text-muted-foreground/60">
-                        {item.desc}
-                      </div>
+        </PopoverTrigger>
+        <PopoverContent
+          side="top"
+          align="start"
+          sideOffset={8}
+          className="w-[260px] p-0 rounded-lg"
+          style={{ fontSize: 13, lineHeight: "normal" }}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          {view === "menu" && (
+            <div className="py-1">
+              {menuItems.map((item) => (
+                <button
+                  key={item.label}
+                  onClick={item.action}
+                  className="flex w-full items-center gap-2.5 px-3 py-2 text-left hover:bg-accent/50"
+                >
+                  <span className="text-muted-foreground">{item.icon}</span>
+                  <div className="min-w-0">
+                    <div className="text-[12px] font-medium text-foreground">
+                      {item.label}
                     </div>
-                  </button>
-                ))}
-              </div>
-            )}
-
-            {view === "skill" && (
-              <div className="p-3">
-                {backButton}
-                <label className="mb-1 block text-[11px] font-semibold text-foreground">
-                  Create Skill
-                </label>
-                <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
-                  Describe what kind of skill you want and the agent will create
-                  it.
-                </p>
-                <textarea
-                  ref={inputRef as React.RefObject<HTMLTextAreaElement>}
-                  value={value}
-                  onChange={(e) => setValue(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault();
-                      submitSkill();
-                    }
-                    if (e.key === "Escape") {
-                      e.stopPropagation();
-                      setView("menu");
-                    }
-                  }}
-                  rows={3}
-                  className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                  placeholder="e.g. A skill that reviews PRs for security issues"
-                />
-                <div className="mt-2.5 flex justify-end">
-                  <button
-                    onClick={submitSkill}
-                    disabled={!value.trim()}
-                    className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
-                  >
-                    Create
-                  </button>
-                </div>
-              </div>
-            )}
-
-            {view === "job" && (
-              <div className="p-3">
-                {backButton}
-                <label className="mb-1 block text-[11px] font-semibold text-foreground">
-                  Scheduled Task
-                </label>
-                <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
-                  Describe what should happen and when.
-                </p>
-                <textarea
-                  ref={inputRef as React.RefObject<HTMLTextAreaElement>}
-                  value={value}
-                  onChange={(e) => setValue(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault();
-                      submitJob();
-                    }
-                    if (e.key === "Escape") {
-                      e.stopPropagation();
-                      setView("menu");
-                    }
-                  }}
-                  rows={3}
-                  className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                  placeholder="e.g. Every weekday at 9am, check for overdue tasks and send a Slack update"
-                />
-                <div className="mt-2.5 flex justify-end">
-                  <button
-                    onClick={submitJob}
-                    disabled={!value.trim()}
-                    className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
-                  >
-                    Create
-                  </button>
-                </div>
-              </div>
-            )}
-
-            {view === "mcp-server" && (
-              <div className="p-3">
-                {backButton}
-                <label className="mb-1 block text-[11px] font-semibold text-foreground">
-                  Connect MCP Server
-                </label>
-                <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
-                  Point at any Streamable HTTP MCP server. Its tools become
-                  available to the agent.
-                </p>
-                <div className="space-y-2">
-                  <div className="flex gap-1 rounded-md border border-border p-0.5">
-                    <button
-                      type="button"
-                      onClick={() => setMcpScope("user")}
-                      className={cn(
-                        "flex-1 rounded px-2 py-1 text-[11px] font-medium",
-                        mcpScope === "user"
-                          ? "bg-accent text-foreground"
-                          : "text-muted-foreground hover:text-foreground",
-                      )}
-                    >
-                      Personal
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        hasOrg && canCreateOrgMcp && setMcpScope("org")
-                      }
-                      disabled={!hasOrg || !canCreateOrgMcp}
-                      title={
-                        !hasOrg
-                          ? "Join an organization to share MCP servers"
-                          : !canCreateOrgMcp
-                            ? "Only owners and admins can add org-scope servers"
-                            : undefined
-                      }
-                      className={cn(
-                        "flex-1 rounded px-2 py-1 text-[11px] font-medium",
-                        mcpScope === "org"
-                          ? "bg-accent text-foreground"
-                          : "text-muted-foreground hover:text-foreground",
-                        (!hasOrg || !canCreateOrgMcp) &&
-                          "cursor-not-allowed opacity-40 hover:text-muted-foreground",
-                      )}
-                    >
-                      Organization
-                    </button>
+                    <div className="mt-0.5 text-[10px] text-muted-foreground/60">
+                      {item.desc}
+                    </div>
                   </div>
-                  <input
-                    ref={inputRef as React.RefObject<HTMLInputElement>}
-                    value={mcpName}
-                    onChange={(e) => setMcpName(e.target.value)}
-                    className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                    placeholder="Server name (e.g. zapier)"
-                  />
-                  <input
-                    value={mcpUrl}
-                    onChange={(e) => setMcpUrl(e.target.value)}
-                    className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                    placeholder="https://mcp.example.com/"
-                  />
-                  <input
-                    value={mcpDescription}
-                    onChange={(e) => setMcpDescription(e.target.value)}
-                    className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                    placeholder="Description (optional)"
-                  />
-                  <label className="block text-[10px] font-medium text-muted-foreground/70">
-                    Headers (one per line, e.g. Authorization: Bearer ...)
-                  </label>
-                  <textarea
-                    value={mcpHeadersText}
-                    onChange={(e) => setMcpHeadersText(e.target.value)}
-                    rows={2}
-                    className="w-full resize-y rounded-md border border-border bg-background px-2.5 py-1.5 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                    style={{
-                      fontFamily:
-                        'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
-                    }}
-                    placeholder="Authorization: Bearer sk-..."
-                  />
-                  {mcpTestResult && (
-                    <div
-                      className={cn(
-                        "flex items-center gap-1 text-[11px]",
-                        mcpTestResult.ok
-                          ? "text-green-600 dark:text-green-400"
-                          : "text-red-600 dark:text-red-400",
-                      )}
-                    >
-                      {mcpTestResult.ok && <IconCheck className="h-3 w-3" />}
-                      {mcpTestResult.message}
-                    </div>
-                  )}
-                  {mcpError && (
-                    <div className="text-[11px] text-red-600 dark:text-red-400">
-                      {mcpError}
-                    </div>
-                  )}
-                </div>
-                <div className="mt-2.5 flex items-center justify-between gap-2">
-                  <button
-                    type="button"
-                    onClick={runMcpTest}
-                    disabled={!mcpUrl.trim() || mcpBusy}
-                    className="rounded-md border border-border bg-background px-2.5 py-1.5 text-[11px] font-medium text-foreground hover:bg-accent disabled:opacity-40 disabled:pointer-events-none"
-                  >
-                    Test
-                  </button>
-                  <button
-                    type="button"
-                    onClick={submitMcpServer}
-                    disabled={!mcpName.trim() || !mcpUrl.trim() || mcpBusy}
-                    className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
-                  >
-                    {mcpBusy ? (
-                      <IconLoader2 className="h-3 w-3 animate-spin" />
-                    ) : (
-                      "Connect"
-                    )}
-                  </button>
-                </div>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {view === "skill" && (
+            <div className="p-3">
+              {backButton}
+              <label className="mb-1 block text-[11px] font-semibold text-foreground">
+                Create Skill
+              </label>
+              <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
+                Describe what kind of skill you want and the agent will create
+                it.
+              </p>
+              <textarea
+                ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    submitSkill();
+                  }
+                  if (e.key === "Escape") {
+                    e.stopPropagation();
+                    setView("menu");
+                  }
+                }}
+                rows={3}
+                className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                placeholder="e.g. A skill that reviews PRs for security issues"
+              />
+              <div className="mt-2.5 flex justify-end">
+                <button
+                  onClick={submitSkill}
+                  disabled={!value.trim()}
+                  className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
+                >
+                  Create
+                </button>
               </div>
-            )}
-          </PopoverPrimitive.Content>
-        </PopoverPrimitive.Portal>
-      </PopoverPrimitive.Root>
+            </div>
+          )}
+
+          {view === "job" && (
+            <div className="p-3">
+              {backButton}
+              <label className="mb-1 block text-[11px] font-semibold text-foreground">
+                Scheduled Task
+              </label>
+              <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
+                Describe what should happen and when.
+              </p>
+              <textarea
+                ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    submitJob();
+                  }
+                  if (e.key === "Escape") {
+                    e.stopPropagation();
+                    setView("menu");
+                  }
+                }}
+                rows={3}
+                className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                placeholder="e.g. Every weekday at 9am, check for overdue tasks and send a Slack update"
+              />
+              <div className="mt-2.5 flex justify-end">
+                <button
+                  onClick={submitJob}
+                  disabled={!value.trim()}
+                  className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
+                >
+                  Create
+                </button>
+              </div>
+            </div>
+          )}
+
+          {view === "mcp-server" && (
+            <div className="p-3">
+              {backButton}
+              <label className="mb-1 block text-[11px] font-semibold text-foreground">
+                Connect MCP Server
+              </label>
+              <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
+                Point at any Streamable HTTP MCP server. Its tools become
+                available to the agent.
+              </p>
+              <div className="space-y-2">
+                <div className="flex gap-1 rounded-md border border-border p-0.5">
+                  <button
+                    type="button"
+                    onClick={() => setMcpScope("user")}
+                    className={cn(
+                      "flex-1 rounded px-2 py-1 text-[11px] font-medium",
+                      mcpScope === "user"
+                        ? "bg-accent text-foreground"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    Personal
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      hasOrg && canCreateOrgMcp && setMcpScope("org")
+                    }
+                    disabled={!hasOrg || !canCreateOrgMcp}
+                    title={
+                      !hasOrg
+                        ? "Join an organization to share MCP servers"
+                        : !canCreateOrgMcp
+                          ? "Only owners and admins can add org-scope servers"
+                          : undefined
+                    }
+                    className={cn(
+                      "flex-1 rounded px-2 py-1 text-[11px] font-medium",
+                      mcpScope === "org"
+                        ? "bg-accent text-foreground"
+                        : "text-muted-foreground hover:text-foreground",
+                      (!hasOrg || !canCreateOrgMcp) &&
+                        "cursor-not-allowed opacity-40 hover:text-muted-foreground",
+                    )}
+                  >
+                    Organization
+                  </button>
+                </div>
+                <input
+                  ref={inputRef as React.RefObject<HTMLInputElement>}
+                  value={mcpName}
+                  onChange={(e) => setMcpName(e.target.value)}
+                  className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                  placeholder="Server name (e.g. zapier)"
+                />
+                <input
+                  value={mcpUrl}
+                  onChange={(e) => setMcpUrl(e.target.value)}
+                  className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                  placeholder="https://mcp.example.com/"
+                />
+                <input
+                  value={mcpDescription}
+                  onChange={(e) => setMcpDescription(e.target.value)}
+                  className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                  placeholder="Description (optional)"
+                />
+                <label className="block text-[10px] font-medium text-muted-foreground/70">
+                  Headers (one per line, e.g. Authorization: Bearer ...)
+                </label>
+                <textarea
+                  value={mcpHeadersText}
+                  onChange={(e) => setMcpHeadersText(e.target.value)}
+                  rows={2}
+                  className="w-full resize-y rounded-md border border-border bg-background px-2.5 py-1.5 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                  style={{
+                    fontFamily:
+                      'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+                  }}
+                  placeholder="Authorization: Bearer sk-..."
+                />
+                {mcpTestResult && (
+                  <div
+                    className={cn(
+                      "flex items-center gap-1 text-[11px]",
+                      mcpTestResult.ok
+                        ? "text-green-600 dark:text-green-400"
+                        : "text-red-600 dark:text-red-400",
+                    )}
+                  >
+                    {mcpTestResult.ok && <IconCheck className="h-3 w-3" />}
+                    {mcpTestResult.message}
+                  </div>
+                )}
+                {mcpError && (
+                  <div className="text-[11px] text-red-600 dark:text-red-400">
+                    {mcpError}
+                  </div>
+                )}
+              </div>
+              <div className="mt-2.5 flex items-center justify-between gap-2">
+                <button
+                  type="button"
+                  onClick={runMcpTest}
+                  disabled={!mcpUrl.trim() || mcpBusy}
+                  className="rounded-md border border-border bg-background px-2.5 py-1.5 text-[11px] font-medium text-foreground hover:bg-accent disabled:opacity-40 disabled:pointer-events-none"
+                >
+                  Test
+                </button>
+                <button
+                  type="button"
+                  onClick={submitMcpServer}
+                  disabled={!mcpName.trim() || !mcpUrl.trim() || mcpBusy}
+                  className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
+                >
+                  {mcpBusy ? (
+                    <IconLoader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    "Connect"
+                  )}
+                </button>
+              </div>
+            </div>
+          )}
+        </PopoverContent>
+      </Popover>
     </>
   );
 }

--- a/packages/core/src/client/composer/ComposerPlusMenu.tsx
+++ b/packages/core/src/client/composer/ComposerPlusMenu.tsx
@@ -1,0 +1,515 @@
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import {
+  IconPlus,
+  IconUpload,
+  IconBulb,
+  IconClock,
+  IconBolt,
+  IconPlugConnected,
+  IconLoader2,
+  IconCheck,
+  IconArrowLeft,
+} from "@tabler/icons-react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { ComposerPrimitive } from "@assistant-ui/react";
+import { cn } from "../utils.js";
+import { sendToAgentChat } from "../agent-chat.js";
+import { useOrg } from "../org/hooks.js";
+import {
+  useCreateMcpServer,
+  testMcpServerUrl,
+  type McpServerScope,
+} from "../resources/use-mcp-servers.js";
+
+type View = "menu" | "skill" | "job" | "mcp-server";
+
+export function ComposerPlusMenu() {
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<View>("menu");
+  const [value, setValue] = useState("");
+
+  // MCP state
+  const { data: org } = useOrg();
+  const canCreateOrgMcp =
+    !org?.orgId || org.role === "owner" || org.role === "admin";
+  const hasOrg = !!org?.orgId;
+  const defaultMcpScope: McpServerScope =
+    hasOrg && canCreateOrgMcp ? "org" : "user";
+  const [mcpScope, setMcpScope] = useState<McpServerScope>(defaultMcpScope);
+  const [mcpName, setMcpName] = useState("");
+  const [mcpUrl, setMcpUrl] = useState("");
+  const [mcpDescription, setMcpDescription] = useState("");
+  const [mcpHeadersText, setMcpHeadersText] = useState("");
+  const [mcpBusy, setMcpBusy] = useState(false);
+  const [mcpError, setMcpError] = useState<string | null>(null);
+  const [mcpTestResult, setMcpTestResult] = useState<{
+    ok: boolean;
+    message: string;
+  } | null>(null);
+  const createMcp = useCreateMcpServer();
+
+  const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+  const fileUploadRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setView("menu");
+      setValue("");
+      setMcpScope(defaultMcpScope);
+      setMcpName("");
+      setMcpUrl("");
+      setMcpDescription("");
+      setMcpHeadersText("");
+      setMcpError(null);
+      setMcpTestResult(null);
+      setMcpBusy(false);
+    }
+  }, [open, defaultMcpScope]);
+
+  useEffect(() => {
+    if (view !== "menu") {
+      setValue("");
+      const t = setTimeout(() => inputRef.current?.focus(), 50);
+      return () => clearTimeout(t);
+    }
+  }, [view]);
+
+  const submitSkill = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    sendToAgentChat({
+      message: `Create a skill: ${trimmed}`,
+      context: `The user wants to create an agent skill. Their description: "${trimmed}"
+
+Follow the create-skill pattern to build this. Before writing:
+
+1. **Determine the skill name** — derive a hyphen-case name from the description (e.g. "code review" → "code-review")
+2. **Determine the skill type** — Pattern (architectural rule), Workflow (step-by-step), or Generator (scaffolding)
+3. **Write the skill** as a personal resource at path "skills/<name>.md" using resource-write
+
+The skill file MUST have YAML frontmatter with name and description (under 40 words), then markdown with:
+- Clear rule/purpose statement
+- Why this skill exists
+- How to follow it (with code examples where helpful)
+- Common violations to avoid
+- Related skills
+
+After creating, update the shared AGENTS.md resource to reference the new skill in its skills table.
+
+Keep the skill concise (under 500 lines) and actionable.`,
+      submit: true,
+    });
+    setOpen(false);
+  };
+
+  const submitJob = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    sendToAgentChat({
+      message: `Create a recurring job: ${trimmed}`,
+      context: `The user wants to create a recurring job. Their description: "${trimmed}"
+
+Use the manage-jobs tool with action "create" to create this. You need to:
+1. Derive a hyphen-case name from the description
+2. Convert the schedule to a cron expression (e.g., "every weekday at 9am" → "0 9 * * 1-5")
+3. Write clear, self-contained instructions for what the agent should do each time the job runs
+4. Create it in personal scope
+
+The job will run automatically on the schedule. Make the instructions specific — include which actions to call and what to do with results.`,
+      submit: true,
+    });
+    setOpen(false);
+  };
+
+  const parseHeaderLines = (
+    text: string,
+  ): Record<string, string> | undefined => {
+    const out: Record<string, string> = {};
+    for (const line of text.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const idx = trimmed.indexOf(":");
+      if (idx <= 0) continue;
+      const key = trimmed.slice(0, idx).trim();
+      const val = trimmed.slice(idx + 1).trim();
+      if (!key || !val) continue;
+      out[key] = val;
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+  };
+
+  const submitMcpServer = async () => {
+    const name = mcpName.trim();
+    const url = mcpUrl.trim();
+    if (!name || !url || mcpBusy) return;
+    setMcpError(null);
+    setMcpBusy(true);
+    try {
+      await createMcp.mutateAsync({
+        scope: mcpScope,
+        name,
+        url,
+        headers: parseHeaderLines(mcpHeadersText),
+        description: mcpDescription.trim() || undefined,
+      });
+      setOpen(false);
+    } catch (err: any) {
+      setMcpError(err?.message ?? String(err));
+    } finally {
+      setMcpBusy(false);
+    }
+  };
+
+  const runMcpTest = async () => {
+    const url = mcpUrl.trim();
+    if (!url || mcpBusy) return;
+    setMcpTestResult(null);
+    setMcpError(null);
+    setMcpBusy(true);
+    try {
+      const res = await testMcpServerUrl(url, parseHeaderLines(mcpHeadersText));
+      if (res.ok) {
+        setMcpTestResult({
+          ok: true,
+          message: `${res.toolCount ?? 0} tool${res.toolCount === 1 ? "" : "s"} available`,
+        });
+      } else {
+        setMcpTestResult({ ok: false, message: res.error ?? "Failed" });
+      }
+    } catch (err: any) {
+      setMcpTestResult({ ok: false, message: err?.message ?? String(err) });
+    } finally {
+      setMcpBusy(false);
+    }
+  };
+
+  const menuItems: {
+    icon: React.ReactNode;
+    label: string;
+    desc: string;
+    action: () => void;
+  }[] = [
+    {
+      icon: <IconUpload className="h-3.5 w-3.5" />,
+      label: "Upload File",
+      desc: "Attach a file to this message",
+      action: () => {
+        setOpen(false);
+        setTimeout(() => fileUploadRef.current?.click(), 0);
+      },
+    },
+    {
+      icon: <IconBulb className="h-3.5 w-3.5" />,
+      label: "Create Skill",
+      desc: "Teach the agent a new ability",
+      action: () => setView("skill"),
+    },
+    {
+      icon: <IconClock className="h-3.5 w-3.5" />,
+      label: "Scheduled Task",
+      desc: "Run something on a schedule",
+      action: () => setView("job"),
+    },
+    {
+      icon: <IconBolt className="h-3.5 w-3.5" />,
+      label: "Create Automation",
+      desc: "Set up a when-X-do-Y rule",
+      action: () => {
+        setOpen(false);
+        window.dispatchEvent(
+          new CustomEvent("agent-panel:set-mode", {
+            detail: { mode: "chat" },
+          }),
+        );
+        sendToAgentChat({
+          message:
+            "Help me create a new automation. Ask me what I want to automate.",
+          context:
+            "The user wants to create a new automation. Scope: personal. Use manage-automations with action=define to create it. Ask clarifying questions if needed about what event to trigger on, conditions, and what actions to take.",
+          submit: true,
+        });
+      },
+    },
+    {
+      icon: <IconPlugConnected className="h-3.5 w-3.5" />,
+      label: "Connect MCP Server",
+      desc: "Expose external tools to the agent",
+      action: () => setView("mcp-server"),
+    },
+  ];
+
+  const backButton = (
+    <button
+      type="button"
+      onClick={() => setView("menu")}
+      className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground mb-1.5"
+    >
+      <IconArrowLeft className="h-3 w-3" />
+      Back
+    </button>
+  );
+
+  return (
+    <>
+      {/* Hidden button to trigger the native file upload */}
+      <ComposerPrimitive.AddAttachment asChild>
+        <button
+          ref={fileUploadRef}
+          type="button"
+          className="hidden"
+          tabIndex={-1}
+          aria-hidden
+        />
+      </ComposerPrimitive.AddAttachment>
+
+      <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+        <PopoverPrimitive.Trigger asChild>
+          <button
+            type="button"
+            className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 disabled:opacity-30 disabled:cursor-not-allowed"
+            title="Add..."
+          >
+            <IconPlus className="h-4 w-4" />
+          </button>
+        </PopoverPrimitive.Trigger>
+        <PopoverPrimitive.Portal>
+          <PopoverPrimitive.Content
+            side="top"
+            align="start"
+            sideOffset={8}
+            className="w-[260px] rounded-lg border border-border bg-popover shadow-lg z-50 animate-in fade-in-0 zoom-in-95"
+            style={{ fontSize: 13, lineHeight: "normal" }}
+            onOpenAutoFocus={(e) => e.preventDefault()}
+          >
+            {view === "menu" && (
+              <div className="py-1">
+                {menuItems.map((item) => (
+                  <button
+                    key={item.label}
+                    onClick={item.action}
+                    className="flex w-full items-center gap-2.5 px-3 py-2 text-left hover:bg-accent/50"
+                  >
+                    <span className="text-muted-foreground">{item.icon}</span>
+                    <div className="min-w-0">
+                      <div className="text-[12px] font-medium text-foreground">
+                        {item.label}
+                      </div>
+                      <div className="text-[10px] text-muted-foreground/60">
+                        {item.desc}
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {view === "skill" && (
+              <div className="p-3">
+                {backButton}
+                <label className="mb-1 block text-[11px] font-semibold text-foreground">
+                  Create Skill
+                </label>
+                <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
+                  Describe what kind of skill you want and the agent will create
+                  it.
+                </p>
+                <textarea
+                  ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      submitSkill();
+                    }
+                    if (e.key === "Escape") {
+                      e.stopPropagation();
+                      setView("menu");
+                    }
+                  }}
+                  rows={3}
+                  className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                  placeholder="e.g. A skill that reviews PRs for security issues"
+                />
+                <div className="mt-2.5 flex justify-end">
+                  <button
+                    onClick={submitSkill}
+                    disabled={!value.trim()}
+                    className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
+                  >
+                    Create
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {view === "job" && (
+              <div className="p-3">
+                {backButton}
+                <label className="mb-1 block text-[11px] font-semibold text-foreground">
+                  Scheduled Task
+                </label>
+                <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
+                  Describe what should happen and when.
+                </p>
+                <textarea
+                  ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      submitJob();
+                    }
+                    if (e.key === "Escape") {
+                      e.stopPropagation();
+                      setView("menu");
+                    }
+                  }}
+                  rows={3}
+                  className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                  placeholder="e.g. Every weekday at 9am, check for overdue tasks and send a Slack update"
+                />
+                <div className="mt-2.5 flex justify-end">
+                  <button
+                    onClick={submitJob}
+                    disabled={!value.trim()}
+                    className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
+                  >
+                    Create
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {view === "mcp-server" && (
+              <div className="p-3">
+                {backButton}
+                <label className="mb-1 block text-[11px] font-semibold text-foreground">
+                  Connect MCP Server
+                </label>
+                <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
+                  Point at any Streamable HTTP MCP server. Its tools become
+                  available to the agent.
+                </p>
+                <div className="space-y-2">
+                  <div className="flex gap-1 rounded-md border border-border p-0.5">
+                    <button
+                      type="button"
+                      onClick={() => setMcpScope("user")}
+                      className={cn(
+                        "flex-1 rounded px-2 py-1 text-[11px] font-medium",
+                        mcpScope === "user"
+                          ? "bg-accent text-foreground"
+                          : "text-muted-foreground hover:text-foreground",
+                      )}
+                    >
+                      Personal
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        hasOrg && canCreateOrgMcp && setMcpScope("org")
+                      }
+                      disabled={!hasOrg || !canCreateOrgMcp}
+                      title={
+                        !hasOrg
+                          ? "Join an organization to share MCP servers"
+                          : !canCreateOrgMcp
+                            ? "Only owners and admins can add org-scope servers"
+                            : undefined
+                      }
+                      className={cn(
+                        "flex-1 rounded px-2 py-1 text-[11px] font-medium",
+                        mcpScope === "org"
+                          ? "bg-accent text-foreground"
+                          : "text-muted-foreground hover:text-foreground",
+                        (!hasOrg || !canCreateOrgMcp) &&
+                          "cursor-not-allowed opacity-40 hover:text-muted-foreground",
+                      )}
+                    >
+                      Organization
+                    </button>
+                  </div>
+                  <input
+                    ref={inputRef as React.RefObject<HTMLInputElement>}
+                    value={mcpName}
+                    onChange={(e) => setMcpName(e.target.value)}
+                    className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                    placeholder="Server name (e.g. zapier)"
+                  />
+                  <input
+                    value={mcpUrl}
+                    onChange={(e) => setMcpUrl(e.target.value)}
+                    className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                    placeholder="https://mcp.example.com/"
+                  />
+                  <input
+                    value={mcpDescription}
+                    onChange={(e) => setMcpDescription(e.target.value)}
+                    className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                    placeholder="Description (optional)"
+                  />
+                  <label className="block text-[10px] font-medium text-muted-foreground/70">
+                    Headers (one per line, e.g. Authorization: Bearer ...)
+                  </label>
+                  <textarea
+                    value={mcpHeadersText}
+                    onChange={(e) => setMcpHeadersText(e.target.value)}
+                    rows={2}
+                    className="w-full resize-y rounded-md border border-border bg-background px-2.5 py-1.5 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                    style={{
+                      fontFamily:
+                        'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+                    }}
+                    placeholder="Authorization: Bearer sk-..."
+                  />
+                  {mcpTestResult && (
+                    <div
+                      className={cn(
+                        "flex items-center gap-1 text-[11px]",
+                        mcpTestResult.ok
+                          ? "text-green-600 dark:text-green-400"
+                          : "text-red-600 dark:text-red-400",
+                      )}
+                    >
+                      {mcpTestResult.ok && <IconCheck className="h-3 w-3" />}
+                      {mcpTestResult.message}
+                    </div>
+                  )}
+                  {mcpError && (
+                    <div className="text-[11px] text-red-600 dark:text-red-400">
+                      {mcpError}
+                    </div>
+                  )}
+                </div>
+                <div className="mt-2.5 flex items-center justify-between gap-2">
+                  <button
+                    type="button"
+                    onClick={runMcpTest}
+                    disabled={!mcpUrl.trim() || mcpBusy}
+                    className="rounded-md border border-border bg-background px-2.5 py-1.5 text-[11px] font-medium text-foreground hover:bg-accent disabled:opacity-40 disabled:pointer-events-none"
+                  >
+                    Test
+                  </button>
+                  <button
+                    type="button"
+                    onClick={submitMcpServer}
+                    disabled={!mcpName.trim() || !mcpUrl.trim() || mcpBusy}
+                    className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
+                  >
+                    {mcpBusy ? (
+                      <IconLoader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      "Connect"
+                    )}
+                  </button>
+                </div>
+              </div>
+            )}
+          </PopoverPrimitive.Content>
+        </PopoverPrimitive.Portal>
+      </PopoverPrimitive.Root>
+    </>
+  );
+}

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -35,6 +35,7 @@ import type {
 } from "./types.js";
 import { useVoiceDictation } from "./useVoiceDictation.js";
 import { VoiceButton, VoiceRecordingOverlay } from "./VoiceButton.js";
+import { ComposerPlusMenu } from "./ComposerPlusMenu.js";
 
 export interface TiptapComposerHandle {
   focus(): void;
@@ -998,17 +999,7 @@ export function TiptapComposer({
       </div>
       {voiceEnabled && <VoiceRecordingOverlay voice={voice} />}
       <div className="flex items-center gap-1 px-2 py-1.5">
-        {attachButton ?? (
-          <ComposerPrimitive.AddAttachment asChild>
-            <button
-              type="button"
-              className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 disabled:opacity-30 disabled:cursor-not-allowed"
-              title="Attach files"
-            >
-              <IconPlus className="h-4 w-4" />
-            </button>
-          </ComposerPrimitive.AddAttachment>
-        )}
+        {attachButton ?? <ComposerPlusMenu />}
         <div className="flex-1" />
         {actionButton ?? (
           <>

--- a/packages/core/src/client/observability/ThumbsFeedback.tsx
+++ b/packages/core/src/client/observability/ThumbsFeedback.tsx
@@ -94,11 +94,11 @@ export function ThumbsFeedback({
           "flex h-6 w-6 items-center justify-center rounded",
           selection === "up"
             ? "text-emerald-500"
-            : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-accent/50",
+            : "text-muted-foreground/70 hover:text-muted-foreground hover:bg-accent/50",
         )}
       >
         <IconThumbUp
-          size={14}
+          size={16}
           stroke={selection === "up" ? 2.5 : 1.5}
           fill={selection === "up" ? "currentColor" : "none"}
         />
@@ -114,11 +114,11 @@ export function ThumbsFeedback({
               "flex h-6 w-6 items-center justify-center rounded",
               selection === "down"
                 ? "text-red-500"
-                : "text-muted-foreground/50 hover:text-muted-foreground hover:bg-accent/50",
+                : "text-muted-foreground/70 hover:text-muted-foreground hover:bg-accent/50",
             )}
           >
             <IconThumbDown
-              size={14}
+              size={16}
               stroke={selection === "down" ? 2.5 : 1.5}
               fill={selection === "down" ? "currentColor" : "none"}
             />

--- a/packages/core/src/client/observability/ThumbsFeedback.tsx
+++ b/packages/core/src/client/observability/ThumbsFeedback.tsx
@@ -93,7 +93,7 @@ export function ThumbsFeedback({
         className={cn(
           "flex h-6 w-6 items-center justify-center rounded",
           selection === "up"
-            ? "text-emerald-500"
+            ? "text-foreground"
             : "text-muted-foreground/70 hover:text-muted-foreground hover:bg-accent/50",
         )}
       >
@@ -113,7 +113,7 @@ export function ThumbsFeedback({
             className={cn(
               "flex h-6 w-6 items-center justify-center rounded",
               selection === "down"
-                ? "text-red-500"
+                ? "text-foreground"
                 : "text-muted-foreground/70 hover:text-muted-foreground hover:bg-accent/50",
             )}
           >

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -537,7 +537,7 @@ The result should be a reusable agent profile, not a one-off task response.`,
                     <div className="text-[12px] font-medium text-foreground">
                       {item.label}
                     </div>
-                    <div className="text-[10px] text-muted-foreground/60">
+                    <div className="mt-0.5 text-[10px] text-muted-foreground/60">
                       {item.desc}
                     </div>
                   </div>

--- a/packages/core/src/styles/agent-native.css
+++ b/packages/core/src/styles/agent-native.css
@@ -13,8 +13,8 @@
  *   - shadcn/ui-compatible `@theme` color tokens that resolve from raw HSL
  *     CSS variables (--background, --foreground, --muted, …) defined per
  *     template in `:root`/`.dark` (or `.light`).
- *   - Accordion keyframes/animations (replaces the v3 tailwindcss-animate
- *     plugin for the small subset of animations the framework uses).
+ *   - Full shadcn/ui animation utilities via tw-animate-css (animate-in,
+ *     animate-out, fade, zoom, slide, spin) plus accordion keyframes.
  *   - The official typography plugin.
  *
  * Templates remain in control of their own colour palette: they only need
@@ -32,6 +32,10 @@
 @custom-variant dark (&:is(.dark *));
 
 @plugin "@tailwindcss/typography";
+
+/* shadcn/ui animation utilities (animate-in, animate-out, fade-in/out,
+   zoom-in/out, slide-in-from-*, spin-in, etc.). */
+@import "tw-animate-css";
 
 @theme {
   --color-border: hsl(var(--border));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,42 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    '@tabler/icons-react':
-      specifier: ^3.41.1
-      version: 3.41.1
-    '@tailwindcss/vite':
-      specifier: ^4.2.4
-      version: 4.2.4
-    '@vitejs/plugin-react':
-      specifier: ^6.0.1
-      version: 6.0.1
-    h3:
-      specifier: ^2.0.1-rc.20
-      version: 2.0.1-rc.20
-    listhen:
-      specifier: ^1.9.1
-      version: 1.9.1
-    react:
-      specifier: ^19.2.5
-      version: 19.2.5
-    react-dom:
-      specifier: ^19.2.5
-      version: 19.2.5
-    tailwindcss:
-      specifier: ^4.2.4
-      version: 4.2.4
-    tsx:
-      specifier: ^4.20.3
-      version: 4.21.0
-    typescript:
-      specifier: ^6.0.3
-      version: 6.0.3
-    vite:
-      specifier: 8.0.3
-      version: 8.0.3
-
 overrides:
   '@types/react': ^19.2.14
   '@types/react-dom': ^19.2.3
@@ -233,6 +197,9 @@ importers:
       tiptap-markdown:
         specifier: ^0.9.0
         version: 0.9.0(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
+      tw-animate-css:
+        specifier: 1.4.0
+        version: 1.4.0
       y-protocols:
         specifier: ^1.0.7
         version: 1.0.7(yjs@13.6.30)
@@ -14687,6 +14654,9 @@ packages:
   tunnel-rat@0.1.2:
     resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
+
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
@@ -27555,6 +27525,8 @@ snapshots:
       - '@types/react'
       - immer
       - react
+
+  tw-animate-css@1.4.0: {}
 
   type-fest@0.13.1:
     optional: true

--- a/templates/analytics/app/components/ui/alert-dialog.tsx
+++ b/templates/analytics/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/analytics/app/components/ui/dialog.tsx
+++ b/templates/analytics/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/analytics/app/components/ui/menubar.tsx
+++ b/templates/analytics/app/components/ui/menubar.tsx
@@ -95,7 +95,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/templates/calendar/app/components/ui/alert-dialog.tsx
+++ b/templates/calendar/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/calendar/app/components/ui/dialog.tsx
+++ b/templates/calendar/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/calendar/app/components/ui/menubar.tsx
+++ b/templates/calendar/app/components/ui/menubar.tsx
@@ -95,7 +95,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/templates/calls/AGENTS.md
+++ b/templates/calls/AGENTS.md
@@ -410,7 +410,7 @@ All standard CRUD (list, get, create, update) goes through `/_agent-native/actio
 - **Inter font** for all UI.
 - **Monochrome palette** — `#111111` is the Calls primary brand color. It maps to `--brand` in the Tailwind config and is the default `workspaces.brand_color`.
 - **1.0x** is the default playback speed for calls (stored in `calls.default_speed`). Calls are conversations, not demos — normal speed by default.
-- **No decorative CSS transitions.** Keep the UI snappy.
+- **Keep shadcn default transitions** (animate-in/out, fade, zoom, slide). Avoid custom decorative transitions — keep the UI snappy.
 
 ## Rules
 

--- a/templates/calls/app/components/ui/alert-dialog.tsx
+++ b/templates/calls/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/calls/app/components/ui/dialog.tsx
+++ b/templates/calls/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/calls/app/components/ui/menubar.tsx
+++ b/templates/calls/app/components/ui/menubar.tsx
@@ -95,7 +95,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -346,7 +346,7 @@ All standard CRUD (list, get, create, update) goes through `/_agent-native/actio
 - **Inter font** for all UI.
 - **Monochrome aesthetic.** Default space/folder/org color is `#18181B` (neutral zinc-900). Brand color is user-customizable via `set-organization-branding` (stored in `organization_settings`).
 - **1.2x** is the default playback speed for every recording (stored in `recordings.default_speed`).
-- **No decorative CSS transitions.** Keep the UI snappy.
+- **Keep shadcn default transitions** (animate-in/out, fade, zoom, slide). Avoid custom decorative transitions — keep the UI snappy.
 
 ## Rules
 

--- a/templates/clips/app/components/ui/alert-dialog.tsx
+++ b/templates/clips/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/clips/app/components/ui/dialog.tsx
+++ b/templates/clips/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/clips/app/components/ui/menubar.tsx
+++ b/templates/clips/app/components/ui/menubar.tsx
@@ -95,7 +95,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/templates/content/app/components/ui/dialog.tsx
+++ b/templates/content/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/dispatch/app/components/ui/alert-dialog.tsx
+++ b/templates/dispatch/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/dispatch/app/components/ui/dialog.tsx
+++ b/templates/dispatch/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/dispatch/app/components/ui/menubar.tsx
+++ b/templates/dispatch/app/components/ui/menubar.tsx
@@ -95,7 +95,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/templates/forms/app/components/ui/alert-dialog.tsx
+++ b/templates/forms/app/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/forms/app/components/ui/dialog.tsx
+++ b/templates/forms/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/forms/app/components/ui/menubar.tsx
+++ b/templates/forms/app/components/ui/menubar.tsx
@@ -115,7 +115,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-menubar-content-transform-origin]",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-menubar-content-transform-origin]",
           className,
         )}
         {...props}

--- a/templates/issues/app/components/ui/alert-dialog.tsx
+++ b/templates/issues/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/issues/app/components/ui/dialog.tsx
+++ b/templates/issues/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/issues/app/components/ui/menubar.tsx
+++ b/templates/issues/app/components/ui/menubar.tsx
@@ -95,7 +95,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/templates/macros/app/components/ui/alert-dialog.tsx
+++ b/templates/macros/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/macros/app/components/ui/dialog.tsx
+++ b/templates/macros/app/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         // Mobile: positioned at top with padding, scrollable
-        "fixed left-[50%] top-4 z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] gap-4 border bg-background p-6 shadow-lg max-h-[calc(100vh-2rem)] overflow-y-auto rounded-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "fixed left-[50%] top-4 z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] gap-4 border bg-background p-6 shadow-lg max-h-[calc(100vh-2rem)] overflow-y-auto rounded-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
         // Desktop: centered vertically
         "sm:top-[50%] sm:translate-y-[-50%] sm:max-h-[85vh]",
         className,

--- a/templates/macros/app/components/ui/dialog.tsx
+++ b/templates/macros/app/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         // Mobile: positioned at top with padding, scrollable
-        "fixed left-[50%] top-4 z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] gap-4 border bg-background p-6 shadow-lg max-h-[calc(100vh-2rem)] overflow-y-auto rounded-lg",
+        "fixed left-[50%] top-4 z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] gap-4 border bg-background p-6 shadow-lg max-h-[calc(100vh-2rem)] overflow-y-auto rounded-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         // Desktop: centered vertically
         "sm:top-[50%] sm:translate-y-[-50%] sm:max-h-[85vh]",
         className,

--- a/templates/macros/app/components/ui/menubar.tsx
+++ b/templates/macros/app/components/ui/menubar.tsx
@@ -99,7 +99,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/templates/mail/app/components/ui/alert-dialog.tsx
+++ b/templates/mail/app/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/mail/app/components/ui/dialog.tsx
+++ b/templates/mail/app/components/ui/dialog.tsx
@@ -42,7 +42,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/mail/app/components/ui/dropdown-menu.tsx
+++ b/templates/mail/app/components/ui/dropdown-menu.tsx
@@ -39,7 +39,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}

--- a/templates/mail/app/components/ui/menubar.tsx
+++ b/templates/mail/app/components/ui/menubar.tsx
@@ -115,7 +115,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-menubar-content-transform-origin]",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-menubar-content-transform-origin]",
           className,
         )}
         {...props}

--- a/templates/scheduling/AGENTS.md
+++ b/templates/scheduling/AGENTS.md
@@ -155,9 +155,10 @@ can _manage_ a resource, not who can book against it.
   no emoji icons.
 - **No browser dialogs** (`window.confirm/alert/prompt`) — use
   `AlertDialog` from shadcn.
-- **No decorative transitions** — keep UI snappy. Framer-motion is allowed
-  for booker stage transitions where a continuous, animated feel is the
-  intended product polish.
+- **Keep shadcn default transitions** (animate-in/out, fade, zoom, slide).
+  Avoid custom decorative transitions — keep the UI snappy. Framer-motion is
+  allowed for booker stage transitions where a continuous, animated feel is
+  the intended product polish.
 - **Use shadcn's default pill tabs** for the event type editor — not
   MUI-style underline tabs.
 - **Call view-screen first** when the user's request is ambiguous about

--- a/templates/scheduling/app/components/ui/alert-dialog.tsx
+++ b/templates/scheduling/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/scheduling/app/components/ui/dialog.tsx
+++ b/templates/scheduling/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/slides/app/components/ui/alert-dialog.tsx
+++ b/templates/slides/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/slides/app/components/ui/dialog.tsx
+++ b/templates/slides/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/slides/app/components/ui/menubar.tsx
+++ b/templates/slides/app/components/ui/menubar.tsx
@@ -95,7 +95,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/templates/starter/app/components/ui/alert-dialog.tsx
+++ b/templates/starter/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/starter/app/components/ui/dialog.tsx
+++ b/templates/starter/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/starter/app/components/ui/menubar.tsx
+++ b/templates/starter/app/components/ui/menubar.tsx
@@ -95,7 +95,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/templates/videos/app/components/ui/alert-dialog.tsx
+++ b/templates/videos/app/components/ui/alert-dialog.tsx
@@ -34,7 +34,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/videos/app/components/ui/dialog.tsx
+++ b/templates/videos/app/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/templates/videos/app/components/ui/menubar.tsx
+++ b/templates/videos/app/components/ui/menubar.tsx
@@ -95,7 +95,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary
- Only show the plan/act execution mode selector in the agent sidebar when in development mode
- Production mode always uses act mode — the toggle is hidden and stale localStorage plan-mode values are ignored

## Test plan
- [ ] In dev mode, verify plan/act toggle appears in the composer
- [ ] Switch to production mode, verify toggle is gone
- [ ] Set localStorage to plan mode in dev, switch to prod, verify messages don't get plan mode instruction prefix