### PR TITLE
Fix "Stop Sharing" button not stopping recording

### DIFF
--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -45,6 +45,14 @@ export interface RecorderEngineOptions {
   }) => void;
   /** Fired on any error. */
   onError?: (err: Error) => void;
+  /**
+   * Called when the display stream's video track ends because the user clicked
+   * the browser's native "Stop sharing" button. When provided, the engine
+   * delegates the stop flow to this callback instead of calling `stop()`
+   * internally — so the UI can run its own side-effects (thumbnail capture,
+   * transcription flush, navigation) before the MediaRecorder is finalized.
+   */
+  onDisplayTrackEnded?: () => void;
 }
 
 export interface RecorderStartResult {
@@ -190,11 +198,20 @@ export class RecorderEngine {
 
       // If the display stream's video track ends (user hit "Stop sharing" in
       // browser chrome) we want to end the recording gracefully.
+      //
+      // When `onDisplayTrackEnded` is provided the UI handles the stop flow
+      // (thumbnail capture, transcription flush, state updates, navigation).
+      // Without it we fall back to stopping the engine directly — but this
+      // bypasses all UI side-effects, so always provide the callback.
       if (this.displayStream) {
         for (const track of this.displayStream.getVideoTracks()) {
           track.addEventListener("ended", () => {
             if (this.state === "recording" || this.state === "paused") {
-              void this.stop();
+              if (this.opts.onDisplayTrackEnded) {
+                this.opts.onDisplayTrackEnded();
+              } else {
+                void this.stop();
+              }
             }
           });
         }
@@ -322,8 +339,43 @@ export class RecorderEngine {
       }
     }
 
+    // The MediaRecorder may have auto-stopped if all its tracks ended (e.g.
+    // display-only mode with no mic). In that case the browser already fired
+    // `dataavailable` with the final buffered data, which was queued for
+    // upload by our existing `dataavailable` listener. We just need to drain
+    // that queue and send the `isFinal=1` marker so the server can finalize.
     if (this.recorder.state === "inactive") {
-      throw new Error("Recorder already stopped");
+      this.transition("stopping");
+      await this.chunkQueue.catch(() => {});
+      const dimensions = this.readDimensions();
+      const durationMs = Math.round(this.getElapsedMs());
+      const hasAudio = this.hasAudioTrack();
+      const hasCamera = !!this.cameraStream;
+      this.transition("uploading", { progress: 100 });
+      const result = await this.uploadChunk(
+        new Blob([], { type: this.mimeType }),
+        this.chunkIndex++,
+        {
+          isFinal: true,
+          total: this.chunkIndex,
+          mimeType: this.mimeType,
+          durationMs,
+          width: dimensions.width,
+          height: dimensions.height,
+          hasAudio,
+          hasCamera,
+        },
+      );
+      this.cleanupTracks();
+      this.transition("complete");
+      return {
+        videoUrl: (result?.videoUrl as string | undefined) ?? null,
+        durationMs,
+        width: dimensions.width,
+        height: dimensions.height,
+        hasAudio,
+        hasCamera,
+      };
     }
 
     this.transition("stopping");

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -340,33 +340,42 @@ export class RecorderEngine {
     }
 
     // The MediaRecorder may have auto-stopped if all its tracks ended (e.g.
-    // display-only mode with no mic). In that case the browser already fired
-    // `dataavailable` with the final buffered data, which was queued for
-    // upload by our existing `dataavailable` listener. We just need to drain
-    // that queue and send the `isFinal=1` marker so the server can finalize.
+    // display-only mode with no mic). Different browsers dispatch `dataavailable`
+    // either before or after state transitions to `inactive`. Yielding one
+    // macrotask (setTimeout 0) ensures any still-pending `dataavailable` event
+    // runs first and gets queued by our start()-time listener before we drain
+    // the chunk queue and send the isFinal=1 sentinel.
     if (this.recorder.state === "inactive") {
       this.transition("stopping");
+      // Yield to the event loop so any pending dataavailable event from the
+      // auto-stop can fire and be queued before we drain chunkQueue.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
       await this.chunkQueue.catch(() => {});
       const dimensions = this.readDimensions();
       const durationMs = Math.round(this.getElapsedMs());
       const hasAudio = this.hasAudioTrack();
       const hasCamera = !!this.cameraStream;
       this.transition("uploading", { progress: 100 });
-      const result = await this.uploadChunk(
-        new Blob([], { type: this.mimeType }),
-        this.chunkIndex++,
-        {
-          isFinal: true,
-          total: this.chunkIndex,
-          mimeType: this.mimeType,
-          durationMs,
-          width: dimensions.width,
-          height: dimensions.height,
-          hasAudio,
-          hasCamera,
-        },
-      );
-      this.cleanupTracks();
+      let result: Record<string, unknown> | undefined;
+      try {
+        result = await this.uploadChunk(
+          new Blob([], { type: this.mimeType }),
+          this.chunkIndex++,
+          {
+            isFinal: true,
+            total: this.chunkIndex,
+            mimeType: this.mimeType,
+            durationMs,
+            width: dimensions.width,
+            height: dimensions.height,
+            hasAudio,
+            hasCamera,
+          },
+        );
+      } finally {
+        // Always release hardware resources, even if the final upload failed.
+        this.cleanupTracks();
+      }
       this.transition("complete");
       return {
         videoUrl: (result?.videoUrl as string | undefined) ?? null,

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -133,6 +133,9 @@ export default function RecordRoute() {
   const engineRef = useRef<RecorderEngine | null>(null);
   const pendingRef = useRef<PendingRecording | null>(null);
   const confettiRef = useRef<ConfettiHandle>(null);
+  // Stable ref to doStop so engine callbacks created during startFlow always
+  // call the latest version (avoids stale-closure problems with useCallback deps).
+  const doStopRef = useRef<() => Promise<void>>(async () => {});
   // Tracks whether opening the stop-confirm dialog auto-paused a live
   // recording — so closing the dialog without choosing an action resumes
   // it, but doesn't unpause a recording the user had paused themselves.
@@ -267,6 +270,14 @@ export default function RecordRoute() {
               updatedAt: new Date().toISOString(),
             }).catch(() => {});
           },
+          // When the user clicks the browser's native "Stop sharing" button,
+          // delegate to doStop() so the UI runs its full stop flow: thumbnail
+          // capture, transcription flush, state updates, and navigation.
+          // Using a ref so we always call the latest version of doStop even
+          // though startFlow itself has empty deps.
+          onDisplayTrackEnded: () => {
+            void doStopRef.current();
+          },
         });
         engineRef.current = engine;
 
@@ -319,6 +330,16 @@ export default function RecordRoute() {
     const engine = engineRef.current;
     const pending = pendingRef.current;
     if (!engine || !pending) return;
+    // Guard against concurrent calls (e.g. browser "Stop sharing" fires at the
+    // same time the user also clicks the in-app stop button).
+    const engineState = engine.getState();
+    if (
+      engineState === "stopping" ||
+      engineState === "uploading" ||
+      engineState === "complete"
+    ) {
+      return;
+    }
     setUiState("uploading");
     try {
       // Capture a still-frame thumbnail from the preview while the stream is
@@ -362,6 +383,9 @@ export default function RecordRoute() {
       toast.error(message);
     }
   }, [navigate, liveTranscription]);
+
+  // Keep the ref current so engine callbacks always invoke the latest doStop.
+  doStopRef.current = doStop;
 
   const requestStop = useCallback(() => {
     setIsDrawing(false);


### PR DESCRIPTION
### Summary
Fixes a bug where clicking the browser's native "Stop Sharing" button from the mini-toolbar did not properly stop the recording. The engine now delegates the stop flow to the UI so all side-effects are correctly executed.

### Problem
When a user clicked the browser's native "Stop sharing" button during a screen recording, the `RecorderEngine` would call `stop()` internally, bypassing all UI-level side-effects such as thumbnail capture, transcription flushing, state updates, and navigation. As a result, the recording appeared to not stop as expected from the user's perspective.

### Solution
Introduced an `onDisplayTrackEnded` callback option on `RecorderEngine` that, when provided, delegates the stop flow to the UI instead of calling `stop()` internally. The `record.tsx` route wires this callback to a stable ref (`doStopRef`) pointing to the full `doStop` function, ensuring the complete stop flow always runs — even when the browser fires the track-ended event.

### Key Changes
- **`recorder-engine.ts`**: Added `onDisplayTrackEnded` option to `RecorderEngineOptions`; when the display video track ends, the engine calls this callback instead of `stop()` if provided
- **`recorder-engine.ts`**: Handled the edge case where `MediaRecorder` is already `inactive` (e.g. display-only mode with no mic) by draining the chunk queue and sending the final upload marker instead of throwing an error
- **`record.tsx`**: Added `doStopRef` — a stable ref to `doStop` — to avoid stale-closure issues in engine callbacks created during `startFlow`
- **`record.tsx`**: Wired `onDisplayTrackEnded` to `doStopRef.current()` so the full UI stop flow (thumbnail, transcription, navigation) always runs when the user clicks "Stop sharing"
- **`record.tsx`**: Added a concurrency guard in `doStop` to prevent duplicate stop calls when the browser event and an in-app stop button fire simultaneously

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/focal-escape-ssaegzwj"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-focal-escape-ssaegzwj_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

💬 [View Slack Thread](https://slack.com/app_redirect?team=T0GCV21GE&channel=C0ATLA31V36&message_ts=1777402565.139919)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 336`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>focal-escape-ssaegzwj</branchName>-->