### PR TITLE
fix(agent-discovery): prevent localhost URL overrides on prod, revert debug log

### DIFF
--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -268,17 +268,26 @@ async function _doEnsureTable(): Promise<void> {
     ],
   });
 
-  // Seed built-in agents as shared resources under agents/
+  // Seed built-in agents as shared resources under remote-agents/. ALWAYS
+  // use the production URL here, never the env-resolved devUrl. The seed
+  // runs once per DB (ON CONFLICT DO NOTHING), so a localhost URL written
+  // during a dev run sticks forever — including when that DB is later used
+  // by a prod deploy and the override wins over the built-in's prod URL.
+  // (Verified problem: `dispatch.agent-native.com` had every remote-agents
+  // entry pointing at localhost from an early-seed run, breaking call-agent
+  // outbound from Lambda for ~12h before this was caught.)
   try {
-    const { getBuiltinAgents } = await import("../server/agent-discovery.js");
-    const builtins = getBuiltinAgents();
+    const { getBuiltinAgents, BUILTIN_AGENTS_FOR_SEEDING } =
+      await import("../server/agent-discovery.js");
+    void getBuiltinAgents; // referenced to keep type-only import alive
+    const builtins = BUILTIN_AGENTS_FOR_SEEDING;
     for (const agent of builtins) {
       const agentJson = JSON.stringify(
         {
           id: agent.id,
           name: agent.name,
           description: agent.description,
-          url: agent.url,
+          url: agent.url, // always prod
           color: agent.color,
         },
         null,

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -141,9 +141,6 @@ export async function run(
       // but the receiving agent's full response still surfaces via the
       // tool_result event below.
       try {
-        console.log(
-          `[call-agent] dispatching to ${agent.name} url=${agent.url} caller=${callerEmail} orgDomain=${callerOrgDomain} hasOrgSecret=${!!callerOrgSecret} hasEnvSecret=${!!process.env.A2A_SECRET}`,
-        );
         responseText = await callAgent(agent.url, message, {
           userEmail: callerEmail,
           orgDomain: callerOrgDomain,
@@ -152,14 +149,6 @@ export async function run(
         // Mirror the response into the streaming UI so the user sees it.
         if (responseText) emitNewText(responseText);
       } catch (pollErr: any) {
-        // Verbose log so we can see what actually broke when this returns
-        // the "didn't reply in time" fallback. errors of cause:
-        //   * fetch failed → network/DNS/TLS — log .cause for details
-        //   * 401/403 → JWT mismatch, look at sign secret vs receiver env
-        //   * timeout/Inactivity → analytics handler exceeded poll budget
-        console.error(
-          `[call-agent] dispatch to ${agent.name} failed: name=${pollErr?.name} message=${pollErr?.message} cause=${JSON.stringify(pollErr?.cause)?.substring(0, 300)} stack=${pollErr?.stack?.substring(0, 500)}`,
-        );
         const reason = pollErr?.message ?? "unknown error";
         responseText = `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;
       }

--- a/packages/core/src/server/agent-discovery.ts
+++ b/packages/core/src/server/agent-discovery.ts
@@ -175,18 +175,32 @@ export async function discoverAgents(
         const full = await resourceGet(r.id);
         if (!full) continue;
         const manifest = parseRemoteAgentManifest(full.content, r.path);
-        const agent = manifest
-          ? {
-              id: manifest.id,
-              name: manifest.name,
-              description: manifest.description || "",
-              url: manifest.url,
-              color: manifest.color || "#6B7280",
-            }
-          : null;
-        if (agent && agent.id !== selfAppId) {
-          agentsById.set(agent.id, agent);
+        if (!manifest || manifest.id === selfAppId) continue;
+
+        // If the resource override carries a localhost URL but we're running
+        // in production (e.g. a stale dev-time seed got promoted to the prod
+        // DB), fall back to the matching built-in's prod URL instead of
+        // letting the override win — otherwise outbound `call-agent` fetches
+        // from a serverless function would target localhost and fail with
+        // "fetch failed" instantly. The override still wins for non-localhost
+        // URLs (the supported case for self-hosted custom agents).
+        let url = manifest.url;
+        if (
+          !isDevMode &&
+          typeof url === "string" &&
+          /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:|\/|$)/.test(url)
+        ) {
+          const builtin = agentsById.get(manifest.id);
+          if (builtin?.url) url = builtin.url;
         }
+
+        agentsById.set(manifest.id, {
+          id: manifest.id,
+          name: manifest.name,
+          description: manifest.description || "",
+          url,
+          color: manifest.color || "#6B7280",
+        });
       } catch {
         // Skip unreadable resources
       }
@@ -222,3 +236,21 @@ function resolveAgentUrl(app: AgentEntry): string {
   }
   return app.url;
 }
+
+/**
+ * Like `getBuiltinAgents`, but always returns the production URL — never the
+ * env-resolved devUrl. Used by the resource seeder so that a one-time seed
+ * (`ON CONFLICT DO NOTHING`) can't permanently bake a localhost URL into the
+ * DB, which would override the built-in's prod URL for every later
+ * production deploy.
+ */
+export const BUILTIN_AGENTS_FOR_SEEDING: DiscoveredAgent[] =
+  BUILTIN_AGENTS.filter(
+    (app) => app.enabled && !app.placeholder && app.url,
+  ).map((app) => ({
+    id: app.id,
+    name: app.name,
+    description: app.description,
+    url: app.url, // ALWAYS prod
+    color: app.color,
+  }));


### PR DESCRIPTION
## Summary

The dispatch's `call-agent` action was getting fast "fetch failed" errors on Slack cross-app calls. Direct A2A async to the same agent worked, which made it puzzling — until inspecting dispatch's prod DB showed `remote-agents/analytics.json` with `url=http://localhost:8088`. The seed function had run at some point with `NODE_ENV != "production"` (dev shell, build context, etc.), wrote a localhost URL, and the `INSERT...ON CONFLICT DO NOTHING` guard kept that stale row forever through every later prod deploy. `discoverAgents` overlays resource agents over built-ins, so the localhost override won on every cross-app dispatch from Lambda and instant-failed.

**Two-part fix:**

1. **`resources/store.ts`** — seed `remote-agents/*.json` with a new `BUILTIN_AGENTS_FOR_SEEDING` list that ALWAYS uses the prod URL, never the env-resolved devUrl. Fresh deploys can no longer poison the prod DB this way.

2. **`agent-discovery.ts`** — when overlaying resource-based agents in production, if the resource's URL points at `localhost` / `127.0.0.1` / `0.0.0.0`, fall back to the matching built-in's prod URL. Self-heals the existing prod DB rows at request time, before any redeploy.

Also reverts the debug logging from #352 (root cause now known).

## Verified live

Already manually rewrote dispatch's existing localhost rows to prod URLs in the DB. After that, a synthetic Slack `@agent-native how many signups did we get yesterday?` returned **630** in ~35s end-to-end (Slack → dispatch `/process-task` → `call-agent` → analytics async A2A → BigQuery → dispatch `chat.postMessage` with thread deep-link). Replied in `#test-agent-native-slack-bot` at 2026-04-29 05:44Z. This PR codifies the fix so it survives future seeds and redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)