### PR TITLE
feat(clips-desktop): friendly preflight when Rust toolchain is missing

### DIFF
--- a/templates/clips/desktop/package.json
+++ b/templates/clips/desktop/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "description": "Clips menu-bar tray app (Tauri 2). Quick-record + recent recordings from the OS tray.",
   "scripts": {
-    "dev": "tauri dev",
+    "check:prereqs": "node ./scripts/check-tauri-prereqs.mjs",
+    "dev": "pnpm run check:prereqs && tauri dev",
     "build": "vite build",
-    "build:tauri": "tauri build",
+    "build:tauri": "pnpm run check:prereqs && tauri build",
     "tauri": "tauri",
     "vite:dev": "vite",
     "vite:build": "vite build"

--- a/templates/clips/desktop/scripts/check-tauri-prereqs.mjs
+++ b/templates/clips/desktop/scripts/check-tauri-prereqs.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// Preflight: verify Tauri's native prerequisites before invoking `tauri dev` /
+// `tauri build`. Without this, devs see a cryptic
+// `failed to run 'cargo metadata' command` error from the Tauri CLI.
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const CYAN = "\x1b[36m";
+const DIM = "\x1b[2m";
+
+function has(cmd) {
+  try {
+    execFileSync(platform() === "win32" ? "where" : "which", [cmd], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function cargoOnDisk() {
+  // rustup installs to ~/.cargo/bin but the shell PATH update only takes effect
+  // in new shells — detect this case so we can give a clearer "restart shell" hint.
+  const bin = platform() === "win32" ? "cargo.exe" : "cargo";
+  const candidate = join(homedir(), ".cargo", "bin", bin);
+  return existsSync(candidate) ? candidate : null;
+}
+
+function fail(lines) {
+  process.stderr.write("\n");
+  process.stderr.write(
+    `${RED}${BOLD}Clips Desktop — missing prerequisites${RESET}\n`,
+  );
+  process.stderr.write(`${DIM}${"─".repeat(60)}${RESET}\n`);
+  for (const line of lines) process.stderr.write(line + "\n");
+  process.stderr.write(`${DIM}${"─".repeat(60)}${RESET}\n`);
+  process.stderr.write(
+    `${DIM}Full Tauri prerequisites: https://tauri.app/start/prerequisites/${RESET}\n\n`,
+  );
+  process.exit(1);
+}
+
+if (!has("cargo")) {
+  const stranded = cargoOnDisk();
+  if (stranded) {
+    fail([
+      "",
+      `${YELLOW}Rust is installed but ${BOLD}not on your PATH${RESET}${YELLOW} in this shell.${RESET}`,
+      "",
+      `Found: ${DIM}${stranded}${RESET}`,
+      "",
+      `${BOLD}Fix:${RESET} either open a new terminal, or run:`,
+      "",
+      `  ${CYAN}source "$HOME/.cargo/env"${RESET}`,
+      "",
+      "Then re-run this command.",
+    ]);
+  }
+
+  const os = platform();
+  const installLines = [
+    "",
+    `${YELLOW}Tauri needs the Rust toolchain (${BOLD}cargo${RESET}${YELLOW}), and it isn't installed.${RESET}`,
+    "",
+    `${BOLD}Install Rust:${RESET}`,
+    "",
+  ];
+
+  if (os === "win32") {
+    installLines.push(
+      `  ${CYAN}1.${RESET} Download and run ${CYAN}https://win.rustup.rs/x86_64${RESET}`,
+      `  ${CYAN}2.${RESET} You'll also need the ${BOLD}Microsoft C++ Build Tools${RESET}:`,
+      `     ${DIM}https://visualstudio.microsoft.com/visual-cpp-build-tools/${RESET}`,
+      `  ${CYAN}3.${RESET} Open a new terminal, then re-run this command.`,
+    );
+  } else {
+    installLines.push(
+      `  ${CYAN}curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y${RESET}`,
+      "",
+      `Then load it into the current shell:`,
+      "",
+      `  ${CYAN}source "$HOME/.cargo/env"${RESET}`,
+      "",
+      `…and re-run this command.`,
+    );
+    if (os === "darwin") {
+      installLines.push(
+        "",
+        `${DIM}macOS also needs Xcode Command Line Tools. If they aren't installed,`,
+        `the next \`cargo build\` will prompt you — or run \`xcode-select --install\`.${RESET}`,
+      );
+    } else {
+      installLines.push(
+        "",
+        `${DIM}Linux also needs system libs (webkit2gtk, libssl, etc.). See the Tauri prerequisites link below.${RESET}`,
+      );
+    }
+  }
+
+  fail(installLines);
+}


### PR DESCRIPTION
## Summary

- `pnpm dev:all:desktop` previously failed with a cryptic `failed to run 'cargo metadata' command: No such file or directory` when Rust wasn't installed.
- Adds a small preflight script (`templates/clips/desktop/scripts/check-tauri-prereqs.mjs`) that runs before `tauri dev` / `tauri build` and prints clear, OS-specific install instructions instead.
- Detects three states:
  - `cargo` on PATH → exit 0, run normally
  - `~/.cargo/bin/cargo` exists but isn't on PATH (rustup just ran, shell not re-sourced) → tells the dev to `source "$HOME/.cargo/env"` or open a new terminal
  - Nothing installed → prints the rustup install command (curl one-liner on macOS/Linux, link to win.rustup.rs + MSVC build tools on Windows), plus a hint about Xcode CLT on macOS

## Test plan

- [x] Verified preflight exits 1 with the friendly "missing prerequisites" message when `cargo` isn't on PATH
- [x] Verified the "stranded cargo" branch fires when `~/.cargo/bin/cargo` exists but isn't on PATH
- [x] Verified preflight exits 0 when `cargo` is on PATH (running `tauri dev` proceeds normally)