### PR TITLE
fix(call-agent): cap cross-app poll at 18s to fit Netlify 26s timeout

### DIFF
--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -141,10 +141,19 @@ export async function run(
       // but the receiving agent's full response still surfaces via the
       // tool_result event below.
       try {
+        // Cap the polling budget at 18s so dispatch always returns something
+        // within Netlify's 26s function-timeout window. The remaining ~8s is
+        // budget for Haiku to format and post the response to Slack. Without
+        // this cap, a slow analytics handler (~25s+) would kill dispatch's
+        // lambda mid-poll and leave the integration task stuck "processing"
+        // for ~5min until the retry sweep resets it. Better UX: tell the
+        // user we couldn't reach the agent in time so they can retry, while
+        // the underlying A2A task may still complete in the background.
         responseText = await callAgent(agent.url, message, {
           userEmail: callerEmail,
           orgDomain: callerOrgDomain,
           orgSecret: callerOrgSecret,
+          timeoutMs: 18000,
         });
         // Mirror the response into the streaming UI so the user sees it.
         if (responseText) emitNewText(responseText);


### PR DESCRIPTION
## Summary

Verified live tonight: when an A2A handler (e.g. analytics's BigQuery query) takes longer than dispatch's 26s Netlify function timeout, the integration task gets stuck \`processing\` for ~5min until the retry sweep resets it. The user sees dead silence in Slack/Telegram for minutes.

Cap dispatch's polling budget at 18s by passing \`timeoutMs: 18000\` to \`callAgent\`. Net effect: dispatch always returns something within ~25s (18s poll + ~5s Haiku format + post-to-Slack overhead), well inside the 26s budget. If analytics genuinely takes longer, the user sees a clear "agent is taking longer than expected, didn't reply in time" message and can retry — strictly better than silence.

Trade-off: caps how slow we'll wait for cross-app responses. 18s is empirically enough for typical analytics queries (verified ~10-15s round-trips post-#353); if a query genuinely needs more than that, the user gets a retry hint instead of waiting in silence.

## Test plan

- [x] \`pnpm prep\` clean
- [ ] After deploy: re-test the slow-Telegram case from earlier — instead of staying stuck \`processing\`, the integration task should complete with the "didn't reply in time" message.
- [ ] Slack signups query → still returns "630"-style answer in <25s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)