### PR TITLE
Fix mini toolbar persisting after recording error

### DIFF
--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -344,6 +344,10 @@ export default function RecordRoute() {
       }
 
       await engine.stop();
+      // Recording is fully saved — clear refs so that if anything below throws
+      // and the user clicks "Try again", doCancel() won't trash a good recording.
+      pendingRef.current = null;
+      engineRef.current = null;
       setCameraStream(null);
       setPreviewStream(null);
       setUiState("complete");

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -257,6 +257,7 @@ export default function RecordRoute() {
             console.error("[recorder] error:", err);
             toast.error(err.message);
             setError(err.message);
+            setUiState("error");
           },
           onChunk: ({ index, bytes }) => {
             void writeAppState(`recording-upload-${info.id}`, {
@@ -729,8 +730,7 @@ export default function RecordRoute() {
                 <Button
                   variant="outline"
                   onClick={() => {
-                    setError(null);
-                    setUiState("idle");
+                    void doCancel();
                   }}
                 >
                   Try again


### PR DESCRIPTION
### Summary
Fixes an issue where clicking "Try again" after a recording save/upload error left the mini toolbar visible, causing multiple instances to stack up.

### Problem
When an error occurred during saving or uploading a recording, clicking "Try again" only reset local state (`setError(null)` and `setUiState("idle")`) without properly dismissing the mini toolbar. This caused multiple toolbar instances to remain visible on screen.

### Solution
Set the UI state to `"error"` when a recording error is caught, and replace the inline state reset in the "Try again" button with a call to `doCancel()`, which properly tears down the recording session and dismisses the mini toolbar before returning to idle.

### Key Changes
- Added `setUiState("error")` in the recorder error handler so the UI correctly reflects the error state.
- Replaced the "Try again" button's inline `setError(null)` + `setUiState("idle")` logic with `void doCancel()` to ensure the mini toolbar is fully dismissed and all state is cleaned up properly.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/blazing-hold-oves39ss"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-blazing-hold-oves39ss_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<h3>Preview</h3>
<img src="https://cdn.builder.io/o/assets%2FYJIGb4i01jvw0SRdL5Bt%2F2bf8f28fcbe449469b6db3e0dca996b7?alt=media&token=f957cf1c-49da-49b2-825e-9e763d57c5b4&apiKey=YJIGb4i01jvw0SRdL5Bt" alt="Changes preview" style="max-width: 100%; height: auto;">
<!-- FUSION_KEEP_END -->

---

💬 [View Slack Thread](https://slack.com/app_redirect?team=T0GCV21GE&channel=C0ATLA31V36&message_ts=1777403058.039489)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 338`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>blazing-hold-oves39ss</branchName>-->