### PR TITLE
fix(dispatch): preserve ?thread= query through root → /overview redirect

### DIFF
--- a/packages/core/src/client/dev-overlay/DevOverlay.tsx
+++ b/packages/core/src/client/dev-overlay/DevOverlay.tsx
@@ -1,0 +1,556 @@
+/**
+ * <DevOverlay /> — the framework dev/configuration panel.
+ *
+ * Templates render this once at the root of their app. The user toggles it
+ * with Cmd+Ctrl+A (also exposed as `useDevOverlayShortcut`). Panels register
+ * via `registerDevPanel`; values for option-style controls persist to
+ * localStorage via `useDevOption`.
+ *
+ * Visibility note: the overlay only mounts when the host explicitly opens it
+ * via the keybinding (or the `open` prop). It is dev-only by convention —
+ * shipping with the keybinding active in prod is fine because nothing renders
+ * unless invoked.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconLoader2,
+  IconRefresh,
+  IconTrash,
+  IconX,
+} from "@tabler/icons-react";
+import { listDevPanels, subscribeDevPanels } from "./registry.js";
+import {
+  clearAllDevOverlayStorage,
+  useDevOption,
+  DEV_OVERLAY_STORAGE_PREFIX,
+} from "./use-dev-option.js";
+import { useDevOverlayShortcut } from "./use-dev-overlay-shortcut.js";
+import type {
+  DevActionOption,
+  DevBooleanOption,
+  DevOption,
+  DevPanel,
+  DevSelectOption,
+  DevStringOption,
+} from "./types.js";
+import "./builtins.js";
+
+const PANEL_OPEN_KEY = `${DEV_OVERLAY_STORAGE_PREFIX}open`;
+const COLLAPSED_KEY_PREFIX = `${DEV_OVERLAY_STORAGE_PREFIX}collapsed-`;
+
+export interface DevOverlayProps {
+  /**
+   * Force-control the overlay's visibility. When omitted the overlay manages
+   * its own state and listens to Cmd+Ctrl+A.
+   */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function DevOverlay({ open, onOpenChange }: DevOverlayProps = {}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : internalOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setInternalOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  useDevOverlayShortcut(useCallback(() => setOpen(!isOpen), [isOpen, setOpen]));
+
+  // Esc closes (only when overlay is the topmost UI — skip when typing).
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, setOpen]);
+
+  if (!isOpen) return null;
+  return <DevOverlayPanel onClose={() => setOpen(false)} />;
+}
+
+function DevOverlayPanel({ onClose }: { onClose: () => void }) {
+  const panels = useSyncExternalStore(
+    subscribeDevPanels,
+    listDevPanels,
+    listDevPanels,
+  );
+
+  return (
+    <div style={styles.shell} role="dialog" aria-label="Dev overlay">
+      <div style={styles.header}>
+        <div>
+          <div style={styles.headerTitle}>Dev Overlay</div>
+          <div style={styles.headerSub}>Cmd+Ctrl+A · localStorage-backed</div>
+        </div>
+        <button
+          type="button"
+          style={styles.iconBtn}
+          onClick={onClose}
+          aria-label="Close"
+          title="Close (Esc)"
+        >
+          <IconX size={16} />
+        </button>
+      </div>
+
+      <div style={styles.body}>
+        {panels.length === 0 ? (
+          <div style={styles.empty}>
+            No panels registered. Call <code>registerDevPanel(...)</code> from
+            your template to add options here.
+          </div>
+        ) : (
+          panels.map((panel) => <DevPanelCard key={panel.id} panel={panel} />)
+        )}
+      </div>
+
+      <div style={styles.footer}>
+        <button
+          type="button"
+          style={{ ...styles.footerBtn, ...styles.footerBtnDanger }}
+          onClick={() => {
+            clearAllDevOverlayStorage();
+          }}
+          title="Reset every dev-overlay value back to its default"
+        >
+          <IconTrash size={13} />
+          Clear all dev-overlay values
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DevPanelCard({ panel }: { panel: DevPanel }) {
+  const [collapsedRaw, setCollapsedRaw] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return (
+        window.localStorage.getItem(`${COLLAPSED_KEY_PREFIX}${panel.id}`) ===
+        "1"
+      );
+    } catch {
+      return false;
+    }
+  });
+  const setCollapsed = (next: boolean) => {
+    setCollapsedRaw(next);
+    try {
+      window.localStorage.setItem(
+        `${COLLAPSED_KEY_PREFIX}${panel.id}`,
+        next ? "1" : "0",
+      );
+    } catch {
+      // ignore — collapsed state is just UX sugar
+    }
+  };
+
+  return (
+    <div style={styles.panel}>
+      <button
+        type="button"
+        style={styles.panelHeader}
+        onClick={() => setCollapsed(!collapsedRaw)}
+      >
+        {collapsedRaw ? (
+          <IconChevronRight size={14} />
+        ) : (
+          <IconChevronDown size={14} />
+        )}
+        <span style={styles.panelLabel}>{panel.label}</span>
+      </button>
+      {!collapsedRaw && (
+        <div style={styles.panelBody}>
+          {panel.description && (
+            <div style={styles.panelDesc}>{panel.description}</div>
+          )}
+          {(panel.options ?? []).map((option) => (
+            <DevOptionRow key={option.id} panelId={panel.id} option={option} />
+          ))}
+          {panel.render ? (
+            <div style={styles.customRender}>{panel.render()}</div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DevOptionRow({
+  panelId,
+  option,
+}: {
+  panelId: string;
+  option: DevOption;
+}) {
+  if (option.type === "boolean") {
+    return <DevBooleanRow panelId={panelId} option={option} />;
+  }
+  if (option.type === "select") {
+    return <DevSelectRow panelId={panelId} option={option} />;
+  }
+  if (option.type === "string") {
+    return <DevStringRow panelId={panelId} option={option} />;
+  }
+  return <DevActionRow option={option} />;
+}
+
+function DevBooleanRow({
+  panelId,
+  option,
+}: {
+  panelId: string;
+  option: DevBooleanOption;
+}) {
+  const [value, setValue] = useDevOption(
+    panelId,
+    option.id,
+    option.default ?? false,
+  );
+  return (
+    <label style={styles.row}>
+      <div style={styles.rowLabels}>
+        <div style={styles.rowLabel}>{option.label}</div>
+        {option.description && (
+          <div style={styles.rowDesc}>{option.description}</div>
+        )}
+      </div>
+      <input
+        type="checkbox"
+        checked={!!value}
+        onChange={(e) => {
+          const next = e.target.checked;
+          setValue(next);
+          option.onChange?.(next);
+        }}
+        style={styles.checkbox}
+      />
+    </label>
+  );
+}
+
+function DevSelectRow({
+  panelId,
+  option,
+}: {
+  panelId: string;
+  option: DevSelectOption;
+}) {
+  const [value, setValue] = useDevOption(
+    panelId,
+    option.id,
+    option.default ?? option.choices[0]?.value ?? "",
+  );
+  return (
+    <div style={styles.row}>
+      <div style={styles.rowLabels}>
+        <div style={styles.rowLabel}>{option.label}</div>
+        {option.description && (
+          <div style={styles.rowDesc}>{option.description}</div>
+        )}
+      </div>
+      <select
+        value={value}
+        onChange={(e) => {
+          const next = e.target.value;
+          setValue(next);
+          option.onChange?.(next);
+        }}
+        style={styles.select}
+      >
+        {option.choices.map((c) => (
+          <option key={c.value} value={c.value}>
+            {c.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function DevStringRow({
+  panelId,
+  option,
+}: {
+  panelId: string;
+  option: DevStringOption;
+}) {
+  const [value, setValue] = useDevOption(
+    panelId,
+    option.id,
+    option.default ?? "",
+  );
+  return (
+    <div
+      style={{ ...styles.row, alignItems: "stretch", flexDirection: "column" }}
+    >
+      <div style={styles.rowLabels}>
+        <div style={styles.rowLabel}>{option.label}</div>
+        {option.description && (
+          <div style={styles.rowDesc}>{option.description}</div>
+        )}
+      </div>
+      <input
+        type="text"
+        value={value}
+        placeholder={option.placeholder}
+        onChange={(e) => {
+          const next = e.target.value;
+          setValue(next);
+          option.onChange?.(next);
+        }}
+        style={styles.input}
+      />
+    </div>
+  );
+}
+
+function DevActionRow({ option }: { option: DevActionOption }) {
+  const [busy, setBusy] = useState(false);
+  return (
+    <div style={styles.row}>
+      <div style={styles.rowLabels}>
+        <div style={styles.rowLabel}>{option.label}</div>
+        {option.description && (
+          <div style={styles.rowDesc}>{option.description}</div>
+        )}
+      </div>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={async () => {
+          setBusy(true);
+          try {
+            await option.onClick();
+          } finally {
+            setBusy(false);
+          }
+        }}
+        style={{
+          ...styles.actionBtn,
+          ...(option.destructive ? styles.actionBtnDanger : {}),
+        }}
+      >
+        {busy ? (
+          <IconLoader2
+            size={13}
+            style={{ animation: "spin 1s linear infinite" }}
+          />
+        ) : (
+          <IconRefresh size={13} />
+        )}
+        {option.buttonLabel ?? option.label}
+      </button>
+    </div>
+  );
+}
+
+// Shadow / border styles tuned to read well over both light and dark app
+// chrome — the overlay is dev-only so we don't bother with theme tokens.
+const styles: Record<string, React.CSSProperties> = {
+  shell: {
+    position: "fixed",
+    top: 16,
+    right: 16,
+    bottom: 16,
+    width: 380,
+    maxWidth: "calc(100vw - 32px)",
+    background: "rgba(20, 20, 23, 0.96)",
+    color: "#f4f4f5",
+    border: "1px solid rgba(255,255,255,0.08)",
+    borderRadius: 12,
+    boxShadow: "0 24px 60px rgba(0,0,0,0.5)",
+    backdropFilter: "blur(12px)",
+    WebkitBackdropFilter: "blur(12px)",
+    fontFamily:
+      "-apple-system, BlinkMacSystemFont, system-ui, 'Segoe UI', sans-serif",
+    fontSize: 13,
+    zIndex: 2147483646,
+    display: "flex",
+    flexDirection: "column",
+    overflow: "hidden",
+  },
+  header: {
+    display: "flex",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    padding: "14px 16px",
+    borderBottom: "1px solid rgba(255,255,255,0.06)",
+  },
+  headerTitle: { fontWeight: 600, fontSize: 14 },
+  headerSub: { fontSize: 11, opacity: 0.55, marginTop: 2 },
+  iconBtn: {
+    background: "transparent",
+    border: "none",
+    color: "inherit",
+    cursor: "pointer",
+    padding: 4,
+    borderRadius: 6,
+    display: "inline-flex",
+    alignItems: "center",
+  },
+  body: {
+    padding: 12,
+    overflowY: "auto",
+    flex: 1,
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+  },
+  empty: {
+    padding: 16,
+    fontSize: 12,
+    opacity: 0.7,
+    background: "rgba(255,255,255,0.03)",
+    borderRadius: 8,
+    border: "1px dashed rgba(255,255,255,0.1)",
+  },
+  panel: {
+    background: "rgba(255,255,255,0.03)",
+    border: "1px solid rgba(255,255,255,0.06)",
+    borderRadius: 8,
+    overflow: "hidden",
+  },
+  panelHeader: {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    width: "100%",
+    background: "transparent",
+    border: "none",
+    color: "inherit",
+    padding: "10px 12px",
+    cursor: "pointer",
+    fontSize: 13,
+    textAlign: "left",
+  },
+  panelLabel: { fontWeight: 600 },
+  panelBody: {
+    padding: "0 12px 12px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+  },
+  panelDesc: { fontSize: 11, opacity: 0.65, lineHeight: 1.4 },
+  customRender: { marginTop: 4 },
+  row: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  rowLabels: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+    flex: 1,
+    minWidth: 0,
+  },
+  rowLabel: { fontSize: 13 },
+  rowDesc: { fontSize: 11, opacity: 0.6, lineHeight: 1.4 },
+  checkbox: {
+    width: 16,
+    height: 16,
+    cursor: "pointer",
+    accentColor: "#3b82f6",
+  },
+  select: {
+    background: "rgba(255,255,255,0.06)",
+    color: "inherit",
+    border: "1px solid rgba(255,255,255,0.1)",
+    borderRadius: 6,
+    padding: "4px 8px",
+    fontSize: 12,
+    minWidth: 120,
+    cursor: "pointer",
+  },
+  input: {
+    background: "rgba(255,255,255,0.06)",
+    color: "inherit",
+    border: "1px solid rgba(255,255,255,0.1)",
+    borderRadius: 6,
+    padding: "6px 8px",
+    fontSize: 12,
+    width: "100%",
+    boxSizing: "border-box",
+  },
+  actionBtn: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    background: "rgba(59,130,246,0.15)",
+    color: "#bfdbfe",
+    border: "1px solid rgba(59,130,246,0.3)",
+    borderRadius: 6,
+    padding: "5px 10px",
+    fontSize: 12,
+    cursor: "pointer",
+    fontWeight: 500,
+  },
+  actionBtnDanger: {
+    background: "rgba(239,68,68,0.15)",
+    color: "#fecaca",
+    border: "1px solid rgba(239,68,68,0.3)",
+  },
+  footer: {
+    padding: 10,
+    borderTop: "1px solid rgba(255,255,255,0.06)",
+    display: "flex",
+    justifyContent: "flex-end",
+  },
+  footerBtn: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    background: "transparent",
+    color: "inherit",
+    border: "1px solid rgba(255,255,255,0.12)",
+    borderRadius: 6,
+    padding: "5px 10px",
+    fontSize: 11,
+    cursor: "pointer",
+  },
+  footerBtnDanger: { color: "#fecaca", borderColor: "rgba(239,68,68,0.3)" },
+};
+
+// Inject keyframes for the spinner once.
+if (
+  typeof document !== "undefined" &&
+  !document.getElementById("agent-native-dev-overlay-keyframes")
+) {
+  const styleEl = document.createElement("style");
+  styleEl.id = "agent-native-dev-overlay-keyframes";
+  styleEl.textContent = "@keyframes spin { to { transform: rotate(360deg); } }";
+  document.head.appendChild(styleEl);
+}
+
+// `ReactNode` is intentionally re-imported here so the file is self-contained
+// when consumed via the package's exports map.
+export type { ReactNode };

--- a/packages/core/src/client/dev-overlay/OnboardingPreview.tsx
+++ b/packages/core/src/client/dev-overlay/OnboardingPreview.tsx
@@ -1,0 +1,246 @@
+/**
+ * Onboarding preview — read-only render of the registered onboarding steps
+ * with completion forced to false. Used by the framework's built-in dev
+ * panel so template authors can see what a brand-new user would see without
+ * actually resetting their own setup.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  IconCircle,
+  IconLink,
+  IconLoader2,
+  IconPlugConnected,
+  IconRefresh,
+  IconRobot,
+  IconSettings,
+} from "@tabler/icons-react";
+import type {
+  OnboardingMethod,
+  OnboardingStepStatus,
+} from "../../onboarding/types.js";
+
+export function OnboardingPreview() {
+  const [steps, setSteps] = useState<OnboardingStepStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/_agent-native/onboarding/steps?preview=1");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as OnboardingStepStatus[];
+      setSteps(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load steps");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading && steps.length === 0) {
+    return (
+      <div style={styles.placeholder}>
+        <IconLoader2
+          size={14}
+          style={{ animation: "spin 1s linear infinite" }}
+        />
+        Loading onboarding steps…
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div style={styles.error}>Couldn't load onboarding: {error}</div>;
+  }
+
+  if (steps.length === 0) {
+    return (
+      <div style={styles.placeholder}>
+        No onboarding steps registered for this app.
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.wrapper}>
+      <div style={styles.intro}>
+        Read-only preview — what a new user sees. No state is mutated.
+      </div>
+      {steps.map((step, i) => (
+        <StepCard key={step.id} step={step} index={i + 1} />
+      ))}
+      <button type="button" style={styles.refreshBtn} onClick={load}>
+        <IconRefresh size={12} />
+        Refresh
+      </button>
+    </div>
+  );
+}
+
+function StepCard({
+  step,
+  index,
+}: {
+  step: OnboardingStepStatus;
+  index: number;
+}) {
+  return (
+    <div style={styles.card}>
+      <div style={styles.cardHeader}>
+        <span style={styles.cardIndex}>
+          <IconCircle size={14} />
+          <span style={styles.cardIndexNum}>{index}</span>
+        </span>
+        <div style={styles.cardTitle}>{step.title}</div>
+        {step.required && <span style={styles.requiredPill}>required</span>}
+      </div>
+      <div style={styles.cardDesc}>{step.description}</div>
+      <div style={styles.methods}>
+        {step.methods.map((m) => (
+          <MethodRow key={m.id} method={m} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MethodRow({ method }: { method: OnboardingMethod }) {
+  const Icon =
+    method.kind === "link"
+      ? IconLink
+      : method.kind === "form"
+        ? IconSettings
+        : method.kind === "agent-task"
+          ? IconRobot
+          : IconPlugConnected;
+  return (
+    <div style={styles.methodRow}>
+      <Icon size={14} style={{ flexShrink: 0, opacity: 0.7 }} />
+      <div style={styles.methodLabel}>
+        <span>{method.label}</span>
+        {method.badge && <span style={styles.badge}>{method.badge}</span>}
+        {method.primary && <span style={styles.primaryDot} title="Primary" />}
+      </div>
+      <span style={styles.methodKind}>{method.kind}</span>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  wrapper: { display: "flex", flexDirection: "column", gap: 8 },
+  intro: { fontSize: 11, opacity: 0.6, marginBottom: 4 },
+  placeholder: {
+    fontSize: 12,
+    opacity: 0.7,
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+  },
+  error: {
+    fontSize: 12,
+    color: "#fecaca",
+    background: "rgba(239,68,68,0.1)",
+    border: "1px solid rgba(239,68,68,0.2)",
+    borderRadius: 6,
+    padding: 8,
+  },
+  card: {
+    background: "rgba(255,255,255,0.04)",
+    border: "1px solid rgba(255,255,255,0.06)",
+    borderRadius: 8,
+    padding: 10,
+    display: "flex",
+    flexDirection: "column",
+    gap: 6,
+  },
+  cardHeader: { display: "flex", alignItems: "center", gap: 8 },
+  cardIndex: {
+    position: "relative",
+    width: 18,
+    height: 18,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    opacity: 0.6,
+  },
+  cardIndexNum: {
+    position: "absolute",
+    fontSize: 9,
+    fontWeight: 700,
+  },
+  cardTitle: { fontSize: 13, fontWeight: 600, flex: 1 },
+  cardDesc: { fontSize: 11, opacity: 0.65, lineHeight: 1.4 },
+  requiredPill: {
+    fontSize: 9,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    background: "rgba(239,68,68,0.15)",
+    color: "#fecaca",
+    padding: "2px 6px",
+    borderRadius: 4,
+    fontWeight: 600,
+  },
+  methods: { display: "flex", flexDirection: "column", gap: 4, marginTop: 4 },
+  methodRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    fontSize: 11,
+    background: "rgba(255,255,255,0.03)",
+    border: "1px solid rgba(255,255,255,0.05)",
+    borderRadius: 5,
+    padding: "5px 7px",
+  },
+  methodLabel: {
+    flex: 1,
+    minWidth: 0,
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  methodKind: {
+    fontSize: 10,
+    opacity: 0.5,
+    fontFamily: "ui-monospace, monospace",
+  },
+  badge: {
+    fontSize: 9,
+    background: "rgba(34,197,94,0.15)",
+    color: "#bbf7d0",
+    padding: "1px 5px",
+    borderRadius: 3,
+    fontWeight: 600,
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+  },
+  primaryDot: {
+    width: 5,
+    height: 5,
+    borderRadius: "50%",
+    background: "#3b82f6",
+    flexShrink: 0,
+  },
+  refreshBtn: {
+    alignSelf: "flex-start",
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 4,
+    background: "transparent",
+    color: "inherit",
+    border: "1px solid rgba(255,255,255,0.12)",
+    borderRadius: 5,
+    padding: "3px 8px",
+    fontSize: 11,
+    cursor: "pointer",
+  },
+};

--- a/packages/core/src/client/dev-overlay/builtins.ts
+++ b/packages/core/src/client/dev-overlay/builtins.ts
@@ -1,0 +1,42 @@
+/**
+ * Framework-shipped dev-overlay panels. Loaded as a side-effect import from
+ * `DevOverlay.tsx` so any app that mounts the overlay gets these for free.
+ */
+
+import { createElement } from "react";
+import { registerDevPanel } from "./registry.js";
+import { OnboardingPreview } from "./OnboardingPreview.js";
+
+let registered = false;
+
+function registerBuiltins() {
+  if (registered) return;
+  registered = true;
+
+  registerDevPanel({
+    id: "framework-onboarding",
+    label: "Onboarding",
+    description:
+      "Preview the new-user onboarding flow without resetting your own setup.",
+    order: 10,
+    options: [
+      {
+        id: "reopen",
+        label: "Reopen onboarding",
+        description: "Un-dismiss the setup checklist for the current session.",
+        type: "action",
+        buttonLabel: "Reopen",
+        onClick: async () => {
+          await fetch("/_agent-native/onboarding/reopen", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: "{}",
+          });
+        },
+      },
+    ],
+    render: () => createElement(OnboardingPreview),
+  });
+}
+
+registerBuiltins();

--- a/packages/core/src/client/dev-overlay/index.ts
+++ b/packages/core/src/client/dev-overlay/index.ts
@@ -1,0 +1,23 @@
+export { DevOverlay, type DevOverlayProps } from "./DevOverlay.js";
+export { useDevOverlayShortcut } from "./use-dev-overlay-shortcut.js";
+export {
+  registerDevPanel,
+  unregisterDevPanel,
+  listDevPanels,
+  subscribeDevPanels,
+} from "./registry.js";
+export {
+  useDevOption,
+  clearAllDevOverlayStorage,
+  devOptionKey,
+  DEV_OVERLAY_STORAGE_PREFIX,
+} from "./use-dev-option.js";
+export type {
+  DevPanel,
+  DevOption,
+  DevBooleanOption,
+  DevSelectOption,
+  DevStringOption,
+  DevActionOption,
+  DevOptionValue,
+} from "./types.js";

--- a/packages/core/src/client/dev-overlay/registry.ts
+++ b/packages/core/src/client/dev-overlay/registry.ts
@@ -1,0 +1,67 @@
+/**
+ * Client-side registry for dev-overlay panels.
+ *
+ * Panels register at module load (or via React effect) and the overlay reads
+ * from this registry on each render. Re-registering the same id replaces the
+ * previous panel — templates can override framework defaults.
+ */
+
+import type { DevPanel } from "./types.js";
+
+const panels = new Map<string, DevPanel>();
+const listeners = new Set<() => void>();
+// Cache the sorted snapshot so useSyncExternalStore receives a stable
+// reference between unrelated renders. Recomputed lazily on the next read
+// after `emit()`.
+let cachedSnapshot: DevPanel[] | null = [];
+
+function invalidateSnapshot() {
+  cachedSnapshot = null;
+}
+
+function emit() {
+  invalidateSnapshot();
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch {
+      // listeners are UI subscribers — never let one break the others
+    }
+  }
+}
+
+export function registerDevPanel(panel: DevPanel): () => void {
+  if (!panel || typeof panel.id !== "string" || !panel.id) {
+    throw new Error("registerDevPanel: panel.id is required");
+  }
+  panels.set(panel.id, panel);
+  emit();
+  return () => {
+    if (panels.get(panel.id) === panel) {
+      panels.delete(panel.id);
+      emit();
+    }
+  };
+}
+
+export function unregisterDevPanel(id: string): void {
+  if (panels.delete(id)) emit();
+}
+
+export function listDevPanels(): DevPanel[] {
+  if (cachedSnapshot) return cachedSnapshot;
+  cachedSnapshot = Array.from(panels.values()).sort((a, b) => {
+    const aOrder = a.order ?? 100;
+    const bOrder = b.order ?? 100;
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    return a.label.localeCompare(b.label);
+  });
+  return cachedSnapshot;
+}
+
+export function subscribeDevPanels(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/packages/core/src/client/dev-overlay/types.ts
+++ b/packages/core/src/client/dev-overlay/types.ts
@@ -1,0 +1,64 @@
+/**
+ * Dev overlay — types for the framework-level dev/configuration panel.
+ *
+ * Toggled with Cmd+Ctrl+A. Templates register panels at module load time;
+ * each panel exposes typed options whose values are persisted to localStorage.
+ * Built-in framework panels (e.g. onboarding preview) live alongside.
+ */
+
+import type { ReactNode } from "react";
+
+export type DevOptionValue = boolean | string | number | null;
+
+interface DevOptionBase {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface DevBooleanOption extends DevOptionBase {
+  type: "boolean";
+  default?: boolean;
+  onChange?: (value: boolean) => void | Promise<void>;
+}
+
+export interface DevSelectOption extends DevOptionBase {
+  type: "select";
+  choices: { value: string; label: string }[];
+  default?: string;
+  onChange?: (value: string) => void | Promise<void>;
+}
+
+export interface DevStringOption extends DevOptionBase {
+  type: "string";
+  default?: string;
+  placeholder?: string;
+  onChange?: (value: string) => void | Promise<void>;
+}
+
+export interface DevActionOption extends DevOptionBase {
+  type: "action";
+  /** Optional secondary label rendered on the button (defaults to `label`). */
+  buttonLabel?: string;
+  /** Mark destructive / risky actions so the UI can style them differently. */
+  destructive?: boolean;
+  onClick: () => void | Promise<void>;
+}
+
+export type DevOption =
+  | DevBooleanOption
+  | DevSelectOption
+  | DevStringOption
+  | DevActionOption;
+
+export interface DevPanel {
+  /** Stable id — used for the localStorage key prefix. */
+  id: string;
+  label: string;
+  description?: string;
+  /** Lower = earlier. Framework built-ins use 10–30; templates default to 100. */
+  order?: number;
+  options?: DevOption[];
+  /** Custom React content rendered after the options list. */
+  render?: () => ReactNode;
+}

--- a/packages/core/src/client/dev-overlay/use-dev-option.ts
+++ b/packages/core/src/client/dev-overlay/use-dev-option.ts
@@ -1,0 +1,78 @@
+/**
+ * `useDevOption` — read/write a dev-overlay option backed by localStorage.
+ *
+ * Storage layout: `agent-native-dev-overlay-option-<panelId>-<optionId>` holds
+ * a JSON-encoded value. Falls back to `defaultValue` when the key is missing
+ * or the JSON is corrupt.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+export const DEV_OVERLAY_STORAGE_PREFIX = "agent-native-dev-overlay-";
+
+export function devOptionKey(panelId: string, optionId: string): string {
+  return `${DEV_OVERLAY_STORAGE_PREFIX}option-${panelId}-${optionId}`;
+}
+
+function readRaw<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function useDevOption<T>(
+  panelId: string,
+  optionId: string,
+  defaultValue: T,
+): [T, (next: T) => void] {
+  const key = devOptionKey(panelId, optionId);
+  const [value, setValue] = useState<T>(() => readRaw(key, defaultValue));
+
+  // Keep tabs (and the overlay's "Clear all" button) in sync.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== key && e.key !== null) return;
+      setValue(readRaw(key, defaultValue));
+    };
+    const onLocal = () => setValue(readRaw(key, defaultValue));
+    window.addEventListener("storage", onStorage);
+    window.addEventListener("agent-native-dev-overlay:changed", onLocal);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener("agent-native-dev-overlay:changed", onLocal);
+    };
+  }, [key, defaultValue]);
+
+  const update = useCallback(
+    (next: T) => {
+      setValue(next);
+      if (typeof window === "undefined") return;
+      try {
+        window.localStorage.setItem(key, JSON.stringify(next));
+        window.dispatchEvent(new Event("agent-native-dev-overlay:changed"));
+      } catch {
+        // localStorage may be disabled — UI state still updates in-memory.
+      }
+    },
+    [key],
+  );
+
+  return [value, update];
+}
+
+export function clearAllDevOverlayStorage(): void {
+  if (typeof window === "undefined") return;
+  const toRemove: string[] = [];
+  for (let i = 0; i < window.localStorage.length; i++) {
+    const k = window.localStorage.key(i);
+    if (k && k.startsWith(DEV_OVERLAY_STORAGE_PREFIX)) toRemove.push(k);
+  }
+  for (const k of toRemove) window.localStorage.removeItem(k);
+  window.dispatchEvent(new Event("agent-native-dev-overlay:changed"));
+}

--- a/packages/core/src/client/dev-overlay/use-dev-overlay-shortcut.ts
+++ b/packages/core/src/client/dev-overlay/use-dev-overlay-shortcut.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+
+/**
+ * Toggle the dev overlay with Cmd+Ctrl+A (Mac) / Ctrl+Alt+A (Windows/Linux).
+ * Mirrors the useCommandMenuShortcut pattern — skip when an input is focused.
+ */
+export function useDevOverlayShortcut(onToggle: () => void): void {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const isMacCombo = e.metaKey && e.ctrlKey;
+      const isWinCombo = !e.metaKey && e.ctrlKey && e.altKey;
+      if (!(isMacCombo || isWinCombo)) return;
+      if (e.key !== "a" && e.key !== "A") return;
+
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      e.preventDefault();
+      onToggle();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [onToggle]);
+}

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -128,6 +128,26 @@ export {
   type CommandShortcutProps,
 } from "./CommandMenu.js";
 export {
+  DevOverlay,
+  useDevOverlayShortcut,
+  registerDevPanel,
+  unregisterDevPanel,
+  listDevPanels,
+  subscribeDevPanels,
+  useDevOption,
+  clearAllDevOverlayStorage,
+  devOptionKey,
+  DEV_OVERLAY_STORAGE_PREFIX,
+  type DevOverlayProps,
+  type DevPanel,
+  type DevOption,
+  type DevBooleanOption,
+  type DevSelectOption,
+  type DevStringOption,
+  type DevActionOption,
+  type DevOptionValue,
+} from "./dev-overlay/index.js";
+export {
   useActionQuery,
   useActionMutation,
   type ActionRegistry,

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -12,6 +12,12 @@ export interface BuilderStatus {
   userId?: string;
   orgName?: string;
   orgKind?: string;
+  /**
+   * Set when the OAuth callback ran but failed to persist credentials.
+   * Surfaced as a one-shot row by the server so the connect-flow polling
+   * can stop with a clear message instead of timing out at 5min.
+   */
+  connectError?: { message: string; at: number };
 }
 
 /**
@@ -139,6 +145,7 @@ export function useBuilderConnectFlow(
       return (await r.json()) as {
         configured: boolean;
         orgName?: string | null;
+        connectError?: { message: string; at: number };
       };
     } catch {
       return null;
@@ -217,6 +224,14 @@ export function useBuilderConnectFlow(
           // Consumer's callback failed; we've already flipped the UI state
           // to connected. Swallow so we don't re-arm the flow.
         }
+      } else if (s?.connectError?.message) {
+        // OAuth callback ran but writeBuilderCredentials threw — surface the
+        // real error instead of letting the user wait 5 minutes for timeout.
+        stopPoll();
+        setConnecting(false);
+        setError(
+          `Couldn't save Builder credentials: ${s.connectError.message}. Try again or contact support.`,
+        );
       } else if (Date.now() - started > POLL_TIMEOUT_MS) {
         stopPoll();
         setConnecting(false);
@@ -226,6 +241,23 @@ export function useBuilderConnectFlow(
       }
     }, POLL_INTERVAL_MS);
   }, [fetchStatus, popupUrl, stopPoll]);
+
+  // Popup-side fast path: the error page postMessages us so we stop polling
+  // immediately rather than waiting for the next 2s tick (and so we still
+  // surface the error if the settings-row write also failed).
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (e.origin !== window.location.origin) return;
+      const data = e.data as { type?: string; message?: string } | undefined;
+      if (data?.type !== "builder-connect-error") return;
+      if (typeof data.message !== "string" || !data.message) return;
+      stopPoll();
+      setConnecting(false);
+      setError(`Couldn't save Builder credentials: ${data.message}.`);
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, [stopPoll]);
 
   return { configured, orgName, connecting, error, hasFetchedStatus, start };
 }

--- a/packages/core/src/onboarding/plugin.ts
+++ b/packages/core/src/onboarding/plugin.ts
@@ -54,21 +54,27 @@ async function hasOverride(
 /**
  * Serialise every registered onboarding step (awaiting `isComplete()`).
  * Honours the per-session "manual override" flag in application-state.
+ *
+ * `preview` short-circuits both the resolver and the override lookup so the
+ * dev overlay can render the new-user flow without touching real state.
  */
 async function serializeSteps(
   sessionId: string,
+  options: { preview?: boolean } = {},
 ): Promise<OnboardingStepStatus[]> {
   const steps = listOnboardingSteps();
   const out: OnboardingStepStatus[] = [];
   for (const step of steps) {
     let complete = false;
-    try {
-      complete = (await step.isComplete()) === true;
-    } catch {
-      complete = false;
-    }
-    if (!complete) {
-      complete = await hasOverride(sessionId, step.id);
+    if (!options.preview) {
+      try {
+        complete = (await step.isComplete()) === true;
+      } catch {
+        complete = false;
+      }
+      if (!complete) {
+        complete = await hasOverride(sessionId, step.id);
+      }
     }
     out.push({
       id: step.id,
@@ -117,7 +123,8 @@ export function createOnboardingPlugin(
             return { error: "Method not allowed" };
           }
           const sessionId = await resolveSessionId(event);
-          return serializeSteps(sessionId);
+          const preview = event.url?.searchParams?.get("preview") === "1";
+          return serializeSteps(sessionId, { preview });
         }
 
         // Override endpoint — POST /steps/:id/complete

--- a/packages/core/src/onboarding/plugin.ts
+++ b/packages/core/src/onboarding/plugin.ts
@@ -11,6 +11,7 @@
 import {
   defineEventHandler,
   getMethod,
+  getQuery,
   setResponseStatus,
   type H3Event,
 } from "h3";
@@ -123,7 +124,8 @@ export function createOnboardingPlugin(
             return { error: "Method not allowed" };
           }
           const sessionId = await resolveSessionId(event);
-          const preview = event.url?.searchParams?.get("preview") === "1";
+          const query = getQuery(event) as Record<string, unknown>;
+          const preview = query.preview === "1" || query.preview === 1;
           return serializeSteps(sessionId, { preview });
         }
 

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -317,6 +317,92 @@ export function createBuilderBrowserCallbackPage(previewUrl: string): string {
 </html>`;
 }
 
+/**
+ * HTML page rendered inside the OAuth popup when the callback handler caught
+ * an error persisting the per-user Builder credentials. Without this, the
+ * popup would show the success page even though the write failed — leaving
+ * the parent window stuck on "Waiting for Builder…" until the 5-minute poll
+ * timeout fires (Midhun reported this on 2026-04-28).
+ *
+ * The page does two things:
+ * 1. Shows the user a clear "couldn't save credentials" message with the
+ *    underlying error so they can retry or report.
+ * 2. `postMessage`s the parent (same-origin opener) so the connect-flow
+ *    polling stops immediately rather than waiting for the next /status
+ *    poll to surface the SQL `builder-connect-error:<email>` row.
+ */
+export function createBuilderBrowserCallbackErrorPage(message: string): string {
+  const escapedMessage = JSON.stringify(message);
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+    <title>Builder connect failed</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background:
+          radial-gradient(circle at top, rgba(244, 63, 94, 0.14), transparent 38%),
+          linear-gradient(180deg, #f7fafc 0%, #eef2f7 100%);
+        color: #0f172a;
+        font: 14px/1.5 ui-sans-serif, system-ui, sans-serif;
+      }
+      .card {
+        width: min(460px, calc(100vw - 32px));
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 18px;
+        padding: 28px;
+        background: rgba(255, 255, 255, 0.92);
+        box-shadow: 0 24px 80px rgba(15, 23, 42, 0.12);
+      }
+      h1 { margin: 0 0 8px; font-size: 22px; color: #b91c1c; }
+      p { margin: 0 0 12px; color: #475569; }
+      pre {
+        margin: 0 0 12px;
+        padding: 10px 12px;
+        background: #fef2f2;
+        border: 1px solid #fecaca;
+        border-radius: 8px;
+        color: #991b1b;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <h1>Couldn't save Builder connection</h1>
+      <p>Builder authorized your account but the server couldn't persist the credentials.</p>
+      <pre id="msg"></pre>
+      <p>You can close this tab and try again from settings. The connect dialog has the same error so you can copy it.</p>
+    </main>
+    <script>
+      try {
+        var msg = ${escapedMessage};
+        document.getElementById("msg").textContent = msg;
+        // Stop the parent's poll immediately. /builder/status also surfaces
+        // a connectError row written by the callback so the parent picks
+        // this up even if the popup closed before postMessage delivered.
+        if (window.opener && !window.opener.closed) {
+          try {
+            window.opener.postMessage(
+              { type: "builder-connect-error", message: msg },
+              window.location.origin,
+            );
+          } catch (e) {}
+        }
+      } catch (e) {}
+    </script>
+  </body>
+</html>`;
+}
+
 export interface RunBuilderAgentArgs {
   prompt: string;
   projectId?: string;

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -16,6 +16,7 @@ import {
   BUILDER_ENV_KEYS,
   BUILDER_STATE_PARAM,
   buildBuilderCliAuthUrl,
+  createBuilderBrowserCallbackErrorPage,
   createBuilderBrowserCallbackPage,
   getBuilderBrowserStatusForEvent,
   resolveSafePreviewUrl,
@@ -300,6 +301,34 @@ export function createCoreRoutesPlugin(
         } catch {
           // Secrets table not ready — fall through to env status
         }
+        // Surface a recent OAuth callback failure so the parent's polling
+        // stops with a clear message instead of timing out at 5min. The
+        // callback handler writes a `builder-connect-error:<email>` row
+        // when `writeBuilderCredentials` throws; this read self-clears so
+        // the message only fires once.
+        try {
+          const session = await getSession(event).catch(() => null);
+          if (session?.email) {
+            const errKey = `builder-connect-error:${session.email}`;
+            const errRow = await getSetting(errKey);
+            if (errRow && typeof errRow.message === "string") {
+              await deleteSetting(errKey).catch(() => {});
+              return {
+                ...envStatus,
+                configured: false,
+                connectError: {
+                  message: errRow.message as string,
+                  at:
+                    typeof errRow.at === "number"
+                      ? (errRow.at as number)
+                      : Date.now(),
+                },
+              };
+            }
+          }
+        } catch {
+          // settings store unavailable — fall through to legacy/env status
+        }
         // Honor legacy disconnect flag for existing deployments.
         try {
           const disconnected = await getSetting("builder-disconnected");
@@ -456,6 +485,15 @@ export function createCoreRoutesPlugin(
         // Store per-user in app_secrets so each user's Builder connection
         // is independent. No more shared env vars that the last connector
         // overwrites.
+        //
+        // Failure handling: a silent catch here (returning the success page
+        // anyway) was Midhun's bug on 2026-04-28 — popup said "yay", parent
+        // window polled `/builder/status` for 5 minutes seeing
+        // configured:false, never got a real error. Now we surface the
+        // failure two ways: (a) a settings row that the next /builder/status
+        // poll picks up, and (b) postMessage from the error page itself,
+        // wired into the popup HTML, so the parent stops polling immediately.
+        let writeError: string | null = null;
         try {
           const { writeBuilderCredentials } =
             await import("./credential-provider.js");
@@ -467,17 +505,44 @@ export function createCoreRoutesPlugin(
             orgKind,
           });
         } catch (err) {
-          console.warn(
-            "[builder] Failed to write per-user credentials:",
-            (err as Error)?.message ?? err,
+          writeError = (err as Error)?.message ?? String(err);
+          console.error(
+            "[builder] Failed to persist per-user credentials:",
+            writeError,
           );
         }
 
-        // Clear any legacy disconnect flag.
+        if (writeError) {
+          // Best-effort signal to /builder/status. If putSetting also fails
+          // (entire DB unreachable) the popup's postMessage still notifies
+          // the parent. If both fail the parent times out at 5min as today.
+          try {
+            await putSetting(`builder-connect-error:${session.email}`, {
+              message: writeError,
+              at: Date.now(),
+            });
+          } catch (settingsErr) {
+            console.error(
+              "[builder] Couldn't even record connect-error to settings:",
+              (settingsErr as Error)?.message ?? settingsErr,
+            );
+          }
+          setResponseStatus(event, 500);
+          setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
+          return createBuilderBrowserCallbackErrorPage(writeError);
+        }
+
+        // Clear any legacy disconnect flag and any prior connect-error row
+        // (so a successful retry doesn't surface the previous failure).
         try {
           await deleteSetting("builder-disconnected");
         } catch {
           // DB not ready — proceed
+        }
+        try {
+          await deleteSetting(`builder-connect-error:${session.email}`);
+        } catch {
+          // No prior error row — fine
         }
 
         const previewUrl = resolveSafePreviewUrl(

--- a/packages/core/src/templates/workspace-core/package.json
+++ b/packages/core/src/templates/workspace-core/package.json
@@ -43,6 +43,7 @@
     "@agent-native/core": "^0.7.10"
   },
   "devDependencies": {
+    "@types/node": "^24.2.1",
     "@types/react": "^19.2.14",
     "react": "^19.2.5",
     "typescript": "^6.0.3"

--- a/templates/clips/app/root.tsx
+++ b/templates/clips/app/root.tsx
@@ -12,6 +12,7 @@ import {
   ClientOnly,
   CommandMenu,
   DefaultSpinner,
+  DevOverlay,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
 import { IconSun, IconMoon } from "@tabler/icons-react";
@@ -120,6 +121,7 @@ export default function Root() {
                 <ThemeToggleItem />
               </CommandMenu.Group>
             </CommandMenu>
+            <DevOverlay />
             <Outlet />
             <Toaster position="bottom-left" />
           </TooltipProvider>

--- a/templates/dispatch/app/routes/_index.tsx
+++ b/templates/dispatch/app/routes/_index.tsx
@@ -1,9 +1,14 @@
-import { Navigate } from "react-router";
+import { Navigate, useLocation } from "react-router";
 
 export function meta() {
   return [{ title: "Dispatch" }];
 }
 
 export default function IndexPage() {
-  return <Navigate to="/overview" replace />;
+  // Preserve the query string when bouncing to /overview, otherwise the
+  // ?thread=<id> deep-link from a Slack "Open thread" button gets dropped
+  // before root.tsx's useThreadDeepLink can read it. Same for ?tab=, etc.
+  const location = useLocation();
+  const target = `/overview${location.search}${location.hash}`;
+  return <Navigate to={target} replace />;
 }


### PR DESCRIPTION
**Symptom:** Clicking the "Open thread" button on a Slack reply (added in #355) dropped the user on the dispatch overview with no thread loaded.

**Root cause:** \`templates/dispatch/app/routes/_index.tsx\` did \`<Navigate to="/overview" replace />\` — bare path, no query forwarded. So \`?thread=<id>\` was stripped before \`root.tsx\`'s \`useThreadDeepLink\` hook could read it and write the chat-command application-state.

**Fix:** forward \`location.search\` and \`location.hash\` through to \`/overview\` so the deep-link handler still sees the query on the destination route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)