### PR TITLE
fix(deploy): bump Netlify function timeout for A2A

### DIFF
--- a/packages/core/src/client/org/TeamPage.tsx
+++ b/packages/core/src/client/org/TeamPage.tsx
@@ -17,6 +17,7 @@ import {
   IconRefresh,
   IconEye,
   IconEyeOff,
+  IconCloudUpload,
 } from "@tabler/icons-react";
 import {
   useOrg,
@@ -30,6 +31,8 @@ import {
   useSwitchOrg,
   useSetOrgDomain,
   useSetA2ASecret,
+  useSyncA2ASecret,
+  type SyncA2ASecretResult,
 } from "./hooks.js";
 
 export interface TeamPageProps {
@@ -529,10 +532,14 @@ function DomainSettingsSection({ domain }: { domain: string | null }) {
 
 function A2ASecretSection({ secret }: { secret: string | null | undefined }) {
   const setA2ASecret = useSetA2ASecret();
+  const syncA2ASecret = useSyncA2ASecret();
   const [revealed, setRevealed] = useState(false);
   const [copied, setCopied] = useState(false);
   const [pasteMode, setPasteMode] = useState(false);
   const [pasteValue, setPasteValue] = useState("");
+  const [syncResult, setSyncResult] = useState<SyncA2ASecretResult | null>(
+    null,
+  );
 
   function copyToClipboard() {
     if (!secret) return;
@@ -542,10 +549,26 @@ function A2ASecretSection({ secret }: { secret: string | null | undefined }) {
     });
   }
 
+  // Push the current secret to all connected apps. Optionally pass the
+  // PREVIOUS secret as `signSecret` so the receiving apps (which still
+  // hold the previous value) can verify the JWT.
+  function syncToApps(signSecret?: string) {
+    setSyncResult(null);
+    syncA2ASecret.mutate(signSecret ? { signSecret } : undefined, {
+      onSuccess: (result) => {
+        setSyncResult(result);
+      },
+    });
+  }
+
   function regenerate() {
     setA2ASecret.mutate(undefined, {
-      onSuccess: () => {
+      onSuccess: (result) => {
         setRevealed(false);
+        // Auto-sync the new secret to all connected apps. Sign with the
+        // PREVIOUS secret (which peers still hold) so verification on
+        // their side succeeds and they accept the new value.
+        syncToApps(result.previousSecret ?? undefined);
       },
     });
   }
@@ -554,9 +577,12 @@ function A2ASecretSection({ secret }: { secret: string | null | undefined }) {
     const trimmed = pasteValue.trim();
     if (!trimmed) return;
     setA2ASecret.mutate(trimmed, {
-      onSuccess: () => {
+      onSuccess: (result) => {
         setPasteMode(false);
         setPasteValue("");
+        // Same auto-sync flow as regenerate: peers verify with the
+        // previous secret, then update to the new pasted value.
+        syncToApps(result.previousSecret ?? undefined);
       },
     });
   }
@@ -573,7 +599,7 @@ function A2ASecretSection({ secret }: { secret: string | null | undefined }) {
         Analytics). All apps in your organization need the same secret.
       </p>
 
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 flex-wrap">
         <span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-sm font-mono">
           <IconKey className="h-3.5 w-3.5 text-muted-foreground" />
           {revealed && secret ? secret : masked}
@@ -609,9 +635,9 @@ function A2ASecretSection({ secret }: { secret: string | null | undefined }) {
         <button
           type="button"
           onClick={regenerate}
-          disabled={setA2ASecret.isPending}
+          disabled={setA2ASecret.isPending || syncA2ASecret.isPending}
           className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-accent/50 disabled:opacity-50"
-          title="Regenerate secret"
+          title="Regenerate secret and sync to connected apps"
         >
           {setA2ASecret.isPending ? (
             <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
@@ -620,7 +646,50 @@ function A2ASecretSection({ secret }: { secret: string | null | undefined }) {
           )}
           Regenerate
         </button>
+        {secret && (
+          <button
+            type="button"
+            onClick={() => syncToApps()}
+            disabled={setA2ASecret.isPending || syncA2ASecret.isPending}
+            className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-accent/50 disabled:opacity-50"
+            title="Push this secret to every connected app"
+          >
+            {syncA2ASecret.isPending ? (
+              <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <IconCloudUpload className="h-3.5 w-3.5" />
+            )}
+            Sync to apps
+          </button>
+        )}
       </div>
+
+      {syncA2ASecret.isPending && (
+        <p className="text-[11px] text-muted-foreground">
+          Syncing to connected apps…
+        </p>
+      )}
+
+      {syncResult && !syncA2ASecret.isPending && (
+        <div className="space-y-1">
+          <p className="text-[11px] text-muted-foreground">
+            Synced to {syncResult.succeeded}/{syncResult.total} app
+            {syncResult.total === 1 ? "" : "s"}
+            {syncResult.failed > 0 ? ` (${syncResult.failed} failed)` : ""}.
+          </p>
+          {syncResult.failed > 0 && (
+            <ul className="text-[11px] text-red-500 list-disc pl-5 space-y-0.5">
+              {syncResult.results
+                .filter((r) => !r.ok)
+                .map((r) => (
+                  <li key={r.id}>
+                    {r.name}: {r.error || `HTTP ${r.status ?? "?"}`}
+                  </li>
+                ))}
+            </ul>
+          )}
+        </div>
+      )}
 
       {!pasteMode ? (
         <button
@@ -674,6 +743,7 @@ function A2ASecretSection({ secret }: { secret: string | null | undefined }) {
       )}
 
       <ErrorText error={setA2ASecret.error} />
+      <ErrorText error={syncA2ASecret.error} />
     </div>
   );
 }

--- a/packages/core/src/client/org/hooks.ts
+++ b/packages/core/src/client/org/hooks.ts
@@ -201,7 +201,11 @@ export function useSetOrgDomain() {
 
 export function useSetA2ASecret() {
   const qc = useQueryClient();
-  return useMutation({
+  return useMutation<
+    { a2aSecret: string; previousSecret: string | null },
+    Error,
+    string | undefined
+  >({
     mutationFn: (secret?: string) =>
       apiFetch(`${ORG_BASE}/a2a-secret`, {
         method: "PUT",
@@ -210,5 +214,43 @@ export function useSetA2ASecret() {
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: ["org-me"] });
     },
+  });
+}
+
+export interface SyncA2ASecretResult {
+  total: number;
+  succeeded: number;
+  failed: number;
+  results: Array<{
+    id: string;
+    name: string;
+    url: string;
+    ok: boolean;
+    status?: number;
+    error?: string;
+  }>;
+}
+
+/**
+ * Push the org's A2A secret to every connected app so cross-app delegation
+ * works without manual copy/paste. Optionally pass a `signSecret` to sign
+ * the outbound JWTs with a different secret (used by the regenerate-then-
+ * sync flow where the new secret is in DB but peers still hold the old
+ * one).
+ */
+export function useSyncA2ASecret() {
+  return useMutation<
+    SyncA2ASecretResult,
+    Error,
+    { signSecret?: string } | void
+  >({
+    mutationFn: (vars) =>
+      apiFetch(`${ORG_BASE}/a2a-secret/sync`, {
+        method: "POST",
+        body: JSON.stringify({
+          signSecret:
+            vars && "signSecret" in vars ? vars.signSecret : undefined,
+        }),
+      }),
   });
 }

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -17,6 +17,8 @@ import {
 } from "../agent/thread-data-builder.js";
 import { updateThreadData } from "../chat-threads/store.js";
 import { readBody } from "../server/h3-helpers.js";
+import { runWithRequestContext } from "../server/request-context.js";
+import { resolveOrgIdForEmail } from "../org/context.js";
 
 /**
  * Tracks recently processed event IDs to deduplicate webhook retries.
@@ -213,7 +215,11 @@ async function processMessageInBackground(
     { role: "user", content: [{ type: "text", text: incoming.text }] },
   ];
 
-  // Step 6: Run agent loop via startRun
+  // Step 6: Run agent loop via startRun, wrapped in a request context so that
+  // tools (especially call-agent) can resolve the caller's org for org-scoped
+  // A2A delegation. Without this, getRequestOrgId() returns undefined and
+  // call-agent can't look up the org's a2a_secret or org_domain.
+  const orgId = await resolveOrgIdForEmail(ownerEmail);
   const engine = createAnthropicEngine({ apiKey });
   const tools = actionsToEngineTools(actions);
 
@@ -223,16 +229,20 @@ async function processMessageInBackground(
     runId,
     threadId,
     async (send, signal) => {
-      await runAgentLoop({
-        engine,
-        model,
-        systemPrompt,
-        tools,
-        messages,
-        actions,
-        send,
-        signal,
-      });
+      await runWithRequestContext(
+        { userEmail: ownerEmail, orgId: orgId ?? undefined },
+        () =>
+          runAgentLoop({
+            engine,
+            model,
+            systemPrompt,
+            tools,
+            messages,
+            actions,
+            send,
+            signal,
+          }),
+      );
     },
     async (completedRun: ActiveRun) => {
       // Step 7: On completion, send response back to platform

--- a/packages/core/src/org/context.ts
+++ b/packages/core/src/org/context.ts
@@ -101,6 +101,37 @@ export async function getOrgContext(event: H3Event): Promise<OrgContext> {
   };
 }
 
+/**
+ * Resolve the active org ID for a given email — for non-HTTP contexts like
+ * the integration webhook handler where we have an email but no event/session.
+ * Picks the user's active-org-id setting if set, otherwise the first membership.
+ * Returns null if the user has no memberships.
+ */
+export async function resolveOrgIdForEmail(
+  email: string,
+): Promise<string | null> {
+  const exec = getDbExec();
+  if (!exec) return null;
+  try {
+    const { rows } = await exec.execute({
+      sql: `SELECT org_id FROM org_members WHERE LOWER(email) = ?`,
+      args: [email.toLowerCase()],
+    });
+    if (rows.length === 0) return null;
+    const ids = rows.map((r: any) => String(r.org_id));
+    if (ids.length === 1) return ids[0];
+    const activeOrgSetting = (await getUserSetting(email, "active-org-id")) as {
+      orgId: string;
+    } | null;
+    if (activeOrgSetting?.orgId && ids.includes(activeOrgSetting.orgId)) {
+      return activeOrgSetting.orgId;
+    }
+    return ids[0];
+  } catch {
+    return null;
+  }
+}
+
 function defaultOrgName(
   email: string,
   session: { name?: string } | null,

--- a/packages/core/src/org/handlers.ts
+++ b/packages/core/src/org/handlers.ts
@@ -654,11 +654,274 @@ export const setA2ASecretHandler = defineEventHandler(
     }
 
     const e = await exec();
+    // Read the previous secret BEFORE overwriting so the client can chain a
+    // sync call that signs JWTs with the secret peers still hold.
+    const prevRes = await e.execute({
+      sql: `SELECT a2a_secret FROM organizations WHERE id = ? LIMIT 1`,
+      args: [ctx.orgId],
+    });
+    const previousSecret =
+      String((prevRes.rows[0] as any)?.a2a_secret ?? "") || null;
+
     await e.execute({
       sql: `UPDATE organizations SET a2a_secret = ? WHERE id = ?`,
       args: [secret, ctx.orgId],
     });
 
-    return { a2aSecret: secret };
+    return { a2aSecret: secret, previousSecret };
+  },
+);
+
+/**
+ * POST /_agent-native/org/a2a-secret/sync — push the org's A2A secret to all
+ * connected apps so cross-app delegation works without manual copy/paste.
+ *
+ * Auth: standard session — owner/admin only.
+ *
+ * For each discovered agent, signs a JWT with the org's CURRENT a2a_secret
+ * and POSTs to `<app>/_agent-native/org/a2a-secret/receive` with the same
+ * secret + the org's domain. The receiving app verifies the JWT using its
+ * own copy of the secret (peers must already share a secret to be trusted)
+ * — for the first-ever sync this means at least one peer must already hold
+ * the secret, which is the bootstrap. For ongoing rotation, regenerate
+ * locally and call sync immediately; sync signs with the secret that's
+ * currently in DB, which the peers still have.
+ *
+ * Body (optional): { signSecret?: string } — sign the outbound JWTs with
+ * this secret instead of the org's current secret. Used by the regenerate-
+ * then-sync flow: regenerate stores the NEW secret, but sync needs to
+ * authenticate using the OLD one that peers still hold. Owner/admin only,
+ * gated by the session.
+ */
+export const syncA2ASecretHandler = defineEventHandler(
+  async (event: H3Event) => {
+    const ctx = await getOrgContext(event);
+    if (!ctx.orgId) {
+      throw createError({
+        statusCode: 400,
+        message: "No active organization",
+      });
+    }
+    if (ctx.role !== "owner" && ctx.role !== "admin") {
+      throw createError({
+        statusCode: 403,
+        message: "Only owners and admins can sync the A2A secret",
+      });
+    }
+
+    const body = await readBody(event).catch(() => null);
+    const overrideSignSecret =
+      typeof body?.signSecret === "string" && body.signSecret.trim()
+        ? body.signSecret.trim()
+        : null;
+
+    const e = await exec();
+    const orgRes = await e.execute({
+      sql: `SELECT a2a_secret, allowed_domain FROM organizations WHERE id = ? LIMIT 1`,
+      args: [ctx.orgId],
+    });
+    if (orgRes.rows.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: "Organization not found",
+      });
+    }
+    const orgRow = orgRes.rows[0] as any;
+    const secret = String(orgRow.a2a_secret ?? "") || null;
+    const orgDomain = String(orgRow.allowed_domain ?? "") || null;
+
+    if (!secret) {
+      throw createError({
+        statusCode: 400,
+        message: "Org has no A2A secret. Generate one first before syncing.",
+      });
+    }
+    if (!orgDomain) {
+      throw createError({
+        statusCode: 400,
+        message:
+          "Org has no allowed domain set. Set the email domain first so connected apps can identify which org to update.",
+      });
+    }
+
+    const signSecret = overrideSignSecret || secret;
+
+    const { discoverAgents } = await import("../server/agent-discovery.js");
+    const { signA2AToken } = await import("../a2a/client.js");
+
+    const agents = await discoverAgents();
+
+    const results: Array<{
+      id: string;
+      name: string;
+      url: string;
+      ok: boolean;
+      status?: number;
+      error?: string;
+    }> = [];
+
+    await Promise.all(
+      agents.map(async (agent) => {
+        try {
+          const token = await signA2AToken(ctx.email, orgDomain, signSecret);
+
+          const target = `${agent.url.replace(/\/$/, "")}/_agent-native/org/a2a-secret/receive`;
+          const res = await fetch(target, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ secret, orgDomain }),
+          });
+
+          if (!res.ok) {
+            const text = await res.text().catch(() => "");
+            results.push({
+              id: agent.id,
+              name: agent.name,
+              url: agent.url,
+              ok: false,
+              status: res.status,
+              error: text || res.statusText,
+            });
+            return;
+          }
+          results.push({
+            id: agent.id,
+            name: agent.name,
+            url: agent.url,
+            ok: true,
+            status: res.status,
+          });
+        } catch (err) {
+          results.push({
+            id: agent.id,
+            name: agent.name,
+            url: agent.url,
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }),
+    );
+
+    const succeeded = results.filter((r) => r.ok).length;
+    return {
+      total: results.length,
+      succeeded,
+      failed: results.length - succeeded,
+      results,
+    };
+  },
+);
+
+/**
+ * POST /_agent-native/org/a2a-secret/receive — accept a secret push from a
+ * connected agent-native app. Auth-exempt at the route guard; we verify a
+ * JWT signed by the calling app using OUR copy of the org's a2a_secret. If
+ * verification succeeds the calling app is a trusted peer and we overwrite
+ * our local org's secret with the supplied value.
+ *
+ * Body: { secret: string, orgDomain: string }
+ *
+ * Header: Authorization: Bearer <JWT signed with the existing shared
+ * a2a_secret, with `org_domain` matching the body's orgDomain>.
+ */
+export const receiveA2ASecretHandler = defineEventHandler(
+  async (event: H3Event) => {
+    const { getRequestHeader } = await import("h3");
+    const jose = await import("jose");
+
+    const authHeader = getRequestHeader(event, "authorization");
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      throw createError({
+        statusCode: 401,
+        message: "Bearer token required",
+      });
+    }
+    const token = authHeader.slice("Bearer ".length);
+
+    const body = await readBody(event);
+    const newSecret =
+      typeof body?.secret === "string" ? body.secret.trim() : "";
+    const orgDomain =
+      typeof body?.orgDomain === "string"
+        ? body.orgDomain.trim().toLowerCase()
+        : "";
+    if (!newSecret || !orgDomain) {
+      throw createError({
+        statusCode: 400,
+        message: "secret and orgDomain are required",
+      });
+    }
+
+    // Peek at JWT (unverified) to confirm it claims the same domain we're
+    // updating. Verification still happens below with the trusted secret.
+    let claimedDomain: string | undefined;
+    try {
+      const unverified = jose.decodeJwt(token);
+      claimedDomain =
+        (unverified.org_domain as string | undefined) || undefined;
+    } catch {
+      throw createError({
+        statusCode: 401,
+        message: "Malformed JWT",
+      });
+    }
+    if (
+      !claimedDomain ||
+      claimedDomain.toLowerCase() !== orgDomain.toLowerCase()
+    ) {
+      throw createError({
+        statusCode: 401,
+        message: "JWT org_domain does not match request body",
+      });
+    }
+
+    // Look up our local org by the domain and grab the existing secret.
+    const e = await exec();
+    const orgRes = await e.execute({
+      sql: `SELECT id, a2a_secret FROM organizations WHERE LOWER(allowed_domain) = ? LIMIT 1`,
+      args: [orgDomain],
+    });
+    if (orgRes.rows.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: "No local org matches that domain",
+      });
+    }
+    const row = orgRes.rows[0] as any;
+    const localOrgId = String(row.id);
+    const existingSecret = String(row.a2a_secret ?? "") || null;
+
+    if (!existingSecret) {
+      // Bootstrap requires an existing shared secret to verify the caller.
+      // If we have nothing on file, we can't verify trust — refuse.
+      throw createError({
+        statusCode: 401,
+        message:
+          "Local org has no A2A secret yet — cannot verify caller. Set the secret manually for the first time.",
+      });
+    }
+
+    // Verify the JWT using OUR existing secret. If the caller is a trusted
+    // peer they signed with the same secret and verification succeeds.
+    try {
+      await jose.jwtVerify(token, new TextEncoder().encode(existingSecret));
+    } catch {
+      throw createError({
+        statusCode: 401,
+        message: "Invalid or expired JWT signature",
+      });
+    }
+
+    // Trusted — apply the new secret.
+    await e.execute({
+      sql: `UPDATE organizations SET a2a_secret = ? WHERE id = ?`,
+      args: [newSecret, localOrgId],
+    });
+
+    return { ok: true, orgId: localOrgId };
   },
 );

--- a/packages/core/src/org/index.ts
+++ b/packages/core/src/org/index.ts
@@ -16,6 +16,7 @@ export {
   getOrgA2ASecret,
   getA2ASecretByDomain,
   resolveOrgByDomain,
+  resolveOrgIdForEmail,
 } from "./context.js";
 
 export { acceptPendingInvitationsForEmail } from "./accept-pending.js";

--- a/packages/core/src/org/index.ts
+++ b/packages/core/src/org/index.ts
@@ -43,4 +43,6 @@ export {
   createInvitationHandler,
   acceptInvitationHandler,
   setA2ASecretHandler,
+  syncA2ASecretHandler,
+  receiveA2ASecretHandler,
 } from "./handlers.js";

--- a/packages/core/src/org/plugin.ts
+++ b/packages/core/src/org/plugin.ts
@@ -25,6 +25,8 @@ import {
   joinByDomainHandler,
   setDomainHandler,
   setA2ASecretHandler,
+  syncA2ASecretHandler,
+  receiveA2ASecretHandler,
 } from "./handlers.js";
 
 type NitroPluginDef = (nitroApp: any) => void | Promise<void>;
@@ -48,6 +50,8 @@ const ORG_PREFIX = `${FRAMEWORK_PREFIX}/org`;
  *   POST   /_agent-native/org/join-by-domain              — join org via email domain match
  *   PUT    /_agent-native/org/domain                      — set/clear allowed email domain (owner/admin)
  *   PUT    /_agent-native/org/a2a-secret                  — regenerate or set A2A secret (owner/admin)
+ *   POST   /_agent-native/org/a2a-secret/sync             — push secret to all connected apps (owner/admin)
+ *   POST   /_agent-native/org/a2a-secret/receive          — accept a peer's secret push (JWT-auth, no session)
  */
 export function createOrgPlugin(): NitroPluginDef {
   const migrate = runMigrations(ORG_MIGRATIONS, { table: "_org_migrations" });
@@ -136,10 +140,52 @@ export function createOrgPlugin(): NitroPluginDef {
       }),
     );
 
-    // PUT /a2a-secret
+    // POST /a2a-secret/sync — must mount BEFORE /a2a-secret since h3
+    // matches by prefix. Pushes the org's A2A secret to every connected app.
+    app.use(
+      `${ORG_PREFIX}/a2a-secret/sync`,
+      defineEventHandler(async (event: H3Event) => {
+        if (getMethod(event) !== "POST") {
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
+        return syncA2ASecretHandler(event);
+      }),
+    );
+
+    // POST /a2a-secret/receive — must mount BEFORE /a2a-secret. Accepts a
+    // peer's secret push; auth is JWT-based (see auth guard exemption).
+    app.use(
+      `${ORG_PREFIX}/a2a-secret/receive`,
+      defineEventHandler(async (event: H3Event) => {
+        if (getMethod(event) !== "POST") {
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
+        return receiveA2ASecretHandler(event);
+      }),
+    );
+
+    // PUT /a2a-secret — must mount AFTER /a2a-secret/sync and /receive.
+    // Dispatches by tail to keep PUT semantics on the parent path while
+    // letting POST /a2a-secret return 405 (rather than silently routing
+    // to the more-specific handlers above).
     app.use(
       `${ORG_PREFIX}/a2a-secret`,
       defineEventHandler(async (event: H3Event) => {
+        const tail = getRequestURL(event).pathname || "/";
+        // The sub-route handlers above intercept these tails first; if we
+        // see them here it means the method didn't match (e.g. GET) and
+        // we should 405 rather than fall into the PUT handler.
+        if (
+          tail === "/sync" ||
+          tail === "/sync/" ||
+          tail === "/receive" ||
+          tail === "/receive/"
+        ) {
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
         if (getMethod(event) !== "PUT") {
           setResponseStatus(event, 405);
           return { error: "Method not allowed" };

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -554,6 +554,13 @@ function createAuthGuardFn(): (
       return;
     }
 
+    // A2A secret receive endpoint — verifies authenticity via JWT signed
+    // with the calling app's A2A secret, not via session cookies. Used to
+    // sync the org A2A secret across connected apps.
+    if (p === "/_agent-native/org/a2a-secret/receive") {
+      return;
+    }
+
     // Force-sign-in entrypoint. Templates send viewers from public pages
     // (share links, embeds) here with a `?return=<path>` query — anonymous
     // visitors get the loginHtml, and once they sign in the loginHtml's

--- a/templates/analytics/netlify.toml
+++ b/templates/analytics/netlify.toml
@@ -6,3 +6,9 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+
+# A2A delegation calls run a full agent loop (LLM + BigQuery + tool calls),
+# which exceeds the default 10s function timeout. Bump to 26s (Netlify Pro max).
+[functions]
+  node_bundler = "esbuild"
+  timeout = 26

--- a/templates/clips/netlify.toml
+++ b/templates/clips/netlify.toml
@@ -6,3 +6,8 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+
+# Allow A2A delegation calls (LLM + tool calls) past the default 10s.
+[functions]
+  node_bundler = "esbuild"
+  timeout = 26

--- a/templates/content/netlify.toml
+++ b/templates/content/netlify.toml
@@ -6,3 +6,8 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+
+# Allow A2A delegation calls (LLM + tool calls) past the default 10s.
+[functions]
+  node_bundler = "esbuild"
+  timeout = 26

--- a/templates/design/netlify.toml
+++ b/templates/design/netlify.toml
@@ -6,3 +6,8 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+
+# Allow A2A delegation calls (LLM + tool calls) past the default 10s.
+[functions]
+  node_bundler = "esbuild"
+  timeout = 26

--- a/templates/dispatch/netlify.toml
+++ b/templates/dispatch/netlify.toml
@@ -6,3 +6,8 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+
+# Allow A2A delegation calls (LLM + tool calls) past the default 10s.
+[functions]
+  node_bundler = "esbuild"
+  timeout = 26

--- a/templates/forms/netlify.toml
+++ b/templates/forms/netlify.toml
@@ -6,3 +6,8 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+
+# Allow A2A delegation calls (LLM + tool calls) past the default 10s.
+[functions]
+  node_bundler = "esbuild"
+  timeout = 26

--- a/templates/slides/netlify.toml
+++ b/templates/slides/netlify.toml
@@ -6,3 +6,8 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+
+# Allow A2A delegation calls (LLM + tool calls) past the default 10s.
+[functions]
+  node_bundler = "esbuild"
+  timeout = 26

--- a/templates/videos/netlify.toml
+++ b/templates/videos/netlify.toml
@@ -6,3 +6,8 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+
+# Allow A2A delegation calls (LLM + tool calls) past the default 10s.
+[functions]
+  node_bundler = "esbuild"
+  timeout = 26


### PR DESCRIPTION
Default 10s timeout was truncating A2A delegation calls that run LLM + tool loops. Bumped to 26s (Netlify Pro plan max) so analytics/slides queries can complete.