### PR TITLE
feat(slack): Block Kit replies with thinking placeholder + Open thread button

### DIFF
--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -257,4 +257,118 @@ describe("AgentEngine registry", () => {
     expect(createFn).toHaveBeenCalled();
     expect(resolved).toBe(fakeEngine);
   });
+
+  describe("detectEngineFromUserSecrets", () => {
+    beforeEach(() => {
+      vi.resetModules();
+      delete process.env.AGENT_ENGINE;
+      delete process.env.AGENT_ENGINE_PREFER_BYO_KEY;
+    });
+
+    it("returns null when no request user is set", async () => {
+      vi.doMock("../../server/request-context.js", () => ({
+        getRequestUserEmail: () => undefined,
+      }));
+      const { detectEngineFromUserSecrets } = await import("./registry.js");
+      expect(await detectEngineFromUserSecrets()).toBeNull();
+    });
+
+    it("returns null for the local-dev session", async () => {
+      vi.doMock("../../server/request-context.js", () => ({
+        getRequestUserEmail: () => "local@localhost",
+      }));
+      const { detectEngineFromUserSecrets } = await import("./registry.js");
+      expect(await detectEngineFromUserSecrets()).toBeNull();
+    });
+
+    it("picks the Builder engine when the user has BUILDER_PRIVATE_KEY in app_secrets", async () => {
+      vi.doMock("../../server/request-context.js", () => ({
+        getRequestUserEmail: () => "brent@example.com",
+      }));
+      vi.doMock("../../secrets/storage.js", () => ({
+        readAppSecret: vi.fn(async ({ key }: { key: string }) =>
+          key === "BUILDER_PRIVATE_KEY"
+            ? { key, value: "p-key-from-app-secrets" }
+            : null,
+        ),
+      }));
+
+      const { registerAgentEngine, detectEngineFromUserSecrets } =
+        await import("./registry.js");
+
+      registerAgentEngine({
+        name: "builder",
+        label: "Builder",
+        description: "",
+        capabilities: {} as any,
+        defaultModel: "m",
+        supportedModels: [],
+        requiredEnvVars: ["BUILDER_PRIVATE_KEY"],
+        create: vi.fn() as any,
+      });
+      registerAgentEngine({
+        name: "anthropic",
+        label: "Anthropic",
+        description: "",
+        capabilities: {} as any,
+        defaultModel: "m",
+        supportedModels: [],
+        requiredEnvVars: ["ANTHROPIC_API_KEY"],
+        create: vi.fn() as any,
+      });
+
+      const detected = await detectEngineFromUserSecrets();
+      expect(detected?.name).toBe("builder");
+    });
+
+    it("resolveEngine routes to Builder when the user has Builder creds in app_secrets and no env-level keys", async () => {
+      delete process.env.BUILDER_PRIVATE_KEY;
+      delete process.env.ANTHROPIC_API_KEY;
+
+      vi.doMock("../../server/request-context.js", () => ({
+        getRequestUserEmail: () => "brent@example.com",
+      }));
+      vi.doMock("../../secrets/storage.js", () => ({
+        readAppSecret: vi.fn(async ({ key }: { key: string }) =>
+          key === "BUILDER_PRIVATE_KEY"
+            ? { key, value: "p-key-from-app-secrets" }
+            : null,
+        ),
+      }));
+
+      const { registerAgentEngine, resolveEngine } =
+        await import("./registry.js");
+
+      const builderEngine = { name: "builder", stream: vi.fn() } as any;
+      const anthropicEngine = { name: "anthropic", stream: vi.fn() } as any;
+      const builderCreate = vi.fn().mockReturnValue(builderEngine);
+      const anthropicCreate = vi.fn().mockReturnValue(anthropicEngine);
+
+      registerAgentEngine({
+        name: "builder",
+        label: "Builder",
+        description: "",
+        capabilities: {} as any,
+        defaultModel: "m",
+        supportedModels: [],
+        requiredEnvVars: ["BUILDER_PRIVATE_KEY"],
+        create: builderCreate,
+      });
+      registerAgentEngine({
+        name: "anthropic",
+        label: "Anthropic",
+        description: "",
+        capabilities: {} as any,
+        defaultModel: "m",
+        supportedModels: [],
+        requiredEnvVars: ["ANTHROPIC_API_KEY"],
+        create: anthropicCreate,
+      });
+
+      const resolved = await resolveEngine({});
+      expect(builderCreate).toHaveBeenCalled();
+      expect(anthropicCreate).not.toHaveBeenCalled();
+      expect(resolved).toBe(builderEngine);
+    });
+  });
 });

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -105,6 +105,76 @@ export function detectEngineFromEnv(): AgentEngineEntry | null {
 }
 
 /**
+ * Detect a usable engine from the current request user's per-user
+ * `app_secrets` rows. Mirrors `detectEngineFromEnv` but consults the
+ * encrypted secret store instead of `process.env`.
+ *
+ * Required because the Builder OAuth callback (and the settings UI's
+ * "paste your own key" flow) writes credentials to app_secrets, not env.
+ * Without this check, a user who connected Builder would see status
+ * "configured" but the next chat turn would fall through to the default
+ * Anthropic engine and hit `missing_api_key` — exactly Brent's symptom
+ * on the docs site (Loom 2026-04-28: "It doesn't seem to realize I'm
+ * connected once I do a chat").
+ *
+ * Returns `null` for unauthenticated requests and for `local@localhost`
+ * — both rely on env-based detection (the dev box's deploy-level keys
+ * are unambiguous, and unauthenticated requests have no user to scope by).
+ */
+export async function detectEngineFromUserSecrets(): Promise<AgentEngineEntry | null> {
+  let email: string | undefined;
+  try {
+    const { getRequestUserEmail } =
+      await import("../../server/request-context.js");
+    email = getRequestUserEmail();
+  } catch {
+    return null;
+  }
+  if (!email || email === "local@localhost") return null;
+
+  let readAppSecret: typeof import("../../secrets/storage.js").readAppSecret;
+  try {
+    ({ readAppSecret } = await import("../../secrets/storage.js"));
+  } catch {
+    return null;
+  }
+
+  const hasAllKeys = async (entry: AgentEngineEntry): Promise<boolean> => {
+    if (entry.requiredEnvVars.length === 0) return false;
+    for (const key of entry.requiredEnvVars) {
+      try {
+        const secret = await readAppSecret({
+          key,
+          scope: "user",
+          scopeId: email!,
+        });
+        if (!secret?.value) return false;
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const preferByo = /^(1|true)$/i.test(
+    process.env.AGENT_ENGINE_PREFER_BYO_KEY ?? "",
+  );
+
+  if (preferByo) {
+    for (const entry of _registry.values()) {
+      if (entry.name === "builder") continue;
+      if (await hasAllKeys(entry)) return entry;
+    }
+    // No BYO key matched — fall through to include Builder as fallback.
+  }
+
+  for (const entry of _registry.values()) {
+    if (await hasAllKeys(entry)) return entry;
+  }
+  return null;
+}
+
+/**
  * True when an `agent-engine` setting entry names an engine AND carries an
  * API key (top-level or inside `config`). Shared between the onboarding step
  * and the /agent-engine/status endpoint so both agree on "is this configured".
@@ -226,7 +296,14 @@ export async function resolveEngine(
     if (entry) return entry.create({ apiKey });
   }
 
-  // 6. Auto-detect from any provider env var — so just dropping a key in
+  // 6. Auto-detect from the current user's per-user `app_secrets` rows
+  // (Builder OAuth callback + "paste your own key" settings flow write
+  // here, not env). Comes before env-detection so a user-specific
+  // connection wins over a stale deploy-level key.
+  const detectedFromUser = await detectEngineFromUserSecrets();
+  if (detectedFromUser) return detectedFromUser.create({ apiKey });
+
+  // 7. Auto-detect from any provider env var — so just dropping a key in
   // .env works without also setting AGENT_ENGINE.
   const detected = detectEngineFromEnv();
   if (detected) return detected.create({ apiKey });

--- a/packages/core/src/integrations/adapters/slack.ts
+++ b/packages/core/src/integrations/adapters/slack.ts
@@ -152,9 +152,57 @@ export function slackAdapter(): PlatformAdapter {
       return null;
     },
 
+    async postProcessingPlaceholder(
+      incoming: IncomingMessage,
+    ): Promise<{ placeholderRef: string } | null> {
+      const token = process.env.SLACK_BOT_TOKEN;
+      if (!token) return null;
+
+      const channelId = incoming.platformContext.channelId as string;
+      const threadTs = incoming.platformContext.threadTs as string;
+      if (!channelId || !threadTs) return null;
+
+      const blocks = buildThinkingBlocks();
+      try {
+        const res = await fetch("https://slack.com/api/chat.postMessage", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            channel: channelId,
+            thread_ts: threadTs,
+            text: "Working on it…",
+            blocks,
+            // Suppress URL unfurl previews — the agent's reply often includes
+            // a deep-link to the dispatch UI and we want a clean section
+            // block, not Slack's auto-generated card.
+            unfurl_links: false,
+            unfurl_media: false,
+            mrkdwn: true,
+          }),
+        });
+        const data = (await res.json()) as {
+          ok: boolean;
+          ts?: string;
+          error?: string;
+        };
+        if (!data.ok || !data.ts) {
+          console.error("[slack] postProcessingPlaceholder error:", data.error);
+          return null;
+        }
+        return { placeholderRef: data.ts };
+      } catch (err) {
+        console.error("[slack] postProcessingPlaceholder failed:", err);
+        return null;
+      }
+    },
+
     async sendResponse(
       message: OutgoingMessage,
       context: IncomingMessage,
+      opts?: { placeholderRef?: string },
     ): Promise<void> {
       const token = process.env.SLACK_BOT_TOKEN;
       if (!token) {
@@ -164,33 +212,70 @@ export function slackAdapter(): PlatformAdapter {
 
       const channelId = context.platformContext.channelId as string;
       const threadTs = context.platformContext.threadTs as string;
+      const blocks = (message.platformContext as any)?.blocks as
+        | unknown[]
+        | undefined;
+      const placeholderRef = opts?.placeholderRef;
 
-      // Split long messages
+      // Block-rich path: split text into chunks but render the FIRST chunk as
+      // blocks (so we keep the in-place edit + button) and any overflow as
+      // plain follow-up posts. The vast majority of replies fit in one block.
       const chunks = splitMessage(message.text, SLACK_MAX_LENGTH);
+      const firstChunk = chunks[0] ?? "";
+      const restChunks = chunks.slice(1);
 
-      for (const chunk of chunks) {
-        const body: Record<string, unknown> = {
-          channel: channelId,
-          text: chunk,
-          thread_ts: threadTs,
-        };
+      const finalBlocks =
+        blocks ??
+        buildResponseBlocks(firstChunk, {
+          threadDeepLinkUrl: (message.platformContext as any)
+            ?.threadDeepLinkUrl,
+        });
 
-        try {
-          const res = await fetch("https://slack.com/api/chat.postMessage", {
+      const baseBody: Record<string, unknown> = {
+        channel: channelId,
+        text: firstChunk,
+        blocks: finalBlocks,
+        unfurl_links: false,
+        unfurl_media: false,
+        mrkdwn: true,
+      };
+
+      try {
+        if (placeholderRef) {
+          // Replace the "thinking…" placeholder in place.
+          const res = await fetch("https://slack.com/api/chat.update", {
             method: "POST",
             headers: {
               Authorization: `Bearer ${token}`,
               "Content-Type": "application/json",
             },
-            body: JSON.stringify(body),
+            body: JSON.stringify({ ...baseBody, ts: placeholderRef }),
           });
-          const data = (await res.json()) as { ok: boolean; error?: string };
+          const data = (await res.json()) as {
+            ok: boolean;
+            error?: string;
+          };
           if (!data.ok) {
-            console.error("[slack] chat.postMessage error:", data.error);
+            console.error("[slack] chat.update error:", data.error);
+            // Fall back to a fresh post so the user still sees a reply
+            await postFresh(token, channelId, threadTs, baseBody);
           }
-        } catch (err) {
-          console.error("[slack] Failed to send message:", err);
+        } else {
+          await postFresh(token, channelId, threadTs, baseBody);
         }
+
+        // Overflow chunks (rare) — post as plain follow-ups in the same thread
+        for (const chunk of restChunks) {
+          await postFresh(token, channelId, threadTs, {
+            channel: channelId,
+            text: chunk,
+            unfurl_links: false,
+            unfurl_media: false,
+            mrkdwn: true,
+          });
+        }
+      } catch (err) {
+        console.error("[slack] Failed to send message:", err);
       }
     },
 
@@ -232,8 +317,16 @@ export function slackAdapter(): PlatformAdapter {
       }
     },
 
-    formatAgentResponse(text: string): OutgoingMessage {
-      return { text: markdownToSlackMrkdwn(text), platformContext: {} };
+    formatAgentResponse(
+      text: string,
+      opts?: { threadDeepLinkUrl?: string },
+    ): OutgoingMessage {
+      return {
+        text: markdownToSlackMrkdwn(text),
+        platformContext: opts?.threadDeepLinkUrl
+          ? { threadDeepLinkUrl: opts.threadDeepLinkUrl }
+          : {},
+      };
     },
 
     async getStatus(baseUrl?: string): Promise<IntegrationStatus> {
@@ -304,4 +397,82 @@ function markdownToSlackMrkdwn(text: string): string {
       // 's' flag (dotAll) so `.` matches newlines — bold text can span lines.
       .replace(/\*\*(.+?)\*\*/gs, "*$1*")
   );
+}
+
+/**
+ * Block Kit payload for the "Working on it…" placeholder posted as soon as
+ * the webhook arrives. Slack will swap this for the final answer via
+ * `chat.update` once the agent loop completes — same message ts, no extra
+ * post in the thread.
+ */
+function buildThinkingBlocks(): unknown[] {
+  return [
+    {
+      type: "context",
+      elements: [
+        { type: "mrkdwn", text: ":hourglass_flowing_sand: _Working on it…_" },
+      ],
+    },
+  ];
+}
+
+/**
+ * Block Kit payload for the final answer. We avoid auto-unfurl previews by
+ * separating the deep-link out into a button instead of inlining it as a
+ * `<url|text>` markdown link in the section body — that's what was producing
+ * the giant "Agent-Native Dispatch" card in every thread reply.
+ */
+function buildResponseBlocks(
+  text: string,
+  opts: { threadDeepLinkUrl?: string },
+): unknown[] {
+  const blocks: any[] = [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: text || "_(no response)_" },
+    },
+  ];
+  if (opts.threadDeepLinkUrl) {
+    blocks.push({
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Open thread", emoji: true },
+          url: opts.threadDeepLinkUrl,
+          action_id: "open_dispatch_thread",
+        },
+      ],
+    });
+  }
+  return blocks;
+}
+
+/**
+ * Post a fresh message to a thread. Used as the placeholder-fallback path
+ * (e.g. when chat.update fails) and for follow-up overflow chunks.
+ */
+async function postFresh(
+  token: string,
+  channelId: string,
+  threadTs: string | undefined,
+  body: Record<string, unknown>,
+): Promise<void> {
+  const payload: Record<string, unknown> = {
+    ...body,
+    channel: channelId,
+  };
+  if (threadTs && !payload.thread_ts) payload.thread_ts = threadTs;
+  const res = await fetch("https://slack.com/api/chat.postMessage", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  const data = (await res.json()) as { ok: boolean; error?: string };
+  if (!data.ok) {
+    console.error("[slack] chat.postMessage error:", data.error);
+  }
 }

--- a/packages/core/src/integrations/types.ts
+++ b/packages/core/src/integrations/types.ts
@@ -110,11 +110,31 @@ export interface PlatformAdapter {
 
   /**
    * Send the agent's response back to the messaging platform.
+   *
+   * If `opts.placeholderRef` is provided (returned earlier by
+   * `postProcessingPlaceholder`), adapters that support in-place edits should
+   * update that placeholder message rather than posting a new one. Adapters
+   * without an "update message" API can ignore the ref and post fresh.
    */
   sendResponse(
     message: OutgoingMessage,
     context: IncomingMessage,
+    opts?: { placeholderRef?: string },
   ): Promise<void>;
+
+  /**
+   * Optionally post a "working on it…" placeholder message immediately when a
+   * webhook arrives, before the agent loop runs. Adapters that support
+   * in-place message edits (Slack via `chat.update`, etc.) return an opaque
+   * `placeholderRef` that the webhook flow threads through to `sendResponse`
+   * so the same message is updated with the final answer once ready.
+   *
+   * Adapters without edit support should leave this undefined; the webhook
+   * handler will skip the placeholder step entirely.
+   */
+  postProcessingPlaceholder?(
+    incoming: IncomingMessage,
+  ): Promise<{ placeholderRef: string } | null>;
 
   /**
    * Send a proactive outbound message to a platform destination. Adapters that
@@ -128,8 +148,16 @@ export interface PlatformAdapter {
   /**
    * Format plain agent response text into a platform-appropriate message.
    * Handles markdown conversion, message splitting for length limits, etc.
+   *
+   * `opts.threadDeepLinkUrl`, when present, is a URL back to the originating
+   * thread in the dispatch UI. Adapters that support rich blocks should
+   * render this as a button (Slack); adapters that don't may inline it as a
+   * link or simply omit it.
    */
-  formatAgentResponse(text: string): OutgoingMessage;
+  formatAgentResponse(
+    text: string,
+    opts?: { threadDeepLinkUrl?: string },
+  ): OutgoingMessage;
 
   /** Return current connection/configuration status for the settings UI. */
   getStatus(baseUrl?: string): Promise<IntegrationStatus>;

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -190,7 +190,25 @@ async function enqueueAndDispatch(
     orgId = null;
   }
 
-  const payload = JSON.stringify({ incoming });
+  // Post a "thinking…" placeholder immediately if the adapter supports
+  // in-place edits. The processor flow will update this same message with
+  // the final answer, so users see one tidy thread reply instead of
+  // "[silence] → answer". Adapters without edit support skip this and the
+  // processor posts a fresh response.
+  let placeholderRef: string | undefined;
+  try {
+    if (options.adapter.postProcessingPlaceholder) {
+      const placeholder =
+        await options.adapter.postProcessingPlaceholder(incoming);
+      if (placeholder?.placeholderRef) {
+        placeholderRef = placeholder.placeholderRef;
+      }
+    }
+  } catch (err) {
+    console.error("[integrations] postProcessingPlaceholder failed:", err);
+  }
+
+  const payload = JSON.stringify({ incoming, placeholderRef });
 
   await insertPendingTask({
     id: taskId,
@@ -280,8 +298,13 @@ export async function processIntegrationTask(
   task: PendingTask,
   options: WebhookHandlerOptions,
 ): Promise<void> {
-  const incoming: IncomingMessage = JSON.parse(task.payload).incoming;
-  await processIncomingMessage(incoming, options);
+  const parsed = JSON.parse(task.payload) as {
+    incoming: IncomingMessage;
+    placeholderRef?: string;
+  };
+  await processIncomingMessage(parsed.incoming, options, {
+    placeholderRef: parsed.placeholderRef,
+  });
 }
 
 /**
@@ -291,6 +314,7 @@ export async function processIntegrationTask(
 async function processIncomingMessage(
   incoming: IncomingMessage,
   options: WebhookHandlerOptions,
+  opts: { placeholderRef?: string } = {},
 ): Promise<void> {
   const { adapter, systemPrompt, actions, model, apiKey, ownerEmail } = options;
 
@@ -421,15 +445,25 @@ async function processIncomingMessage(
             }
           }
 
-          // Append thread link for web UI access
+          // Compute the deep-link to the dispatch UI for this thread, then
+          // hand it to the adapter as a structured `threadDeepLinkUrl` so
+          // platforms with rich blocks (Slack) can render a button instead
+          // of inlining a `<url|text>` link that auto-unfurls into a giant
+          // preview card.
           const baseUrl = process.env.APP_URL || process.env.URL || "";
-          if (baseUrl && threadId) {
-            responseText += `\n\n<${baseUrl}/?thread=${threadId}|View full thread>`;
-          }
+          const threadDeepLinkUrl =
+            baseUrl && threadId
+              ? `${baseUrl.replace(/\/$/, "")}/?thread=${threadId}`
+              : undefined;
 
-          // Format and send back to platform
-          const outgoing = adapter.formatAgentResponse(responseText);
-          await adapter.sendResponse(outgoing, incoming);
+          // Format and send back to platform — update the "thinking…"
+          // placeholder in place if the adapter supplied one.
+          const outgoing = adapter.formatAgentResponse(responseText, {
+            threadDeepLinkUrl,
+          });
+          await adapter.sendResponse(outgoing, incoming, {
+            placeholderRef: opts.placeholderRef,
+          });
 
           // Persist thread data
           await persistThreadData(

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -61,6 +61,7 @@ import {
   isAgentEngineSettingConfigured,
   getAgentEngineEntry,
   detectEngineFromEnv,
+  detectEngineFromUserSecrets,
   isStoredEngineUsable,
 } from "../agent/engine/registry.js";
 
@@ -751,6 +752,19 @@ export function createCoreRoutesPlugin(
                 envVar: entry.requiredEnvVars[0],
               };
             }
+          }
+          // Per-user app_secrets — a user who connected Builder (or pasted
+          // their own provider key) may not have any deploy-level env vars
+          // set, so check their per-user secret store before reporting "no
+          // engine configured" and re-showing the onboarding gate.
+          const detectedFromUser = await detectEngineFromUserSecrets();
+          if (detectedFromUser) {
+            return {
+              configured: true,
+              engine: detectedFromUser.name,
+              source: "app_secrets" as const,
+              envVar: detectedFromUser.requiredEnvVars[0],
+            };
           }
           const detected = detectEngineFromEnv();
           if (detected) {

--- a/packages/core/src/templates/workspace-core/package.json
+++ b/packages/core/src/templates/workspace-core/package.json
@@ -6,21 +6,38 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "default": "./src/index.ts"
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
     },
     "./server": {
       "types": "./src/server/index.ts",
-      "default": "./src/server/index.ts"
+      "development": "./src/server/index.ts",
+      "default": "./dist/server/index.js"
     },
     "./client": {
       "types": "./src/client/index.ts",
-      "default": "./src/client/index.ts"
+      "development": "./src/client/index.ts",
+      "default": "./dist/client/index.js"
     },
     "./credentials": {
       "types": "./src/credentials.ts",
-      "default": "./src/credentials.ts"
+      "development": "./src/credentials.ts",
+      "default": "./dist/credentials.js"
     },
     "./styles/tokens.css": "./styles/tokens.css"
+  },
+  "files": [
+    "dist",
+    "src",
+    "styles",
+    "actions",
+    "AGENTS.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch --preserveWatchOutput",
+    "typecheck": "tsc --noEmit",
+    "prepare": "tsc"
   },
   "dependencies": {
     "@agent-native/core": "^0.7.10"

--- a/packages/core/src/templates/workspace-core/tsconfig.json
+++ b/packages/core/src/templates/workspace-core/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "noEmit": true
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "composite": false
   },
   "include": ["src/**/*"]
 }

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -12,6 +12,88 @@ import { fileURLToPath } from "url";
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Sync discovery for the workspace-core in an enterprise monorepo.
+ *
+ * Mirrors `getWorkspaceCoreExports` in deploy/workspace-core.ts but stays
+ * synchronous so it can run inline in `defineConfig`. Returns the workspace
+ * core's package name + absolute directory, or null if no workspace core is
+ * declared in the ancestor chain.
+ *
+ * Walks up from `startDir` looking for a package.json with
+ * `agent-native.workspaceCore`. Resolves the declared package name through
+ * `<workspaceRoot>/node_modules/<name>` (pnpm symlink, fastest) or by
+ * scanning `packages/*` for a matching `name` field (fallback for
+ * pre-install scenarios).
+ */
+function findWorkspaceCoreSync(
+  startDir: string,
+): { packageName: string; packageDir: string } | null {
+  // 1) Walk up looking for the root package.json that declares workspaceCore.
+  let dir = path.resolve(startDir);
+  let workspaceRoot: string | null = null;
+  let packageName: string | null = null;
+  for (let i = 0; i < 20; i++) {
+    const pkgPath = path.join(dir, "package.json");
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+        const declared = pkg?.["agent-native"]?.workspaceCore;
+        if (typeof declared === "string" && declared.length > 0) {
+          workspaceRoot = dir;
+          packageName = declared;
+          break;
+        }
+      } catch {
+        // Malformed package.json — keep walking up.
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  if (!workspaceRoot || !packageName) return null;
+
+  // 2a) pnpm/npm symlink under workspaceRoot/node_modules.
+  const nm = path.join(workspaceRoot, "node_modules", packageName);
+  if (fs.existsSync(path.join(nm, "package.json"))) {
+    return { packageName, packageDir: fs.realpathSync(nm) };
+  }
+
+  // 2b) Scan packages/* and packages/@scope/* for a matching `name`.
+  const packagesDir = path.join(workspaceRoot, "packages");
+  if (fs.existsSync(packagesDir)) {
+    const candidates: string[] = [];
+    for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      candidates.push(path.join(packagesDir, entry.name));
+      if (entry.name.startsWith("@")) {
+        const scopeDir = path.join(packagesDir, entry.name);
+        for (const sub of fs.readdirSync(scopeDir, { withFileTypes: true })) {
+          if (sub.isDirectory()) candidates.push(path.join(scopeDir, sub.name));
+        }
+      }
+    }
+    for (const c of candidates) {
+      const p = path.join(c, "package.json");
+      if (!fs.existsSync(p)) continue;
+      try {
+        const pkg = JSON.parse(fs.readFileSync(p, "utf-8"));
+        if (pkg?.name === packageName)
+          return { packageName, packageDir: fs.realpathSync(c) };
+      } catch {
+        // ignore malformed package.json
+      }
+    }
+  }
+  return null;
+}
+
+/** Escape a string so it can be embedded as a regex literal. */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /** Check if a package is installed in the project */
 function hasDep(pkg: string, cwd: string): boolean {
   try {
@@ -638,6 +720,17 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
     path.resolve(cwd, "../core"),
   ].filter((candidate) => fs.existsSync(path.join(candidate, "package.json")));
 
+  // Workspace-core (enterprise monorepo): pull its directory into Vite's
+  // file watcher + module graph so edits to its TS sources hot-reload the
+  // dev server, and its package name into ssr.noExternal so the dynamic
+  // import in framework-request-handler.ts goes through Vite's transform
+  // pipeline (TypeScript, SSR HMR, the works).
+  const workspaceCore = findWorkspaceCoreSync(cwd);
+  const workspaceCoreFsAllow = workspaceCore ? [workspaceCore.packageDir] : [];
+  const workspaceCoreNoExternal = workspaceCore
+    ? [new RegExp(`^${escapeRegex(workspaceCore.packageName)}(/.*)?$`)]
+    : [];
+
   return {
     envDir,
     base,
@@ -645,7 +738,12 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
       host: "::",
       port: options.port ?? 8080,
       fs: {
-        allow: [".", ...monorepoCoreAllow, ...(options.fsAllow ?? [])],
+        allow: [
+          ".",
+          ...monorepoCoreAllow,
+          ...workspaceCoreFsAllow,
+          ...(options.fsAllow ?? []),
+        ],
         deny: [
           ".env",
           ".env.*",
@@ -672,9 +770,25 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
     ssr: process.argv.includes("build")
       ? {
           noExternal: /^(?!node:)/,
+          // Pick the workspace-core's compiled `dist/` exports in prod —
+          // Node-style `default` condition matches what edge runtimes (CF
+          // Workers, Deno) can actually load. Without this, Vite's prod
+          // build inherits the dev-condition src/ entry and ships unbuilt
+          // TypeScript into the worker.
+          resolve: {
+            conditions: ["node", "module", "import", "default"],
+            externalConditions: ["node", "module", "import", "default"],
+          },
         }
       : {
-          noExternal: [/^@agent-native\/core(\/.*)?$/],
+          // Vite already sets `development` in the dev resolve conditions,
+          // so the workspace-core template's exports.development → src/
+          // entry is picked automatically — Vite handles TS compilation
+          // and triggers a server restart when those files change.
+          noExternal: [
+            /^@agent-native\/core(\/.*)?$/,
+            ...workspaceCoreNoExternal,
+          ],
           external: [
             "react",
             "react-dom",

--- a/templates/dispatch/app/components/messaging-setup-panel.tsx
+++ b/templates/dispatch/app/components/messaging-setup-panel.tsx
@@ -77,6 +77,7 @@ const PLATFORM_DEFINITIONS: PlatformDefinition[] = [
       "Save the bot token and signing secret below — the webhook URL appears once they're saved.",
       "Back in Slack, enable Event Subscriptions and paste the webhook URL.",
       "Subscribe to app_mention and message.im events, then install the app.",
+      "Optional but recommended: Basic Information → Display Information → upload an app icon and pick a background color so the bot has a clean avatar in every channel.",
     ],
   },
   {


### PR DESCRIPTION
## Summary

Two unrelated fixes were bundled into this PR by concurrent agents. Both pass `pnpm prep` (494 tests).

### 1. Slack Block Kit replies + in-thread placeholder (original)

Steve's screenshot showed the existing Slack reply rendering as a giant unfurled `Agent-Native Dispatch` card stuck on every message, with no in-thread progress indicator and the deep-link inlined as plain text. This switches the Slack adapter to the Block Kit pattern Builder's existing slackbot uses (mirrors `/Users/steve/Projects/builder/ai-services/packages/service/integrations/slack/`).

**New flow:**

1. Webhook arrives → Slack adapter immediately posts a thread reply with a `Working on it…` context block (hourglass emoji, italic). Captures the message `ts` as a `placeholderRef` and bakes it into the queued task payload.
2. Processor finishes the agent loop → calls `chat.update` on the same `ts`, swapping the placeholder for a clean Block Kit response: a `section` block with the agent's mrkdwn answer, plus an `actions` block with an "Open thread" button URL-linking to the dispatch UI.
3. `unfurl_links` + `unfurl_media` are forced off so the deep-link no longer auto-unfurls into the giant card.

Adapters without `postProcessingPlaceholder` (Telegram, email) fall back to the existing post-on-completion behavior — no regression.

#### Interface changes

- `PlatformAdapter.postProcessingPlaceholder?(incoming) → { placeholderRef }` — optional, returns an opaque ref for in-place message updates.
- `PlatformAdapter.sendResponse(msg, ctx, opts?: { placeholderRef })` — adapters that support edits use the ref to update the placeholder; others ignore it and post fresh.
- `PlatformAdapter.formatAgentResponse(text, opts?: { threadDeepLinkUrl })` — the deep-link flows as structured data instead of inline `<url|text>` text, so adapters can render it as a button (Slack) or whatever else fits the platform (omit, inline as link, etc.).

#### App icon note

The bot's missing avatar is a separate concern — it has to be uploaded by the workspace admin at `api.slack.com/apps` → Basic Information → Display Information. The Slack API doesn't allow setting it programmatically. Added a step to the messaging-setup-panel onboarding list flagging this as recommended.

### 2. Fix Builder-connected chat on multi-tenant deploys (engine selection regression)

Reported by Brent on prod docs (Loom 2026-04-28): "It says it connected, but it doesn't seem to realize I'm connected once I do a chat."

**Root cause:** Commit 83a7e763 moved Builder credentials from `process.env.BUILDER_*` to per-user `app_secrets` rows (scope=user, scopeId=email). The OAuth callback writes there, and `/builder/status` reads from there — so the UI correctly shows "connected." But `resolveEngine` in `packages/core/src/agent/engine/registry.ts` only checks `process.env` and the global `settings` table; it never consulted `app_secrets`. On a multi-tenant deploy with no deploy-level `BUILDER_PRIVATE_KEY` env var, engine selection silently fell back to the default Anthropic engine (which had no API key either) and emitted `missing_api_key` → "Connect AI" gate re-appeared the moment the user tried to chat.

**Fix:** Added `detectEngineFromUserSecrets()` — async helper that mirrors `detectEngineFromEnv()` but reads from per-user `app_secrets`. Wired into `resolveEngine` ahead of the env-detect step, and into the `/_agent-native/agent-engine/status` endpoint so the engine-status UI gate stays consistent. Returns `null` for unauthenticated requests and for `local@localhost` so the existing dev-box / CLI / background-job paths are unchanged. Also handles the `AGENT_ENGINE_PREFER_BYO_KEY` escape hatch the same way `detectEngineFromEnv` does.

This also helps users who paste their own provider key (e.g. ANTHROPIC_API_KEY) via the settings UI: previously chat only routed to the right engine when the deploy also had that var in `process.env`, now per-user app_secrets are sufficient.

#### Files

- `packages/core/src/agent/engine/registry.ts` — new `detectEngineFromUserSecrets()` + wired into `resolveEngine`
- `packages/core/src/server/core-routes-plugin.ts` — `/agent-engine/status` consults per-user secrets before falling back to env
- `packages/core/src/agent/engine/registry.spec.ts` — 4 new tests covering: null for unauthenticated / local-dev, picks Builder when user has Builder creds, `resolveEngine` end-to-end routes to Builder

## Test plan

- [x] `pnpm prep` clean (494 tests pass — was 490 before, +4 for the new helper)
- [ ] After deploy: `@agent-native` in `#test-agent-native-slack-bot` →
  - thread shows "Working on it…" within a second
  - same message updates in place with `Open thread` button
  - no auto-unfurl card
- [ ] After deploy: on agent-native.com docs site, fresh user → connect Builder → send a chat message → response streams in (no "Connect AI" gate flash)