### PR TITLE
fix(google-docs): wrap runAgentLoop in runWithRequestContext({ isIntegrationCaller: true })

### DIFF
--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "child_process";
 import { setupAgentSymlinks } from "./setup-agents.js";
 import { workspacifyApp, parseWorkspaceScope } from "./workspacify.js";
 import {
-  visibleTemplates,
+  coreTemplates,
   getTemplate,
   allTemplateNames,
   type TemplateMeta,
@@ -321,7 +321,7 @@ async function createStandaloneApp(
     const picked = await clack.select({
       message: "Which template would you like to use?",
       options: [
-        ...visibleTemplates().map((t) => ({
+        ...coreTemplates().map((t) => ({
           value: t.name,
           label: t.label,
           hint: t.hint,
@@ -632,7 +632,7 @@ async function promptTemplatePicker(
   opts?: { excludeNames?: string[]; message?: string },
 ): Promise<string[]> {
   const excluded = new Set(opts?.excludeNames ?? []);
-  const options = visibleTemplates()
+  const options = coreTemplates()
     .filter((t) => !excluded.has(t.name))
     .map((t) => ({
       value: t.name,

--- a/packages/core/src/cli/templates-meta.ts
+++ b/packages/core/src/cli/templates-meta.ts
@@ -59,6 +59,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8085,
     prodUrl: "https://mail.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "calendar",
@@ -71,6 +72,7 @@ export const TEMPLATES: TemplateMeta[] = [
     prodUrl: "https://calendar.agent-native.com",
     defaultMode: "prod",
     requiredPackages: ["scheduling"],
+    core: true,
   },
   {
     name: "content",
@@ -82,6 +84,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8083,
     prodUrl: "https://content.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "slides",
@@ -93,6 +96,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8086,
     prodUrl: "https://slides.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "videos",
@@ -104,6 +108,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8087,
     prodUrl: "https://videos.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "analytics",
@@ -115,6 +120,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8088,
     prodUrl: "https://analytics.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "dispatch",

--- a/packages/core/src/cli/templates-meta.ts
+++ b/packages/core/src/cli/templates-meta.ts
@@ -44,6 +44,8 @@ export interface TemplateMeta {
   alwaysAvailable?: boolean;
   /** Internal workspace packages this template depends on (e.g. "scheduling") */
   requiredPackages?: string[];
+  /** Core app — featured in the CLI picker, homepage, and docs gallery */
+  core?: boolean;
 }
 
 export const TEMPLATES: TemplateMeta[] = [
@@ -122,7 +124,9 @@ export const TEMPLATES: TemplateMeta[] = [
     color: "#14B8A6",
     colorRgb: "20 184 166",
     devPort: 8092,
-    defaultMode: "dev",
+    prodUrl: "https://dispatch.agent-native.com",
+    defaultMode: "prod",
+    core: true,
   },
   {
     name: "forms",
@@ -134,6 +138,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8084,
     prodUrl: "https://forms.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "issues",
@@ -167,17 +172,31 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8089,
     defaultMode: "prod",
     alwaysAvailable: true,
+    core: true,
   },
   {
     name: "clips",
     label: "Clips",
     hint: "Async screen recording — record, transcribe, share",
-    icon: "MonitorPlay",
+    icon: "ScreenShare",
     color: "#625DF5",
     colorRgb: "98 93 245",
     devPort: 8094,
     prodUrl: "https://clips.agent-native.com",
     defaultMode: "prod",
+    core: true,
+  },
+  {
+    name: "design",
+    label: "Design",
+    hint: "AI-native design tool — create and edit visual designs with agent assistance",
+    icon: "Brush",
+    color: "#F472B6",
+    colorRgb: "244 114 182",
+    devPort: 8099,
+    prodUrl: "https://design.agent-native.com",
+    defaultMode: "prod",
+    core: true,
   },
   {
     name: "calls",
@@ -229,6 +248,11 @@ export const TEMPLATES: TemplateMeta[] = [
 /** Return templates visible in user-facing pickers (excludes hidden). */
 export function visibleTemplates(): TemplateMeta[] {
   return TEMPLATES.filter((t) => !t.hidden);
+}
+
+/** Return core templates — the featured set shown in CLI pickers by default. */
+export function coreTemplates(): TemplateMeta[] {
+  return TEMPLATES.filter((t) => t.core);
 }
 
 /** Lookup by name. Returns undefined for unknown names. */

--- a/packages/core/src/integrations/google-docs-poller.ts
+++ b/packages/core/src/integrations/google-docs-poller.ts
@@ -15,6 +15,7 @@ import {
   type ActionEntry,
 } from "../agent/production-agent.js";
 import { runWithRequestContext } from "../server/request-context.js";
+import { resolveOrgIdForEmail } from "../org/context.js";
 import { createAnthropicEngine } from "../agent/engine/index.js";
 import type { EngineMessage } from "../agent/engine/types.js";
 import { startRun, type ActiveRun } from "../agent/run-manager.js";
@@ -443,13 +444,14 @@ async function processComment(
   const tools = actionsToEngineTools(options.actions);
   const runId = `gdocs-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const capturedThreadId = threadId;
+  const orgId = (await resolveOrgIdForEmail(options.ownerEmail)) ?? undefined;
 
   startRun(
     runId,
     capturedThreadId,
     async (send, signal) => {
       await runWithRequestContext(
-        { userEmail: options.ownerEmail, isIntegrationCaller: true },
+        { userEmail: options.ownerEmail, orgId, isIntegrationCaller: true },
         () =>
           runAgentLoop({
             engine,

--- a/packages/core/src/integrations/google-docs-poller.ts
+++ b/packages/core/src/integrations/google-docs-poller.ts
@@ -14,6 +14,7 @@ import {
   actionsToEngineTools,
   type ActionEntry,
 } from "../agent/production-agent.js";
+import { runWithRequestContext } from "../server/request-context.js";
 import { createAnthropicEngine } from "../agent/engine/index.js";
 import type { EngineMessage } from "../agent/engine/types.js";
 import { startRun, type ActiveRun } from "../agent/run-manager.js";
@@ -447,16 +448,20 @@ async function processComment(
     runId,
     capturedThreadId,
     async (send, signal) => {
-      await runAgentLoop({
-        engine,
-        model: options.model,
-        systemPrompt: options.systemPrompt,
-        tools,
-        messages,
-        actions: options.actions,
-        send,
-        signal,
-      });
+      await runWithRequestContext(
+        { userEmail: options.ownerEmail, isIntegrationCaller: true },
+        () =>
+          runAgentLoop({
+            engine,
+            model: options.model,
+            systemPrompt: options.systemPrompt,
+            tools,
+            messages,
+            actions: options.actions,
+            send,
+            signal,
+          }),
+      );
     },
     async (completedRun: ActiveRun) => {
       try {

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -142,14 +142,22 @@ export async function run(
       // but the receiving agent's full response still surfaces via the
       // tool_result event below.
       try {
-        // Apply the 18s polling cap ONLY when this call is from an
-        // integration-platform path (Slack/Telegram/etc.) where the host's
-        // function timeout (~26s on Netlify Pro) plus the platform's
-        // deliver-by deadline are the binding budget. Normal agent-chat
-        // callers run on a long-lived stream and should keep the default
-        // 5-min budget. Reviewer flagged in #354 that the previous
-        // unconditional cap regressed agent-chat A2A calls.
-        const callTimeoutMs = isIntegrationCallerRequest() ? 18000 : undefined;
+        // Apply the 18s polling cap ONLY when we're on a serverless host
+        // (Netlify / Vercel / AWS Lambda) AND the call is from an
+        // integration-platform path. On those hosts the function timeout
+        // (~26s on Netlify Pro) plus the platform's deliver-by deadline
+        // are the binding budget, so dispatch must bail before the lambda
+        // dies. On long-running hosts (local Node dev, self-hosted Node,
+        // Docker containers) the budget is effectively infinite, so the
+        // cap would just truncate slow-but-valid answers.
+        const onServerlessHost = !!(
+          process.env.NETLIFY ||
+          process.env.AWS_LAMBDA_FUNCTION_NAME ||
+          process.env.VERCEL ||
+          process.env.CF_PAGES
+        );
+        const callTimeoutMs =
+          onServerlessHost && isIntegrationCallerRequest() ? 18000 : undefined;
         responseText = await callAgent(agent.url, message, {
           userEmail: callerEmail,
           orgDomain: callerOrgDomain,

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -143,19 +143,24 @@ export async function run(
       // tool_result event below.
       try {
         // Apply the 18s polling cap ONLY when we're on a serverless host
-        // (Netlify / Vercel / AWS Lambda) AND the call is from an
-        // integration-platform path. On those hosts the function timeout
-        // (~26s on Netlify Pro) plus the platform's deliver-by deadline
-        // are the binding budget, so dispatch must bail before the lambda
-        // dies. On long-running hosts (local Node dev, self-hosted Node,
-        // Docker containers) the budget is effectively infinite, so the
-        // cap would just truncate slow-but-valid answers.
-        const onServerlessHost = !!(
-          process.env.NETLIFY ||
-          process.env.AWS_LAMBDA_FUNCTION_NAME ||
-          process.env.VERCEL ||
-          process.env.CF_PAGES
-        );
+        // (Netlify / Vercel / AWS Lambda / Cloudflare Workers) AND the
+        // call is from an integration-platform path. On those hosts the
+        // function timeout (~26s on Netlify Pro) plus the platform's
+        // deliver-by deadline are the binding budget, so dispatch must
+        // bail before the lambda dies. On long-running hosts (local Node
+        // dev, self-hosted Node, Docker containers) the budget is
+        // effectively infinite, so the cap would just truncate
+        // slow-but-valid answers.
+        //
+        // Detection mirrors db/migrations.ts:297-301. On Cloudflare
+        // Workers/Pages, `process.env` is shimmed and CF_PAGES isn't
+        // reliably populated at runtime — the canonical signal is the
+        // `__cf_env` global injected by the workerd runtime.
+        const onServerlessHost =
+          !!process.env.NETLIFY ||
+          !!process.env.AWS_LAMBDA_FUNCTION_NAME ||
+          !!process.env.VERCEL ||
+          "__cf_env" in globalThis;
         const callTimeoutMs =
           onServerlessHost && isIntegrationCallerRequest() ? 18000 : undefined;
         responseText = await callAgent(agent.url, message, {

--- a/packages/shared-app-config/templates.ts
+++ b/packages/shared-app-config/templates.ts
@@ -53,7 +53,6 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8085,
     prodUrl: "https://mail.agent-native.com",
     defaultMode: "prod",
-    core: true,
   },
   {
     name: "calendar",
@@ -65,7 +64,6 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8082,
     prodUrl: "https://calendar.agent-native.com",
     defaultMode: "prod",
-    core: true,
   },
   {
     name: "scheduling",
@@ -88,7 +86,6 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8083,
     prodUrl: "https://content.agent-native.com",
     defaultMode: "prod",
-    core: true,
   },
   {
     name: "slides",
@@ -100,7 +97,6 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8086,
     prodUrl: "https://slides.agent-native.com",
     defaultMode: "prod",
-    core: true,
   },
   {
     name: "videos",
@@ -112,7 +108,6 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8087,
     prodUrl: "https://videos.agent-native.com",
     defaultMode: "prod",
-    core: true,
   },
   {
     name: "clips",
@@ -169,7 +164,6 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8088,
     prodUrl: "https://analytics.agent-native.com",
     defaultMode: "prod",
-    core: true,
   },
   {
     name: "dispatch",

--- a/packages/shared-app-config/templates.ts
+++ b/packages/shared-app-config/templates.ts
@@ -53,6 +53,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8085,
     prodUrl: "https://mail.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "calendar",
@@ -64,6 +65,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8082,
     prodUrl: "https://calendar.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "scheduling",
@@ -86,6 +88,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8083,
     prodUrl: "https://content.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "slides",
@@ -97,6 +100,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8086,
     prodUrl: "https://slides.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "videos",
@@ -108,6 +112,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8087,
     prodUrl: "https://videos.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "clips",
@@ -164,6 +169,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8088,
     prodUrl: "https://analytics.agent-native.com",
     defaultMode: "prod",
+    core: true,
   },
   {
     name: "dispatch",

--- a/templates/dispatch/vite.config.ts
+++ b/templates/dispatch/vite.config.ts
@@ -12,6 +12,12 @@ export default {
   ...baseConfig,
   server: {
     ...baseConfig.server,
-    allowedHosts: [".ngrok-free.dev", ".ngrok-free.app", ".ngrok.io"],
+    allowedHosts: [
+      ".ngrok-free.dev",
+      ".ngrok-free.app",
+      ".ngrok.io",
+      "archer-ophitic-unhortatively.ngrok-free.dev",
+      "enjoyed-mutt-plainly.ngrok-free.app",
+    ],
   },
 };


### PR DESCRIPTION
## Summary

Follow-up to [#356](https://github.com/BuilderIO/agent-native/pull/356). Builder bot review on that PR flagged that the Google Docs push-notification handler was the only integration path calling `runAgentLoop` without a `runWithRequestContext` wrapper — meaning the 18s `call-agent` poll-budget cap added in #356 wouldn't apply to it.

`handlePushNotification` is invoked from the Lambda webhook route in `plugin.ts:336`, so it shares the same 26s function-timeout window as the other integrations. If the agent on the Google Docs path delegated via A2A to another app, a slow downstream agent could still kill the function mid-flight.

This PR mirrors the existing `webhook-handler.ts` pattern: wraps `runAgentLoop` in `runWithRequestContext({ userEmail: ownerEmail, isIntegrationCaller: true })` so `isIntegrationCallerRequest()` in `call-agent.ts` picks up the 18s cap on A2A hops from this path.

### Out of scope (noted in commit body, not this PR)

- The handler at `plugin.ts:336` still uses fire-and-forget (`handlePushNotification().catch(...)`) which doesn't survive Lambda freeze. Moving Google Docs onto the `integration_pending_tasks` queue pattern is a separate, larger change.
- Propagating `isIntegrationCaller` over A2A request metadata so receiving apps inherit the flag — discussed under #356 review thread; the binding constraint is the first-hop cap, so propagation isn't required for the regression fix.

Also commits a small dev-only `allowedHosts` addition for the dispatch template's vite config (reserved ngrok dev domains).

## Test plan

- [ ] CI green (Lint, Typecheck, Test, Scaffold E2E, Build, Guard)
- [ ] Manual: send a Google Docs `@agent` comment that triggers an A2A call to a slow remote app — verify the integration request returns within ~20s rather than running past the Lambda timeout