### PR TITLE
fix(integrations,a2a): give fire-and-forget ~250ms to leave the box (cold-start)

### DIFF
--- a/packages/core/src/a2a/handlers.ts
+++ b/packages/core/src/a2a/handlers.ts
@@ -75,13 +75,21 @@ async function fireProcessTaskDispatch(
     // unsigned dispatches when no secret is set (mirrors the integration
     // webhook flow).
   }
-  fetch(url, {
+  // Race the fetch against a short timer. On Netlify Lambda, returning
+  // immediately can freeze the function before the outbound TCP handshake
+  // starts, leaving the request stuck. This gives it ~250ms to leave the
+  // box at the cost of slightly higher response latency on async A2A sends.
+  const dispatchPromise = fetch(url, {
     method: "POST",
     headers,
     body: JSON.stringify({ taskId }),
   }).catch((err) => {
     console.error("[a2a] Process-task dispatch fetch failed:", err);
   });
+  await Promise.race([
+    dispatchPromise,
+    new Promise<void>((resolve) => setTimeout(resolve, 250)),
+  ]);
 }
 
 /**

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -219,15 +219,24 @@ async function enqueueAndDispatch(
     // No A2A_SECRET — proceed without a signed token. See note above.
   }
 
-  // Fire-and-forget: do NOT await. The dispatched request runs on its own
-  // function execution, freed from the current handler's timeout.
-  fetch(processUrl, {
+  // Fire-and-forget: do NOT await the full response (the processor's run
+  // takes minutes — we don't want to block the caller). BUT on Netlify
+  // Lambda, when we return immediately, the runtime can freeze the function
+  // before the outbound TCP handshake even starts, which leaves the dispatch
+  // request stuck waiting for the 60s retry-sweep job. Race the fetch
+  // against a short timer so the request gets at least ~250ms to leave the
+  // box; the trade-off is at most ~250ms of added webhook latency.
+  const dispatchPromise = fetch(processUrl, {
     method: "POST",
     headers,
     body: JSON.stringify({ taskId }),
   }).catch((err) => {
     console.error("[integrations] Failed to dispatch processor request:", err);
   });
+  await Promise.race([
+    dispatchPromise,
+    new Promise<void>((resolve) => setTimeout(resolve, 250)),
+  ]);
 }
 
 /**

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -128,49 +128,29 @@ export async function run(
         responseText = newText;
       };
 
-      let streamErr: any = null;
+      // Skip the SSE streaming attempt and go straight to async + poll.
+      // Why: on Netlify (Lambda), the receiving server has no streaming
+      // response support, so message/stream returns a single JSON-RPC error
+      // body in a 200 response that our SSE parser silently consumes — the
+      // `for await` loop yields nothing AND keeps the connection open until
+      // the function timeout, eating the 26s budget. By the time we get to
+      // the sync fallback, Lambda is dead and the second fetch errors out
+      // as "fetch failed". Async+poll has its own short fetches with their
+      // own budgets, so it works reliably across hosts. The trade-off is
+      // we lose progressive in-UI text streaming for cross-app A2A calls,
+      // but the receiving agent's full response still surfaces via the
+      // tool_result event below.
       try {
-        for await (const task of client.stream(
-          {
-            role: "user",
-            parts: [{ type: "text", text: message }],
-          },
-          Object.keys(a2aMetadata).length > 0
-            ? { metadata: a2aMetadata }
-            : undefined,
-        )) {
-          const newText =
-            task.status?.message?.parts
-              ?.filter(
-                (p): p is { type: "text"; text: string } => p.type === "text",
-              )
-              ?.map((p) => p.text)
-              ?.join("") ?? "";
-          emitNewText(newText);
-        }
-      } catch (err: any) {
-        streamErr = err;
-      }
-
-      // Fall back to sync send if streaming threw OR yielded nothing. The
-      // "yielded nothing" case happens on Netlify because the receiving
-      // function has no node response stream available, so the streaming
-      // endpoint replies with a JSON-RPC error body in a single 200 response
-      // that our SSE parser silently skips (no `data: ` lines).
-      if (!responseText) {
-        try {
-          responseText = await callAgent(agent.url, message, {
-            userEmail: callerEmail,
-            orgDomain: callerOrgDomain,
-            orgSecret: callerOrgSecret,
-          });
-          // Mirror the response into the streaming UI so the user sees it.
-          if (responseText) emitNewText(responseText);
-        } catch (pollErr: any) {
-          const reason =
-            pollErr?.message ?? streamErr?.message ?? "unknown error";
-          responseText = `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;
-        }
+        responseText = await callAgent(agent.url, message, {
+          userEmail: callerEmail,
+          orgDomain: callerOrgDomain,
+          orgSecret: callerOrgSecret,
+        });
+        // Mirror the response into the streaming UI so the user sees it.
+        if (responseText) emitNewText(responseText);
+      } catch (pollErr: any) {
+        const reason = pollErr?.message ?? "unknown error";
+        responseText = `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;
       }
 
       context.send({


### PR DESCRIPTION
## Summary

After #350 deployed, integration webhook tasks (and A2A async sends) were no longer getting picked up by the initial fire-and-forget self-fire to `/process-task`. The 60s retry sweep took over and got tasks completed, but only after `attempts=3` — which means a Slack reply took 60-180s instead of <30s.

**Root cause:** on Netlify Lambda, when the handler returns immediately, the runtime can freeze the function instance before the outbound TCP handshake even starts. The non-awaited fetch promise dangles, the request never leaves the box, and the queue's retry sweep ends up doing all the dispatch work.

**Fix:** race the fetch promise against a 250ms timer in both the integration webhook handler and the A2A async fanout. We still don't await the full response (the processor takes minutes by design), but we keep the function alive long enough for the request to actually go out. Cost: at most ~250ms of added webhook latency, well under the platforms' delivery deadlines (Slack 3s, Telegram 60s).

The same pattern was already implicitly working when functions were warm — the retry sweep was effectively masking the issue. Cold-start frequency must have changed (less traffic) and exposed it.

## Test plan

- [x] `pnpm prep` clean
- [ ] After deploy: synthetic Slack `@agent-native ping` → task should complete with `attempts=1` (initial dispatch worked) and reply within ~5s, not 90s
- [ ] Direct A2A async send to analytics → still completes in ~10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)