### PR TITLE
feat: lightweight dev:all:desktop for low-RAM machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "guard:no-drizzle-push": "node scripts/guard-no-drizzle-push.mjs",
     "prep": "concurrently -n fmt,types,test,guard -c blue,cyan,green,yellow \"pnpm fmt\" \"pnpm typecheck\" \"pnpm test\" \"pnpm guard:no-drizzle-push\"",
     "dev:all": "(pnpm --filter @agent-native/core build || true) && node scripts/dev-all.ts",
-    "dev:all:desktop": "concurrently -k -n apps,tray -c blue,magenta \"pnpm dev:all\" \"pnpm --filter clips-desktop dev\"",
+    "dev:all:desktop": "concurrently -k -n apps,tray -c blue,magenta \"(pnpm --filter @agent-native/core build || true) && node scripts/dev-all.ts --apps clips --no-docs --no-frame\" \"pnpm --filter clips-desktop dev\"",
     "dev:docs": "pnpm --filter @agent-native/docs dev",
     "dev:electron": "node scripts/dev-electron.ts",
     "dev:electron:apps": "node scripts/dev-electron.ts --apps"

--- a/scripts/dev-all.ts
+++ b/scripts/dev-all.ts
@@ -12,6 +12,23 @@ const TEMPLATES_DIR = path.resolve("templates");
 const DOCS_PORT = 3000;
 const FALLBACK_BASE_PORT = 9001; // for templates not in the config
 
+// ── Args ──────────────────────────────────────────────────────
+// Lightweight mode for low-RAM machines / focused work:
+//   --apps clips,calendar  → only boot listed templates (default: all)
+//   --no-docs              → skip docs server
+//   --no-frame             → skip dev frame server
+const argv = process.argv.slice(2);
+function flagValue(name: string): string | null {
+  const i = argv.indexOf(name);
+  return i !== -1 && argv[i + 1] ? argv[i + 1] : null;
+}
+const appsFilter = flagValue("--apps")
+  ?.split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+const skipDocs = argv.includes("--no-docs");
+const skipFrame = argv.includes("--no-frame");
+
 // Import the app config to get stable ports. Ports live in templates.ts
 // (the single source of truth for template metadata); shared-app-config/index.ts
 // derives AppConfig[] from it at runtime, so there are no literal id/port pairs
@@ -28,10 +45,27 @@ while ((m = re.exec(configSrc)) !== null) {
 }
 
 // Discover templates
-const templates = fs
+let templates = fs
   .readdirSync(TEMPLATES_DIR)
   .filter((d) => fs.existsSync(path.join(TEMPLATES_DIR, d, "package.json")))
   .sort();
+
+if (appsFilter && appsFilter.length > 0) {
+  const known = new Set(templates);
+  const unknown = appsFilter.filter((a) => !known.has(a));
+  if (unknown.length > 0) {
+    console.warn(
+      `\x1b[33m[dev-all]\x1b[0m Warning: unknown apps in --apps: ${unknown.join(", ")}`,
+    );
+  }
+  templates = templates.filter((t) => appsFilter.includes(t));
+  if (templates.length === 0) {
+    console.error(
+      `\x1b[31m[dev-all]\x1b[0m No templates matched --apps; nothing to start`,
+    );
+    process.exit(1);
+  }
+}
 
 // Assign ports: use shared-app-config if available, otherwise fallback
 let nextFallback = FALLBACK_BASE_PORT;
@@ -75,7 +109,9 @@ if (killPortProcesses()) {
 console.log(
   `\x1b[36m[dev-all]\x1b[0m Found templates: ${templates.join(", ")}`,
 );
-console.log(`\x1b[36m[dev-all]\x1b[0m Docs: http://localhost:${DOCS_PORT}`);
+if (!skipDocs) {
+  console.log(`\x1b[36m[dev-all]\x1b[0m Docs: http://localhost:${DOCS_PORT}`);
+}
 
 // Prebuild core once before templates boot. Templates import from
 // @agent-native/core/server; if tsc --watch is mid-rewrite of dist/ when a
@@ -115,13 +151,17 @@ commands.push(
 );
 
 // Local Dev Frame
-names.push("frame");
-commands.push("pnpm --filter @agent-native/frame dev");
-console.log(`\x1b[36m[dev-all]\x1b[0m frame: http://localhost:3334`);
+if (!skipFrame) {
+  names.push("frame");
+  commands.push("pnpm --filter @agent-native/frame dev");
+  console.log(`\x1b[36m[dev-all]\x1b[0m frame: http://localhost:3334`);
+}
 
 // Docs site
-names.push("docs");
-commands.push(`pnpm --filter @agent-native/docs dev`);
+if (!skipDocs) {
+  names.push("docs");
+  commands.push(`pnpm --filter @agent-native/docs dev`);
+}
 
 const proc = spawn(
   "npx",


### PR DESCRIPTION
## Summary
- `dev:all:desktop` was booting all 18 template Vite/Nitro servers (~1GB each) plus docs + frame, shredding RAM on smaller machines.
- Added `--apps a,b,c`, `--no-docs`, `--no-frame` flags to `scripts/dev-all.ts`.
- Repointed `dev:all:desktop` at the lightweight subset: just the `clips` template + core watch + tray. ~20GB → ~3GB at startup.
- Full-fat mode is unchanged via `pnpm dev:all`.

## Test plan
- [ ] `pnpm dev:all:desktop` boots only `clips` + tray; no docs/frame/other templates
- [ ] `pnpm dev:all` still boots all 18 templates + docs + frame
- [ ] `node scripts/dev-all.ts --apps clips,calendar --no-docs` boots exactly those two templates
- [ ] `--apps` with an unknown name warns and exits cleanly