### PR TITLE
fix(call-agent): skip SSE streaming for cross-app calls (causes Lambda timeout)

### DIFF
--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -128,49 +128,29 @@ export async function run(
         responseText = newText;
       };
 
-      let streamErr: any = null;
+      // Skip the SSE streaming attempt and go straight to async + poll.
+      // Why: on Netlify (Lambda), the receiving server has no streaming
+      // response support, so message/stream returns a single JSON-RPC error
+      // body in a 200 response that our SSE parser silently consumes — the
+      // `for await` loop yields nothing AND keeps the connection open until
+      // the function timeout, eating the 26s budget. By the time we get to
+      // the sync fallback, Lambda is dead and the second fetch errors out
+      // as "fetch failed". Async+poll has its own short fetches with their
+      // own budgets, so it works reliably across hosts. The trade-off is
+      // we lose progressive in-UI text streaming for cross-app A2A calls,
+      // but the receiving agent's full response still surfaces via the
+      // tool_result event below.
       try {
-        for await (const task of client.stream(
-          {
-            role: "user",
-            parts: [{ type: "text", text: message }],
-          },
-          Object.keys(a2aMetadata).length > 0
-            ? { metadata: a2aMetadata }
-            : undefined,
-        )) {
-          const newText =
-            task.status?.message?.parts
-              ?.filter(
-                (p): p is { type: "text"; text: string } => p.type === "text",
-              )
-              ?.map((p) => p.text)
-              ?.join("") ?? "";
-          emitNewText(newText);
-        }
-      } catch (err: any) {
-        streamErr = err;
-      }
-
-      // Fall back to sync send if streaming threw OR yielded nothing. The
-      // "yielded nothing" case happens on Netlify because the receiving
-      // function has no node response stream available, so the streaming
-      // endpoint replies with a JSON-RPC error body in a single 200 response
-      // that our SSE parser silently skips (no `data: ` lines).
-      if (!responseText) {
-        try {
-          responseText = await callAgent(agent.url, message, {
-            userEmail: callerEmail,
-            orgDomain: callerOrgDomain,
-            orgSecret: callerOrgSecret,
-          });
-          // Mirror the response into the streaming UI so the user sees it.
-          if (responseText) emitNewText(responseText);
-        } catch (pollErr: any) {
-          const reason =
-            pollErr?.message ?? streamErr?.message ?? "unknown error";
-          responseText = `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;
-        }
+        responseText = await callAgent(agent.url, message, {
+          userEmail: callerEmail,
+          orgDomain: callerOrgDomain,
+          orgSecret: callerOrgSecret,
+        });
+        // Mirror the response into the streaming UI so the user sees it.
+        if (responseText) emitNewText(responseText);
+      } catch (pollErr: any) {
+        const reason = pollErr?.message ?? "unknown error";
+        responseText = `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;
       }
 
       context.send({


### PR DESCRIPTION
## Summary

After #344 + #348 + #349, direct A2A async calls finally work end-to-end (verified: 20s round-trip from CLI, task transitions `working` → `processing` → `completed` with a real answer). But dispatch's Slack flow still returns "fetch failed" — the request never reaches the receiving agent's DB at all.

**Root cause:** on Netlify Lambda the receiving server has no streaming response support (Nitro on Lambda doesn't expose `event.node.res` for chunked output), so `message/stream` returns a single JSON-RPC error body inside a 200 response. The SSE parser silently consumes that (no `data:` lines) AND the connection stays open, so the `for await` loop yields nothing while quietly burning the 26s function budget. Once the budget is exhausted, the function dies and the sync `callAgent` fallback fetch errors out as `fetch failed` *before* it can hit the receiver.

**Fix:** when an action `context.send` is present, skip the streaming attempt entirely and go straight to the async+poll `callAgent` path. Each individual fetch in async+poll is short (the receiver returns `working` immediately and we poll), so we don't hit the timeout.

**Trade-off:** cross-app A2A calls no longer stream progressive text into the agent UI — but the receiving agent's full reply still surfaces via the standard `tool_result` event, and "no answer at all" was a strictly worse UX. We can reintroduce streaming once the receiving server supports it on Netlify (probably via Builder.io Background Functions, but that's platform-specific).

## Test plan

- [x] `pnpm prep` clean
- [x] Direct A2A async to analytics works (verified post-#349 deploy)
- [ ] After deploy: synthetic Slack `@agent-native how many signups did we get yesterday?` → dispatch returns the analytics number
- [ ] Live Slack test in `#test-agent-native-slack-bot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)