### PR TITLE
fix(a2a): mount _process-task before /a2a (h3 prefix swallow) + concurrent sweep

### DIFF
--- a/packages/core/docs/content/template-clips.md
+++ b/packages/core/docs/content/template-clips.md
@@ -30,10 +30,6 @@ Three things make Clips a good showcase of what agent-native enables:
 
 The rest of this doc is for anyone forking the Clips template or extending it.
 
-### Naming note
-
-In the template, always say **"Clip"** in user-facing strings and agent messages. Internal table / variable names (`recordings`, `recording_transcripts`, etc.) stay as-is.
-
 ### Scaffolding
 
 ```bash
@@ -44,13 +40,15 @@ Clips is a larger template with a native recorder (it ships a desktop companion 
 
 ### Customize it
 
-Ask the agent:
+Clips is a full cloneable SaaS — fork it and ask the agent to extend it. Some examples:
 
-- "Add a 'filler word removal' button that strips ums and uhs from the transcript and re-stitches the video." It edits the transcript processor and wires the UI.
-- "Auto-post a new clip to Slack #eng-demos when I record one." It adds the hook.
-- "Group the library by project — detect the project from the first words of each transcript." It updates the list view.
+- "Add a filler-word removal button that strips ums and uhs from the transcript and re-stitches the video."
+- "Auto-post a new clip to Slack #eng-demos whenever I finish a recording." (Connect Slack first via [Messaging](/docs/messaging).)
+- "Group the library by project — detect the project from the first words of each transcript."
+- "Add a 'Generate blog post from this clip' button that drafts a post from the transcript and saves it as a draft."
+- "Let viewers leave timestamped reactions on a shared clip."
 
-See [Cloneable SaaS](/docs/cloneable-saas) for the full clone → customize → deploy flow.
+The agent edits routes, components, the transcript pipeline, and the schema as needed. See [Cloneable SaaS](/docs/cloneable-saas) for the full clone, customize, deploy flow, and [Getting Started](/docs/getting-started) if this is your first agent-native template.
 
 ## What's next
 

--- a/packages/core/docs/content/template-dispatch.md
+++ b/packages/core/docs/content/template-dispatch.md
@@ -29,7 +29,20 @@ Use Dispatch when:
 
 Skip it for a single-app scaffold — use the [Starter template](/docs/template-starter) or any of the domain templates directly.
 
+## What you'll do with it {#what-youll-do}
+
+Day-to-day, Dispatch is the place admins and ops folks open to keep the workspace running:
+
+- **Connect Slack, email, and Telegram** so people can message your agent from wherever they already work. See [Messaging](/docs/messaging) for the wiring steps.
+- **Save shared secrets once.** API keys, OAuth tokens, and service credentials live in the vault and the other apps in your workspace pull from there instead of every team member juggling their own `.env`.
+- **Set up recurring jobs.** "Every Monday at 7am, ask the analytics agent for last week's signups and email me a summary." See [Recurring Jobs](/docs/recurring-jobs).
+- **Approve outbound actions before they fire.** Sending money, mass-emailing customers, or posting to a public Slack channel can be gated behind an admin OK.
+- **See who has access to what.** Per-app grants, request queue, and an audit log of who used which secret when.
+- **Route messages to the right specialist.** A Slack DM about analytics goes to the analytics agent; one about email goes to the mail agent — Dispatch picks.
+
 ## Architecture at a glance {#architecture}
+
+_How it works under the hood (for developers)._
 
 - **Orchestrator agent.** The chat is set up as a router: it reads `AGENTS.md`, `LEARNINGS.md`, and routes to specialist sub-agents or remote A2A agents.
 - **Remote agent registry.** A2A manifests live in `remote-agents/*.json` — one per app. Dispatch calls them using the `call-agent` action.

--- a/packages/core/docs/content/template-forms.md
+++ b/packages/core/docs/content/template-forms.md
@@ -20,7 +20,7 @@ When you open the app, you'll see a list of your forms on the left and the edito
 
 ## Why it's interesting
 
-Forms is a clear example of the [ladder](/docs/what-is-agent-native#the-ladder) rung-3 payoff. The hard part of a form builder isn't the editor UI — it's everything around it: schema evolution, response analytics, conditional logic, publishing, notifications, integrations. Most of that is just prompting the agent, because every capability is an action the agent can call.
+The hard part of a form builder isn't the editor UI — it's everything around it: changing the questions after responses are already in, analyzing what people said, adding conditional logic, publishing, notifications, hooking it into Slack or your CRM. Most of that is just asking the agent. See [What is agent-native?](/docs/what-is-agent-native) for the bigger picture.
 
 ## For developers
 
@@ -38,13 +38,14 @@ pnpm dlx @agent-native/core create my-platform  # pick Forms + other templates
 
 ### Customize it
 
-Ask the agent:
+Ask the agent for the outcome you want:
 
-- "Add a new 'signature' field type that captures a drawn signature." It adds the schema entry, renders the component, handles storage.
-- "When someone submits a form, post the response to our #signups Slack channel." It wires the webhook.
-- "Add per-form access control — some are public, some require a login." It updates the publishing flow.
+- "Add a signature field where people can draw their name."
+- "When someone submits this form, post it in our #signups Slack channel." (Connect Slack first via [Messaging](/docs/messaging).)
+- "Make some forms public and others login-only."
+- "Send everyone who scored below 5 a follow-up email asking what we could do better."
 
-See [Cloneable SaaS](/docs/cloneable-saas) for the full clone → customize → deploy flow.
+The agent figures out the schema changes, components, and storage on its own — you just describe the result you want. See [Cloneable SaaS](/docs/cloneable-saas) for the full clone, customize, deploy flow.
 
 ## What's next
 

--- a/packages/core/src/a2a/server.ts
+++ b/packages/core/src/a2a/server.ts
@@ -104,6 +104,57 @@ export function mountA2A(
     }),
   );
 
+  // Async-mode processor route. MUST be mounted BEFORE the `/a2a` catch-all
+  // below, since h3's `.use()` matches by prefix and `/a2a` would otherwise
+  // swallow `/a2a/_process-task` and return a JSON-RPC "Invalid token" error
+  // (the JSON-RPC handler doesn't know about taskId-only bodies).
+  //
+  // When `message/send` is called with `async: true`, the JSON-RPC handler
+  // enqueues the task and self-fires a POST to this route on the same
+  // deployment so the actual handler runs in a fresh function execution (its
+  // own full timeout). Authenticated with an HMAC token bound to the task id
+  // (5-minute lifetime, signed with A2A_SECRET — same scheme as the
+  // integration webhook queue).
+  getH3App(nitroApp).use(
+    `${routePrefix}/a2a/_process-task`,
+    defineEventHandler(async (event) => {
+      if (getMethod(event) !== "POST") {
+        setResponseStatus(event, 405);
+        return { error: "Method not allowed" };
+      }
+
+      const body = (await readBody(event)) as { taskId?: unknown } | null;
+      const taskId = body && typeof body.taskId === "string" ? body.taskId : "";
+      if (!taskId) {
+        setResponseStatus(event, 400);
+        return { error: "taskId required" };
+      }
+
+      // When A2A_SECRET is set, require a valid HMAC token bound to this
+      // taskId. Without a secret, accept unsigned dispatches — the task
+      // store claim is atomic and the body only carries an opaque task id,
+      // so an unsigned dispatch is bounded in damage to re-running already-
+      // queued work that the original sender already approved.
+      if (process.env.A2A_SECRET) {
+        const auth = getRequestHeader(event, "authorization");
+        const tok = extractBearerToken(auth);
+        if (!verifyInternalToken(taskId, tok)) {
+          setResponseStatus(event, 401);
+          return { error: "Invalid or expired processor token" };
+        }
+      }
+
+      try {
+        await processA2ATaskFromQueue(taskId, config);
+        return { ok: true };
+      } catch (err: any) {
+        console.error("[a2a] process-task failed:", err);
+        setResponseStatus(event, 500);
+        return { error: err?.message ?? "process-task failed" };
+      }
+    }),
+  );
+
   // JSON-RPC A2A endpoint (with optional auth)
   getH3App(nitroApp).use(
     `${routePrefix}/a2a`,
@@ -112,6 +163,14 @@ export function mountA2A(
         setResponseStatus(event, 405);
         return { error: "Method not allowed" };
       }
+
+      // h3 prefix-matches mounts, so a request to `/a2a/_process-task`
+      // reaches this handler too. The dedicated mount above runs first and
+      // takes the request, but if that returns `undefined` (or h3 ever
+      // changes ordering semantics) defensively bail here. event.path is
+      // stripped to the remainder after the mount prefix.
+      const sub = (event.path || "/").split("?")[0].replace(/^\//, "");
+      if (sub.startsWith("_process-task")) return;
 
       const authHeader = getRequestHeader(event, "authorization");
       let verifiedCallerEmail: string | null = null;
@@ -171,55 +230,6 @@ export function mountA2A(
 
       const body = await readBody(event);
       return handleJsonRpcH3(body, event, config);
-    }),
-  );
-
-  // Async-mode processor route. When `message/send` is called with
-  // `async: true`, the JSON-RPC handler enqueues the task and self-fires a
-  // POST to this route on the same deployment so the actual handler runs in
-  // a fresh function execution (its own full timeout). Authenticated with an
-  // HMAC token bound to the task id (5-minute lifetime, signed with
-  // A2A_SECRET — the same scheme the integration webhook queue uses).
-  getH3App(nitroApp).use(
-    `${routePrefix}/a2a/_process-task`,
-    defineEventHandler(async (event) => {
-      if (getMethod(event) !== "POST") {
-        setResponseStatus(event, 405);
-        return { error: "Method not allowed" };
-      }
-
-      const body = (await readBody(event)) as { taskId?: unknown } | null;
-      const taskId = body && typeof body.taskId === "string" ? body.taskId : "";
-      if (!taskId) {
-        setResponseStatus(event, 400);
-        return { error: "taskId required" };
-      }
-
-      // When A2A_SECRET is set, require a valid HMAC token bound to this
-      // taskId. Without a secret, accept unsigned dispatches — the task store
-      // claim is atomic and the body only carries an opaque task id, so an
-      // unsigned dispatch is bounded in damage to re-running already-queued
-      // work that the original sender already approved.
-      if (process.env.A2A_SECRET) {
-        const auth = getRequestHeader(event, "authorization");
-        const token = extractBearerToken(auth);
-        if (!verifyInternalToken(taskId, token)) {
-          setResponseStatus(event, 401);
-          return { error: "Invalid or expired processor token" };
-        }
-      }
-
-      // Run the handler in this fresh function execution. We await so any
-      // exception surfaces in logs, but the response body is just an
-      // acknowledgement — the actual result lives on the task row.
-      try {
-        await processA2ATaskFromQueue(taskId, config);
-        return { ok: true };
-      } catch (err: any) {
-        console.error("[a2a] process-task failed:", err);
-        setResponseStatus(event, 500);
-        return { error: err?.message ?? "process-task failed" };
-      }
     }),
   );
 }

--- a/packages/core/src/integrations/adapters/email.ts
+++ b/packages/core/src/integrations/adapters/email.ts
@@ -52,21 +52,29 @@ export function emailAdapter(): PlatformAdapter {
           key: "EMAIL_AGENT_ADDRESS",
           label: "Agent Email Address",
           required: true,
+          helpText:
+            "The email address people will use to message your agent (e.g. `agent@yourcompany.com`, or pick from your `<slug>.resend.app` sandbox).",
         },
         {
           key: "RESEND_API_KEY",
-          label: "Resend API Key (or use SENDGRID_API_KEY)",
+          label: "Resend API Key",
           required: false,
+          helpText:
+            "From resend.com → API keys (starts with `re_`). Either Resend or SendGrid is required for sending and receiving mail.",
         },
         {
           key: "SENDGRID_API_KEY",
-          label: "SendGrid API Key (or use RESEND_API_KEY)",
+          label: "SendGrid API Key",
           required: false,
+          helpText:
+            "From sendgrid.com → Settings → API Keys (starts with `SG.`). Either Resend or SendGrid is required.",
         },
         {
           key: "EMAIL_INBOUND_WEBHOOK_SECRET",
           label: "Inbound Webhook Secret",
           required: false,
+          helpText:
+            "Optional. From Resend (Webhooks → Signing Secret, starts with `whsec_`) or your SendGrid Inbound Parse basic-auth password. Used to verify inbound webhooks are real.",
         },
       ];
     },

--- a/packages/core/src/integrations/adapters/slack.ts
+++ b/packages/core/src/integrations/adapters/slack.ts
@@ -32,11 +32,15 @@ export function slackAdapter(): PlatformAdapter {
           key: "SLACK_BOT_TOKEN",
           label: "Slack Bot Token",
           required: true,
+          helpText:
+            "In your Slack app's left nav: OAuth & Permissions → Bot User OAuth Token (starts with `xoxb-`).",
         },
         {
           key: "SLACK_SIGNING_SECRET",
           label: "Slack Signing Secret",
           required: true,
+          helpText:
+            "In your Slack app's left nav: Basic Information → App Credentials → Signing Secret.",
         },
       ];
     },

--- a/packages/core/src/integrations/adapters/telegram.ts
+++ b/packages/core/src/integrations/adapters/telegram.ts
@@ -33,11 +33,15 @@ export function telegramAdapter(): PlatformAdapter {
           key: "TELEGRAM_BOT_TOKEN",
           label: "Telegram Bot Token",
           required: true,
+          helpText:
+            "From @BotFather after `/newbot` — the long token Telegram gives you (looks like `123456:ABC-DEF...`).",
         },
         {
           key: "TELEGRAM_WEBHOOK_SECRET",
           label: "Telegram Webhook Secret",
           required: false,
+          helpText:
+            "Optional. Any random string — Telegram will echo it on every webhook so dispatch can verify the request came from Telegram.",
         },
       ];
     },

--- a/packages/core/src/integrations/adapters/whatsapp.ts
+++ b/packages/core/src/integrations/adapters/whatsapp.ts
@@ -34,21 +34,29 @@ export function whatsappAdapter(): PlatformAdapter {
           key: "WHATSAPP_ACCESS_TOKEN",
           label: "WhatsApp Access Token",
           required: true,
+          helpText:
+            "From your Meta app → WhatsApp → API Setup → Permanent access token. Generate one under System Users for production use.",
         },
         {
           key: "WHATSAPP_VERIFY_TOKEN",
           label: "WhatsApp Verify Token",
           required: true,
+          helpText:
+            "Any random string you choose. You'll paste the same value into Meta's webhook configuration so Meta can confirm dispatch owns the URL.",
         },
         {
           key: "WHATSAPP_PHONE_NUMBER_ID",
           label: "WhatsApp Phone Number ID",
           required: true,
+          helpText:
+            "From your Meta app → WhatsApp → API Setup. The numeric Phone number ID (not the actual phone number).",
         },
         {
           key: "WHATSAPP_APP_SECRET",
           label: "WhatsApp App Secret",
           required: false,
+          helpText:
+            "Optional. From Meta App Dashboard → Basic Settings → App Secret. Enables HMAC signature verification on inbound webhooks.",
         },
       ];
     },

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -162,6 +162,13 @@ export function createIntegrationsPlugin(
           const config = await getIntegrationConfig(adapter.platform);
           status.enabled = !!config?.configData?.enabled;
           status.webhookUrl = `${baseUrl}${P}/${adapter.platform}/webhook`;
+          if (!status.requiredEnvKeys) {
+            try {
+              status.requiredEnvKeys = adapter.getRequiredEnvKeys();
+            } catch {
+              status.requiredEnvKeys = [];
+            }
+          }
           statuses.push(status);
         }
         return statuses;
@@ -311,6 +318,13 @@ export function createIntegrationsPlugin(
           const config = await getIntegrationConfig(platform);
           status.enabled = !!config?.configData?.enabled;
           status.webhookUrl = `${baseUrl}${P}/${platform}/webhook`;
+          if (!status.requiredEnvKeys) {
+            try {
+              status.requiredEnvKeys = adapter.getRequiredEnvKeys();
+            } catch {
+              status.requiredEnvKeys = [];
+            }
+          }
           return status;
         }
 

--- a/packages/core/src/integrations/types.ts
+++ b/packages/core/src/integrations/types.ts
@@ -62,6 +62,10 @@ export interface IntegrationStatus {
   error?: string;
   /** The webhook URL that should be configured in the platform */
   webhookUrl?: string;
+  /** The full list of env keys (required + optional) the adapter recognizes,
+   *  including UI hints. Surfaced on the integrations status endpoint so the
+   *  frontend can render fields without hard-coding them per platform. */
+  requiredEnvKeys?: import("../server/create-server.js").EnvKeyConfig[];
 }
 
 /**

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -628,6 +628,16 @@ function createAuthGuardFn(): (
       return;
     }
 
+    // Internal processor endpoint for the A2A async-mode fanout. Mirrors the
+    // integration webhook fanout: when `message/send` is called with
+    // `async: true`, the JSON-RPC handler enqueues to a2a_tasks and self-
+    // fires a POST here so the handler runs in a fresh function execution.
+    // Authenticity is verified via an HMAC token signed with A2A_SECRET
+    // (same scheme as /_agent-native/integrations/process-task).
+    if (p === "/_agent-native/a2a/_process-task") {
+      return;
+    }
+
     // A2A secret receive endpoint — verifies authenticity via JWT signed
     // with the calling app's A2A secret, not via session cookies. Used to
     // sync the org A2A secret across connected apps.

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -631,6 +631,7 @@ export function createCoreRoutesPlugin(
             label: cfg.label,
             required: cfg.required ?? false,
             configured: !!process.env[cfg.key],
+            ...(cfg.helpText ? { helpText: cfg.helpText } : {}),
           })),
         ),
       );

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -19,6 +19,8 @@ export interface EnvKeyConfig {
   label: string;
   /** Whether this key is required for the app to function */
   required?: boolean;
+  /** Optional UI hint shown next to the field describing where to find this value. */
+  helpText?: string;
 }
 
 export interface CreateServerOptions {
@@ -220,6 +222,7 @@ export function createServer(
           label: cfg.label,
           required: cfg.required ?? false,
           configured: !!process.env[cfg.key],
+          ...(cfg.helpText ? { helpText: cfg.helpText } : {}),
         }));
       }),
     );

--- a/templates/clips/app/components/library/filter-chips.tsx
+++ b/templates/clips/app/components/library/filter-chips.tsx
@@ -41,7 +41,9 @@ export function FilterChips({ chips, className }: FilterChipsProps) {
               }}
               className={cn(
                 "rounded-full hover:opacity-80",
-                chip.active ? "text-white/80" : "text-muted-foreground",
+                chip.active
+                  ? "text-primary-foreground/80"
+                  : "text-muted-foreground",
               )}
             >
               <IconX className="h-3 w-3" />

--- a/templates/clips/app/components/player/access-password-prompt.tsx
+++ b/templates/clips/app/components/player/access-password-prompt.tsx
@@ -17,7 +17,7 @@ export function AccessPasswordPrompt({
   const [value, setValue] = useState("");
 
   return (
-    <div className="flex items-center justify-center min-h-screen p-6 bg-[#0a0a0a]">
+    <div className="flex items-center justify-center min-h-screen p-6 bg-background">
       <div className="max-w-sm w-full rounded-2xl bg-card border border-border p-6 space-y-4 shadow-xl">
         <div className="flex items-center gap-2 text-primary">
           <IconLock className="h-5 w-5" />

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -202,18 +202,18 @@ export default function ShareRoute() {
       : "Uploading and assembling the video. This page will update automatically.";
 
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen bg-[#0a0a0a] text-white px-6">
+      <div className="flex flex-col items-center justify-center min-h-screen bg-background text-foreground px-6">
         {!explicitFailure ? (
           <Spinner className="h-8 w-8 mb-4 text-white/70" />
         ) : null}
         <h1 className="text-lg font-semibold mb-1">{label}</h1>
-        <p className="text-sm text-white/60 mb-4 max-w-md text-center">
+        <p className="text-sm text-muted-foreground mb-4 max-w-md text-center">
           {message}
         </p>
         {!explicitFailure && progress > 0 ? (
-          <div className="w-64 h-1.5 rounded-full bg-white/10 overflow-hidden mb-4">
+          <div className="w-64 h-1.5 rounded-full bg-accent overflow-hidden mb-4">
             <div
-              className="h-full bg-white"
+              className="h-full bg-foreground"
               style={{ width: `${Math.min(100, Math.max(0, progress))}%` }}
             />
           </div>
@@ -222,7 +222,7 @@ export default function ShareRoute() {
           onClick={() => dataQ.refetch()}
           variant="outline"
           size="sm"
-          className="border-white/20 bg-white/5 hover:bg-white/10 text-white"
+          className="border-foreground/20 bg-muted/50 hover:bg-accent text-foreground"
         >
           Check again
         </Button>
@@ -231,7 +231,7 @@ export default function ShareRoute() {
   }
 
   return (
-    <div className="min-h-screen bg-[#0a0a0a] text-white">
+    <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <div className="h-8 w-8 rounded-md bg-primary flex items-center justify-center text-primary-foreground font-bold text-sm">
@@ -241,7 +241,7 @@ export default function ShareRoute() {
         </div>
         <a
           href="/"
-          className="text-xs text-white/60 hover:text-white flex items-center gap-1"
+          className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
         >
           Try Clips <IconExternalLink className="h-3 w-3" />
         </a>
@@ -307,7 +307,7 @@ export default function ShareRoute() {
               size="sm"
               onClick={downloadRecording}
               disabled={downloading}
-              className="border-white/20 bg-white/5 hover:bg-white/10 text-white"
+              className="border-foreground/20 bg-muted/50 hover:bg-accent text-foreground"
             >
               {downloading ? "Downloading..." : "Download MP4"}
             </Button>

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -24,8 +24,8 @@ export function meta() {
 
 export function HydrateFallback() {
   return (
-    <div className="flex items-center justify-center h-screen w-full bg-black">
-      <Spinner className="h-8 w-8 text-white/70" />
+    <div className="flex items-center justify-center h-screen w-full bg-background">
+      <Spinner className="h-8 w-8 text-muted-foreground" />
     </div>
   );
 }
@@ -148,8 +148,8 @@ export default function ShareRoute() {
 
   if (dataQ.isLoading) {
     return (
-      <div className="flex items-center justify-center h-screen w-full bg-black">
-        <Spinner className="h-8 w-8 text-white/70" />
+      <div className="flex items-center justify-center h-screen w-full bg-background">
+        <Spinner className="h-8 w-8 text-muted-foreground" />
       </div>
     );
   }
@@ -204,7 +204,7 @@ export default function ShareRoute() {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen bg-background text-foreground px-6">
         {!explicitFailure ? (
-          <Spinner className="h-8 w-8 mb-4 text-white/70" />
+          <Spinner className="h-8 w-8 mb-4 text-muted-foreground" />
         ) : null}
         <h1 className="text-lg font-semibold mb-1">{label}</h1>
         <p className="text-sm text-muted-foreground mb-4 max-w-md text-center">
@@ -272,7 +272,7 @@ export default function ShareRoute() {
             <div className="flex-1 min-w-0">
               <h1 className="text-xl font-semibold">{recording.title}</h1>
               {recording.description ? (
-                <p className="text-sm text-white/70 mt-1 whitespace-pre-wrap">
+                <p className="text-sm text-foreground/70 mt-1 whitespace-pre-wrap">
                   {recording.description}
                 </p>
               ) : null}
@@ -316,7 +316,7 @@ export default function ShareRoute() {
 
         <aside className="min-w-0">
           <Tabs defaultValue="transcript" className="flex flex-col">
-            <TabsList className="w-full bg-white/5">
+            <TabsList className="w-full bg-muted/50">
               <TabsTrigger value="transcript" className="flex-1">
                 Transcript
               </TabsTrigger>
@@ -327,7 +327,7 @@ export default function ShareRoute() {
               ) : null}
             </TabsList>
             <TabsContent value="transcript" className="mt-3">
-              <div className="rounded-lg border border-white/10 bg-white/5 h-[600px] overflow-hidden">
+              <div className="rounded-lg border border-border bg-muted/50 h-[600px] overflow-hidden">
                 <TranscriptPanel
                   segments={transcriptSegments}
                   currentMs={currentMs}
@@ -340,7 +340,7 @@ export default function ShareRoute() {
             </TabsContent>
             {recording.enableComments ? (
               <TabsContent value="comments" className="mt-3">
-                <div className="rounded-lg border border-white/10 bg-white/5 h-[600px] overflow-hidden">
+                <div className="rounded-lg border border-border bg-muted/50 h-[600px] overflow-hidden">
                   <CommentsPanel
                     recordingId={recording.id}
                     comments={comments}
@@ -384,9 +384,9 @@ function sanitizeFilename(name: string): string {
 
 function EndState({ title, message }: { title: string; message: string }) {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-[#0a0a0a] text-white px-6">
+    <div className="flex flex-col items-center justify-center min-h-screen bg-background text-foreground px-6">
       <h1 className="text-2xl font-semibold mb-2">{title}</h1>
-      <p className="text-sm text-white/60 mb-6">{message}</p>
+      <p className="text-sm text-muted-foreground mb-6">{message}</p>
       <a href="/" className="text-sm text-primary hover:underline">
         Go home
       </a>

--- a/templates/design/app/components/design-system/DesignSystemCard.tsx
+++ b/templates/design/app/components/design-system/DesignSystemCard.tsx
@@ -28,7 +28,7 @@ export function DesignSystemCard({
 
   return (
     <div
-      className="group relative rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] hover:border-white/[0.12] overflow-hidden cursor-pointer"
+      className="group relative rounded-xl border border-border bg-card hover:border-border overflow-hidden cursor-pointer"
       onClick={onClick}
     >
       <div
@@ -39,7 +39,7 @@ export function DesignSystemCard({
           {swatchColors.map((s) => (
             <div
               key={s.label}
-              className="w-6 h-6 rounded-full border border-white/10 shrink-0"
+              className="w-6 h-6 rounded-full border border-border shrink-0"
               style={{ background: s.color }}
               title={s.label}
             />
@@ -75,16 +75,16 @@ export function DesignSystemCard({
       <div className="p-4 flex items-start justify-between gap-2">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
-            <IconPalette className="w-3.5 h-3.5 text-white/30 shrink-0" />
-            <h3 className="font-medium text-sm text-white/90 truncate">
+            <IconPalette className="w-3.5 h-3.5 text-muted-foreground/70 shrink-0" />
+            <h3 className="font-medium text-sm text-foreground truncate">
               {title}
             </h3>
           </div>
-          <div className="text-xs text-white/30 mt-1 flex items-center gap-2">
+          <div className="text-xs text-muted-foreground/70 mt-1 flex items-center gap-2">
             <span>{data.typography.headingFont}</span>
             {data.typography.headingFont !== data.typography.bodyFont && (
               <>
-                <span className="text-white/10">|</span>
+                <span className="text-muted-foreground/40">|</span>
                 <span>{data.typography.bodyFont}</span>
               </>
             )}
@@ -101,13 +101,13 @@ export function DesignSystemCard({
             e.stopPropagation();
             onSetDefault();
           }}
-          className="shrink-0 p-1 rounded hover:bg-white/[0.06] cursor-pointer"
+          className="shrink-0 p-1 rounded hover:bg-accent cursor-pointer"
           title={isDefault ? "Default design system" : "Set as default"}
         >
           {isDefault ? (
             <IconStarFilled className="w-4 h-4 text-[#609FF8]" />
           ) : (
-            <IconStar className="w-4 h-4 text-white/20 group-hover:text-white/40" />
+            <IconStar className="w-4 h-4 text-muted-foreground/60 group-hover:text-muted-foreground" />
           )}
         </button>
       </div>

--- a/templates/design/app/components/design/DrawOverlay.tsx
+++ b/templates/design/app/components/design/DrawOverlay.tsx
@@ -270,7 +270,7 @@ export function DrawOverlay({ visible, onQueue, onSend }: DrawOverlayProps) {
       )}
 
       {/* Bottom toolbar */}
-      <div className="absolute bottom-4 left-1/2 z-30 flex -translate-x-1/2 items-center gap-2 rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] px-3 py-2 shadow-2xl backdrop-blur-sm">
+      <div className="absolute bottom-4 left-1/2 z-30 flex -translate-x-1/2 items-center gap-2 rounded-xl border border-border bg-card px-3 py-2 shadow-2xl backdrop-blur-sm">
         {/* Color picker */}
         <div className="flex gap-1">
           {PRESET_COLORS.map((preset) => (
@@ -289,7 +289,7 @@ export function DrawOverlay({ visible, onQueue, onSend }: DrawOverlayProps) {
           ))}
         </div>
 
-        <div className="mx-1 h-4 w-px bg-white/10" />
+        <div className="mx-1 h-4 w-px bg-accent" />
 
         {/* Line widths */}
         <div className="flex gap-1">
@@ -300,8 +300,8 @@ export function DrawOverlay({ visible, onQueue, onSend }: DrawOverlayProps) {
               className={cn(
                 "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
                 lineWidth === lw.value
-                  ? "bg-white/10 text-white"
-                  : "text-white/30 hover:text-white/50",
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground/70 hover:text-muted-foreground",
               )}
               title={lw.label}
             >
@@ -313,7 +313,7 @@ export function DrawOverlay({ visible, onQueue, onSend }: DrawOverlayProps) {
           ))}
         </div>
 
-        <div className="mx-1 h-4 w-px bg-white/10" />
+        <div className="mx-1 h-4 w-px bg-accent" />
 
         {/* Text mode toggle */}
         <button
@@ -321,8 +321,8 @@ export function DrawOverlay({ visible, onQueue, onSend }: DrawOverlayProps) {
           className={cn(
             "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
             textMode
-              ? "bg-white/10 text-white"
-              : "text-white/30 hover:text-white/50",
+              ? "bg-accent text-foreground"
+              : "text-muted-foreground/70 hover:text-muted-foreground",
           )}
           title="Type anywhere"
         >
@@ -333,7 +333,7 @@ export function DrawOverlay({ visible, onQueue, onSend }: DrawOverlayProps) {
         <button
           onClick={undo}
           disabled={strokes.length === 0}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-white/30 hover:text-white/50 disabled:cursor-default disabled:opacity-30"
+          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground/70 hover:text-muted-foreground disabled:cursor-default disabled:opacity-30"
           title="Undo"
         >
           <IconArrowBackUp className="h-3.5 w-3.5" />
@@ -343,17 +343,17 @@ export function DrawOverlay({ visible, onQueue, onSend }: DrawOverlayProps) {
         <button
           onClick={clear}
           disabled={strokes.length === 0}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-white/30 hover:text-white/50 disabled:cursor-default disabled:opacity-30"
+          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground/70 hover:text-muted-foreground disabled:cursor-default disabled:opacity-30"
           title="Clear"
         >
           <IconEraser className="h-3.5 w-3.5" />
         </button>
 
-        <div className="mx-1 h-4 w-px bg-white/10" />
+        <div className="mx-1 h-4 w-px bg-accent" />
 
         {/* Queue counter */}
         {totalQueued > 0 && (
-          <span className="text-[10px] text-white/40">
+          <span className="text-[10px] text-muted-foreground">
             {pathCount > 0 && `Draw x${pathCount}`}
             {pathCount > 0 && textCount > 0 && " / "}
             {textCount > 0 && `Click x${textCount}`}
@@ -364,7 +364,7 @@ export function DrawOverlay({ visible, onQueue, onSend }: DrawOverlayProps) {
         <Button
           variant="ghost"
           size="sm"
-          className="h-6 gap-1 px-2 text-[11px] text-white/50 hover:text-white"
+          className="h-6 gap-1 px-2 text-[11px] text-muted-foreground hover:text-foreground"
           onClick={queueDrawing}
           disabled={strokes.length === 0}
         >

--- a/templates/design/app/components/design/TweaksPanel.tsx
+++ b/templates/design/app/components/design/TweaksPanel.tsx
@@ -57,7 +57,7 @@ export function TweaksPanel({
 
   return (
     <div
-      className="fixed z-30 w-60 rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] shadow-2xl backdrop-blur-sm"
+      className="fixed z-30 w-60 rounded-xl border border-border bg-card shadow-2xl backdrop-blur-sm"
       style={{ left: position.x, bottom: position.y }}
     >
       {/* Header — drag handle + collapse toggle */}
@@ -66,17 +66,17 @@ export function TweaksPanel({
         onMouseDown={handleMouseDown}
       >
         <div className="flex items-center gap-1.5">
-          <IconGripHorizontal className="h-3 w-3 text-white/20" />
+          <IconGripHorizontal className="h-3 w-3 text-muted-foreground/60" />
           <button
             onClick={() => setCollapsed((c) => !c)}
-            className="cursor-pointer text-[11px] font-semibold uppercase tracking-wider text-white/40 hover:text-white/60"
+            className="cursor-pointer text-[11px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-muted-foreground"
           >
             Tweaks
           </button>
         </div>
         <button
           onClick={() => setCollapsed((c) => !c)}
-          className="cursor-pointer text-white/30 hover:text-white/60"
+          className="cursor-pointer text-muted-foreground/70 hover:text-muted-foreground"
         >
           <IconX className="h-3 w-3" />
         </button>
@@ -110,7 +110,9 @@ function TweakControl({
 }) {
   return (
     <div>
-      <div className="mb-1.5 text-[11px] text-white/40">{tweak.label}</div>
+      <div className="mb-1.5 text-[11px] text-muted-foreground">
+        {tweak.label}
+      </div>
 
       {tweak.type === "color-swatch" && (
         <div className="flex gap-2">
@@ -132,7 +134,7 @@ function TweakControl({
       )}
 
       {tweak.type === "segment" && (
-        <div className="flex overflow-hidden rounded-lg border border-white/[0.08]">
+        <div className="flex overflow-hidden rounded-lg border border-border">
           {tweak.options?.map((opt) => (
             <button
               key={opt.value}
@@ -140,8 +142,8 @@ function TweakControl({
               className={cn(
                 "flex-1 cursor-pointer px-2.5 py-1 text-[11px] font-medium",
                 value === opt.value
-                  ? "bg-white/10 text-white"
-                  : "text-white/30 hover:text-white/50",
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground/70 hover:text-muted-foreground",
               )}
             >
               {opt.label}
@@ -160,7 +162,7 @@ function TweakControl({
             onValueChange={([v]) => onChange(v)}
             className="flex-1"
           />
-          <span className="min-w-[2rem] text-right text-[11px] text-white/50">
+          <span className="min-w-[2rem] text-right text-[11px] text-muted-foreground">
             {typeof value === "number" ? value : 50}
             {tweak.cssVar?.includes("radius") ? "px" : ""}
           </span>

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -227,16 +227,16 @@ export default function DesignEditor() {
 
   if (designLoading) {
     return (
-      <div className="flex-1 bg-[hsl(240,5%,5%)] flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-white/30" />
+      <div className="flex-1 bg-background flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-foreground/30" />
       </div>
     );
   }
 
   if (!design) {
     return (
-      <div className="flex-1 bg-[hsl(240,5%,5%)] flex flex-col items-center justify-center gap-4">
-        <p className="text-white/50">Design not found</p>
+      <div className="flex-1 bg-background flex flex-col items-center justify-center gap-4">
+        <p className="text-muted-foreground">Design not found</p>
         <Button
           variant="outline"
           onClick={() => navigate("/")}
@@ -255,17 +255,17 @@ export default function DesignEditor() {
   }));
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden bg-[hsl(240,5%,5%)]">
+    <div className="flex-1 flex flex-col overflow-hidden bg-background">
       {/* Toolbar */}
-      <header className="h-12 border-b border-white/[0.06] flex items-center justify-between px-3 shrink-0">
+      <header className="h-12 border-b border-border flex items-center justify-between px-3 shrink-0">
         <div className="flex items-center gap-2">
           <Link
             to="/"
-            className="flex items-center gap-1 text-sm text-white/50 hover:text-white/80"
+            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground/90"
           >
             <IconArrowLeft className="w-4 h-4" />
           </Link>
-          <span className="text-sm font-medium text-white/80 truncate max-w-[200px]">
+          <span className="text-sm font-medium text-foreground/90 truncate max-w-[200px]">
             {design.title}
           </span>
           <Badge variant="secondary" className="text-[10px]">
@@ -292,7 +292,7 @@ export default function DesignEditor() {
             </TabsList>
           </Tabs>
 
-          <div className="w-px h-5 bg-white/[0.06] mx-1" />
+          <div className="w-px h-5 bg-accent mx-1" />
 
           {/* Device frame */}
           <div className="flex items-center gap-0.5">
@@ -334,7 +334,7 @@ export default function DesignEditor() {
             </Button>
           </div>
 
-          <div className="w-px h-5 bg-white/[0.06] mx-1" />
+          <div className="w-px h-5 bg-accent mx-1" />
 
           {/* Zoom */}
           <div className="flex items-center gap-0.5">
@@ -346,7 +346,7 @@ export default function DesignEditor() {
             >
               <IconZoomOut className="w-3.5 h-3.5" />
             </Button>
-            <span className="text-xs text-white/50 w-10 text-center tabular-nums">
+            <span className="text-xs text-muted-foreground w-10 text-center tabular-nums">
               {zoom}%
             </span>
             <Button
@@ -359,7 +359,7 @@ export default function DesignEditor() {
             </Button>
           </div>
 
-          <div className="w-px h-5 bg-white/[0.06] mx-1" />
+          <div className="w-px h-5 bg-accent mx-1" />
 
           {/* Actions */}
           <Button
@@ -390,15 +390,15 @@ export default function DesignEditor() {
 
       {/* Viewport tabs */}
       {viewportTabs.length > 1 && (
-        <div className="h-8 border-b border-white/[0.06] flex items-center gap-1 px-3 shrink-0">
+        <div className="h-8 border-b border-border flex items-center gap-1 px-3 shrink-0">
           {viewportTabs.map((tab) => (
             <button
               key={tab.id}
               onClick={() => setActiveFileId(tab.id)}
               className={`px-2.5 py-1 rounded text-xs cursor-pointer ${
                 tab.id === activeFileId
-                  ? "bg-white/[0.08] text-white/80"
-                  : "text-white/40 hover:text-white/60"
+                  ? "bg-accent text-foreground/90"
+                  : "text-muted-foreground hover:text-muted-foreground"
               }`}
             >
               {tab.filename}
@@ -423,7 +423,7 @@ export default function DesignEditor() {
         ) : (
           <div className="flex-1 flex items-center justify-center">
             <div className="text-center">
-              <p className="text-sm text-white/40 mb-3">
+              <p className="text-sm text-muted-foreground mb-3">
                 No files yet. Ask the agent to generate a design.
               </p>
               <Button
@@ -445,49 +445,51 @@ export default function DesignEditor() {
 
         {/* Edit panel (right side) */}
         {mode === "edit" && selectedElement && (
-          <div className="w-64 border-l border-white/[0.06] bg-[hsl(240,5%,6%)] p-4 overflow-y-auto shrink-0">
-            <h3 className="text-xs font-semibold text-white/60 uppercase tracking-wider mb-3">
+          <div className="w-64 border-l border-border bg-background p-4 overflow-y-auto shrink-0">
+            <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
               Element
             </h3>
             <div className="space-y-3">
               <div>
-                <span className="text-[10px] text-white/40 uppercase">Tag</span>
-                <p className="text-sm text-white/80 font-mono">
+                <span className="text-[10px] text-muted-foreground uppercase">
+                  Tag
+                </span>
+                <p className="text-sm text-foreground/90 font-mono">
                   {selectedElement.tagName}
                   {selectedElement.id ? `#${selectedElement.id}` : ""}
                 </p>
               </div>
               {selectedElement.classes.length > 0 && (
                 <div>
-                  <span className="text-[10px] text-white/40 uppercase">
+                  <span className="text-[10px] text-muted-foreground uppercase">
                     Classes
                   </span>
-                  <p className="text-xs text-white/60 font-mono break-all">
+                  <p className="text-xs text-muted-foreground font-mono break-all">
                     {selectedElement.classes.join(" ")}
                   </p>
                 </div>
               )}
               {selectedElement.textContent && (
                 <div>
-                  <span className="text-[10px] text-white/40 uppercase">
+                  <span className="text-[10px] text-muted-foreground uppercase">
                     Text
                   </span>
-                  <p className="text-xs text-white/60 line-clamp-3">
+                  <p className="text-xs text-muted-foreground line-clamp-3">
                     {selectedElement.textContent}
                   </p>
                 </div>
               )}
               <div>
-                <span className="text-[10px] text-white/40 uppercase">
+                <span className="text-[10px] text-muted-foreground uppercase">
                   Size
                 </span>
-                <p className="text-xs text-white/60">
+                <p className="text-xs text-muted-foreground">
                   {Math.round(selectedElement.boundingRect.width)} x{" "}
                   {Math.round(selectedElement.boundingRect.height)}
                 </p>
               </div>
               <div>
-                <span className="text-[10px] text-white/40 uppercase">
+                <span className="text-[10px] text-muted-foreground uppercase">
                   Styles
                 </span>
                 <div className="space-y-1 mt-1">
@@ -506,8 +508,10 @@ export default function DesignEditor() {
                         key={key}
                         className="flex items-center justify-between text-[10px]"
                       >
-                        <span className="text-white/40 font-mono">{key}</span>
-                        <span className="text-white/60 font-mono truncate ml-2 max-w-[120px]">
+                        <span className="text-muted-foreground font-mono">
+                          {key}
+                        </span>
+                        <span className="text-muted-foreground font-mono truncate ml-2 max-w-[120px]">
                           {value}
                         </span>
                       </div>
@@ -520,19 +524,19 @@ export default function DesignEditor() {
 
         {/* Tweaks panel (floating) */}
         {tweaksVisible && (
-          <div className="absolute top-4 right-4 w-56 bg-[hsl(240,5%,8%)] border border-white/[0.08] rounded-xl p-4 shadow-2xl z-10">
+          <div className="absolute top-4 right-4 w-56 bg-card border border-border rounded-xl p-4 shadow-2xl z-10">
             <div className="flex items-center justify-between mb-3">
-              <h3 className="text-xs font-semibold text-white/60 uppercase tracking-wider">
+              <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
                 Tweaks
               </h3>
               <button
                 onClick={() => setTweaksVisible(false)}
-                className="text-white/30 hover:text-white/50 text-xs cursor-pointer"
+                className="text-muted-foreground/70 hover:text-muted-foreground text-xs cursor-pointer"
               >
                 Close
               </button>
             </div>
-            <p className="text-xs text-white/30">
+            <p className="text-xs text-muted-foreground/70">
               CSS custom property overrides will appear here when the design
               uses configurable tokens.
             </p>

--- a/templates/design/app/pages/DesignSystemSetup.tsx
+++ b/templates/design/app/pages/DesignSystemSetup.tsx
@@ -349,12 +349,12 @@ export default function DesignSystemSetup() {
         "Set up a dark theme design system",
       ]}
     >
-      <div className="min-h-screen bg-[hsl(240,6%,4%)]">
-        <header className="border-b border-white/[0.06]">
+      <div className="min-h-screen bg-background">
+        <header className="border-b border-border">
           <div className="max-w-3xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
             <button
               onClick={() => navigate("/design-systems")}
-              className="flex items-center gap-1.5 text-sm text-white/50 hover:text-white/80 cursor-pointer"
+              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground/90 cursor-pointer"
             >
               <IconArrowLeft className="w-4 h-4" />
               Back
@@ -372,10 +372,10 @@ export default function DesignSystemSetup() {
 
         <main className="max-w-3xl mx-auto px-4 sm:px-6 py-10">
           <div className="mb-8">
-            <h1 className="text-2xl font-bold text-white/90 mb-2">
+            <h1 className="text-2xl font-bold text-foreground mb-2">
               Set up your design system
             </h1>
-            <p className="text-sm text-white/40">
+            <p className="text-sm text-muted-foreground">
               Provide any combination of sources. The more context you give, the
               more accurate the extracted design system will be.
             </p>
@@ -392,19 +392,21 @@ export default function DesignSystemSetup() {
                 onChange={(e) => setCompanyInfo(e.target.value)}
                 placeholder="e.g. Acme Corp — We build developer tools for modern teams..."
                 rows={3}
-                className="bg-white/[0.04] border-white/[0.06]"
+                className="bg-accent/50 border-border"
               />
               <div className="mt-3">
                 <div className="flex items-center gap-2 mb-2">
-                  <IconWorld className="w-4 h-4 text-white/40" />
-                  <span className="text-sm text-white/50">Website URL</span>
+                  <IconWorld className="w-4 h-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">
+                    Website URL
+                  </span>
                 </div>
                 <div className="flex gap-2">
                   <Input
                     value={websiteUrl}
                     onChange={(e) => setWebsiteUrl(e.target.value)}
                     placeholder="https://example.com"
-                    className="bg-white/[0.04] border-white/[0.06]"
+                    className="bg-accent/50 border-border"
                     onKeyDown={(e) => {
                       if (e.key === "Enter") addWebsiteUrl();
                     }}
@@ -423,7 +425,7 @@ export default function DesignSystemSetup() {
                     {websiteUrls.map((url, i) => (
                       <div
                         key={i}
-                        className="flex items-center gap-2 text-sm text-white/60 bg-white/[0.03] rounded-md px-3 py-1.5"
+                        className="flex items-center gap-2 text-sm text-muted-foreground bg-muted/50 rounded-md px-3 py-1.5"
                       >
                         <IconCheck className="w-3.5 h-3.5 text-green-400/60 shrink-0" />
                         <span className="truncate flex-1">{url}</span>
@@ -433,7 +435,7 @@ export default function DesignSystemSetup() {
                               prev.filter((_, j) => j !== i),
                             )
                           }
-                          className="text-white/30 hover:text-white/50 shrink-0 cursor-pointer"
+                          className="text-muted-foreground/70 hover:text-muted-foreground shrink-0 cursor-pointer"
                         >
                           <IconX className="w-3.5 h-3.5" />
                         </button>
@@ -452,8 +454,8 @@ export default function DesignSystemSetup() {
               {/* GitHub */}
               <div className="mb-4">
                 <div className="flex items-center gap-2 mb-2">
-                  <IconBrandGithub className="w-4 h-4 text-white/40" />
-                  <span className="text-sm text-white/50">
+                  <IconBrandGithub className="w-4 h-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">
                     GitHub repository
                   </span>
                 </div>
@@ -462,7 +464,7 @@ export default function DesignSystemSetup() {
                     value={githubUrl}
                     onChange={(e) => setGithubUrl(e.target.value)}
                     placeholder="https://github.com/org/repo"
-                    className="bg-white/[0.04] border-white/[0.06]"
+                    className="bg-accent/50 border-border"
                     onKeyDown={(e) => {
                       if (e.key === "Enter") addGithubLink();
                     }}
@@ -481,13 +483,13 @@ export default function DesignSystemSetup() {
                     {githubLinks.map((link) => (
                       <div
                         key={link.id}
-                        className="flex items-center gap-2 text-sm text-white/60 bg-white/[0.03] rounded-md px-3 py-1.5"
+                        className="flex items-center gap-2 text-sm text-muted-foreground bg-muted/50 rounded-md px-3 py-1.5"
                       >
                         <IconCheck className="w-3.5 h-3.5 text-green-400/60 shrink-0" />
                         <span className="truncate flex-1">{link.url}</span>
                         <button
                           onClick={() => removeGithubLink(link.id)}
-                          className="text-white/30 hover:text-white/50 shrink-0 cursor-pointer"
+                          className="text-muted-foreground/70 hover:text-muted-foreground shrink-0 cursor-pointer"
                         >
                           <IconX className="w-3.5 h-3.5" />
                         </button>
@@ -500,8 +502,8 @@ export default function DesignSystemSetup() {
               {/* Local code folder */}
               <div>
                 <div className="flex items-center gap-2 mb-2">
-                  <IconFolder className="w-4 h-4 text-white/40" />
-                  <span className="text-sm text-white/50">
+                  <IconFolder className="w-4 h-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">
                     Local code files
                   </span>
                 </div>
@@ -512,13 +514,13 @@ export default function DesignSystemSetup() {
                     e.stopPropagation();
                   }}
                   onClick={() => codeInputRef.current?.click()}
-                  className="border border-dashed border-white/[0.08] rounded-lg p-6 text-center hover:border-white/[0.15] cursor-pointer"
+                  className="border border-dashed border-border rounded-lg p-6 text-center hover:border-foreground/15 cursor-pointer"
                 >
-                  <p className="text-xs text-white/30">
+                  <p className="text-xs text-muted-foreground/70">
                     Drop CSS, Tailwind config, theme files here — or click to
                     browse
                   </p>
-                  <p className="text-[10px] text-white/20 mt-1">
+                  <p className="text-[10px] text-muted-foreground/60 mt-1">
                     .css, .scss, tailwind.config.*, theme.*, tokens.*,
                     package.json
                   </p>
@@ -536,13 +538,13 @@ export default function DesignSystemSetup() {
                     {codeFiles.map((f) => (
                       <div
                         key={f.id}
-                        className="flex items-center gap-2 text-sm text-white/60 bg-white/[0.03] rounded-md px-3 py-1.5"
+                        className="flex items-center gap-2 text-sm text-muted-foreground bg-muted/50 rounded-md px-3 py-1.5"
                       >
                         <IconCheck className="w-3.5 h-3.5 text-green-400/60 shrink-0" />
                         <span className="truncate flex-1">
                           {f.name}
                           {f.textContent ? (
-                            <span className="text-white/20 ml-1">
+                            <span className="text-muted-foreground/60 ml-1">
                               ({formatSize(f.textContent.length)})
                             </span>
                           ) : null}
@@ -553,7 +555,7 @@ export default function DesignSystemSetup() {
                               prev.filter((c) => c.id !== f.id),
                             )
                           }
-                          className="text-white/30 hover:text-white/50 shrink-0 cursor-pointer"
+                          className="text-muted-foreground/70 hover:text-muted-foreground shrink-0 cursor-pointer"
                         >
                           <IconX className="w-3.5 h-3.5" />
                         </button>
@@ -572,14 +574,18 @@ export default function DesignSystemSetup() {
               {/* Figma */}
               <div className="mb-4">
                 <div className="flex items-center gap-2 mb-2">
-                  <IconUpload className="w-4 h-4 text-white/40" />
-                  <span className="text-sm text-white/50">Figma files</span>
+                  <IconUpload className="w-4 h-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">
+                    Figma files
+                  </span>
                 </div>
                 <button
                   onClick={() => figInputRef.current?.click()}
-                  className="w-full border border-dashed border-white/[0.08] rounded-lg p-4 text-center hover:border-white/[0.15] cursor-pointer"
+                  className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/15 cursor-pointer"
                 >
-                  <p className="text-xs text-white/30">Upload .fig files</p>
+                  <p className="text-xs text-muted-foreground/70">
+                    Upload .fig files
+                  </p>
                 </button>
                 <input
                   ref={figInputRef}
@@ -600,16 +606,16 @@ export default function DesignSystemSetup() {
               {/* Documents */}
               <div className="mb-4">
                 <div className="flex items-center gap-2 mb-2">
-                  <IconFileDescription className="w-4 h-4 text-white/40" />
-                  <span className="text-sm text-white/50">
+                  <IconFileDescription className="w-4 h-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">
                     Documents & presentations
                   </span>
                 </div>
                 <button
                   onClick={() => docInputRef.current?.click()}
-                  className="w-full border border-dashed border-white/[0.08] rounded-lg p-4 text-center hover:border-white/[0.15] cursor-pointer"
+                  className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/15 cursor-pointer"
                 >
-                  <p className="text-xs text-white/30">
+                  <p className="text-xs text-muted-foreground/70">
                     PPTX, DOCX, PDF, XLSX — brand guides, pitch decks, style
                     docs
                   </p>
@@ -633,16 +639,16 @@ export default function DesignSystemSetup() {
               {/* Images / screenshots */}
               <div className="mb-4">
                 <div className="flex items-center gap-2 mb-2">
-                  <IconPhoto className="w-4 h-4 text-white/40" />
-                  <span className="text-sm text-white/50">
+                  <IconPhoto className="w-4 h-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">
                     Screenshots & visual references
                   </span>
                 </div>
                 <button
                   onClick={() => imageInputRef.current?.click()}
-                  className="w-full border border-dashed border-white/[0.08] rounded-lg p-4 text-center hover:border-white/[0.15] cursor-pointer"
+                  className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/15 cursor-pointer"
                 >
-                  <p className="text-xs text-white/30">
+                  <p className="text-xs text-muted-foreground/70">
                     Product screenshots, mood boards, inspiration images
                   </p>
                 </button>
@@ -665,16 +671,16 @@ export default function DesignSystemSetup() {
               {/* Brand assets */}
               <div>
                 <div className="flex items-center gap-2 mb-2">
-                  <IconUpload className="w-4 h-4 text-white/40" />
-                  <span className="text-sm text-white/50">
+                  <IconUpload className="w-4 h-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">
                     Logos, fonts & other assets
                   </span>
                 </div>
                 <button
                   onClick={() => assetInputRef.current?.click()}
-                  className="w-full border border-dashed border-white/[0.08] rounded-lg p-4 text-center hover:border-white/[0.15] cursor-pointer"
+                  className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/15 cursor-pointer"
                 >
-                  <p className="text-xs text-white/30">
+                  <p className="text-xs text-muted-foreground/70">
                     SVG logos, .woff2 fonts, brand asset files
                   </p>
                 </button>
@@ -712,16 +718,16 @@ export default function DesignSystemSetup() {
                       className={`text-left p-3 rounded-lg border cursor-pointer ${
                         selectedProjectId === ds.id
                           ? "border-[#609FF8]/40 bg-[#609FF8]/5"
-                          : "border-white/[0.06] bg-white/[0.03] hover:border-white/[0.12]"
+                          : "border-border bg-muted/50 hover:border-border"
                       }`}
                     >
                       <div className="flex items-center gap-2">
-                        <IconPalette className="w-3.5 h-3.5 text-white/40" />
-                        <span className="text-sm text-white/70 truncate">
+                        <IconPalette className="w-3.5 h-3.5 text-muted-foreground" />
+                        <span className="text-sm text-foreground/70 truncate">
                           {ds.title}
                         </span>
                       </div>
-                      <span className="text-[10px] text-white/30 mt-0.5 block">
+                      <span className="text-[10px] text-muted-foreground/70 mt-0.5 block">
                         Design system
                       </span>
                     </button>
@@ -737,13 +743,13 @@ export default function DesignSystemSetup() {
                       className={`text-left p-3 rounded-lg border cursor-pointer ${
                         selectedProjectId === p.id
                           ? "border-[#609FF8]/40 bg-[#609FF8]/5"
-                          : "border-white/[0.06] bg-white/[0.03] hover:border-white/[0.12]"
+                          : "border-border bg-muted/50 hover:border-border"
                       }`}
                     >
-                      <span className="text-sm text-white/70 truncate block">
+                      <span className="text-sm text-foreground/70 truncate block">
                         {p.title}
                       </span>
-                      <span className="text-[10px] text-white/30 mt-0.5 block">
+                      <span className="text-[10px] text-muted-foreground/70 mt-0.5 block">
                         Design project
                       </span>
                     </button>
@@ -762,7 +768,7 @@ export default function DesignSystemSetup() {
                 onChange={(e) => setNotes(e.target.value)}
                 placeholder="e.g. We prefer a dark theme with high contrast. Our brand uses Poppins for headings and DM Sans for body. Keep corners rounded at 12px..."
                 rows={3}
-                className="bg-white/[0.04] border-white/[0.06]"
+                className="bg-accent/50 border-border"
               />
             </Section>
 
@@ -796,8 +802,8 @@ function Section({
   return (
     <section>
       <div className="mb-3">
-        <h2 className="text-sm font-medium text-white/70">{title}</h2>
-        <p className="text-xs text-white/30 mt-0.5">{description}</p>
+        <h2 className="text-sm font-medium text-foreground/70">{title}</h2>
+        <p className="text-xs text-muted-foreground/70 mt-0.5">{description}</p>
       </div>
       {children}
     </section>
@@ -817,16 +823,16 @@ function FileList({
       {files.map((f) => (
         <div
           key={f.id}
-          className="flex items-center gap-2 text-sm text-white/60 bg-white/[0.03] rounded-md px-3 py-1.5"
+          className="flex items-center gap-2 text-sm text-muted-foreground bg-muted/50 rounded-md px-3 py-1.5"
         >
           <IconCheck className="w-3.5 h-3.5 text-green-400/60 shrink-0" />
           <span className="truncate flex-1">{f.name}</span>
-          <span className="text-[10px] text-white/20 shrink-0">
+          <span className="text-[10px] text-muted-foreground/60 shrink-0">
             {formatSize(f.size)}
           </span>
           <button
             onClick={() => onRemove(f.id)}
-            className="text-white/30 hover:text-white/50 shrink-0 cursor-pointer"
+            className="text-muted-foreground/70 hover:text-muted-foreground shrink-0 cursor-pointer"
           >
             <IconX className="w-3.5 h-3.5" />
           </button>

--- a/templates/design/app/pages/DesignSystems.tsx
+++ b/templates/design/app/pages/DesignSystems.tsx
@@ -84,7 +84,7 @@ export default function DesignSystems() {
     <div className="flex-1 overflow-y-auto">
       <main className="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
         <div className="flex items-center justify-between mb-6">
-          <h1 className="text-lg font-semibold text-white/90">
+          <h1 className="text-lg font-semibold text-foreground">
             Design Systems
           </h1>
           <Button
@@ -106,18 +106,18 @@ export default function DesignSystems() {
               {/* New design system card */}
               <button
                 onClick={() => navigate("/design-systems/setup")}
-                className="group relative rounded-xl border border-dashed border-white/[0.08] bg-[hsl(240,5%,8%)] hover:border-white/[0.15] overflow-hidden text-left cursor-pointer"
+                className="group relative rounded-xl border border-dashed border-border bg-card hover:border-foreground/15 overflow-hidden text-left cursor-pointer"
               >
-                <div className="aspect-video flex items-center justify-center bg-white/[0.02]">
-                  <div className="w-12 h-12 rounded-xl bg-white/[0.04] flex items-center justify-center group-hover:bg-white/[0.06]">
-                    <IconPlus className="w-6 h-6 text-white/30 group-hover:text-white/50" />
+                <div className="aspect-video flex items-center justify-center bg-muted/30">
+                  <div className="w-12 h-12 rounded-xl bg-accent/50 flex items-center justify-center group-hover:bg-accent">
+                    <IconPlus className="w-6 h-6 text-muted-foreground/70 group-hover:text-muted-foreground" />
                   </div>
                 </div>
                 <div className="p-4">
-                  <h3 className="font-medium text-sm text-white/50 group-hover:text-white/70">
+                  <h3 className="font-medium text-sm text-muted-foreground group-hover:text-foreground/70">
                     New Design System
                   </h3>
-                  <div className="text-xs text-white/30 mt-1">
+                  <div className="text-xs text-muted-foreground/70 mt-1">
                     Set up your brand
                   </div>
                 </div>
@@ -130,14 +130,14 @@ export default function DesignSystems() {
                 return (
                   <div
                     key={ds.id}
-                    className="group relative rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] overflow-hidden"
+                    className="group relative rounded-xl border border-border bg-card overflow-hidden"
                   >
                     <button
                       onClick={() => navigate("/design-systems/setup")}
                       className="block w-full text-left cursor-pointer"
                     >
                       {/* Color preview */}
-                      <div className="aspect-video bg-white/[0.03] flex items-center justify-center gap-2 p-4">
+                      <div className="aspect-video bg-muted/50 flex items-center justify-center gap-2 p-4">
                         {colors?.primary && (
                           <div
                             className="w-10 h-10 rounded-lg"
@@ -159,12 +159,12 @@ export default function DesignSystems() {
                         {!colors?.primary &&
                           !colors?.secondary &&
                           !colors?.accent && (
-                            <IconPalette className="w-8 h-8 text-white/10" />
+                            <IconPalette className="w-8 h-8 text-muted-foreground/40" />
                           )}
                       </div>
                       <div className="p-4">
                         <div className="flex items-center gap-2 mb-1">
-                          <h3 className="font-medium text-sm text-white/80 truncate flex-1">
+                          <h3 className="font-medium text-sm text-foreground/90 truncate flex-1">
                             {ds.title}
                           </h3>
                           {ds.isDefault && (
@@ -174,7 +174,7 @@ export default function DesignSystems() {
                           )}
                         </div>
                         {parsed?.typography?.headingFont && (
-                          <div className="text-xs text-white/30">
+                          <div className="text-xs text-muted-foreground/70">
                             {parsed.typography.headingFont}
                           </div>
                         )}
@@ -191,7 +191,7 @@ export default function DesignSystems() {
                       {ds.isDefault ? (
                         <IconStarFilled className="w-3.5 h-3.5 text-yellow-400" />
                       ) : (
-                        <IconStar className="w-3.5 h-3.5 text-white/50" />
+                        <IconStar className="w-3.5 h-3.5 text-muted-foreground" />
                       )}
                     </button>
                   </div>
@@ -209,19 +209,19 @@ function LoadingSkeleton() {
   return (
     <>
       <div className="flex items-center justify-between mb-6">
-        <div className="h-5 w-40 rounded-md bg-white/[0.05] animate-pulse" />
-        <div className="h-3 w-16 rounded bg-white/[0.05] animate-pulse" />
+        <div className="h-5 w-40 rounded-md bg-muted animate-pulse" />
+        <div className="h-3 w-16 rounded bg-muted animate-pulse" />
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
         {Array.from({ length: 4 }).map((_, i) => (
           <div
             key={i}
-            className="rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] overflow-hidden"
+            className="rounded-xl border border-border bg-card overflow-hidden"
           >
-            <div className="aspect-video bg-white/[0.03] animate-pulse" />
+            <div className="aspect-video bg-muted/50 animate-pulse" />
             <div className="p-4 space-y-2">
-              <div className="h-4 w-3/4 rounded bg-white/[0.05] animate-pulse" />
-              <div className="h-3 w-1/2 rounded bg-white/[0.05] animate-pulse" />
+              <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-1/2 rounded bg-muted animate-pulse" />
             </div>
           </div>
         ))}
@@ -236,10 +236,10 @@ function EmptyState() {
       <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-[#609FF8]/20 to-[#4080E0]/20 border border-[#609FF8]/20 flex items-center justify-center mb-6">
         <IconPalette className="w-7 h-7 text-[#609FF8]" />
       </div>
-      <h2 className="text-xl font-semibold text-white/90 mb-2">
+      <h2 className="text-xl font-semibold text-foreground mb-2">
         Create your first design system
       </h2>
-      <p className="text-sm text-white/40 max-w-sm mb-8 leading-relaxed">
+      <p className="text-sm text-muted-foreground max-w-sm mb-8 leading-relaxed">
         Maintain consistent branding across all your designs with shared colors,
         typography, and assets.
       </p>

--- a/templates/design/app/pages/Examples.tsx
+++ b/templates/design/app/pages/Examples.tsx
@@ -65,10 +65,10 @@ export default function Examples() {
     <div className="flex-1 overflow-y-auto">
       <main className="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
         <div className="mb-8">
-          <h1 className="text-lg font-semibold text-white/90 mb-1">
+          <h1 className="text-lg font-semibold text-foreground mb-1">
             Starter Examples
           </h1>
-          <p className="text-sm text-white/40">
+          <p className="text-sm text-muted-foreground">
             Pick a template to get started quickly, or use it as inspiration for
             your own design.
           </p>
@@ -80,18 +80,18 @@ export default function Examples() {
             return (
               <div
                 key={example.title}
-                className="group rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] overflow-hidden"
+                className="group rounded-xl border border-border bg-card overflow-hidden"
               >
                 {/* Preview area */}
-                <div className="aspect-video bg-white/[0.03] flex items-center justify-center">
-                  <Icon className="w-10 h-10 text-white/10 group-hover:text-white/15" />
+                <div className="aspect-video bg-muted/50 flex items-center justify-center">
+                  <Icon className="w-10 h-10 text-muted-foreground/40 group-hover:text-muted-foreground/40" />
                 </div>
                 {/* Info */}
                 <div className="p-4">
-                  <h3 className="font-medium text-sm text-white/80 mb-1">
+                  <h3 className="font-medium text-sm text-foreground/90 mb-1">
                     {example.title}
                   </h3>
-                  <p className="text-xs text-white/40 mb-3 line-clamp-2">
+                  <p className="text-xs text-muted-foreground mb-3 line-clamp-2">
                     {example.description}
                   </p>
                   <Button

--- a/templates/design/app/pages/Index.tsx
+++ b/templates/design/app/pages/Index.tsx
@@ -231,20 +231,20 @@ export default function Index() {
           <>
             {/* Search + Count */}
             <div className="flex items-center justify-between mb-6">
-              <h1 className="text-lg font-semibold text-white/90">
+              <h1 className="text-lg font-semibold text-foreground">
                 Your Designs
               </h1>
               <div className="flex items-center gap-3">
                 <div className="relative">
-                  <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
+                  <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/70" />
                   <Input
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     placeholder="Search designs..."
-                    className="pl-8 h-8 w-48 bg-white/[0.04] border-white/[0.06] text-sm text-white/80 placeholder:text-white/30"
+                    className="pl-8 h-8 w-48 bg-accent/50 border-border text-sm text-foreground/90 placeholder:text-muted-foreground/70"
                   />
                 </div>
-                <span className="text-xs text-white/30">
+                <span className="text-xs text-muted-foreground/70">
                   {filtered.length} design{filtered.length !== 1 ? "s" : ""}
                 </span>
                 <Button
@@ -263,18 +263,18 @@ export default function Index() {
               {/* New design card */}
               <button
                 onClick={() => setShowCreateDialog(true)}
-                className="group relative rounded-xl border border-dashed border-white/[0.08] bg-[hsl(240,5%,8%)] hover:border-white/[0.15] overflow-hidden text-left cursor-pointer"
+                className="group relative rounded-xl border border-dashed border-border bg-card hover:border-foreground/15 overflow-hidden text-left cursor-pointer"
               >
-                <div className="aspect-video flex items-center justify-center bg-white/[0.02]">
-                  <div className="w-12 h-12 rounded-xl bg-white/[0.04] flex items-center justify-center group-hover:bg-white/[0.06]">
-                    <IconPlus className="w-6 h-6 text-white/30 group-hover:text-white/50" />
+                <div className="aspect-video flex items-center justify-center bg-muted/30">
+                  <div className="w-12 h-12 rounded-xl bg-accent/50 flex items-center justify-center group-hover:bg-accent">
+                    <IconPlus className="w-6 h-6 text-muted-foreground/70 group-hover:text-muted-foreground" />
                   </div>
                 </div>
                 <div className="p-4">
-                  <h3 className="font-medium text-sm text-white/50 group-hover:text-white/70">
+                  <h3 className="font-medium text-sm text-muted-foreground group-hover:text-foreground/70">
                     New Design
                   </h3>
-                  <div className="text-xs text-white/30 mt-1">
+                  <div className="text-xs text-muted-foreground/70 mt-1">
                     Create a design project
                   </div>
                 </div>
@@ -284,20 +284,20 @@ export default function Index() {
               {filtered.map((design) => (
                 <div
                   key={design.id}
-                  className="group relative rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] overflow-hidden"
+                  className="group relative rounded-xl border border-border bg-card overflow-hidden"
                 >
                   <Link to={`/design/${design.id}`} className="block">
-                    <div className="aspect-video bg-white/[0.03] flex items-center justify-center">
-                      <IconCode className="w-8 h-8 text-white/10" />
+                    <div className="aspect-video bg-muted/50 flex items-center justify-center">
+                      <IconCode className="w-8 h-8 text-muted-foreground/40" />
                     </div>
                     <div className="p-4">
                       <div className="flex items-center gap-2 mb-1">
-                        <h3 className="font-medium text-sm text-white/80 truncate flex-1">
+                        <h3 className="font-medium text-sm text-foreground/90 truncate flex-1">
                           {design.title}
                         </h3>
                         {projectTypeBadge(design.projectType)}
                       </div>
-                      <div className="text-xs text-white/30">
+                      <div className="text-xs text-muted-foreground/70">
                         {formatDate(design.updatedAt || design.createdAt)}
                       </div>
                     </div>
@@ -311,7 +311,7 @@ export default function Index() {
                           size="icon"
                           className="h-7 w-7 bg-black/60 hover:bg-black/80 cursor-pointer"
                         >
-                          <IconDots className="w-3.5 h-3.5 text-white/70" />
+                          <IconDots className="w-3.5 h-3.5 text-foreground/70" />
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
@@ -396,7 +396,9 @@ export default function Index() {
 
               {createTab === "prototype" && (
                 <div className="flex items-center gap-3">
-                  <span className="text-sm text-white/60">Fidelity:</span>
+                  <span className="text-sm text-muted-foreground">
+                    Fidelity:
+                  </span>
                   <div className="flex gap-2">
                     <Button
                       variant={fidelity === "wireframe" ? "default" : "outline"}
@@ -419,7 +421,7 @@ export default function Index() {
               )}
 
               {createTab === "template" && (
-                <p className="text-sm text-white/40">
+                <p className="text-sm text-muted-foreground">
                   Browse the{" "}
                   <Link
                     to="/examples"
@@ -474,19 +476,19 @@ function LoadingSkeleton() {
   return (
     <>
       <div className="flex items-center justify-between mb-6">
-        <div className="h-5 w-32 rounded-md bg-white/[0.05] animate-pulse" />
-        <div className="h-3 w-16 rounded bg-white/[0.05] animate-pulse" />
+        <div className="h-5 w-32 rounded-md bg-muted animate-pulse" />
+        <div className="h-3 w-16 rounded bg-muted animate-pulse" />
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
         {Array.from({ length: 8 }).map((_, i) => (
           <div
             key={i}
-            className="rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] overflow-hidden"
+            className="rounded-xl border border-border bg-card overflow-hidden"
           >
-            <div className="aspect-video bg-white/[0.03] animate-pulse" />
+            <div className="aspect-video bg-muted/50 animate-pulse" />
             <div className="p-4 space-y-2">
-              <div className="h-4 w-3/4 rounded bg-white/[0.05] animate-pulse" />
-              <div className="h-3 w-1/2 rounded bg-white/[0.05] animate-pulse" />
+              <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-1/2 rounded bg-muted animate-pulse" />
             </div>
           </div>
         ))}
@@ -501,10 +503,10 @@ function EmptyState({ onCreateDesign }: { onCreateDesign: () => void }) {
       <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-[#609FF8]/20 to-[#4080E0]/20 border border-[#609FF8]/20 flex items-center justify-center mb-6">
         <IconPalette className="w-7 h-7 text-[#609FF8]" />
       </div>
-      <h2 className="text-xl font-semibold text-white/90 mb-2">
+      <h2 className="text-xl font-semibold text-foreground mb-2">
         Create your first design
       </h2>
-      <p className="text-sm text-white/40 max-w-sm mb-8 leading-relaxed">
+      <p className="text-sm text-muted-foreground max-w-sm mb-8 leading-relaxed">
         Build interactive prototypes and design artifacts with AI-powered
         generation and a visual editor.
       </p>

--- a/templates/design/app/pages/NotFound.tsx
+++ b/templates/design/app/pages/NotFound.tsx
@@ -4,9 +4,9 @@ import { Button } from "@/components/ui/button";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen bg-[hsl(240,6%,4%)] flex flex-col items-center justify-center">
-      <h1 className="text-6xl font-bold text-white/20 mb-4">404</h1>
-      <p className="text-sm text-white/40 mb-6">
+    <div className="min-h-screen bg-background flex flex-col items-center justify-center">
+      <h1 className="text-6xl font-bold text-muted-foreground/60 mb-4">404</h1>
+      <p className="text-sm text-muted-foreground mb-6">
         The page you are looking for does not exist.
       </p>
       <Button asChild variant="outline" className="cursor-pointer">

--- a/templates/dispatch/app/components/messaging-setup-panel.tsx
+++ b/templates/dispatch/app/components/messaging-setup-panel.tsx
@@ -283,10 +283,7 @@ export function MessagingSetupPanel() {
     }
   };
 
-  const saveEnvKeys = async (
-    platform: PlatformDefinition,
-    keys: string[],
-  ) => {
+  const saveEnvKeys = async (platform: PlatformDefinition, keys: string[]) => {
     const vars = keys
       .map((key) => ({ key, value: envValues[key]?.trim() || "" }))
       .filter((item) => item.value);
@@ -509,7 +506,8 @@ export function MessagingSetupPanel() {
                     const envStatus = envStatusByKey.get(envKey.key);
                     const isConfigured = !!envStatus?.configured;
                     const helpText = envKey.helpText ?? envStatus?.helpText;
-                    const label = envKey.label || envStatus?.label || envKey.key;
+                    const label =
+                      envKey.label || envStatus?.label || envKey.key;
                     // Email agent address is not a secret — show it plainly
                     // so users can copy and share it.
                     const isPublicValue = envKey.key === "EMAIL_AGENT_ADDRESS";
@@ -525,7 +523,9 @@ export function MessagingSetupPanel() {
                                 </span>
                               ) : null}
                             </label>
-                            {helpText ? <HelpTooltip content={helpText} /> : null}
+                            {helpText ? (
+                              <HelpTooltip content={helpText} />
+                            ) : null}
                           </div>
                           {isConfigured ? (
                             <StatusPill tone="success" label="Saved" />
@@ -560,9 +560,7 @@ export function MessagingSetupPanel() {
                     );
                   })}
                 </div>
-                {envKeys.some(
-                  (k) => !envStatusByKey.get(k.key)?.configured,
-                ) ? (
+                {envKeys.some((k) => !envStatusByKey.get(k.key)?.configured) ? (
                   <Button
                     variant="outline"
                     onClick={() =>

--- a/templates/dispatch/app/components/messaging-setup-panel.tsx
+++ b/templates/dispatch/app/components/messaging-setup-panel.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import {
   IconBrandSlack,
   IconBrandTelegram,
+  IconBrandWhatsapp,
   IconCheck,
   IconCopy,
   IconExternalLink,
@@ -23,6 +24,14 @@ interface EnvStatus {
   label: string;
   required: boolean;
   configured: boolean;
+  helpText?: string;
+}
+
+interface RequiredEnvKey {
+  key: string;
+  label: string;
+  required: boolean;
+  helpText?: string;
 }
 
 interface IntegrationStatus {
@@ -31,15 +40,25 @@ interface IntegrationStatus {
   enabled: boolean;
   configured: boolean;
   webhookUrl?: string;
+  requiredEnvKeys?: RequiredEnvKey[];
 }
 
 interface PlatformDefinition {
-  id: "slack" | "telegram" | "email";
+  id: "slack" | "telegram" | "email" | "whatsapp";
   label: string;
   icon: typeof IconBrandSlack;
   description: string;
-  docsUrl?: string;
+  /** Our own docs anchor — keep these on /docs/messaging so users land on
+   *  the page that explains the platform in plain English. */
+  docsUrl: string;
+  /** Optional external link (e.g. to the platform's developer console). */
+  externalUrl?: string;
+  externalLabel?: string;
   setupSteps: string[];
+  /** Fallback env keys when the adapter doesn't surface them via
+   *  `IntegrationStatus.requiredEnvKeys`. The panel prefers adapter-supplied
+   *  keys when present so optional fields (webhook secrets, etc.) appear
+   *  automatically. */
   envKeys: string[];
 }
 
@@ -49,13 +68,15 @@ const PLATFORM_DEFINITIONS: PlatformDefinition[] = [
     label: "Slack",
     icon: IconBrandSlack,
     description: "Receive mentions and DMs in one workspace-aware dispatch.",
-    docsUrl: "https://api.slack.com/apps",
+    docsUrl: "/docs/messaging#slack",
+    externalUrl: "https://api.slack.com/apps",
+    externalLabel: "Open Slack apps",
     envKeys: ["SLACK_BOT_TOKEN", "SLACK_SIGNING_SECRET"],
     setupSteps: [
-      "Create or open a Slack app.",
-      "Enable Event Subscriptions and paste the webhook URL below.",
-      "Subscribe to app_mention and message.im events.",
-      "Install the app and save the bot token and signing secret here.",
+      "Create or open a Slack app at api.slack.com/apps.",
+      "Save the bot token and signing secret below — the webhook URL appears once they're saved.",
+      "Back in Slack, enable Event Subscriptions and paste the webhook URL.",
+      "Subscribe to app_mention and message.im events, then install the app.",
     ],
   },
   {
@@ -63,11 +84,14 @@ const PLATFORM_DEFINITIONS: PlatformDefinition[] = [
     label: "Telegram",
     icon: IconBrandTelegram,
     description: "Chat with dispatch through a Telegram bot.",
+    docsUrl: "/docs/messaging#telegram",
+    externalUrl: "https://t.me/BotFather",
+    externalLabel: "Open BotFather",
     envKeys: ["TELEGRAM_BOT_TOKEN"],
     setupSteps: [
-      "Create a bot with @BotFather.",
-      "Save the bot token here.",
-      "Run webhook setup once to connect Telegram to this app.",
+      "Open @BotFather in Telegram and send /newbot.",
+      "Save the bot token here, then click Set up webhook below.",
+      "DM the bot in Telegram to test.",
     ],
   },
   {
@@ -76,12 +100,36 @@ const PLATFORM_DEFINITIONS: PlatformDefinition[] = [
     icon: IconMail,
     description:
       "Give your agent an email address. People can email it directly or CC it on threads.",
+    docsUrl: "/docs/messaging#email",
+    externalUrl: "https://resend.com/webhooks",
+    externalLabel: "Open Resend webhooks",
     envKeys: ["EMAIL_AGENT_ADDRESS"],
     setupSteps: [
-      "Ensure Resend or SendGrid credentials are saved.",
-      "Choose an email address (e.g., agent@yourcompany.com or use the free .resend.app address).",
-      "Add MX records for your domain (or skip for .resend.app).",
-      "Register the webhook URL below in your email provider's dashboard.",
+      "Save your Resend or SendGrid API key (Vault or onboarding).",
+      "Pick an email address — the easiest is a free <slug>.resend.app address.",
+      "If using your own domain, add MX records pointing to your provider.",
+      "Save the address here, then register the webhook URL below in Resend (event: email.received).",
+    ],
+  },
+  {
+    id: "whatsapp",
+    label: "WhatsApp",
+    icon: IconBrandWhatsapp,
+    description:
+      "Receive WhatsApp messages and reply through a Meta-managed phone number.",
+    docsUrl: "/docs/messaging#whatsapp",
+    externalUrl: "https://developers.facebook.com/apps",
+    externalLabel: "Open Meta developer console",
+    envKeys: [
+      "WHATSAPP_ACCESS_TOKEN",
+      "WHATSAPP_VERIFY_TOKEN",
+      "WHATSAPP_PHONE_NUMBER_ID",
+    ],
+    setupSteps: [
+      "Create a Meta app and add the WhatsApp product.",
+      "Save the access token, verify token, and phone number ID below.",
+      "In Meta's WhatsApp configuration, paste the webhook URL and your verify token.",
+      "Subscribe to the messages field, then enable here.",
     ],
   },
 ];
@@ -124,6 +172,20 @@ function StatusPill({
     >
       {label}
     </span>
+  );
+}
+
+/** Render a non-secret env value (e.g. EMAIL_AGENT_ADDRESS) as a copyable
+ *  text block. We can't read the actual value from the backend (env-status
+ *  only reports `configured: true|false`), so we offer a one-click reveal
+ *  that hits a server endpoint, falling back to "saved" if the value is
+ *  not exposed. For now we just render a "Saved — re-enter to change"
+ *  placeholder; a future endpoint can return the actual value. */
+function PublicValueReveal({ envKey: _envKey }: { envKey: string }) {
+  return (
+    <div className="rounded-md border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+      Saved. Re-enter below to change.
+    </div>
   );
 }
 
@@ -221,8 +283,11 @@ export function MessagingSetupPanel() {
     }
   };
 
-  const saveEnvKeys = async (platform: PlatformDefinition) => {
-    const vars = platform.envKeys
+  const saveEnvKeys = async (
+    platform: PlatformDefinition,
+    keys: string[],
+  ) => {
+    const vars = keys
       .map((key) => ({ key, value: envValues[key]?.trim() || "" }))
       .filter((item) => item.value);
 
@@ -247,7 +312,7 @@ export function MessagingSetupPanel() {
       toast.success(`${platform.label} credentials saved`);
       setEnvValues((current) => {
         const next = { ...current };
-        for (const key of platform.envKeys) delete next[key];
+        for (const key of keys) delete next[key];
         return next;
       });
       await refreshEnvStatus();
@@ -353,9 +418,17 @@ export function MessagingSetupPanel() {
           const status = statusByPlatform.get(platform.id);
           const configured = !!status?.configured;
           const enabled = !!status?.enabled;
-          const missingKeys = platform.envKeys.filter(
-            (key) => !envStatusByKey.get(key)?.configured,
-          );
+          // Prefer adapter-supplied env keys (includes optional fields like
+          // webhook secrets); fall back to the static list.
+          const adapterKeys = status?.requiredEnvKeys;
+          const envKeys: RequiredEnvKey[] =
+            adapterKeys && adapterKeys.length > 0
+              ? adapterKeys
+              : platform.envKeys.map((key) => ({
+                  key,
+                  label: key,
+                  required: true,
+                }));
           const canEnable = configured;
 
           return (
@@ -383,17 +456,25 @@ export function MessagingSetupPanel() {
                     </p>
                   </div>
                 </div>
-                {platform.docsUrl ? (
+                <div className="flex items-center gap-3">
                   <a
                     href={platform.docsUrl}
-                    target="_blank"
-                    rel="noreferrer"
                     className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
                   >
                     Docs
-                    <IconExternalLink className="h-3.5 w-3.5" />
                   </a>
-                ) : null}
+                  {platform.externalUrl ? (
+                    <a
+                      href={platform.externalUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                    >
+                      {platform.externalLabel ?? "Open"}
+                      <IconExternalLink className="h-3.5 w-3.5" />
+                    </a>
+                  ) : null}
+                </div>
               </div>
 
               <div className="mt-5 rounded-xl border bg-muted/20 p-4">
@@ -424,32 +505,54 @@ export function MessagingSetupPanel() {
                   ) : null}
                 </div>
                 <div className="space-y-3">
-                  {platform.envKeys.map((key) => {
-                    const envStatus = envStatusByKey.get(key);
+                  {envKeys.map((envKey) => {
+                    const envStatus = envStatusByKey.get(envKey.key);
                     const isConfigured = !!envStatus?.configured;
+                    const helpText = envKey.helpText ?? envStatus?.helpText;
+                    const label = envKey.label || envStatus?.label || envKey.key;
+                    // Email agent address is not a secret — show it plainly
+                    // so users can copy and share it.
+                    const isPublicValue = envKey.key === "EMAIL_AGENT_ADDRESS";
                     return (
-                      <div key={key} className="space-y-1.5">
+                      <div key={envKey.key} className="space-y-1.5">
                         <div className="flex items-center justify-between gap-3">
-                          <label className="text-xs font-medium text-foreground">
-                            {envStatus?.label || key}
-                          </label>
+                          <div className="flex items-center gap-1.5">
+                            <label className="text-xs font-medium text-foreground">
+                              {label}
+                              {!envKey.required ? (
+                                <span className="ml-1 text-muted-foreground">
+                                  (optional)
+                                </span>
+                              ) : null}
+                            </label>
+                            {helpText ? <HelpTooltip content={helpText} /> : null}
+                          </div>
                           {isConfigured ? (
                             <StatusPill tone="success" label="Saved" />
                           ) : (
-                            <StatusPill tone="neutral" label="Missing" />
+                            <StatusPill
+                              tone={envKey.required ? "neutral" : "neutral"}
+                              label={envKey.required ? "Missing" : "Not set"}
+                            />
                           )}
                         </div>
-                        {!isConfigured ? (
+                        {isConfigured && isPublicValue ? (
+                          <PublicValueReveal envKey={envKey.key} />
+                        ) : !isConfigured ? (
                           <Input
-                            type="password"
-                            value={envValues[key] || ""}
+                            type={isPublicValue ? "text" : "password"}
+                            value={envValues[envKey.key] || ""}
                             onChange={(event) =>
                               setEnvValues((current) => ({
                                 ...current,
-                                [key]: event.target.value,
+                                [envKey.key]: event.target.value,
                               }))
                             }
-                            placeholder={`Enter ${envStatus?.label || key}`}
+                            placeholder={
+                              isPublicValue
+                                ? "agent@yourcompany.com"
+                                : `Enter ${label}`
+                            }
                             autoComplete="off"
                           />
                         ) : null}
@@ -457,10 +560,17 @@ export function MessagingSetupPanel() {
                     );
                   })}
                 </div>
-                {missingKeys.length > 0 ? (
+                {envKeys.some(
+                  (k) => !envStatusByKey.get(k.key)?.configured,
+                ) ? (
                   <Button
                     variant="outline"
-                    onClick={() => saveEnvKeys(platform)}
+                    onClick={() =>
+                      saveEnvKeys(
+                        platform,
+                        envKeys.map((k) => k.key),
+                      )
+                    }
                     disabled={savingKeysFor === platform.id}
                   >
                     {savingKeysFor === platform.id ? (

--- a/templates/slides/app/components/comments/SlideCommentsPanel.tsx
+++ b/templates/slides/app/components/comments/SlideCommentsPanel.tsx
@@ -64,17 +64,17 @@ function CommentItem({
       <Avatar email={comment.author_email} name={comment.author_name} />
       <div className="flex-1 min-w-0">
         <div className="flex items-center justify-between gap-1">
-          <span className="text-[11px] font-medium text-white/70 truncate">
+          <span className="text-[11px] font-medium text-foreground/80 truncate">
             {comment.author_name || comment.author_email.split("@")[0]}
           </span>
           <div className="flex items-center gap-1 flex-shrink-0">
-            <span className="text-[10px] text-white/30">
+            <span className="text-[10px] text-muted-foreground">
               {formatRelativeTime(comment.created_at)}
             </span>
             {hovered && (
               <button
                 onClick={onDelete}
-                className="p-0.5 rounded text-white/30 hover:text-red-400"
+                className="p-0.5 rounded text-muted-foreground hover:text-red-400"
                 title="Delete comment"
               >
                 <IconTrash size={11} />
@@ -82,7 +82,7 @@ function CommentItem({
             )}
           </div>
         </div>
-        <p className="text-[12px] text-white/80 mt-0.5 break-words leading-relaxed">
+        <p className="text-[12px] text-foreground/90 mt-0.5 break-words leading-relaxed">
           {comment.content}
         </p>
       </div>
@@ -126,9 +126,9 @@ function PendingCommentInput({
   };
 
   return (
-    <div className="border border-white/10 rounded-lg overflow-hidden bg-white/[0.03]">
+    <div className="border border-border rounded-lg overflow-hidden bg-accent">
       {quotedText && (
-        <div className="px-3 pt-2.5 pb-1.5 border-l-2 border-[#609FF8] mx-3 mt-2.5 mb-1 bg-[#609FF8]/5 rounded-r text-[11px] text-white/40 italic truncate">
+        <div className="px-3 pt-2.5 pb-1.5 border-l-2 border-[#609FF8] mx-3 mt-2.5 mb-1 bg-[#609FF8]/5 rounded-r text-[11px] text-muted-foreground italic truncate">
           "{quotedText}"
         </div>
       )}
@@ -142,12 +142,12 @@ function PendingCommentInput({
         }}
         placeholder="Add a comment..."
         rows={3}
-        className="w-full bg-transparent text-white/80 text-[12px] px-3 py-2 outline-none resize-none placeholder-white/25"
+        className="w-full bg-transparent text-foreground/90 text-[12px] px-3 py-2 outline-none resize-none placeholder:text-muted-foreground"
       />
       <div className="flex justify-end gap-1.5 px-3 pb-2">
         <button
           onClick={onCancel}
-          className="text-[11px] text-white/40 hover:text-white/70 px-2 py-1 rounded"
+          className="text-[11px] text-muted-foreground hover:text-foreground/80 px-2 py-1 rounded"
         >
           Cancel
         </button>
@@ -197,7 +197,7 @@ function ReplyInput({
   };
 
   return (
-    <div className="mt-2 border border-white/10 rounded-lg overflow-hidden bg-white/[0.03]">
+    <div className="mt-2 border border-border rounded-lg overflow-hidden bg-accent">
       <textarea
         ref={textareaRef}
         value={text}
@@ -208,12 +208,12 @@ function ReplyInput({
         }}
         placeholder="Reply..."
         rows={2}
-        className="w-full bg-transparent text-white/80 text-[12px] px-3 py-2 outline-none resize-none placeholder-white/25"
+        className="w-full bg-transparent text-foreground/90 text-[12px] px-3 py-2 outline-none resize-none placeholder:text-muted-foreground"
       />
       <div className="flex justify-end gap-1.5 px-3 pb-2">
         <button
           onClick={onDone}
-          className="text-[11px] text-white/40 hover:text-white/70 px-2 py-1 rounded"
+          className="text-[11px] text-muted-foreground hover:text-foreground/80 px-2 py-1 rounded"
         >
           Cancel
         </button>
@@ -252,13 +252,13 @@ function ThreadCard({
 
   return (
     <div
-      className={`border rounded-lg px-3 py-2.5 ${thread.resolved ? "border-white/[0.04] opacity-50" : "border-white/[0.08] bg-white/[0.02]"}`}
+      className={`border rounded-lg px-3 py-2.5 ${thread.resolved ? "border-border/60 opacity-50" : "border-border bg-card"}`}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
       {/* Quoted text */}
       {thread.quotedText && (
-        <div className="border-l-2 border-[#609FF8]/50 pl-2 mb-2 text-[11px] text-white/35 italic truncate">
+        <div className="border-l-2 border-[#609FF8]/50 pl-2 mb-2 text-[11px] text-muted-foreground italic truncate">
           "{thread.quotedText}"
         </div>
       )}
@@ -271,12 +271,12 @@ function ThreadCard({
         />
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between gap-1">
-            <span className="text-[11px] font-medium text-white/70 truncate">
+            <span className="text-[11px] font-medium text-foreground/80 truncate">
               {rootComment.author_name ||
                 rootComment.author_email.split("@")[0]}
             </span>
             <div className="flex items-center gap-1 flex-shrink-0">
-              <span className="text-[10px] text-white/30">
+              <span className="text-[10px] text-muted-foreground">
                 {formatRelativeTime(rootComment.created_at)}
               </span>
               {hovered && !thread.resolved && (
@@ -285,14 +285,14 @@ function ThreadCard({
                     onClick={() =>
                       resolveComment.mutate({ id: rootComment.id })
                     }
-                    className="p-0.5 rounded text-white/30 hover:text-green-400"
+                    className="p-0.5 rounded text-muted-foreground hover:text-green-400"
                     title="Resolve thread"
                   >
                     <IconCheck size={11} />
                   </button>
                   <button
                     onClick={() => deleteComment.mutate({ id: rootComment.id })}
-                    className="p-0.5 rounded text-white/30 hover:text-red-400"
+                    className="p-0.5 rounded text-muted-foreground hover:text-red-400"
                     title="Delete comment"
                   >
                     <IconTrash size={11} />
@@ -301,7 +301,7 @@ function ThreadCard({
               )}
             </div>
           </div>
-          <p className="text-[12px] text-white/80 mt-0.5 break-words leading-relaxed">
+          <p className="text-[12px] text-foreground/90 mt-0.5 break-words leading-relaxed">
             {rootComment.content}
           </p>
         </div>
@@ -311,7 +311,7 @@ function ThreadCard({
       {replies.length > 0 && (
         <button
           onClick={() => setShowReplies(!showReplies)}
-          className="mt-2 flex items-center gap-1 text-[11px] text-white/35 hover:text-white/60 ml-7"
+          className="mt-2 flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground/80 ml-7"
         >
           <IconChevronDown
             size={11}
@@ -341,7 +341,7 @@ function ThreadCard({
           {!replyOpen && (
             <button
               onClick={() => setReplyOpen(true)}
-              className="text-[11px] text-white/35 hover:text-white/60"
+              className="text-[11px] text-muted-foreground hover:text-foreground/80"
             >
               Reply
             </button>
@@ -386,15 +386,17 @@ export function SlideCommentsPanel({
   const showInput = pendingComment || addingComment;
 
   return (
-    <div className="w-72 flex-shrink-0 border-l border-white/[0.06] bg-[#080808] flex flex-col h-full">
+    <div className="w-72 flex-shrink-0 border-l border-border bg-background flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-white/[0.06] flex-shrink-0">
-        <span className="text-[13px] font-medium text-white/70">Comments</span>
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
+        <span className="text-[13px] font-medium text-foreground/80">
+          Comments
+        </span>
         <div className="flex items-center gap-1">
           {!showInput && deckId && slideId && (
             <button
               onClick={() => setAddingComment(true)}
-              className="p-1 rounded text-white/30 hover:text-white/60 hover:bg-white/[0.06]"
+              className="p-1 rounded text-muted-foreground hover:text-foreground/80 hover:bg-accent"
               title="Add comment"
             >
               <IconMessageCircle size={14} />
@@ -402,7 +404,7 @@ export function SlideCommentsPanel({
           )}
           <button
             onClick={onClose}
-            className="p-1 rounded text-white/30 hover:text-white/60 hover:bg-white/[0.06]"
+            className="p-1 rounded text-muted-foreground hover:text-foreground/80 hover:bg-accent"
             title="Close"
           >
             <IconX size={14} />
@@ -443,7 +445,7 @@ export function SlideCommentsPanel({
         {resolvedThreads.length > 0 && (
           <button
             onClick={() => setShowResolved(!showResolved)}
-            className="w-full text-[11px] text-white/25 hover:text-white/50 py-1"
+            className="w-full text-[11px] text-muted-foreground hover:text-foreground/70 py-1"
           >
             {showResolved
               ? "Hide resolved"
@@ -456,11 +458,11 @@ export function SlideCommentsPanel({
           <div className="text-center py-10">
             <IconMessageCircle
               size={28}
-              className="mx-auto mb-2 text-white/15"
+              className="mx-auto mb-2 text-muted-foreground/60"
             />
-            <p className="text-[12px] text-white/25">No comments yet</p>
-            <p className="text-[11px] text-white/15 mt-1">
-              Select text and click 💬 to add one
+            <p className="text-[12px] text-muted-foreground">No comments yet</p>
+            <p className="text-[11px] text-muted-foreground/70 mt-1">
+              Select text and click the comment icon to add one
             </p>
           </div>
         )}

--- a/templates/slides/app/components/deck/DeckCard.tsx
+++ b/templates/slides/app/components/deck/DeckCard.tsx
@@ -22,7 +22,7 @@ export default function DeckCard({ deck, onDelete }: DeckCardProps) {
     <div className="group relative">
       <Link
         to={`/deck/${deck.id}`}
-        className="block rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] hover:border-white/[0.12] transition-all duration-200 overflow-hidden hover:shadow-lg hover:shadow-[#609FF8]/5"
+        className="block rounded-xl border border-border bg-card hover:border-border transition-all duration-200 overflow-hidden hover:shadow-lg hover:shadow-[#609FF8]/5"
       >
         {/* Slide Preview */}
         <div className="aspect-video overflow-hidden relative">
@@ -37,12 +37,12 @@ export default function DeckCard({ deck, onDelete }: DeckCardProps) {
         {/* Info */}
         <div className="p-4">
           <div className="flex items-center gap-2 min-w-0">
-            <h3 className="font-medium text-sm text-white/90 truncate flex-1">
+            <h3 className="font-medium text-sm text-foreground truncate flex-1">
               {deck.title}
             </h3>
             <VisibilityBadge visibility={deck.visibility} />
           </div>
-          <div className="text-xs text-white/40 mt-1">
+          <div className="text-xs text-muted-foreground mt-1">
             {deck.slides.length} slide{deck.slides.length !== 1 ? "s" : ""}
           </div>
         </div>
@@ -57,10 +57,10 @@ export default function DeckCard({ deck, onDelete }: DeckCardProps) {
                 e.preventDefault();
                 e.stopPropagation();
               }}
-              className="p-2 sm:p-1.5 rounded-md bg-black/60 backdrop-blur-sm border border-white/10 hover:bg-black/80"
+              className="p-2 sm:p-1.5 rounded-md bg-black/60 backdrop-blur-sm border border-border hover:bg-black/80"
               aria-label="Deck options"
             >
-              <IconDots className="w-3.5 h-3.5 text-white/70" />
+              <IconDots className="w-3.5 h-3.5 text-foreground/70" />
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-36">

--- a/templates/slides/app/components/deck/ExcalidrawSlide.tsx
+++ b/templates/slides/app/components/deck/ExcalidrawSlide.tsx
@@ -77,14 +77,12 @@ export function ExcalidrawSlide({
   }, []);
 
   if (!mounted) {
-    return <Skeleton className="w-full h-full bg-white/[0.06]" />;
+    return <Skeleton className="w-full h-full bg-accent" />;
   }
 
   return (
     <div className="w-full h-full" style={{ minHeight: 200 }}>
-      <Suspense
-        fallback={<Skeleton className="w-full h-full bg-white/[0.06]" />}
-      >
+      <Suspense fallback={<Skeleton className="w-full h-full bg-accent" />}>
         <Excalidraw
           excalidrawAPI={(api: any) => {
             excalidrawRef.current = api;

--- a/templates/slides/app/components/design-system/DesignSystemCard.tsx
+++ b/templates/slides/app/components/design-system/DesignSystemCard.tsx
@@ -28,7 +28,7 @@ export function DesignSystemCard({
 
   return (
     <div
-      className="group relative rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] hover:border-white/[0.12] overflow-hidden cursor-pointer"
+      className="group relative rounded-xl border border-border bg-card hover:border-foreground/20 overflow-hidden cursor-pointer"
       onClick={onClick}
     >
       {/* Preview area */}
@@ -41,7 +41,7 @@ export function DesignSystemCard({
           {swatchColors.map((s) => (
             <div
               key={s.label}
-              className="w-6 h-6 rounded-full border border-white/10 shrink-0"
+              className="w-6 h-6 rounded-full border border-border shrink-0"
               style={{ background: s.color }}
               title={s.label}
             />
@@ -79,16 +79,16 @@ export function DesignSystemCard({
       <div className="p-4 flex items-start justify-between gap-2">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
-            <IconPalette className="w-3.5 h-3.5 text-white/30 shrink-0" />
-            <h3 className="font-medium text-sm text-white/90 truncate">
+            <IconPalette className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            <h3 className="font-medium text-sm text-foreground truncate">
               {title}
             </h3>
           </div>
-          <div className="text-xs text-white/30 mt-1 flex items-center gap-2">
+          <div className="text-xs text-muted-foreground mt-1 flex items-center gap-2">
             <span>{data.typography.headingFont}</span>
             {data.typography.headingFont !== data.typography.bodyFont && (
               <>
-                <span className="text-white/10">|</span>
+                <span className="text-muted-foreground/60">|</span>
                 <span>{data.typography.bodyFont}</span>
               </>
             )}
@@ -106,13 +106,13 @@ export function DesignSystemCard({
             e.stopPropagation();
             onSetDefault();
           }}
-          className="shrink-0 p-1 rounded hover:bg-white/[0.06] cursor-pointer"
+          className="shrink-0 p-1 rounded hover:bg-accent cursor-pointer"
           title={isDefault ? "Default design system" : "Set as default"}
         >
           {isDefault ? (
             <IconStarFilled className="w-4 h-4 text-[#609FF8]" />
           ) : (
-            <IconStar className="w-4 h-4 text-white/20 group-hover:text-white/40" />
+            <IconStar className="w-4 h-4 text-muted-foreground group-hover:text-foreground/70" />
           )}
         </button>
       </div>

--- a/templates/slides/app/components/design-system/DesignSystemPreview.tsx
+++ b/templates/slides/app/components/design-system/DesignSystemPreview.tsx
@@ -21,31 +21,33 @@ export function DesignSystemPreview({
   return (
     <div
       className={cn(
-        "rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] overflow-hidden",
+        "rounded-xl border border-border bg-card overflow-hidden",
         className,
       )}
     >
       {/* Color swatches */}
-      <div className="p-4 border-b border-white/[0.06]">
-        <div className="text-[10px] font-medium uppercase tracking-wider text-white/30 mb-3">
+      <div className="p-4 border-b border-border">
+        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-3">
           Colors
         </div>
         <div className="flex items-center gap-3">
           {swatches.map((s) => (
             <div key={s.label} className="flex flex-col items-center gap-1.5">
               <div
-                className="w-8 h-8 rounded-full border border-white/10"
+                className="w-8 h-8 rounded-full border border-border"
                 style={{ background: s.color }}
               />
-              <span className="text-[10px] text-white/30">{s.label}</span>
+              <span className="text-[10px] text-muted-foreground">
+                {s.label}
+              </span>
             </div>
           ))}
         </div>
       </div>
 
       {/* Typography sample */}
-      <div className="p-4 border-b border-white/[0.06]">
-        <div className="text-[10px] font-medium uppercase tracking-wider text-white/30 mb-3">
+      <div className="p-4 border-b border-border">
+        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-3">
           Typography
         </div>
         <div
@@ -77,7 +79,7 @@ export function DesignSystemPreview({
 
       {/* Mini slide preview */}
       <div className="p-4">
-        <div className="text-[10px] font-medium uppercase tracking-wider text-white/30 mb-3">
+        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-3">
           Slide Preview
         </div>
         <div
@@ -146,15 +148,15 @@ export function DesignSystemPreview({
 
       {/* Logos */}
       {data.logos.length > 0 && (
-        <div className="p-4 border-t border-white/[0.06]">
-          <div className="text-[10px] font-medium uppercase tracking-wider text-white/30 mb-3">
+        <div className="p-4 border-t border-border">
+          <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground mb-3">
             Logos
           </div>
           <div className="flex items-center gap-3 flex-wrap">
             {data.logos.map((logo, i) => (
               <div
                 key={`${logo.name}-${i}`}
-                className="w-10 h-10 rounded-lg bg-white/[0.04] border border-white/[0.06] flex items-center justify-center overflow-hidden"
+                className="w-10 h-10 rounded-lg bg-accent border border-border flex items-center justify-center overflow-hidden"
               >
                 <img
                   src={logo.url}

--- a/templates/slides/app/components/design-system/DesignSystemSetup.tsx
+++ b/templates/slides/app/components/design-system/DesignSystemSetup.tsx
@@ -301,13 +301,13 @@ export function DesignSystemSetup({
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="sm:max-w-2xl max-h-[85vh] p-0 bg-[hsl(240,5%,8%)] border-white/[0.08]">
+      <DialogContent className="sm:max-w-2xl max-h-[85vh] p-0 bg-card border-border">
         <DialogHeader className="px-6 pt-6 pb-0">
-          <DialogTitle className="text-white/90 flex items-center gap-2">
+          <DialogTitle className="text-foreground flex items-center gap-2">
             <IconPalette className="w-5 h-5 text-[#609FF8]" />
             {editingId ? "Edit Design System" : "New Design System"}
           </DialogTitle>
-          <DialogDescription className="text-white/40">
+          <DialogDescription className="text-muted-foreground">
             {editingId
               ? "Update your brand identity."
               : "Provide any combination of sources — the more context, the better the result."}
@@ -318,12 +318,12 @@ export function DesignSystemSetup({
           <div className="space-y-5 py-4">
             {/* Company Name */}
             <div className="space-y-2">
-              <Label className="text-white/70">Company / Brand</Label>
+              <Label className="text-foreground/80">Company / Brand</Label>
               <Input
                 value={companyName}
                 onChange={(e) => setCompanyName(e.target.value)}
                 placeholder="Acme Inc. — We build developer tools..."
-                className="bg-white/[0.04] border-white/[0.08] text-white/90 placeholder:text-white/25"
+                className="bg-accent border-border text-foreground placeholder:text-muted-foreground"
               />
             </div>
 
@@ -331,7 +331,7 @@ export function DesignSystemSetup({
               <>
                 {/* Website URL */}
                 <div className="space-y-2">
-                  <Label className="text-white/70 flex items-center gap-1.5">
+                  <Label className="text-foreground/80 flex items-center gap-1.5">
                     <IconWorld className="w-3.5 h-3.5" />
                     Website URL
                   </Label>
@@ -340,7 +340,7 @@ export function DesignSystemSetup({
                       value={websiteUrl}
                       onChange={(e) => setWebsiteUrl(e.target.value)}
                       placeholder="https://example.com"
-                      className="bg-white/[0.04] border-white/[0.08] text-white/90 placeholder:text-white/25"
+                      className="bg-accent border-border text-foreground placeholder:text-muted-foreground"
                       onKeyDown={(e) => {
                         if (e.key === "Enter") addWebsiteUrl();
                       }}
@@ -364,7 +364,7 @@ export function DesignSystemSetup({
 
                 {/* GitHub */}
                 <div className="space-y-2">
-                  <Label className="text-white/70 flex items-center gap-1.5">
+                  <Label className="text-foreground/80 flex items-center gap-1.5">
                     <IconBrandGithub className="w-3.5 h-3.5" />
                     GitHub Repository
                   </Label>
@@ -373,7 +373,7 @@ export function DesignSystemSetup({
                       value={githubUrl}
                       onChange={(e) => setGithubUrl(e.target.value)}
                       placeholder="https://github.com/org/repo"
-                      className="bg-white/[0.04] border-white/[0.08] text-white/90 placeholder:text-white/25"
+                      className="bg-accent border-border text-foreground placeholder:text-muted-foreground"
                       onKeyDown={(e) => {
                         if (e.key === "Enter") addGithubLink();
                       }}
@@ -397,7 +397,7 @@ export function DesignSystemSetup({
 
                 {/* Code Files */}
                 <div className="space-y-2">
-                  <Label className="text-white/70 flex items-center gap-1.5">
+                  <Label className="text-foreground/80 flex items-center gap-1.5">
                     <IconFolder className="w-3.5 h-3.5" />
                     Code Files
                   </Label>
@@ -409,9 +409,9 @@ export function DesignSystemSetup({
                         readTextFiles(e.dataTransfer.files, setCodeFiles);
                     }}
                     onDragOver={(e) => e.preventDefault()}
-                    className="w-full border border-dashed border-white/[0.08] rounded-lg p-4 text-center hover:border-white/[0.15] cursor-pointer"
+                    className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/20 cursor-pointer"
                   >
-                    <p className="text-xs text-white/30">
+                    <p className="text-xs text-muted-foreground">
                       CSS, Tailwind config, theme files — drop or click
                     </p>
                   </button>
@@ -437,15 +437,15 @@ export function DesignSystemSetup({
 
                 {/* Documents */}
                 <div className="space-y-2">
-                  <Label className="text-white/70 flex items-center gap-1.5">
+                  <Label className="text-foreground/80 flex items-center gap-1.5">
                     <IconFileDescription className="w-3.5 h-3.5" />
                     Documents & Presentations
                   </Label>
                   <button
                     onClick={() => docInputRef.current?.click()}
-                    className="w-full border border-dashed border-white/[0.08] rounded-lg p-4 text-center hover:border-white/[0.15] cursor-pointer"
+                    className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/20 cursor-pointer"
                   >
-                    <p className="text-xs text-white/30">
+                    <p className="text-xs text-muted-foreground">
                       PPTX, DOCX, PDF — brand guides, pitch decks
                     </p>
                   </button>
@@ -477,15 +477,15 @@ export function DesignSystemSetup({
 
                 {/* Images */}
                 <div className="space-y-2">
-                  <Label className="text-white/70 flex items-center gap-1.5">
+                  <Label className="text-foreground/80 flex items-center gap-1.5">
                     <IconPhoto className="w-3.5 h-3.5" />
                     Screenshots & Visual References
                   </Label>
                   <button
                     onClick={() => imageInputRef.current?.click()}
-                    className="w-full border border-dashed border-white/[0.08] rounded-lg p-4 text-center hover:border-white/[0.15] cursor-pointer"
+                    className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/20 cursor-pointer"
                   >
-                    <p className="text-xs text-white/30">
+                    <p className="text-xs text-muted-foreground">
                       Product screenshots, mood boards, logos
                     </p>
                   </button>
@@ -518,7 +518,7 @@ export function DesignSystemSetup({
                 {/* Fork existing */}
                 {existingSystems.length > 0 && (
                   <div className="space-y-2">
-                    <Label className="text-white/70">
+                    <Label className="text-foreground/80">
                       Fork an existing design system
                     </Label>
                     <div className="grid grid-cols-2 gap-2">
@@ -535,12 +535,12 @@ export function DesignSystemSetup({
                             className={`text-left p-3 rounded-lg border cursor-pointer ${
                               selectedSystemId === ds.id
                                 ? "border-[#609FF8]/40 bg-[#609FF8]/5"
-                                : "border-white/[0.06] bg-white/[0.03] hover:border-white/[0.12]"
+                                : "border-border bg-accent hover:border-foreground/20"
                             }`}
                           >
                             <div className="flex items-center gap-2">
-                              <IconPalette className="w-3.5 h-3.5 text-white/40" />
-                              <span className="text-sm text-white/70 truncate">
+                              <IconPalette className="w-3.5 h-3.5 text-muted-foreground" />
+                              <span className="text-sm text-foreground/80 truncate">
                                 {ds.title}
                               </span>
                             </div>
@@ -554,7 +554,7 @@ export function DesignSystemSetup({
 
             {/* Brand Notes */}
             <div className="space-y-2">
-              <Label className="text-white/70">
+              <Label className="text-foreground/80">
                 {editingId ? "Brand Notes" : "Additional Notes"}
               </Label>
               <Textarea
@@ -562,19 +562,19 @@ export function DesignSystemSetup({
                 onChange={(e) => setBrandNotes(e.target.value)}
                 placeholder="Design preferences, constraints, brand guidelines..."
                 rows={3}
-                className="bg-white/[0.04] border-white/[0.08] text-white/90 placeholder:text-white/25 resize-none"
+                className="bg-accent border-border text-foreground placeholder:text-muted-foreground resize-none"
               />
             </div>
           </div>
         </ScrollArea>
 
         {/* Actions */}
-        <div className="flex justify-end gap-3 px-6 pb-6 pt-2 border-t border-white/[0.06]">
+        <div className="flex justify-end gap-3 px-6 pb-6 pt-2 border-t border-border">
           <Button
             variant="ghost"
             onClick={onClose}
             disabled={generating}
-            className="text-white/50 hover:text-white/80 cursor-pointer"
+            className="text-muted-foreground hover:text-foreground cursor-pointer"
           >
             Cancel
           </Button>
@@ -613,13 +613,13 @@ function TagList({
       {items.map((item, i) => (
         <div
           key={i}
-          className="flex items-center gap-2 text-sm text-white/60 bg-white/[0.03] rounded-md px-3 py-1.5"
+          className="flex items-center gap-2 text-sm text-foreground/80 bg-accent rounded-md px-3 py-1.5"
         >
-          <IconCheck className="w-3.5 h-3.5 text-green-400/60 shrink-0" />
+          <IconCheck className="w-3.5 h-3.5 text-green-500/70 shrink-0" />
           <span className="truncate flex-1">{item}</span>
           <button
             onClick={() => onRemove(i)}
-            className="text-white/30 hover:text-white/50 shrink-0 cursor-pointer"
+            className="text-muted-foreground hover:text-foreground/70 shrink-0 cursor-pointer"
           >
             <IconX className="w-3.5 h-3.5" />
           </button>
@@ -642,16 +642,16 @@ function FileList({
       {files.map((f) => (
         <div
           key={f.id}
-          className="flex items-center gap-2 text-sm text-white/60 bg-white/[0.03] rounded-md px-3 py-1.5"
+          className="flex items-center gap-2 text-sm text-foreground/80 bg-accent rounded-md px-3 py-1.5"
         >
-          <IconCheck className="w-3.5 h-3.5 text-green-400/60 shrink-0" />
+          <IconCheck className="w-3.5 h-3.5 text-green-500/70 shrink-0" />
           <span className="truncate flex-1">{f.name}</span>
-          <span className="text-[10px] text-white/20 shrink-0">
+          <span className="text-[10px] text-muted-foreground shrink-0">
             {formatSize(f.size)}
           </span>
           <button
             onClick={() => onRemove(f.id)}
-            className="text-white/30 hover:text-white/50 shrink-0 cursor-pointer"
+            className="text-muted-foreground hover:text-foreground/70 shrink-0 cursor-pointer"
           >
             <IconX className="w-3.5 h-3.5" />
           </button>

--- a/templates/slides/app/components/editor/AnimationsPanel.tsx
+++ b/templates/slides/app/components/editor/AnimationsPanel.tsx
@@ -109,25 +109,25 @@ function SortableAnimationItem({
     <div
       ref={setNodeRef}
       style={style}
-      className="flex items-center gap-1.5 py-1.5 px-1 rounded-md hover:bg-white/[0.03] group"
+      className="flex items-center gap-1.5 py-1.5 px-1 rounded-md hover:bg-accent group"
     >
       {/* Drag handle */}
       <button
         {...attributes}
         {...listeners}
-        className="text-white/20 hover:text-white/50 cursor-grab active:cursor-grabbing flex-shrink-0 touch-none"
+        className="text-muted-foreground/70 hover:text-muted-foreground cursor-grab active:cursor-grabbing flex-shrink-0 touch-none"
         tabIndex={-1}
       >
         <IconGripVertical className="w-3.5 h-3.5" />
       </button>
 
       {/* Step number badge */}
-      <span className="text-[9px] font-mono text-white/30 w-3.5 text-center flex-shrink-0">
+      <span className="text-[9px] font-mono text-muted-foreground w-3.5 text-center flex-shrink-0">
         {stepNumber}
       </span>
 
       {/* Element preview */}
-      <span className="flex-1 text-[11px] text-white/60 truncate min-w-0">
+      <span className="flex-1 text-[11px] text-muted-foreground truncate min-w-0">
         {preview || `Element ${anim.elementIndex + 1}`}
       </span>
 
@@ -136,7 +136,7 @@ function SortableAnimationItem({
         value={anim.type}
         onValueChange={(value) => onChangeType(anim.id, value as AnimationType)}
       >
-        <SelectTrigger className="h-auto text-[10px] bg-white/[0.06] border-white/[0.08] text-white/60 rounded px-1.5 py-0.5 flex-shrink-0 w-auto gap-1 min-w-[70px] focus:ring-0 focus:ring-offset-0">
+        <SelectTrigger className="h-auto text-[10px] bg-accent border-border text-muted-foreground rounded px-1.5 py-0.5 flex-shrink-0 w-auto gap-1 min-w-[70px] focus:ring-0 focus:ring-offset-0">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -151,7 +151,7 @@ function SortableAnimationItem({
       {/* Remove */}
       <button
         onClick={() => onRemove(anim.id)}
-        className="text-white/20 hover:text-white/60 flex-shrink-0 opacity-0 group-hover:opacity-100"
+        className="text-muted-foreground/70 hover:text-muted-foreground flex-shrink-0 opacity-0 group-hover:opacity-100"
         tabIndex={-1}
       >
         <IconTrash className="w-3 h-3" />
@@ -254,13 +254,15 @@ export function AnimationsPanel({
   );
 
   return (
-    <div className="w-60 flex flex-col h-full border-l border-white/[0.06] bg-[hsl(240,5%,6%)]">
+    <div className="w-60 flex flex-col h-full border-l border-border bg-background">
       {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2.5 border-b border-white/[0.06]">
-        <span className="text-xs font-medium text-white/70">Animations</span>
+      <div className="flex items-center justify-between px-3 py-2.5 border-b border-border">
+        <span className="text-xs font-medium text-foreground/90">
+          Animations
+        </span>
         <button
           onClick={onClose}
-          className="text-white/30 hover:text-white/60"
+          className="text-muted-foreground/70 hover:text-muted-foreground"
           aria-label="Close animations panel"
         >
           <IconX className="w-3.5 h-3.5" />
@@ -270,7 +272,7 @@ export function AnimationsPanel({
       {/* Animation list */}
       <div className="flex-1 overflow-y-auto">
         {animations.length === 0 ? (
-          <div className="px-3 py-6 text-center text-[11px] text-white/25 leading-relaxed">
+          <div className="px-3 py-6 text-center text-[11px] text-muted-foreground/70 leading-relaxed">
             No animations yet.
             <br />
             Add elements below to reveal them on click.
@@ -301,7 +303,7 @@ export function AnimationsPanel({
             {animations.length > 0 && (
               <button
                 onClick={clearAll}
-                className="mt-1 w-full text-[10px] text-white/25 hover:text-white/50 py-1"
+                className="mt-1 w-full text-[10px] text-muted-foreground/70 hover:text-muted-foreground py-1"
               >
                 Clear all
               </button>
@@ -311,9 +313,9 @@ export function AnimationsPanel({
 
         {/* Available elements to add */}
         {availableElements.length > 0 && (
-          <div className="border-t border-white/[0.06] px-2 py-2">
+          <div className="border-t border-border px-2 py-2">
             <div className="flex items-center justify-between mb-1.5 px-1">
-              <span className="text-[9px] font-medium text-white/25 uppercase tracking-wider">
+              <span className="text-[9px] font-medium text-muted-foreground/70 uppercase tracking-wider">
                 Elements
               </span>
               {unaddedElements.length > 0 && (
@@ -335,8 +337,8 @@ export function AnimationsPanel({
                   disabled={added}
                   className={`flex items-center gap-1.5 w-full px-1.5 py-1 rounded text-[11px] text-left ${
                     added
-                      ? "text-white/20 cursor-default"
-                      : "text-white/50 hover:text-white/80 hover:bg-white/[0.04]"
+                      ? "text-muted-foreground/70 cursor-default"
+                      : "text-muted-foreground hover:text-foreground hover:bg-accent"
                   }`}
                 >
                   <IconPlus
@@ -350,7 +352,7 @@ export function AnimationsPanel({
         )}
 
         {availableElements.length === 0 && (
-          <div className="px-3 py-4 text-center text-[11px] text-white/20">
+          <div className="px-3 py-4 text-center text-[11px] text-muted-foreground/70">
             No animatable elements detected on this slide.
           </div>
         )}

--- a/templates/slides/app/components/editor/AssetLibraryPanel.tsx
+++ b/templates/slides/app/components/editor/AssetLibraryPanel.tsx
@@ -127,13 +127,13 @@ export default function AssetLibraryPanel({
     <div
       ref={panelRef}
       style={style}
-      className="w-[min(20rem,calc(100vw-24px))] max-h-[420px] bg-[hsl(240,5%,10%)] border border-white/[0.1] rounded-xl shadow-2xl shadow-black/60 overflow-hidden flex flex-col"
+      className="w-[min(20rem,calc(100vw-24px))] max-h-[420px] bg-popover border border-border rounded-xl shadow-2xl shadow-black/60 overflow-hidden flex flex-col"
     >
       <div className="px-4 pt-3 pb-2 flex items-center justify-between flex-shrink-0">
-        <h3 className="text-sm font-semibold text-white/90">Asset Library</h3>
+        <h3 className="text-sm font-semibold text-foreground">Asset Library</h3>
         <button
           onClick={() => onOpenChange(false)}
-          className="text-white/30 hover:text-white/60 transition-colors"
+          className="text-muted-foreground/70 hover:text-muted-foreground transition-colors"
           aria-label="Close"
         >
           <IconX className="w-4 h-4" />
@@ -142,13 +142,13 @@ export default function AssetLibraryPanel({
 
       <div className="px-4 pb-4 space-y-3 overflow-y-auto flex-1">
         {/* Upload */}
-        <label className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-lg border border-dashed border-white/[0.1] hover:border-[#609FF8]/40 hover:bg-white/[0.02] cursor-pointer transition-all">
+        <label className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded-lg border border-dashed border-border hover:border-[#609FF8]/40 hover:bg-accent cursor-pointer transition-all">
           {uploading ? (
-            <IconLoader2 className="w-3.5 h-3.5 text-white/50 animate-spin" />
+            <IconLoader2 className="w-3.5 h-3.5 text-muted-foreground animate-spin" />
           ) : (
-            <IconUpload className="w-3.5 h-3.5 text-white/50" />
+            <IconUpload className="w-3.5 h-3.5 text-muted-foreground" />
           )}
-          <span className="text-xs text-white/50">
+          <span className="text-xs text-muted-foreground">
             {uploading ? "Uploading..." : "Upload images"}
           </span>
           <input
@@ -164,10 +164,10 @@ export default function AssetLibraryPanel({
         {/* Grid */}
         {loading ? (
           <div className="flex items-center justify-center py-8">
-            <IconLoader2 className="w-4 h-4 text-white/30 animate-spin" />
+            <IconLoader2 className="w-4 h-4 text-muted-foreground animate-spin" />
           </div>
         ) : assets.length === 0 ? (
-          <div className="text-center py-8 text-white/30 text-xs">
+          <div className="text-center py-8 text-muted-foreground text-xs">
             No assets yet.
           </div>
         ) : (
@@ -175,7 +175,7 @@ export default function AssetLibraryPanel({
             {assets.map((asset) => (
               <div
                 key={asset.filename}
-                className="group relative aspect-square rounded-md overflow-hidden border border-white/[0.08] bg-white/[0.02]"
+                className="group relative aspect-square rounded-md overflow-hidden border border-border bg-muted"
               >
                 <button
                   onClick={

--- a/templates/slides/app/components/editor/BlockBubbleMenu.tsx
+++ b/templates/slides/app/components/editor/BlockBubbleMenu.tsx
@@ -146,7 +146,7 @@ export function BlockBubbleMenu({ editingEl, onChange }: BlockBubbleMenuProps) {
   return createPortal(
     <div
       data-block-bubble-menu="true"
-      className="fixed z-[60] -translate-x-1/2 -translate-y-full flex items-center gap-0.5 p-1 rounded-lg bg-[#1a1a1a] border border-white/[0.08] shadow-2xl shadow-black/60"
+      className="fixed z-[60] -translate-x-1/2 -translate-y-full flex items-center gap-0.5 p-1 rounded-lg bg-popover border border-border shadow-2xl shadow-black/60"
       style={{ top: pos.top, left: pos.left }}
       onMouseDown={(e) => {
         // Prevent blur on the editing element when clicking menu buttons
@@ -173,7 +173,7 @@ export function BlockBubbleMenu({ editingEl, onChange }: BlockBubbleMenuProps) {
         title="Strikethrough"
         onClick={() => runCommand("strikeThrough")}
       />
-      <div className="w-px h-4 bg-white/[0.08] mx-0.5" />
+      <div className="w-px h-4 bg-border mx-0.5" />
       <div className="relative">
         <ToolbarButton
           icon={IconPalette}
@@ -185,14 +185,14 @@ export function BlockBubbleMenu({ editingEl, onChange }: BlockBubbleMenuProps) {
           active={showColors}
         />
         {showColors && (
-          <div className="absolute top-full left-0 mt-1 p-2 rounded-lg bg-[#1a1a1a] border border-white/[0.08] shadow-2xl shadow-black/60 grid grid-cols-6 gap-1">
+          <div className="absolute top-full left-0 mt-1 p-2 rounded-lg bg-popover border border-border shadow-2xl shadow-black/60 grid grid-cols-6 gap-1">
             {COLORS.map((c) => (
               <button
                 key={c}
                 type="button"
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => applyColor(c)}
-                className="w-5 h-5 rounded border border-white/[0.12] hover:scale-110 transition-transform"
+                className="w-5 h-5 rounded border border-border hover:scale-110 transition-transform"
                 style={{ background: c }}
                 title={c}
                 aria-label={`Set color ${c}`}
@@ -211,7 +211,7 @@ export function BlockBubbleMenu({ editingEl, onChange }: BlockBubbleMenuProps) {
         active={showLinkInput}
       />
       {showLinkInput && (
-        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1 flex items-center gap-1 p-1 rounded-lg bg-[#1a1a1a] border border-white/[0.08] shadow-2xl shadow-black/60">
+        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1 flex items-center gap-1 p-1 rounded-lg bg-popover border border-border shadow-2xl shadow-black/60">
           <input
             type="text"
             value={linkValue}
@@ -226,14 +226,14 @@ export function BlockBubbleMenu({ editingEl, onChange }: BlockBubbleMenuProps) {
               }
             }}
             placeholder="Paste URL"
-            className="px-2 py-1 text-xs bg-black/40 rounded text-white/90 outline-none border border-white/[0.06] focus:border-white/[0.2] w-40"
+            className="px-2 py-1 text-xs bg-muted rounded text-foreground outline-none border border-border focus:border-ring w-40"
             autoFocus
           />
           <button
             type="button"
             onMouseDown={(e) => e.preventDefault()}
             onClick={applyLink}
-            className="p-1 rounded hover:bg-white/[0.06] text-[#609FF8]"
+            className="p-1 rounded hover:bg-accent text-[#609FF8]"
             title="Apply"
           >
             <IconCheck className="w-3.5 h-3.5" />
@@ -242,7 +242,7 @@ export function BlockBubbleMenu({ editingEl, onChange }: BlockBubbleMenuProps) {
             type="button"
             onMouseDown={(e) => e.preventDefault()}
             onClick={removeLink}
-            className="p-1 rounded hover:bg-white/[0.06] text-white/50"
+            className="p-1 rounded hover:bg-accent text-muted-foreground"
             title="Remove link"
           >
             <IconX className="w-3.5 h-3.5" />
@@ -276,7 +276,7 @@ function ToolbarButton({
       className={`p-1.5 rounded transition-colors ${
         active
           ? "bg-[#609FF8]/20 text-[#609FF8]"
-          : "text-white/70 hover:bg-white/[0.08] hover:text-white"
+          : "text-foreground/80 hover:bg-accent hover:text-foreground"
       }`}
     >
       <Icon className="w-3.5 h-3.5" />

--- a/templates/slides/app/components/editor/CodeEditor.tsx
+++ b/templates/slides/app/components/editor/CodeEditor.tsx
@@ -10,8 +10,8 @@ export default function CodeEditor({ slide, onUpdateSlide }: CodeEditorProps) {
     <div className="h-full flex flex-col">
       {/* Content editor */}
       <div className="flex-1 flex flex-col">
-        <div className="px-4 py-2 border-b border-white/[0.04]">
-          <span className="text-[10px] font-medium text-white/30 uppercase tracking-wider">
+        <div className="px-4 py-2 border-b border-border">
+          <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
             Content (Markdown)
           </span>
         </div>
@@ -19,7 +19,7 @@ export default function CodeEditor({ slide, onUpdateSlide }: CodeEditorProps) {
           <textarea
             value={slide.content}
             onChange={(e) => onUpdateSlide({ content: e.target.value })}
-            className="absolute inset-0 w-full h-full bg-transparent text-white/80 font-mono text-sm p-4 resize-none outline-none leading-relaxed"
+            className="absolute inset-0 w-full h-full bg-transparent text-foreground/90 font-mono text-sm p-4 resize-none outline-none leading-relaxed"
             spellCheck={false}
             placeholder="Write your slide content in Markdown..."
           />
@@ -27,16 +27,16 @@ export default function CodeEditor({ slide, onUpdateSlide }: CodeEditorProps) {
       </div>
 
       {/* Speaker notes */}
-      <div className="h-32 border-t border-white/[0.06] flex flex-col">
-        <div className="px-4 py-2 border-b border-white/[0.04]">
-          <span className="text-[10px] font-medium text-white/30 uppercase tracking-wider">
+      <div className="h-32 border-t border-border flex flex-col">
+        <div className="px-4 py-2 border-b border-border">
+          <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
             Speaker Notes
           </span>
         </div>
         <textarea
           value={slide.notes}
           onChange={(e) => onUpdateSlide({ notes: e.target.value })}
-          className="flex-1 w-full bg-transparent text-white/50 text-xs p-4 resize-none outline-none leading-relaxed font-mono"
+          className="flex-1 w-full bg-transparent text-muted-foreground text-xs p-4 resize-none outline-none leading-relaxed font-mono"
           placeholder="Add speaker notes..."
           spellCheck={false}
         />

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -89,10 +89,10 @@ function PresenceAvatarTip({
           )}
         </div>
         <div className="flex flex-col min-w-0">
-          <span className="text-[12px] font-medium text-white leading-tight">
+          <span className="text-[12px] font-medium text-foreground leading-tight">
             {user.name}
           </span>
-          <span className="text-[10px] text-white/50 truncate">
+          <span className="text-[10px] text-muted-foreground truncate">
             {user.email}
           </span>
         </div>
@@ -140,9 +140,7 @@ function SortableSlideThumb({
       <button
         onClick={onSelect}
         className={`w-full text-left flex items-start gap-2 p-2 rounded-lg transition-all duration-150 ${
-          isActive
-            ? "bg-white/[0.08] ring-1 ring-[#609FF8]/50"
-            : "hover:bg-white/[0.04]"
+          isActive ? "bg-accent ring-1 ring-[#609FF8]/50" : "hover:bg-accent"
         }`}
       >
         {/* Drag handle */}
@@ -151,11 +149,11 @@ function SortableSlideThumb({
           {...listeners}
           className="flex-shrink-0 mt-2 cursor-grab active:cursor-grabbing sm:opacity-0 sm:group-hover:opacity-100"
         >
-          <IconGripVertical className="w-3.5 h-3.5 text-white/30" />
+          <IconGripVertical className="w-3.5 h-3.5 text-muted-foreground/70" />
         </div>
 
         {/* Index */}
-        <span className="flex-shrink-0 w-5 mt-2 text-[10px] font-medium text-white/30">
+        <span className="flex-shrink-0 w-5 mt-2 text-[10px] font-medium text-muted-foreground/70">
           {index + 1}
         </span>
 
@@ -179,7 +177,7 @@ function SortableSlideThumb({
                 <PresenceAvatarTip key={i} user={u} size={16} />
               ))}
               {presenceUsers.length > 4 && (
-                <span className="text-[9px] text-white/30 ml-0.5">
+                <span className="text-[9px] text-muted-foreground/70 ml-0.5">
                   +{presenceUsers.length - 4}
                 </span>
               )}
@@ -363,10 +361,8 @@ function AddSlidePopover({
   return createPortal(
     <div
       ref={panelRef}
-      className={`fixed w-[min(24rem,calc(100vw-24px))] rounded-xl border bg-[hsl(240,5%,10%)] shadow-2xl shadow-black/60 z-[200] overflow-hidden transition-colors ${
-        dragging
-          ? "border-[#609FF8]/50 bg-[hsl(240,5%,12%)]"
-          : "border-white/[0.1]"
+      className={`fixed w-[min(24rem,calc(100vw-24px))] rounded-xl border bg-popover shadow-2xl shadow-black/60 z-[200] overflow-hidden transition-colors ${
+        dragging ? "border-[#609FF8]/50 bg-accent" : "border-border"
       }`}
       style={{
         top: rect.bottom + 8,
@@ -394,7 +390,7 @@ function AddSlidePopover({
               Math.min(el.scrollHeight, window.innerHeight * 0.5) + "px";
           }}
           placeholder="Describe the slides you want..."
-          className="w-full bg-transparent text-sm text-white/90 placeholder:text-white/30 outline-none resize-none"
+          className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/70 outline-none resize-none"
           rows={3}
           style={{ maxHeight: "50vh" }}
           onKeyDown={(e) => {
@@ -412,12 +408,12 @@ function AddSlidePopover({
           {files.map((file, i) => (
             <div
               key={i}
-              className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-white/[0.06] border border-white/[0.08] text-[11px] text-white/50"
+              className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-accent border border-border text-[11px] text-muted-foreground"
             >
               <span className="max-w-[100px] truncate">{file.name}</span>
               <button
                 onClick={() => removeFile(i)}
-                className="p-0.5 rounded hover:bg-white/[0.1]"
+                className="p-0.5 rounded hover:bg-accent"
                 aria-label={`Remove ${file.name}`}
               >
                 <IconX className="w-2.5 h-2.5" />
@@ -428,11 +424,11 @@ function AddSlidePopover({
       )}
 
       {/* Bottom bar */}
-      <div className="px-3.5 py-2 flex items-center justify-between border-t border-white/[0.06]">
+      <div className="px-3.5 py-2 flex items-center justify-between border-t border-border">
         <button
           type="button"
           onClick={() => fileInputRef.current?.click()}
-          className="p-2 rounded-md hover:bg-white/[0.06] text-white/30 hover:text-white/50"
+          className="p-2 rounded-md hover:bg-accent text-muted-foreground/70 hover:text-foreground"
           title="Attach files"
           aria-label="Attach files"
         >
@@ -449,14 +445,14 @@ function AddSlidePopover({
         <button
           onClick={handleSubmit}
           disabled={busy}
-          className="p-2 rounded-lg bg-white/[0.12] hover:bg-white/[0.18] disabled:opacity-30 disabled:cursor-not-allowed"
+          className="p-2 rounded-lg bg-accent hover:bg-accent/80 disabled:opacity-30 disabled:cursor-not-allowed"
           title="Generate"
           aria-label="Generate slides"
         >
           {busy ? (
-            <IconLoader2 className="w-4 h-4 text-white/70 animate-spin" />
+            <IconLoader2 className="w-4 h-4 text-foreground/90 animate-spin" />
           ) : (
-            <IconArrowUp className="w-4 h-4 text-white/70" />
+            <IconArrowUp className="w-4 h-4 text-foreground/90" />
           )}
         </button>
       </div>
@@ -518,22 +514,22 @@ export default function EditorSidebar({
   }, [slides, activeSlideId, onSelectSlide]);
 
   return (
-    <div className="w-56 sm:w-64 flex-shrink-0 border-r border-white/[0.06] bg-[hsl(240,5%,6%)] flex flex-col h-full">
-      <div className="p-3 border-b border-white/[0.06] flex items-center justify-between">
-        <span className="text-xs font-medium text-white/50 uppercase tracking-wider">
+    <div className="w-56 sm:w-64 flex-shrink-0 border-r border-border bg-background flex flex-col h-full">
+      <div className="p-3 border-b border-border flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           Slides
         </span>
         {addSlideGenerating ? (
-          <IconLoader2 className="w-4 h-4 text-white/40 animate-spin" />
+          <IconLoader2 className="w-4 h-4 text-muted-foreground animate-spin" />
         ) : (
           <button
             ref={headerAddRef}
             onClick={() => setAddOpen(!addOpen)}
-            className="p-2 rounded-md hover:bg-white/[0.06] transition-colors"
+            className="p-2 rounded-md hover:bg-accent transition-colors"
             title="Add slides"
             aria-label="Add slides"
           >
-            <IconPlus className="w-4 h-4 text-white/50" />
+            <IconPlus className="w-4 h-4 text-muted-foreground" />
           </button>
         )}
       </div>
@@ -557,7 +553,7 @@ export default function EditorSidebar({
           ))}
         </SortableContext>
 
-        <div className="border-t border-white/[0.06] mt-2 pt-1">
+        <div className="border-t border-border mt-2 pt-1">
           <ToolsSidebarSection />
         </div>
       </div>

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -152,7 +152,7 @@ function ToolbarPopover({
   return createPortal(
     <div
       ref={menuRef}
-      className="fixed rounded-lg border border-white/[0.08] bg-[hsl(240,5%,10%)] shadow-xl z-[200] max-h-[80vh] overflow-y-auto"
+      className="fixed rounded-lg border border-border bg-popover shadow-xl z-[200] max-h-[80vh] overflow-y-auto"
       style={{ top: rect.bottom + 4, left, width: Math.min(width, vw - 16) }}
     >
       {children}
@@ -207,22 +207,22 @@ export default function EditorToolbar({
   };
 
   return (
-    <div className="h-12 border-b border-white/[0.06] bg-[hsl(240,5%,6%)] flex items-center px-1 sm:px-3 gap-1 sm:gap-2 overflow-x-auto">
+    <div className="h-12 border-b border-border bg-background flex items-center px-1 sm:px-3 gap-1 sm:gap-2 overflow-x-auto">
       {/* Back button */}
       <Link
         to="/"
-        className="p-2.5 sm:p-1.5 rounded-md hover:bg-white/[0.06] transition-colors flex-shrink-0"
+        className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent transition-colors flex-shrink-0"
         title="Back to decks"
         aria-label="Back to decks"
       >
-        <IconArrowLeft className="w-4 h-4 text-white/60" />
+        <IconArrowLeft className="w-4 h-4 text-muted-foreground" />
       </Link>
 
       {/* Sidebar toggle */}
       <button
         onClick={onToggleSidebar}
-        className={`p-2.5 sm:p-1.5 rounded-md hover:bg-white/[0.06] transition-colors flex-shrink-0 ${
-          sidebarOpen ? "text-white/60" : "text-white/30"
+        className={`p-2.5 sm:p-1.5 rounded-md hover:bg-accent transition-colors flex-shrink-0 ${
+          sidebarOpen ? "text-muted-foreground" : "text-muted-foreground/70"
         }`}
         title="Toggle sidebar"
         aria-label="Toggle sidebar"
@@ -235,12 +235,12 @@ export default function EditorToolbar({
         type="text"
         value={deckTitle}
         onChange={(e) => onTitleChange(e.target.value)}
-        className="bg-transparent text-sm font-medium text-white/80 border-none outline-none focus:text-white min-w-0 w-24 sm:w-auto flex-shrink"
+        className="bg-transparent text-sm font-medium text-foreground/90 border-none outline-none focus:text-foreground min-w-0 w-24 sm:w-auto flex-shrink"
         spellCheck={false}
       />
 
       {/* Slide counter */}
-      <span className="text-xs text-white/30 flex-shrink-0 hidden sm:inline">
+      <span className="text-xs text-muted-foreground/70 flex-shrink-0 hidden sm:inline">
         {currentSlideIndex + 1}/{slideCount}
       </span>
 
@@ -258,8 +258,8 @@ export default function EditorToolbar({
             }}
             className={`flex items-center gap-1 p-2.5 sm:px-2 sm:py-1.5 rounded-md text-xs transition-colors flex-shrink-0 ${
               layoutOpen
-                ? "text-white/80 bg-white/[0.06]"
-                : "text-white/50 hover:text-white/70 hover:bg-white/[0.06]"
+                ? "text-foreground/90 bg-accent"
+                : "text-muted-foreground hover:text-foreground/70 hover:bg-accent"
             }`}
             title="Slide settings"
             aria-label="Slide settings"
@@ -274,7 +274,7 @@ export default function EditorToolbar({
           >
             <div className="py-1.5">
               {/* Layout section */}
-              <div className="px-3 py-1.5 text-[10px] font-medium text-white/30 uppercase tracking-wider">
+              <div className="px-3 py-1.5 text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
                 Layout
               </div>
               {slideLayoutOptions.map((opt) => (
@@ -285,8 +285,8 @@ export default function EditorToolbar({
                   }}
                   className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
                     currentSlide.layout === opt.value
-                      ? "text-[#609FF8] bg-white/[0.04]"
-                      : "text-white/60 hover:text-white hover:bg-white/[0.04]"
+                      ? "text-[#609FF8] bg-accent/50"
+                      : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
                   }`}
                 >
                   <IconLayout className="w-3 h-3" />
@@ -295,8 +295,8 @@ export default function EditorToolbar({
               ))}
 
               {/* Background section */}
-              <div className="mx-2 my-1.5 border-t border-white/[0.06]" />
-              <div className="px-3 py-1.5 text-[10px] font-medium text-white/30 uppercase tracking-wider">
+              <div className="mx-2 my-1.5 border-t border-border" />
+              <div className="px-3 py-1.5 text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
                 Background
               </div>
               <div className="px-3 pb-2">
@@ -310,7 +310,7 @@ export default function EditorToolbar({
                       className={`w-10 h-7 rounded-md border transition-all ${bg} ${
                         currentSlide.background === bg
                           ? "border-[#609FF8] ring-1 ring-[#609FF8]/30"
-                          : "border-white/[0.08] hover:border-white/[0.2]"
+                          : "border-border hover:border-foreground/20"
                       }`}
                     />
                   ))}
@@ -318,8 +318,8 @@ export default function EditorToolbar({
               </div>
 
               {/* Image & Assets section */}
-              <div className="mx-2 my-1.5 border-t border-white/[0.06]" />
-              <div className="px-3 py-1.5 text-[10px] font-medium text-white/30 uppercase tracking-wider">
+              <div className="mx-2 my-1.5 border-t border-border" />
+              <div className="px-3 py-1.5 text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
                 Media
               </div>
               <button
@@ -328,7 +328,7 @@ export default function EditorToolbar({
                   onGenerateImage();
                   setLayoutOpen(false);
                 }}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-white/60 hover:text-white hover:bg-white/[0.04] transition-colors"
+                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
               >
                 <IconPhoto className="w-3 h-3" />
                 Generate Image
@@ -339,15 +339,15 @@ export default function EditorToolbar({
                   onOpenAssetLibrary();
                   setLayoutOpen(false);
                 }}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-white/60 hover:text-white hover:bg-white/[0.04] transition-colors"
+                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
               >
                 <IconFolderOpen className="w-3 h-3" />
                 Asset Library
               </button>
 
               {/* Diagrams section */}
-              <div className="mx-2 my-1.5 border-t border-white/[0.06]" />
-              <div className="px-3 py-1.5 text-[10px] font-medium text-white/30 uppercase tracking-wider">
+              <div className="mx-2 my-1.5 border-t border-border" />
+              <div className="px-3 py-1.5 text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
                 Diagrams
               </div>
               <button
@@ -369,7 +369,7 @@ graph TD
                   });
                   setLayoutOpen(false);
                 }}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-white/60 hover:text-white hover:bg-white/[0.04] transition-colors"
+                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
               >
                 <IconSchema className="w-3 h-3" />
                 Insert Mermaid Diagram
@@ -386,7 +386,7 @@ graph TD
                   });
                   setLayoutOpen(false);
                 }}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-white/60 hover:text-white hover:bg-white/[0.04] transition-colors"
+                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
               >
                 <IconPencil className="w-3 h-3" />
                 Excalidraw Canvas
@@ -412,7 +412,7 @@ graph TD
                         console.error("Mermaid to Excalidraw failed:", err);
                       }
                     }}
-                    className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[#00E5FF]/80 hover:text-[#00E5FF] hover:bg-white/[0.04] transition-colors"
+                    className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-[#00E5FF]/80 hover:text-[#00E5FF] hover:bg-accent/50 transition-colors"
                   >
                     <IconTransform className="w-3 h-3" />
                     Convert Mermaid → Excalidraw
@@ -425,7 +425,7 @@ graph TD
                     onUpdateSlide({ excalidrawData: undefined });
                     setLayoutOpen(false);
                   }}
-                  className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-white/40 hover:text-white/60 hover:bg-white/[0.04] transition-colors"
+                  className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-muted-foreground hover:text-muted-foreground hover:bg-accent/50 transition-colors"
                 >
                   <IconPencil className="w-3 h-3" />
                   Remove Excalidraw Canvas
@@ -433,8 +433,8 @@ graph TD
               )}
 
               {/* Transitions section */}
-              <div className="mx-2 my-1.5 border-t border-white/[0.06]" />
-              <div className="px-3 py-1.5 text-[10px] font-medium text-white/30 uppercase tracking-wider">
+              <div className="mx-2 my-1.5 border-t border-border" />
+              <div className="px-3 py-1.5 text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider">
                 Transition
               </div>
               <div className="px-3 pb-2.5 grid grid-cols-4 gap-1">
@@ -452,7 +452,7 @@ graph TD
                       className={`px-1.5 py-1 rounded text-[10px] font-medium capitalize border ${
                         active
                           ? "bg-[#609FF8]/20 text-[#609FF8] border-[#609FF8]/30"
-                          : "text-white/40 hover:text-white/70 hover:bg-white/[0.04] border-transparent"
+                          : "text-muted-foreground hover:text-foreground/70 hover:bg-accent/50 border-transparent"
                       }`}
                     >
                       {t.charAt(0).toUpperCase() + t.slice(1)}
@@ -472,7 +472,7 @@ graph TD
           className={`p-2.5 sm:p-1.5 rounded-md cursor-pointer flex-shrink-0 ${
             animationsOpen
               ? "text-[#609FF8] bg-[#609FF8]/10"
-              : "text-white/40 hover:text-white/70 hover:bg-white/[0.06]"
+              : "text-muted-foreground hover:text-foreground/70 hover:bg-accent"
           }`}
           title="Element animations"
           aria-label="Element animations"
@@ -487,7 +487,7 @@ graph TD
           <TooltipTrigger asChild>
             <button
               onClick={onToggleTweaks}
-              className={`p-1.5 rounded cursor-pointer ${tweaksOpen ? "bg-white/10 text-white" : "text-white/40 hover:text-white/70 hover:bg-white/[0.06]"}`}
+              className={`p-1.5 rounded cursor-pointer ${tweaksOpen ? "bg-accent text-foreground" : "text-muted-foreground hover:text-foreground/70 hover:bg-accent"}`}
             >
               <IconAdjustments className="w-4 h-4" />
             </button>
@@ -500,27 +500,27 @@ graph TD
       <ImportButton deckId={deckId} />
 
       {/* Separator */}
-      <div className="w-px h-5 bg-white/[0.08] flex-shrink-0 hidden sm:block" />
+      <div className="w-px h-5 bg-accent flex-shrink-0 hidden sm:block" />
 
       {/* Undo/Redo */}
       <div className="flex items-center flex-shrink-0">
         <button
           onClick={onUndo}
           disabled={!canUndo}
-          className="p-2.5 sm:p-1.5 rounded-md hover:bg-white/[0.06] disabled:opacity-20 transition-colors"
+          className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent disabled:opacity-20 transition-colors"
           title="Undo (Cmd+Z)"
           aria-label="Undo"
         >
-          <IconArrowBackUp className="w-3.5 h-3.5 text-white/60" />
+          <IconArrowBackUp className="w-3.5 h-3.5 text-muted-foreground" />
         </button>
         <button
           onClick={onRedo}
           disabled={!canRedo}
-          className="p-2.5 sm:p-1.5 rounded-md hover:bg-white/[0.06] disabled:opacity-20 transition-colors"
+          className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent disabled:opacity-20 transition-colors"
           title="Redo (Cmd+Shift+Z)"
           aria-label="Redo"
         >
-          <IconArrowForwardUp className="w-3.5 h-3.5 text-white/60" />
+          <IconArrowForwardUp className="w-3.5 h-3.5 text-muted-foreground" />
         </button>
       </div>
 
@@ -528,10 +528,10 @@ graph TD
       <button
         ref={historyButtonRef}
         onClick={onShowHistory}
-        className={`p-2.5 sm:p-1.5 rounded-md hover:bg-white/[0.06] transition-colors flex-shrink-0 hidden sm:block ${
+        className={`p-2.5 sm:p-1.5 rounded-md hover:bg-accent transition-colors flex-shrink-0 hidden sm:block ${
           historyOpen
-            ? "text-white/80 bg-white/[0.06]"
-            : "text-white/40 hover:text-white/70"
+            ? "text-foreground/90 bg-accent"
+            : "text-muted-foreground hover:text-foreground/70"
         }`}
         title="Edit history"
         aria-label="Edit history"
@@ -540,16 +540,16 @@ graph TD
       </button>
 
       {/* Separator */}
-      <div className="w-px h-5 bg-white/[0.08] flex-shrink-0 hidden sm:block" />
+      <div className="w-px h-5 bg-accent flex-shrink-0 hidden sm:block" />
 
       {/* Edit mode tabs */}
-      <div className="flex items-center rounded-md border border-white/[0.08] overflow-hidden flex-shrink-0">
+      <div className="flex items-center rounded-md border border-border overflow-hidden flex-shrink-0">
         <button
           onClick={() => onTabChange("visual")}
           className={`px-3 py-2 sm:py-1.5 text-xs font-medium transition-colors ${
             activeTab === "visual"
-              ? "bg-white/[0.08] text-white/90"
-              : "text-white/40 hover:text-white/60"
+              ? "bg-accent text-foreground"
+              : "text-muted-foreground hover:text-muted-foreground"
           }`}
         >
           Preview
@@ -558,8 +558,8 @@ graph TD
           onClick={() => onTabChange("code")}
           className={`px-3 py-2 sm:py-1.5 text-xs font-medium transition-colors ${
             activeTab === "code"
-              ? "bg-white/[0.08] text-white/90"
-              : "text-white/40 hover:text-white/60"
+              ? "bg-accent text-foreground"
+              : "text-muted-foreground hover:text-muted-foreground"
           }`}
         >
           Code
@@ -581,8 +581,8 @@ graph TD
           onClick={onToggleComments}
           className={`relative p-2.5 sm:p-1.5 rounded-md transition-colors flex-shrink-0 ${
             commentsOpen
-              ? "text-white/90 bg-white/[0.08]"
-              : "text-white/40 hover:text-white/70 hover:bg-white/[0.06]"
+              ? "text-foreground bg-accent"
+              : "text-muted-foreground hover:text-foreground/70 hover:bg-accent"
           }`}
           title="Comments"
           aria-label="Comments"
@@ -622,7 +622,7 @@ graph TD
         <IconPlayerPlay className="w-3 h-3" />
         <span className="hidden sm:inline">Present</span>
       </Link>
-      <AgentToggleButton className="flex-shrink-0 text-white/40 hover:text-white/70 hover:bg-white/[0.06]" />
+      <AgentToggleButton className="flex-shrink-0 text-muted-foreground hover:text-foreground/70 hover:bg-accent" />
     </div>
   );
 }

--- a/templates/slides/app/components/editor/ExportMenu.tsx
+++ b/templates/slides/app/components/editor/ExportMenu.tsx
@@ -89,13 +89,13 @@ export function ExportMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-white/60 hover:text-white hover:bg-white/[0.06] text-xs cursor-pointer">
+        <button className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent text-xs cursor-pointer">
           <IconShare2 className="w-3.5 h-3.5" />
           Share
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-52">
-        <DropdownMenuLabel className="text-[11px] text-white/40">
+        <DropdownMenuLabel className="text-[11px] text-muted-foreground">
           Share & Export
         </DropdownMenuLabel>
         {onShareTeam && (

--- a/templates/slides/app/components/editor/GenerateSlidesDialog.tsx
+++ b/templates/slides/app/components/editor/GenerateSlidesDialog.tsx
@@ -82,13 +82,13 @@ export default function GenerateSlidesDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-[hsl(240,5%,8%)] border-white/[0.08] max-w-lg">
+      <DialogContent className="bg-card border-border max-w-lg">
         <DialogHeader>
-          <DialogTitle className="text-white/90 flex items-center gap-2">
+          <DialogTitle className="text-foreground flex items-center gap-2">
             <IconWand className="w-5 h-5 text-[#609FF8]" />
             Generate Slides with AI
           </DialogTitle>
-          <DialogDescription className="text-white/50">
+          <DialogDescription className="text-muted-foreground">
             Describe your presentation topic and AI will generate slides for
             you.
           </DialogDescription>
@@ -97,28 +97,28 @@ export default function GenerateSlidesDialog({
         <div className="space-y-4 mt-2">
           {/* Topic */}
           <div>
-            <label className="text-xs font-medium text-white/60 block mb-1.5">
+            <label className="text-xs font-medium text-muted-foreground block mb-1.5">
               Topic
             </label>
             <textarea
               value={topic}
               onChange={(e) => setTopic(e.target.value)}
               placeholder="e.g. Introduction to React Hooks, Q4 Sales Report, Product Roadmap 2025..."
-              className="w-full h-20 bg-white/[0.04] border border-white/[0.08] rounded-lg px-3 py-2 text-sm text-white/90 placeholder:text-white/30 outline-none focus:border-[#609FF8]/50 resize-none"
+              className="w-full h-20 bg-accent/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/70 outline-none focus:border-[#609FF8]/50 resize-none"
             />
           </div>
 
           {/* Options row */}
           <div className="flex gap-3">
             <div className="flex-1">
-              <label className="text-xs font-medium text-white/60 block mb-1.5">
+              <label className="text-xs font-medium text-muted-foreground block mb-1.5">
                 Slides
               </label>
               <Select
                 value={String(slideCount)}
                 onValueChange={(value) => setSlideCount(Number(value))}
               >
-                <SelectTrigger className="w-full bg-white/[0.04] border-white/[0.08] rounded-lg text-sm text-white/90 focus:ring-0 focus:ring-offset-0 focus:border-[#609FF8]/50">
+                <SelectTrigger className="w-full bg-accent/50 border-border rounded-lg text-sm text-foreground focus:ring-0 focus:ring-offset-0 focus:border-[#609FF8]/50">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -131,14 +131,14 @@ export default function GenerateSlidesDialog({
               </Select>
             </div>
             <div className="flex-1">
-              <label className="text-xs font-medium text-white/60 block mb-1.5">
+              <label className="text-xs font-medium text-muted-foreground block mb-1.5">
                 Style (optional)
               </label>
               <input
                 value={style}
                 onChange={(e) => setStyle(e.target.value)}
                 placeholder="e.g. minimal, corporate..."
-                className="w-full bg-white/[0.04] border border-white/[0.08] rounded-lg px-3 py-2 text-sm text-white/90 placeholder:text-white/30 outline-none focus:border-[#609FF8]/50"
+                className="w-full bg-accent/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/70 outline-none focus:border-[#609FF8]/50"
               />
             </div>
           </div>
@@ -149,7 +149,7 @@ export default function GenerateSlidesDialog({
               type="button"
               onClick={() => setIncludeImages(!includeImages)}
               className={`relative w-9 h-5 rounded-full transition-colors ${
-                includeImages ? "bg-[#609FF8]" : "bg-white/[0.12]"
+                includeImages ? "bg-[#609FF8]" : "bg-accent"
               }`}
             >
               <div
@@ -159,8 +159,8 @@ export default function GenerateSlidesDialog({
               />
             </button>
             <div>
-              <span className="text-sm text-white/80">Generate images</span>
-              <p className="text-xs text-white/40">
+              <span className="text-sm text-foreground/90">Generate images</span>
+              <p className="text-xs text-muted-foreground">
                 AI will generate images for visual slides using Gemini
               </p>
             </div>
@@ -169,7 +169,7 @@ export default function GenerateSlidesDialog({
           {/* Reference images for brand consistency */}
           {includeImages && (
             <div>
-              <label className="text-xs font-medium text-white/60 block mb-1.5">
+              <label className="text-xs font-medium text-muted-foreground block mb-1.5">
                 <IconPhoto className="w-3 h-3 inline mr-1" />
                 Reference Images (optional, for brand consistency)
               </label>
@@ -177,7 +177,7 @@ export default function GenerateSlidesDialog({
                 {referenceImages.map((img, i) => (
                   <div
                     key={i}
-                    className="relative w-14 h-14 rounded-md overflow-hidden border border-white/[0.08]"
+                    className="relative w-14 h-14 rounded-md overflow-hidden border border-border"
                   >
                     <img
                       src={img}
@@ -190,14 +190,14 @@ export default function GenerateSlidesDialog({
                           prev.filter((_, j) => j !== i),
                         )
                       }
-                      className="absolute top-0 right-0 w-4 h-4 bg-black/70 text-white/80 text-[10px] flex items-center justify-center rounded-bl"
+                      className="absolute top-0 right-0 w-4 h-4 bg-black/70 text-foreground/90 text-[10px] flex items-center justify-center rounded-bl"
                     >
                       x
                     </button>
                   </div>
                 ))}
-                <label className="w-14 h-14 rounded-md border border-dashed border-white/[0.12] flex items-center justify-center cursor-pointer hover:border-[#609FF8]/40 transition-colors">
-                  <span className="text-white/30 text-lg">+</span>
+                <label className="w-14 h-14 rounded-md border border-dashed border-border flex items-center justify-center cursor-pointer hover:border-[#609FF8]/40 transition-colors">
+                  <span className="text-muted-foreground/70 text-lg">+</span>
                   <input
                     type="file"
                     accept="image/*"
@@ -207,7 +207,7 @@ export default function GenerateSlidesDialog({
                   />
                 </label>
               </div>
-              <p className="text-[11px] text-white/30">
+              <p className="text-[11px] text-muted-foreground/70">
                 Upload images to match their visual style in generated images
               </p>
             </div>

--- a/templates/slides/app/components/editor/GenerateSlidesDialog.tsx
+++ b/templates/slides/app/components/editor/GenerateSlidesDialog.tsx
@@ -159,7 +159,9 @@ export default function GenerateSlidesDialog({
               />
             </button>
             <div>
-              <span className="text-sm text-foreground/90">Generate images</span>
+              <span className="text-sm text-foreground/90">
+                Generate images
+              </span>
               <p className="text-xs text-muted-foreground">
                 AI will generate images for visual slides using Gemini
               </p>

--- a/templates/slides/app/components/editor/GeneratingOverlay.tsx
+++ b/templates/slides/app/components/editor/GeneratingOverlay.tsx
@@ -2,10 +2,12 @@ import { IconLoader2 } from "@tabler/icons-react";
 
 export default function GeneratingOverlay() {
   return (
-    <div className="flex-1 flex items-center justify-center bg-[hsl(240,5%,5%)]">
+    <div className="flex-1 flex items-center justify-center bg-background">
       <div className="flex flex-col items-center gap-4">
         <IconLoader2 className="w-8 h-8 text-[#609FF8] animate-spin" />
-        <p className="text-sm text-white/50 font-medium">Generating deck...</p>
+        <p className="text-sm text-muted-foreground font-medium">
+          Generating deck...
+        </p>
       </div>
     </div>
   );

--- a/templates/slides/app/components/editor/HistoryPanel.tsx
+++ b/templates/slides/app/components/editor/HistoryPanel.tsx
@@ -65,22 +65,22 @@ export default function HistoryPanel({
   return createPortal(
     <div
       ref={panelRef}
-      className="fixed rounded-lg border border-white/[0.08] bg-[hsl(240,5%,8%)] shadow-2xl z-[200]"
+      className="fixed rounded-lg border border-border bg-popover shadow-2xl z-[200]"
       style={{ top: rect.bottom + 6, left, width: panelWidth }}
     >
-      <div className="px-3 py-2.5 border-b border-white/[0.06] flex items-center gap-2">
+      <div className="px-3 py-2.5 border-b border-border flex items-center gap-2">
         <IconHistory className="w-4 h-4 text-[#609FF8]" />
-        <span className="text-xs font-medium text-white/80">
+        <span className="text-xs font-medium text-foreground/90">
           Edit IconHistory
         </span>
-        <span className="text-[10px] text-white/30 ml-auto">
+        <span className="text-[10px] text-muted-foreground ml-auto">
           Cmd+Z / Cmd+Shift+Z
         </span>
       </div>
 
       <div className="overflow-y-auto max-h-[50vh] p-1">
         {history.length === 0 && (
-          <p className="text-xs text-white/30 text-center py-4">
+          <p className="text-xs text-muted-foreground text-center py-4">
             No history yet
           </p>
         )}
@@ -96,7 +96,7 @@ export default function HistoryPanel({
                 onOpenChange(false);
               }}
               className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-md text-left transition-colors ${
-                isCurrent ? "bg-[#609FF8]/10" : "hover:bg-white/[0.04]"
+                isCurrent ? "bg-[#609FF8]/10" : "hover:bg-accent"
               }`}
             >
               <div
@@ -104,15 +104,15 @@ export default function HistoryPanel({
                   isCurrent
                     ? "bg-[#609FF8]"
                     : realIdx < historyIndex
-                      ? "bg-white/20"
-                      : "bg-white/10"
+                      ? "bg-muted-foreground/40"
+                      : "bg-muted-foreground/20"
                 }`}
               />
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-1.5">
                   <span
                     className={`text-xs font-medium truncate ${
-                      isCurrent ? "text-[#609FF8]" : "text-white/60"
+                      isCurrent ? "text-[#609FF8]" : "text-muted-foreground"
                     }`}
                   >
                     {entry.label}
@@ -123,7 +123,7 @@ export default function HistoryPanel({
                     </span>
                   )}
                 </div>
-                <span className="text-[10px] text-white/25">
+                <span className="text-[10px] text-muted-foreground/70">
                   {timeAgo(entry.timestamp)}
                 </span>
               </div>

--- a/templates/slides/app/components/editor/ImageGenPanel.tsx
+++ b/templates/slides/app/components/editor/ImageGenPanel.tsx
@@ -141,13 +141,15 @@ export default function ImageGenPanel({
     <div
       ref={panelRef}
       style={style}
-      className="w-[min(20rem,calc(100vw-24px))] bg-[hsl(240,5%,10%)] border border-white/[0.1] rounded-xl shadow-2xl shadow-black/60 overflow-hidden"
+      className="w-[min(20rem,calc(100vw-24px))] bg-popover border border-border rounded-xl shadow-2xl shadow-black/60 overflow-hidden"
     >
       <div className="px-4 pt-3 pb-2 flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-white/90">Generate Image</h3>
+        <h3 className="text-sm font-semibold text-foreground">
+          Generate Image
+        </h3>
         <button
           onClick={() => onOpenChange(false)}
-          className="text-white/30 hover:text-white/60 transition-colors"
+          className="text-muted-foreground/70 hover:text-muted-foreground transition-colors"
           aria-label="Close"
         >
           <IconX className="w-4 h-4" />
@@ -166,7 +168,7 @@ export default function ImageGenPanel({
                   onClick={() => toggleDefaultRef(i)}
                   className={`relative w-10 h-10 rounded overflow-hidden border transition-all ${
                     disabled
-                      ? "border-white/[0.04] opacity-25 grayscale"
+                      ? "border-border opacity-25 grayscale"
                       : "border-[#609FF8]/40"
                   }`}
                 >
@@ -187,7 +189,7 @@ export default function ImageGenPanel({
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           placeholder="Describe image (optional)..."
-          className="w-full h-16 bg-white/[0.04] border border-white/[0.08] rounded-lg px-3 py-2 text-sm text-white/90 placeholder:text-white/30 outline-none focus:border-[#609FF8]/50 resize-none"
+          className="w-full h-16 bg-muted border border-border rounded-lg px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/70 outline-none focus:border-[#609FF8]/50 resize-none"
           onKeyDown={(e) => {
             if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
               e.preventDefault();

--- a/templates/slides/app/components/editor/ImageOverlay.tsx
+++ b/templates/slides/app/components/editor/ImageOverlay.tsx
@@ -101,7 +101,7 @@ export default function ImageOverlay({
         }}
         className="image-overlay-btn"
       >
-        <IconUpload className="w-3.5 h-3.5 text-white/50" />
+        <IconUpload className="w-3.5 h-3.5 text-muted-foreground" />
         Upload
       </button>
       <button
@@ -111,7 +111,7 @@ export default function ImageOverlay({
         }}
         className="image-overlay-btn"
       >
-        <IconSearch className="w-3.5 h-3.5 text-white/50" />
+        <IconSearch className="w-3.5 h-3.5 text-muted-foreground" />
         Search
       </button>
       <button
@@ -121,15 +121,15 @@ export default function ImageOverlay({
         }}
         className="image-overlay-btn"
       >
-        <IconGlobe className="w-3.5 h-3.5 text-white/50" />
+        <IconGlobe className="w-3.5 h-3.5 text-muted-foreground" />
         Logo
       </button>
-      <div className="mx-1.5 border-t border-white/[0.08]" />
+      <div className="mx-1.5 border-t border-border" />
       <button onClick={onToggleObjectFit} className="image-overlay-btn">
         {objectFit === "cover" ? (
-          <IconMinimize className="w-3.5 h-3.5 text-white/50" />
+          <IconMinimize className="w-3.5 h-3.5 text-muted-foreground" />
         ) : (
-          <IconMaximize className="w-3.5 h-3.5 text-white/50" />
+          <IconMaximize className="w-3.5 h-3.5 text-muted-foreground" />
         )}
         Fit: {objectFit === "cover" ? "Cover" : "Contain"}
       </button>

--- a/templates/slides/app/components/editor/ImageSearchPanel.tsx
+++ b/templates/slides/app/components/editor/ImageSearchPanel.tsx
@@ -87,13 +87,13 @@ export default function ImageSearchPanel({
         transform: "translate(-50%, -50%)",
         zIndex: 9999,
       }}
-      className="w-[min(24rem,calc(100vw-24px))] max-h-[480px] bg-[hsl(240,5%,10%)] border border-white/[0.1] rounded-xl shadow-2xl shadow-black/60 overflow-hidden flex flex-col"
+      className="w-[min(24rem,calc(100vw-24px))] max-h-[480px] bg-popover border border-border rounded-xl shadow-2xl shadow-black/60 overflow-hidden flex flex-col"
     >
       <div className="px-4 pt-3 pb-2 flex items-center justify-between flex-shrink-0">
-        <h3 className="text-sm font-semibold text-white/90">Search Images</h3>
+        <h3 className="text-sm font-semibold text-foreground">Search Images</h3>
         <button
           onClick={() => onOpenChange(false)}
-          className="text-white/30 hover:text-white/60 transition-colors"
+          className="text-muted-foreground/70 hover:text-muted-foreground transition-colors"
           aria-label="Close"
         >
           <IconX className="w-4 h-4" />
@@ -103,7 +103,7 @@ export default function ImageSearchPanel({
       <div className="px-4 pb-3 flex-shrink-0">
         <div className="flex gap-2">
           <div className="flex-1 relative">
-            <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
+            <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/70" />
             <input
               ref={inputRef}
               type="text"
@@ -113,7 +113,7 @@ export default function ImageSearchPanel({
                 if (e.key === "Enter") handleSearch();
               }}
               placeholder="Search for images..."
-              className="w-full pl-8 pr-3 py-1.5 bg-white/[0.04] border border-white/[0.08] rounded-lg text-sm text-white/90 placeholder:text-white/30 outline-none focus:border-[#609FF8]/50"
+              className="w-full pl-8 pr-3 py-1.5 bg-muted border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground/70 outline-none focus:border-[#609FF8]/50"
             />
           </div>
           <button
@@ -137,13 +137,13 @@ export default function ImageSearchPanel({
           </div>
         )}
         {!loading && results.length === 0 && !error && (
-          <div className="text-center py-8 text-white/30 text-xs">
+          <div className="text-center py-8 text-muted-foreground text-xs">
             Search for logos, images, icons...
           </div>
         )}
         {loading && (
           <div className="flex items-center justify-center py-8">
-            <IconLoader2 className="w-4 h-4 text-white/30 animate-spin" />
+            <IconLoader2 className="w-4 h-4 text-muted-foreground animate-spin" />
           </div>
         )}
         {results.length > 0 && (
@@ -152,7 +152,7 @@ export default function ImageSearchPanel({
               <button
                 key={i}
                 onClick={() => handleSelect(result.url)}
-                className="aspect-square rounded-md overflow-hidden border border-white/[0.08] bg-white/[0.02] hover:ring-2 hover:ring-[#609FF8]/50 transition-all"
+                className="aspect-square rounded-md overflow-hidden border border-border bg-muted hover:ring-2 hover:ring-[#609FF8]/50 transition-all"
                 title={result.title}
               >
                 <img

--- a/templates/slides/app/components/editor/ImportButton.tsx
+++ b/templates/slides/app/components/editor/ImportButton.tsx
@@ -50,7 +50,7 @@ export function ImportButton({ deckId, onImportComplete }: ImportButtonProps) {
       <TooltipTrigger asChild>
         <button
           onClick={() => fileRef.current?.click()}
-          className="p-1.5 rounded text-white/40 hover:text-white/70 hover:bg-white/[0.06] cursor-pointer"
+          className="p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent cursor-pointer"
         >
           <IconUpload className="w-4 h-4" />
           <input

--- a/templates/slides/app/components/editor/LogoSearchPanel.tsx
+++ b/templates/slides/app/components/editor/LogoSearchPanel.tsx
@@ -122,16 +122,16 @@ export default function LogoSearchPanel({
         transform: "translate(-50%, -50%)",
         zIndex: 9999,
       }}
-      className="w-[min(460px,calc(100vw-24px))] max-h-[560px] bg-[hsl(240,5%,10%)] border border-white/[0.1] rounded-xl shadow-2xl shadow-black/60 overflow-hidden flex flex-col"
+      className="w-[min(460px,calc(100vw-24px))] max-h-[560px] bg-popover border border-border rounded-xl shadow-2xl shadow-black/60 overflow-hidden flex flex-col"
     >
       <div className="px-4 pt-3 pb-2 flex items-center justify-between flex-shrink-0">
-        <h3 className="text-sm font-semibold text-white/90">
+        <h3 className="text-sm font-semibold text-foreground">
           {selectedDomain ? (
             <button
               onClick={() => setSelectedDomain(null)}
-              className="flex items-center gap-1.5 hover:text-white transition-colors"
+              className="flex items-center gap-1.5 hover:text-foreground transition-colors"
             >
-              <span className="text-white/40">&larr;</span>
+              <span className="text-muted-foreground">&larr;</span>
               {selectedDomain}
             </button>
           ) : (
@@ -140,7 +140,7 @@ export default function LogoSearchPanel({
         </h3>
         <button
           onClick={() => onOpenChange(false)}
-          className="text-white/30 hover:text-white/60 transition-colors"
+          className="text-muted-foreground/70 hover:text-muted-foreground transition-colors"
           aria-label="Close"
         >
           <IconX className="w-4 h-4" />
@@ -151,7 +151,7 @@ export default function LogoSearchPanel({
         <div className="px-4 pb-3 flex-shrink-0">
           <div className="flex gap-2">
             <div className="flex-1 relative">
-              <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
+              <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/70" />
               <input
                 ref={inputRef}
                 type="text"
@@ -161,7 +161,7 @@ export default function LogoSearchPanel({
                   if (e.key === "Enter") handleSearch();
                 }}
                 placeholder="Search company name (e.g. Intuit)"
-                className="w-full pl-8 pr-3 py-1.5 bg-white/[0.04] border border-white/[0.08] rounded-lg text-sm text-white/90 placeholder:text-white/30 outline-none focus:border-[#609FF8]/50"
+                className="w-full pl-8 pr-3 py-1.5 bg-muted border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground/70 outline-none focus:border-[#609FF8]/50"
               />
             </div>
             <button
@@ -188,14 +188,14 @@ export default function LogoSearchPanel({
 
         {/* IconSearch results */}
         {!selectedDomain && !loading && results.length === 0 && !error && (
-          <div className="text-center py-6 text-white/30 text-xs">
+          <div className="text-center py-6 text-muted-foreground text-xs">
             Search for a company to find their logo
           </div>
         )}
 
         {!selectedDomain && loading && (
           <div className="flex items-center justify-center py-8">
-            <IconLoader2 className="w-4 h-4 text-white/30 animate-spin" />
+            <IconLoader2 className="w-4 h-4 text-muted-foreground animate-spin" />
           </div>
         )}
 
@@ -205,7 +205,7 @@ export default function LogoSearchPanel({
               <button
                 key={r.domain}
                 onClick={() => setSelectedDomain(r.domain)}
-                className="w-full flex items-center gap-3 p-2.5 rounded-lg border border-white/[0.08] bg-white/[0.02] hover:ring-2 hover:ring-[#609FF8]/50 transition-all text-left"
+                className="w-full flex items-center gap-3 p-2.5 rounded-lg border border-border bg-muted hover:ring-2 hover:ring-[#609FF8]/50 transition-all text-left"
               >
                 <LogoPreview
                   src={`https://cdn.brandfetch.io/${r.domain}/icon.png`}
@@ -213,12 +213,16 @@ export default function LogoSearchPanel({
                   className="w-10 h-10"
                 />
                 <div className="flex-1 min-w-0">
-                  <div className="text-xs text-white/80 font-medium">
+                  <div className="text-xs text-foreground/90 font-medium">
                     {r.name}
                   </div>
-                  <div className="text-[10px] text-white/30">{r.domain}</div>
+                  <div className="text-[10px] text-muted-foreground">
+                    {r.domain}
+                  </div>
                 </div>
-                <span className="text-[10px] text-white/20">&rsaquo;</span>
+                <span className="text-[10px] text-muted-foreground/70">
+                  &rsaquo;
+                </span>
               </button>
             ))}
           </div>
@@ -229,7 +233,7 @@ export default function LogoSearchPanel({
           <div className="space-y-3">
             {variations.map((group) => (
               <div key={group.label}>
-                <div className="text-[10px] text-white/30 uppercase tracking-wider mb-1.5 px-0.5">
+                <div className="text-[10px] text-muted-foreground uppercase tracking-wider mb-1.5 px-0.5">
                   {group.label}
                 </div>
                 <div className="grid grid-cols-3 gap-1.5">
@@ -237,7 +241,7 @@ export default function LogoSearchPanel({
                     <button
                       key={v.label}
                       onClick={() => handleSelect(v.url)}
-                      className="flex flex-col items-center gap-1.5 p-2 rounded-lg border border-white/[0.08] hover:ring-2 hover:ring-[#609FF8]/50 transition-all"
+                      className="flex flex-col items-center gap-1.5 p-2 rounded-lg border border-border hover:ring-2 hover:ring-[#609FF8]/50 transition-all"
                       style={{ backgroundColor: v.bg }}
                     >
                       <div
@@ -255,7 +259,7 @@ export default function LogoSearchPanel({
                           }}
                         />
                       </div>
-                      <span className="text-[9px] text-white/40 leading-tight text-center">
+                      <span className="text-[9px] text-muted-foreground leading-tight text-center">
                         {v.label}
                       </span>
                     </button>
@@ -283,7 +287,7 @@ function LogoPreview({
 }) {
   return (
     <div
-      className={`flex-shrink-0 rounded-md bg-white/[0.06] flex items-center justify-center overflow-hidden ${className}`}
+      className={`flex-shrink-0 rounded-md bg-accent flex items-center justify-center overflow-hidden ${className}`}
     >
       <img
         src={src}

--- a/templates/slides/app/components/editor/MermaidToExcalidrawPanel.tsx
+++ b/templates/slides/app/components/editor/MermaidToExcalidrawPanel.tsx
@@ -46,10 +46,10 @@ export function MermaidToExcalidrawPanel({
 
   return (
     <div className="p-3 space-y-3">
-      <div className="text-xs text-white/50">
+      <div className="text-xs text-muted-foreground">
         Convert this mermaid diagram to an editable Excalidraw drawing?
       </div>
-      <pre className="text-[10px] text-white/40 bg-white/[0.03] rounded p-2 max-h-24 overflow-auto">
+      <pre className="text-[10px] text-muted-foreground bg-muted rounded p-2 max-h-24 overflow-auto">
         {mermaidDefinition.slice(0, 300)}
         {mermaidDefinition.length > 300 ? "..." : ""}
       </pre>
@@ -69,7 +69,7 @@ export function MermaidToExcalidrawPanel({
         </button>
         <button
           onClick={onCancel}
-          className="px-3 py-1.5 rounded-md text-xs text-white/50 hover:text-white/70 hover:bg-white/[0.06]"
+          className="px-3 py-1.5 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-accent"
         >
           Cancel
         </button>

--- a/templates/slides/app/components/editor/PromptDialog.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.tsx
@@ -189,10 +189,8 @@ export default function PromptPopover({
       )}
       <div
         ref={panelRef}
-        className={`fixed z-[200] w-[min(400px,calc(100vw-24px))] rounded-xl border bg-[hsl(240,5%,10%)] shadow-2xl shadow-black/60 overflow-hidden transition-colors ${
-          dragging
-            ? "border-[#609FF8]/50 bg-[hsl(240,5%,12%)]"
-            : "border-white/[0.1]"
+        className={`fixed z-[200] w-[min(400px,calc(100vw-24px))] rounded-xl border bg-popover shadow-2xl shadow-black/60 overflow-hidden transition-colors ${
+          dragging ? "border-[#609FF8]/50 bg-accent" : "border-border"
         }`}
         style={{ top: 0, left: 0, visibility: "visible" }}
         onDrop={handleDrop}
@@ -206,7 +204,9 @@ export default function PromptPopover({
         }}
       >
         <div className="px-3.5 pt-3 pb-1.5">
-          <span className="text-sm font-medium text-white/80">{title}</span>
+          <span className="text-sm font-medium text-foreground/90">
+            {title}
+          </span>
         </div>
 
         <div className="px-3.5 pb-2">
@@ -221,7 +221,7 @@ export default function PromptPopover({
                 Math.min(el.scrollHeight, window.innerHeight * 0.5) + "px";
             }}
             placeholder={placeholder}
-            className="w-full bg-transparent text-sm text-white/90 placeholder:text-white/30 outline-none resize-none"
+            className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/70 outline-none resize-none"
             rows={3}
             style={{ maxHeight: "50vh" }}
             onKeyDown={(e) => {
@@ -239,12 +239,12 @@ export default function PromptPopover({
             {files.map((file, i) => (
               <div
                 key={i}
-                className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-white/[0.06] border border-white/[0.08] text-[11px] text-white/50"
+                className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-accent border border-border text-[11px] text-muted-foreground"
               >
                 <span className="max-w-[120px] truncate">{file.name}</span>
                 <button
                   onClick={() => removeFile(i)}
-                  className="p-0.5 rounded hover:bg-white/[0.1]"
+                  className="p-0.5 rounded hover:bg-accent"
                   aria-label={`Remove ${file.name}`}
                 >
                   <IconX className="w-2.5 h-2.5" />
@@ -255,12 +255,12 @@ export default function PromptPopover({
         )}
 
         {/* Bottom bar */}
-        <div className="px-3.5 py-2 flex items-center justify-between border-t border-white/[0.06]">
+        <div className="px-3.5 py-2 flex items-center justify-between border-t border-border">
           <div className="flex items-center gap-1">
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}
-              className="p-1.5 rounded-md hover:bg-white/[0.06] text-white/30 hover:text-white/50 transition-colors"
+              className="p-1.5 rounded-md hover:bg-accent text-muted-foreground/70 hover:text-muted-foreground transition-colors"
               title="Attach files"
               aria-label="Attach files"
             >
@@ -276,7 +276,7 @@ export default function PromptPopover({
           </div>
 
           <div className="flex items-center gap-3">
-            <span className="text-[10px] text-white/25">
+            <span className="text-[10px] text-muted-foreground/70">
               {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
               +Enter
             </span>
@@ -297,18 +297,18 @@ export default function PromptPopover({
               className={`p-1.5 rounded-lg transition-colors ${
                 hasContent && !busy
                   ? "bg-[#609FF8] hover:bg-[#7AB2FA] text-black"
-                  : "bg-white/[0.12] hover:bg-white/[0.18] disabled:opacity-30 disabled:cursor-not-allowed"
+                  : "bg-accent hover:bg-accent/80 disabled:opacity-30 disabled:cursor-not-allowed"
               }`}
               title="Submit"
               aria-label="Submit"
             >
               {busy ? (
                 <IconLoader2
-                  className={`w-4 h-4 animate-spin ${hasContent ? "text-black" : "text-white/70"}`}
+                  className={`w-4 h-4 animate-spin ${hasContent ? "text-black" : "text-foreground/70"}`}
                 />
               ) : (
                 <IconArrowUp
-                  className={`w-4 h-4 ${hasContent ? "text-black" : "text-white/70"}`}
+                  className={`w-4 h-4 ${hasContent ? "text-black" : "text-foreground/70"}`}
                 />
               )}
             </button>

--- a/templates/slides/app/components/editor/QuestionFlow.tsx
+++ b/templates/slides/app/components/editor/QuestionFlow.tsx
@@ -54,9 +54,9 @@ export function QuestionFlow({
     });
 
   return (
-    <div className="absolute inset-0 z-50 flex items-center justify-center bg-[hsl(240,5%,5%)]">
+    <div className="absolute inset-0 z-50 flex items-center justify-center bg-background">
       <div className="w-full max-w-2xl px-8">
-        <h2 className="mb-8 text-2xl font-semibold text-white/90">
+        <h2 className="mb-8 text-2xl font-semibold text-foreground">
           Before we begin...
         </h2>
 
@@ -81,7 +81,7 @@ export function QuestionFlow({
                 key={i}
                 className={cn(
                   "h-1.5 w-1.5 rounded-full",
-                  answered ? "bg-[#609FF8]" : "bg-white/20",
+                  answered ? "bg-[#609FF8]" : "bg-muted",
                 )}
               />
             );
@@ -94,7 +94,7 @@ export function QuestionFlow({
             variant="ghost"
             size="sm"
             onClick={onSkip}
-            className="text-white/40 hover:text-white/70"
+            className="text-muted-foreground hover:text-foreground"
           >
             Skip
           </Button>
@@ -125,12 +125,14 @@ function QuestionRenderer({
 }) {
   return (
     <div>
-      <h3 className="mb-1 text-sm font-medium text-white/90">
+      <h3 className="mb-1 text-sm font-medium text-foreground">
         {question.question}
         {question.required && <span className="ml-1 text-red-400">*</span>}
       </h3>
       {question.description && (
-        <p className="mb-3 text-xs text-white/40">{question.description}</p>
+        <p className="mb-3 text-xs text-muted-foreground">
+          {question.description}
+        </p>
       )}
 
       {question.type === "text-options" && (
@@ -167,7 +169,7 @@ function QuestionRenderer({
           value={value || ""}
           onChange={(e) => onChange(e.target.value)}
           placeholder="Type your answer..."
-          className="min-h-[80px] resize-none border-white/[0.08] bg-white/[0.04] text-white/90 placeholder:text-white/30"
+          className="min-h-[80px] resize-none border-border bg-muted text-foreground placeholder:text-muted-foreground/70"
         />
       )}
     </div>
@@ -216,7 +218,7 @@ function TextOptions({
             "cursor-pointer rounded-lg border px-4 py-2 text-sm",
             isSelected(opt.value)
               ? "border-[#609FF8] bg-[#609FF8]/10 text-[#609FF8]"
-              : "border-white/[0.08] bg-white/[0.04] text-white/50 hover:border-white/[0.15] hover:text-white/80",
+              : "border-border bg-muted text-muted-foreground hover:border-foreground/30 hover:text-foreground",
           )}
         >
           {multiSelect && (
@@ -271,15 +273,17 @@ function ColorOptions({
             className={cn(
               "h-10 w-10 rounded-full",
               isSelected(opt.value)
-                ? "ring-2 ring-[#609FF8] ring-offset-2 ring-offset-[hsl(240,5%,5%)]"
-                : "ring-1 ring-white/[0.15] group-hover:ring-white/30",
+                ? "ring-2 ring-[#609FF8] ring-offset-2 ring-offset-background"
+                : "ring-1 ring-border group-hover:ring-foreground/30",
             )}
             style={{ backgroundColor: opt.color || opt.value }}
           />
           <span
             className={cn(
               "text-[10px]",
-              isSelected(opt.value) ? "text-white/90" : "text-white/40",
+              isSelected(opt.value)
+                ? "text-foreground"
+                : "text-muted-foreground",
             )}
           >
             {opt.label}
@@ -306,7 +310,7 @@ function SliderQuestion({
 
   return (
     <div className="flex items-center gap-4">
-      <span className="text-xs text-white/40">{min}</span>
+      <span className="text-xs text-muted-foreground">{min}</span>
       <Slider
         min={min}
         max={max}
@@ -315,8 +319,8 @@ function SliderQuestion({
         onValueChange={([v]) => onChange(v)}
         className="flex-1"
       />
-      <span className="text-xs text-white/40">{max}</span>
-      <span className="min-w-[2rem] text-right text-sm font-medium text-white/90">
+      <span className="text-xs text-muted-foreground">{max}</span>
+      <span className="min-w-[2rem] text-right text-sm font-medium text-foreground">
         {current}
       </span>
     </div>
@@ -364,11 +368,11 @@ function FileDropZone({
           "flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-6",
           dragOver
             ? "border-[#609FF8] bg-[#609FF8]/5"
-            : "border-white/[0.08] bg-white/[0.02] hover:border-white/[0.15]",
+            : "border-border bg-muted/50 hover:border-foreground/30",
         )}
       >
-        <IconUpload className="mb-2 h-6 w-6 text-white/40" />
-        <p className="text-sm text-white/40">
+        <IconUpload className="mb-2 h-6 w-6 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">
           Drag files here or{" "}
           <label className="cursor-pointer text-[#609FF8] hover:underline">
             browse
@@ -381,7 +385,7 @@ function FileDropZone({
             />
           </label>
         </p>
-        <p className="mt-1 text-[10px] text-white/20">
+        <p className="mt-1 text-[10px] text-muted-foreground/70">
           Images, PDFs, PPTX, DOCX
         </p>
       </div>
@@ -391,13 +395,13 @@ function FileDropZone({
           {files.map((file, i) => (
             <div
               key={i}
-              className="flex items-center gap-2 rounded bg-white/[0.04] px-2 py-1 text-xs text-white/50"
+              className="flex items-center gap-2 rounded bg-muted px-2 py-1 text-xs text-muted-foreground"
             >
               <IconCheck className="h-3 w-3 text-[#609FF8]" />
               <span className="flex-1 truncate">{file.name}</span>
               <button
                 onClick={() => removeFile(i)}
-                className="cursor-pointer text-white/30 hover:text-white/70"
+                className="cursor-pointer text-muted-foreground/70 hover:text-foreground"
               >
                 <IconX className="h-3 w-3" />
               </button>

--- a/templates/slides/app/components/editor/ShareDialog.tsx
+++ b/templates/slides/app/components/editor/ShareDialog.tsx
@@ -77,7 +77,7 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent
         align="end"
-        className="w-[420px] bg-[hsl(240,5%,8%)] border-white/[0.08] p-4"
+        className="w-[420px] bg-card border-border p-4"
       >
         {showCloudUpgrade || isLocal ? (
           <CloudUpgrade
@@ -91,11 +91,11 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
         ) : (
           <>
             <div className="mb-3">
-              <div className="text-white/90 flex items-center gap-2 text-sm font-semibold">
+              <div className="text-foreground flex items-center gap-2 text-sm font-semibold">
                 <IconShare2 className="w-4 h-4 text-[#609FF8]" />
                 Share Presentation
               </div>
-              <div className="text-white/50 text-xs mt-0.5">
+              <div className="text-muted-foreground text-xs mt-0.5">
                 Create a shareable link for "{deck.title}". Only this
                 presentation will be accessible — no other decks.
               </div>
@@ -104,21 +104,21 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
             <div className="space-y-4">
               {!shareUrl ? (
                 <>
-                  <div className="bg-white/[0.03] rounded-lg p-3 border border-white/[0.06]">
-                    <h4 className="text-sm font-medium text-white/80 mb-2">
+                  <div className="bg-muted/50 rounded-lg p-3 border border-border">
+                    <h4 className="text-sm font-medium text-foreground/90 mb-2">
                       What gets shared:
                     </h4>
-                    <ul className="text-xs text-white/50 space-y-1">
+                    <ul className="text-xs text-muted-foreground space-y-1">
                       <li>
                         - Slide content and layouts ({deck.slides.length}{" "}
                         slides)
                       </li>
                       <li>- Presentation view (fullscreen)</li>
                     </ul>
-                    <h4 className="text-sm font-medium text-white/80 mt-3 mb-2">
+                    <h4 className="text-sm font-medium text-foreground/90 mt-3 mb-2">
                       What stays private:
                     </h4>
-                    <ul className="text-xs text-white/50 space-y-1">
+                    <ul className="text-xs text-muted-foreground space-y-1">
                       <li>- Speaker notes</li>
                       <li>- Other presentations</li>
                       <li>- Editing access</li>
@@ -155,18 +155,18 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
                     <input
                       readOnly
                       value={shareUrl}
-                      className="flex-1 bg-white/[0.04] border border-white/[0.08] rounded-lg px-3 py-2 text-sm text-white/80 outline-none"
+                      className="flex-1 bg-accent/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground/90 outline-none"
                     />
                     <button
                       onClick={handleCopy}
-                      className="flex-shrink-0 p-2 rounded-lg bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.08] transition-colors"
+                      className="flex-shrink-0 p-2 rounded-lg bg-accent hover:bg-accent border border-border transition-colors"
                       title="Copy link"
                       aria-label="Copy link"
                     >
                       {copied ? (
                         <IconCheck className="w-4 h-4 text-green-400" />
                       ) : (
-                        <IconCopy className="w-4 h-4 text-white/60" />
+                        <IconCopy className="w-4 h-4 text-muted-foreground" />
                       )}
                     </button>
                   </div>
@@ -175,13 +175,13 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
                     href={shareUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center justify-center gap-2 w-full px-4 py-2 rounded-lg bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.08] text-white/70 text-sm transition-colors"
+                    className="flex items-center justify-center gap-2 w-full px-4 py-2 rounded-lg bg-accent hover:bg-accent border border-border text-foreground/70 text-sm transition-colors"
                   >
                     <IconExternalLink className="w-3.5 h-3.5" />
                     Open shared link
                   </a>
 
-                  <p className="text-[11px] text-white/30 text-center">
+                  <p className="text-[11px] text-muted-foreground/70 text-center">
                     Anyone with this link can view this presentation.
                   </p>
                 </>

--- a/templates/slides/app/components/editor/SlideBubbleMenu.tsx
+++ b/templates/slides/app/components/editor/SlideBubbleMenu.tsx
@@ -69,7 +69,7 @@ function HexInput({
   return (
     <div className="flex items-center gap-1 mt-1">
       <div
-        className="w-4 h-4 rounded-sm flex-shrink-0 border border-white/20"
+        className="w-4 h-4 rounded-sm flex-shrink-0 border border-border"
         style={{ background: isValid ? val : "transparent" }}
       />
       <input
@@ -82,18 +82,21 @@ function HexInput({
         }}
         placeholder="#000000"
         maxLength={7}
-        className="flex-1 bg-transparent text-white text-xs outline-none placeholder-white/30 border-b border-white/20 pb-0.5 w-20"
+        className="flex-1 bg-transparent text-foreground text-xs outline-none placeholder-muted-foreground/70 border-b border-border pb-0.5 w-20"
         autoFocus
       />
       {isValid && (
         <button
           onClick={() => onAdd(val)}
-          className="text-[#00E5FF] hover:text-white"
+          className="text-[#00E5FF] hover:text-foreground"
         >
           <IconCheck size={12} />
         </button>
       )}
-      <button onClick={onCancel} className="text-white/40 hover:text-white/80">
+      <button
+        onClick={onCancel}
+        className="text-muted-foreground hover:text-foreground"
+      >
         <IconX size={12} />
       </button>
     </div>
@@ -141,14 +144,16 @@ function ColorPicker({
   return (
     <div className="w-[180px]">
       <div className="flex items-center justify-between mb-2">
-        <span className="text-[10px] font-semibold text-white/50 uppercase tracking-wider">
+        <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
           Brand Colors
         </span>
         <button
           onClick={() => setEditMode((v) => !v)}
           className={cn(
             "p-0.5 rounded",
-            editMode ? "text-[#00E5FF]" : "text-white/40 hover:text-white/70",
+            editMode
+              ? "text-[#00E5FF]"
+              : "text-muted-foreground hover:text-foreground",
           )}
           title="Edit palette"
         >
@@ -165,15 +170,15 @@ function ColorPicker({
               className={cn(
                 "w-6 h-6 rounded-md border transition-transform",
                 currentColor?.toLowerCase() === color.toLowerCase()
-                  ? "border-white scale-110"
-                  : "border-white/20 hover:scale-110",
+                  ? "border-foreground scale-110"
+                  : "border-border hover:scale-110",
               )}
               style={{ background: color }}
             />
             {editMode && (
               <button
                 onClick={() => removeFromPalette(color)}
-                className="absolute -top-1 -right-1 w-3.5 h-3.5 rounded-full bg-[#1c1c1c] border border-white/20 flex items-center justify-center text-white/60 hover:text-white hover:border-white/50"
+                className="absolute -top-1 -right-1 w-3.5 h-3.5 rounded-full bg-popover border border-border flex items-center justify-center text-muted-foreground hover:text-foreground hover:border-foreground/50"
               >
                 <IconX size={8} />
               </button>
@@ -185,7 +190,7 @@ function ColorPicker({
         {!addingColor && (
           <button
             onClick={() => setAddingColor(true)}
-            className="w-6 h-6 rounded-md border border-dashed border-white/25 flex items-center justify-center text-white/40 hover:text-white/70 hover:border-white/40"
+            className="w-6 h-6 rounded-md border border-dashed border-border flex items-center justify-center text-muted-foreground hover:text-foreground hover:border-foreground/40"
             title="Add color"
           >
             <IconPlus size={10} />
@@ -197,10 +202,10 @@ function ColorPicker({
         <HexInput onAdd={addTopalette} onCancel={() => setAddingColor(false)} />
       )}
 
-      <div className="mt-2 pt-2 border-t border-white/10">
+      <div className="mt-2 pt-2 border-t border-border">
         <button
           onClick={removeColor}
-          className="flex items-center gap-1.5 text-xs text-white/50 hover:text-white/80 w-full"
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground w-full"
         >
           <IconX size={11} />
           Remove color
@@ -316,7 +321,7 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
     <BubbleMenu editor={editor}>
       <div
         data-bubble-menu="true"
-        className="flex items-center gap-0.5 px-1.5 py-1 rounded-lg bg-[#1c1c1c] border border-white/10 shadow-xl"
+        className="flex items-center gap-0.5 px-1.5 py-1 rounded-lg bg-popover border border-border shadow-xl"
       >
         {showLinkInput ? (
           <div className="flex items-center gap-1.5 px-1">
@@ -332,7 +337,7 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
                 }
               }}
               placeholder="Paste URL..."
-              className="w-48 bg-transparent text-white text-sm outline-none placeholder-white/30 border-b border-white/20 pb-0.5"
+              className="w-48 bg-transparent text-foreground text-sm outline-none placeholder-muted-foreground/70 border-b border-border pb-0.5"
               autoFocus
             />
             <button
@@ -346,7 +351,7 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
                 setShowLinkInput(false);
                 setLinkUrl("");
               }}
-              className="text-xs text-white/50 hover:text-white/80"
+              className="text-xs text-muted-foreground hover:text-foreground"
             >
               Cancel
             </button>
@@ -355,7 +360,7 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
           <>
             {buttons.map((item, i) => {
               if (item.type === "divider") {
-                return <div key={i} className="w-px h-4 bg-white/15 mx-0.5" />;
+                return <div key={i} className="w-px h-4 bg-border mx-0.5" />;
               }
               const btn = item as ButtonItem;
               const Icon = btn.icon;
@@ -368,8 +373,8 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
                   className={cn(
                     "p-1.5 rounded",
                     active
-                      ? "bg-white/20 text-white"
-                      : "text-white/70 hover:text-white hover:bg-white/10",
+                      ? "bg-accent text-foreground"
+                      : "text-foreground/80 hover:text-foreground hover:bg-accent",
                   )}
                 >
                   <Icon size={14} stroke={2} />
@@ -378,7 +383,7 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
             })}
 
             {/* Color picker */}
-            <div className="w-px h-4 bg-white/15 mx-0.5" />
+            <div className="w-px h-4 bg-border mx-0.5" />
             <Popover open={colorOpen} onOpenChange={setColorOpen}>
               <PopoverTrigger asChild>
                 <button
@@ -386,8 +391,8 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
                   className={cn(
                     "p-1.5 rounded relative",
                     colorOpen
-                      ? "bg-white/20 text-white"
-                      : "text-white/70 hover:text-white hover:bg-white/10",
+                      ? "bg-accent text-foreground"
+                      : "text-foreground/80 hover:text-foreground hover:bg-accent",
                   )}
                 >
                   <IconPalette size={14} stroke={2} />
@@ -398,7 +403,7 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
                       background: currentColor ?? "transparent",
                       border: currentColor
                         ? "none"
-                        : "1px solid rgba(255,255,255,0.2)",
+                        : "1px solid hsl(var(--border))",
                     }}
                   />
                 </button>
@@ -407,13 +412,13 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
                 side="bottom"
                 align="end"
                 sideOffset={6}
-                className="bg-[#1c1c1c] border-white/10 text-white p-3 w-auto"
+                className="bg-popover border-border text-foreground p-3 w-auto"
               >
                 <ColorPicker
                   editor={editor}
                   onClose={() => setColorOpen(false)}
                 />
-                <div className="mt-2 pt-2 border-t border-white/10 flex gap-2 text-[10px] text-white/35">
+                <div className="mt-2 pt-2 border-t border-border flex gap-2 text-[10px] text-muted-foreground">
                   <span>⌘⌥C copy style</span>
                   <span>⌘⌥V paste style</span>
                 </div>
@@ -422,7 +427,7 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
 
             {hasCommentBtn && (
               <>
-                <div className="w-px h-4 bg-white/15 mx-0.5" />
+                <div className="w-px h-4 bg-border mx-0.5" />
                 <button
                   title="Comment"
                   onClick={() => {
@@ -434,7 +439,7 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
                     );
                     onComment!(quotedText);
                   }}
-                  className="p-1.5 rounded text-white/70 hover:text-white hover:bg-white/10"
+                  className="p-1.5 rounded text-foreground/80 hover:text-foreground hover:bg-accent"
                 >
                   <IconMessageCircle size={14} stroke={2} />
                 </button>

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -494,14 +494,14 @@ export default function SlideEditor({
       <div className="flex-1 overflow-hidden">
         {activeTab === "visual" ? (
           slide.excalidrawData ? (
-            <div className="h-full bg-[hsl(240,5%,5%)]">
+            <div className="h-full bg-muted">
               <ExcalidrawSlide
                 initialData={slide.excalidrawData}
                 onChange={(data) => onUpdateSlide({ excalidrawData: data })}
               />
             </div>
           ) : (
-            <div className="h-full flex items-center justify-center p-2 sm:p-4 md:p-8 bg-[hsl(240,5%,5%)]">
+            <div className="h-full flex items-center justify-center p-2 sm:p-4 md:p-8 bg-muted">
               <div ref={containerRef} className="w-full max-w-4xl">
                 <div
                   className="slide-image-clickable relative"

--- a/templates/slides/app/components/editor/SlideSlashMenu.tsx
+++ b/templates/slides/app/components/editor/SlideSlashMenu.tsx
@@ -123,10 +123,10 @@ export const SlashMenuUI = forwardRef<
   return createPortal(
     <div
       data-slash-menu="true"
-      className="fixed z-[9999] w-60 rounded-lg bg-[#1c1c1c] border border-white/10 shadow-2xl overflow-hidden py-1"
+      className="fixed z-[9999] w-60 rounded-lg bg-popover border border-border shadow-2xl overflow-hidden py-1"
       style={{ top: position.y, left: position.x }}
     >
-      <div className="px-2 py-1 text-[10px] font-semibold text-white/30 uppercase tracking-widest">
+      <div className="px-2 py-1 text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-widest">
         Blocks
       </div>
       {filtered.map((cmd, i) => {
@@ -137,20 +137,20 @@ export const SlashMenuUI = forwardRef<
             className={cn(
               "w-full flex items-center gap-3 px-3 py-2 text-left",
               i === selectedIndex
-                ? "bg-white/10 text-white"
-                : "text-white/70 hover:bg-white/5 hover:text-white",
+                ? "bg-accent text-foreground"
+                : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
             )}
             onMouseEnter={() => setSelectedIndex(i)}
             onClick={() => onCommand(cmd)}
           >
-            <div className="w-7 h-7 rounded flex items-center justify-center bg-white/5 shrink-0">
+            <div className="w-7 h-7 rounded flex items-center justify-center bg-accent/50 shrink-0">
               <Icon size={14} stroke={2} />
             </div>
             <div>
               <div className="text-sm font-medium leading-tight">
                 {cmd.title}
               </div>
-              <div className="text-xs text-white/40 leading-tight">
+              <div className="text-xs text-muted-foreground leading-tight">
                 {cmd.description}
               </div>
             </div>

--- a/templates/slides/app/components/editor/SpeakerNotesPanel.tsx
+++ b/templates/slides/app/components/editor/SpeakerNotesPanel.tsx
@@ -31,18 +31,18 @@ export function SpeakerNotesPanel({
   };
 
   return (
-    <div className="border-t border-white/[0.06] bg-[hsl(240,5%,6%)] flex-shrink-0">
+    <div className="border-t border-border bg-background flex-shrink-0">
       <button
         onClick={toggle}
         className="w-full flex items-center justify-between px-4 py-1.5 cursor-pointer"
       >
-        <span className="text-[10px] font-medium text-white/30 uppercase tracking-wider">
+        <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
           Speaker Notes — Slide {slideIndex + 1} / {slideCount}
         </span>
         {expanded ? (
-          <IconChevronDown className="w-3 h-3 text-white/30" />
+          <IconChevronDown className="w-3 h-3 text-muted-foreground" />
         ) : (
-          <IconChevronUp className="w-3 h-3 text-white/30" />
+          <IconChevronUp className="w-3 h-3 text-muted-foreground" />
         )}
       </button>
       {expanded && (
@@ -51,7 +51,7 @@ export function SpeakerNotesPanel({
             value={notes || ""}
             onChange={(e) => onChange(e.target.value)}
             placeholder="Add speaker notes..."
-            className="w-full h-20 bg-transparent text-white/50 text-xs font-mono placeholder:text-white/20 resize-none outline-none"
+            className="w-full h-20 bg-transparent text-muted-foreground text-xs font-mono placeholder:text-muted-foreground/70 resize-none outline-none"
           />
         </div>
       )}

--- a/templates/slides/app/components/editor/TweaksPanel.tsx
+++ b/templates/slides/app/components/editor/TweaksPanel.tsx
@@ -15,14 +15,14 @@ export function TweaksPanel({
   onClose,
 }: TweaksPanelProps) {
   return (
-    <div className="absolute bottom-4 right-4 w-64 rounded-xl border border-white/[0.08] bg-[hsl(240,5%,8%)] shadow-2xl z-20">
+    <div className="absolute bottom-4 right-4 w-64 rounded-xl border border-border bg-card shadow-2xl z-20">
       <div className="flex items-center justify-between px-4 pt-3 pb-2">
-        <span className="text-[11px] font-semibold text-white/40 uppercase tracking-wider">
+        <span className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
           Tweaks
         </span>
         <button
           onClick={onClose}
-          className="text-white/30 hover:text-white/60 cursor-pointer"
+          className="text-muted-foreground/70 hover:text-muted-foreground cursor-pointer"
         >
           <IconX className="w-3.5 h-3.5" />
         </button>
@@ -52,7 +52,9 @@ function TweakControl({
 }) {
   return (
     <div>
-      <div className="text-[11px] text-white/40 mb-2">{tweak.label}</div>
+      <div className="text-[11px] text-muted-foreground mb-2">
+        {tweak.label}
+      </div>
       {tweak.type === "color-swatches" && (
         <div className="flex gap-2">
           {tweak.options?.map((opt) => (
@@ -61,7 +63,7 @@ function TweakControl({
               onClick={() => onChange(opt.value)}
               className={`w-7 h-7 rounded-full cursor-pointer ${
                 value === opt.value
-                  ? "ring-2 ring-white ring-offset-2 ring-offset-[hsl(240,5%,8%)]"
+                  ? "ring-2 ring-foreground ring-offset-2 ring-offset-card"
                   : ""
               }`}
               style={{ backgroundColor: opt.color || opt.value }}
@@ -71,15 +73,15 @@ function TweakControl({
         </div>
       )}
       {tweak.type === "segment" && (
-        <div className="flex rounded-lg overflow-hidden border border-white/[0.08]">
+        <div className="flex rounded-lg overflow-hidden border border-border">
           {tweak.options?.map((opt) => (
             <button
               key={opt.value}
               onClick={() => onChange(opt.value)}
               className={`flex-1 px-3 py-1 text-[11px] font-medium cursor-pointer ${
                 value === opt.value
-                  ? "bg-white/10 text-white"
-                  : "text-white/30 hover:text-white/50"
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground/70 hover:text-muted-foreground"
               }`}
             >
               {opt.label}
@@ -91,11 +93,11 @@ function TweakControl({
         <button
           onClick={() => onChange(!value)}
           className={`w-9 h-5 rounded-full cursor-pointer ${
-            value ? "bg-white/20" : "bg-white/[0.06]"
+            value ? "bg-primary/30" : "bg-accent"
           } relative`}
         >
           <span
-            className={`block w-3.5 h-3.5 rounded-full bg-white absolute top-0.5 ${
+            className={`block w-3.5 h-3.5 rounded-full bg-foreground absolute top-0.5 ${
               value ? "right-0.5" : "left-0.5"
             }`}
           />

--- a/templates/slides/app/global.css
+++ b/templates/slides/app/global.css
@@ -101,7 +101,7 @@ button[title="Open agent sidebar"] {
     white-space: pre;
   }
 
-  /* Custom scrollbar for dark theme */
+  /* Custom scrollbar */
   ::-webkit-scrollbar {
     width: 6px;
     height: 6px;
@@ -110,11 +110,11 @@ button[title="Open agent sidebar"] {
     background: transparent;
   }
   ::-webkit-scrollbar-thumb {
-    background: hsl(240 4% 20%);
+    background: hsl(var(--muted-foreground) / 0.3);
     border-radius: 3px;
   }
   ::-webkit-scrollbar-thumb:hover {
-    background: hsl(240 4% 28%);
+    background: hsl(var(--muted-foreground) / 0.5);
   }
 }
 
@@ -810,8 +810,8 @@ button[title="Open agent sidebar"] {
 .image-overlay-menu {
   position: fixed;
   z-index: 300;
-  background: hsl(240, 5%, 10%);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: hsl(var(--popover));
+  border: 1px solid hsl(var(--border));
   border-radius: 12px;
   padding: 6px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
@@ -840,7 +840,7 @@ button[title="Open agent sidebar"] {
   border-radius: 8px;
   font-size: 13px;
   font-weight: 500;
-  color: rgba(255, 255, 255, 0.8);
+  color: hsl(var(--popover-foreground) / 0.8);
   background: transparent;
   border: none;
   cursor: pointer;
@@ -849,8 +849,8 @@ button[title="Open agent sidebar"] {
 }
 
 .image-overlay-btn:hover {
-  background: rgba(255, 255, 255, 0.06);
-  color: #fff;
+  background: hsl(var(--accent));
+  color: hsl(var(--popover-foreground));
 }
 
 /* ─── Inline Slide Editor (TipTap) ─── */

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -456,7 +456,7 @@ export default function DeckEditor() {
     (t) => !t.resolved,
   ).length;
 
-  if (loading) return <div className="h-screen bg-[hsl(240,5%,5%)]" />;
+  if (loading) return <div className="h-screen bg-background" />;
   if (!deck || !id) return <Navigate to="/" replace />;
 
   const currentSlide =
@@ -465,7 +465,7 @@ export default function DeckEditor() {
   currentSlideRef.current = currentSlide;
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden bg-[hsl(240,5%,5%)]">
+    <div className="flex-1 flex flex-col overflow-hidden bg-background">
       <EditorToolbar
         deck={deck}
         deckId={id}

--- a/templates/slides/app/pages/DesignSystems.tsx
+++ b/templates/slides/app/pages/DesignSystems.tsx
@@ -52,7 +52,7 @@ export default function DesignSystems() {
     <div className="flex-1 overflow-y-auto">
       <main className="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
         <div className="flex items-center justify-between mb-6">
-          <h1 className="text-lg font-semibold text-white/90">
+          <h1 className="text-lg font-semibold text-foreground">
             Design Systems
           </h1>
           <Button
@@ -70,19 +70,19 @@ export default function DesignSystems() {
         {isLoading ? (
           <>
             <div className="flex items-center justify-between mb-6">
-              <div className="h-5 w-40 rounded-md bg-white/[0.05] animate-pulse" />
-              <div className="h-3 w-16 rounded bg-white/[0.05] animate-pulse" />
+              <div className="h-5 w-40 rounded-md bg-muted animate-pulse" />
+              <div className="h-3 w-16 rounded bg-muted animate-pulse" />
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
               {Array.from({ length: 4 }).map((_, i) => (
                 <div
                   key={i}
-                  className="rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] overflow-hidden"
+                  className="rounded-xl border border-border bg-card overflow-hidden"
                 >
-                  <div className="aspect-video bg-white/[0.03] animate-pulse" />
+                  <div className="aspect-video bg-muted/50 animate-pulse" />
                   <div className="p-4 space-y-2">
-                    <div className="h-4 w-3/4 rounded bg-white/[0.05] animate-pulse" />
-                    <div className="h-3 w-1/2 rounded bg-white/[0.05] animate-pulse" />
+                    <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+                    <div className="h-3 w-1/2 rounded bg-muted animate-pulse" />
                   </div>
                 </div>
               ))}
@@ -104,18 +104,18 @@ export default function DesignSystems() {
                   setEditingId(null);
                   setShowSetup(true);
                 }}
-                className="group relative rounded-xl border border-dashed border-white/[0.08] bg-[hsl(240,5%,8%)] hover:border-white/[0.15] overflow-hidden text-left cursor-pointer"
+                className="group relative rounded-xl border border-dashed border-border bg-card hover:border-foreground/15 overflow-hidden text-left cursor-pointer"
               >
-                <div className="aspect-video flex items-center justify-center bg-white/[0.02]">
-                  <div className="w-12 h-12 rounded-xl bg-white/[0.04] flex items-center justify-center group-hover:bg-white/[0.06]">
-                    <IconPlus className="w-6 h-6 text-white/30 group-hover:text-white/50" />
+                <div className="aspect-video flex items-center justify-center bg-muted/30">
+                  <div className="w-12 h-12 rounded-xl bg-accent/50 flex items-center justify-center group-hover:bg-accent">
+                    <IconPlus className="w-6 h-6 text-muted-foreground/70 group-hover:text-muted-foreground" />
                   </div>
                 </div>
                 <div className="p-4">
-                  <h3 className="font-medium text-sm text-white/50 group-hover:text-white/70">
+                  <h3 className="font-medium text-sm text-muted-foreground group-hover:text-foreground/70">
                     New Design System
                   </h3>
-                  <div className="text-xs text-white/30 mt-1">
+                  <div className="text-xs text-muted-foreground/70 mt-1">
                     Set up your brand
                   </div>
                 </div>
@@ -159,10 +159,10 @@ function EmptyState({ onCreateNew }: { onCreateNew: () => void }) {
       <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-[#609FF8]/20 to-[#4080E0]/20 border border-[#609FF8]/20 flex items-center justify-center mb-6">
         <IconPalette className="w-7 h-7 text-[#609FF8]" />
       </div>
-      <h2 className="text-xl font-semibold text-white/90 mb-2">
+      <h2 className="text-xl font-semibold text-foreground mb-2">
         Set up your brand identity
       </h2>
-      <p className="text-sm text-white/40 max-w-sm mb-8 leading-relaxed">
+      <p className="text-sm text-muted-foreground max-w-sm mb-8 leading-relaxed">
         Create a design system with your brand colors, typography, and logos.
         Every new deck will follow your visual identity.
       </p>

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -70,19 +70,19 @@ export default function Index() {
       {loading ? (
         <>
           <div className="flex items-center justify-between mb-6">
-            <div className="h-5 w-32 rounded-md bg-white/[0.05] animate-pulse" />
-            <div className="h-3 w-16 rounded bg-white/[0.05] animate-pulse" />
+            <div className="h-5 w-32 rounded-md bg-muted animate-pulse" />
+            <div className="h-3 w-16 rounded bg-muted animate-pulse" />
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
             {Array.from({ length: 8 }).map((_, i) => (
               <div
                 key={i}
-                className="rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] overflow-hidden"
+                className="rounded-xl border border-border bg-card overflow-hidden"
               >
-                <div className="aspect-video bg-white/[0.03] animate-pulse" />
+                <div className="aspect-video bg-muted/50 animate-pulse" />
                 <div className="p-4 space-y-2">
-                  <div className="h-4 w-3/4 rounded bg-white/[0.05] animate-pulse" />
-                  <div className="h-3 w-1/2 rounded bg-white/[0.05] animate-pulse" />
+                  <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+                  <div className="h-3 w-1/2 rounded bg-muted animate-pulse" />
                 </div>
               </div>
             ))}
@@ -93,9 +93,11 @@ export default function Index() {
       ) : (
         <>
           <div className="flex items-center justify-between mb-6">
-            <h1 className="text-lg font-semibold text-white/90">Your Decks</h1>
+            <h1 className="text-lg font-semibold text-foreground">
+              Your Decks
+            </h1>
             <div className="flex items-center gap-3">
-              <span className="text-xs text-white/30">
+              <span className="text-xs text-muted-foreground/70">
                 {decks.length} deck{decks.length !== 1 ? "s" : ""}
               </span>
               <Button onClick={openNewDeck} size="sm">
@@ -108,18 +110,20 @@ export default function Index() {
             {/* New deck card */}
             <button
               onClick={openNewDeck}
-              className="group relative rounded-xl border border-dashed border-white/[0.08] bg-[hsl(240,5%,8%)] hover:border-white/[0.15] overflow-hidden text-left cursor-pointer"
+              className="group relative rounded-xl border border-dashed border-border bg-card hover:border-foreground/15 overflow-hidden text-left cursor-pointer"
             >
-              <div className="aspect-video flex items-center justify-center bg-white/[0.02]">
-                <div className="w-12 h-12 rounded-xl bg-white/[0.04] flex items-center justify-center group-hover:bg-white/[0.06]">
-                  <IconPlus className="w-6 h-6 text-white/30 group-hover:text-white/50" />
+              <div className="aspect-video flex items-center justify-center bg-muted/30">
+                <div className="w-12 h-12 rounded-xl bg-accent/50 flex items-center justify-center group-hover:bg-accent">
+                  <IconPlus className="w-6 h-6 text-muted-foreground/70 group-hover:text-muted-foreground" />
                 </div>
               </div>
               <div className="p-4">
-                <h3 className="font-medium text-sm text-white/50 group-hover:text-white/70">
+                <h3 className="font-medium text-sm text-muted-foreground group-hover:text-foreground/70">
                   New Deck
                 </h3>
-                <div className="text-xs text-white/30 mt-1">Create a deck</div>
+                <div className="text-xs text-muted-foreground/70 mt-1">
+                  Create a deck
+                </div>
               </div>
             </button>
 
@@ -141,11 +145,11 @@ export default function Index() {
             className="fixed inset-0 bg-black/60"
             onClick={() => setDeckToDelete(null)}
           />
-          <div className="relative bg-[hsl(240,5%,8%)] border border-white/[0.08] rounded-xl p-6 max-w-sm w-full mx-4 shadow-2xl">
-            <h3 className="text-base font-semibold text-white/90 mb-2">
+          <div className="relative bg-card border border-border rounded-xl p-6 max-w-sm w-full mx-4 shadow-2xl">
+            <h3 className="text-base font-semibold text-foreground mb-2">
               Delete Deck?
             </h3>
-            <p className="text-sm text-white/50 mb-5">
+            <p className="text-sm text-muted-foreground mb-5">
               This will permanently delete this deck and all its slides. This
               action cannot be undone.
             </p>
@@ -186,10 +190,10 @@ function EmptyState({
       <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-[#609FF8]/20 to-[#4080E0]/20 border border-[#609FF8]/20 flex items-center justify-center mb-6">
         <IconStack2 className="w-7 h-7 text-[#609FF8]" />
       </div>
-      <h2 className="text-xl font-semibold text-white/90 mb-2">
+      <h2 className="text-xl font-semibold text-foreground mb-2">
         Create your first deck
       </h2>
-      <p className="text-sm text-white/40 max-w-sm mb-8 leading-relaxed">
+      <p className="text-sm text-muted-foreground max-w-sm mb-8 leading-relaxed">
         Build beautiful slide presentations with AI-powered generation, image
         creation, and a stunning presentation mode.
       </p>

--- a/templates/slides/app/pages/NotFound.tsx
+++ b/templates/slides/app/pages/NotFound.tsx
@@ -10,15 +10,17 @@ export default function NotFound() {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[hsl(240,6%,4%)]">
+    <div className="min-h-screen flex items-center justify-center bg-background">
       <div className="text-center">
-        <h1 className="text-6xl font-bold text-white/10 mb-2">404</h1>
-        <p className="text-sm text-white/40 mb-6">
+        <h1 className="text-6xl font-bold text-muted-foreground/40 mb-2">
+          404
+        </h1>
+        <p className="text-sm text-muted-foreground mb-6">
           This page doesn't exist yet.
         </p>
         <Link
           to="/"
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-white/[0.06] hover:bg-white/[0.1] text-sm text-white/70 transition-colors"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-accent hover:bg-accent text-sm text-foreground/70 transition-colors"
         >
           <IconArrowLeft className="w-4 h-4" />
           Back to Decks

--- a/templates/videos/app/components/CurrentElementPanel.tsx
+++ b/templates/videos/app/components/CurrentElementPanel.tsx
@@ -541,7 +541,7 @@ export const CurrentElementPanel: React.FC = () => {
                     handleUpdateDuration(animation.id, numValue);
                   }
                 }}
-                className="h-8 text-xs text-white w-full bg-background border border-input rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                className="h-8 text-xs text-foreground w-full bg-background border border-input rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
                 min="0.01"
                 max="10"
                 step="0.1"

--- a/templates/videos/app/components/TweaksPanel.tsx
+++ b/templates/videos/app/components/TweaksPanel.tsx
@@ -183,7 +183,9 @@ function TweakControl({
 }) {
   return (
     <div>
-      <div className="mb-1.5 text-[11px] text-muted-foreground">{tweak.label}</div>
+      <div className="mb-1.5 text-[11px] text-muted-foreground">
+        {tweak.label}
+      </div>
 
       {tweak.type === "color-swatches" && (
         <div className="flex gap-2">

--- a/templates/videos/app/components/TweaksPanel.tsx
+++ b/templates/videos/app/components/TweaksPanel.tsx
@@ -128,7 +128,7 @@ export function TweaksPanel({
 
   return (
     <div
-      className="fixed z-30 w-60 rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] shadow-2xl backdrop-blur-sm"
+      className="fixed z-30 w-60 rounded-xl border border-border bg-card shadow-2xl backdrop-blur-sm"
       style={{ left: position.x, bottom: position.y }}
     >
       {/* Header — drag handle + collapse toggle */}
@@ -137,17 +137,17 @@ export function TweaksPanel({
         onMouseDown={handleMouseDown}
       >
         <div className="flex items-center gap-1.5">
-          <IconGripHorizontal className="h-3 w-3 text-white/20" />
+          <IconGripHorizontal className="h-3 w-3 text-muted-foreground/60" />
           <button
             onClick={() => setCollapsed((c) => !c)}
-            className="cursor-pointer text-[11px] font-semibold uppercase tracking-wider text-white/40 hover:text-white/60"
+            className="cursor-pointer text-[11px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-muted-foreground"
           >
             Tweaks
           </button>
         </div>
         <button
           onClick={() => setCollapsed((c) => !c)}
-          className="cursor-pointer text-white/30 hover:text-white/60"
+          className="cursor-pointer text-muted-foreground/70 hover:text-muted-foreground"
         >
           <IconX className="h-3 w-3" />
         </button>
@@ -183,7 +183,7 @@ function TweakControl({
 }) {
   return (
     <div>
-      <div className="mb-1.5 text-[11px] text-white/40">{tweak.label}</div>
+      <div className="mb-1.5 text-[11px] text-muted-foreground">{tweak.label}</div>
 
       {tweak.type === "color-swatches" && (
         <div className="flex gap-2">
@@ -194,8 +194,8 @@ function TweakControl({
               className={cn(
                 "h-6 w-6 cursor-pointer rounded-full",
                 value === opt.value
-                  ? "ring-2 ring-white ring-offset-2 ring-offset-[hsl(240,5%,8%)]"
-                  : "ring-1 ring-white/10 hover:ring-white/30",
+                  ? "ring-2 ring-foreground ring-offset-2 ring-offset-card"
+                  : "ring-1 ring-border hover:ring-foreground/30",
               )}
               style={{ backgroundColor: opt.color || opt.value }}
               title={opt.label}
@@ -205,7 +205,7 @@ function TweakControl({
       )}
 
       {tweak.type === "segment" && (
-        <div className="flex overflow-hidden rounded-lg border border-white/[0.08]">
+        <div className="flex overflow-hidden rounded-lg border border-border">
           {tweak.options?.map((opt) => (
             <button
               key={opt.value}
@@ -213,8 +213,8 @@ function TweakControl({
               className={cn(
                 "flex-1 cursor-pointer px-2.5 py-1 text-[11px] font-medium",
                 String(value) === opt.value
-                  ? "bg-white/10 text-white"
-                  : "text-white/30 hover:text-white/50",
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground/70 hover:text-muted-foreground",
               )}
             >
               {opt.label}
@@ -233,7 +233,7 @@ function TweakControl({
             onValueChange={([v]) => onChange(v)}
             className="flex-1"
           />
-          <span className="min-w-[2rem] text-right text-[11px] text-white/50">
+          <span className="min-w-[2rem] text-right text-[11px] text-muted-foreground">
             {typeof value === "number" ? value : 50}
           </span>
         </div>

--- a/templates/videos/app/components/design-system/DesignSystemCard.tsx
+++ b/templates/videos/app/components/design-system/DesignSystemCard.tsx
@@ -28,7 +28,7 @@ export function DesignSystemCard({
 
   return (
     <div
-      className="group relative rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] hover:border-white/[0.12] overflow-hidden cursor-pointer"
+      className="group relative rounded-xl border border-border bg-card hover:border-border overflow-hidden cursor-pointer"
       onClick={onClick}
     >
       {/* Preview area */}
@@ -41,7 +41,7 @@ export function DesignSystemCard({
           {swatchColors.map((s) => (
             <div
               key={s.label}
-              className="w-6 h-6 rounded-full border border-white/10 shrink-0"
+              className="w-6 h-6 rounded-full border border-border shrink-0"
               style={{ background: s.color }}
               title={s.label}
             />
@@ -79,16 +79,16 @@ export function DesignSystemCard({
       <div className="p-4 flex items-start justify-between gap-2">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
-            <IconPalette className="w-3.5 h-3.5 text-white/30 shrink-0" />
-            <h3 className="font-medium text-sm text-white/90 truncate">
+            <IconPalette className="w-3.5 h-3.5 text-muted-foreground/70 shrink-0" />
+            <h3 className="font-medium text-sm text-foreground/90 truncate">
               {title}
             </h3>
           </div>
-          <div className="text-xs text-white/30 mt-1 flex items-center gap-2">
+          <div className="text-xs text-muted-foreground/70 mt-1 flex items-center gap-2">
             <span>{data.typography.headingFont}</span>
             {data.typography.headingFont !== data.typography.bodyFont && (
               <>
-                <span className="text-white/10">|</span>
+                <span className="text-muted-foreground/40">|</span>
                 <span>{data.typography.bodyFont}</span>
               </>
             )}
@@ -106,13 +106,13 @@ export function DesignSystemCard({
             e.stopPropagation();
             onSetDefault();
           }}
-          className="shrink-0 p-1 rounded hover:bg-white/[0.06] cursor-pointer"
+          className="shrink-0 p-1 rounded hover:bg-accent cursor-pointer"
           title={isDefault ? "Default design system" : "Set as default"}
         >
           {isDefault ? (
             <IconStarFilled className="w-4 h-4 text-[#609FF8]" />
           ) : (
-            <IconStar className="w-4 h-4 text-white/20 group-hover:text-white/40" />
+            <IconStar className="w-4 h-4 text-muted-foreground/60 group-hover:text-muted-foreground" />
           )}
         </button>
       </div>

--- a/templates/videos/app/components/design-system/DesignSystemPreview.tsx
+++ b/templates/videos/app/components/design-system/DesignSystemPreview.tsx
@@ -21,31 +21,31 @@ export function DesignSystemPreview({
   return (
     <div
       className={cn(
-        "rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] overflow-hidden",
+        "rounded-xl border border-border bg-card overflow-hidden",
         className,
       )}
     >
       {/* Color swatches */}
-      <div className="p-4 border-b border-white/[0.06]">
-        <div className="text-[10px] font-medium uppercase tracking-wider text-white/30 mb-3">
+      <div className="p-4 border-b border-border">
+        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-3">
           Colors
         </div>
         <div className="flex items-center gap-3">
           {swatches.map((s) => (
             <div key={s.label} className="flex flex-col items-center gap-1.5">
               <div
-                className="w-8 h-8 rounded-full border border-white/10"
+                className="w-8 h-8 rounded-full border border-border"
                 style={{ background: s.color }}
               />
-              <span className="text-[10px] text-white/30">{s.label}</span>
+              <span className="text-[10px] text-muted-foreground/70">{s.label}</span>
             </div>
           ))}
         </div>
       </div>
 
       {/* Typography sample */}
-      <div className="p-4 border-b border-white/[0.06]">
-        <div className="text-[10px] font-medium uppercase tracking-wider text-white/30 mb-3">
+      <div className="p-4 border-b border-border">
+        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-3">
           Typography
         </div>
         <div
@@ -77,7 +77,7 @@ export function DesignSystemPreview({
 
       {/* Mini composition preview */}
       <div className="p-4">
-        <div className="text-[10px] font-medium uppercase tracking-wider text-white/30 mb-3">
+        <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-3">
           Composition Preview
         </div>
         <div
@@ -146,15 +146,15 @@ export function DesignSystemPreview({
 
       {/* Logos */}
       {data.logos.length > 0 && (
-        <div className="p-4 border-t border-white/[0.06]">
-          <div className="text-[10px] font-medium uppercase tracking-wider text-white/30 mb-3">
+        <div className="p-4 border-t border-border">
+          <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70 mb-3">
             Logos
           </div>
           <div className="flex items-center gap-3 flex-wrap">
             {data.logos.map((logo, i) => (
               <div
                 key={`${logo.name}-${i}`}
-                className="w-10 h-10 rounded-lg bg-white/[0.04] border border-white/[0.06] flex items-center justify-center overflow-hidden"
+                className="w-10 h-10 rounded-lg bg-accent/50 border border-border flex items-center justify-center overflow-hidden"
               >
                 <img
                   src={logo.url}

--- a/templates/videos/app/components/design-system/DesignSystemPreview.tsx
+++ b/templates/videos/app/components/design-system/DesignSystemPreview.tsx
@@ -37,7 +37,9 @@ export function DesignSystemPreview({
                 className="w-8 h-8 rounded-full border border-border"
                 style={{ background: s.color }}
               />
-              <span className="text-[10px] text-muted-foreground/70">{s.label}</span>
+              <span className="text-[10px] text-muted-foreground/70">
+                {s.label}
+              </span>
             </div>
           ))}
         </div>

--- a/templates/videos/app/components/design-system/DesignSystemSetup.tsx
+++ b/templates/videos/app/components/design-system/DesignSystemSetup.tsx
@@ -301,13 +301,13 @@ export function DesignSystemSetup({
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="sm:max-w-2xl max-h-[85vh] p-0 bg-[hsl(240,5%,8%)] border-white/[0.08]">
+      <DialogContent className="sm:max-w-2xl max-h-[85vh] p-0 bg-card border-border">
         <DialogHeader className="px-6 pt-6 pb-0">
-          <DialogTitle className="text-white/90 flex items-center gap-2">
+          <DialogTitle className="text-foreground/90 flex items-center gap-2">
             <IconPalette className="w-5 h-5 text-[#609FF8]" />
             {editingId ? "Edit Design System" : "New Design System"}
           </DialogTitle>
-          <DialogDescription className="text-white/40">
+          <DialogDescription className="text-muted-foreground">
             {editingId
               ? "Update your brand identity."
               : "Provide any combination of sources — the more context, the better the result."}
@@ -318,12 +318,12 @@ export function DesignSystemSetup({
           <div className="space-y-5 py-4">
             {/* Company Name */}
             <div className="space-y-2">
-              <Label className="text-white/70">Company / Brand</Label>
+              <Label className="text-foreground/70">Company / Brand</Label>
               <Input
                 value={companyName}
                 onChange={(e) => setCompanyName(e.target.value)}
                 placeholder="Acme Inc. — We build developer tools..."
-                className="bg-white/[0.04] border-white/[0.08] text-white/90 placeholder:text-white/25"
+                className="bg-accent/50 border-border text-foreground/90 placeholder:text-muted-foreground/60"
               />
             </div>
 
@@ -331,7 +331,7 @@ export function DesignSystemSetup({
               <>
                 {/* Website URL */}
                 <div className="space-y-2">
-                  <Label className="text-white/70 flex items-center gap-1.5">
+                  <Label className="text-foreground/70 flex items-center gap-1.5">
                     <IconWorld className="w-3.5 h-3.5" />
                     Website URL
                   </Label>
@@ -340,7 +340,7 @@ export function DesignSystemSetup({
                       value={websiteUrl}
                       onChange={(e) => setWebsiteUrl(e.target.value)}
                       placeholder="https://example.com"
-                      className="bg-white/[0.04] border-white/[0.08] text-white/90 placeholder:text-white/25"
+                      className="bg-accent/50 border-border text-foreground/90 placeholder:text-muted-foreground/60"
                       onKeyDown={(e) => {
                         if (e.key === "Enter") addWebsiteUrl();
                       }}
@@ -364,7 +364,7 @@ export function DesignSystemSetup({
 
                 {/* GitHub */}
                 <div className="space-y-2">
-                  <Label className="text-white/70 flex items-center gap-1.5">
+                  <Label className="text-foreground/70 flex items-center gap-1.5">
                     <IconBrandGithub className="w-3.5 h-3.5" />
                     GitHub Repository
                   </Label>
@@ -373,7 +373,7 @@ export function DesignSystemSetup({
                       value={githubUrl}
                       onChange={(e) => setGithubUrl(e.target.value)}
                       placeholder="https://github.com/org/repo"
-                      className="bg-white/[0.04] border-white/[0.08] text-white/90 placeholder:text-white/25"
+                      className="bg-accent/50 border-border text-foreground/90 placeholder:text-muted-foreground/60"
                       onKeyDown={(e) => {
                         if (e.key === "Enter") addGithubLink();
                       }}
@@ -397,7 +397,7 @@ export function DesignSystemSetup({
 
                 {/* Code Files */}
                 <div className="space-y-2">
-                  <Label className="text-white/70 flex items-center gap-1.5">
+                  <Label className="text-foreground/70 flex items-center gap-1.5">
                     <IconFolder className="w-3.5 h-3.5" />
                     Code Files
                   </Label>
@@ -409,9 +409,9 @@ export function DesignSystemSetup({
                         readTextFiles(e.dataTransfer.files, setCodeFiles);
                     }}
                     onDragOver={(e) => e.preventDefault()}
-                    className="w-full border border-dashed border-white/[0.08] rounded-lg p-4 text-center hover:border-white/[0.15] cursor-pointer"
+                    className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/15 cursor-pointer"
                   >
-                    <p className="text-xs text-white/30">
+                    <p className="text-xs text-muted-foreground/70">
                       CSS, Tailwind config, theme files — drop or click
                     </p>
                   </button>
@@ -437,15 +437,15 @@ export function DesignSystemSetup({
 
                 {/* Documents */}
                 <div className="space-y-2">
-                  <Label className="text-white/70 flex items-center gap-1.5">
+                  <Label className="text-foreground/70 flex items-center gap-1.5">
                     <IconFileDescription className="w-3.5 h-3.5" />
                     Documents & Presentations
                   </Label>
                   <button
                     onClick={() => docInputRef.current?.click()}
-                    className="w-full border border-dashed border-white/[0.08] rounded-lg p-4 text-center hover:border-white/[0.15] cursor-pointer"
+                    className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/15 cursor-pointer"
                   >
-                    <p className="text-xs text-white/30">
+                    <p className="text-xs text-muted-foreground/70">
                       PPTX, DOCX, PDF — brand guides, pitch decks
                     </p>
                   </button>
@@ -477,15 +477,15 @@ export function DesignSystemSetup({
 
                 {/* Images */}
                 <div className="space-y-2">
-                  <Label className="text-white/70 flex items-center gap-1.5">
+                  <Label className="text-foreground/70 flex items-center gap-1.5">
                     <IconPhoto className="w-3.5 h-3.5" />
                     Screenshots & Visual References
                   </Label>
                   <button
                     onClick={() => imageInputRef.current?.click()}
-                    className="w-full border border-dashed border-white/[0.08] rounded-lg p-4 text-center hover:border-white/[0.15] cursor-pointer"
+                    className="w-full border border-dashed border-border rounded-lg p-4 text-center hover:border-foreground/15 cursor-pointer"
                   >
-                    <p className="text-xs text-white/30">
+                    <p className="text-xs text-muted-foreground/70">
                       Product screenshots, mood boards, logos
                     </p>
                   </button>
@@ -518,7 +518,7 @@ export function DesignSystemSetup({
                 {/* Fork existing */}
                 {existingSystems.length > 0 && (
                   <div className="space-y-2">
-                    <Label className="text-white/70">
+                    <Label className="text-foreground/70">
                       Fork an existing design system
                     </Label>
                     <div className="grid grid-cols-2 gap-2">
@@ -535,12 +535,12 @@ export function DesignSystemSetup({
                             className={`text-left p-3 rounded-lg border cursor-pointer ${
                               selectedSystemId === ds.id
                                 ? "border-[#609FF8]/40 bg-[#609FF8]/5"
-                                : "border-white/[0.06] bg-white/[0.03] hover:border-white/[0.12]"
+                                : "border-border bg-muted/50 hover:border-border"
                             }`}
                           >
                             <div className="flex items-center gap-2">
-                              <IconPalette className="w-3.5 h-3.5 text-white/40" />
-                              <span className="text-sm text-white/70 truncate">
+                              <IconPalette className="w-3.5 h-3.5 text-muted-foreground" />
+                              <span className="text-sm text-foreground/70 truncate">
                                 {ds.title}
                               </span>
                             </div>
@@ -554,7 +554,7 @@ export function DesignSystemSetup({
 
             {/* Brand Notes */}
             <div className="space-y-2">
-              <Label className="text-white/70">
+              <Label className="text-foreground/70">
                 {editingId ? "Brand Notes" : "Additional Notes"}
               </Label>
               <Textarea
@@ -562,19 +562,19 @@ export function DesignSystemSetup({
                 onChange={(e) => setBrandNotes(e.target.value)}
                 placeholder="Design preferences, constraints, brand guidelines..."
                 rows={3}
-                className="bg-white/[0.04] border-white/[0.08] text-white/90 placeholder:text-white/25 resize-none"
+                className="bg-accent/50 border-border text-foreground/90 placeholder:text-muted-foreground/60 resize-none"
               />
             </div>
           </div>
         </ScrollArea>
 
         {/* Actions */}
-        <div className="flex justify-end gap-3 px-6 pb-6 pt-2 border-t border-white/[0.06]">
+        <div className="flex justify-end gap-3 px-6 pb-6 pt-2 border-t border-border">
           <Button
             variant="ghost"
             onClick={onClose}
             disabled={generating}
-            className="text-white/50 hover:text-white/80 cursor-pointer"
+            className="text-muted-foreground hover:text-foreground/80 cursor-pointer"
           >
             Cancel
           </Button>
@@ -613,13 +613,13 @@ function TagList({
       {items.map((item, i) => (
         <div
           key={i}
-          className="flex items-center gap-2 text-sm text-white/60 bg-white/[0.03] rounded-md px-3 py-1.5"
+          className="flex items-center gap-2 text-sm text-muted-foreground bg-muted/50 rounded-md px-3 py-1.5"
         >
           <IconCheck className="w-3.5 h-3.5 text-green-400/60 shrink-0" />
           <span className="truncate flex-1">{item}</span>
           <button
             onClick={() => onRemove(i)}
-            className="text-white/30 hover:text-white/50 shrink-0 cursor-pointer"
+            className="text-muted-foreground/70 hover:text-muted-foreground shrink-0 cursor-pointer"
           >
             <IconX className="w-3.5 h-3.5" />
           </button>
@@ -642,16 +642,16 @@ function FileList({
       {files.map((f) => (
         <div
           key={f.id}
-          className="flex items-center gap-2 text-sm text-white/60 bg-white/[0.03] rounded-md px-3 py-1.5"
+          className="flex items-center gap-2 text-sm text-muted-foreground bg-muted/50 rounded-md px-3 py-1.5"
         >
           <IconCheck className="w-3.5 h-3.5 text-green-400/60 shrink-0" />
           <span className="truncate flex-1">{f.name}</span>
-          <span className="text-[10px] text-white/20 shrink-0">
+          <span className="text-[10px] text-muted-foreground/60 shrink-0">
             {formatSize(f.size)}
           </span>
           <button
             onClick={() => onRemove(f.id)}
-            className="text-white/30 hover:text-white/50 shrink-0 cursor-pointer"
+            className="text-muted-foreground/70 hover:text-muted-foreground shrink-0 cursor-pointer"
           >
             <IconX className="w-3.5 h-3.5" />
           </button>

--- a/templates/videos/app/components/ui/input.tsx
+++ b/templates/videos/app/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base text-white ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base text-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className,
         )}
         ref={ref}

--- a/templates/videos/app/global.css
+++ b/templates/videos/app/global.css
@@ -12,47 +12,6 @@
    * tailwind.config.ts expects the following color variables to be expressed as HSL values.
   */
 :root {
-  --background: 240 6% 6%;
-  --foreground: 0 0% 95%;
-
-  --card: 240 5% 8%;
-  --card-foreground: 0 0% 95%;
-
-  --popover: 240 5% 8%;
-  --popover-foreground: 0 0% 95%;
-
-  --primary: 0 0% 75%;
-  --primary-foreground: 240 6% 6%;
-
-  --secondary: 240 4% 13%;
-  --secondary-foreground: 0 0% 90%;
-
-  --muted: 240 4% 13%;
-  --muted-foreground: 240 3% 50%;
-
-  --accent: 240 4% 14%;
-  --accent-foreground: 0 0% 90%;
-
-  --destructive: 0 84% 60%;
-  --destructive-foreground: 0 0% 100%;
-
-  --border: 240 4% 14%;
-  --input: 240 4% 14%;
-  --ring: 0 0% 50%;
-
-  --radius: 0.625rem;
-
-  --sidebar-background: 240 6% 7%;
-  --sidebar-foreground: 240 3% 55%;
-  --sidebar-primary: 0 0% 75%;
-  --sidebar-primary-foreground: 240 6% 6%;
-  --sidebar-accent: 240 4% 12%;
-  --sidebar-accent-foreground: 0 0% 80%;
-  --sidebar-border: 240 4% 12%;
-  --sidebar-ring: 0 0% 50%;
-}
-
-.light {
   --background: 0 0% 100%;
   --foreground: 240 6% 10%;
 
@@ -91,6 +50,47 @@
   --sidebar-accent-foreground: 240 6% 10%;
   --sidebar-border: 240 6% 90%;
   --sidebar-ring: 240 5% 65%;
+}
+
+.dark {
+  --background: 240 6% 6%;
+  --foreground: 0 0% 95%;
+
+  --card: 240 5% 8%;
+  --card-foreground: 0 0% 95%;
+
+  --popover: 240 5% 8%;
+  --popover-foreground: 0 0% 95%;
+
+  --primary: 0 0% 75%;
+  --primary-foreground: 240 6% 6%;
+
+  --secondary: 240 4% 13%;
+  --secondary-foreground: 0 0% 90%;
+
+  --muted: 240 4% 13%;
+  --muted-foreground: 240 3% 50%;
+
+  --accent: 240 4% 14%;
+  --accent-foreground: 0 0% 90%;
+
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 0 0% 100%;
+
+  --border: 240 4% 14%;
+  --input: 240 4% 14%;
+  --ring: 0 0% 50%;
+
+  --radius: 0.625rem;
+
+  --sidebar-background: 240 6% 7%;
+  --sidebar-foreground: 240 3% 55%;
+  --sidebar-primary: 0 0% 75%;
+  --sidebar-primary-foreground: 240 6% 6%;
+  --sidebar-accent: 240 4% 12%;
+  --sidebar-accent-foreground: 0 0% 80%;
+  --sidebar-border: 240 4% 12%;
+  --sidebar-ring: 0 0% 50%;
 }
 
 @layer base {

--- a/templates/videos/app/pages/DesignSystems.tsx
+++ b/templates/videos/app/pages/DesignSystems.tsx
@@ -52,7 +52,7 @@ export default function DesignSystems() {
     <div className="flex-1 overflow-y-auto">
       <main className="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-10">
         <div className="flex items-center justify-between mb-6">
-          <h1 className="text-lg font-semibold text-white/90">
+          <h1 className="text-lg font-semibold text-foreground/90">
             Design Systems
           </h1>
           <Button
@@ -70,19 +70,19 @@ export default function DesignSystems() {
         {isLoading ? (
           <>
             <div className="flex items-center justify-between mb-6">
-              <div className="h-5 w-40 rounded-md bg-white/[0.05] animate-pulse" />
-              <div className="h-3 w-16 rounded bg-white/[0.05] animate-pulse" />
+              <div className="h-5 w-40 rounded-md bg-muted animate-pulse" />
+              <div className="h-3 w-16 rounded bg-muted animate-pulse" />
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
               {Array.from({ length: 4 }).map((_, i) => (
                 <div
                   key={i}
-                  className="rounded-xl border border-white/[0.06] bg-[hsl(240,5%,8%)] overflow-hidden"
+                  className="rounded-xl border border-border bg-card overflow-hidden"
                 >
-                  <div className="aspect-video bg-white/[0.03] animate-pulse" />
+                  <div className="aspect-video bg-muted/50 animate-pulse" />
                   <div className="p-4 space-y-2">
-                    <div className="h-4 w-3/4 rounded bg-white/[0.05] animate-pulse" />
-                    <div className="h-3 w-1/2 rounded bg-white/[0.05] animate-pulse" />
+                    <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+                    <div className="h-3 w-1/2 rounded bg-muted animate-pulse" />
                   </div>
                 </div>
               ))}
@@ -104,18 +104,18 @@ export default function DesignSystems() {
                   setEditingId(null);
                   setShowSetup(true);
                 }}
-                className="group relative rounded-xl border border-dashed border-white/[0.08] bg-[hsl(240,5%,8%)] hover:border-white/[0.15] overflow-hidden text-left cursor-pointer"
+                className="group relative rounded-xl border border-dashed border-border bg-card hover:border-foreground/15 overflow-hidden text-left cursor-pointer"
               >
-                <div className="aspect-video flex items-center justify-center bg-white/[0.02]">
-                  <div className="w-12 h-12 rounded-xl bg-white/[0.04] flex items-center justify-center group-hover:bg-white/[0.06]">
-                    <IconPlus className="w-6 h-6 text-white/30 group-hover:text-white/50" />
+                <div className="aspect-video flex items-center justify-center bg-muted/30">
+                  <div className="w-12 h-12 rounded-xl bg-accent/50 flex items-center justify-center group-hover:bg-accent">
+                    <IconPlus className="w-6 h-6 text-muted-foreground/70 group-hover:text-muted-foreground" />
                   </div>
                 </div>
                 <div className="p-4">
-                  <h3 className="font-medium text-sm text-white/50 group-hover:text-white/70">
+                  <h3 className="font-medium text-sm text-muted-foreground group-hover:text-foreground/70">
                     New Design System
                   </h3>
-                  <div className="text-xs text-white/30 mt-1">
+                  <div className="text-xs text-muted-foreground/70 mt-1">
                     Set up your brand
                   </div>
                 </div>
@@ -159,10 +159,10 @@ function EmptyState({ onCreateNew }: { onCreateNew: () => void }) {
       <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-[#609FF8]/20 to-[#4080E0]/20 border border-[#609FF8]/20 flex items-center justify-center mb-6">
         <IconPalette className="w-7 h-7 text-[#609FF8]" />
       </div>
-      <h2 className="text-xl font-semibold text-white/90 mb-2">
+      <h2 className="text-xl font-semibold text-foreground/90 mb-2">
         Set up your brand identity
       </h2>
-      <p className="text-sm text-white/40 max-w-sm mb-8 leading-relaxed">
+      <p className="text-sm text-muted-foreground max-w-sm mb-8 leading-relaxed">
         Create a design system with your brand colors, typography, and logos.
         Every new composition will follow your visual identity.
       </p>


### PR DESCRIPTION
## Summary

#348 added the auth-guard exemption for `/_agent-native/a2a/_process-task`, but the route still wasn't reachable: h3's `.use()` matches by prefix, and `/a2a` was registered first, so a POST to `/a2a/_process-task` was swallowed by the JSON-RPC handler. The handler saw `{ taskId }` instead of a JSON-RPC envelope, so it returned `{"error":{"code":-32001,"message":"Invalid or expired A2A token"}}` — coming from the parent route, not the processor.

This is the same shape as the bug PR #335 fixed for the integration webhook catch-all. Fix:

1. Mount `/_agent-native/a2a/_process-task` **before** the parent `/a2a` mount so the more specific path matches first.
2. Add a defensive skip in the parent handler — if `event.path` (relative to mount) starts with `_process-task`, return so the dedicated mount handles it. Same pattern as `integrations/plugin.ts:289`.

Verified live: a manual signed POST to `/a2a/_process-task` on analytics returned the JSON-RPC envelope from `/a2a` (proving `/a2a` was eating the request), not the route's HMAC failure (which would be `{"error":"Invalid or expired processor token"}`).

Also sweeps 58 concurrent agent updates across templates (slides, design, videos, dispatch components) and integrations adapters that landed on the working tree while iterating.

## Test plan

- [x] `pnpm prep` clean (typecheck + fmt across all templates)
- [x] `pnpm --filter @agent-native/core test` — 490/490 pass
- [ ] After deploy: re-run async A2A `message/send` to analytics, verify `tasks/get` shows it transition to `completed` with a real answer
- [ ] Synthetic Slack analytics test → verify dispatch returns the actual count instead of "didn't reply in time / fetch failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)