### PR TITLE
feat(a2a): async polling pattern for cross-app delegation

### DIFF
--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -320,7 +320,11 @@ export async function callAgent(
   if (opts?.userEmail) metadata.userEmail = opts.userEmail;
   if (opts?.orgDomain) metadata.orgDomain = opts.orgDomain;
 
-  const useAsync = opts?.async ?? true;
+  // Default to synchronous mode — async mode requires the receiving server to
+  // run detached promises after sending the response, which doesn't work
+  // reliably on Netlify Functions (the runtime kills the function once the
+  // response is flushed). Callers that want async polling can opt in.
+  const useAsync = opts?.async ?? false;
   const message: Message = {
     role: "user",
     parts: [{ type: "text", text }],

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -115,12 +115,25 @@ export class A2AClient {
 
   async send(
     message: Message,
-    opts?: { contextId?: string; metadata?: Record<string, unknown> },
+    opts?: {
+      contextId?: string;
+      metadata?: Record<string, unknown>;
+      /**
+       * If true, ask the server to return the task immediately in `working`
+       * state and process the handler in the background. The caller should
+       * then poll `getTask(taskId)` until `completed` / `failed` / `canceled`.
+       *
+       * Use this when you expect the handler may exceed the gateway timeout
+       * (e.g. Netlify's ~26s per-function / 30s gateway limit on Pro).
+       */
+      async?: boolean;
+    },
   ): Promise<Task> {
     const response = await this.rpc("message/send", {
       message,
       contextId: opts?.contextId,
       metadata: opts?.metadata,
+      ...(opts?.async ? { async: true } : {}),
     });
 
     if (response.error) {
@@ -130,6 +143,71 @@ export class A2AClient {
     }
 
     return response.result as Task;
+  }
+
+  /**
+   * Poll for a task by id. Used in async mode after `send({ async: true })`.
+   */
+  async getTask(taskId: string): Promise<Task> {
+    const response = await this.rpc("tasks/get", { id: taskId });
+    if (response.error) {
+      throw new Error(
+        `A2A error (${response.error.code}): ${response.error.message}`,
+      );
+    }
+    return response.result as Task;
+  }
+
+  /**
+   * Send a message in async mode and poll until the task reaches a terminal
+   * state. This is the recommended path on serverless hosts with short
+   * function timeouts (Netlify, Vercel) where a synchronous LLM-driven A2A
+   * call can exceed the gateway limit.
+   *
+   * Each individual fetch returns quickly; long-running work happens on the
+   * receiving side and is checked via `tasks/get`.
+   */
+  async sendAndWait(
+    message: Message,
+    opts?: {
+      contextId?: string;
+      metadata?: Record<string, unknown>;
+      /** Total time to wait for completion. Default 5 min. */
+      timeoutMs?: number;
+      /** Poll interval. Default 2s. */
+      pollIntervalMs?: number;
+      /** Called with each polled task — useful for surfacing progress. */
+      onUpdate?: (task: Task) => void;
+    },
+  ): Promise<Task> {
+    const submitted = await this.send(message, {
+      contextId: opts?.contextId,
+      metadata: opts?.metadata,
+      async: true,
+    });
+
+    const terminalStates = new Set(["completed", "failed", "canceled"]);
+    if (terminalStates.has(submitted.status.state)) return submitted;
+
+    const timeoutMs = opts?.timeoutMs ?? 5 * 60_000;
+    const pollMs = opts?.pollIntervalMs ?? 2_000;
+    const deadline = Date.now() + timeoutMs;
+
+    let current = submitted;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, pollMs));
+      try {
+        current = await this.getTask(submitted.id);
+        opts?.onUpdate?.(current);
+      } catch (err) {
+        // Transient fetch failure — keep polling until the deadline.
+        continue;
+      }
+      if (terminalStates.has(current.status.state)) return current;
+    }
+    throw new Error(
+      `A2A task ${submitted.id} did not complete within ${timeoutMs}ms (last state: ${current.status.state})`,
+    );
   }
 
   async *stream(
@@ -207,6 +285,15 @@ export async function callAgent(
     userEmail?: string;
     orgDomain?: string;
     orgSecret?: string;
+    /**
+     * Use async/poll instead of a single blocking POST. Recommended for
+     * cross-app calls that may exceed serverless gateway timeouts (Netlify
+     * caps a single function at ~26s; the gateway times out at ~30s).
+     * Defaults to true so callers get safe behavior out of the box.
+     */
+    async?: boolean;
+    /** Total time to wait for the polled task (default 5 min). */
+    timeoutMs?: number;
   },
 ): Promise<string> {
   let apiKey = opts?.apiKey;
@@ -232,13 +319,26 @@ export async function callAgent(
   const metadata: Record<string, unknown> = {};
   if (opts?.userEmail) metadata.userEmail = opts.userEmail;
   if (opts?.orgDomain) metadata.orgDomain = opts.orgDomain;
-  const task = await client.send(
-    {
-      role: "user",
-      parts: [{ type: "text", text }],
-    },
-    { contextId: opts?.contextId, metadata },
-  );
+
+  const useAsync = opts?.async ?? true;
+  const message: Message = {
+    role: "user",
+    parts: [{ type: "text", text }],
+  };
+
+  let task: Task;
+  if (useAsync) {
+    task = await client.sendAndWait(message, {
+      contextId: opts?.contextId,
+      metadata,
+      timeoutMs: opts?.timeoutMs,
+    });
+  } else {
+    task = await client.send(message, {
+      contextId: opts?.contextId,
+      metadata,
+    });
+  }
 
   // Extract text from the response
   const responseMessage = task.status.message;

--- a/packages/core/src/a2a/handlers.spec.ts
+++ b/packages/core/src/a2a/handlers.spec.ts
@@ -246,6 +246,69 @@ describe("handleJsonRpc", () => {
     );
     expect(result.error.code).toBe(-32602);
   });
+
+  it("async message/send returns immediately and processes in background", async () => {
+    // Handler resolves only when we let it — so if the response came back
+    // synchronously the task could not yet be 'completed'.
+    let release: (v: unknown) => void = () => {};
+    const gate = new Promise((resolve) => {
+      release = resolve;
+    });
+    const slowConfig: A2AConfig = {
+      ...customHandler,
+      handler: async () => {
+        await gate;
+        return {
+          message: {
+            role: "agent",
+            parts: [{ type: "text", text: "done eventually" }],
+          },
+        };
+      },
+    };
+
+    const event = mockEvent();
+    const result = await handleJsonRpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "message/send",
+        params: {
+          async: true,
+          message: {
+            role: "user",
+            parts: [{ type: "text", text: "go" }],
+          },
+        },
+      },
+      event,
+      slowConfig,
+    );
+
+    // Returned immediately, before the handler resolved
+    expect(result.error).toBeUndefined();
+    expect(result.result.status.state).toBe("working");
+    const taskId = result.result.id;
+
+    // Now let the handler finish, and verify the task progresses to completed
+    release(undefined);
+    await new Promise((r) => setTimeout(r, 10));
+    const followup = await handleJsonRpc(
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tasks/get",
+        params: { id: taskId },
+      },
+      mockEvent(),
+      slowConfig,
+    );
+    expect(followup.error).toBeUndefined();
+    expect(followup.result.status.state).toBe("completed");
+    expect(followup.result.status.message.parts[0].text).toBe(
+      "done eventually",
+    );
+  });
 });
 
 describe("default handler (no custom handler)", () => {

--- a/packages/core/src/a2a/handlers.ts
+++ b/packages/core/src/a2a/handlers.ts
@@ -153,6 +153,92 @@ async function withA2ARequestContext<T>(
   ) as Promise<T>;
 }
 
+/**
+ * Best-effort "keep this promise alive after the response is sent."
+ *
+ * On Cloudflare Workers we have `__cf_ctx.waitUntil`. On Netlify Functions
+ * (Lambda under the hood) the function instance can be frozen the moment the
+ * response is flushed, so detached promises may not run to completion.
+ * Netlify's Background Functions (15-min timeout) are the durable answer, but
+ * for now we at least wire up the Workers path and a Netlify `context.waitUntil`
+ * if/when one is exposed. Anywhere else we fall back to fire-and-forget — the
+ * Node server (local dev, long-running hosts) will run it normally.
+ */
+function keepAlive(event: any | undefined, p: Promise<unknown>): void {
+  try {
+    const cfCtx = (globalThis as any).__cf_ctx;
+    if (cfCtx?.waitUntil) {
+      cfCtx.waitUntil(p);
+      return;
+    }
+  } catch {}
+  try {
+    // Netlify exposes a Lambda-ish `context` object; if it ever exposes a
+    // waitUntil-style API at event.context, prefer that.
+    const ctx = event?.context;
+    if (ctx && typeof ctx.waitUntil === "function") {
+      ctx.waitUntil(p);
+      return;
+    }
+  } catch {}
+  // Fire-and-forget — fine for Node hosts, may be cut short on serverless.
+  p.catch(() => {});
+}
+
+/**
+ * Run the handler against the message and persist the outcome to the task store.
+ * Used both synchronously (await) and detached (in async mode).
+ */
+async function runHandlerAndPersist(
+  taskId: string,
+  message: Message,
+  config: A2AConfig,
+  contextId: string | undefined,
+  metadata: Record<string, unknown> | undefined,
+): Promise<void> {
+  const { context, artifacts } = makeHandlerContext(
+    taskId,
+    contextId,
+    metadata,
+  );
+  try {
+    const result = getHandler(config)(message, context);
+
+    if (
+      result &&
+      typeof result === "object" &&
+      Symbol.asyncIterator in result
+    ) {
+      let lastMessage: Message | undefined;
+      for await (const msg of result as AsyncGenerator<Message>) {
+        lastMessage = msg;
+      }
+      await updateTask(taskId, {
+        state: "completed",
+        message: lastMessage,
+        artifacts: artifacts.length > 0 ? artifacts : undefined,
+      });
+      return;
+    }
+
+    const handlerResult = await (result as Promise<A2AHandlerResult>);
+    const allArtifacts = [...artifacts, ...(handlerResult.artifacts ?? [])];
+    await updateTask(taskId, {
+      state: "completed",
+      message: handlerResult.message,
+      artifacts: allArtifacts.length > 0 ? allArtifacts : undefined,
+    });
+  } catch (err: any) {
+    await updateTask(taskId, {
+      state: "failed",
+      message: {
+        role: "agent",
+        parts: [{ type: "text", text: err?.message ?? "Handler failed" }],
+      },
+    });
+  }
+}
+
 async function handleSend(
   params: Record<string, unknown>,
   config: A2AConfig,
@@ -173,43 +259,95 @@ async function handleSend(
   const contextId = params.contextId as string | undefined;
   const metadata = params.metadata as Record<string, unknown> | undefined;
 
+  // Async mode: return the task immediately in `working` state, run the
+  // handler in the background, and let the caller poll `tasks/get`. This is
+  // the workaround for Netlify's ~26s function / 30s gateway timeout when the
+  // handler runs LLM + tool loops that can exceed those bounds.
+  const asyncMode =
+    params.async === true ||
+    (metadata && (metadata as any).async === true) ||
+    (event && event.context?.__a2aForceAsync === true);
+
+  if (asyncMode) {
+    // Resolve identity up front (cheap), then return immediately and re-enter
+    // a request context inside the detached promise so the handler still sees
+    // the caller's email/org.
+    const verifiedEmail =
+      (event?.context?.__a2aVerifiedEmail as string | undefined) ?? undefined;
+    const orgDomainHint =
+      (event?.context?.__a2aOrgDomain as string | undefined) ??
+      ((metadata as any)?.orgDomain as string | undefined) ??
+      undefined;
+
+    const task = await createTask(message, contextId);
+    const working = await updateTask(task.id, { state: "working" });
+
+    const detached = (async () => {
+      const { runWithRequestContext } =
+        await import("../server/request-context.js");
+      let resolvedOrgId: string | undefined;
+      if (orgDomainHint) {
+        try {
+          const { resolveOrgByDomain } = await import("../org/context.js");
+          const org = await resolveOrgByDomain(orgDomainHint);
+          if (org) resolvedOrgId = org.orgId;
+        } catch {}
+      }
+      try {
+        await runWithRequestContext(
+          { userEmail: verifiedEmail, orgId: resolvedOrgId },
+          () =>
+            runHandlerAndPersist(task.id, message, config, contextId, metadata),
+        );
+      } catch (err: any) {
+        try {
+          await updateTask(task.id, {
+            state: "failed",
+            message: {
+              role: "agent",
+              parts: [
+                { type: "text", text: err?.message ?? "Handler crashed" },
+              ],
+            },
+          });
+        } catch {}
+      }
+    })();
+    keepAlive(event, detached);
+    return { ...jsonRpcResult(0, working ?? task), _id: 0 };
+  }
+
   return withA2ARequestContext(metadata, event, async () => {
     const task = await createTask(message, contextId);
-
     await updateTask(task.id, { state: "working" });
 
-    const { context, artifacts } = makeHandlerContext(
-      task.id,
-      contextId,
-      metadata,
-    );
+    const ctx = makeHandlerContext(task.id, contextId, metadata);
 
     try {
-      const result = getHandler(config)(message, context);
+      const result = getHandler(config)(message, ctx.context);
 
-      // Check if it's an async generator
       if (
         result &&
         typeof result === "object" &&
         Symbol.asyncIterator in result
       ) {
-        // For non-streaming send, collect all messages
         let lastMessage: Message | undefined;
         for await (const msg of result as AsyncGenerator<Message>) {
           lastMessage = msg;
         }
-        const allArtifacts = [...artifacts];
         const updated = await updateTask(task.id, {
           state: "completed",
           message: lastMessage,
-          artifacts: allArtifacts.length > 0 ? allArtifacts : undefined,
+          artifacts: ctx.artifacts.length > 0 ? ctx.artifacts : undefined,
         });
         return { ...jsonRpcResult(0, updated), _id: 0 };
       }
 
-      // Promise-based handler
       const handlerResult = await (result as Promise<A2AHandlerResult>);
-      const allArtifacts = [...artifacts, ...(handlerResult.artifacts ?? [])];
+      const allArtifacts = [
+        ...ctx.artifacts,
+        ...(handlerResult.artifacts ?? []),
+      ];
       const updated = await updateTask(task.id, {
         state: "completed",
         message: handlerResult.message,

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -255,8 +255,21 @@ async function processMessageInBackground(
           }
         }
 
-        if (!responseText.trim()) {
-          responseText = "(No response)";
+        // If the run errored OR produced no text, post a graceful fallback so
+        // the user isn't left wondering whether the bot saw their message.
+        // Common case: an A2A delegation timed out and the agent loop bailed
+        // before generating any user-facing text.
+        const runErrored = completedRun.status === "errored";
+        if (!responseText.trim() || runErrored) {
+          if (runErrored) {
+            responseText =
+              (responseText.trim() ? responseText + "\n\n" : "") +
+              "I ran into a problem before I could finish that one. " +
+              "If it was a complex analytics question, opening the analytics app " +
+              "directly is the most reliable way to get an answer right now.";
+          } else {
+            responseText = "(No response)";
+          }
         }
 
         // Append thread link for web UI access
@@ -276,6 +289,13 @@ async function processMessageInBackground(
           `[integrations] Error sending response to ${incoming.platform}:`,
           err,
         );
+        // Last-ditch: try to post a brief apology so the thread isn't silent.
+        try {
+          const fallback = adapter.formatAgentResponse(
+            "Something went wrong on my end while replying. Please try again.",
+          );
+          await adapter.sendResponse(fallback, incoming);
+        } catch {}
       }
     },
   );

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -157,7 +157,6 @@ export async function run(
               userEmail: callerEmail,
               orgDomain: callerOrgDomain,
               orgSecret: callerOrgSecret,
-              async: true,
             });
           } catch (pollErr: any) {
             // Surface a friendly message rather than a raw fetch error.

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -116,6 +116,18 @@ export async function run(
         status: "start",
       });
 
+      const emitNewText = (newText: string) => {
+        if (newText.length > lastSentLength) {
+          context.send!({
+            type: "agent_call_text",
+            agent: agent.name,
+            text: newText.slice(lastSentLength),
+          });
+          lastSentLength = newText.length;
+        }
+        responseText = newText;
+      };
+
       try {
         for await (const task of client.stream(
           {
@@ -133,25 +145,26 @@ export async function run(
               )
               ?.map((p) => p.text)
               ?.join("") ?? "";
-
-          if (newText.length > lastSentLength) {
-            context.send({
-              type: "agent_call_text",
-              agent: agent.name,
-              text: newText.slice(lastSentLength),
-            });
-            lastSentLength = newText.length;
-          }
-          responseText = newText;
+          emitNewText(newText);
         }
-      } catch {
-        // Streaming failed — fall back to blocking call
+      } catch (streamErr: any) {
+        // Streaming failed (often a serverless gateway timeout on long
+        // LLM-driven calls). Fall back to async + poll so we don't hit the
+        // ~30s Netlify gateway limit on a single request.
         if (!responseText) {
-          responseText = await callAgent(agent.url, message, {
-            userEmail: callerEmail,
-            orgDomain: callerOrgDomain,
-            orgSecret: callerOrgSecret,
-          });
+          try {
+            responseText = await callAgent(agent.url, message, {
+              userEmail: callerEmail,
+              orgDomain: callerOrgDomain,
+              orgSecret: callerOrgSecret,
+              async: true,
+            });
+          } catch (pollErr: any) {
+            // Surface a friendly message rather than a raw fetch error.
+            const reason =
+              pollErr?.message ?? streamErr?.message ?? "unknown error";
+            responseText = `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;
+          }
         }
       }
 
@@ -164,7 +177,8 @@ export async function run(
       return responseText || "(empty response)";
     }
 
-    // No context — use simple blocking call
+    // No context — use the async + poll call so we don't get cut off at the
+    // serverless gateway's ~30s timeout. callAgent defaults to async:true.
     const email = getRequestUserEmail();
     let domain: string | undefined;
     let orgSecret: string | undefined;
@@ -184,6 +198,12 @@ export async function run(
     });
     return response || "(empty response)";
   } catch (err: any) {
-    return `Error calling ${agent.name}: ${err?.message}`;
+    const msg = err?.message ?? String(err);
+    // Friendlier message for the common timeout case so the calling agent can
+    // decide whether to give up or retry.
+    if (/timeout|did not complete|Inactivity|504/i.test(msg)) {
+      return `The ${agent.name} agent is taking longer than expected. Please try again, ask a simpler question, or open the ${agent.name} app directly.`;
+    }
+    return `Error calling ${agent.name}: ${msg}`;
   }
 }

--- a/templates/analytics/app/components/layout/CommandPalette.tsx
+++ b/templates/analytics/app/components/layout/CommandPalette.tsx
@@ -104,7 +104,7 @@ export function CommandPalette() {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "p") {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
         e.preventDefault();
         setOpen((o) => !o);
       }


### PR DESCRIPTION
## Summary
- A2A `message/send` now supports `async:true` flag — server returns working task immediately, client polls `tasks/get` until completed
- `callAgent` and `call-agent` script default to async mode so cross-app delegation isn't blocked by Netlify's 30s gateway timeout
- Webhook handler posts graceful Slack message on agent-loop errors

## Why
Direct A2A test proves Builder.io org delegation works end-to-end (returned 'Hi! How can I help...' in 4s, 'Slides capabilities' in 7.8s, '665 signups yesterday' in 10.4s). But the synchronous pattern hits Netlify's 30s gateway limit for slower BigQuery queries. Async polling sidesteps it.