### PR TITLE
feat(core,clips,macros): mobile sidebar animation, cleanup, meal tool fix

### DIFF
--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1668,9 +1668,6 @@ export function AgentSidebar({
           ? "translateX(0)"
           : `translateX(${isLeft ? "-" : ""}calc(100% + 1px))`
         : undefined,
-      transition: animateMobile
-        ? "transform 260ms cubic-bezier(0.32, 0.72, 0, 1)"
-        : undefined,
       pointerEvents: animateMobile && !open ? "none" : undefined,
       willChange: animateMobile ? "transform" : undefined,
     };
@@ -1714,9 +1711,10 @@ export function AgentSidebar({
           "agent-sidebar-panel flex shrink-0 flex-col overflow-hidden text-[13px] leading-[1.2] antialiased",
           animateMobile &&
             isMobile &&
-            "shadow-2xl motion-reduce:transition-none",
+            "shadow-2xl transition-transform duration-[260ms] ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
         )}
         style={panelStyle}
+        inert={isMobile && !open ? true : undefined}
         aria-hidden={isMobile && !open ? true : undefined}
       >
         <AgentPanel

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1428,6 +1428,8 @@ export interface AgentSidebarProps {
   position?: "left" | "right";
   /** Whether the sidebar starts open. Default: false */
   defaultOpen?: boolean;
+  /** Animate the mobile overlay in a sheet-style slide transition. */
+  animateMobile?: boolean;
 }
 
 /**
@@ -1441,6 +1443,7 @@ export function AgentSidebar({
   sidebarWidth = 380,
   position = "right",
   defaultOpen = false,
+  animateMobile = false,
 }: AgentSidebarProps) {
   const [open, setOpen] = useState(() => {
     // On mobile viewports the sidebar would cover most of the screen, so
@@ -1659,7 +1662,17 @@ export function AgentSidebar({
       background: "hsl(var(--background))",
       borderLeft: isLeft ? "none" : "1px solid hsl(var(--border))",
       borderRight: isLeft ? "1px solid hsl(var(--border))" : "none",
-      display: open ? "flex" : "none",
+      display: animateMobile || open ? "flex" : "none",
+      transform: animateMobile
+        ? open
+          ? "translateX(0)"
+          : `translateX(${isLeft ? "-" : ""}calc(100% + 1px))`
+        : undefined,
+      transition: animateMobile
+        ? "transform 260ms cubic-bezier(0.32, 0.72, 0, 1)"
+        : undefined,
+      pointerEvents: animateMobile && !open ? "none" : undefined,
+      willChange: animateMobile ? "transform" : undefined,
     };
   } else if (effectiveFullscreen) {
     panelStyle = {
@@ -1697,8 +1710,14 @@ export function AgentSidebar({
         <ResizeHandle position={position} onDrag={handleDrag} />
       )}
       <div
-        className="agent-sidebar-panel flex shrink-0 flex-col overflow-hidden text-[13px] leading-[1.2] antialiased"
+        className={cn(
+          "agent-sidebar-panel flex shrink-0 flex-col overflow-hidden text-[13px] leading-[1.2] antialiased",
+          animateMobile &&
+            isMobile &&
+            "shadow-2xl motion-reduce:transition-none",
+        )}
         style={panelStyle}
+        aria-hidden={isMobile && !open ? true : undefined}
       >
         <AgentPanel
           emptyStateText={emptyStateText}
@@ -1717,9 +1736,15 @@ export function AgentSidebar({
   return (
     <div className="flex min-w-0 flex-1 h-screen overflow-hidden">
       {/* Mobile backdrop — tapping it closes the sidebar */}
-      {isMobile && open && !presentationMode && (
+      {isMobile && !presentationMode && (animateMobile || open) && (
         <div
-          className="fixed inset-0 z-40 bg-black/40"
+          className={cn(
+            "fixed inset-0 z-40 bg-black/40",
+            animateMobile &&
+              "transition-opacity duration-200 motion-reduce:transition-none",
+            animateMobile && !open && "pointer-events-none opacity-0",
+            animateMobile && open && "opacity-100",
+          )}
           onClick={() => setOpenPersisted(false)}
         />
       )}

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -79,6 +79,13 @@ export function processEvent(
   if (ev.type === "tool_start") {
     const toolCallId = `tc_${++toolCallCounter.value}`;
     const args = (ev.input ?? {}) as Record<string, string>;
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("agent-native:tool-start", {
+          detail: { tool: ev.tool ?? "unknown", input: args },
+        }),
+      );
+    }
     content.push({
       type: "tool-call",
       toolCallId,
@@ -93,6 +100,13 @@ export function processEvent(
   }
 
   if (ev.type === "tool_done") {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(
+        new CustomEvent("agent-native:tool-done", {
+          detail: { tool: ev.tool ?? "unknown", result: ev.result },
+        }),
+      );
+    }
     for (let i = content.length - 1; i >= 0; i--) {
       const part = content[i];
       if (

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -25,11 +25,6 @@ use util::{is_recording_active, set_capture_excluded};
 // should replace with their real icon.
 pub(crate) const TRAY_PNG: &[u8] = include_bytes!("../icons/tray.png");
 
-#[tauri::command]
-async fn js_log(msg: String) {
-    eprintln!("[clips-js] {}", msg);
-}
-
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -66,8 +61,6 @@ pub fn run() {
             // config commands
             config::get_feature_config,
             config::set_feature_config,
-            // diagnostic
-            js_log,
         ])
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_process::init())

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -433,6 +433,7 @@ export function App() {
 
   useEffect(() => {
     if (!bubbleActive) return;
+    setCameraError(null);
 
     let cancelled = false;
     // Dual-transport bookkeeping. We try WebRTC first; if it fails or

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -432,9 +432,6 @@ export function App() {
   }, [toolbarActive]);
 
   useEffect(() => {
-    invoke("js_log", {
-      msg: `bubbleActive=${bubbleActive} wantsCamera=${wantsCamera} popoverVisible=${popoverVisible} mode=${mode} cameraOn=${cameraOn}`,
-    }).catch(() => {});
     if (!bubbleActive) return;
 
     let cancelled = false;
@@ -507,9 +504,6 @@ export function App() {
       .catch((err) => {
         if (cancelled) return;
         console.error("[clips-popover] camera acquisition failed:", err);
-        invoke("js_log", {
-          msg: `CAMERA FAILED: ${err?.name} ${err?.message}`,
-        }).catch(() => {});
         const msg = err?.message ?? "";
         if (
           msg.includes("AVVideoCaptureSource") ||
@@ -784,9 +778,6 @@ export function App() {
     // flag + popover visibility) were already restored in the finally
     // block above. Now surface any non-cancel error to the UI.
     console.error("[clips-popover] startRecording failed:", startError);
-    invoke("js_log", {
-      msg: `RECORDING FAILED: ${(startError as any)?.name} ${(startError as any)?.message}`,
-    }).catch(() => {});
 
     // User cancelled the macOS screen-picker (or denied permission).
     // WebKit throws DOMException `NotAllowedError` for BOTH cancel and
@@ -991,6 +982,9 @@ export function App() {
         Start recording
       </button>
       {recError ? <div className="error-banner">{recError}</div> : null}
+      {cameraError && !recError ? (
+        <div className="error-banner">{cameraError}</div>
+      ) : null}
 
       <div className="bottom-row">
         <BottomButton

--- a/templates/clips/desktop/src/lib/recorder.ts
+++ b/templates/clips/desktop/src/lib/recorder.ts
@@ -265,9 +265,6 @@ export async function startNativeRecording(
       e?.message,
       err,
     );
-    invoke("js_log", {
-      msg: `RECORDER THREW: ${e?.name} ${e?.message}`,
-    }).catch(() => {});
     throw err;
   }
 }

--- a/templates/macros/AGENTS.md
+++ b/templates/macros/AGENTS.md
@@ -75,6 +75,8 @@ cd templates/macros && pnpm action <name> [args]
 | `edit-item`      | `--type --id [field args]`                             | Edit an existing item        |
 | `get-analytics`  | `[--days]`                                             | Get calorie/weight analytics |
 
+Meal logging rule: for any request to add, log, record, or track a meal, use `log-meal` directly. Never use `web-request`, `fetch`, raw HTTP, or `/_agent-native/actions/log-meal` manually to create a meal entry. If nutrition numbers are not exact, make a reasonable estimate and still call `log-meal`.
+
 ## Common Tasks
 
 | User request                   | What to do                                             |

--- a/templates/macros/actions/log-meal.ts
+++ b/templates/macros/actions/log-meal.ts
@@ -7,7 +7,8 @@ import { db, schema } from "../server/db/index.js";
 import { z } from "zod";
 
 export default defineAction({
-  description: "Log a meal with calories and optional macros",
+  description:
+    "Log/add/record a meal entry with calories and optional macros. Use this for every user request to add a meal; do not use web-request/fetch/raw HTTP to create meals.",
   schema: z.object({
     name: z.string().optional().describe("Meal name"),
     calories: z.coerce.number().optional().describe("Calories"),

--- a/templates/macros/app/components/DailyProgress.tsx
+++ b/templates/macros/app/components/DailyProgress.tsx
@@ -25,8 +25,6 @@ import {
   IconTrendingUp,
   IconActivity,
   IconChartBar,
-  IconChevronDown,
-  IconChevronUp,
 } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 
@@ -53,7 +51,6 @@ export function DailyProgress({
         ? localStorage.getItem("hero_active_chart")
         : null) || "weight",
   );
-  const [showTrendsMobile, setShowTrendsMobile] = useState(false);
 
   useEffect(() => {
     localStorage.setItem("hero_active_chart", activeChart);
@@ -94,7 +91,7 @@ export function DailyProgress({
 
   return (
     <div className="relative overflow-hidden rounded-2xl border border-white/[0.08] bg-white/[0.02] p-4 sm:p-5 backdrop-blur-sm">
-      <div className="grid lg:grid-cols-[1fr,340px] gap-6 sm:gap-8">
+      <div className="grid xl:grid-cols-[1fr_340px] gap-6 xl:gap-8">
         {/* Left Side */}
         <div className="space-y-8 flex flex-col justify-center">
           <div className="flex items-center justify-between">
@@ -102,22 +99,6 @@ export function DailyProgress({
               <p className="text-[10px] font-medium text-muted-foreground uppercase tracking-widest">
                 Daily Summary
               </p>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="lg:hidden h-6 px-2 text-[10px] uppercase tracking-widest text-muted-foreground hover:text-foreground hover:bg-white/5 gap-1"
-                onClick={() => setShowTrendsMobile(!showTrendsMobile)}
-              >
-                {showTrendsMobile ? (
-                  <>
-                    Hide Trends <IconChevronUp className="h-3 w-3" />
-                  </>
-                ) : (
-                  <>
-                    Show Trends <IconChevronDown className="h-3 w-3" />
-                  </>
-                )}
-              </Button>
             </div>
             <div className="px-3 py-1.5 rounded-full bg-white/[0.05] border border-white/[0.05] flex items-center">
               <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-widest leading-none">
@@ -213,12 +194,7 @@ export function DailyProgress({
         </div>
 
         {/* Right Side: Charts */}
-        <div
-          className={cn(
-            "border-t lg:border-t-0 lg:border-l border-white/[0.08] pt-8 lg:pt-0 lg:pl-8 flex flex-col justify-center transition-all duration-300",
-            !showTrendsMobile && "hidden lg:flex",
-          )}
-        >
+        <div className="hidden xl:flex border-l border-white/[0.08] pl-8 flex-col justify-center transition-all duration-300">
           <Tabs
             value={activeChart}
             onValueChange={setActiveChart}

--- a/templates/macros/app/components/layout/AppLayout.tsx
+++ b/templates/macros/app/components/layout/AppLayout.tsx
@@ -65,6 +65,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
     <AgentSidebar
       position="right"
       defaultOpen={false}
+      animateMobile
       emptyStateText="Just tell me what you ate — I'll estimate the macros"
       suggestions={[
         "Fried chicken dinner, 600 cal",

--- a/templates/macros/app/components/layout/AppLayout.tsx
+++ b/templates/macros/app/components/layout/AppLayout.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect, useCallback } from "react";
 import { Link, useLocation, useNavigate } from "react-router";
-import { useIsFetching, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useIsFetching,
+  useIsMutating,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   AgentSidebar,
   AgentToggleButton,
@@ -118,6 +123,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
 
         {/* Page content */}
         <main className="flex-1 overflow-y-auto">{children}</main>
+        <AgentActionOptimisticUpdates />
         <SyncIndicator />
       </div>
     </AgentSidebar>
@@ -125,12 +131,149 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
 }
 
 function SyncIndicator() {
-  const isFetching = useIsFetching({ queryKey: ["action"] });
-  if (!isFetching) return null;
+  const refetchingActions = useIsFetching({
+    predicate: (query) =>
+      query.queryKey[0] === "action" && query.state.dataUpdatedAt > 0,
+  });
+  const mutatingActions = useIsMutating();
+  const [agentToolRuns, setAgentToolRuns] = useState(0);
+
+  useEffect(() => {
+    const trackedTools = new Set(["log-meal", "log-exercise", "log-weight"]);
+    const handleStart = (event: Event) => {
+      const tool = (event as CustomEvent).detail?.tool;
+      if (trackedTools.has(tool)) setAgentToolRuns((count) => count + 1);
+    };
+    const handleDone = (event: Event) => {
+      const tool = (event as CustomEvent).detail?.tool;
+      if (!trackedTools.has(tool)) return;
+      setTimeout(() => {
+        setAgentToolRuns((count) => Math.max(0, count - 1));
+      }, 400);
+    };
+
+    window.addEventListener("agent-native:tool-start", handleStart);
+    window.addEventListener("agent-native:tool-done", handleDone);
+    return () => {
+      window.removeEventListener("agent-native:tool-start", handleStart);
+      window.removeEventListener("agent-native:tool-done", handleDone);
+    };
+  }, []);
+
+  const isSyncing =
+    refetchingActions > 0 || mutatingActions > 0 || agentToolRuns > 0;
+
+  if (!isSyncing) return null;
+
   return (
-    <div className="fixed bottom-4 left-4 z-50 flex items-center gap-2 rounded-full bg-muted/80 backdrop-blur-sm px-3 py-1.5 text-xs text-muted-foreground shadow-sm border border-white/[0.06]">
+    <div className="fixed bottom-10 md:bottom-8 left-4 z-50 flex h-8 items-center gap-2 rounded-full bg-muted/80 backdrop-blur-sm px-3 text-xs text-muted-foreground shadow-sm border border-white/[0.06]">
       <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
       Syncing…
     </div>
   );
+}
+
+function AgentActionOptimisticUpdates() {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const normalizeDate = (value: unknown) => {
+      if (typeof value === "string" && value.trim()) {
+        return value.split("T")[0];
+      }
+      const today = new Date();
+      const year = today.getFullYear();
+      const month = String(today.getMonth() + 1).padStart(2, "0");
+      const day = String(today.getDate()).padStart(2, "0");
+      return `${year}-${month}-${day}`;
+    };
+
+    const updateList = (
+      listAction: string,
+      date: string,
+      optimisticId: number,
+      item: Record<string, unknown>,
+    ) => {
+      queryClient.setQueriesData(
+        {
+          predicate: (query) => {
+            const [prefix, actionName, params] = query.queryKey;
+            return (
+              prefix === "action" &&
+              actionName === listAction &&
+              (!params ||
+                typeof params !== "object" ||
+                (params as { date?: string }).date === date)
+            );
+          },
+        },
+        (oldData: unknown) => {
+          if (!Array.isArray(oldData)) return oldData;
+          if (
+            oldData.some(
+              (existing) =>
+                existing &&
+                typeof existing === "object" &&
+                (existing as { id?: unknown }).id === optimisticId,
+            )
+          ) {
+            return oldData;
+          }
+          return [item, ...oldData];
+        },
+      );
+    };
+
+    const handleToolStart = (event: Event) => {
+      const detail = (event as CustomEvent).detail as
+        | { tool?: string; input?: Record<string, unknown> }
+        | undefined;
+      const tool = detail?.tool;
+      const input = detail?.input ?? {};
+      const date = normalizeDate(input.date);
+      const optimisticId = -Date.now();
+      const created_at = new Date().toISOString();
+
+      if (tool === "log-meal") {
+        updateList("list-meals", date, optimisticId, {
+          id: optimisticId,
+          name: String(input.name || "Meal"),
+          calories: Number(input.calories || 0),
+          protein: input.protein == null ? null : Number(input.protein),
+          carbs: input.carbs == null ? null : Number(input.carbs),
+          fat: input.fat == null ? null : Number(input.fat),
+          date,
+          image_url: null,
+          notes: null,
+          created_at,
+        });
+      } else if (tool === "log-exercise") {
+        updateList("list-exercises", date, optimisticId, {
+          id: optimisticId,
+          name: String(input.name || "Exercise"),
+          calories_burned: Number(input.calories_burned || 0),
+          duration_minutes:
+            input.duration_minutes == null
+              ? null
+              : Number(input.duration_minutes),
+          date,
+          created_at,
+        });
+      } else if (tool === "log-weight" && input.weight != null) {
+        updateList("list-weights", date, optimisticId, {
+          id: optimisticId,
+          weight: Number(input.weight),
+          date,
+          notes: input.notes == null ? null : String(input.notes),
+          created_at,
+        });
+      }
+    };
+
+    window.addEventListener("agent-native:tool-start", handleToolStart);
+    return () =>
+      window.removeEventListener("agent-native:tool-start", handleToolStart);
+  }, [queryClient]);
+
+  return null;
 }

--- a/templates/macros/server/plugins/agent-chat.ts
+++ b/templates/macros/server/plugins/agent-chat.ts
@@ -73,6 +73,12 @@ Users often speak or type in ultra-short form. Parse aggressively:
 - A meal name + number always means log that meal at that many calories
 - Numbers without a unit are always calories (not grams, not time)
 
+## Tool Choice
+
+For any request to add, log, record, or track a meal, you MUST call \`log-meal\`. Do not use \`web-request\`, \`fetch\`, raw HTTP calls, or action HTTP endpoints to create meals. \`log-meal\` is the only correct tool for creating meal entries.
+
+If the user gives a meal and enough detail to estimate calories/macros, estimate from your own nutrition knowledge and call \`log-meal\` immediately. If you are unsure about exact nutrition, make a reasonable estimate rather than looking up an external API first. External lookups are only for explicit research questions like "look up nutrition facts for..." and must not replace \`log-meal\` when the user asked to add a meal.
+
 ## Voice Transcription Quirks
 
 Speech recognition frequently mishears numbers as times:
@@ -96,7 +102,7 @@ Be FAST and MINIMAL:
 
 For straightforward commands ("jog 400", "lunch 550", "snack 200"), go straight to the action — no reasoning needed.
 
-For food items where accurate macro estimation matters (e.g., "300g salmon and an apple", "chicken tikka masala", "avocado toast with eggs"), take a moment to think through the macros and use the fetch tool to look up calories/macros per gram when you're unsure (e.g., fetch a nutrition API or known source). Accuracy matters more than speed for nutrition data — users rely on these numbers.
+For food items where accurate macro estimation matters (e.g., "300g salmon and an apple", "chicken tikka masala", "avocado toast with eggs"), take a moment to think through the macros from nutrition knowledge, then call \`log-meal\`. Accuracy matters, but a reasonable estimate logged with the correct tool is better than delaying or routing the meal through an external API.
 
 Custom instructions from the user override these defaults.
 


### PR DESCRIPTION
## Summary
- **Core AgentPanel**: New `animateMobile` prop for sheet-style slide-in/out on mobile with backdrop fade, respects `motion-reduce`
- **Clips desktop**: Remove unused `js_log` Tauri command and all debug invoke calls; surface camera errors in the UI
- **Macros**: Reinforce `log-meal` as the only tool for meal entries (prevents agent from using web-request/fetch); enable `animateMobile` on the sidebar

## Test plan
- [ ] Verify macros mobile sidebar slides in/out smoothly
- [ ] Verify clips desktop builds without `js_log` references
- [ ] Confirm macros agent uses `log-meal` tool (not web-request) when asked to log a meal

🤖 Generated with [Claude Code](https://claude.com/claude-code)