### PR TITLE
fix(call-agent): scope 18s timeout cap to integration-caller path only (review #354)

### DIFF
--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -404,7 +404,14 @@ async function processIncomingMessage(
       threadId,
       async (send, signal) => {
         await runWithRequestContext(
-          { userEmail: ownerEmail, orgId: orgId ?? undefined },
+          {
+            userEmail: ownerEmail,
+            orgId: orgId ?? undefined,
+            // Lets downstream callers (call-agent script) apply tighter
+            // budgets on integration paths without affecting normal
+            // agent-chat. See `isIntegrationCallerRequest()`.
+            isIntegrationCaller: true,
+          },
           () =>
             runAgentLoop({
               engine,

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -5,6 +5,7 @@ import { A2AClient, callAgent, signA2AToken } from "../a2a/client.js";
 import {
   getRequestUserEmail,
   getRequestOrgId,
+  isIntegrationCallerRequest,
 } from "../server/request-context.js";
 import { getOrgDomain, getOrgA2ASecret } from "../org/context.js";
 
@@ -141,19 +142,21 @@ export async function run(
       // but the receiving agent's full response still surfaces via the
       // tool_result event below.
       try {
-        // Cap the polling budget at 18s so dispatch always returns something
-        // within Netlify's 26s function-timeout window. The remaining ~8s is
-        // budget for Haiku to format and post the response to Slack. Without
-        // this cap, a slow analytics handler (~25s+) would kill dispatch's
-        // lambda mid-poll and leave the integration task stuck "processing"
-        // for ~5min until the retry sweep resets it. Better UX: tell the
-        // user we couldn't reach the agent in time so they can retry, while
-        // the underlying A2A task may still complete in the background.
+        // Apply the 18s polling cap ONLY when this call is from an
+        // integration-platform path (Slack/Telegram/etc.) where the host's
+        // function timeout (~26s on Netlify Pro) plus the platform's
+        // deliver-by deadline are the binding budget. Normal agent-chat
+        // callers run on a long-lived stream and should keep the default
+        // 5-min budget. Reviewer flagged in #354 that the previous
+        // unconditional cap regressed agent-chat A2A calls.
+        const callTimeoutMs = isIntegrationCallerRequest()
+          ? 18000
+          : undefined;
         responseText = await callAgent(agent.url, message, {
           userEmail: callerEmail,
           orgDomain: callerOrgDomain,
           orgSecret: callerOrgSecret,
-          timeoutMs: 18000,
+          ...(callTimeoutMs ? { timeoutMs: callTimeoutMs } : {}),
         });
         // Mirror the response into the streaming UI so the user sees it.
         if (responseText) emitNewText(responseText);

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -149,9 +149,7 @@ export async function run(
         // callers run on a long-lived stream and should keep the default
         // 5-min budget. Reviewer flagged in #354 that the previous
         // unconditional cap regressed agent-chat A2A calls.
-        const callTimeoutMs = isIntegrationCallerRequest()
-          ? 18000
-          : undefined;
+        const callTimeoutMs = isIntegrationCallerRequest() ? 18000 : undefined;
         responseText = await callAgent(agent.url, message, {
           userEmail: callerEmail,
           orgDomain: callerOrgDomain,

--- a/packages/core/src/server/request-context.ts
+++ b/packages/core/src/server/request-context.ts
@@ -21,6 +21,14 @@ export interface RequestContext {
   userEmail?: string;
   orgId?: string;
   timezone?: string;
+  /**
+   * True when this request is being processed by an integration-platform
+   * webhook (Slack, Telegram, etc.) where the function timeout is the
+   * binding constraint (~26s on Netlify Pro). Code that calls slow remote
+   * APIs can use this to apply tighter budgets on this path while leaving
+   * normal agent-chat callers (5+ min budget) unaffected.
+   */
+  isIntegrationCaller?: boolean;
 }
 
 const als = new AsyncLocalStorage<RequestContext>();
@@ -61,4 +69,15 @@ export function getRequestOrgId(): string | undefined {
  */
 export function getRequestTimezone(): string | undefined {
   return als.getStore()?.timezone ?? process.env.AGENT_USER_TIMEZONE;
+}
+
+/**
+ * Returns true when this request is on an integration-platform path (Slack,
+ * Telegram, etc.) — i.e. we're inside the integration plugin's processor
+ * function and the platform's deliver-by deadline plus the host's function
+ * timeout are the binding budget. Non-integration callers (CLI, normal
+ * agent chat) should treat this as `false`.
+ */
+export function isIntegrationCallerRequest(): boolean {
+  return als.getStore()?.isIntegrationCaller === true;
 }

--- a/packages/core/src/templates/workspace-core/package.json
+++ b/packages/core/src/templates/workspace-core/package.json
@@ -43,6 +43,7 @@
     "@agent-native/core": "^0.7.10"
   },
   "devDependencies": {
+    "@types/node": "^24.2.1",
     "@types/react": "^19.2.14",
     "react": "^19.2.5",
     "typescript": "^6.0.3"


### PR DESCRIPTION
Addresses [Builder review on #354](https://github.com/BuilderIO/agent-native/pull/354#discussion_r3158939921): the unconditional \`timeoutMs: 18000\` in the shared \`call-agent.ts\` also capped regular agent-chat A2A calls (which have a 5-min budget). The cap should only apply when the caller is an integration-platform webhook hitting the Netlify 26s function timeout.

- Adds \`isIntegrationCaller\` flag to \`RequestContext\`.
- Integration \`webhook-handler\` sets it to \`true\` around \`runAgentLoop\`.
- \`call-agent.ts\` reads it via \`isIntegrationCallerRequest()\` and applies the 18s cap only when set.
- Normal agent-chat callers fall back to the default 5-min poll budget — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)