### PR TITLE
fix: handle missing dispatch tables in webhook pipeline

### DIFF
--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -202,9 +202,17 @@ export function createIntegrationsPlugin(
             setResponseStatus(event, 200);
             return "ok";
           }
-          const owner = options?.resolveOwner
-            ? await options.resolveOwner(incoming)
-            : `integration@${platform}`;
+          let owner = `integration@${platform}`;
+          if (options?.resolveOwner) {
+            try {
+              owner = await options.resolveOwner(incoming);
+            } catch (err) {
+              console.error(
+                `[integrations] resolveOwner failed, using default:`,
+                err,
+              );
+            }
+          }
           const resources = await loadResourcesForPrompt(owner);
           const systemPrompt = baseSystemPrompt + resources;
           const result = await handleWebhook(event, {

--- a/templates/dispatch/server/lib/dispatch-integrations.ts
+++ b/templates/dispatch/server/lib/dispatch-integrations.ts
@@ -11,11 +11,15 @@ import {
 export async function resolveDispatchOwner(
   incoming: IncomingMessage,
 ): Promise<string> {
-  const owner = await resolveLinkedOwner(
-    incoming.platform,
-    incoming.senderId || null,
-  );
-  return owner || SHARED_DISPATCH_OWNER;
+  try {
+    const owner = await resolveLinkedOwner(
+      incoming.platform,
+      incoming.senderId || null,
+    );
+    return owner || SHARED_DISPATCH_OWNER;
+  } catch {
+    return SHARED_DISPATCH_OWNER;
+  }
 }
 
 export async function beforeDispatchProcess(


### PR DESCRIPTION
## Summary
- `resolveDispatchOwner` now catches errors when `dispatch_identity_links` table doesn't exist (fresh Neon DB without migrations), falling back to `SHARED_DISPATCH_OWNER`
- Integrations plugin wraps `resolveOwner` in try-catch to prevent 500s from crashing the Slack webhook handler

Critical fix for Slack integration — without this, all Slack @mentions return 500 because the dispatch-specific tables haven't been migrated on the production Neon DB.

## Test plan
- [ ] Send `@Agent Native` in Slack → verify response instead of 500
- [ ] Verify `url_verification` challenge still works