### PR TITLE
fix(core): set request context in integration webhook handler

### DIFF
--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -17,6 +17,8 @@ import {
 } from "../agent/thread-data-builder.js";
 import { updateThreadData } from "../chat-threads/store.js";
 import { readBody } from "../server/h3-helpers.js";
+import { runWithRequestContext } from "../server/request-context.js";
+import { resolveOrgIdForEmail } from "../org/context.js";
 
 /**
  * Tracks recently processed event IDs to deduplicate webhook retries.
@@ -213,7 +215,11 @@ async function processMessageInBackground(
     { role: "user", content: [{ type: "text", text: incoming.text }] },
   ];
 
-  // Step 6: Run agent loop via startRun
+  // Step 6: Run agent loop via startRun, wrapped in a request context so that
+  // tools (especially call-agent) can resolve the caller's org for org-scoped
+  // A2A delegation. Without this, getRequestOrgId() returns undefined and
+  // call-agent can't look up the org's a2a_secret or org_domain.
+  const orgId = await resolveOrgIdForEmail(ownerEmail);
   const engine = createAnthropicEngine({ apiKey });
   const tools = actionsToEngineTools(actions);
 
@@ -223,16 +229,20 @@ async function processMessageInBackground(
     runId,
     threadId,
     async (send, signal) => {
-      await runAgentLoop({
-        engine,
-        model,
-        systemPrompt,
-        tools,
-        messages,
-        actions,
-        send,
-        signal,
-      });
+      await runWithRequestContext(
+        { userEmail: ownerEmail, orgId: orgId ?? undefined },
+        () =>
+          runAgentLoop({
+            engine,
+            model,
+            systemPrompt,
+            tools,
+            messages,
+            actions,
+            send,
+            signal,
+          }),
+      );
     },
     async (completedRun: ActiveRun) => {
       // Step 7: On completion, send response back to platform

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -101,6 +101,37 @@ export async function getOrgContext(event: H3Event): Promise<OrgContext> {
   };
 }
 
+/**
+ * Resolve the active org ID for a given email — for non-HTTP contexts like
+ * the integration webhook handler where we have an email but no event/session.
+ * Picks the user's active-org-id setting if set, otherwise the first membership.
+ * Returns null if the user has no memberships.
+ */
+export async function resolveOrgIdForEmail(
+  email: string,
+): Promise<string | null> {
+  const exec = getDbExec();
+  if (!exec) return null;
+  try {
+    const { rows } = await exec.execute({
+      sql: `SELECT org_id FROM org_members WHERE LOWER(email) = ?`,
+      args: [email.toLowerCase()],
+    });
+    if (rows.length === 0) return null;
+    const ids = rows.map((r: any) => String(r.org_id));
+    if (ids.length === 1) return ids[0];
+    const activeOrgSetting = (await getUserSetting(email, "active-org-id")) as {
+      orgId: string;
+    } | null;
+    if (activeOrgSetting?.orgId && ids.includes(activeOrgSetting.orgId)) {
+      return activeOrgSetting.orgId;
+    }
+    return ids[0];
+  } catch {
+    return null;
+  }
+}
+
 function defaultOrgName(
   email: string,
   session: { name?: string } | null,

--- a/packages/core/src/org/index.ts
+++ b/packages/core/src/org/index.ts
@@ -16,6 +16,7 @@ export {
   getOrgA2ASecret,
   getA2ASecretByDomain,
   resolveOrgByDomain,
+  resolveOrgIdForEmail,
 } from "./context.js";
 
 export { acceptPendingInvitationsForEmail } from "./accept-pending.js";


### PR DESCRIPTION
Critical: webhook handler was running agent loop without request context, so call-agent couldn't resolve orgId or look up the org's A2A secret. This caused 'fetch failed' on every cross-app delegation from Slack/Telegram bots. Now resolves orgId from owner email and wraps agent loop in runWithRequestContext.