### PR TITLE
Fix desktop sign-in, clip titles, rename, and draw-mode stop

### DIFF
--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -421,6 +421,10 @@ export function setDesktopExchange(
     email,
     expiresAt: Date.now() + DESKTOP_EXCHANGE_TTL_MS,
   });
+  // Persist to DB so the token survives cross-instance routing (e.g. when
+  // templates call this helper directly instead of going through the OAuth
+  // callback path).
+  void persistDesktopExchangeToDB(flowId, token, email);
 }
 
 /**
@@ -451,15 +455,20 @@ async function consumeDesktopExchangeFromDB(
   flowId: string,
 ): Promise<{ token: string; email: string } | null> {
   try {
-    const packed = await getSessionEmail(`dex:${flowId}`);
+    // Atomic DELETE...RETURNING prevents token replay: two concurrent polls
+    // cannot both retrieve the token because only one DELETE will match the row.
+    // SQLite ≥3.35 and PostgreSQL both support this syntax.
+    const client = getDbExec();
+    const { rows } = await client.execute({
+      sql: `DELETE FROM sessions WHERE token = ? RETURNING email`,
+      args: [`dex:${flowId}`],
+    });
+    if (rows.length === 0) return null;
+    const packed = (rows[0].email ?? rows[0][0]) as string | null;
     if (!packed) return null;
     const sepIdx = packed.indexOf("::");
     if (sepIdx === -1) return null;
-    const token = packed.slice(0, sepIdx);
-    const email = packed.slice(sepIdx + 2);
-    // Single-use — delete immediately after reading.
-    await removeSession(`dex:${flowId}`);
-    return { token, email };
+    return { token: packed.slice(0, sepIdx), email: packed.slice(sepIdx + 2) };
   } catch {
     return null;
   }
@@ -1283,6 +1292,9 @@ async function mountBetterAuthRoutes(
         };
       }
       _desktopExchanges.delete(flowId);
+      // Also wipe the DB-persisted entry so it cannot be replayed via the
+      // DB fallback path after in-memory consumption.
+      void removeSession(`dex:${flowId}`);
       return { token: entry.token, email: entry.email };
     }),
   );

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -397,10 +397,19 @@ let _authGuardConfig: AuthGuardConfig | null = null;
 // Desktop OAuth exchange store — holds session tokens keyed by a unique flow
 // ID so native apps (Tauri, Electron) that open OAuth in the system browser
 // can retrieve the token after the callback completes on the server.
+//
+// Primary: in-memory Map (fast, works for single-instance dev/preview builds).
+// Fallback: sessions table with a "dex:" prefixed key for cross-instance
+// durability (Cloudflare Workers, multi-region deployments). The value stored
+// in the `email` column is "{realToken}::{userEmail}" so both can be recovered
+// from a single DB lookup.
 const _desktopExchanges = new Map<
   string,
   { token: string; email: string; expiresAt: number }
 >();
+
+// 5-minute TTL for exchange entries (short — single-use tokens).
+const DESKTOP_EXCHANGE_TTL_MS = 5 * 60 * 1000;
 
 export function setDesktopExchange(
   flowId: string,
@@ -410,9 +419,52 @@ export function setDesktopExchange(
   _desktopExchanges.set(flowId, {
     token,
     email,
-    expiresAt: Date.now() + 5 * 60 * 1000,
+    expiresAt: Date.now() + DESKTOP_EXCHANGE_TTL_MS,
   });
 }
+
+/**
+ * Persist a desktop exchange entry to the sessions table so it survives
+ * cross-instance routing (e.g. Cloudflare Workers). Stored under a synthetic
+ * token key "dex:{flowId}"; the `email` column packs both the real session
+ * token and the user email so they can be recovered in one query.
+ * Non-fatal — if the DB isn't ready yet the in-memory Map still works for
+ * same-instance requests.
+ */
+async function persistDesktopExchangeToDB(
+  flowId: string,
+  token: string,
+  email: string,
+): Promise<void> {
+  try {
+    await addSession(`dex:${flowId}`, `${token}::${email}`);
+  } catch {
+    // non-fatal — in-memory Map is the primary path
+  }
+}
+
+/**
+ * Retrieve and consume a desktop exchange entry from the DB fallback.
+ * Returns null if not found or already consumed.
+ */
+async function consumeDesktopExchangeFromDB(
+  flowId: string,
+): Promise<{ token: string; email: string } | null> {
+  try {
+    const packed = await getSessionEmail(`dex:${flowId}`);
+    if (!packed) return null;
+    const sepIdx = packed.indexOf("::");
+    if (sepIdx === -1) return null;
+    const token = packed.slice(0, sepIdx);
+    const email = packed.slice(sepIdx + 2);
+    // Single-use — delete immediately after reading.
+    await removeSession(`dex:${flowId}`);
+    return { token, email };
+  } catch {
+    return null;
+  }
+}
+
 setInterval(() => {
   const now = Date.now();
   for (const [k, v] of _desktopExchanges) {
@@ -1178,8 +1230,12 @@ async function mountBetterAuthRoutes(
             _desktopExchanges.set(flowId, {
               token: sessionToken,
               email,
-              expiresAt: Date.now() + 5 * 60 * 1000,
+              expiresAt: Date.now() + DESKTOP_EXCHANGE_TTL_MS,
             });
+            // Also persist to DB for cross-instance durability (Cloudflare
+            // Workers, multi-region). Fire-and-forget — in-memory Map is
+            // still the primary fast path for same-instance requests.
+            void persistDesktopExchangeToDB(flowId, sessionToken, email);
           }
 
           return oauthCallbackResponse(event, email, {
@@ -1201,7 +1257,7 @@ async function mountBetterAuthRoutes(
   // afterwards since they don't share a cookie jar with the browser.
   app.use(
     "/_agent-native/auth/desktop-exchange",
-    defineEventHandler((event) => {
+    defineEventHandler(async (event) => {
       if (getMethod(event) !== "GET") {
         setResponseStatus(event, 405);
         return { error: "Method not allowed" };
@@ -1211,9 +1267,20 @@ async function mountBetterAuthRoutes(
         setResponseStatus(event, 400);
         return { error: "Missing flow_id" };
       }
-      const entry = _desktopExchanges.get(flowId);
+      let entry = _desktopExchanges.get(flowId);
       if (!entry || entry.expiresAt < Date.now()) {
-        return { pending: true };
+        // In-memory miss — fall back to the DB-persisted entry. This handles
+        // cross-instance routing (Cloudflare Workers, multi-region) where the
+        // OAuth callback and the polling request may hit different isolates.
+        const fromDb = await consumeDesktopExchangeFromDB(flowId);
+        if (!fromDb) {
+          return { pending: true };
+        }
+        entry = {
+          token: fromDb.token,
+          email: fromDb.email,
+          expiresAt: Date.now() + 1, // already consumed from DB
+        };
       }
       _desktopExchanges.delete(flowId);
       return { token: entry.token, email: entry.email };

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -458,10 +458,13 @@ async function consumeDesktopExchangeFromDB(
     // Atomic DELETE...RETURNING prevents token replay: two concurrent polls
     // cannot both retrieve the token because only one DELETE will match the row.
     // SQLite ≥3.35 and PostgreSQL both support this syntax.
+    // The created_at predicate enforces the 5-minute TTL so stale DB entries
+    // (e.g. the desktop app never polled) are rejected rather than silently
+    // redeemed with the session table's default 30-day TTL.
     const client = getDbExec();
     const { rows } = await client.execute({
-      sql: `DELETE FROM sessions WHERE token = ? RETURNING email`,
-      args: [`dex:${flowId}`],
+      sql: `DELETE FROM sessions WHERE token = ? AND created_at > ? RETURNING email`,
+      args: [`dex:${flowId}`, Date.now() - DESKTOP_EXCHANGE_TTL_MS],
     });
     if (rows.length === 0) return null;
     const packed = (rows[0].email ?? rows[0][0]) as string | null;

--- a/templates/clips/actions/request-transcript.ts
+++ b/templates/clips/actions/request-transcript.ts
@@ -253,7 +253,14 @@ export default defineAction({
         });
         await writeAppState("refresh-signal", { ts: Date.now() });
 
-        if (isDefaultTitle(rec.title)) {
+        // Re-read title fresh — `rec.title` was fetched before the 30+ s
+        // transcription and may be stale if the user renamed during that window.
+        const [freshRec] = await db
+          .select({ title: schema.recordings.title })
+          .from(schema.recordings)
+          .where(eq(schema.recordings.id, args.recordingId))
+          .limit(1);
+        if (isDefaultTitle(freshRec?.title)) {
           try {
             await regenerateTitle.run({ recordingId: args.recordingId });
           } catch (delegateErr) {

--- a/templates/clips/actions/request-transcript.ts
+++ b/templates/clips/actions/request-transcript.ts
@@ -315,6 +315,24 @@ export default defineAction({
         console.log(
           `[clips] No API key configured but browser transcript exists for ${args.recordingId} — keeping it`,
         );
+        // Still queue a title-generation delegation — the browser transcript
+        // is good enough for the agent to produce a real title even without
+        // Whisper. This covers recordings where no API key is configured.
+        const [recForTitle] = await db
+          .select({ title: schema.recordings.title })
+          .from(schema.recordings)
+          .where(eq(schema.recordings.id, args.recordingId))
+          .limit(1);
+        if (recForTitle && isDefaultTitle(recForTitle.title)) {
+          try {
+            await regenerateTitle.run({ recordingId: args.recordingId });
+          } catch (delegateErr) {
+            console.warn(
+              `[clips] auto-title delegation failed for ${args.recordingId}:`,
+              (delegateErr as Error).message,
+            );
+          }
+        }
         return {
           recordingId: args.recordingId,
           status: "ready" as const,

--- a/templates/clips/actions/save-browser-transcript.ts
+++ b/templates/clips/actions/save-browser-transcript.ts
@@ -6,6 +6,10 @@
  * Higher-quality backends (Groq Whisper, OpenAI Whisper) can refine this
  * later via `request-transcript`, silently replacing the browser draft.
  *
+ * After saving, if the recording still has the default title we queue a
+ * title-generation delegation so the agent can produce a real title from
+ * the transcript even before Whisper runs (or when Whisper isn't configured).
+ *
  * Usage:
  *   pnpm action save-browser-transcript --recordingId=<id> --fullText="..."
  */
@@ -15,6 +19,14 @@ import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import { getCurrentOwnerEmail } from "../server/lib/recordings.js";
+import regenerateTitle from "./regenerate-title.js";
+
+const DEFAULT_TITLE = "Untitled recording";
+
+function isDefaultTitle(title: string | null | undefined): boolean {
+  const trimmed = (title ?? "").trim();
+  return !trimmed || trimmed === DEFAULT_TITLE;
+}
 
 export default defineAction({
   description:
@@ -93,6 +105,26 @@ export default defineAction({
     console.log(
       `[clips] Browser transcript saved for ${args.recordingId} (${args.fullText.trim().length} chars)`,
     );
+
+    // Queue a title-generation delegation if the clip still has the default
+    // title. This fires even when no Whisper provider is configured so that
+    // browser-only recordings always get a real title.
+    const [rec] = await db
+      .select({ title: schema.recordings.title })
+      .from(schema.recordings)
+      .where(eq(schema.recordings.id, args.recordingId))
+      .limit(1);
+
+    if (rec && isDefaultTitle(rec.title)) {
+      try {
+        await regenerateTitle.run({ recordingId: args.recordingId });
+      } catch (err) {
+        console.warn(
+          `[clips] auto-title delegation failed for ${args.recordingId}:`,
+          (err as Error).message,
+        );
+      }
+    }
 
     return {
       recordingId: args.recordingId,

--- a/templates/clips/app/components/library/library-grid.tsx
+++ b/templates/clips/app/components/library/library-grid.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import {
@@ -7,6 +7,7 @@ import {
   useTrashRecording,
   useArchiveRecording,
   useRestoreRecording,
+  useRenameRecording,
   type ListRecordingsArgs,
   type RecordingSummary,
 } from "@/hooks/use-library";
@@ -16,6 +17,14 @@ import { SortMenu, type SortKey } from "./sort-menu";
 import { FilterChips, type FilterChip } from "./filter-chips";
 import { BulkActionToolbar } from "./bulk-action-toolbar";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import { IconChecks } from "@tabler/icons-react";
 
 interface LibraryGridProps {
@@ -57,6 +66,9 @@ export function LibraryGrid({
   const [sort, setSort] = useState<SortKey>("recent");
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [selectionMode, setSelectionMode] = useState(false);
+  const [renamingRec, setRenamingRec] = useState<RecordingSummary | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const renameInputRef = useRef<HTMLInputElement>(null);
 
   const args: ListRecordingsArgs = useMemo(
     () => ({
@@ -76,6 +88,7 @@ export function LibraryGrid({
   const trashRecording = useTrashRecording();
   const archiveRecording = useArchiveRecording();
   const restoreRecording = useRestoreRecording();
+  const renameRecording = useRenameRecording();
 
   const toggleSelect = (id: string) => {
     setSelected((prev) => {
@@ -89,6 +102,32 @@ export function LibraryGrid({
   const clearSelection = () => {
     setSelected(new Set());
     setSelectionMode(false);
+  };
+
+  const openRenameDialog = (rec: RecordingSummary) => {
+    setRenamingRec(rec);
+    setRenameValue(rec.title ?? "");
+    // Focus the input after dialog opens
+    setTimeout(() => renameInputRef.current?.select(), 50);
+  };
+
+  const submitRename = () => {
+    if (!renamingRec) return;
+    const trimmed = renameValue.trim();
+    if (!trimmed) {
+      toast.error("Title cannot be empty");
+      return;
+    }
+    renameRecording.mutate(
+      { id: renamingRec.id, title: trimmed },
+      {
+        onSuccess: () => {
+          toast.success("Clip renamed");
+          setRenamingRec(null);
+        },
+        onError: () => toast.error("Failed to rename clip"),
+      },
+    );
   };
 
   const chips: FilterChip[] = [];
@@ -115,6 +154,46 @@ export function LibraryGrid({
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
+      {/* Rename dialog */}
+      <Dialog
+        open={!!renamingRec}
+        onOpenChange={(open) => {
+          if (!open) setRenamingRec(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Rename clip</DialogTitle>
+          </DialogHeader>
+          <Input
+            ref={renameInputRef}
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submitRename();
+            }}
+            placeholder="Clip title"
+            className="mt-1"
+            autoFocus
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setRenamingRec(null)}
+              disabled={renameRecording.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={submitRename}
+              disabled={renameRecording.isPending || !renameValue.trim()}
+            >
+              {renameRecording.isPending ? "Saving…" : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       {/* Header */}
       <div className="flex flex-wrap items-center gap-3 border-b border-border px-5 py-3">
         <div className="min-w-0">
@@ -175,6 +254,7 @@ export function LibraryGrid({
                   selected={selected.has(r.id)}
                   selectionMode={selectionMode}
                   onToggleSelect={toggleSelect}
+                  onRename={openRenameDialog}
                   onMove={(rec) => {
                     moveRecording.mutate(
                       { id: rec.id, folderId: null },

--- a/templates/clips/app/hooks/use-auto-title.ts
+++ b/templates/clips/app/hooks/use-auto-title.ts
@@ -124,8 +124,16 @@ export function useAutoTitleBridge(): void {
 
             void clearRequest(rec.id);
           } else {
-            // No server-queued delegation (e.g. older recording). Dispatch a
-            // generic title request — the agent will fetch the transcript itself.
+            // No server-queued delegation. Only dispatch the fallback for
+            // recordings that are old enough (>2 min) that the server has had
+            // ample time to write its own clips-ai-request entry. For freshly-
+            // finalized clips the server request may still be en route; if we
+            // mark the recording as dispatched now we'd block that richer
+            // transcript-backed delegation from ever firing.
+            const ageMs = Date.now() - new Date(rec.createdAt).getTime();
+            const TWO_MINUTES_MS = 2 * 60 * 1000;
+            if (ageMs < TWO_MINUTES_MS) continue;
+
             dispatched.current.add(rec.id);
 
             sendToAgentChat({

--- a/templates/clips/app/hooks/use-auto-title.ts
+++ b/templates/clips/app/hooks/use-auto-title.ts
@@ -99,28 +99,45 @@ export function useAutoTitleBridge(): void {
           if (dispatched.current.has(rec.id)) continue;
 
           const request = await readRequest(rec.id);
-          if (!request || request.kind !== "regenerate-title") continue;
-          const dispatchKey = `${rec.id}:${request.requestedAt ?? "0"}`;
-          if (dispatched.current.has(dispatchKey)) continue;
 
-          dispatched.current.add(rec.id);
-          dispatched.current.add(dispatchKey);
+          if (request?.kind === "regenerate-title") {
+            // Server queued a delegation — use the full context it provided.
+            const dispatchKey = `${rec.id}:${request.requestedAt ?? "0"}`;
+            if (dispatched.current.has(dispatchKey)) continue;
 
-          sendToAgentChat({
-            message:
-              request.message ??
-              `Generate a concise 3-8 word title for recording ${rec.id} from its transcript, then call update-recording --id=${rec.id} --title="...".`,
-            context: JSON.stringify({
-              recordingId: rec.id,
-              currentTitle: request.currentTitle ?? rec.title,
-              transcript: request.transcriptText ?? "",
-              transcriptStatus: request.transcriptStatus ?? "ready",
-            }),
-            submit: true,
-            openSidebar: false,
-          });
+            dispatched.current.add(rec.id);
+            dispatched.current.add(dispatchKey);
 
-          void clearRequest(rec.id);
+            sendToAgentChat({
+              message:
+                request.message ??
+                `Generate a concise 3-8 word title for recording ${rec.id} from its transcript, then call update-recording --id=${rec.id} --title="...".`,
+              context: JSON.stringify({
+                recordingId: rec.id,
+                currentTitle: request.currentTitle ?? rec.title,
+                transcript: request.transcriptText ?? "",
+                transcriptStatus: request.transcriptStatus ?? "ready",
+              }),
+              submit: true,
+              openSidebar: false,
+            });
+
+            void clearRequest(rec.id);
+          } else {
+            // No server-queued delegation (e.g. older recording). Dispatch a
+            // generic title request — the agent will fetch the transcript itself.
+            dispatched.current.add(rec.id);
+
+            sendToAgentChat({
+              message: `This clip (${rec.id}) still has its default title. Please read its transcript via get-recording-player-data and generate a concise 3-8 word title, then call update-recording --id=${rec.id} --title="...".`,
+              context: JSON.stringify({
+                recordingId: rec.id,
+                currentTitle: rec.title,
+              }),
+              submit: true,
+              openSidebar: false,
+            });
+          }
         }
       } finally {
         inflight.current = false;

--- a/templates/clips/app/hooks/use-auto-title.ts
+++ b/templates/clips/app/hooks/use-auto-title.ts
@@ -96,16 +96,15 @@ export function useAutoTitleBridge(): void {
       try {
         for (const rec of untitledRecordings) {
           if (cancelled) return;
-          if (dispatched.current.has(rec.id)) continue;
 
           const request = await readRequest(rec.id);
 
           if (request?.kind === "regenerate-title") {
             // Server queued a delegation — use the full context it provided.
+            // Key includes requestedAt so each distinct server request fires
+            // exactly once, independent of any prior fallback dispatch.
             const dispatchKey = `${rec.id}:${request.requestedAt ?? "0"}`;
             if (dispatched.current.has(dispatchKey)) continue;
-
-            dispatched.current.add(rec.id);
             dispatched.current.add(dispatchKey);
 
             sendToAgentChat({
@@ -128,13 +127,17 @@ export function useAutoTitleBridge(): void {
             // recordings that are old enough (>2 min) that the server has had
             // ample time to write its own clips-ai-request entry. For freshly-
             // finalized clips the server request may still be en route; if we
-            // mark the recording as dispatched now we'd block that richer
-            // transcript-backed delegation from ever firing.
+            // dispatch now we'd block that richer transcript-backed delegation.
             const ageMs = Date.now() - new Date(rec.createdAt).getTime();
             const TWO_MINUTES_MS = 2 * 60 * 1000;
             if (ageMs < TWO_MINUTES_MS) continue;
 
-            dispatched.current.add(rec.id);
+            // Use a dedicated key so a later server-queued request (e.g. from
+            // a long transcription that finishes after the 2-min window) is
+            // NOT blocked by this fallback having already run.
+            const fallbackKey = `${rec.id}:fallback`;
+            if (dispatched.current.has(fallbackKey)) continue;
+            dispatched.current.add(fallbackKey);
 
             sendToAgentChat({
               message: `This clip (${rec.id}) still has its default title. Please read its transcript via get-recording-player-data and generate a concise 3-8 word title, then call update-recording --id=${rec.id} --title="...".`,

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -458,6 +458,11 @@ export default function RecordRoute() {
       if (e.key === "Escape") {
         if (!showStopConfirm && uiState === "recording") {
           e.preventDefault();
+          // Stop propagation so the same Esc keydown doesn't also trigger
+          // the AlertDialog's built-in Esc-to-close handler, which would
+          // immediately dismiss the dialog the moment it opens — leaving
+          // the user trapped in recording state with a flickering dialog.
+          e.stopPropagation();
           requestStop();
           return;
         }

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -149,6 +149,7 @@ export function App() {
     "unknown",
   );
   const [signedInAs, setSignedInAs] = useState<string | null>(null);
+  const [signInPending, setSignInPending] = useState(false);
   const isRecording = recorder !== null;
   const updateVoiceShortcut = useCallback((value: VoiceShortcutPreference) => {
     saveBool(VOICE_SHORTCUT_CONFIGURED_KEY, true);
@@ -208,6 +209,7 @@ export function App() {
   // Instead: fetch the Google auth URL, open it externally, then poll a
   // server-side exchange endpoint for the session token.
   async function signInExternal() {
+    if (signInPending) return; // prevent double-tap
     try {
       const flowId =
         crypto.randomUUID?.() ||
@@ -221,30 +223,47 @@ export function App() {
         `${base}/_agent-native/google/auth-url?desktop=1&flow_id=${flowId}&redirect=1`,
       );
 
+      setSignInPending(true);
+
       // Poll the exchange endpoint for the session token.
       const start = Date.now();
+      const TIMEOUT_MS = 180_000; // 3 minutes
       const interval = setInterval(async () => {
         try {
           const xr = await fetch(
             `${base}/_agent-native/auth/desktop-exchange?flow_id=${flowId}`,
           );
+          if (!xr.ok) {
+            if (Date.now() - start > TIMEOUT_MS) {
+              clearInterval(interval);
+              setSignInPending(false);
+            }
+            return;
+          }
           const xd = await xr.json();
           if (xd?.token) {
             clearInterval(interval);
+            // Establish the session cookie in the Tauri WebView's cookie jar.
             await fetch(
               `${base}/_agent-native/auth/session?_session=${xd.token}`,
               { credentials: "include" },
             );
+            setSignInPending(false);
             await checkAuth();
-          } else if (Date.now() - start > 120_000) {
+          } else if (Date.now() - start > TIMEOUT_MS) {
             clearInterval(interval);
+            setSignInPending(false);
           }
         } catch {
-          if (Date.now() - start > 120_000) clearInterval(interval);
+          if (Date.now() - start > TIMEOUT_MS) {
+            clearInterval(interval);
+            setSignInPending(false);
+          }
         }
       }, 1500);
     } catch (err) {
       console.error("[clips-tray] signInExternal failed:", err);
+      setSignInPending(false);
     }
   }
 
@@ -969,13 +988,27 @@ export function App() {
       <div className="app" ref={appRef}>
         <Header mode={mode} onModeChange={setMode} />
         <UpdateBanner />
-        <SignInForm
-          serverUrl={serverUrl}
-          onSignedIn={async () => {
-            await checkAuth();
-          }}
-          onUseBrowser={signInExternal}
-        />
+        {signInPending ? (
+          <div className="signin-pending">
+            <div className="signin-pending-spinner" />
+            <p className="signin-pending-text">Waiting for browser sign-in…</p>
+            <button
+              type="button"
+              className="signin-pending-cancel"
+              onClick={() => setSignInPending(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <SignInForm
+            serverUrl={serverUrl}
+            onSignedIn={async () => {
+              await checkAuth();
+            }}
+            onUseBrowser={signInExternal}
+          />
+        )}
         <div className="footer">
           <a className="footer-link" onClick={() => setShowSettings(true)}>
             Settings

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -150,6 +150,11 @@ export function App() {
   );
   const [signedInAs, setSignedInAs] = useState<string | null>(null);
   const [signInPending, setSignInPending] = useState(false);
+  // Ref-based lock so two fast clicks cannot both enter signInExternal()
+  // (state updates are async; refs are synchronous).
+  const signInInflightRef = useRef(false);
+  // Stored so Cancel can stop the polling loop.
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isRecording = recorder !== null;
   const updateVoiceShortcut = useCallback((value: VoiceShortcutPreference) => {
     saveBool(VOICE_SHORTCUT_CONFIGURED_KEY, true);
@@ -209,7 +214,18 @@ export function App() {
   // Instead: fetch the Google auth URL, open it externally, then poll a
   // server-side exchange endpoint for the session token.
   async function signInExternal() {
-    if (signInPending) return; // prevent double-tap
+    // Synchronous ref guard — prevents a double-click from opening two OAuth
+    // tabs. State updates are async so `signInPending` alone isn't sufficient.
+    if (signInInflightRef.current) return;
+    signInInflightRef.current = true;
+
+    function stopPolling() {
+      if (pollIntervalRef.current !== null) {
+        clearInterval(pollIntervalRef.current);
+        pollIntervalRef.current = null;
+      }
+    }
+
     try {
       const flowId =
         crypto.randomUUID?.() ||
@@ -228,41 +244,46 @@ export function App() {
       // Poll the exchange endpoint for the session token.
       const start = Date.now();
       const TIMEOUT_MS = 180_000; // 3 minutes
-      const interval = setInterval(async () => {
+      pollIntervalRef.current = setInterval(async () => {
         try {
           const xr = await fetch(
             `${base}/_agent-native/auth/desktop-exchange?flow_id=${flowId}`,
           );
           if (!xr.ok) {
             if (Date.now() - start > TIMEOUT_MS) {
-              clearInterval(interval);
+              stopPolling();
+              signInInflightRef.current = false;
               setSignInPending(false);
             }
             return;
           }
           const xd = await xr.json();
           if (xd?.token) {
-            clearInterval(interval);
+            stopPolling();
             // Establish the session cookie in the Tauri WebView's cookie jar.
             await fetch(
               `${base}/_agent-native/auth/session?_session=${xd.token}`,
               { credentials: "include" },
             );
+            signInInflightRef.current = false;
             setSignInPending(false);
             await checkAuth();
           } else if (Date.now() - start > TIMEOUT_MS) {
-            clearInterval(interval);
+            stopPolling();
+            signInInflightRef.current = false;
             setSignInPending(false);
           }
         } catch {
           if (Date.now() - start > TIMEOUT_MS) {
-            clearInterval(interval);
+            stopPolling();
+            signInInflightRef.current = false;
             setSignInPending(false);
           }
         }
       }, 1500);
     } catch (err) {
       console.error("[clips-tray] signInExternal failed:", err);
+      signInInflightRef.current = false;
       setSignInPending(false);
     }
   }
@@ -995,7 +1016,14 @@ export function App() {
             <button
               type="button"
               className="signin-pending-cancel"
-              onClick={() => setSignInPending(false)}
+              onClick={() => {
+                if (pollIntervalRef.current !== null) {
+                  clearInterval(pollIntervalRef.current);
+                  pollIntervalRef.current = null;
+                }
+                signInInflightRef.current = false;
+                setSignInPending(false);
+              }}
             >
               Cancel
             </button>

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1514,7 +1514,9 @@ button {
 }
 
 @keyframes signin-spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .signin-pending-text {

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -1493,6 +1493,51 @@ button {
   border-color: var(--border-strong, var(--border));
 }
 
+/* --- Pending Google sign-in state ---------------------------------------- */
+.signin-pending {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 24px 16px;
+  flex: 1;
+}
+
+.signin-pending-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2.5px solid var(--border);
+  border-top-color: var(--fg-muted, #888);
+  border-radius: 50%;
+  animation: signin-spin 0.8s linear infinite;
+}
+
+@keyframes signin-spin {
+  to { transform: rotate(360deg); }
+}
+
+.signin-pending-text {
+  font-size: 13px;
+  color: var(--fg-muted, #888);
+  margin: 0;
+  text-align: center;
+}
+
+.signin-pending-cancel {
+  font-size: 12px;
+  color: var(--fg-muted, #888);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 2px 4px;
+}
+
+.signin-pending-cancel:hover {
+  color: var(--fg);
+}
+
 /* --- Update banner -------------------------------------------------------
  * Slots into the top of the popover when an update is in flight or ready.
  * Two visual states:


### PR DESCRIPTION
### Summary
Addresses multiple bugs reported in the Loom app: broken Google sign-in on the desktop app, clip titles not populating, rename not working, and a draw-mode "Stop" trap that left users stuck on a flickering screen.

### Problem
- **Desktop Google sign-in**: After completing OAuth in the browser, the desktop app remained on the login screen with no feedback or state update.
- **Clip titles not populating**: Recordings were left with the default "Untitled recording" title because title generation was not triggered when no Whisper API key was configured or when only a browser transcript was available.
- **Rename not working**: The library grid had no UI or hook wired up to support renaming clips.
- **Draw-mode Stop trap**: Pressing "Esc" while in draw mode triggered the stop action but the `AlertDialog`'s built-in Esc handler immediately dismissed the dialog, leaving the user trapped with a flickering screen.

### Solution
- Added a pending sign-in state with a spinner and cancel button in the desktop app, plus a DB-backed fallback for cross-instance OAuth token exchange (Cloudflare Workers / multi-region).
- Wired auto-title delegation into both `save-browser-transcript` and `request-transcript` so clips always get a real title from the agent, even without Whisper.
- Added a `useRenameRecording` hook integration and a rename dialog to the library grid.
- Fixed the Esc key handler in the record route to call `stopPropagation()` so the `AlertDialog` isn't immediately dismissed.

### Key Changes
- **`packages/core/src/server/auth.ts`**: Added `persistDesktopExchangeToDB` / `consumeDesktopExchangeFromDB` helpers using a `dex:{flowId}` key in the sessions table for cross-instance durability; desktop exchange endpoint is now `async` and falls back to the DB on in-memory miss.
- **`templates/clips/desktop/src/app.tsx`**: Added `signInPending` state with a spinner/cancel UI; extended OAuth poll timeout to 3 minutes; prevented double-tap sign-in; properly clears pending state on success, timeout, or error.
- **`templates/clips/desktop/src/styles.css`**: Added `.signin-pending` styles including spinner animation, muted text, and cancel button.
- **`templates/clips/actions/save-browser-transcript.ts`**: After saving a browser transcript, checks if the title is still default and delegates title generation to the agent via `regenerateTitle`.
- **`templates/clips/actions/request-transcript.ts`**: Same auto-title delegation added for the no-API-key path where a browser transcript already exists.
- **`templates/clips/app/hooks/use-auto-title.ts`**: Extended the bridge to handle recordings with no server-queued delegation by dispatching a generic title request so older recordings also get titles.
- **`templates/clips/app/components/library/library-grid.tsx`**: Integrated `useRenameRecording` hook and added a rename dialog with an input field, triggered via `onRename` prop on each clip card.
- **`templates/clips/app/routes/record.tsx`**: Added `e.stopPropagation()` on the Esc keydown handler to prevent the `AlertDialog` from being dismissed the instant it opens.

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/chiffon-stronghold-4rxjtozn"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-chiffon-stronghold-4rxjtozn_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

💬 [View Slack Thread](https://slack.com/app_redirect?team=T0GCV21GE&channel=C0ATLA31V36&message_ts=1777338023.477069)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 329`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>chiffon-stronghold-4rxjtozn</branchName>-->