### PR TITLE
fix(auth): exempt A2A async processor route from session auth

### DIFF
--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -628,6 +628,16 @@ function createAuthGuardFn(): (
       return;
     }
 
+    // Internal processor endpoint for the A2A async-mode fanout. Mirrors the
+    // integration webhook fanout: when `message/send` is called with
+    // `async: true`, the JSON-RPC handler enqueues to a2a_tasks and self-
+    // fires a POST here so the handler runs in a fresh function execution.
+    // Authenticity is verified via an HMAC token signed with A2A_SECRET
+    // (same scheme as /_agent-native/integrations/process-task).
+    if (p === "/_agent-native/a2a/_process-task") {
+      return;
+    }
+
     // A2A secret receive endpoint — verifies authenticity via JWT signed
     // with the calling app's A2A secret, not via session cookies. Used to
     // sync the org A2A secret across connected apps.


### PR DESCRIPTION
## Summary

#344 added the A2A async-mode self-fire to `/_agent-native/a2a/_process-task`, but the framework auth guard's exemption list only matched the literal `/_agent-native/a2a` path. So when dispatch's async send caused analytics to self-fire to its own processor route, the auth guard rejected the signed POST with a generic `401 Unauthorized` *before* the route's HMAC check ran — every async task stayed stuck in `working` forever.

Verified live: an async `message/send` to `analytics.agent-native.com` created the task with the new `__a2a_processor` metadata shape, but no processor invocation was recorded against it. A manual signed POST to `/_agent-native/a2a/_process-task` returned `401 {"error":"Unauthorized"}` — the framework auth guard's response, not the route's HMAC failure (which would be a JSON-RPC envelope).

This adds the exemption alongside the existing `/_agent-native/integrations/process-task` one. Authenticity is still enforced by the route's own `verifyInternalToken` HMAC check (5-min lifetime, A2A_SECRET-keyed).

## Test plan

- [ ] After deploy: re-run an async `message/send` to analytics, poll `tasks/get`, verify the task transitions to `completed` with a real answer instead of staying in `working`.
- [ ] Re-fire the synthetic Slack `@agent-native how many signups did we get yesterday?` and verify dispatch returns the analytics answer instead of "didn't reply in time / fetch failed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)