### PR TITLE
fix: mount /process-task route + correct signatures

### DIFF
--- a/packages/core/src/integrations/pending-tasks-retry-job.ts
+++ b/packages/core/src/integrations/pending-tasks-retry-job.ts
@@ -123,16 +123,18 @@ export async function retryStuckPendingTasks(
         continue;
       }
 
-      // Touch updated_at so we don't re-fire it on the very next tick if the
-      // processor is just slow to pick it up. The processor itself will
-      // increment the attempt count when it claims the task.
+      // Reset stuck `processing` rows back to `pending` so the processor's
+      // atomic claim (which only matches pending/failed) can re-acquire it.
+      // Without this, processing rows stay stuck forever.
+      // For pending rows, just touch updated_at to avoid re-firing every tick.
+      const newStatus = row.status === "processing" ? "pending" : row.status;
       await client.execute({
         sql: `
           UPDATE integration_pending_tasks
-             SET updated_at = ?
+             SET status = ?, updated_at = ?
            WHERE id = ?
         `,
-        args: [Date.now(), row.id],
+        args: [newStatus, Date.now(), row.id],
       });
 
       await refireProcessor(row.id, baseUrl);

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -188,6 +188,79 @@ export function createIntegrationsPlugin(
       }),
     );
 
+    // ─── Process pending task (cross-platform task queue) ────────
+    // POST /_agent-native/integrations/process-task
+    // Internal endpoint invoked via fire-and-forget self-webhook from the
+    // public webhook handler. Auth: HMAC bearer signed with A2A_SECRET.
+    // Each invocation runs the agent loop in a fresh function execution.
+    h3.use(
+      `${P}/process-task`,
+      defineEventHandler(async (event) => {
+        if (getMethod(event) !== "POST") {
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
+
+        const body = (await readBody(event)) as { taskId?: string };
+        const taskId = body?.taskId;
+        if (!taskId) {
+          setResponseStatus(event, 400);
+          return { error: "taskId required" };
+        }
+
+        // Auth: HMAC token. Falls open when A2A_SECRET is unset (the SQL
+        // atomic claim is then the only gating factor — same posture as
+        // the A2A endpoint when no secret is configured).
+        if (process.env.A2A_SECRET) {
+          const tok = extractBearerToken(
+            getRequestHeader(event, "authorization"),
+          );
+          if (!tok || !verifyInternalToken(tok, taskId)) {
+            setResponseStatus(event, 401);
+            return { error: "Invalid or expired internal token" };
+          }
+        }
+
+        // Atomic claim: only one invocation gets to process this task
+        const claim = await claimPendingTask(taskId);
+        if (!claim.task) {
+          setResponseStatus(event, 200);
+          return { ok: true, skipped: claim.reason ?? "already-claimed" };
+        }
+
+        try {
+          const adapter = adapterMap.get(claim.task.platform);
+          if (!adapter) {
+            await markTaskFailed(
+              taskId,
+              `Unknown platform: ${claim.task.platform}`,
+            );
+            setResponseStatus(event, 404);
+            return { error: "Unknown platform" };
+          }
+          await processIntegrationTask({
+            task: claim.task,
+            adapter,
+            systemPrompt: baseSystemPrompt,
+            actions,
+            model,
+            apiKey,
+          });
+          await markTaskCompleted(taskId);
+          return { ok: true, taskId };
+        } catch (err: any) {
+          await markTaskFailed(
+            taskId,
+            err?.message
+              ? String(err.message).slice(0, 1000)
+              : "processor failed",
+          );
+          setResponseStatus(event, 500);
+          return { error: err?.message ?? String(err) };
+        }
+      }),
+    );
+
     // ─── Per-platform catch-all ───────────────────────────────────
     // Handles: webhook, status, enable, disable, setup for each platform
     h3.use(
@@ -202,6 +275,8 @@ export function createIntegrationsPlugin(
         if (parts[0] === "status" && parts.length === 1) return;
         // Already handled by the dedicated /task-queue/status route above
         if (parts[0] === "task-queue") return;
+        // Already handled by the dedicated /process-task route above
+        if (parts[0] === "process-task") return;
 
         const platform = parts[0];
         const action = parts[1]; // webhook, status, enable, disable, setup

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -215,7 +215,7 @@ export function createIntegrationsPlugin(
           const tok = extractBearerToken(
             getRequestHeader(event, "authorization"),
           );
-          if (!tok || !verifyInternalToken(tok, taskId)) {
+          if (!tok || !verifyInternalToken(taskId, tok)) {
             setResponseStatus(event, 401);
             return { error: "Invalid or expired internal token" };
           }

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -222,29 +222,26 @@ export function createIntegrationsPlugin(
         }
 
         // Atomic claim: only one invocation gets to process this task
-        const claim = await claimPendingTask(taskId);
-        if (!claim.task) {
+        const task = await claimPendingTask(taskId);
+        if (!task) {
           setResponseStatus(event, 200);
-          return { ok: true, skipped: claim.reason ?? "already-claimed" };
+          return { ok: true, skipped: "already-claimed-or-missing" };
         }
 
         try {
-          const adapter = adapterMap.get(claim.task.platform);
+          const adapter = adapterMap.get(task.platform);
           if (!adapter) {
-            await markTaskFailed(
-              taskId,
-              `Unknown platform: ${claim.task.platform}`,
-            );
+            await markTaskFailed(taskId, `Unknown platform: ${task.platform}`);
             setResponseStatus(event, 404);
             return { error: "Unknown platform" };
           }
-          await processIntegrationTask({
-            task: claim.task,
+          await processIntegrationTask(task, {
             adapter,
             systemPrompt: baseSystemPrompt,
             actions,
             model,
             apiKey,
+            ownerEmail: task.ownerEmail,
           });
           await markTaskCompleted(taskId);
           return { ok: true, taskId };

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -138,8 +138,10 @@ export async function handleWebhook(
       `[integrations] Failed to enqueue/dispatch ${incoming.platform} message:`,
       err,
     );
-    // Still return 200 so the platform doesn't retry — the user-visible
-    // failure surfaces as the bot not replying, not as an HTTP retry storm.
+    // Return 500 so the platform retries. If the SQL insert failed, the
+    // message is genuinely lost — better to let Slack retry (it will
+    // re-fire the same event_callback) than silently drop it.
+    return { status: 500, body: { error: "enqueue failed" } };
   }
 
   return { status: 200, body: "ok" };


### PR DESCRIPTION
Critical: the cross-platform task queue's processor endpoint wasn't mounted, causing all webhooks to enqueue tasks that never got processed. Now properly mounted before the catch-all + skip clause added.