### PR TITLE
fix(a2a): cross-platform async+poll for slow A2A handlers

### DIFF
--- a/packages/core/docs/content/cloneable-saas.md
+++ b/packages/core/docs/content/cloneable-saas.md
@@ -1,98 +1,95 @@
 ---
 title: "Cloneable SaaS"
-description: "Agent-native templates are not demos — they're complete, SaaS-grade products you clone, customize, and own."
+description: "Fork a working SaaS product and make it yours — agent included."
 ---
 
 # Cloneable SaaS
 
-The word "template" undersells what ships with agent-native.
+Want to ship your own AI-powered analytics tool? Mail client? Forms builder? Pick a template, and you've got a working SaaS in minutes — agent, database, auth, and deploy pipeline already wired up.
 
-In most frameworks, a template is a bare-bones scaffold: a couple of routes, a few components, and a lot of "TODO." Agent-native inverts that. Every template is a **full, SaaS-grade product** — email client, calendar, analytics, deck generator, video editor, form builder, issue tracker — complete enough to use as-is, and also complete enough to fork and make your own.
+Most templates give you a blank scaffold and a long TODO list. Agent-native flips that. Each template is a **complete, SaaS-grade product** — already runnable on day one, already shippable, and entirely yours to customize, brand, and deploy.
 
-Think of them less like "templates" and more like **cloneable SaaS**. You get a real product, not a starting point.
+We call them **cloneable SaaS**, not templates. You're not starting from scratch. You're forking a finished product.
 
-## The pitch {#pitch}
+## Templates available {#catalog}
 
-Every SaaS product you use today hits the same wall: it gives you 80% of what you need, and you can't change the 20% that really matters. You can't touch the data model. You can't add the metric. You can't wire it to your internal system. You can't give it instructions.
+Each one is a real app you could use today, and the launching pad for your own version of it.
 
-Cloneable SaaS flips that. You start from a production-quality app, and everything about it is yours — the code, the database, the agent, the deploy target, the brand. If you don't like how the inbox groups by thread, change it. If you need a field that the template doesn't have, add it. The agent helps you do all of this in natural language.
+| Template       | What it is                                                                                                |
+| -------------- | --------------------------------------------------------------------------------------------------------- |
+| **Mail**       | An agent-native Superhuman. Inbox, labels, AI triage, keyboard-first, drafts and sends through the agent. |
+| **Calendar**   | An agent-native Google Calendar. Events, sync, public booking links, agent-driven scheduling.             |
+| **Content**    | An agent-native Notion / Google Docs. Markdown + Tiptap editor, Notion sync, real-time multi-user collab. |
+| **Slides**     | An agent-native Google Slides. React-based decks the agent generates and edits directly.                  |
+| **Video**      | An agent-native video editor on Remotion. Prompt for a cut, the agent assembles it.                       |
+| **Analytics**  | An agent-native Amplitude/Mixpanel. Connect data sources, prompt for charts, pin to dashboards.           |
+| **Forms**      | An agent-native Typeform. Build, share, and collect; the agent handles schema and submission analysis.    |
+| **Issues**     | An agent-native Jira. Projects, issues, priorities, with the agent as your project manager.               |
+| **Recruiting** | An agent-native Greenhouse. Candidate pipelines, scoring, outreach drafts.                                |
+| **Dispatch**   | The workspace control plane: shared secrets, cross-app integrations, Slack/Telegram, scheduled jobs.      |
+| **Starter**    | The minimal scaffold. Agent chat plus the architecture, nothing else. Build something new.                |
 
-This isn't a theoretical claim: it's how Steve (the framework's author) has been using it for months. The mail template _is_ his inbox. The analytics template _is_ his dashboard. The calendar template _is_ his calendar.
+More are in active development: **Clips** (screen recording + transcription), **Calls** (Gong-style conversation intelligence), and **Scheduling** (a standalone scheduling app).
 
-## What's in the catalog {#catalog}
+See the full catalog under [Templates](/templates), or jump straight to one — for example, [Dispatch](/docs/template-dispatch) is a great place to start if you want a workspace-style app.
 
-All of these ship in the `BuilderIO/agent-native` repo and scaffold via `agent-native create`:
+## What you get out of the box {#what-you-get}
 
-| Template       | What it is                                                                                                      |
-| -------------- | --------------------------------------------------------------------------------------------------------------- |
-| **Mail**       | An agent-native Superhuman. Inbox, labels, AI triage, keyboard-first, with an agent that can draft and send.    |
-| **Calendar**   | An agent-native Google Calendar. Events, sync, public booking links, agent-driven scheduling.                   |
-| **Content**    | An agent-native Notion / Google Docs. Markdown + Tiptap editor, Notion sync, multi-user real-time collab.       |
-| **Slides**     | An agent-native Google Slides. React-based decks the agent generates and edits directly.                        |
-| **Video**      | An agent-native video editor built on Remotion. Prompt for a cut, the agent assembles it.                       |
-| **Analytics**  | An agent-native Amplitude/Mixpanel. Connect data sources, prompt for charts, pin to dashboards.                 |
-| **Forms**      | An agent-native Typeform. Build, share, and collect; agent handles the schema and analysis of submissions.      |
-| **Issues**     | An agent-native Jira. Projects, issues, priorities, with the agent as your project manager.                     |
-| **Recruiting** | An agent-native Greenhouse. Candidate pipelines, scoring, outreach drafts.                                      |
-| **Dispatch**   | The **workspace control plane**: central secrets vault, cross-app integrations, Slack/Telegram, scheduled jobs. |
-| **Starter**    | The minimal scaffold. Agent chat + the six-rules architecture wired up, nothing else. Build from scratch.       |
+Every cloneable SaaS ships with the parts that normally take months to build:
 
-Additional templates in active development in the repo: **Clips** (screen recording + transcription), **Calls** (Gong-style conversation intelligence), **Scheduling** (a standalone scheduling app and reusable package).
+- **A working agent** — already wired into the app, already able to take actions on your data, already context-aware about what you're looking at. See [Messaging the agent](/docs/messaging) for how it works.
+- **Auth** — sign in, sessions, organizations, multi-tenant isolation. Already done.
+- **A database** — every template has its schema, queries, and migrations ready to go. Bring your own SQL database (Postgres, SQLite, Turso, D1) — the framework adapts.
+- **A real-time UI** — the screen stays in sync with what the agent does. Click "draft an email" in chat, watch the draft appear in your inbox immediately.
+- **Deploy-ready** — push to Netlify, Vercel, Cloudflare, AWS, or anywhere else that runs Node. No vendor lock-in.
+- **Branding hooks** — name, colors, logo, copy are all easy to change.
 
-## The clone → customize → deploy flow {#flow}
+This isn't a theoretical claim. The framework's author runs his actual inbox on the Mail template, his actual calendar on the Calendar template, and his actual analytics on the Analytics template. Templates are daily-driver software.
 
-Every cloneable SaaS follows the same lifecycle:
+## What you do {#what-you-do}
 
-### 1. Clone
+The path from "I want my own SaaS" to "I have my own SaaS" is short:
+
+1. **Pick a template.** Use the CLI picker, or browse the docs and pick one to start from.
+2. **Brand it.** Change the name, colors, logo, and copy. Most templates expose this in a single config file.
+3. **Customize it.** Ask the agent to add the column you need, change how the inbox groups, connect to your internal API, add a new view. The agent edits the code; you review the diff.
+4. **Ship it.** Run the deploy command. You now have your own production SaaS at your own domain.
+
+Steps 2–4 typically take days, not months. Step 3 is open-ended — your forked SaaS evolves over time, in plain English, by talking to the agent.
+
+## Why this is practical {#why}
+
+A traditional fork-the-codebase model breaks down at scale: every user maintaining their own inbox sounds like a maintenance nightmare. Two framework decisions make it work:
+
+1. **The agent does the maintenance.** You don't write code to add a column or wire a new integration — you ask the agent. So "your own forked inbox" is a feature, not a burden.
+2. **Per-user customization without per-user code.** Skills, memory, instructions, connected MCP servers, and sub-agents all live in SQL. Every user gets their own customization layer; the shared codebase hosts all of them at once.
+
+The result: Claude-Code-level flexibility for each user, with normal SaaS deployment economics.
+
+## Don't want to fork? {#hosted}
+
+You don't have to. Every template is also available as a hosted app on `agent-native.com` — `mail.agent-native.com`, `calendar.agent-native.com`, and so on. Use the hosted version for free or paid; fork only when you want to change something the hosted version doesn't expose.
+
+## Building on this
+
+- [**Getting Started**](/docs/getting-started) — clone your first template and run it locally
+- [**Messaging the agent**](/docs/messaging) — how users (and you) talk to the agent that ships with each template
+- [**Multi-App Workspace**](/docs/multi-app-workspace) — bundle several cloneable-SaaS apps into one workspace that shares auth, brand, and agent
+- [**Dispatch**](/docs/template-dispatch) — the workspace control plane template
+- [**Creating Templates**](/docs/creating-templates) — author and publish your own cloneable SaaS
+
+### For developers {#dev-details}
+
+If you're scaffolding now, the CLI command is:
 
 ```bash
 pnpm dlx @agent-native/core create my-platform
 ```
 
-The CLI shows a multi-select picker. Pick one app (standalone) or several (workspace — apps share auth, brand, agent config, and database). Each picked template is scaffolded into `apps/<name>/` with every file you need. See [Getting Started](/docs) for the full flow or [Multi-App Workspace](/docs/multi-app-workspace) for the workspace story.
+You'll get a multi-select picker. Pick one app (standalone) or several (workspace — apps share auth, brand, agent config, and database). Each picked template is scaffolded into `apps/<name>/` with every file you need.
 
-### 2. Use it immediately
+Fill in `.env` (mostly `ANTHROPIC_API_KEY` and `DATABASE_URL`), `pnpm install`, `pnpm dev`, and it works. No "TODO: implement login," no placeholder routes.
 
-Every template is runnable the moment it scaffolds. Fill in `.env` (mostly `ANTHROPIC_API_KEY` and `DATABASE_URL`), `pnpm install`, `pnpm dev`, and it works. No "TODO: implement login," no placeholder routes.
+Deploy targets: any Nitro-compatible host (Node, Cloudflare, Netlify, Vercel, Deno, Lambda, Bun) and any Drizzle-compatible SQL database (SQLite, Postgres, Turso, D1, Supabase, Neon). For workspaces, `agent-native deploy` builds every app at once and ships them behind a single origin. See [Deployment](/docs/deployment).
 
-### 3. Customize with the agent
-
-The agent can modify code — components, routes, actions, styles, the schema. This is a feature, not a bug:
-
-- "Change the inbox to group by sender instead of thread." _The agent edits the component._
-- "Add a `leadScore` column to contacts and compute it from the last email." _The agent adds the Drizzle column, runs a migration, writes the scoring action._
-- "Connect this to our internal HR API." _The agent writes the integration._
-
-Every edit is normal Git-tracked code. Bad changes? Revert them. Good changes? Keep them. See [Self-Modifying Code](/docs/key-concepts#agent-modifies-code) for the full mental model.
-
-### 4. Deploy anywhere
-
-Agent-native apps run on any Nitro-compatible host (Node, Cloudflare, Netlify, Vercel, Deno, Lambda, Bun) and any Drizzle-compatible SQL database (SQLite, Postgres, Turso, D1, Supabase, Neon). The framework doesn't lock you in.
-
-For workspaces, `agent-native deploy` builds every app at once and ships them behind a single origin — your own domain, your own cert, one command. See [Deployment](/docs/deployment).
-
-### 5. Stay on `agent-native.com`, or self-host
-
-You can also use these as hosted apps on the Builder-operated `agent-native.com` platform — `mail.agent-native.com`, `calendar.agent-native.com`, etc. — without forking. Fork only when you want to change something the hosted version doesn't let you change.
-
-## Why this works {#why-this-works}
-
-Cloneable SaaS wouldn't be practical in a traditional codebase. Every user forking their own inbox would mean every user maintaining their own inbox — no thanks.
-
-Two framework decisions unlock it:
-
-1. **Agents do the maintenance.** You don't write code to add a column or wire a new integration — you ask the agent. So "your own forked inbox" is a feature, not a burden, because the agent is doing the work.
-2. **The workspace is SQL, not files.** Every user gets their own customization layer (skills, memory, instructions, connected MCP servers, sub-agents) without a dev-box. The shared codebase hosts all of them at once. See [Workspace](/docs/workspace).
-
-Combined, you get Claude-Code-level flexibility per user, with SaaS-grade deployment economics.
-
-## Authoring your own cloneable SaaS {#authoring}
-
-Want to publish a new template — your own cloneable SaaS? See [Creating Templates](/docs/creating-templates). You can publish to `BuilderIO/agent-native` for inclusion in the CLI picker, or host elsewhere and scaffold with `--template github:user/repo`.
-
-## What's next
-
-- [**Multi-App Workspace**](/docs/multi-app-workspace) — bundle many cloneable-SaaS apps into one monorepo that shares auth, brand, and agent instructions
-- [**Key Concepts**](/docs/key-concepts) — the architecture that makes this work
-- [**Deployment**](/docs/deployment) — ship your forked app
-- [**Creating Templates**](/docs/creating-templates) — author and publish a new cloneable SaaS
+To author and publish your own cloneable SaaS, see [Creating Templates](/docs/creating-templates).

--- a/packages/core/docs/content/faq.md
+++ b/packages/core/docs/content/faq.md
@@ -1,31 +1,102 @@
 ---
 title: "FAQ"
-description: "Frequently asked questions about agent-native apps, development, architecture, and templates."
+description: "Common questions about agent-native — what it is, who it's for, what you can build, and how it works."
 ---
 
 # FAQ
 
-Frequently asked questions about agent-native apps, development, and the framework.
+Common questions about agent-native, organized from "I'm just looking" to "I'm wiring up auth right now."
 
-## General {#general}
+## The basics {#general}
 
 ### What is agent-native? {#what-is-agent-native}
 
 Agent-native is a framework for building apps where the AI agent and the UI are equal partners. They share the same database, the same state, and they always stay in sync. Everything the UI can do, the agent can do — and vice versa. See [What Is Agent-Native?](/docs/what-is-agent-native) for the full explanation.
 
+### Who is this for? {#who-is-this-for}
+
+Anyone who wants to ship an AI-powered product without spending a year building the boring parts. That includes:
+
+- **Founders and PMs** who want to fork a working SaaS and make it their own — see [Cloneable SaaS](/docs/cloneable-saas).
+- **Operators** who want a [pure-agent app](/docs/pure-agent-apps) — an agent that does work in the background with a minimal management UI.
+- **Developers** building agent-driven products from scratch and want auth, multi-tenancy, real-time sync, and an architecture that won't break when AI is the primary user.
+
 ### How is this different from adding AI to an existing app? {#how-is-this-different}
 
 Most apps bolt AI on as an afterthought — an autocomplete here, a chat sidebar there. The AI can't actually _do_ things in the app. In an agent-native app, the agent is a first-class citizen. It can create emails, schedule events, build forms, generate slides, and modify the app's own code. The architecture is designed for this from the ground up.
 
-### Do I need to know AI/ML? {#do-i-need-to-know-ai}
-
-No. You don't train models, fine-tune, or deal with embeddings. You build a regular web app with React, TypeScript, and SQL. The framework handles the agent integration — routing messages, running actions, syncing state. You write standard web code and the agent just works.
-
-### Is this open source? {#is-this-open-source}
+### Is it open source? {#is-this-open-source}
 
 Yes. The framework and all templates are open source. You can run everything locally, self-host, or use Builder.io's cloud for managed hosting, collaboration, and team features.
 
-## Development {#development}
+### How much does it cost? {#how-much}
+
+The framework itself is free. The two costs you'll see in practice:
+
+- **AI usage.** You bring your own API key (Anthropic, OpenAI, etc.) and pay the model provider directly. There's no markup from us.
+- **Hosting.** Whatever your host charges. Most templates run fine on free tiers (Netlify, Vercel, Cloudflare) for small workloads.
+
+If you'd rather not manage any of this, the hosted version on `agent-native.com` (operated by Builder.io) bundles inference and hosting into a per-seat plan.
+
+### Can I host this myself? {#can-i-self-host}
+
+Yes. Pick any host that runs Node — Netlify, Vercel, Cloudflare, AWS, Deno Deploy, your own server — and any SQL database (Postgres, SQLite, Turso, D1). The framework is built to be portable. See [Deployment](/docs/deployment).
+
+### What AI models does it support? {#what-models}
+
+Anthropic Claude, OpenAI (GPT-5 family), Google Gemini, and any provider that speaks the OpenAI API shape (including local models via Ollama). You configure the model in settings; switching is a config change, not a code rewrite. The framework's heaviest tested path is Claude, so that's the default recommendation.
+
+### Do I need to know AI/ML? {#do-i-need-to-know-ai}
+
+No. You don't train models, fine-tune, or deal with embeddings. You build a regular web app — and on the hosted version, you barely build anything at all. The framework handles the agent integration: routing messages, running actions, syncing state.
+
+### Can I migrate an existing app to agent-native? {#can-i-use-existing-code}
+
+You can, but agent-native works best when built from the ground up. The architecture — shared database, polling sync, actions, application state — needs to be integrated throughout. Starting from a template and customizing it is the recommended path. Think of it like the shift from desktop-first to mobile-first: you _can_ retrofit, but building native is better.
+
+## Templates and what you can build {#templates}
+
+### What templates are available? {#what-templates-are-available}
+
+The framework ships with production-ready templates you can use as daily drivers:
+
+- **[Mail](/templates/mail)** — full-featured email client (like Superhuman)
+- **[Calendar](/templates/calendar)** — Google Calendar + Calendly-style booking links
+- **[Content](/templates/content)** — Notion-style documents
+- **[Slides](/templates/slides)** — presentation builder
+- **[Video](/templates/video)** — video composition with Remotion
+- **[Analytics](/templates/analytics)** — data platform (like Amplitude/Mixpanel)
+- **[Forms](/templates/forms)**, **[Issues](/templates/issues)**, **[Recruiting](/templates/recruiting)**, and the **[Dispatch](/docs/template-dispatch)** workspace control plane.
+
+Each template is a complete app with UI, agent actions, database schema, and AI instructions. See [Cloneable SaaS](/docs/cloneable-saas) for the full picture, or all [Templates](/templates).
+
+### Can I customize templates? {#can-i-customize-templates}
+
+That's the whole point. Fork a template and customize it by asking the agent. "Add a priority field to forms." "Connect to our Salesforce instance." "Change the color scheme to match our brand." The agent modifies the code, and your app evolves over time.
+
+### Can I build something the templates don't cover? {#build-from-scratch}
+
+Yes. Run `npx @agent-native/core create my-app` without picking a template — you get the framework scaffolding (frontend, backend, agent panel, database) but no domain-specific code. See [Getting Started](/docs/getting-started). For agent-first products with no traditional UI, see [Pure-Agent Apps](/docs/pure-agent-apps).
+
+## Agent capabilities {#agent-capabilities}
+
+### Can the agent really modify the app's own code? {#can-the-agent-modify-code}
+
+Yes, and it's a feature. The agent can safely edit components, routes, styles, and actions. You ask "add a cohort analysis chart" and the agent builds it. You ask "connect to our Stripe account" and the agent writes the integration. Everything is normal Git-tracked code, so bad changes are easy to revert.
+
+### Can users talk to the agent from outside the app? {#external-channels}
+
+Yes. The same agent runs in your web UI, in Slack, in Telegram, over email, and from other agents (via [A2A](/docs/a2a-protocol)). It's the same agent with the same memory and the same actions, just reached through different channels. See [Messaging the agent](/docs/messaging).
+
+### Can agents talk to each other? {#can-agents-talk-to-each-other}
+
+Yes, via the [A2A (Agent-to-Agent) protocol](/docs/a2a-protocol). Every agent-native app automatically gets an A2A endpoint. From the mail app, you can tag the analytics agent to query data. An agent discovers what other agents are available, calls them over the protocol, and shows results in the UI. No configuration needed — the agent card is auto-generated from your template's actions.
+
+### What can the agent see in the app? {#what-can-the-agent-see}
+
+The agent always knows what the user is currently viewing. The UI writes navigation state to the database on every route change — which view is open, which item is selected. The agent reads this before taking action. If an email is open, the agent knows which email. If a slide is selected, the agent knows which slide. See [Context Awareness](/docs/context-awareness).
+
+## Development questions {#development}
 
 ### Which AI coding tools work with agent-native? {#which-ai-tools-work}
 
@@ -39,15 +110,11 @@ Any AI coding tool that reads project instructions. The framework uses AGENTS.md
 
 ### Can I use my own database? {#can-i-use-my-own-database}
 
-Yes. Set `DATABASE_URL` and the framework auto-detects your database. Supported databases include SQLite, Postgres (Neon, Supabase, plain), Turso (libSQL), and Cloudflare D1. All SQL is dialect-agnostic via Drizzle ORM — the same code works everywhere.
+Yes. Set `DATABASE_URL` and the framework auto-detects it. Supported databases include SQLite, Postgres (Neon, Supabase, plain), Turso (libSQL), and Cloudflare D1. All SQL is dialect-agnostic via Drizzle ORM — the same code works everywhere.
 
 ### Where can I deploy? {#where-can-i-deploy}
 
 Anywhere. The server runs on Nitro, which compiles to any deployment target: Node.js, Cloudflare Workers/Pages, Netlify, Vercel, Deno Deploy, AWS Lambda, and Bun. You can also use Builder.io's hosting for managed deployments. See the [Deployment guide](/docs/deployment).
-
-### Can I migrate an existing app to agent-native? {#can-i-use-existing-code}
-
-You can, but agent-native works best when built from the ground up. The architecture — shared database, polling sync, actions, application state — needs to be integrated throughout. Starting from a template and customizing it is the recommended path. Think of it like the shift from desktop-first to mobile-first: you _can_ retrofit, but building native is better.
 
 ## Architecture {#architecture}
 
@@ -62,40 +129,3 @@ AI is non-deterministic — you need conversation flow to give feedback and iter
 ### Why is this a framework and not a library? {#why-framework-not-library}
 
 The shared database, polling sync, actions system, and application state all need to work together as a cohesive architecture. A library could give you pieces, but agent-native requires that the agent and UI are wired together from the ground up. Multiple agents need to be able to communicate, the UI needs to react to agent changes instantly, and the agent needs to understand what the user is looking at. That's an architecture, not a utility.
-
-## Agent Capabilities {#agent-capabilities}
-
-### Can the agent really modify the app's own code? {#can-the-agent-modify-code}
-
-Yes, and it's a feature. The agent can safely edit components, routes, styles, and actions. You ask "add a cohort analysis chart" and the agent builds it. You ask "connect to our Stripe account" and the agent writes the integration.
-
-### Can agents talk to each other? {#can-agents-talk-to-each-other}
-
-Yes, via the [A2A (Agent-to-Agent) protocol](/docs/a2a-protocol). Every agent-native app automatically gets an A2A endpoint. From the mail app, you can tag the analytics agent to query data. An agent discovers what other agents are available, calls them over the protocol, and shows results in the UI. No configuration needed — the agent card is auto-generated from your template's actions.
-
-### What can the agent see in the app? {#what-can-the-agent-see}
-
-The agent always knows what the user is currently viewing. The UI writes navigation state to the database on every route change — which view is open, which item is selected. The agent reads this via the `view-screen` action before taking action. If an email is open, the agent knows which email. If a slide is selected, the agent knows which slide. See [Context Awareness](/docs/context-awareness).
-
-## Templates {#templates}
-
-### What templates are available? {#what-templates-are-available}
-
-The framework ships with production-ready templates that you can use as daily drivers:
-
-- **[Mail](/templates/mail)** — full-featured email client (like Superhuman)
-- **[Calendar](/templates/calendar)** — Google Calendar + Calendly-style meeting links
-- **[Content](/templates/content)** — Notion-style documents
-- **[Slides](/templates/slides)** — presentation builder
-- **[Video](/templates/video)** — video composition with Remotion
-- **[Analytics](/templates/analytics)** — data platform (like Amplitude/Mixpanel)
-
-Each template is a complete app with UI, agent actions, database schema, and AI instructions. See all [Templates](/templates).
-
-### Can I customize templates? {#can-i-customize-templates}
-
-That's the whole point. Fork a template and customize it by asking the agent. "Add a priority field to forms." "Connect to our Salesforce instance." "Change the color scheme to match our brand." The agent modifies the code, and your app evolves over time.
-
-### Can I build from scratch without a template? {#can-i-build-from-scratch}
-
-Yes. Run `npx @agent-native/core create my-app` without the `--template` flag. You get the framework scaffolding — React frontend, Nitro backend, agent panel, database — but no domain-specific code. See [Getting Started](/docs).

--- a/packages/core/docs/content/getting-started.md
+++ b/packages/core/docs/content/getting-started.md
@@ -5,37 +5,51 @@ description: "Pick a template, create your app, and start customizing it with AI
 
 # Getting Started
 
-The fastest way to get started is to pick a template and make it yours. Agent-native templates are **[cloneable SaaS](/docs/cloneable-saas)** — complete, production-grade apps, not starter kits. You get a working product in under a minute and start customizing it with the agent.
+By the end of this page, you'll have a working app — Mail, Calendar, Forms, or any other template — running with an AI agent built into the sidebar that can drive every part of it.
 
-## Create Your Workspace {#create-your-app}
+## Who is this for? {#who-is-this-for}
+
+There are two ways to use agent-native, depending on how hands-on you want to be:
+
+- **You want to use a hosted version.** Try a template right now at [agent-native.com/templates](/templates). Each template is a live, hosted app — you sign in, start using it, and the agent is already there. No install, no setup. You can stop reading this page and head straight to the [template gallery](/templates).
+- **You want to run locally or customize it.** You'll clone a template, run it on your machine, and shape it however you want — branding, features, integrations. The rest of this page is for you. You'll need [Node.js](https://nodejs.org) and [pnpm](https://pnpm.io) installed.
+
+Not sure which path? If you've never written code, the hosted version is for you. If you have a developer or AI coding tool ready, the local path gives you total control.
+
+## First run {#create-your-app}
+
+Three commands and you're up:
 
 ```bash
 npx @agent-native/core create my-platform
-```
-
-The CLI shows a multi-select picker — pick as many templates as you want (Mail + Calendar + Forms, for example) and they all get scaffolded into the same workspace sharing auth, brand, and agent config. Then boot them all:
-
-```bash
 cd my-platform
-pnpm install
-pnpm dev
+pnpm install && pnpm dev
 ```
 
-That's it — you have every app running locally with an AI agent built in. Open the agent panel, ask it to do something, and watch it work.
+The `create` command shows a multi-select picker — pick one template or several (Mail + Calendar + Forms, for example) and they all scaffold into one workspace sharing auth, brand, and agent config.
 
-Want a single app with no monorepo? Pass `--standalone`:
+Open the URL the dev server prints (usually `http://localhost:3000`).
 
-```bash
-npx @agent-native/core create my-app --standalone --template mail
-```
+## What just happened? {#what-just-happened}
 
-Need to add more apps later? From inside the workspace:
+You now have a real, full-featured app running on your machine. Open it in the browser and try it:
 
-```bash
-agent-native add-app
-```
+- Click around the UI like you would any SaaS product.
+- Open the agent panel on the right side. Type something like "show me my settings" or "create a new entry called Welcome." Watch the agent click through the app on your behalf.
+- Anything you do by clicking, the agent can do by reading and writing the same database. Anything the agent does shows up in the UI immediately.
 
-From here, use your AI coding tool (Claude Code, Cursor, Windsurf, etc.) to customize it. The agent instructions in `AGENTS.md` are already set up so any tool understands the codebase. See [Multi-App Workspace](/docs/multi-app-workspace) for the full story on sharing auth, skills, components, and credentials across apps.
+That parity between agent and UI is the whole point — see [What Is Agent-Native?](/docs/what-is-agent-native) for the bigger picture.
+
+## What's next {#whats-next}
+
+From here, use any AI coding tool (Claude Code, Cursor, Windsurf, Builder.io) to customize the app. The agent instructions in `AGENTS.md` are already set up so any tool understands the codebase.
+
+Common next steps:
+
+- **Add another app to the same workspace** — run `agent-native add-app` from inside the workspace folder. See [Multi-App Workspace](/docs/multi-app-workspace) for sharing auth, components, and credentials across apps.
+- **Single app instead of a monorepo?** Pass `--standalone` when creating: `npx @agent-native/core create my-app --standalone --template mail`.
+- **Build a brand-new template from scratch** — see [Creating Templates](/docs/creating-templates) for the full Vite, Tailwind, and TypeScript setup.
+- **Understand the architecture** — see [Key Concepts](/docs/key-concepts) for how SQL, actions, polling sync, and context awareness fit together.
 
 ## Templates {#templates}
 
@@ -55,7 +69,7 @@ Each template is a complete app with UI, agent actions, database schema, and AI 
 
 Browse the [template gallery](/templates) for live demos, or see [Cloneable SaaS](/docs/cloneable-saas) for the full list and the clone → customize → deploy flow.
 
-## Project Structure {#project-structure}
+## Project structure {#project-structure}
 
 Every agent-native app — whether from a template or from scratch — follows the same structure:
 
@@ -67,53 +81,15 @@ my-app/
   .agents/         # Agent instructions and skills
 ```
 
-Templates add domain-specific code on top of this: database schemas in `server/db/`, API routes in `server/routes/api/`, and actions in `actions/`.
+Templates add domain-specific code on top: database schemas in `server/db/`, API routes in `server/routes/api/`, and actions in `actions/`. Building from scratch? See [Creating Templates](/docs/creating-templates) for `vite.config.ts`, `tsconfig.json`, and Tailwind setup.
 
-## Configuration {#configuration}
+## Architecture principles {#architecture-principles}
 
-Templates come pre-configured. If you're starting from scratch, here are the config files:
-
-```ts
-// vite.config.ts
-import { defineConfig } from "@agent-native/core/vite";
-export default defineConfig();
-```
-
-```json
-// tsconfig.json
-{ "extends": "@agent-native/core/tsconfig.base.json" }
-```
-
-```css
-/* app/global.css — Tailwind v4 (CSS-first, no tailwind.config.ts needed) */
-@import "tailwindcss";
-@import "@agent-native/core/styles/agent-native.css";
-
-@source "./**/*.{ts,tsx}";
-
-:root {
-  --background: 0 0% 100%;
-  --foreground: 220 10% 10%;
-  /* ...rest of your shadcn-style tokens */
-}
-
-.dark {
-  --background: 220 6% 6%;
-  --foreground: 0 0% 90%;
-  /* ... */
-}
-```
-
-The framework auto-injects `@tailwindcss/vite` from `defineConfig()`.
-No `tailwind.config.ts`, `postcss.config.js`, or vite changes needed.
-
-## Architecture Principles {#architecture-principles}
-
-These principles apply to all agent-native apps. Understanding them helps you customize templates or build from scratch:
+These principles apply to all agent-native apps. Skim them now, revisit them when you're customizing.
 
 1. **Agent + UI are equal partners** — Everything the UI can do, the agent can do, and vice versa. They share the same database and always stay in sync. You don't think about "the agent" and "the app" separately — you think about them together.
 2. **Context-aware** — The agent always knows what you're looking at. If an email is open, it knows which one. If you select text and hit Cmd+I, it can act on just that selection.
-3. **Skills-driven** — Core functionalities have instructions so the agent doesn't explore from scratch every time. When you add a feature, you update all four areas: UI, actions, skills/instructions, and application state.
+3. **Skills-driven** — Core functionality has written instructions so the agent doesn't explore from scratch every time. New features update all four areas: UI, actions, skills/instructions, and application state.
 4. **Inter-agent communication** — Agents can discover and call each other via the A2A protocol. Tag your analytics agent from the mail app to pull data into a draft.
 5. **Fully portable** — Any SQL database Drizzle supports, any hosting backend Nitro supports, any AI coding tool. These are non-negotiable.
 6. **Fork and customize** — Apps you clone and evolve. The agent can modify the app's own code — components, routes, styles, actions — so it gets better over time.

--- a/packages/core/docs/content/pure-agent-apps.md
+++ b/packages/core/docs/content/pure-agent-apps.md
@@ -1,69 +1,96 @@
 ---
 title: "Pure-Agent Apps"
-description: "Build an agent without a heavy UI — just the agent plus a minimal observability/management surface. All the framework benefits, none of the dashboard work."
+description: "Apps where the agent is the whole product — open it, ask for what you want, and the agent does the rest."
 ---
 
 # Pure-Agent Apps
 
-Not every agent-native app needs a full SaaS-style interface. Sometimes the agent _is_ the product. A support triage agent. A daily report generator. A research bot. An email auto-responder. An ops runbook executor.
+Imagine opening an app and seeing… just a chat. No dashboard. No sidebar full of menus. No forms. You ask for what you want — "summarize my unread emails," "post the daily metrics to Slack," "find the candidates who replied last week" — and the agent goes off and does it. The output shows up in chat, in Slack, in your inbox, wherever it belongs.
 
-For these, the "app" is mostly just the agent doing work in the background. You still want a UI — but a minimal one, focused on **observability, management, and steering** rather than hand-crafted dashboards and forms.
+That's a pure-agent app. The agent _is_ the product.
 
-This is the "agents benefit from a UI even when there's no rich app around them" pattern. The hot take is "agents will replace apps." The reality is "every agent eventually needs a UI for humans to supervise, configure, and debug it." Agent-native gives you that UI for free.
+## What it feels like to use one {#user-experience}
 
-## The minimum viable UI {#minimum-ui}
+Most apps are built around a UI: a database table you browse, a form you fill, a chart you read. The agent is a sidekick.
 
-A pure-agent app ships with five surfaces, all provided by the framework — you don't build them:
+In a pure-agent app, that's flipped. The chat is the front door. You type a request; the agent takes action; you see the result. Everything else — settings, history, what's currently running — is one click away, but most of the time you don't need it.
 
-1. **Chat** — the main input. Users talk to the agent, steer it, queue tasks. (`<AgentSidebar>` or `<AgentPanel>`)
-2. **Workspace** — skills, memory (`learnings.md`), `AGENTS.md`, custom sub-agents, connected MCP servers, scheduled jobs. Customize the agent's behavior without shipping code. (Workspace tab in the sidebar)
-3. **Job history** — which scheduled jobs ran, when, whether they succeeded, what they did. (Workspace tab → `jobs/`)
-4. **Thread history** — every past conversation, each preserved with its tool calls and final output. (Chat tab)
-5. **Settings** — API keys, connected accounts, onboarding status. (Sidebar settings)
+Examples of where this works really well:
 
-Those five together are enough UI for most pure-agent use cases. No analytics dashboard. No Kanban. No forms. Just: talk to it, see what it's done, configure how it behaves.
+- **Background workers** — a triage agent that watches your inbox and labels things, a daily-report agent that posts to Slack each morning, an on-call agent that responds to alerts.
+- **One-shot helpers** — "research this company and write a one-pager," "scan my GitHub issues and tell me which ones look stale."
+- **Channel-driven assistants** — agents you mostly talk to from Slack, Telegram, email, or another agent (via [A2A](/docs/a2a-protocol)). The "app" itself is mostly a control panel.
+- **Internal tools** — an agent that knows your runbooks, your APIs, your conventions, and can act on them.
 
-## When to pick this pattern {#when-to-pick}
+The hot take is "agents will replace apps." The honest version is "agents still need a UI — for humans to supervise, configure, and steer them." Pure-agent apps give you that UI without the dashboard sprawl.
 
-Pure-agent makes sense when:
+## When this beats a traditional app {#when}
 
-- **The work happens in the background.** Scheduled jobs, webhook-triggered handlers, Slack/Telegram responders. Users rarely sit in the app.
-- **The output leaves the app.** The agent posts to Slack, sends email, writes to a third-party system. There's nothing to view in-app; the value is elsewhere.
-- **The domain is one-shot.** A research bot that returns a report. No persistent object to dashboard.
-- **You're prototyping.** Ship the agent now; add a rich UI only when you've proven users need it.
+Pick the pure-agent pattern when:
 
-Pick a full [cloneable SaaS](/docs/cloneable-saas) template instead when the app has real persistent objects (emails, events, documents, charts) users need to browse, pivot, and share.
+- **The work happens in the background.** Most of the value is created while the user isn't looking.
+- **The output leaves the app.** The agent posts to Slack, sends email, updates a third-party system. There's nothing to browse in-app — the value is elsewhere.
+- **The domain is one-shot.** Research bot, summary generator, report writer. There's no persistent object that needs a list view.
+- **You're prototyping.** Ship the agent now; add a richer UI later if it turns out users actually want one.
 
-## The minimal scaffold {#scaffold}
+If your product is built around persistent objects users browse, pivot, and share — emails, events, documents, charts — pick a [cloneable SaaS](/docs/cloneable-saas) template instead. Those have full UIs _plus_ the agent.
 
-Start from the **Starter** template:
+## What ships in the box {#minimum-ui}
+
+Every pure-agent app gets five built-in surfaces, all provided by the framework — you don't build them:
+
+1. **Chat** — the main input. Users talk to the agent, steer it, queue tasks.
+2. **Workspace** — skills, memory, instructions, custom sub-agents, connected MCP servers, scheduled jobs. Customize the agent's behavior without shipping code.
+3. **Job history** — which scheduled jobs ran, when, whether they succeeded, what they did.
+4. **Thread history** — every past conversation, each preserved with its tool calls and final output.
+5. **Settings** — API keys, connected accounts, onboarding status.
+
+Those five are usually enough. No analytics dashboard. No Kanban. No forms. Just: talk to it, see what it's done, configure how it behaves.
+
+## Why you'd pick this over "an app with an AI sidebar" {#vs-traditional}
+
+Two reasons:
+
+1. **You don't have to build the UI.** A pure-agent app skips weeks of dashboard work. The chat handles input; the framework handles supervision and history; the agent handles output.
+2. **It's channel-agnostic from day one.** The same agent that runs in your web UI also runs from Slack, Telegram, email, and other agents — because everything goes through the agent, not the UI. See [Messaging the agent](/docs/messaging) for how that works.
+
+The trade-off: pure-agent apps don't give users a "browse-everything-at-a-glance" view. If your users need that, mix patterns: start pure-agent, add a small status page or list view if you discover users want one.
+
+## Building one {#building}
+
+If you're not a developer, you can usually start with the [Dispatch template](/docs/template-dispatch) — it's a workspace-style pure-agent app with Slack/Telegram, scheduled jobs, and shared secrets out of the box.
+
+For developers who want the absolute minimum, start from the **Starter** template:
 
 ```bash
 pnpm dlx @agent-native/core create my-agent --template starter
 ```
 
-Starter gives you the six-rules architecture, the agent panel, the workspace, auth, polling, and one example action — and nothing else. Add your own actions in `actions/`, connect any MCP servers you need, write the relevant skills into the workspace, and you're done. The "UI" is the agent sidebar — which is already complete.
+Starter gives you the architecture, the agent panel, the workspace, auth, polling, and one example action — and nothing else. Add your own actions in `actions/`, connect any MCP servers you need, write the relevant skills into the workspace, and you're done.
 
-If you really want _zero_ UI except the agent, `app/routes/index.tsx` can just render `<AgentPanel defaultMode="chat" />` fullscreen. The only thing the user sees is the chat. Everything else — job history, workspace, settings — is one click away in the panel's tabs.
+If you really want _zero_ UI except the agent, `app/routes/index.tsx` can render `<AgentPanel defaultMode="chat" />` fullscreen. The only thing the user sees is the chat. Everything else — job history, workspace, settings — is one click away in the panel's tabs.
 
-## What you still get for free {#still-free}
+### What you still get for free {#still-free}
 
 Even with no custom UI, you still inherit every framework benefit:
 
-- **Actions** as agent tools + HTTP endpoints + MCP tools + A2A tools. External agents, Claude Desktop, and your own HTTP clients can drive the agent without going through the chat UI.
-- **Recurring jobs** for scheduled work — "every morning at 7 summarize my unread emails and post to Slack."
+- **Actions** as agent tools, HTTP endpoints, MCP tools, and A2A tools. External agents, Claude Desktop, and your own HTTP clients can drive the agent without going through the chat UI.
+- **Recurring jobs** for scheduled work — "every morning at 7, summarize my unread emails and post to Slack."
 - **The workspace** for per-user customization, skills, memory, MCP connections.
 - **Sub-agent delegation** via [agent teams](/docs/agent-teams).
 - **Portability** — deploys to any serverless host, any SQL database.
 - **Multi-tenant by default** — each user gets their own workspace without a dev-box.
 
-## Adding a tiny bit of UI {#tiny-ui}
+### Adding a tiny bit of UI {#tiny-ui}
 
-Most "pure-agent" apps eventually want a little bit of custom UI — not a dashboard, but maybe a status page, a job history, or a config screen. The [drop-in agent](/docs/drop-in-agent) components coexist with anything else you render. Add a single `/status` route that lists recent runs; keep everything else in the chat. That's usually enough.
+Most pure-agent apps eventually want a little custom UI — not a dashboard, but maybe a status page, a job history, or a config screen. The [drop-in agent](/docs/drop-in-agent) components coexist with anything else you render. Add a single `/status` route that lists recent runs; keep everything else in the chat. That's usually enough.
 
 ## What's next
 
+- [**Getting Started**](/docs/getting-started) — clone the Starter template
+- [**Messaging the agent**](/docs/messaging) — how users talk to the agent across web, Slack, Telegram, email
 - [**Recurring Jobs**](/docs/recurring-jobs) — scheduled prompts the agent runs on its own
+- [**Dispatch**](/docs/template-dispatch) — the workspace template that's a great starting point for pure-agent apps
 - [**Drop-in Agent**](/docs/drop-in-agent) — mounting `<AgentPanel>` fullscreen or in a sidebar
 - [**Actions**](/docs/actions) — the tools your pure-agent will call
 - [**Workspace**](/docs/workspace) — the customization surface for skills, memory, and MCP servers

--- a/packages/core/docs/content/template-calendar.md
+++ b/packages/core/docs/content/template-calendar.md
@@ -1,26 +1,61 @@
 ---
-title: "Calendar Template"
-description: "AI-native calendar with Google Calendar sync and a Calendly-style public booking page."
+title: "Calendar"
+description: "An agent-powered calendar with Google Calendar sync and Calendly-style booking links. Schedule, find slots, and manage availability through plain English."
 ---
 
-# Calendar Template
+# Calendar
 
-The Calendar template is a complete scheduling app: a full calendar UI on top of Google Calendar, plus Calendly-style public booking links, all driven by an agent that can schedule, search, and manage availability on your behalf. It replaces the Google Calendar + Calendly combo with something you own and can extend.
+An agent-powered calendar app. Connect your Google Calendar and the agent can read your schedule, find free slots, create events, and manage Calendly-style booking links — all in plain English. It replaces the Google Calendar + Calendly combo with one app you own.
 
-## Overview {#overview}
+When you open the app, you'll see your calendar in the middle and the agent in the sidebar. The agent always knows which day, week, or event you're looking at, so you can say "schedule a 30-minute call with Alex on this day" without spelling everything out.
 
-Calendar is for anyone who currently juggles Google Calendar for their own schedule and Calendly (or similar) for letting other people book time. It gives you:
+## What you can do with it
 
-- Day, week, and month calendar views backed by the Google Calendar API.
-- Multi-account Google OAuth, so several calendars can overlay in one view.
-- External ICS calendar subscriptions (webcal feeds).
-- Configurable weekly availability with timezone support.
-- Public booking links at `/book/{slug}` or `/meet/{username}/{slug}` with custom durations, custom fields, and meeting-link options.
-- An agent that can answer schedule questions, create events, find free slots, and manage booking links through natural language.
+- **See your real Google Calendar** in day, week, or month view, with multiple accounts overlayed.
+- **Subscribe to ICS feeds** (HR time off, conference schedules, team calendars) — read-only, mixed into the same view.
+- **Set weekly availability** with timezone support — the agent uses this when finding free slots.
+- **Create public booking links** at `/book/{slug}` for things like "15-minute intro" or "30-minute demo." Configure durations, custom fields, and which conferencing tool to use.
+- **Ask the agent anything schedule-related**: "Am I free Thursday afternoon?" "Find a 1-hour slot next week and put 'Planning with Alex' on it." "Pause my demo booking link."
+- **Share booking links** with teammates so they can manage them too.
 
-Events themselves are not copied into the local database. The app reads them from Google Calendar on every request. Bookings, booking links, and settings live in SQL.
+## Getting started
 
-## Quick start {#quick-start}
+Live demo: [calendar.agent-native.com](https://calendar.agent-native.com).
+
+When you first open the app:
+
+1. Click **Settings**.
+2. Click **Connect Google Calendar** and approve.
+3. (Optional) Connect more Google accounts if you want personal + work overlayed.
+4. Open the main view — your real calendar will load.
+
+To create your first booking link:
+
+1. Click **Booking Links** in the sidebar.
+2. Click **New booking link**, set a title and duration.
+3. Share the public URL — visitors pick from your available slots.
+
+Or just ask the agent: "Create a 15-minute intro booking link with a name field."
+
+### Useful prompts
+
+- "What is on my calendar today?"
+- "Am I free Thursday afternoon for 30 minutes?"
+- "Find a 1-hour slot next week and put 'Planning with Alex' on it."
+- "Reschedule this event to Friday at 2pm." (when an event is selected)
+- "Switch to day view and jump to next Monday."
+- "Create a booking link called '15 min intro' at 15 minutes with a note field."
+- "Pause my '30 min demo' booking link."
+- "Block Friday afternoons on my availability."
+- "What meetings do I have about 'launch' this month?"
+
+The agent will query Google Calendar live for any schedule question — it never guesses.
+
+## For developers
+
+The rest of this doc is for anyone forking the Calendar template or extending it.
+
+### Quick start
 
 Create a new workspace with the Calendar template:
 
@@ -33,29 +68,17 @@ pnpm dev
 
 Open `http://localhost:8082` (the default Calendar dev port).
 
-Live demo: [https://calendar.agent-native.com](https://calendar.agent-native.com).
+To connect Google Calendar in dev, open the Settings view, paste a `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` from [Google Cloud Console](https://console.cloud.google.com/), and click "Connect Google Calendar". The OAuth redirect URI is `http://localhost:8082/_agent-native/google/callback` in dev. Tokens are stored in the `oauth_tokens` SQL table and refresh automatically.
 
-To connect Google Calendar, open the Settings view, paste a `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` from [Google Cloud Console](https://console.cloud.google.com/), and click "Connect Google Calendar". The OAuth redirect URI is `http://localhost:8082/_agent-native/google/callback` in dev. Tokens are stored in the `oauth_tokens` SQL table and refresh automatically.
+### Key features (technical)
 
-## Key features {#key-features}
+**Calendar views.** The main view at `/` (route `app/routes/_app._index.tsx`) renders the calendar in day, week, or month mode. Switch views from the toolbar, or ask the agent to switch for you. Events are fetched live from Google Calendar — no local sync step is required to see the latest state.
 
-### Calendar views
+**Multi-account Google Calendar sync.** Connect as many Google accounts as you like. Each connection appears in Settings, and events from every connected calendar overlay in the main view. Sync is pull-based, so no webhooks or background workers are required. The `sync-google-calendar` action refetches a date range on demand. Supporting actions: `list-events`, `search-events`, `get-event`, `create-event`, `sync-google-calendar`.
 
-The main view at `/` (route `app/routes/_app._index.tsx`) renders the calendar in day, week, or month mode. Switch views from the toolbar, or ask the agent to switch for you. Events are fetched live from Google Calendar — no local sync step is required to see the latest state.
+**External calendars (ICS subscriptions).** Subscribe to read-only ICS or `webcal://` feeds — useful for HR time off, conference schedules, or shared team calendars. Feeds are added in Settings and stored per user. Relevant actions: `add-external-calendar`, `list-external-calendars`, `remove-external-calendar`, `update-external-calendars`.
 
-### Multi-account Google Calendar sync
-
-Connect as many Google accounts as you like. Each connection appears in Settings, and events from every connected calendar overlay in the main view. Sync is pull-based, so no webhooks or background workers are required. The `sync-google-calendar` action refetches a date range on demand.
-
-Supporting actions: `list-events`, `search-events`, `get-event`, `create-event`, `sync-google-calendar`.
-
-### External calendars (ICS subscriptions)
-
-Subscribe to read-only ICS or `webcal://` feeds — useful for HR time off, conference schedules, or shared team calendars. Feeds are added in Settings and stored per user. Relevant actions: `add-external-calendar`, `list-external-calendars`, `remove-external-calendar`, `update-external-calendars`.
-
-### Availability rules
-
-Availability is a weekly schedule of time windows per day, plus a timezone. It is stored in the settings table under the key `calendar-availability`:
+**Availability rules.** Availability is a weekly schedule of time windows per day, plus a timezone. It is stored in the settings table under the key `calendar-availability`:
 
 ```json
 {
@@ -77,9 +100,7 @@ Availability is a weekly schedule of time windows per day, plus a timezone. It i
 
 Edit it at `/availability` (`app/routes/_app.availability.tsx`) or via the `update-availability` action. The `check-availability` action reads this schedule, subtracts your existing Google Calendar events, and returns free slots of the requested duration.
 
-### Public booking pages
-
-Booking links are the Calendly replacement. Create one in the UI at `/booking-links` (`app/routes/_app.booking-links._index.tsx`), configure it in the editor at `/booking-links/{id}`, and share the public URL.
+**Public booking pages.** Booking links are the Calendly replacement. Create one in the UI at `/booking-links` (`app/routes/_app.booking-links._index.tsx`), configure it in the editor at `/booking-links/{id}`, and share the public URL.
 
 Every link has:
 
@@ -93,9 +114,7 @@ Visitors land on the public page, pick a date and time from the available slots,
 
 There is also a per-user public URL at `/meet/{username}/{slug}` for clean personal sharing.
 
-### Sharing booking links with teammates
-
-Booking links are private by default — only the creator can edit or delete them. To let a teammate manage a link, either change the link's visibility or grant explicit access. The framework ships these actions, auto-mounted for any `booking-link` resource:
+**Sharing booking links with teammates.** Booking links are private by default — only the creator can edit or delete them. To let a teammate manage a link, either change the link's visibility or grant explicit access. The framework ships these actions, auto-mounted for any `booking-link` resource:
 
 - `share-resource` — grant a user or org `viewer`, `editor`, or `admin` access.
 - `unshare-resource` — revoke a grant.
@@ -104,29 +123,15 @@ Booking links are private by default — only the creator can edit or delete the
 
 Sharing only controls who can manage the link. The public booking URL always accepts bookings from unauthenticated visitors as long as `isActive` is true.
 
-### Inline event previews in chat
+**Inline event previews in chat.** The `/event` route (`app/routes/event.tsx`) renders a compact, chromeless event card that the agent can embed in chat when you ask about a specific event. Title, time, location, attendees, and a description snippet are shown with a button to jump into the main calendar.
 
-The `/event` route (`app/routes/event.tsx`) renders a compact, chromeless event card that the agent can embed in chat when you ask about a specific event. Title, time, location, attendees, and a description snippet are shown with a button to jump into the main calendar.
-
-## Working with the agent {#working-with-the-agent}
+### Working with the agent
 
 The agent sees what you are looking at. The current calendar view, the selected date, and the selected event are included in every message as a `current-screen` block, so you can say "this event" or "this day" and it resolves correctly.
 
-Example prompts:
-
-- "What is on my calendar today?"
-- "Am I free Thursday afternoon for 30 minutes?"
-- "Find a 1-hour slot next week and put 'Planning with Alex' on it."
-- "Reschedule this event to Friday at 2pm." (when an event is selected)
-- "Switch to day view and jump to next Monday."
-- "Create a booking link called '15 min intro' at 15 minutes with a note field."
-- "Pause my '30 min demo' booking link."
-- "Block Friday afternoons on my availability."
-- "What meetings do I have about 'launch' this month?"
-
 Under the hood the agent calls actions like `list-events`, `check-availability`, `create-event`, `navigate`, and `update-availability`. Because events live in Google Calendar, the agent always queries the API instead of guessing — it will not return empty results without running a script first.
 
-## Data model {#data-model}
+### Data model
 
 Defined in `templates/calendar/server/db/schema.ts`. Only non-event data is stored locally:
 
@@ -137,7 +142,7 @@ Defined in `templates/calendar/server/db/schema.ts`. Only non-event data is stor
 
 Availability rules and per-user configuration live in the settings table, keyed by `calendar-availability`. Google OAuth tokens live in the framework `oauth_tokens` table. Ephemeral UI state (current view, date, selected event) lives in `application_state` under the `navigation` key.
 
-## Customizing it {#customizing-it}
+### Customizing it
 
 Every part of the app is editable source. Start here:
 

--- a/packages/core/docs/content/template-clips.md
+++ b/packages/core/docs/content/template-clips.md
@@ -1,36 +1,40 @@
 ---
-title: "Clips Template"
-description: "Agent-native screen recording with AI transcription, auto-titles, summaries, chapter markers, and full-text search across every clip."
+title: "Clips"
+description: "Record your screen, get an AI-generated title, summary, and chapter markers automatically, and search across every recording you've ever made."
 ---
 
 # Clips
 
-Clips is an agent-native screen-recording app. The user records a video, the app transcribes it, and the agent takes over: suggests titles, writes summaries, builds chapters, finds the exact moment someone said X, opens the right recording, shares it with the right teammate, drafts replies to comments.
+A screen-recording app where the agent does the post-production work for you. Record your screen, and Clips transcribes it, suggests a title and summary, builds chapter markers, and tags the content automatically. Ask "find the clip where we discussed the rollout plan" and the agent searches across every transcript you've ever made.
 
-Think Loom, but the agent is a first-class editor — and the recordings are yours, not a SaaS vendor's.
+Think along the lines of products that record short async videos for your team — but the agent is a first-class editor, and the recordings are yours, not a SaaS vendor's.
 
-## What it does {#what-it-does}
+## What you can do with it
 
-- **Record your screen.** Built-in recorder with webcam overlay, audio capture, and pause/trim.
-- **Auto-transcribe.** Every recording is transcribed on upload. Speaker turns, timestamps, searchable.
-- **Agent-generated metadata.** Titles, summaries, chapter markers, tags — the agent fills them in and keeps them current.
-- **Full-text search.** Query across every transcript in your library. "Find the clip where we discussed the rollout plan."
-- **Share links.** Per-clip permissions (public, team, private), link tracking, comments threaded with the agent in the loop.
-- **Smart library.** Group by project, filter by speaker, auto-tag based on content.
+- **Record your screen** with a built-in recorder, webcam overlay, audio capture, and pause/trim.
+- **Get an auto-generated title, summary, and chapter markers** for every recording — the agent fills them in and keeps them current.
+- **Search across every transcript** with full-text search. "Find the clip where we discussed the rollout plan."
+- **Share clips** with per-clip permissions (public, team, private). Link tracking and threaded comments work too.
+- **Smart library views.** Group by project, filter by speaker, auto-tag based on content.
+- **Edit the transcript through chat.** "Fix the mis-transcribed word at 1:42." "Pull three quotes for a blog post." The agent edits the transcript and the UI updates live.
 
-## Why it's interesting {#why}
+## Why it's interesting
 
-Three things make the Clips template a good showcase of what agent-native enables:
+Three things make Clips a good showcase of what agent-native enables:
 
 1. **The agent edits the transcript.** Fix a mis-transcribed word, generate chapter timestamps, pull quotes for a blog post — all in natural language, in the chat, with the UI updating live via polling.
 2. **Context awareness on recordings.** When you're viewing a clip, the agent knows the clip id, the current playhead, and the selected transcript range. Ask "summarize from here to the end" and it understands what "here" means.
-3. **Clips you own, not a vendor.** Unlike Loom, the recordings live in your storage, the transcripts live in your SQL, and the agent is yours. Fork the template, change how chapters get built, wire it to your own CDN — it's your code.
+3. **Clips you own, not a vendor.** The recordings live in your storage, the transcripts live in your SQL, and the agent is yours. Fork the template, change how chapters get built, wire it to your own CDN — it's your code.
 
-## Naming note {#naming-note}
+## For developers
 
-In the template, always say **"Clip"** in user-facing strings and agent messages — never "Loom." Internal table / variable names (`recordings`, `recording_transcripts`, etc.) stay as-is.
+The rest of this doc is for anyone forking the Clips template or extending it.
 
-## Scaffolding {#scaffolding}
+### Naming note
+
+In the template, always say **"Clip"** in user-facing strings and agent messages. Internal table / variable names (`recordings`, `recording_transcripts`, etc.) stay as-is.
+
+### Scaffolding
 
 ```bash
 pnpm dlx @agent-native/core create my-clips --template clips --standalone
@@ -38,7 +42,7 @@ pnpm dlx @agent-native/core create my-clips --template clips --standalone
 
 Clips is a larger template with a native recorder (it ships a desktop companion for local capture). See the template `README.md` for setup specifics around screen-capture permissions and storage configuration.
 
-## Customize it {#customize}
+### Customize it
 
 Ask the agent:
 

--- a/packages/core/docs/content/template-content.md
+++ b/packages/core/docs/content/template-content.md
@@ -1,19 +1,43 @@
 ---
-title: "Content Template"
-description: "A Notion-style document editor with an AI agent that can read, write, organize, and publish your pages."
+title: "Content"
+description: "A Notion-style document editor with an AI agent that can read, write, reorganize, and publish your pages — all in plain English."
 ---
 
-# Content Template
+# Content
 
-A hierarchical document editor in the style of Notion or Google Docs. The AI agent has full parity with the UI — it can create pages, edit selections, reorganize the tree, and sync with Notion, all while seeing exactly what you see.
+A Notion-style document workspace where the agent can read, write, reorganize, and publish pages for you. Open a doc, ask "rewrite this paragraph to be more concise" or "create a page called Q4 Planning with sub-pages for Goals, Metrics, and Risks" — same result whether you do it yourself or ask.
 
-## Overview {#overview}
+When you open the app, you'll see a sidebar tree of pages on the left, the editor in the middle, and the agent in the sidebar on the right. The agent always knows which page you're viewing and what text you have selected.
 
-The Content template is a rich-text document workspace with a sidebar tree, a Tiptap-based editor, and an agent panel. Pages live in a nested tree, content is stored as markdown in SQL, and the agent uses the same actions the UI calls for every operation.
+## What you can do with it
 
-Everything lives in one database (SQLite, Postgres, Turso — anything Drizzle supports) and the agent sees your current view, so you can say "rewrite this paragraph" or "add a sub-page for Q4 planning" and it knows what you mean without you pasting anything.
+- **Write rich text** with headings, lists, tables, code blocks, images, and links. Slash commands (`/`) insert blocks; selecting text pops up a formatting toolbar.
+- **Organize pages in a tree** — nest infinitely, drag to reorder, favorite pages you use often.
+- **Search across everything** with full-text search across titles and content.
+- **Sync with Notion.** Link a local doc to a Notion page and pull or push content in either direction. Comments sync both ways too.
+- **Collaborate in real time.** Multiple people (and the agent) can edit the same doc at the same time.
+- **Share docs** with teammates or make them public — private by default, with viewer / editor / admin roles.
+- **Ask the agent for anything**: "Rewrite this paragraph." "Add a TL;DR at the top." "Find all my meeting notes from last week." "Make this tone more formal."
 
-## Quick start {#quick-start}
+## Getting started
+
+Live demo: [content.agent-native.com](https://content.agent-native.com).
+
+When you open the app, click **+ New page** in the sidebar, give it a title, and start writing. To use the agent, type in the sidebar:
+
+- "Create a page called Onboarding and add three sub-pages under it."
+- "Rewrite this paragraph to be more concise." (with a page open)
+- "Add a section about pricing with three bullet points."
+- "Summarize this doc into a TL;DR at the top."
+- "Pull the latest from Notion." (after linking a Notion page)
+
+Select text and hit Cmd+I to focus the agent with that selection pre-loaded — "make this punchier" then operates on exactly what you highlighted.
+
+## For developers
+
+The rest of this doc is for anyone forking the Content template or extending it.
+
+### Quick start
 
 Scaffold a new workspace with the Content template:
 
@@ -26,9 +50,7 @@ pnpm dev
 
 Open `http://localhost:8080` and create your first page. The agent panel is on the right — try asking it to "create a page called Onboarding and add three sub-pages under it".
 
-Live demo: https://content.agent-native.com
-
-## Key features {#key-features}
+### Key features (technical) {#key-features}
 
 ### Hierarchical pages
 
@@ -92,27 +114,15 @@ See the `sharing` skill.
 
 A dedicated team page at `/team` (see `app/routes/_app.team.tsx`) uses the framework's `TeamPage` component for creating orgs and managing members.
 
-## Working with the agent {#working-with-the-agent}
+### Working with the agent
 
 Because the agent sees your current screen, most prompts don't need you to reference a document explicitly. When you have a page open, "this" means that page.
-
-Example prompts:
-
-- "Rewrite this paragraph to be more concise."
-- "Add a section about pricing with three bullet points."
-- "Create a page called Q4 Planning with sub-pages for Goals, Metrics, and Risks."
-- "Summarize this doc into a TL;DR at the top."
-- "Find all my meeting notes from last week."
-- "Change the tone of this page to be more formal."
-- "Pull the latest from Notion."
-- "Share this doc with hbikna@gmail.com as an editor."
-- "Move this page under Onboarding."
 
 For small edits, the agent uses `edit-document --find ... --replace ...` so only the changed text flows through Yjs — you'll see the diff applied in place rather than the whole page re-render. For bigger rewrites it uses `update-document --content ...`.
 
 If you select text and press Cmd+I (or focus the agent panel), the selection travels with your next message as context, so "make this punchier" operates on exactly what you highlighted.
 
-## Data model {#data-model}
+### Data model
 
 Four core tables, all defined in `server/db/schema.ts`:
 
@@ -126,7 +136,7 @@ Content is stored as markdown. The editor converts to and from the Tiptap JSON m
 
 All ownable tables include `owner_email` and `org_id` via `ownableColumns()`, so a local-mode workspace (`local@localhost`) can be upgraded to a real account without losing history.
 
-## Customizing it {#customizing-it}
+### Customizing it
 
 The four places to look when changing behavior:
 

--- a/packages/core/docs/content/template-dispatch.md
+++ b/packages/core/docs/content/template-dispatch.md
@@ -11,7 +11,7 @@ If you're running an [multi-app workspace](/docs/multi-app-workspace) with many 
 
 ## What it does {#what-it-does}
 
-- **Central inbox.** Slack DMs, Telegram messages, email notifications, A2A requests from other agents — all land in one place. The Dispatch agent triages and either handles them itself or delegates.
+- **Central inbox.** Slack DMs, Telegram messages, email notifications, A2A requests from other agents — all land in one place. The Dispatch agent triages and either handles them itself or delegates. See [Messaging](/docs/messaging) for how to wire Slack, email, and Telegram into your workspace.
 - **Orchestrator, not specialist.** Dispatch does _not_ try to be the email app or the analytics app. When someone asks "summarize last week's signups," Dispatch calls the analytics agent over A2A and returns the answer. When someone asks "draft a reply to Alice," Dispatch calls the mail agent.
 - **Secrets vault.** A central store for API keys, OAuth tokens, and shared credentials. Apps in the workspace resolve secrets from Dispatch instead of duplicating them in every `.env`. Requests + approvals for sensitive access.
 - **Integrations catalog.** One page showing every third-party integration — Slack, Telegram, SendGrid, Apollo, etc. — with a "configured / not configured / pending approval" status per app.
@@ -52,6 +52,7 @@ Dispatch is a full cloneable SaaS like any other template — see [Cloneable Saa
 
 ## What's next
 
+- [**Messaging**](/docs/messaging) — connecting Slack, email, and Telegram so you can talk to your agent from anywhere
 - [**Multi-App Workspace**](/docs/multi-app-workspace) — running Dispatch alongside multiple apps
 - [**A2A Protocol**](/docs/a2a-protocol) — how Dispatch delegates to specialist agents
 - [**MCP Clients — Hub Mode**](/docs/mcp-clients#hub) — sharing MCP servers across the workspace

--- a/packages/core/docs/content/template-forms.md
+++ b/packages/core/docs/content/template-forms.md
@@ -5,24 +5,26 @@ description: "Agent-native form builder — create, edit, and analyze forms thro
 
 # Forms
 
-Forms is an agent-native form builder with a simple premise: everything the GUI can do, the agent can do, and vice versa. You can drag fields around in the editor, or you can type "add a 'how did you hear about us' dropdown with five options and make it required" — same result, same underlying data.
+A form builder where the form builder _is_ the agent. Drag fields around in the editor, or just say "add a 'how did you hear about us' dropdown with five options and make it required" — same result, same underlying data. Think Typeform, but you can build, edit, and analyze forms by talking to the agent.
 
-Think Typeform, but the form builder _is_ the agent.
+When you open the app, you'll see a list of your forms on the left and the editor in the middle. Open a form and you can click any field to fine-tune it, or ask the agent to make changes for you.
 
-## What it does {#what-it-does}
+## What you can do with it
 
-- **Build forms conversationally.** "Create a contact form," "add a NPS score question," "make the email field required." The agent updates the schema; the preview updates live.
+- **Build forms conversationally.** "Create a contact form," "add an NPS score question," "make the email field required." The agent updates the schema and the preview updates live.
 - **Click-to-edit fine-tuning.** Every field in the preview is editable in place — label, placeholder, validation, conditional logic — with the usual GUI controls.
-- **Field types** out of the box: short text, long text, email, phone, URL, number, date, single-select, multi-select, rating, file upload, section header, conditional branch.
-- **Responses dashboard.** Per-response view + an aggregate dashboard the agent can pivot on request: "show me signups from the last 30 days grouped by source."
+- **Field types out of the box:** short text, long text, email, phone, URL, number, date, single-select, multi-select, rating, file upload, section header, conditional branch.
+- **Responses dashboard.** Per-response view plus an aggregate dashboard the agent can pivot on request: "show me signups from the last 30 days grouped by source."
 - **Agent-driven analysis.** Ask the agent to cluster free-text responses, extract sentiments, or draft a reply to everyone who scored the NPS below 7.
-- **Publishing.** Public share link with embed snippet, branded thank-you page, webhook on submit.
+- **Publish anywhere.** Public share link, embed snippet, branded thank-you page, webhook on submit.
 
-## Why it's interesting {#why}
+## Why it's interesting
 
-Forms is a clear example of the [ladder](/docs/what-is-agent-native#the-ladder) rung 3 payoff. The hard part of a form builder isn't the editor UI — it's everything around it: schema evolution, response analytics, conditional logic, publishing, notifications, integrations. Most of that is just prompting the agent, because every capability is an action the agent can call.
+Forms is a clear example of the [ladder](/docs/what-is-agent-native#the-ladder) rung-3 payoff. The hard part of a form builder isn't the editor UI — it's everything around it: schema evolution, response analytics, conditional logic, publishing, notifications, integrations. Most of that is just prompting the agent, because every capability is an action the agent can call.
 
-## Scaffolding {#scaffolding}
+## For developers
+
+### Scaffolding
 
 ```bash
 pnpm dlx @agent-native/core create my-forms --template forms --standalone
@@ -34,7 +36,7 @@ For a workspace with forms alongside other apps:
 pnpm dlx @agent-native/core create my-platform  # pick Forms + other templates
 ```
 
-## Customize it {#customize}
+### Customize it
 
 Ask the agent:
 

--- a/packages/core/docs/content/template-slides.md
+++ b/packages/core/docs/content/template-slides.md
@@ -1,25 +1,51 @@
 ---
-title: "Slides Template"
-description: "Agent-native presentation editor — generate decks from a prompt, edit visually, and present in full-screen."
+title: "Slides"
+description: "Generate decks from a prompt, edit visually, and present full-screen. An open-source replacement for Google Slides, Pitch, and PowerPoint."
 ---
 
-# Slides Template
+# Slides
 
-An open-source, agent-native presentation editor built on `@agent-native/core`. It replaces Google Slides, Pitch, and PowerPoint with a deck you can author in three ways at once — by talking to the agent, by clicking the canvas, or by editing HTML.
+Generate full presentation decks from a prompt, edit slides visually, and present full-screen. Ask the agent for "a 10-slide pitch deck for a coffee subscription service" and watch it stream slide-by-slide into the editor in seconds. An open-source replacement for Google Slides, Pitch, and PowerPoint.
 
-## Overview {#overview}
+When you open the app, you'll see your deck list. Click into a deck and you get a slide editor in the middle, a sidebar of slides on the left, and the agent on the right.
 
-The Slides template is a full presentation studio:
+## What you can do with it
 
-- Generate complete decks from a prompt, one slide at a time.
-- Edit slides visually or drop into raw HTML for full control.
-- Generate images with Gemini, search stock photos, and look up company logos.
-- Present full-screen with keyboard navigation and speaker notes.
-- Comment, share, and collaborate in real time over Yjs.
+- **Generate decks from a prompt.** "Generate a 10-slide pitch deck for a coffee subscription service, audience is investors."
+- **Edit slides visually** — double-click text to edit, click a block for the bubble menu, use `/` for the slash menu to insert blocks.
+- **Generate images with AI.** Hero images, product mockups, illustrations — generated with Gemini, multiple variations per request.
+- **Search stock photos and company logos.** "Find the logo for stripe.com and add it to slide 2."
+- **Present full-screen** with keyboard navigation, auto-hiding controls, and speaker notes.
+- **Comment, collaborate, and share.** Multiple people can edit the same deck in real time. Generate a public read-only URL or share with specific teammates.
+- **Import from PDF.** Turn a PDF into a starter deck — the agent parses it and lays out the content.
 
-Every operation the UI does — creating a deck, adding a slide, swapping an image — is exposed as an action the agent can call too. The agent and UI always stay in sync because they read and write the same SQL database.
+## Getting started
 
-## Quick start {#quick-start}
+Live demo: [slides.agent-native.com](https://slides.agent-native.com).
+
+When you open the app:
+
+1. Click **New deck**.
+2. In the agent sidebar, ask: "Generate a 10-slide pitch deck for a coffee subscription service, audience is investors."
+3. Watch slides stream in. Click any slide to edit, or keep asking the agent to refine.
+
+### Useful prompts
+
+- "Generate a 10-slide pitch deck for a coffee subscription service, audience is investors."
+- "Add a pricing slide after slide 3."
+- "Make the title on this slide bigger and change the accent color to green."
+- "Generate a hero image for the current slide — dark, minimal, cinematic."
+- "Find the logo for stripe.com and add it to slide 2."
+- "Replace the word 'customers' with 'members' everywhere in this deck."
+- "Summarize this PDF as a 6-slide deck." (attach the PDF)
+
+Select text on a slide and hit Cmd+I to focus the agent with that selection — it'll act only on what you selected.
+
+## For developers
+
+The rest of this doc is for anyone forking the Slides template or extending it.
+
+### Quick start
 
 Create a new Slides app from the CLI:
 
@@ -29,11 +55,7 @@ cd my-slides
 pnpm dev
 ```
 
-Or try the hosted demo at [slides.agent-native.com](https://slides.agent-native.com).
-
-Once running, open the app, click "New deck", and ask the agent in the sidebar: "Generate a 10-slide pitch deck for a coffee subscription service."
-
-## Key features {#key-features}
+### Key features (technical) {#key-features}
 
 ### Prompt-to-deck generation
 
@@ -91,19 +113,9 @@ Cmd+Z and Cmd+Shift+Z work across the whole deck, with a labeled history panel (
 
 Turn a PDF into a starter deck. The `extract-pdf` action parses the file and hands the content to the agent for layout.
 
-## Working with the agent {#working-with-the-agent}
+### Working with the agent
 
 The agent chat lives in the sidebar. It can create decks, edit individual slides, generate images, search logos, and navigate the UI — all using the same actions you'd run from the CLI.
-
-### Example prompts
-
-- "Generate a 10-slide pitch deck for a coffee subscription service, audience is investors."
-- "Add a pricing slide after slide 3."
-- "Make the title on this slide bigger and change the accent color to green."
-- "Generate a hero image for the current slide — dark, minimal, cinematic."
-- "Find the logo for stripe.com and add it to slide 2."
-- "Replace the word 'customers' with 'members' everywhere in this deck."
-- "Summarize this PDF as a 6-slide deck." (attach the PDF)
 
 ### What the agent sees
 
@@ -123,7 +135,7 @@ Select text on a slide and hit Cmd+I to focus the agent with that selection pre-
 
 The agent can embed a live slide preview directly in a chat reply using the framework's embed fence. It renders a chromeless iframe via `app/routes/slide.tsx` so you can see the result without leaving the conversation.
 
-## Data model {#data-model}
+### Data model
 
 All deck data lives in SQL via Drizzle ORM. Schema: `templates/slides/server/db/schema.ts`.
 
@@ -169,7 +181,7 @@ Each slide inside `decks.data` is:
 
 `content` is raw HTML — the renderer (`app/components/deck/SlideRenderer.tsx`) provides the black background and fixed aspect ratio, and the HTML provides everything inside. Rich embedding is supported too: Excalidraw diagrams via `ExcalidrawSlide.tsx` and Mermaid charts via `MermaidRenderer.tsx`.
 
-## Customizing it {#customizing-it}
+### Customizing it
 
 The Slides template is fully forkable. Key places to look when extending it:
 

--- a/packages/core/docs/content/template-video.md
+++ b/packages/core/docs/content/template-video.md
@@ -1,19 +1,58 @@
 ---
-title: "Video Template"
-description: "A Remotion-based animation studio where compositions are React components, animations are timeline tracks, and the agent edits alongside you."
+title: "Video"
+description: "A programmatic video studio for motion graphics, product demos, and kinetic text. Generate animations from a prompt and tune them on a timeline."
 ---
 
-# Video Template
+# Video
 
-The Video template is a programmatic video studio built on [Remotion](https://remotion.dev). Compositions are React components, animations are tracks on a timeline, and renders output to MP4 or WebM. It replaces point-and-click editors like After Effects, Premiere, and Veed for the kind of motion graphics, product demos, and kinetic text videos that are a pain to keyframe by hand.
+A programmatic video studio for the kind of motion graphics, product demos, and kinetic-text videos that are a pain to keyframe by hand. Ask the agent for "a 6-second logo reveal that fades in at 2 seconds" and it builds the animation. Tune timing, easing, and camera moves on a timeline, then render to MP4 or WebM.
 
-## Overview {#overview}
+When you open the studio, you'll see a list of compositions on the home screen. Click into one and you get a player on top, a timeline at the bottom, and a properties panel on the right. The agent always knows which composition you have open.
+
+## What you can do with it
+
+- **Generate animations from a prompt.** "Add a title card that fades in at 2 seconds and holds until 5." The agent edits the composition.
+- **Tune timing on a timeline.** Drag and resize animation tracks, scrub through frames, set easing curves visually.
+- **Animate the camera.** Pan, zoom, and tilt with on-screen tools. Click the tool, drag in the preview, and a keyframe is auto-created.
+- **Built-in compositions to start from.** Twelve examples ship: kinetic text, logo reveals, particle bursts, interactive UI demos, slideshows.
+- **Edit easing curves visually.** 30+ curves shipped — power, back, bounce, circ, elastic, expo, sine, plus spring physics.
+- **Render to MP4 or WebM** at 1x, 2x, or 3x supersampling for crisp text and vectors during camera zoom.
+
+This is more of a developer-flavored tool than other templates — compositions are React components, so power users (or the agent) can write whole new animation types from scratch. But everyday tweaks ("make the typing slower," "drop the particle count to 12") are just chat.
+
+## Getting started
+
+Live demo: [videos.agent-native.com](https://videos.agent-native.com).
+
+When you open the studio:
+
+1. Pick a composition from the home screen.
+2. Try the agent: "add a logo reveal that fades in at 2 seconds." Watch the timeline update.
+3. Drag tracks to retime, click the camera tool, scrub the player.
+
+### Useful prompts
+
+- "Add a title card that fades in at 2 seconds and holds until 5."
+- "Change the camera to zoom 2x on the logo between frames 60 and 90."
+- "Make the typing reveal slower — 40% longer."
+- "The particle burst is too dense. Drop the count to 12."
+- "Create a new composition called intro-loop, 1080x1080, 6 seconds."
+- "Add a click animation on the button zone and animate the cursor to it."
+- "Give this track a spring easing instead of ease-out."
+
+If you select a track in the timeline and hit Cmd+I, the agent picks up that selection — "make this one snappier" just works.
+
+## For developers
+
+The rest of this doc is for anyone forking the Video template or extending it. This template is more code-forward than the others — every composition is a React component and every animation is data on a track.
+
+### Architecture
 
 Everything you see in the studio is code. A composition is a `CompositionEntry` in `app/remotion/registry.ts` that points at a React component in `app/remotion/compositions/`. Every animation in that component reads from an `AnimationTrack` so users can drag, resize, and retime it in the timeline UI. The agent can create new compositions, add tracks, tune easing, and write whole React components that plug into the registry.
 
 The studio runs on Remotion's `<Player>` for preview and the Remotion CLI for final render. Output defaults to 1920x1080 at 30fps.
 
-## Quick start {#quick-start}
+### Quick start
 
 Create a workspace with the Video app scaffolded:
 
@@ -33,7 +72,7 @@ Open the studio in your browser and pick a composition from the home screen. Ask
 
 Live demo: [videos.agent-native.com](https://videos.agent-native.com).
 
-## Key features {#key-features}
+### Key features (technical)
 
 ### React-based compositions
 
@@ -81,25 +120,13 @@ Composition size, fps, and render quality are per-composition in the Properties 
 
 User edits (track values, parameter values, prop overrides, composition settings) persist to localStorage per composition. The **Save** button in the top-right of the composition view writes the current state back to `app/remotion/registry.ts` as TypeScript — so new users and sessions pick up the changes.
 
-## Working with the agent {#working-with-the-agent}
+### Working with the agent
 
 The agent always knows which composition you have open. Navigation state (`{ view, compositionId }`) is written to the framework's `application_state` table, and the `view-screen` action returns it plus a hint pointing at `app/remotion/registry.ts`. You don't have to tell the agent which composition you're on — ask it to act on "this one" and it will.
 
-Example prompts:
-
-- "Add a title card that fades in at 2 seconds and holds until 5."
-- "Change the camera to zoom 2x on the logo between frames 60 and 90."
-- "Make the typing reveal slower — 40% longer."
-- "The particle burst is too dense. Drop the count to 12."
-- "Create a new composition called intro-loop, 1080x1080, 6 seconds."
-- "Add a click animation on the button zone and animate the cursor to it."
-- "Give this track a spring easing instead of ease-out."
-
 Under the hood the agent calls actions like `navigate`, `create-composition`, `generate-animated-component`, and edits `app/remotion/registry.ts` and `app/remotion/compositions/*.tsx` directly. Every change shows up in the timeline.
 
-If you select a track in the UI and hit Cmd+I to focus the agent, it sees which track you've selected — "make this one snappier" just works.
-
-## Data model {#data-model}
+### Data model
 
 Server-side schema is in `templates/videos/server/db/schema.ts`:
 
@@ -116,7 +143,7 @@ Core TypeScript shapes (`app/types.ts`):
 
 Compositions are private by default. Visibility can be `private`, `org`, or `public`, and share grants give `viewer`, `editor`, or `admin` roles — wired through the framework's sharing primitive.
 
-## Customizing it {#customizing-it}
+### Customizing it
 
 The template folder is `templates/videos/` (the user-facing slug is `video`, but the folder is plural).
 

--- a/packages/core/docs/content/what-is-agent-native.md
+++ b/packages/core/docs/content/what-is-agent-native.md
@@ -1,108 +1,73 @@
 ---
 title: "What Is Agent-Native?"
-description: "The ladder from a naked llm() call to a full agent-native app — and why every agent needs a UI (and every app benefits from an agent)."
+description: "Why most AI apps feel half-built, what makes an app truly agent-native, and what your day-to-day experience looks like as a result."
 ---
 
 # What Is Agent-Native?
 
 Agent-native is a way of building software where the AI agent and the UI are **equal partners**. Everything the agent can do, the UI can do. Everything the UI can do, the agent can do. They share the same database, the same state, and they stay in sync.
 
-If you only remember one thing from this page, remember this: most AI apps today stop at the first rung of the ladder, and it's the biggest mistake in the space right now.
+If you only remember one thing from this page, remember this: most AI apps today stop one step short of being useful, and that gap is the biggest mistake in the space right now.
 
-## The ladder {#the-ladder}
+## What it looks like as a user {#what-it-looks-like}
 
-Here's the progression. Most teams stop at rung 1. Agent-native is rung 3.
+Picture your inbox, calendar, or analytics dashboard. Now picture an agent panel docked on the right side of that app. You can:
+
+- **Click anything you'd normally click.** All the buttons, lists, dashboards, keyboard shortcuts — they all still work. This is a real app, not a chat window pretending to be one.
+- **Or just ask.** Type "reply to the email from Sara saying I'll be there by 3" into the agent. It opens the right thread, drafts the reply, and shows it to you for approval — exactly as if you'd done it by hand.
+- **See what it sees.** Open an email, and the agent knows which one. Select a chart, and the agent knows which chart. Highlight a paragraph and hit Cmd+I, and the agent acts on just that paragraph.
+- **Watch it work.** As the agent does things — opens views, edits drafts, runs reports — the UI updates in real time. You can stop it, redirect it, or take over with the mouse at any moment.
+- **Steer it like a teammate.** Give feedback, queue another task, edit its instructions, audit what it did yesterday. It remembers, and it gets better at your workflows over time.
+
+That's the experience agent-native is designed for. Now here's why most products don't get there.
+
+## Why most "AI apps" fall short {#the-ladder}
+
+There's a progression most teams climb, and most stop one rung too early.
 
 ### Rung 1 — a single LLM call (the anti-pattern) {#rung-one}
 
-```ts
-const output = await llm(prompt);
-```
+A text box sends a prompt, the AI returns a string, and you display it. Maybe with a spinner. There's no way for the user to course-correct, no way for the AI to take action, no way to see what happened or why.
 
-A text box sends a prompt, you get a string back, maybe you parse it, and you render it. There's no way for the user to course-correct, no way for the LLM to take action, no way to inspect what happened. Non-deterministic output → deterministic pipeline. It breaks the moment reality gets messy.
+You see this everywhere: "AI features" that are basically a "Summarize" button bolted onto a SaaS product. They look impressive in demos and break the moment reality gets messy. That's not a product; that's a toy.
 
-You see this everywhere: "AI features" bolted onto SaaS that are basically `fetch('/summarize')` with a spinner. That's not AI product; that's a toy.
+### Rung 2 — a chat with tools {#rung-two}
 
-### Rung 2 — tools and a loop {#rung-two}
+Now the AI can _do things_. It has tools — "draft email," "search contacts," "run query" — and a chat interface where it works in front of you, showing tool calls and results as it goes. This is what Claude, ChatGPT, and Cursor look like under the hood.
 
-```ts
-const loop = query({ prompt, tools });
-for await (const msg of loop) {
-  if (msg.type === "tool_use") {
-    // run the tool, feed the result back into the loop
-  }
-  if (msg.type === "result") {
-    output = msg.text;
-  }
-}
-```
+This is a real step up. But on its own, it's still a chat window. There's no proper UI. No dashboards, no lists, no forms, no keyboard shortcuts, no team collaboration. If the AI gets confused, you're stuck retyping rather than just clicking the right button. Non-developers struggle to get real work done in this format.
 
-Now the LLM can _do things_. You give it tools (`draftEmail`, `searchEmails`, `queryData`) and run a loop: LLM requests a tool → your code runs it → result goes back → loop continues until the task is done. This is what Claude Code, Codex, and the Anthropic/OpenAI agent SDKs all do under the hood.
+### Rung 3 — agent + UI as equal partners {#rung-three}
 
-This is a real step up. But on its own it still assumes the agent is correct. When it's not, the user has no steering wheel.
+This is agent-native. You add a real, full-featured app around the agent — and crucially, every action the agent can take is also a button in the UI, and every button the user clicks runs the same logic the agent uses. One implementation, two ways in.
 
-So the next move is obvious: stream the agent's work into a chat UI where the user can watch, interrupt, give feedback, queue the next message. That's the state of the art today — and it's still not enough for a real product.
+Three things change when you reach rung 3:
 
-### Rung 3 — `<Agent />` + actions + workspace {#rung-three}
-
-```tsx
-// actions/reply-to-email.ts
-import { defineAction } from "@agent-native/core";
-import { z } from "zod";
-
-export default defineAction({
-  description: "Reply to an email thread",
-  schema: z.object({
-    emailId: z.string(),
-    body: z.string(),
-  }),
-  run: async ({ emailId, body }) => {
-    await db.replies.insert({ emailId, body });
-  },
-});
-```
-
-```tsx
-// Anywhere in your React app
-import { AgentSidebar } from "@agent-native/core/client";
-
-<AgentSidebar />;
-```
-
-```tsx
-// The same action, typesafe, from a button
-const { mutate } = useActionMutation("replyToEmail");
-
-<Button onClick={() => mutate({ emailId, body: "Thanks!" })}>
-  Send Reply
-</Button>;
-```
-
-One action. The agent calls it as a tool. The UI calls it as an HTTP endpoint. External agents call it over [A2A](/docs/a2a-protocol). Claude Desktop calls it as an [MCP server](/docs/mcp-protocol). Four surfaces, one implementation.
-
-And you didn't just add buttons to a chatbot — you added an agent to an app. The user has a real UI with dashboards, lists, forms, and keyboard shortcuts. The agent has real tools, real memory, and real context. Both write to the same database; both see the same state.
+- **You stopped adding buttons to a chatbot. You added an agent to an app.** That's a much higher-quality product on both sides.
+- **The agent has real context.** It sees what you're looking at, what you've selected, what you just did. It writes to the same database the UI reads from, so its work shows up immediately.
+- **External agents can use it too.** Other agent-native apps can call this one's actions over the [A2A protocol](/docs/a2a-protocol). Tools like Claude Desktop can drive it as an [MCP server](/docs/mcp-protocol). One app, many entry points.
 
 That's rung 3. That's agent-native.
 
 ## Why every agent needs a UI {#why-every-agent-needs-a-ui}
 
-The hot take floating around right now is "apps are dead, agents will replace UIs, everyone will just text an agent in Telegram." That's wrong.
+The hot take in 2026 is "apps are dead, agents will replace UIs, everyone will just text an agent in Telegram." That's wrong.
 
-Every agent eventually needs a UI. Even if the agent does all the _work_, humans still need to:
+Even when the agent does all the heavy lifting, humans still need to:
 
-- **See what it's doing** — progress, tool calls, intermediate output
+- **See what it's doing** — progress, intermediate output, what it touched
 - **Steer it** — give feedback, interrupt, queue the next task
 - **Manage it** — edit its instructions, skills, memory, scheduled jobs, connected accounts
-- **Inspect its work** — review drafts, audit trails, rollbacks
-- **Share its output** — dashboards, reports, forms, links
+- **Inspect its work** — review drafts, audit history, roll back mistakes
+- **Share its output** — dashboards, reports, forms, links to send to teammates
 
-At minimum, "a UI for the agent" is an observability + management interface. At maximum, it's a full SaaS app with an agent embedded in it. Both ends of that spectrum are agent-native — see [Pure-Agent Apps](/docs/pure-agent-apps) for the minimal end and [Cloneable SaaS](/docs/cloneable-saas) for the maximal end.
+At minimum, "a UI for the agent" is an observability and management dashboard. At maximum, it's a full SaaS app with the agent embedded as a co-pilot. Both ends count as agent-native — see [Pure-Agent Apps](/docs/pure-agent-apps) for the minimal end and [Cloneable SaaS](/docs/cloneable-saas) for the maximal end.
 
 ## Why every app benefits from an agent {#why-every-app-benefits-from-an-agent}
 
-The flip side is equally important. Existing SaaS products hit a wall: 80% of what you need, and 20% you can't change. Bolting a sidebar chat onto a SaaS app rarely works because the chat can't actually _do_ the things the UI can.
+The flip side is just as important. Existing SaaS products keep hitting the same wall: 80% of what you need works great, and 20% you just can't change. Adding a chat sidebar rarely fixes that — the chat usually can't actually _do_ the things the UI can.
 
-Agent-native flips that. Because every action in the app is defined once and exposed as both a UI handler and an agent tool, the agent can do everything the buttons can — and a lot more — without a separate "AI world" to maintain. Natural language becomes a first-class input alongside clicks.
+Agent-native flips that. Because every action in the app is defined once and exposed as both a button and an agent tool, the agent can do everything the buttons can — and more — without a separate "AI world" to maintain. Natural language becomes a first-class input alongside clicks.
 
 The argument isn't "agents replace UI." It's "**agents belong inside applications, with a UI on top, as equal partners**." Neither can stand alone.
 
@@ -114,22 +79,22 @@ This is the defining principle.
 >
 > **From the agent** — natural language, other agents via A2A, Slack, Telegram. The agent writes to the database; the UI updates automatically.
 
-When the agent creates a draft email, it appears in the UI. When the user clicks "Send," the agent knows it was sent. There's no separate "agent world" and "UI world" — it's one system. See [Key Concepts](/docs/key-concepts) for the architecture that makes this work.
+When the agent creates a draft email, it appears in the UI. When you click "Send," the agent knows it was sent. There's no separate "agent world" and "UI world" — it's one system. See [Key Concepts](/docs/key-concepts) for the architecture that makes this work.
 
-## Customization that's usually reserved for Claude Code {#workspace-customization}
+## Customization usually reserved for power tools {#workspace-customization}
 
-The reason tools like Claude Code and Codex are so powerful isn't the model — it's the **customization layer**: per-project instructions, skills, memory files, sub-agents, connected MCP servers. You can shape the agent to your codebase, your preferences, your team.
+The reason tools like Claude Code feel so powerful isn't the model — it's the **customization layer**: per-project instructions, skills, memory, sub-agents, connected services. You can shape the agent to your codebase, your preferences, your team.
 
-Agent-native ships the same customization layer as a first-class part of every app — the **workspace**. Each app includes:
+Agent-native gives every user that same customization layer — without ever leaving the app. Each app comes with a personal **workspace** where you (or anyone on your team) can:
 
-- `AGENTS.md` — team-wide rules (shared)
-- `learnings.md` — per-user memory the agent writes to automatically (personal)
-- `skills/` — reusable how-to guides (`/slash` commands)
-- `agents/` — custom sub-agent profiles (invoked with `@mentions`)
-- `jobs/` — scheduled tasks that run on a cron
-- MCP servers — local _or_ remote, per-user or per-org
+- Edit team-wide rules everyone's agent reads
+- Let the agent remember preferences automatically as you correct it
+- Write reusable how-to guides as `/slash` commands
+- Keep custom sub-agents for specific tasks (invoked with `@mentions`)
+- Schedule jobs to run on a cron (e.g. "every Monday morning, summarize last week")
+- Connect external services (Gmail, Stripe, Slack, internal APIs) via per-user MCP servers
 
-The twist: it's **SQL-backed, not filesystem-backed.** There's no dev-box to spin up, no container per user, no files to sync. Every user gets their own full workspace — personal memory, personal MCP servers, personal skills — for essentially free, because it's all rows in a database. That makes this model viable for real SaaS: multi-tenant, deployable to any serverless or edge host, with Claude-Code-level flexibility per user.
+The twist: it's all stored in the database, not the filesystem. There's no dev environment to spin up, no container per user. Every user gets their own full workspace — personal memory, personal connections, personal skills — for essentially free, because it's all rows in a table. That's what makes Claude-Code-level flexibility viable inside a real multi-tenant SaaS product.
 
 See [Workspace](/docs/workspace) for the full concept.
 
@@ -142,39 +107,22 @@ See [Workspace](/docs/workspace) for the full concept.
 | **Claude Code / Codex for SaaS**       | Great for devs on their own machines. Doesn't translate to multi-tenant SaaS — one codebase per user on a dev-box doesn't scale.       |
 | **Agent-native apps**                  | The agent is a first-class citizen. It shares the same database, the same state, and can do everything the UI can do — and vice versa. |
 
-## What is agent-native development? {#what-is-agent-native-development}
-
-Agent-native development means building with agents first. Projects are structured so any AI coding tool — Claude Code, Codex, Cursor, Windsurf, Builder.io — reads the same instructions and follows the same patterns.
-
-The payoff: the agent tends to do _better_ than a human developer because you can encode rules like "when you add a feature, also add a skill for it" — the kind of thing humans skip when they're tired or rushed.
-
-## Agents as first-class developers {#agents-as-first-class-developers}
-
-In an agent-native project:
-
-- **AGENTS.md** gives every AI coding tool the same instructions — Claude Code, Cursor, Windsurf, and others all read the same file
-- **Skills** teach the agent patterns for specific tasks — adding features, storing data, wiring real-time sync
-- **Agent PR reviewers** validate the four-area checklist, that skills were updated, and that code matches conventions
-- **Auto-maintained docs and tests** — agents are instructed to keep docs current and tests passing
-
-This is the shift from desktop-first to mobile-first applied to development. Mobile-first didn't mean "no desktop" — it meant designing for mobile constraints first. Agent-native development means designing for agent workflows first, then ensuring humans work effectively too.
-
 ## Whole-team development {#whole-team-development}
 
-Agent-native development isn't just for developers:
+Agent-native isn't just for developers. Because the agent can edit the app's own code, evolving an app stops being a developer-only activity:
 
-- **Designers** update designs directly in the code through the agent
-- **Product managers** update functionalities and requirements
-- **QA** tests and prompts for fixes
+- **Designers** update designs directly in the running app through the agent
+- **Product managers** add functionality and update flows by describing them
+- **QA** tests the app and asks the agent to fix what's broken
 - **Anyone on the team** contributes through natural language
 
-The vision: reduce handoffs, enable one-person-to-full-team productivity.
+The vision: fewer handoffs, one person doing the work of a small team.
 
 ## Fork and customize {#fork-and-customize}
 
 Agent-native apps follow a fork-and-customize model. You start from a **cloneable SaaS** template — Mail, Calendar, Analytics, Slides, Clips, Forms, Dispatch — and make it yours:
 
-1. Pick a template on [agent-native.com](/templates)
+1. Pick a template on [agent-native.com/templates](/templates)
 2. Use it immediately as a hosted app (e.g. mail.agent-native.com)
 3. Fork it when you want to customize — "connect our Stripe account," "add a cohort chart"
 4. The agent modifies the code to match your needs
@@ -184,14 +132,50 @@ Because it's _your_ app, not shared infrastructure, the agent can safely evolve 
 
 ## Composable agents {#composable-agents}
 
-Agent-native apps talk to each other over the [A2A protocol](/docs/a2a-protocol). From the mail app, you can tag the analytics agent to query data and include the results in a draft email. Agents discover what other agents are available, call them over the protocol, and show results in the UI.
+Agent-native apps can talk to each other. From inside the mail app, you can tag the analytics agent to query data and include the result in a draft email. The agents discover what other agents are available, hand off work between each other, and surface the results in the UI you're already in.
 
-Every action you define is also a tool exposed over A2A _and_ as an MCP server, so external tools like Claude Desktop can drive your app directly. Same definition, four surfaces.
+This is powered by [A2A](/docs/a2a-protocol) and [MCP](/docs/mcp-protocol) under the hood — same definition, multiple surfaces — but as a user, all you have to know is "I can ask any of my apps for help with anything any of them can do."
 
-## What's next
+## What does this look like in code? {#what-does-it-look-like-in-code}
 
+If you're building or extending an agent-native app, here's the central pattern: every operation in the app is an **action** — defined once, available to both the agent and the UI.
+
+```ts
+// actions/reply-to-email.ts
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+
+export default defineAction({
+  description: "Reply to an email thread",
+  schema: z.object({ emailId: z.string(), body: z.string() }),
+  run: async ({ emailId, body }) => {
+    await db.replies.insert({ emailId, body });
+  },
+});
+```
+
+```tsx
+// In any React component — same action, called from a button
+const { mutate } = useActionMutation("replyToEmail");
+
+<Button onClick={() => mutate({ emailId, body: "Thanks!" })}>
+  Send Reply
+</Button>;
+```
+
+```tsx
+// And the agent panel mounted anywhere in your app
+import { AgentSidebar } from "@agent-native/core/client";
+
+<AgentSidebar />;
+```
+
+One action, four surfaces: the agent calls it as a tool, the UI calls it as a typesafe mutation, external agents reach it over [A2A](/docs/a2a-protocol), and tools like Claude Desktop talk to it as an [MCP server](/docs/mcp-protocol). See [Actions](/docs/actions) for the full reference.
+
+## What's next {#whats-next}
+
+- [**Getting Started**](/docs) — pick a template and run it
 - [**Key Concepts**](/docs/key-concepts) — the architecture: SQL, actions, polling sync, context awareness, portability
 - [**Cloneable SaaS**](/docs/cloneable-saas) — templates as complete products you own
 - [**Workspace**](/docs/workspace) — the per-user customization layer (skills, memory, instructions, MCP)
 - [**Drop-in Agent**](/docs/drop-in-agent) — mount `<AgentPanel>` into any React app
-- [**Getting Started**](/docs) — scaffold your first app

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",
@@ -125,6 +125,7 @@
     "drizzle-orm": "^0.45.2",
     "h3": "^2.0.1-rc.20",
     "isbot": "^5",
+    "jiti": "^2.6.1",
     "jose": "^6.2.2",
     "minimatch": "^10.0.0",
     "nanoid": "^5.1.9",

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -320,11 +320,12 @@ export async function callAgent(
   if (opts?.userEmail) metadata.userEmail = opts.userEmail;
   if (opts?.orgDomain) metadata.orgDomain = opts.orgDomain;
 
-  // Default to synchronous mode — async mode requires the receiving server to
-  // run detached promises after sending the response, which doesn't work
-  // reliably on Netlify Functions (the runtime kills the function once the
-  // response is flushed). Callers that want async polling can opt in.
-  const useAsync = opts?.async ?? false;
+  // Default to async + poll. The receiving A2A server's `_process-task` route
+  // runs the handler in a fresh function execution (cross-platform queue
+  // pattern), so async mode now works on every host instead of relying on
+  // detached promises that get killed on Netlify/Vercel. Callers that
+  // explicitly want a single-shot blocking POST can pass `async: false`.
+  const useAsync = opts?.async ?? true;
   const message: Message = {
     role: "user",
     parts: [{ type: "text", text }],

--- a/packages/core/src/a2a/handlers.spec.ts
+++ b/packages/core/src/a2a/handlers.spec.ts
@@ -17,7 +17,11 @@ vi.mock("./task-store.js", () => {
   let tasks: Record<string, any> = {};
   let counter = 0;
   return {
-    async createTask(message: Message, contextId?: string) {
+    async createTask(
+      message: Message,
+      contextId?: string,
+      metadata?: Record<string, unknown>,
+    ) {
       const id = `task-${++counter}`;
       const task = {
         id,
@@ -25,6 +29,7 @@ vi.mock("./task-store.js", () => {
         status: { state: "submitted", timestamp: new Date().toISOString() },
         history: [message],
         artifacts: [],
+        metadata,
       };
       tasks[id] = task;
       return task;
@@ -50,8 +55,27 @@ vi.mock("./task-store.js", () => {
       }
       return task;
     },
+    async claimA2ATaskForProcessing(id: string) {
+      const task = tasks[id];
+      if (!task) return null;
+      if (!["submitted", "working"].includes(task.status.state)) return null;
+      task.status = {
+        state: "processing",
+        message: task.status.message,
+        timestamp: new Date().toISOString(),
+      };
+      return task;
+    },
   };
 });
+
+// Mock the integrations/internal-token import so the a2a handler tests don't
+// require A2A_SECRET to be set in the test environment for sign().
+vi.mock("../integrations/internal-token.js", () => ({
+  signInternalToken: () => "test-token",
+  verifyInternalToken: () => true,
+  extractBearerToken: (h?: string) => h?.replace(/^Bearer\s+/i, "") ?? null,
+}));
 
 // Mock agentChat.call for default handler tests
 vi.mock("../shared/agent-chat.js", () => ({
@@ -247,7 +271,7 @@ describe("handleJsonRpc", () => {
     expect(result.error.code).toBe(-32602);
   });
 
-  it("async message/send returns immediately and processes in background", async () => {
+  it("async message/send returns immediately and processor runs in fresh execution", async () => {
     // Handler resolves only when we let it — so if the response came back
     // synchronously the task could not yet be 'completed'.
     let release: (v: unknown) => void = () => {};
@@ -285,14 +309,21 @@ describe("handleJsonRpc", () => {
       slowConfig,
     );
 
-    // Returned immediately, before the handler resolved
+    // Returned immediately, before the handler resolved. The dispatcher
+    // self-fires a POST to /_process-task on the same deployment — in the
+    // real wire-up `mountA2A` mounts that route and calls
+    // `processA2ATaskFromQueue` in a fresh function execution. Here we
+    // invoke it directly to simulate that next request.
     expect(result.error).toBeUndefined();
     expect(result.result.status.state).toBe("working");
     const taskId = result.result.id;
 
+    const { processA2ATaskFromQueue } = await import("./handlers.js");
+    const processorPromise = processA2ATaskFromQueue(taskId, slowConfig);
+
     // Now let the handler finish, and verify the task progresses to completed
     release(undefined);
-    await new Promise((r) => setTimeout(r, 10));
+    await processorPromise;
     const followup = await handleJsonRpc(
       {
         jsonrpc: "2.0",

--- a/packages/core/src/a2a/handlers.ts
+++ b/packages/core/src/a2a/handlers.ts
@@ -9,8 +9,159 @@ import type {
   Message,
   Artifact,
 } from "./types.js";
-import { createTask, getTask, updateTask } from "./task-store.js";
+import {
+  createTask,
+  getTask,
+  updateTask,
+  claimA2ATaskForProcessing,
+} from "./task-store.js";
 import { agentChat } from "../shared/agent-chat.js";
+import { signInternalToken } from "../integrations/internal-token.js";
+
+// Inlined to avoid pulling the entire core-routes-plugin (and its h3
+// transitive deps) into the a2a/handlers test boundary. Must stay in sync
+// with FRAMEWORK_ROUTE_PREFIX in `server/core-routes-plugin.ts`.
+const A2A_PROCESS_TASK_PATH = "/_agent-native/a2a/_process-task";
+
+/**
+ * Resolve the base URL we should fire the A2A processor request to. Mirrors
+ * the integration-webhook resolveBaseUrl pattern — prefer explicit env vars
+ * (most reliable on serverless), fall back to inbound request headers.
+ */
+function resolveSelfBaseUrl(event: any | undefined): string {
+  const fromEnv =
+    process.env.APP_URL ||
+    process.env.URL ||
+    process.env.DEPLOY_URL ||
+    process.env.BETTER_AUTH_URL;
+  if (fromEnv) return String(fromEnv).replace(/\/$/, "");
+
+  try {
+    const headers = event?.node?.req?.headers ?? event?.headers;
+    const get = (name: string): string | undefined => {
+      if (!headers) return undefined;
+      if (typeof headers.get === "function") {
+        return headers.get(name) ?? undefined;
+      }
+      const map = headers as Record<string, string | undefined>;
+      return map[name] ?? map[String(name).toLowerCase()];
+    };
+    const proto = get("x-forwarded-proto") || "http";
+    const host = get("host") || `localhost:${process.env.PORT || 3000}`;
+    return `${proto}://${host}`;
+  } catch {
+    return `http://localhost:${process.env.PORT || 3000}`;
+  }
+}
+
+/**
+ * Fire-and-forget POST to the A2A processor route on the same deployment.
+ * Used when an A2A send is requested in async mode — the processor runs the
+ * handler in a fresh function execution so it gets its own full timeout.
+ */
+async function fireProcessTaskDispatch(
+  event: any,
+  taskId: string,
+): Promise<void> {
+  const baseUrl = resolveSelfBaseUrl(event);
+  const url = `${baseUrl}${A2A_PROCESS_TASK_PATH}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  try {
+    headers["Authorization"] = `Bearer ${signInternalToken(taskId)}`;
+  } catch {
+    // No A2A_SECRET configured — self-fire unsigned. The processor accepts
+    // unsigned dispatches when no secret is set (mirrors the integration
+    // webhook flow).
+  }
+  fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ taskId }),
+  }).catch((err) => {
+    console.error("[a2a] Process-task dispatch fetch failed:", err);
+  });
+}
+
+/**
+ * Process a previously-enqueued A2A task. Called by the `_process-task`
+ * route in `server.ts`, in a fresh function execution. Atomically claims the
+ * task, reconstructs the caller's request context from the task's metadata,
+ * runs the handler, and persists the outcome.
+ *
+ * Idempotent on duplicate dispatches: the atomic claim returns null if some
+ * other invocation already picked the task up, in which case we no-op.
+ */
+export async function processA2ATaskFromQueue(
+  taskId: string,
+  config: A2AConfig,
+): Promise<void> {
+  const claimed = await claimA2ATaskForProcessing(taskId);
+  if (!claimed) {
+    // Already in flight, terminal, or missing. Nothing to do.
+    return;
+  }
+
+  const message = claimed.history?.[0];
+  if (!message) {
+    await updateTask(taskId, {
+      state: "failed",
+      message: {
+        role: "agent",
+        parts: [{ type: "text", text: "Task is missing its inbound message" }],
+      },
+    });
+    return;
+  }
+
+  const meta = (claimed.metadata ?? {}) as Record<string, unknown>;
+  const processorMeta = (meta.__a2a_processor ?? {}) as Record<string, unknown>;
+  const verifiedEmail = processorMeta.verifiedEmail as string | undefined;
+  const orgDomainHint = processorMeta.orgDomainHint as string | undefined;
+  const contextId =
+    (processorMeta.contextId as string | null | undefined) ?? undefined;
+  const callerMetadata =
+    (processorMeta.callerMetadata as
+      | Record<string, unknown>
+      | null
+      | undefined) ?? undefined;
+
+  let resolvedOrgId: string | undefined;
+  if (orgDomainHint) {
+    try {
+      const { resolveOrgByDomain } = await import("../org/context.js");
+      const org = await resolveOrgByDomain(orgDomainHint);
+      if (org) resolvedOrgId = org.orgId;
+    } catch {}
+  }
+
+  const { runWithRequestContext } =
+    await import("../server/request-context.js");
+  try {
+    await runWithRequestContext(
+      { userEmail: verifiedEmail, orgId: resolvedOrgId },
+      () =>
+        runHandlerAndPersist(
+          taskId,
+          message,
+          config,
+          contextId,
+          callerMetadata,
+        ),
+    );
+  } catch (err: any) {
+    try {
+      await updateTask(taskId, {
+        state: "failed",
+        message: {
+          role: "agent",
+          parts: [{ type: "text", text: err?.message ?? "Handler crashed" }],
+        },
+      });
+    } catch {}
+  }
+}
 
 /**
  * Default A2A handler that delegates to agentChat.call().
@@ -154,40 +305,9 @@ async function withA2ARequestContext<T>(
 }
 
 /**
- * Best-effort "keep this promise alive after the response is sent."
- *
- * On Cloudflare Workers we have `__cf_ctx.waitUntil`. On Netlify Functions
- * (Lambda under the hood) the function instance can be frozen the moment the
- * response is flushed, so detached promises may not run to completion.
- * Netlify's Background Functions (15-min timeout) are the durable answer, but
- * for now we at least wire up the Workers path and a Netlify `context.waitUntil`
- * if/when one is exposed. Anywhere else we fall back to fire-and-forget — the
- * Node server (local dev, long-running hosts) will run it normally.
- */
-function keepAlive(event: any | undefined, p: Promise<unknown>): void {
-  try {
-    const cfCtx = (globalThis as any).__cf_ctx;
-    if (cfCtx?.waitUntil) {
-      cfCtx.waitUntil(p);
-      return;
-    }
-  } catch {}
-  try {
-    // Netlify exposes a Lambda-ish `context` object; if it ever exposes a
-    // waitUntil-style API at event.context, prefer that.
-    const ctx = event?.context;
-    if (ctx && typeof ctx.waitUntil === "function") {
-      ctx.waitUntil(p);
-      return;
-    }
-  } catch {}
-  // Fire-and-forget — fine for Node hosts, may be cut short on serverless.
-  p.catch(() => {});
-}
-
-/**
  * Run the handler against the message and persist the outcome to the task store.
- * Used both synchronously (await) and detached (in async mode).
+ * Used in sync mode (awaited inline) and in async mode (called by the
+ * `_process-task` processor route in a fresh function execution).
  */
 async function runHandlerAndPersist(
   taskId: string,
@@ -269,9 +389,13 @@ async function handleSend(
     (event && event.context?.__a2aForceAsync === true);
 
   if (asyncMode) {
-    // Resolve identity up front (cheap), then return immediately and re-enter
-    // a request context inside the detached promise so the handler still sees
-    // the caller's email/org.
+    // Resolve identity up front (cheap), bake it into the task's metadata,
+    // and dispatch the actual handler run to a SEPARATE function execution.
+    // On serverless hosts (Netlify, Vercel, Cloudflare) detached promises get
+    // killed when the response is flushed, so we self-fire a webhook to a
+    // dedicated processor route — same cross-platform pattern the integration
+    // webhook queue uses. The processor reconstructs the request context from
+    // the task metadata and runs the handler with its own full timeout.
     const verifiedEmail =
       (event?.context?.__a2aVerifiedEmail as string | undefined) ?? undefined;
     const orgDomainHint =
@@ -279,41 +403,22 @@ async function handleSend(
       ((metadata as any)?.orgDomain as string | undefined) ??
       undefined;
 
-    const task = await createTask(message, contextId);
+    const taskMetadata: Record<string, unknown> = {
+      ...(metadata ?? {}),
+      __a2a_processor: {
+        verifiedEmail,
+        orgDomainHint,
+        contextId: contextId ?? null,
+        callerMetadata: metadata ?? null,
+      },
+    };
+    const task = await createTask(message, contextId, taskMetadata);
     const working = await updateTask(task.id, { state: "working" });
 
-    const detached = (async () => {
-      const { runWithRequestContext } =
-        await import("../server/request-context.js");
-      let resolvedOrgId: string | undefined;
-      if (orgDomainHint) {
-        try {
-          const { resolveOrgByDomain } = await import("../org/context.js");
-          const org = await resolveOrgByDomain(orgDomainHint);
-          if (org) resolvedOrgId = org.orgId;
-        } catch {}
-      }
-      try {
-        await runWithRequestContext(
-          { userEmail: verifiedEmail, orgId: resolvedOrgId },
-          () =>
-            runHandlerAndPersist(task.id, message, config, contextId, metadata),
-        );
-      } catch (err: any) {
-        try {
-          await updateTask(task.id, {
-            state: "failed",
-            message: {
-              role: "agent",
-              parts: [
-                { type: "text", text: err?.message ?? "Handler crashed" },
-              ],
-            },
-          });
-        } catch {}
-      }
-    })();
-    keepAlive(event, detached);
+    fireProcessTaskDispatch(event, task.id).catch((err) => {
+      console.error("[a2a] Failed to dispatch process-task:", err);
+    });
+
     return { ...jsonRpcResult(0, working ?? task), _id: 0 };
   }
 

--- a/packages/core/src/a2a/server.ts
+++ b/packages/core/src/a2a/server.ts
@@ -9,8 +9,12 @@ import {
 } from "h3";
 import type { A2AConfig } from "./types.js";
 import { generateAgentCard } from "./agent-card.js";
-import { handleJsonRpcH3 } from "./handlers.js";
+import { handleJsonRpcH3, processA2ATaskFromQueue } from "./handlers.js";
 import { readBody } from "../server/h3-helpers.js";
+import {
+  extractBearerToken,
+  verifyInternalToken,
+} from "../integrations/internal-token.js";
 
 /**
  * Verify an inbound A2A JWT signed with the shared A2A_SECRET.
@@ -167,6 +171,55 @@ export function mountA2A(
 
       const body = await readBody(event);
       return handleJsonRpcH3(body, event, config);
+    }),
+  );
+
+  // Async-mode processor route. When `message/send` is called with
+  // `async: true`, the JSON-RPC handler enqueues the task and self-fires a
+  // POST to this route on the same deployment so the actual handler runs in
+  // a fresh function execution (its own full timeout). Authenticated with an
+  // HMAC token bound to the task id (5-minute lifetime, signed with
+  // A2A_SECRET — the same scheme the integration webhook queue uses).
+  getH3App(nitroApp).use(
+    `${routePrefix}/a2a/_process-task`,
+    defineEventHandler(async (event) => {
+      if (getMethod(event) !== "POST") {
+        setResponseStatus(event, 405);
+        return { error: "Method not allowed" };
+      }
+
+      const body = (await readBody(event)) as { taskId?: unknown } | null;
+      const taskId = body && typeof body.taskId === "string" ? body.taskId : "";
+      if (!taskId) {
+        setResponseStatus(event, 400);
+        return { error: "taskId required" };
+      }
+
+      // When A2A_SECRET is set, require a valid HMAC token bound to this
+      // taskId. Without a secret, accept unsigned dispatches — the task store
+      // claim is atomic and the body only carries an opaque task id, so an
+      // unsigned dispatch is bounded in damage to re-running already-queued
+      // work that the original sender already approved.
+      if (process.env.A2A_SECRET) {
+        const auth = getRequestHeader(event, "authorization");
+        const token = extractBearerToken(auth);
+        if (!verifyInternalToken(taskId, token)) {
+          setResponseStatus(event, 401);
+          return { error: "Invalid or expired processor token" };
+        }
+      }
+
+      // Run the handler in this fresh function execution. We await so any
+      // exception surfaces in logs, but the response body is just an
+      // acknowledgement — the actual result lives on the task row.
+      try {
+        await processA2ATaskFromQueue(taskId, config);
+        return { ok: true };
+      } catch (err: any) {
+        console.error("[a2a] process-task failed:", err);
+        setResponseStatus(event, 500);
+        return { error: err?.message ?? "process-task failed" };
+      }
     }),
   );
 }

--- a/packages/core/src/a2a/task-store.ts
+++ b/packages/core/src/a2a/task-store.ts
@@ -47,6 +47,7 @@ function taskFromRow(row: any): Task {
 export async function createTask(
   message: Message,
   contextId?: string,
+  metadata?: Record<string, unknown>,
 ): Promise<Task> {
   await ensureTable();
   const client = getDbExec();
@@ -60,10 +61,11 @@ export async function createTask(
     status: { state: "submitted", timestamp },
     history: [message],
     artifacts: [],
+    metadata,
   };
 
   await client.execute({
-    sql: `INSERT INTO a2a_tasks (id, context_id, status_state, status_timestamp, history, artifacts, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    sql: `INSERT INTO a2a_tasks (id, context_id, status_state, status_timestamp, history, artifacts, metadata, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     args: [
       id,
       contextId ?? null,
@@ -71,12 +73,50 @@ export async function createTask(
       timestamp,
       JSON.stringify([message]),
       "[]",
+      metadata ? JSON.stringify(metadata) : null,
       now,
       now,
     ],
   });
 
   return task;
+}
+
+/**
+ * Atomically claim a task for processing. Only succeeds when the task is in
+ * state 'submitted' or 'working' — flipping it to 'processing' so concurrent
+ * processors can't pick it up twice. Returns the task if claimed, null if it
+ * was already claimed/completed/missing.
+ *
+ * Used by the cross-platform async processor (`_process-task` route) to avoid
+ * duplicate handler runs when retries fire.
+ */
+export async function claimA2ATaskForProcessing(
+  id: string,
+): Promise<Task | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const timestamp = new Date().toISOString();
+
+  const result = await client.execute({
+    sql: `UPDATE a2a_tasks
+            SET status_state = 'processing',
+                status_timestamp = ?,
+                updated_at = ?
+          WHERE id = ?
+            AND status_state IN ('submitted', 'working')`,
+    args: [timestamp, now, id],
+  });
+  const affected = (result as any)?.rowsAffected ?? (result as any)?.rowCount;
+  if (affected === 0) return null;
+
+  const { rows } = await client.execute({
+    sql: `SELECT * FROM a2a_tasks WHERE id = ?`,
+    args: [id],
+  });
+  if (rows.length === 0) return null;
+  return taskFromRow(rows[0]);
 }
 
 export async function getTask(id: string): Promise<Task | null> {

--- a/packages/core/src/scripts/db/index.ts
+++ b/packages/core/src/scripts/db/index.ts
@@ -8,4 +8,6 @@ export const coreDbScripts: Record<string, (args: string[]) => Promise<void>> =
       import("./check-scoping.js").then((m) => m.default(args)),
     "db-wipe-leaked-builder-keys": (args) =>
       import("./wipe-leaked-builder-keys.js").then((m) => m.default(args)),
+    "db-migrate-user-api-keys": (args) =>
+      import("./migrate-user-api-keys.js").then((m) => m.default(args)),
   };

--- a/packages/core/src/scripts/db/migrate-user-api-keys.ts
+++ b/packages/core/src/scripts/db/migrate-user-api-keys.ts
@@ -1,0 +1,244 @@
+/**
+ * Core script: db-migrate-user-api-keys
+ *
+ * One-shot migration: copy legacy `user-api-key:<provider>:<email>` and
+ * `user-anthropic-api-key:<email>` rows from the unscoped `settings` table
+ * into `app_secrets` (encrypted, scope=user, scopeId=email), then delete
+ * the legacy rows.
+ *
+ * Background. The pre-secrets-migration `agent-chat-plugin` save-key endpoint
+ * persisted user-pasted LLM API keys to `settings` under email-prefixed
+ * keys. The `app_secrets` system (encrypted, properly scoped) now owns
+ * user-pasted credentials. `getOwnerApiKey()` reads `app_secrets` first
+ * and falls back to the legacy settings rows for compat. This script
+ * clears that compat tail so the legacy rows don't sit around indefinitely.
+ *
+ * Idempotent — re-running on an already-migrated DB is a no-op.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... pnpm action db-migrate-user-api-keys
+ *   pnpm action db-migrate-user-api-keys --db ./data/app.db
+ *   pnpm action db-migrate-user-api-keys --dry-run
+ */
+
+import path from "path";
+import { createClient } from "@libsql/client";
+import { getDatabaseUrl, getDatabaseAuthToken } from "../../db/client.js";
+import { parseArgs } from "../utils.js";
+import { PROVIDER_TO_ENV } from "../../agent/engine/provider-env-vars.js";
+
+interface LegacyRow {
+  settingsKey: string;
+  provider: string;
+  email: string;
+  apiKey: string;
+}
+
+function isPostgresUrl(url: string): boolean {
+  return url.startsWith("postgres://") || url.startsWith("postgresql://");
+}
+
+function parseLegacyKey(
+  settingsKey: string,
+): { provider: string; email: string } | null {
+  // user-api-key:<provider>:<email>
+  // (email may itself contain `:` if someone has a weird local-part — split
+  // on the first two segments only.)
+  if (settingsKey.startsWith("user-api-key:")) {
+    const rest = settingsKey.slice("user-api-key:".length);
+    const colonIdx = rest.indexOf(":");
+    if (colonIdx <= 0) return null;
+    const provider = rest.slice(0, colonIdx);
+    const email = rest.slice(colonIdx + 1);
+    if (!provider || !email) return null;
+    return { provider, email };
+  }
+  // user-anthropic-api-key:<email> (legacy alias)
+  if (settingsKey.startsWith("user-anthropic-api-key:")) {
+    const email = settingsKey.slice("user-anthropic-api-key:".length);
+    if (!email) return null;
+    return { provider: "anthropic", email };
+  }
+  return null;
+}
+
+function secretKeyForProvider(provider: string): string {
+  return PROVIDER_TO_ENV[provider] ?? `${provider.toUpperCase()}_API_KEY`;
+}
+
+function maskApiKey(value: string): string {
+  if (!value) return "(empty)";
+  if (value.length <= 8) return "***";
+  return `${value.slice(0, 4)}…${value.slice(-4)} (len=${value.length})`;
+}
+
+export default async function dbMigrateUserApiKeys(
+  args: string[],
+): Promise<void> {
+  const parsed = parseArgs(args);
+
+  if (parsed.help === "true") {
+    console.log(`Usage: pnpm action db-migrate-user-api-keys [options]
+
+Copies legacy user-api-key:* + user-anthropic-api-key:* settings rows
+into app_secrets (encrypted, scope=user) and deletes the originals.
+
+Options:
+  --db <path>   Path to SQLite database (default: data/app.db)
+  --dry-run     Print what would be migrated without writing
+  --help        Show this help message`);
+    return;
+  }
+
+  const dryRun = parsed["dry-run"] === "true";
+
+  let url: string;
+  if (parsed.db) {
+    url = "file:" + path.resolve(parsed.db);
+  } else if (getDatabaseUrl()) {
+    url = getDatabaseUrl();
+  } else {
+    url = "file:" + path.resolve(process.cwd(), "data", "app.db");
+  }
+
+  const dbLabel = url.startsWith("file:")
+    ? url.slice("file:".length)
+    : new URL(url).host || url;
+  console.log(
+    `[migrate-user-api-keys] target: ${dbLabel}${dryRun ? "  (dry-run)" : ""}`,
+  );
+
+  const legacy = await fetchLegacyRows(url);
+  if (legacy.length === 0) {
+    console.log("[migrate-user-api-keys] nothing to migrate.");
+    return;
+  }
+
+  console.log(`[migrate-user-api-keys] found ${legacy.length} legacy row(s):`);
+  for (const row of legacy) {
+    const target = secretKeyForProvider(row.provider);
+    console.log(
+      `  - ${row.email}  ${row.provider} → app_secrets[${target}]  ${maskApiKey(row.apiKey)}`,
+    );
+  }
+  if (dryRun) return;
+
+  const { writeAppSecret } = await import("../../secrets/storage.js");
+
+  let migrated = 0;
+  let skipped = 0;
+  for (const row of legacy) {
+    try {
+      await writeAppSecret({
+        key: secretKeyForProvider(row.provider),
+        value: row.apiKey,
+        scope: "user",
+        scopeId: row.email,
+      });
+      await deleteLegacyRow(url, row.settingsKey);
+      migrated++;
+    } catch (err) {
+      console.error(
+        `  ! failed to migrate ${row.settingsKey}:`,
+        err instanceof Error ? err.message : err,
+      );
+      skipped++;
+    }
+  }
+
+  console.log(
+    `[migrate-user-api-keys] done. migrated=${migrated} skipped=${skipped}`,
+  );
+}
+
+async function fetchLegacyRows(url: string): Promise<LegacyRow[]> {
+  const out: LegacyRow[] = [];
+  if (isPostgresUrl(url)) {
+    const { default: pg } = await import("postgres");
+    const sql = pg(url);
+    try {
+      const rows = (await sql.unsafe(
+        `SELECT key, value FROM settings WHERE key LIKE 'user-api-key:%' OR key LIKE 'user-anthropic-api-key:%'`,
+      )) as unknown as Array<{ key: string; value: string }>;
+      for (const row of rows) {
+        const parsed = parseLegacyKey(row.key);
+        if (!parsed) continue;
+        const apiKey = extractKeyFromValue(row.value);
+        if (!apiKey) continue;
+        out.push({
+          settingsKey: row.key,
+          provider: parsed.provider,
+          email: parsed.email,
+          apiKey,
+        });
+      }
+    } finally {
+      await sql.end();
+    }
+    return out;
+  }
+
+  const client = createClient({ url, authToken: getDatabaseAuthToken() });
+  try {
+    const result = await client.execute({
+      sql: `SELECT key, value FROM settings WHERE key LIKE 'user-api-key:%' OR key LIKE 'user-anthropic-api-key:%'`,
+      args: [],
+    });
+    for (const row of result.rows) {
+      const settingsKey = row.key as string;
+      const value = row.value as string;
+      const parsed = parseLegacyKey(settingsKey);
+      if (!parsed) continue;
+      const apiKey = extractKeyFromValue(value);
+      if (!apiKey) continue;
+      out.push({
+        settingsKey,
+        provider: parsed.provider,
+        email: parsed.email,
+        apiKey,
+      });
+    }
+  } finally {
+    client.close();
+  }
+  return out;
+}
+
+function extractKeyFromValue(value: string): string | null {
+  // Settings rows store JSON. The save-key endpoint historically wrote
+  // `{ key: "sk-..." }`. Tolerate raw strings just in case.
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed === "string" && parsed.trim()) return parsed.trim();
+    if (parsed && typeof parsed.key === "string" && parsed.key.trim()) {
+      return parsed.key.trim();
+    }
+    return null;
+  } catch {
+    const trimmed = value.trim();
+    return trimmed || null;
+  }
+}
+
+async function deleteLegacyRow(url: string, key: string): Promise<void> {
+  if (isPostgresUrl(url)) {
+    const { default: pg } = await import("postgres");
+    const sql = pg(url);
+    try {
+      await sql.unsafe(`DELETE FROM settings WHERE key = $1`, [key]);
+    } finally {
+      await sql.end();
+    }
+    return;
+  }
+  const client = createClient({ url, authToken: getDatabaseAuthToken() });
+  try {
+    await client.execute({
+      sql: `DELETE FROM settings WHERE key = ?`,
+      args: [key],
+    });
+  } finally {
+    client.close();
+  }
+}

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -306,8 +306,9 @@ async function bootstrapDefaultPlugins(nitroApp: any): Promise<void> {
       const ws = await getWorkspaceCoreExports(cwd);
       if (ws && Object.keys(ws.plugins).length > 0) {
         try {
-          const wsServerModule = await import(
-            /* @vite-ignore */ `${ws.packageName}/server`
+          const wsServerModule = await loadWorkspaceCoreServer(
+            ws.packageName,
+            ws.packageDir,
           );
           for (const [slot, exportName] of Object.entries(ws.plugins)) {
             if (!exportName) continue;
@@ -354,6 +355,48 @@ async function bootstrapDefaultPlugins(nitroApp: any): Promise<void> {
     }
   } finally {
     IN_BOOTSTRAP.delete(nitroApp);
+  }
+}
+
+/**
+ * Load a workspace-core's `/server` entry, transparently handling TS source.
+ *
+ * The scaffolded workspace-core template ships TS sources without a build
+ * step (exports point at `./src/server/index.ts`), so plain `await import()`
+ * blows up the moment Node hits a relative `.js` import inside (the standard
+ * TS ESM convention). Try Node's plain `import()` first — fastest path when
+ * the user has compiled to dist/ — then fall back to jiti, which handles TS
+ * source files and re-maps the `.js` ESM extension convention back to `.ts`
+ * at resolve time.
+ *
+ * Edge runtimes without `fs` won't be able to load jiti at all; the outer
+ * try/catch silently falls through to framework defaults in that case.
+ */
+async function loadWorkspaceCoreServer(
+  packageName: string,
+  packageDir: string,
+): Promise<any> {
+  try {
+    return await import(/* @vite-ignore */ `${packageName}/server`);
+  } catch (firstErr) {
+    const msg = (firstErr as Error)?.message ?? "";
+    const looksLikeTsResolution =
+      /\.js' imported from .*\.ts/.test(msg) ||
+      /Cannot find module .*\.js' imported/.test(msg) ||
+      /Unknown file extension "\.ts"/.test(msg);
+    if (!looksLikeTsResolution) throw firstErr;
+
+    const { createJiti } = await import("jiti");
+    const { pathToFileURL } = await import("node:url");
+    const path = await import("node:path");
+    // Anchor jiti to a real file inside the workspace-core package so its
+    // module resolution starts in the right node_modules tree (handles pnpm
+    // hoisting and linked workspaces).
+    const anchor = pathToFileURL(
+      path.join(packageDir, "package.json"),
+    ).toString();
+    const jiti = createJiti(anchor, { interopDefault: true });
+    return await jiti.import(`${packageName}/server`);
   }
 }
 

--- a/packages/core/src/terminal/terminal-plugin.ts
+++ b/packages/core/src/terminal/terminal-plugin.ts
@@ -44,6 +44,11 @@ import { defineEventHandler } from "h3";
       }
     }
   } catch (err) {
+    // node-pty not installed → stay silent here; createTerminalPlugin emits
+    // the "install node-pty" message when the PTY server actually fails to
+    // start. Logging twice for the same root cause just adds noise.
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND") return;
     console.warn(
       "[terminal] Could not verify node-pty spawn-helper permissions:",
       (err as Error).message,
@@ -198,17 +203,34 @@ export function createTerminalPlugin(options: TerminalPluginOptions = {}) {
     } catch (err) {
       // Clear the running flag so a retry can spawn a fresh server
       delete process.env.__AGENT_TERMINAL_RUNNING;
-      console.error("[terminal] Failed to start PTY server:", err);
-      console.error(
-        "[terminal] Make sure node-pty is installed: pnpm add node-pty",
-      );
+
+      // Distinguish "node-pty not installed" (expected when the user opts
+      // out of the terminal feature) from real failures (port conflict,
+      // native binding mismatch). Native deps are optional — log as info
+      // so the dev console isn't filled with red noise.
+      const code = (err as NodeJS.ErrnoException)?.code;
+      const missingPty =
+        code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
+      if (missingPty) {
+        console.log(
+          "[terminal] node-pty not installed — embedded terminal disabled. " +
+            "Install with `pnpm add node-pty` to enable.",
+        );
+      } else {
+        console.error("[terminal] Failed to start PTY server:", err);
+        console.error(
+          "[terminal] If node-pty is installed but PTY fails to spawn, " +
+            "try `pnpm rebuild node-pty` (common after switching Node " +
+            "versions via fnm/nvm).",
+        );
+      }
 
       // Mount a fallback info endpoint
       getH3App(nitroApp).use(
         "/_agent-native/agent-terminal-info",
         defineEventHandler(() => ({
           available: false,
-          error: "PTY server failed to start",
+          error: missingPty ? "node-pty not installed" : "PTY server failed",
         })),
       );
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       isbot:
         specifier: ^5
         version: 5.1.37
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
       jose:
         specifier: ^6.2.2
         version: 6.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,4 @@ onlyBuiltDependencies:
   - lightningcss
   - electron
   - "@swc/core"
+  - node-pty


### PR DESCRIPTION
## Summary

Dispatch was getting "fetch failed" on Slack analytics questions because the analytics A2A reply takes >30s and Netlify's gateway times out. The async branch existed but relied on a detached promise that gets killed when Lambda flushes the response, so polls hung in `working` forever.

This swaps the detached-promise path for the same cross-platform self-fire pattern the integration webhook queue already uses:

- `handleSend` (async mode) writes verified caller identity into the task's `metadata` column, then fire-and-forgets a signed POST to `/_agent-native/a2a/_process-task` on the same deployment and returns immediately in `working` state.
- `mountA2A` mounts the new processor route. It validates the HMAC token (`signInternalToken`/`verifyInternalToken`, A2A_SECRET-keyed, 5-min lifetime — same as the webhook queue), atomically claims the task via the new `claimA2ATaskForProcessing`, rebuilds the request context, and runs the handler with the fresh function's full timeout budget.
- `callAgent` flips its default to `async: true` so cross-app calls get the safe behavior out of the box.

Existing async-mode behavior on the receiver (task-store create/update) is unchanged from the wire perspective — `tasks/get` keeps returning the same shape — so existing pollers (including the one in `A2AClient.sendAndWait`) work without changes.

## Test plan

- [x] `pnpm --filter @agent-native/core test` — all 488 tests pass
- [x] `pnpm prep` — fmt + typecheck across all templates
- [ ] After merge + deploy: send Slack `@agent-native how many signups did we get yesterday?` and verify dispatch returns the analytics answer instead of the "didn't reply in time / fetch failed" fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)