### PR TITLE
[codex] Harden generated tools UX and persistence

### DIFF
--- a/.agents/skills/tools/SKILL.md
+++ b/.agents/skills/tools/SKILL.md
@@ -307,7 +307,7 @@ See the `sharing` skill for visibility levels and roles.
 pnpm action navigate --view=tools
 
 # Navigate to a specific tool
-pnpm action navigate --view=tools --toolId=TOOL_ID
+set-url-path({ "pathname": "/tools/TOOL_ID" })
 ```
 
 ## Example tools

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1068,16 +1068,13 @@ export function AgentPanel({
 
       {/* CLI terminals — dev mode: real terminal, prod mode: prompt to use dev */}
       {isDevMode
-        ? cliTabs.map((id) => (
+        ? mode === "cli" &&
+          cliTabs.map((id) => (
             <div
               key={id}
-              className={cn(
-                "min-h-0 relative",
-                mode === "cli" ? "flex-1" : "hidden",
-              )}
+              className="min-h-0 relative flex-1"
               style={{
-                display:
-                  mode === "cli" && id === activeCliTab ? undefined : "none",
+                display: id === activeCliTab ? undefined : "none",
               }}
             >
               <Suspense

--- a/packages/core/src/client/AgentTaskCard.tsx
+++ b/packages/core/src/client/AgentTaskCard.tsx
@@ -109,6 +109,8 @@ export function AgentTaskCard({
                 // null or non-running status means the run finished
                 if (
                   !runData ||
+                  runData.active === false ||
+                  (runData.status && runData.status !== "running") ||
                   runData.status === "completed" ||
                   runData.status === "errored"
                 ) {

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -134,9 +134,9 @@ Use manage-automations with action=define to create it. Ask clarifying questions
 
 Use the create-tool action with Alpine.js HTML content. The tool runs as a sandboxed iframe with Tailwind CSS.
 
-After creating the tool, navigate the user to it using the navigate action with --view=tools --toolId=<id>.
+After creating the tool, navigate the user to it with set-url-path using pathname "/tools/<id>".
 
-Make the tool functional and visually polished. Tools can use toolFetch() for API calls and dbQuery()/dbExec() for data storage.`,
+Make the tool functional and visually polished. Tools can use toolFetch() for external API calls, appAction()/appFetch() for app operations, toolData for tool-specific persistence, and dbQuery()/dbExec() only for existing app tables.`,
   },
 };
 

--- a/packages/core/src/client/tools/ToolEditor.tsx
+++ b/packages/core/src/client/tools/ToolEditor.tsx
@@ -226,7 +226,7 @@ export function ToolEditor({ toolId }: ToolEditorProps) {
             <iframe
               srcDoc={content}
               className="h-full w-full border-0"
-              sandbox="allow-scripts"
+              sandbox="allow-scripts allow-forms"
               title="Tool preview"
             />
           ) : (

--- a/packages/core/src/client/tools/ToolViewer.tsx
+++ b/packages/core/src/client/tools/ToolViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { IconArrowLeft, IconPencil } from "@tabler/icons-react";
@@ -85,9 +85,75 @@ function EditToolPopover({ tool }: { tool: Tool }) {
 
 export function ToolViewer({ toolId }: ToolViewerProps) {
   const [isDark, setIsDark] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
 
   useEffect(() => {
     setIsDark(document.documentElement.classList.contains("dark"));
+
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains("dark"));
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const handleMessage = async (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow) return;
+      const message = event.data;
+      if (!message || message.type !== "agent-native-tool-request") return;
+
+      const requestId = String(message.requestId ?? "");
+      const path = String(message.path ?? "");
+      const respond = (payload: Record<string, unknown>) => {
+        iframeRef.current?.contentWindow?.postMessage(
+          {
+            type: "agent-native-tool-response",
+            requestId,
+            ...payload,
+          },
+          "*",
+        );
+      };
+
+      if (!requestId || !isAllowedToolPath(path)) {
+        respond({ error: "Tool request path is not allowed" });
+        return;
+      }
+
+      try {
+        const options = sanitizeToolRequestOptions(message.options);
+        const res = await fetch(path, {
+          ...options,
+          credentials: "same-origin",
+        });
+        const text = await res.text();
+        let body: unknown = text;
+        if (text) {
+          try {
+            body = JSON.parse(text);
+          } catch {
+            body = text;
+          }
+        }
+        respond({
+          response: {
+            ok: res.ok,
+            status: res.status,
+            statusText: res.statusText,
+            body,
+          },
+        });
+      } catch (err: any) {
+        respond({ error: err?.message ?? "Tool host request failed" });
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
   }, []);
 
   const { data: tool, isLoading } = useQuery<Tool>({
@@ -141,11 +207,54 @@ export function ToolViewer({ toolId }: ToolViewerProps) {
         </div>
       </div>
       <iframe
+        ref={iframeRef}
         src={`/_agent-native/tools/${toolId}/render?dark=${isDark}`}
         className="flex-1 w-full border-0"
-        sandbox="allow-scripts allow-same-origin"
+        sandbox="allow-scripts allow-forms"
         title={tool.name}
       />
     </div>
   );
+}
+
+function isAllowedToolPath(path: string): boolean {
+  if (!path.startsWith("/") || path.startsWith("//")) return false;
+  if (path.includes("\\") || path.includes("\0")) return false;
+  return true;
+}
+
+function sanitizeToolRequestOptions(value: unknown): RequestInit {
+  if (!value || typeof value !== "object") return {};
+  const raw = value as Record<string, unknown>;
+  const method =
+    typeof raw.method === "string" && raw.method.trim()
+      ? raw.method.toUpperCase()
+      : "GET";
+  const headers =
+    raw.headers && typeof raw.headers === "object"
+      ? Object.fromEntries(
+          Object.entries(raw.headers as Record<string, unknown>)
+            .filter(([key, val]) => isAllowedHeader(key) && val !== undefined)
+            .map(([key, val]) => [key, String(val)]),
+        )
+      : undefined;
+  const body =
+    typeof raw.body === "string" ||
+    raw.body instanceof Blob ||
+    raw.body instanceof FormData
+      ? raw.body
+      : raw.body === undefined
+        ? undefined
+        : JSON.stringify(raw.body);
+
+  return {
+    method,
+    headers,
+    body: method === "GET" || method === "HEAD" ? undefined : body,
+  };
+}
+
+function isAllowedHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  return !["cookie", "host", "origin", "referer"].includes(lower);
 }

--- a/packages/core/src/client/tools/ToolsSidebarSection.tsx
+++ b/packages/core/src/client/tools/ToolsSidebarSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useLocation } from "react-router";
+import { Link, useLocation, useNavigate } from "react-router";
 import {
   IconTool,
   IconPlus,
@@ -47,6 +47,7 @@ function saveFavorites(ids: Set<string>) {
 
 export function ToolsSidebarSection() {
   const location = useLocation();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [favoriteIds, setFavoriteIds] = useState<Set<string>>(() =>
     typeof window !== "undefined" ? getFavorites() : new Set(),
@@ -89,12 +90,25 @@ export function ToolsSidebarSection() {
           method: "DELETE",
         });
         if (!res.ok) throw new Error("Delete failed");
+        queryClient.removeQueries({ queryKey: ["tool", toolId] });
         queryClient.invalidateQueries({ queryKey: ["tools"] });
+        setFavoriteIds((prev) => {
+          const next = new Set(prev);
+          next.delete(toolId);
+          saveFavorites(next);
+          return next;
+        });
+        if (
+          location.pathname === `/tools/${toolId}` ||
+          location.pathname === `/tools/${toolId}/edit`
+        ) {
+          navigate("/tools");
+        }
       } catch {
         if (prev) queryClient.setQueryData(["tools"], prev);
       }
     },
-    [queryClient],
+    [location.pathname, navigate, queryClient],
   );
 
   // Close menu on click outside
@@ -232,7 +246,7 @@ export function ToolsSidebarSection() {
                       "cursor-pointer rounded p-0.5",
                       isFav
                         ? "text-yellow-500"
-                        : "text-muted-foreground/40 opacity-0 group-hover/tool:opacity-100 hover:text-yellow-500",
+                        : "text-muted-foreground/40 opacity-100 hover:text-yellow-500 md:opacity-0 md:group-hover/tool:opacity-100 md:group-focus-within/tool:opacity-100",
                     )}
                     aria-label={isFav ? "Unfavorite" : "Favorite"}
                   >
@@ -251,7 +265,7 @@ export function ToolsSidebarSection() {
                         e.stopPropagation();
                         setMenuOpenId(menuOpenId === tool.id ? null : tool.id);
                       }}
-                      className="cursor-pointer rounded p-0.5 text-muted-foreground/40 opacity-0 group-hover/tool:opacity-100 hover:text-foreground"
+                      className="cursor-pointer rounded p-0.5 text-muted-foreground/40 opacity-100 hover:text-foreground md:opacity-0 md:group-hover/tool:opacity-100 md:group-focus-within/tool:opacity-100"
                       aria-label="Tool actions"
                     >
                       <IconDots className="h-3 w-3" />

--- a/packages/core/src/secrets/substitution.ts
+++ b/packages/core/src/secrets/substitution.ts
@@ -12,6 +12,10 @@
 
 import { readAppSecret, readAppSecretMeta } from "./storage.js";
 import type { SecretScope } from "./register.js";
+import {
+  getRequestOrgId,
+  getRequestUserEmail,
+} from "../server/request-context.js";
 
 const KEY_REFERENCE_REGEX = /\$\{keys\.([A-Za-z0-9_-]+)\}/g;
 
@@ -45,7 +49,11 @@ export async function resolveKeyReferences(
 
     let result = await readAppSecret({ key: name, scope, scopeId });
     if (!result && scope === "user") {
-      result = await readAppSecret({ key: name, scope: "workspace", scopeId });
+      result = await readAppSecret({
+        key: name,
+        scope: "workspace",
+        scopeId: getWorkspaceScopeId(scopeId),
+      });
     }
     if (!result) {
       throw new Error(
@@ -109,8 +117,15 @@ export async function getKeyAllowlist(
     meta = await readAppSecretMeta({
       key: name,
       scope: "workspace",
-      scopeId,
+      scopeId: getWorkspaceScopeId(scopeId),
     });
   }
   return meta?.urlAllowlist ?? null;
+}
+
+function getWorkspaceScopeId(userScopeId: string): string {
+  const orgId = getRequestOrgId();
+  if (orgId) return orgId;
+  const email = getRequestUserEmail() || userScopeId;
+  return `solo:${email}`;
 }

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -2270,6 +2270,11 @@ export function createAgentChatPlugin(
           },
         });
       } catch {}
+      let toolActions: Record<string, ActionEntry> = {};
+      try {
+        const { createToolActionEntries } = await import("../tools/actions.js");
+        toolActions = createToolActionEntries();
+      } catch {}
 
       // In dev mode, template actions (templateScripts and discoveredActions) are
       // NOT registered as native tools — the agent invokes them via shell instead.
@@ -2281,12 +2286,14 @@ export function createAgentChatPlugin(
             ...resourceScripts,
             ...docsScripts,
             ...(lazyContext ? frameworkContextTool : {}),
+            ...urlTools,
             ...chatScripts,
             ...callAgentScript,
             ...automationTools,
             ...notificationTools,
             ...progressTools,
             ...fetchTool,
+            ...toolActions,
             ...browserTools,
             ...devScriptsForA2A,
           }
@@ -2305,6 +2312,7 @@ export function createAgentChatPlugin(
             ...notificationTools,
             ...progressTools,
             ...fetchTool,
+            ...toolActions,
             ...browserTools,
             ...devScriptsForA2A,
           };
@@ -2412,7 +2420,9 @@ export function createAgentChatPlugin(
                 ...resourceScripts,
                 ...docsScripts,
                 ...(lazyContext ? frameworkContextTool : {}),
+                ...urlTools,
                 ...chatScripts,
+                ...toolActions,
                 ...browserTools,
                 ...devScriptsForA2A,
               }
@@ -2425,6 +2435,7 @@ export function createAgentChatPlugin(
                 ...(lazyContext ? frameworkContextTool : {}),
                 ...urlTools,
                 ...chatScripts,
+                ...toolActions,
                 ...browserTools,
               };
 
@@ -2546,6 +2557,7 @@ export function createAgentChatPlugin(
                 ...resourceScripts,
                 ...docsScripts,
                 ...(lazyContext ? frameworkContextTool : {}),
+                ...urlTools,
                 ...chatScripts,
                 ...devScriptsForA2A,
               }
@@ -2897,6 +2909,7 @@ export function createAgentChatPlugin(
         ...refreshScreenTool,
         ...urlTools,
         ...chatScripts,
+        ...toolActions,
       };
 
       const prodActions = {
@@ -2915,6 +2928,7 @@ export function createAgentChatPlugin(
         ...notificationTools,
         ...progressTools,
         ...fetchTool,
+        ...toolActions,
         ...browserTools,
         ...mcpActionEntries,
       };
@@ -3042,6 +3056,7 @@ export function createAgentChatPlugin(
                 ...notificationTools,
                 ...progressTools,
                 ...fetchTool,
+                ...toolActions,
                 ...browserTools,
                 ...mcpActionEntries,
                 ...(await createDevScriptRegistry()),
@@ -3776,11 +3791,16 @@ export function createAgentChatPlugin(
             // Check in-memory first, then SQL (cross-isolate on Workers)
             const run = await getActiveRunForThreadAsync(threadId);
             if (!run) {
-              setResponseStatus(event, 404);
-              return { error: "No active run for this thread" };
+              return {
+                active: false,
+                threadId,
+                status: "idle",
+                heartbeatAt: null,
+              };
             }
 
             return {
+              active: true,
               runId: run.runId,
               threadId: run.threadId,
               status: run.status,
@@ -4153,6 +4173,7 @@ export function createAgentChatPlugin(
             ...notificationTools,
             ...progressTools,
             ...fetchTool,
+            ...toolActions,
           }),
           getSystemPrompt: async (owner: string) => {
             const resources = await loadResourcesForPrompt(owner, lazyContext);
@@ -4195,6 +4216,7 @@ export function createAgentChatPlugin(
             ...notificationTools,
             ...progressTools,
             ...fetchTool,
+            ...toolActions,
           }),
           getSystemPrompt: async (owner: string) => {
             const resources = await loadResourcesForPrompt(owner, lazyContext);

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -234,7 +234,7 @@ function registerMiddleware(
       }
       return {
         error: e?.message || "Internal server error",
-        ...(process.env.NODE_ENV !== "production" && e?.stack
+        ...(status >= 500 && process.env.NODE_ENV !== "production" && e?.stack
           ? { stack: e.stack }
           : {}),
       };

--- a/packages/core/src/templates/default/react-router.config.ts
+++ b/packages/core/src/templates/default/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/packages/core/src/tools/actions.ts
+++ b/packages/core/src/tools/actions.ts
@@ -1,0 +1,152 @@
+import type { ActionEntry } from "../agent/production-agent.js";
+import { createTool, getTool, updateTool, updateToolContent } from "./store.js";
+
+type ToolPatch = { find: string; replace: string };
+
+export function createToolActionEntries(): Record<string, ActionEntry> {
+  return {
+    "create-tool": {
+      tool: {
+        description:
+          "Create a sandboxed Alpine.js mini-app tool. Use this when the user asks to create, build, or make a tool/widget/dashboard/calculator. The content must be a self-contained Alpine.js HTML body snippet that can use appAction(), appFetch(), dbQuery(), dbExec(), toolFetch(), and toolData.",
+        parameters: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "Short display name for the tool.",
+            },
+            description: {
+              type: "string",
+              description: "One-sentence summary of what the tool does.",
+            },
+            content: {
+              type: "string",
+              description:
+                "Self-contained Alpine.js HTML body snippet. Do not include a full app build, React code, or source files.",
+            },
+            icon: {
+              type: "string",
+              description: "Optional icon name or short label.",
+            },
+          },
+          required: ["name", "content"],
+        },
+      },
+      run: async (args) => {
+        const name = String(args?.name ?? "").trim();
+        const content = String(args?.content ?? "").trim();
+        if (!name) return "Error: name is required.";
+        if (!content) return "Error: content is required.";
+
+        const tool = await createTool({
+          name,
+          description: String(args?.description ?? "").trim(),
+          content,
+          icon: args?.icon ? String(args.icon) : undefined,
+        });
+
+        return {
+          ok: true,
+          tool,
+          next: `Navigate to /tools/${tool.id} or use the navigate action with --view=tools --toolId=${tool.id}.`,
+        };
+      },
+    },
+
+    "update-tool": {
+      tool: {
+        description:
+          "Update an existing sandboxed Alpine.js mini-app tool. Prefer patches for surgical edits; use full content replacement only when necessary.",
+        parameters: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              description: "Tool id to update.",
+            },
+            name: {
+              type: "string",
+              description: "Optional new display name.",
+            },
+            description: {
+              type: "string",
+              description: "Optional new description.",
+            },
+            content: {
+              type: "string",
+              description:
+                "Optional full replacement Alpine.js HTML body snippet.",
+            },
+            patches: {
+              type: "string",
+              description:
+                'Optional JSON array of { "find": "...", "replace": "..." } patches to apply to the current content.',
+            },
+            icon: {
+              type: "string",
+              description: "Optional icon name or short label.",
+            },
+            visibility: {
+              type: "string",
+              description: "Optional sharing visibility.",
+              enum: ["private", "org", "public"],
+            },
+          },
+          required: ["id"],
+        },
+      },
+      run: async (args) => {
+        const id = String(args?.id ?? "").trim();
+        if (!id) return "Error: id is required.";
+
+        let result = null;
+        if (args?.content !== undefined || args?.patches !== undefined) {
+          const patches = parsePatches((args as any).patches);
+          if (args?.patches !== undefined && !patches) {
+            return "Error: patches must be a JSON array of { find, replace } objects.";
+          }
+          result = await updateToolContent(id, {
+            content:
+              args?.content !== undefined ? String(args.content) : undefined,
+            patches,
+          });
+        }
+
+        const meta: Record<string, string> = {};
+        if (args?.name !== undefined) meta.name = String(args.name).trim();
+        if (args?.description !== undefined) {
+          meta.description = String(args.description).trim();
+        }
+        if (args?.icon !== undefined) meta.icon = String(args.icon);
+        if (args?.visibility !== undefined) {
+          meta.visibility = String(args.visibility);
+        }
+        if (Object.keys(meta).length > 0) {
+          result = await updateTool(id, meta as any);
+        }
+
+        if (!result) result = await getTool(id);
+        if (!result) return `Error: tool not found: ${id}`;
+        return { ok: true, tool: result };
+      },
+    },
+  };
+}
+
+function parsePatches(value: unknown): ToolPatch[] | undefined {
+  if (value === undefined) return undefined;
+  const parsed = typeof value === "string" ? JSON.parse(value) : value;
+  if (!Array.isArray(parsed)) return undefined;
+  if (
+    parsed.some(
+      (patch) =>
+        !patch ||
+        typeof patch.find !== "string" ||
+        typeof patch.replace !== "string",
+    )
+  ) {
+    return undefined;
+  }
+  return parsed;
+}

--- a/packages/core/src/tools/html-shell.ts
+++ b/packages/core/src/tools/html-shell.ts
@@ -4,12 +4,15 @@ export function buildToolHtml(
   isDark: boolean,
   toolId?: string,
 ): string {
+  const toolIdJson = JSON.stringify(toolId ?? "");
+  const toolIdAttr = escapeHtmlAttribute(toolId ?? "");
+
   return `<!DOCTYPE html>
 <html lang="en"${isDark ? ' class="dark"' : ""}>
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self'; img-src 'self' data: https:;" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self'; img-src 'self' data: https:; form-action 'none';" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&display=swap" rel="stylesheet" />
@@ -50,70 +53,105 @@ export function buildToolHtml(
       --radius-sm: calc(var(--radius) - 4px);
     }
   </style>
-  <style>
-    *, *::before, *::after { border-color: hsl(var(--border)); }
-    body { font-family: 'Inter', sans-serif; margin: 0; padding: 1.5rem; }
-  </style>
-  <script>
-    function toolFetch(url, options) {
-      var opts = options || {};
-      return fetch('/_agent-native/tools/proxy', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          url: url,
+	  <style>
+	    *, *::before, *::after { border-color: hsl(var(--border)); }
+	    body { font-family: 'Inter', sans-serif; margin: 0; padding: 1.5rem; }
+	  </style>
+	  <script>
+	    var _toolRequestSeq = 0;
+	    var _toolPendingRequests = {};
+
+	    window.addEventListener('message', function(event) {
+	      var message = event.data || {};
+	      if (message.type !== 'agent-native-tool-response') return;
+	      var pending = _toolPendingRequests[message.requestId];
+	      if (!pending) return;
+	      delete _toolPendingRequests[message.requestId];
+	      if (message.error) {
+	        pending.reject(new Error(message.error));
+	      } else {
+	        pending.resolve(message.response);
+	      }
+	    });
+
+	    function hostRequest(path, options) {
+	      options = options || {};
+	      return new Promise(function(resolve, reject) {
+	        var requestId = 'tool-req-' + (++_toolRequestSeq);
+	        _toolPendingRequests[requestId] = { resolve: resolve, reject: reject };
+	        window.parent.postMessage({
+	          type: 'agent-native-tool-request',
+	          requestId: requestId,
+	          path: path,
+	          options: {
+	            method: options.method || 'GET',
+	            headers: options.headers || {},
+	            body: options.body,
+	          },
+	        }, '*');
+	        setTimeout(function() {
+	          var pending = _toolPendingRequests[requestId];
+	          if (!pending) return;
+	          delete _toolPendingRequests[requestId];
+	          pending.reject(new Error('Tool host request timed out'));
+	        }, 30000);
+	      });
+	    }
+
+	    function toolFetch(url, options) {
+	      var opts = options || {};
+	      return hostRequest('/_agent-native/tools/proxy', {
+	        method: 'POST',
+	        headers: { 'Content-Type': 'application/json' },
+	        body: JSON.stringify({
+	          url: url,
           method: opts.method || 'GET',
           headers: opts.headers,
           body: opts.body,
         }),
-      }).then(function(res) {
-        return res.json().then(function(data) {
-          if (data.error && data.status === undefined) {
-            throw new Error(data.error);
-          }
+	      }).then(function(res) {
+	        var data = res.body;
+	          if (data.error && data.status === undefined) {
+	            throw new Error(data.error);
+	          }
           return {
             ok: data.status >= 200 && data.status < 300,
             status: data.status,
-            json: function() { return Promise.resolve(data.body); },
-            text: function() { return Promise.resolve(typeof data.body === 'string' ? data.body : JSON.stringify(data.body)); },
-          };
-        });
-      });
-    }
+	            json: function() { return Promise.resolve(data.body); },
+	            text: function() { return Promise.resolve(typeof data.body === 'string' ? data.body : JSON.stringify(data.body)); },
+	          };
+	      });
+	    }
 
-    async function appAction(name, params) {
-      params = params || {};
-      var res = await fetch('/_agent-native/actions/' + encodeURIComponent(name), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'same-origin',
-        body: JSON.stringify(params),
-      });
-      if (!res.ok) {
-        var err = await res.json().catch(function() { return { error: res.statusText }; });
-        throw new Error(err.error || 'Action failed: ' + res.status);
-      }
-      return res.json();
-    }
+	    async function appAction(name, params) {
+	      params = params || {};
+	      var res = await hostRequest('/_agent-native/actions/' + encodeURIComponent(name), {
+	        method: 'POST',
+	        headers: { 'Content-Type': 'application/json' },
+	        body: JSON.stringify(params),
+	      });
+	      if (!res.ok) {
+	        var err = res.body || { error: res.statusText };
+	        throw new Error(err.error || 'Action failed: ' + res.status);
+	      }
+	      return res.body;
+	    }
 
-    async function appFetch(path, options) {
-      options = options || {};
-      var res = await fetch(path, {
-        ...options,
-        credentials: 'same-origin',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(options.headers || {}),
-        },
-      });
-      if (!res.ok) {
-        var err = await res.json().catch(function() { return { error: res.statusText }; });
-        throw new Error(err.error || 'Request failed: ' + res.status);
-      }
-      var text = await res.text();
-      try { return JSON.parse(text); } catch(e) { return text; }
-    }
+	    async function appFetch(path, options) {
+	      options = options || {};
+	      var res = await hostRequest(path, {
+	        ...options,
+	        headers: {
+	          'Content-Type': 'application/json',
+	          ...(options.headers || {}),
+	        },
+	      });
+	      if (!res.ok) {
+	        var err = typeof res.body === 'object' && res.body ? res.body : { error: res.statusText };
+	        throw new Error(err.error || 'Request failed: ' + res.status);
+	      }
+	      return res.body;
+	    }
 
     async function dbQuery(sql, args) {
       var body = { sql: sql };
@@ -133,44 +171,48 @@ export function buildToolHtml(
       });
     }
 
-    var _toolId = document.body.getAttribute('data-tool-id');
+    var _toolId = ${toolIdJson};
 
     var toolData = {
-      async list(collection, opts) {
-        var limit = (opts && opts.limit) || 100;
-        var res = await fetch('/_agent-native/tools/data/' + _toolId + '/' + encodeURIComponent(collection) + '?limit=' + limit, {
-          credentials: 'same-origin',
-        });
-        if (!res.ok) throw new Error('Failed to list tool data');
-        return res.json();
-      },
+	      async list(collection, opts) {
+	        var limit = (opts && opts.limit) || 100;
+	        var res = await hostRequest('/_agent-native/tools/data/' + _toolId + '/' + encodeURIComponent(collection) + '?limit=' + limit);
+	        if (!res.ok) throw new Error('Failed to list tool data');
+	        return res.body;
+	      },
       async get(collection, id) {
         var items = await this.list(collection);
         return (items || []).find(function(item) { return item.id === id; }) || null;
       },
       async set(collection, id, data) {
-        var res = await fetch('/_agent-native/tools/data/' + _toolId + '/' + encodeURIComponent(collection), {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id: id, data: typeof data === 'string' ? data : JSON.stringify(data) }),
-        });
-        if (!res.ok) throw new Error('Failed to save tool data');
-        return res.json();
-      },
-      async remove(collection, id) {
-        var res = await fetch('/_agent-native/tools/data/' + _toolId + '/' + encodeURIComponent(collection) + '/' + encodeURIComponent(id), {
-          method: 'DELETE',
-          credentials: 'same-origin',
-        });
-        if (!res.ok) throw new Error('Failed to delete tool data');
-        return res.json();
-      },
-    };
-  </script>
-</head>
-<body${toolId ? ` data-tool-id="${toolId}"` : ""} class="bg-background text-foreground">
-${content}
-</body>
-</html>`;
+	        var res = await hostRequest('/_agent-native/tools/data/' + _toolId + '/' + encodeURIComponent(collection), {
+	          method: 'POST',
+	          headers: { 'Content-Type': 'application/json' },
+	          body: JSON.stringify({ id: id, data: data }),
+	        });
+	        if (!res.ok) throw new Error('Failed to save tool data');
+	        return res.body;
+	      },
+	      async remove(collection, id) {
+	        var res = await hostRequest('/_agent-native/tools/data/' + _toolId + '/' + encodeURIComponent(collection) + '/' + encodeURIComponent(id), {
+	          method: 'DELETE',
+	        });
+	        if (!res.ok) throw new Error('Failed to delete tool data');
+	        return res.body;
+	      },
+	    };
+	  </script>
+	</head>
+	<body${toolId ? ` data-tool-id="${toolIdAttr}"` : ""} class="bg-background text-foreground">
+	${content}
+	</body>
+	</html>`;
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }

--- a/packages/core/src/tools/routes.ts
+++ b/packages/core/src/tools/routes.ts
@@ -196,6 +196,11 @@ async function handleToolDataList(
   userEmail: string,
 ): Promise<unknown> {
   await ensureToolsTables();
+  const tool = await getTool(toolId);
+  if (!tool) {
+    setResponseStatus(event, 404);
+    return { error: "Tool not found" };
+  }
   const client = getDbExec();
   const url = event.url;
   const limitParam = url?.searchParams?.get("limit");
@@ -203,7 +208,11 @@ async function handleToolDataList(
     ? Math.min(Math.max(1, Number(limitParam)), 1000)
     : 100;
   const result = await client.execute({
-    sql: `SELECT * FROM tool_data WHERE tool_id = ? AND collection = ? AND owner_email = ? ORDER BY created_at DESC LIMIT ?`,
+    sql: `SELECT COALESCE(item_id, id) AS id, tool_id, collection, data, owner_email, created_at, updated_at
+      FROM tool_data
+      WHERE tool_id = ? AND collection = ? AND owner_email = ?
+      ORDER BY created_at DESC
+      LIMIT ?`,
     args: [toolId, collection, userEmail, limit],
   });
   return result.rows ?? [];
@@ -216,12 +225,17 @@ async function handleToolDataUpsert(
   userEmail: string,
 ): Promise<unknown> {
   await ensureToolsTables();
+  const tool = await getTool(toolId);
+  if (!tool) {
+    setResponseStatus(event, 404);
+    return { error: "Tool not found" };
+  }
   const body = await readBody(event);
-  if (!body.data) {
+  if (body.data === undefined) {
     setResponseStatus(event, 400);
     return { error: "data is required" };
   }
-  const id = body.id || randomUUID();
+  const itemId = String(body.id || randomUUID());
   const data =
     typeof body.data === "string" ? body.data : JSON.stringify(body.data);
   const now = new Date().toISOString();
@@ -229,20 +243,41 @@ async function handleToolDataUpsert(
   const pg = isPostgres();
   if (pg) {
     await client.execute({
-      sql: `INSERT INTO tool_data (id, tool_id, collection, data, owner_email, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, updated_at = EXCLUDED.updated_at`,
-      args: [id, toolId, collection, data, userEmail, now, now],
+      sql: `INSERT INTO tool_data (id, tool_id, collection, item_id, data, owner_email, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (tool_id, collection, owner_email, item_id)
+       DO UPDATE SET data = EXCLUDED.data, updated_at = EXCLUDED.updated_at`,
+      args: [
+        randomUUID(),
+        toolId,
+        collection,
+        itemId,
+        data,
+        userEmail,
+        now,
+        now,
+      ],
     });
   } else {
     await client.execute({
-      sql: `INSERT OR REPLACE INTO tool_data (id, tool_id, collection, data, owner_email, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      args: [id, toolId, collection, data, userEmail, now, now],
+      sql: `INSERT INTO tool_data (id, tool_id, collection, item_id, data, owner_email, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (tool_id, collection, owner_email, item_id)
+       DO UPDATE SET data = excluded.data, updated_at = excluded.updated_at`,
+      args: [
+        randomUUID(),
+        toolId,
+        collection,
+        itemId,
+        data,
+        userEmail,
+        now,
+        now,
+      ],
     });
   }
   return {
-    id,
+    id: itemId,
     toolId,
     collection,
     data,
@@ -255,15 +290,20 @@ async function handleToolDataUpsert(
 async function handleToolDataDelete(
   event: H3Event,
   toolId: string,
-  _collection: string,
+  collection: string,
   itemId: string,
   userEmail: string,
 ): Promise<unknown> {
   await ensureToolsTables();
+  const tool = await getTool(toolId);
+  if (!tool) {
+    setResponseStatus(event, 404);
+    return { error: "Tool not found" };
+  }
   const client = getDbExec();
   await client.execute({
-    sql: `DELETE FROM tool_data WHERE id = ? AND tool_id = ? AND owner_email = ?`,
-    args: [itemId, toolId, userEmail],
+    sql: `DELETE FROM tool_data WHERE COALESCE(item_id, id) = ? AND tool_id = ? AND collection = ? AND owner_email = ?`,
+    args: [itemId, toolId, collection, userEmail],
   });
   return { ok: true };
 }
@@ -330,6 +370,9 @@ const DNS_REBIND_SUFFIXES = [
 function isBlockedUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return true;
+    }
     const host = parsed.hostname.toLowerCase();
     if (isPrivateHost(host)) return true;
     if (DNS_REBIND_SUFFIXES.some((s) => host.endsWith(s))) return true;
@@ -506,6 +549,16 @@ async function handleSqlQuery(event: H3Event): Promise<unknown> {
     return { error: "sql is required" };
   }
 
+  const cleanSql = stripSqlComments(sql);
+  if (!/^\s*(SELECT|WITH)\b/i.test(cleanSql)) {
+    setResponseStatus(event, 403);
+    return { error: "Only SELECT queries are allowed from tools" };
+  }
+  if (SENSITIVE_SQL_RE.test(cleanSql)) {
+    setResponseStatus(event, 403);
+    return { error: "Sensitive framework tables are not readable from tools" };
+  }
+
   try {
     const mod = await import("../scripts/db/query.js");
     const args = ["--sql", sql, "--format", "json"];
@@ -523,7 +576,10 @@ async function handleSqlQuery(event: H3Event): Promise<unknown> {
 }
 
 const DESTRUCTIVE_SQL_RE =
-  /\b(DROP\s+(TABLE|INDEX|VIEW|SCHEMA|DATABASE)|TRUNCATE|DELETE\s+FROM\s+(?!tool_data\b)|ALTER\s+TABLE\s+(?!tool_data\b))/i;
+  /\b(CREATE\s+(TABLE|INDEX|VIEW|SCHEMA|DATABASE|TRIGGER)|DROP\s+(TABLE|INDEX|VIEW|SCHEMA|DATABASE|TRIGGER)|TRUNCATE|DELETE\s+FROM\s+(?!tool_data\b)|ALTER\s+TABLE\s+(?!tool_data\b)|ATTACH|DETACH|VACUUM|REINDEX|PRAGMA)\b/i;
+
+const SENSITIVE_SQL_RE =
+  /\b(app_secrets|user|users|session|sessions|account|accounts|verification|oauth_tokens|tool_shares)\b/i;
 
 function stripSqlComments(sql: string): string {
   return sql.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/--[^\n]*/g, " ");
@@ -537,12 +593,16 @@ async function handleSqlExec(event: H3Event): Promise<unknown> {
     return { error: "sql is required" };
   }
 
-  if (DESTRUCTIVE_SQL_RE.test(stripSqlComments(sql))) {
+  const cleanSql = stripSqlComments(sql);
+  if (DESTRUCTIVE_SQL_RE.test(cleanSql)) {
     setResponseStatus(event, 403);
     return {
-      error:
-        "Destructive SQL (DROP, TRUNCATE, DELETE, ALTER) is not allowed from tools",
+      error: "Schema changes and destructive SQL are not allowed from tools",
     };
+  }
+  if (SENSITIVE_SQL_RE.test(cleanSql)) {
+    setResponseStatus(event, 403);
+    return { error: "Sensitive framework tables are not writable from tools" };
   }
 
   try {

--- a/packages/core/src/tools/schema.ts
+++ b/packages/core/src/tools/schema.ts
@@ -76,6 +76,7 @@ export const toolData = table("tool_data", {
   id: text("id").primaryKey(),
   toolId: text("tool_id").notNull(),
   collection: text("collection").notNull(),
+  itemId: text("item_id").notNull(),
   data: text("data").notNull(),
   ownerEmail: text("owner_email").notNull().default("local@localhost"),
   createdAt: text("created_at").notNull().default(now()),
@@ -86,6 +87,7 @@ export const TOOL_DATA_CREATE_SQL = `CREATE TABLE IF NOT EXISTS tool_data (
   id TEXT PRIMARY KEY,
   tool_id TEXT NOT NULL,
   collection TEXT NOT NULL,
+  item_id TEXT NOT NULL,
   data TEXT NOT NULL,
   owner_email TEXT NOT NULL DEFAULT 'local@localhost',
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -96,8 +98,15 @@ export const TOOL_DATA_CREATE_SQL_PG = `CREATE TABLE IF NOT EXISTS tool_data (
   id TEXT PRIMARY KEY,
   tool_id TEXT NOT NULL,
   collection TEXT NOT NULL,
+  item_id TEXT NOT NULL,
   data TEXT NOT NULL,
   owner_email TEXT NOT NULL DEFAULT 'local@localhost',
   created_at TEXT NOT NULL DEFAULT now(),
   updated_at TEXT NOT NULL DEFAULT now()
 )`;
+
+export const TOOL_DATA_ITEM_INDEX_SQL = `CREATE UNIQUE INDEX IF NOT EXISTS tool_data_scope_item_idx
+  ON tool_data (tool_id, collection, owner_email, item_id)`;
+
+export const TOOL_DATA_ITEM_INDEX_SQL_PG = `CREATE UNIQUE INDEX IF NOT EXISTS tool_data_scope_item_idx
+  ON tool_data (tool_id, collection, owner_email, item_id)`;

--- a/packages/core/src/tools/store.ts
+++ b/packages/core/src/tools/store.ts
@@ -17,6 +17,8 @@ import {
   TOOL_SHARES_CREATE_SQL_PG,
   TOOL_DATA_CREATE_SQL,
   TOOL_DATA_CREATE_SQL_PG,
+  TOOL_DATA_ITEM_INDEX_SQL,
+  TOOL_DATA_ITEM_INDEX_SQL_PG,
 } from "./schema.js";
 
 const getDb = createGetDb({ tools, toolShares });
@@ -33,9 +35,39 @@ export async function ensureToolsTables(): Promise<void> {
         pg ? TOOL_SHARES_CREATE_SQL_PG : TOOL_SHARES_CREATE_SQL,
       );
       await client.execute(pg ? TOOL_DATA_CREATE_SQL_PG : TOOL_DATA_CREATE_SQL);
+      await ensureToolDataItemId(client, pg);
+      await client.execute(
+        pg ? TOOL_DATA_ITEM_INDEX_SQL_PG : TOOL_DATA_ITEM_INDEX_SQL,
+      );
     })();
   }
   return _initPromise;
+}
+
+async function ensureToolDataItemId(
+  client: ReturnType<typeof getDbExec>,
+  pg: boolean,
+): Promise<void> {
+  if (pg) {
+    await client.execute(
+      `ALTER TABLE tool_data ADD COLUMN IF NOT EXISTS item_id TEXT`,
+    );
+  } else {
+    try {
+      await client.execute(`ALTER TABLE tool_data ADD COLUMN item_id TEXT`);
+    } catch (err: any) {
+      if (
+        !String(err?.message ?? err)
+          .toLowerCase()
+          .includes("duplicate")
+      ) {
+        throw err;
+      }
+    }
+  }
+  await client.execute(
+    `UPDATE tool_data SET item_id = id WHERE item_id IS NULL`,
+  );
 }
 
 export function registerToolsShareable() {
@@ -103,7 +135,7 @@ export async function createTool(data: CreateToolData): Promise<ToolRow> {
     updatedAt: now,
     ownerEmail: userEmail,
     orgId: orgId ?? null,
-    visibility: orgId ? "org" : "private",
+    visibility: "private",
   };
   await db.insert(tools).values(row);
   return row;
@@ -177,6 +209,10 @@ export async function deleteTool(id: string): Promise<boolean> {
   const rows = await db.select().from(tools).where(eq(tools.id, id));
   if (!rows[0]) return false;
   await db.delete(toolShares).where(eq(toolShares.resourceId, id));
+  await getDbExec().execute({
+    sql: `DELETE FROM tool_data WHERE tool_id = ?`,
+    args: [id],
+  });
   await db.delete(tools).where(eq(tools.id, id));
   return true;
 }

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -124,6 +124,10 @@ function getCoreSourceAliases(
     "@agent-native/core": path.join(coreSrc, "index.browser.ts"),
     "@agent-native/core/server": path.join(coreSrc, "server/index.ts"),
     "@agent-native/core/client": path.join(coreSrc, "client/index.ts"),
+    "@agent-native/core/client/tools": path.join(
+      coreSrc,
+      "client/tools/index.ts",
+    ),
     "@agent-native/core/db": path.join(coreSrc, "db/index.ts"),
     "@agent-native/core/db/schema": path.join(coreSrc, "db/schema.ts"),
     "@agent-native/core/shared": path.join(coreSrc, "shared/index.ts"),
@@ -629,6 +633,10 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
   const appBasePath =
     process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH || "/";
   const base = appBasePath.endsWith("/") ? appBasePath : `${appBasePath}/`;
+  const monorepoCoreAllow = [
+    path.resolve(cwd, "../../packages/core"),
+    path.resolve(cwd, "../core"),
+  ].filter((candidate) => fs.existsSync(path.join(candidate, "package.json")));
 
   return {
     envDir,
@@ -637,7 +645,7 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
       host: "::",
       port: options.port ?? 8080,
       fs: {
-        allow: [".", ...(options.fsAllow ?? [])],
+        allow: [".", ...monorepoCoreAllow, ...(options.fsAllow ?? [])],
         deny: [
           ".env",
           ".env.*",
@@ -656,11 +664,26 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
       // the blur in prod where the unprefixed form was expected.
       cssTarget: ["es2020", "safari18"],
     },
-    // Bundle all non-Node.js deps into the SSR server build.
+    // Bundle all non-Node.js deps into the production SSR server build.
     // Edge runtimes (CF Workers, Deno) don't have node_modules at runtime.
-    ssr: {
-      noExternal: /^(?!node:)/,
-    },
+    // In dev, React Router's Vite Environment runner expects CJS packages
+    // like React to stay external; forcing them through the module runner
+    // raises `module is not defined`.
+    ssr: process.argv.includes("build")
+      ? {
+          noExternal: /^(?!node:)/,
+        }
+      : {
+          noExternal: [/^@agent-native\/core(\/.*)?$/],
+          external: [
+            "react",
+            "react-dom",
+            "react-dom/server",
+            "react-router",
+            "react-router/dom",
+            "react-router-dom",
+          ],
+        },
     plugins: [
       // Stub packages from `options.ssrStubs` in the SSR bundle so they
       // don't bloat the edge worker. Opt-in per template — the framework
@@ -670,6 +693,7 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
         const p = ssrStubPlugin(options.ssrStubs ?? []);
         return p ? [p] : [];
       })(),
+      ...(options.plugins ?? []),
       actionTypesPlugin(),
       agentsBundlePlugin(),
       autoReloadOnOptimizeDep(),
@@ -689,7 +713,6 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
           ]),
       reactPluginInstance,
       tailwindPluginInstance,
-      ...(options.plugins ?? []),
     ].filter(Boolean),
     optimizeDeps: {
       include: [

--- a/templates/analytics/react-router.config.ts
+++ b/templates/analytics/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/calendar/react-router.config.ts
+++ b/templates/calendar/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/calls/react-router.config.ts
+++ b/templates/calls/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/clips/react-router.config.ts
+++ b/templates/clips/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/content/react-router.config.ts
+++ b/templates/content/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/design/react-router.config.ts
+++ b/templates/design/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/dispatch/react-router.config.ts
+++ b/templates/dispatch/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/forms/react-router.config.ts
+++ b/templates/forms/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/issues/react-router.config.ts
+++ b/templates/issues/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/macros/react-router.config.ts
+++ b/templates/macros/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/mail/react-router.config.ts
+++ b/templates/mail/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/meeting-notes/react-router.config.ts
+++ b/templates/meeting-notes/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/recruiting/react-router.config.ts
+++ b/templates/recruiting/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/scheduling/react-router.config.ts
+++ b/templates/scheduling/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/slides/react-router.config.ts
+++ b/templates/slides/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/starter/react-router.config.ts
+++ b/templates/starter/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/videos/react-router.config.ts
+++ b/templates/videos/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;

--- a/templates/voice/react-router.config.ts
+++ b/templates/voice/react-router.config.ts
@@ -3,4 +3,7 @@ import type { Config } from "@react-router/dev/config";
 export default {
   appDirectory: "app",
   ssr: true,
+  future: {
+    v8_viteEnvironmentApi: true,
+  },
 } satisfies Config;


### PR DESCRIPTION
## Summary

This PR hardens the generated tools feature after a multi-agent QA pass across the tool viewer, tool data persistence, agent action registration, and template dev/build behavior.

## What Changed

- Restores tool CRUD reliability inside sandboxed iframes with a host postMessage bridge, form support, and safer iframe sandboxing.
- Fixes `toolData` persistence edge cases by separating storage row IDs from caller item IDs, adding an additive `item_id` migration/index, scoping access checks, and cleaning orphan data on delete.
- Registers `create-tool` and `update-tool` actions with the agent tool registry, including URL navigation support for generated tools.
- Tightens tool security around SSRF/private-host proxying, broad SQL access, stack traces on access errors, and workspace secret fallback scoping.
- Improves UX around tool deletion, favorites, mobile/coarse pointer actions, theme changes, active-run polling, and hidden dev terminals spawning unnecessarily.
- Enables the React Router Vite Environment API across the templates and adjusts core Vite dev SSR aliases/externalization so templates build and run with the current Vite/React Router stack.

## Validation

- `pnpm --filter @agent-native/core typecheck`
- `pnpm --filter @agent-native/core test` with bundled Node 24: 48 files / 480 tests passed
- `pnpm --filter @agent-native/core build` with bundled Node 24
- `pnpm --dir templates/starter build` with bundled Node 24
- `git diff --check`
- Headless Chrome smoke against `templates/starter` on port 8089: generated tool iframe renders, creates persistent CRUD data, reload preserves checked state, delete clears data, and no app errors were reported

## Notes

The repo shell default Node is v18.15.0, which cannot run the current Rolldown/Vite dependency stack because `node:util.styleText` is unavailable. Verification used the bundled Node v24.14.0 runtime from Codex workspace dependencies.