### PR TITLE
Tighten access scoping in calls/slides/videos handlers + clips desktop voice polish

### DIFF
--- a/packages/core/src/resources/script-helpers.ts
+++ b/packages/core/src/resources/script-helpers.ts
@@ -20,14 +20,14 @@ import { getRequestUserEmail } from "../server/request-context.js";
 
 // Dev-mode fallback identity. Scripts run as standalone CLI processes
 // without HTTP context — when no AGENT_USER_EMAIL is set we fall back to
-// "local@localhost" so a developer running `pnpm action` locally without
+// the dev-mode user so a developer running `pnpm action` locally without
 // signing in still gets a usable scope. Production multi-user deployments
 // always set AGENT_USER_EMAIL via the agent runtime.
-const DEV_FALLBACK_OWNER = "local@localhost";
+import { DEV_MODE_USER_EMAIL } from "../server/auth.js";
 
 function getOwner(shared?: boolean): string {
   if (shared) return SHARED_OWNER;
-  return getRequestUserEmail() ?? DEV_FALLBACK_OWNER;
+  return getRequestUserEmail() ?? DEV_MODE_USER_EMAIL;
 }
 
 export async function readResource(
@@ -67,6 +67,6 @@ export async function listResources(
 export async function listAllResources(
   prefix?: string,
 ): Promise<ResourceMeta[]> {
-  const userEmail = getRequestUserEmail() ?? DEV_FALLBACK_OWNER;
+  const userEmail = getRequestUserEmail() ?? DEV_MODE_USER_EMAIL;
   return resourceListAccessible(userEmail, prefix);
 }

--- a/templates/calendar/server/handlers/booking-links.ts
+++ b/templates/calendar/server/handlers/booking-links.ts
@@ -287,6 +287,7 @@ export const getPublicBookingLink = defineEventHandler(
         return { error: "slug is required" };
       }
 
+      // guard:allow-unscoped — public booking URL — anonymous booking by design, gated by isActive
       const rows = await getDb()
         .select()
         .from(schema.bookingLinks)

--- a/templates/calls/actions/request-transcript.ts
+++ b/templates/calls/actions/request-transcript.ts
@@ -479,6 +479,7 @@ async function failTranscript(
     failureReason: reason,
     now: nowIso,
   });
+  // guard:allow-unscoped — only called from the action body which already ran assertAccess("call", callId, "editor")
   await db
     .update(schema.calls)
     .set({ status: "failed", failureReason: reason, updatedAt: nowIso })

--- a/templates/calls/server/lib/calls.ts
+++ b/templates/calls/server/lib/calls.ts
@@ -184,11 +184,18 @@ export function colorForSpeaker(label: string): string {
 
 /**
  * Fetch a single call row, throwing if not found.
+ *
+ * Access control is the caller's responsibility — every caller in this
+ * template (set-thumbnail, tag-call, update-call, request-transcript) runs
+ * `assertAccess("call", id, "editor")` immediately before invoking this
+ * helper. We don't re-assert here so the helper stays usable from contexts
+ * (background jobs, finalize-call) that have already established access.
  */
 export async function getCallOrThrow(
   id: string,
 ): Promise<typeof schema.calls.$inferSelect> {
   const db = getDb();
+  // guard:allow-unscoped — caller must assertAccess("call", id, ...) first; helper for already-authorized lookups
   const [row] = await db
     .select()
     .from(schema.calls)

--- a/templates/calls/server/routes/api/uploads/[callId]/abort.post.ts
+++ b/templates/calls/server/routes/api/uploads/[callId]/abort.post.ts
@@ -3,9 +3,16 @@
  * and marks the call row as failed.
  *
  * Route: POST /api/uploads/:callId/abort
+ *
+ * Auth: requires an authenticated session AND `editor` access on the call.
+ * The callId comes from the URL — without re-asserting access here a guesser
+ * could wipe another tenant's in-flight upload. Each chunk/abort/complete
+ * request is independent on serverless so the check has to happen on every
+ * request, not once at upload-start.
  */
 
 import {
+  createError,
   defineEventHandler,
   getRouterParam,
   setResponseStatus,
@@ -13,7 +20,8 @@ import {
 } from "h3";
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "../../../../db/index.js";
-import { assertAccess } from "@agent-native/core/sharing";
+import { assertAccess, ForbiddenError } from "@agent-native/core/sharing";
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
 import {
   deleteAppState,
   deleteAppStateByPrefix,
@@ -27,28 +35,41 @@ export default defineEventHandler(async (event: H3Event) => {
     return { error: "Missing callId" };
   }
 
-  try {
-    await assertAccess("call", callId, "editor");
-  } catch {
-    setResponseStatus(event, 403);
-    return { error: "Forbidden" };
+  const session = await getSession(event).catch(() => null);
+  if (!session?.email) {
+    throw createError({ statusCode: 401, statusMessage: "Unauthenticated" });
   }
 
-  const db = getDb();
-  const cleared = await deleteAppStateByPrefix(`call-chunks-${callId}-`);
-  await deleteAppState(`call-upload-${callId}`);
+  return runWithRequestContext(
+    { userEmail: session.email, orgId: session.orgId },
+    async () => {
+      try {
+        await assertAccess("call", callId, "editor");
+      } catch (err) {
+        if (err instanceof ForbiddenError) {
+          setResponseStatus(event, 403);
+          return { error: "Forbidden" };
+        }
+        throw err;
+      }
 
-  const now = new Date().toISOString();
-  await db
-    .update(schema.calls)
-    .set({
-      status: "failed",
-      failureReason: "upload aborted",
-      updatedAt: now,
-    })
-    .where(eq(schema.calls.id, callId));
+      const db = getDb();
+      const cleared = await deleteAppStateByPrefix(`call-chunks-${callId}-`);
+      await deleteAppState(`call-upload-${callId}`);
 
-  await writeAppState("refresh-signal", { ts: Date.now() });
+      const now = new Date().toISOString();
+      await db
+        .update(schema.calls)
+        .set({
+          status: "failed",
+          failureReason: "upload aborted",
+          updatedAt: now,
+        })
+        .where(eq(schema.calls.id, callId));
 
-  return { ok: true, callId, chunksCleared: cleared };
+      await writeAppState("refresh-signal", { ts: Date.now() });
+
+      return { ok: true, callId, chunksCleared: cleared };
+    },
+  );
 });

--- a/templates/calls/server/routes/api/uploads/[callId]/chunk.post.ts
+++ b/templates/calls/server/routes/api/uploads/[callId]/chunk.post.ts
@@ -11,9 +11,16 @@
  *   durationMs / width / height — forwarded to finalize
  *
  * Route: POST /api/uploads/:callId/chunk?index=N&total=T&isFinal=0|1
+ *
+ * Auth: requires an authenticated session AND `editor` access on the call.
+ * The callId comes from the URL — without re-asserting access here a guesser
+ * could overwrite another tenant's recording. Each chunk request is
+ * independent on serverless so the check has to happen on every chunk, not
+ * once at upload-start.
  */
 
 import {
+  createError,
   defineEventHandler,
   getRouterParam,
   getQuery,
@@ -23,7 +30,8 @@ import {
 } from "h3";
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "../../../../db/index.js";
-import { assertAccess } from "@agent-native/core/sharing";
+import { assertAccess, ForbiddenError } from "@agent-native/core/sharing";
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
 import { writeAppState } from "@agent-native/core/application-state";
 import finalizeCall from "../../../../../actions/finalize-call.js";
 
@@ -57,92 +65,107 @@ export default defineEventHandler(async (event: H3Event) => {
     return { error: "Invalid chunk index" };
   }
 
-  try {
-    await assertAccess("call", callId, "editor");
-  } catch {
-    setResponseStatus(event, 403);
-    return { error: "Forbidden" };
+  const session = await getSession(event).catch(() => null);
+  if (!session?.email) {
+    throw createError({ statusCode: 401, statusMessage: "Unauthenticated" });
   }
 
-  const db = getDb();
-  const raw = await readRawBody(event, false);
-  if (!raw || raw.byteLength === 0) {
-    setResponseStatus(event, 400);
-    return { error: "Empty chunk body" };
-  }
+  return runWithRequestContext(
+    { userEmail: session.email, orgId: session.orgId },
+    async () => {
+      try {
+        await assertAccess("call", callId, "editor");
+      } catch (err) {
+        if (err instanceof ForbiddenError) {
+          setResponseStatus(event, 403);
+          return { error: "Forbidden" };
+        }
+        throw err;
+      }
 
-  const bytes: Uint8Array = raw;
-  const paddedIndex = String(index).padStart(6, "0");
-  const chunkKey = `call-chunks-${callId}-${paddedIndex}`;
+      const db = getDb();
+      const raw = await readRawBody(event, false);
+      if (!raw || raw.byteLength === 0) {
+        setResponseStatus(event, 400);
+        return { error: "Empty chunk body" };
+      }
 
-  await writeAppState(chunkKey, {
-    callId,
-    index,
-    bytes: bytes.byteLength,
-    mimeType,
-    data: toBase64(bytes),
-    createdAt: new Date().toISOString(),
-  });
+      const bytes: Uint8Array = raw;
+      const paddedIndex = String(index).padStart(6, "0");
+      const chunkKey = `call-chunks-${callId}-${paddedIndex}`;
 
-  if (total > 0) {
-    const progress = Math.min(100, Math.round(((index + 1) / total) * 100));
-    await writeAppState(`call-upload-${callId}`, {
-      callId,
-      status: isFinal ? "processing" : "uploading",
-      progress,
-      chunksReceived: index + 1,
-      totalChunks: total,
-      mimeType,
-      updatedAt: new Date().toISOString(),
-    });
-
-    await db
-      .update(schema.calls)
-      .set({
-        progressPct: progress,
-        updatedAt: new Date().toISOString(),
-      })
-      .where(eq(schema.calls.id, callId));
-  }
-
-  if (isFinal) {
-    try {
-      const result = await finalizeCall.run({
-        id: callId,
-        durationMs: query.durationMs ? Number(query.durationMs) : undefined,
-        width: query.width ? Number(query.width) : undefined,
-        height: query.height ? Number(query.height) : undefined,
-        mimeType,
-      });
-      return { ok: true, finalized: true, ...result };
-    } catch (err) {
-      console.error("[calls] finalize-call failed:", err);
-      await db
-        .update(schema.calls)
-        .set({
-          status: "failed",
-          failureReason: err instanceof Error ? err.message : "Finalize failed",
-          updatedAt: new Date().toISOString(),
-        })
-        .where(eq(schema.calls.id, callId));
-      await writeAppState(`call-upload-${callId}`, {
+      await writeAppState(chunkKey, {
         callId,
-        status: "failed",
-        failureReason: err instanceof Error ? err.message : "Finalize failed",
-        updatedAt: new Date().toISOString(),
+        index,
+        bytes: bytes.byteLength,
+        mimeType,
+        data: toBase64(bytes),
+        createdAt: new Date().toISOString(),
       });
-      setResponseStatus(event, 500);
-      return {
-        ok: false,
-        error: err instanceof Error ? err.message : "Finalize failed",
-      };
-    }
-  }
 
-  return {
-    ok: true,
-    finalized: false,
-    index,
-    bytes: bytes.byteLength,
-  };
+      if (total > 0) {
+        const progress = Math.min(100, Math.round(((index + 1) / total) * 100));
+        await writeAppState(`call-upload-${callId}`, {
+          callId,
+          status: isFinal ? "processing" : "uploading",
+          progress,
+          chunksReceived: index + 1,
+          totalChunks: total,
+          mimeType,
+          updatedAt: new Date().toISOString(),
+        });
+
+        await db
+          .update(schema.calls)
+          .set({
+            progressPct: progress,
+            updatedAt: new Date().toISOString(),
+          })
+          .where(eq(schema.calls.id, callId));
+      }
+
+      if (isFinal) {
+        try {
+          const result = await finalizeCall.run({
+            id: callId,
+            durationMs: query.durationMs ? Number(query.durationMs) : undefined,
+            width: query.width ? Number(query.width) : undefined,
+            height: query.height ? Number(query.height) : undefined,
+            mimeType,
+          });
+          return { ok: true, finalized: true, ...result };
+        } catch (err) {
+          console.error("[calls] finalize-call failed:", err);
+          await db
+            .update(schema.calls)
+            .set({
+              status: "failed",
+              failureReason:
+                err instanceof Error ? err.message : "Finalize failed",
+              updatedAt: new Date().toISOString(),
+            })
+            .where(eq(schema.calls.id, callId));
+          await writeAppState(`call-upload-${callId}`, {
+            callId,
+            status: "failed",
+            failureReason:
+              err instanceof Error ? err.message : "Finalize failed",
+            updatedAt: new Date().toISOString(),
+          });
+          setResponseStatus(event, 500);
+          return {
+            ok: false,
+            error: err instanceof Error ? err.message : "Finalize failed",
+          };
+        }
+      }
+
+      return {
+        ok: true,
+        finalized: false,
+        index,
+        bytes: bytes.byteLength,
+      };
+    },
+  );
 });

--- a/templates/calls/server/routes/api/uploads/[callId]/complete.post.ts
+++ b/templates/calls/server/routes/api/uploads/[callId]/complete.post.ts
@@ -6,9 +6,16 @@
  *
  * Route: POST /api/uploads/:callId/complete
  * Body:  { durationMs?, width?, height?, mimeType? }
+ *
+ * Auth: requires an authenticated session AND `editor` access on the call.
+ * The callId comes from the URL — without re-asserting access here a guesser
+ * could finalize another tenant's recording. Each request is independent on
+ * serverless so the check has to happen on every complete call, not once at
+ * upload-start.
  */
 
 import {
+  createError,
   defineEventHandler,
   getRouterParam,
   readBody,
@@ -17,7 +24,8 @@ import {
 } from "h3";
 import { eq } from "drizzle-orm";
 import { getDb, schema } from "../../../../db/index.js";
-import { assertAccess } from "@agent-native/core/sharing";
+import { assertAccess, ForbiddenError } from "@agent-native/core/sharing";
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
 import { writeAppState } from "@agent-native/core/application-state";
 import finalizeCall from "../../../../../actions/finalize-call.js";
 
@@ -35,46 +43,63 @@ export default defineEventHandler(async (event: H3Event) => {
     return { error: "Missing callId" };
   }
 
-  try {
-    await assertAccess("call", callId, "editor");
-  } catch {
-    setResponseStatus(event, 403);
-    return { error: "Forbidden" };
+  const session = await getSession(event).catch(() => null);
+  if (!session?.email) {
+    throw createError({ statusCode: 401, statusMessage: "Unauthenticated" });
   }
 
-  const body = (await readBody(event).catch(() => null)) as CompleteBody | null;
+  return runWithRequestContext(
+    { userEmail: session.email, orgId: session.orgId },
+    async () => {
+      try {
+        await assertAccess("call", callId, "editor");
+      } catch (err) {
+        if (err instanceof ForbiddenError) {
+          setResponseStatus(event, 403);
+          return { error: "Forbidden" };
+        }
+        throw err;
+      }
 
-  try {
-    const result = await finalizeCall.run({
-      id: callId,
-      durationMs:
-        typeof body?.durationMs === "number" ? body.durationMs : undefined,
-      width: typeof body?.width === "number" ? body.width : undefined,
-      height: typeof body?.height === "number" ? body.height : undefined,
-      mimeType: typeof body?.mimeType === "string" ? body.mimeType : undefined,
-    });
-    return { ok: true, finalized: true, ...result };
-  } catch (err) {
-    console.error("[calls] finalize-call failed:", err);
-    const db = getDb();
-    await db
-      .update(schema.calls)
-      .set({
-        status: "failed",
-        failureReason: err instanceof Error ? err.message : "Finalize failed",
-        updatedAt: new Date().toISOString(),
-      })
-      .where(eq(schema.calls.id, callId));
-    await writeAppState(`call-upload-${callId}`, {
-      callId,
-      status: "failed",
-      failureReason: err instanceof Error ? err.message : "Finalize failed",
-      updatedAt: new Date().toISOString(),
-    });
-    setResponseStatus(event, 500);
-    return {
-      ok: false,
-      error: err instanceof Error ? err.message : "Finalize failed",
-    };
-  }
+      const body = (await readBody(event).catch(
+        () => null,
+      )) as CompleteBody | null;
+
+      try {
+        const result = await finalizeCall.run({
+          id: callId,
+          durationMs:
+            typeof body?.durationMs === "number" ? body.durationMs : undefined,
+          width: typeof body?.width === "number" ? body.width : undefined,
+          height: typeof body?.height === "number" ? body.height : undefined,
+          mimeType:
+            typeof body?.mimeType === "string" ? body.mimeType : undefined,
+        });
+        return { ok: true, finalized: true, ...result };
+      } catch (err) {
+        console.error("[calls] finalize-call failed:", err);
+        const db = getDb();
+        await db
+          .update(schema.calls)
+          .set({
+            status: "failed",
+            failureReason:
+              err instanceof Error ? err.message : "Finalize failed",
+            updatedAt: new Date().toISOString(),
+          })
+          .where(eq(schema.calls.id, callId));
+        await writeAppState(`call-upload-${callId}`, {
+          callId,
+          status: "failed",
+          failureReason: err instanceof Error ? err.message : "Finalize failed",
+          updatedAt: new Date().toISOString(),
+        });
+        setResponseStatus(event, 500);
+        return {
+          ok: false,
+          error: err instanceof Error ? err.message : "Finalize failed",
+        };
+      }
+    },
+  );
 });

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -614,7 +614,7 @@ pub async fn complete_voice_dictation(app: AppHandle, text: String) -> Result<()
         return Ok(());
     }
     eprintln!(
-        "[clips-tray] complete_voice_dictation: writing {} chars to clipboard + Cmd+V",
+        "[clips-tray] complete_voice_dictation: typing {} chars via CGEvent unicode",
         trimmed.chars().count()
     );
     if let Some(last) = app.try_state::<LastTranscript>() {
@@ -622,8 +622,14 @@ pub async fn complete_voice_dictation(app: AppHandle, text: String) -> Result<()
             *g = Some(trimmed.clone());
         }
     }
+    // Keep the clipboard updated so users can ⌘V again to repeat the last
+    // dictation, but don't rely on Cmd+V for the actual insertion — many
+    // terminals (Ghostty, iTerm with custom keybindings, etc.) intercept
+    // Cmd+V or only accept paste through their own copy/paste pipeline.
+    // CGEvent unicode injection types the characters directly into the
+    // focused field and works in every terminal + editor we've tested.
     write_clipboard(&trimmed)?;
-    paste_clipboard();
+    type_text_unicode(&trimmed);
     Ok(())
 }
 
@@ -655,35 +661,63 @@ fn write_clipboard(_text: &str) -> Result<(), String> {
 }
 
 #[cfg(target_os = "macos")]
-fn paste_clipboard() {
-    use core_graphics::event::{CGEvent, CGEventFlags, CGEventTapLocation};
+fn type_text_unicode(text: &str) {
+    use core_graphics::event::{CGEvent, CGEventTapLocation};
     use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 
-    thread::spawn(|| {
-        thread::sleep(Duration::from_millis(80));
+    let owned = text.to_string();
+    thread::spawn(move || {
+        // Brief delay so the focused-app context is ready (mirrors the
+        // delay the previous Cmd+V path used).
+        thread::sleep(Duration::from_millis(40));
         let Ok(source) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
-            eprintln!("[clips-tray] paste failed: no CGEventSource");
+            eprintln!("[clips-tray] type failed: no CGEventSource");
             return;
         };
-        // ANSI V on macOS.
-        let key_v: u16 = 9;
-        let Ok(down) = CGEvent::new_keyboard_event(source.clone(), key_v, true) else {
-            eprintln!("[clips-tray] paste failed: no keydown event");
-            return;
+        // CGEventKeyboardSetUnicodeString has a per-event payload limit
+        // (Apple docs: ~20 UTF-16 units, with longer bounded by ~75 char
+        // in practice). Chunk by codepoint to stay safely under that.
+        let chunks: Vec<String> = {
+            let mut out: Vec<String> = Vec::new();
+            let mut current = String::new();
+            let mut count = 0usize;
+            for c in owned.chars() {
+                current.push(c);
+                count += 1;
+                if count >= 20 {
+                    out.push(std::mem::take(&mut current));
+                    count = 0;
+                }
+            }
+            if !current.is_empty() {
+                out.push(current);
+            }
+            out
         };
-        let Ok(up) = CGEvent::new_keyboard_event(source, key_v, false) else {
-            eprintln!("[clips-tray] paste failed: no keyup event");
-            return;
-        };
-        down.set_flags(CGEventFlags::CGEventFlagCommand);
-        up.set_flags(CGEventFlags::CGEventFlagCommand);
-        down.post(CGEventTapLocation::HID);
-        up.post(CGEventTapLocation::HID);
+        for chunk in chunks {
+            let utf16: Vec<u16> = chunk.encode_utf16().collect();
+            let Ok(down) = CGEvent::new_keyboard_event(source.clone(), 0, true) else {
+                eprintln!("[clips-tray] type failed: no keydown event");
+                return;
+            };
+            let Ok(up) = CGEvent::new_keyboard_event(source.clone(), 0, false) else {
+                eprintln!("[clips-tray] type failed: no keyup event");
+                return;
+            };
+            down.set_string_from_utf16_unchecked(&utf16);
+            up.set_string_from_utf16_unchecked(&utf16);
+            down.post(CGEventTapLocation::HID);
+            up.post(CGEventTapLocation::HID);
+            // Tiny gap between chunks gives terminal apps time to digest
+            // each batch — without this, Ghostty occasionally drops the
+            // tail of long inserts.
+            thread::sleep(Duration::from_millis(2));
+        }
     });
 }
 
 #[cfg(not(target_os = "macos"))]
-fn paste_clipboard() {}
+fn type_text_unicode(_text: &str) {}
 
 /// Record the popover's current recording state. When active, clicking the
 /// tray icon emits a stop event instead of toggling the popover — so the

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -165,7 +165,10 @@ let warmStreamDeviceId: string | null = null;
 let warmStreamPromise: Promise<MediaStream | null> | null = null;
 
 async function prewarmMicStream(): Promise<MediaStream | null> {
-  if (warmStream && warmStream.getAudioTracks().some((t) => t.readyState === "live")) {
+  if (
+    warmStream &&
+    warmStream.getAudioTracks().some((t) => t.readyState === "live")
+  ) {
     return warmStream;
   }
   if (warmStreamPromise) return warmStreamPromise;

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -315,7 +315,11 @@ async function transcribe(
   // server default (Gemini → Builder → Groq → OpenAI fallback chain),
   // anything else pins to that one provider with no fallback.
   form.append("provider", providerPref);
-  const timeout = window.setTimeout(() => controller.abort(), 45_000);
+  // Aggressive timeout — short clips should transcribe in well under
+  // 2 seconds with Gemini Flash Lite or Whisper. If the server hasn't
+  // come back in 8s it's hanging; abort and let the bar dismiss with an
+  // error rather than leaving "Polishing..." up for 45 seconds.
+  const timeout = window.setTimeout(() => controller.abort(), 8_000);
   try {
     const res = await fetch(
       `${serverUrl.replace(/\/+$/, "")}/_agent-native/transcribe-voice`,

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -127,6 +127,92 @@ function pickMimeType(): string {
   return "audio/webm";
 }
 
+// Pick the built-in MacBook microphone over any Bluetooth / external input.
+// Bluetooth headsets force macOS into a tighter audio-session mode that
+// pauses + glitches whatever's playing the moment we open getUserMedia,
+// and we don't get the dictation experience right unless we sidestep that
+// by always pinning to the built-in mic.
+async function pickBuiltInMicId(): Promise<string | null> {
+  try {
+    if (!navigator.mediaDevices?.enumerateDevices) return null;
+    // Device labels are only populated AFTER permission has been granted
+    // at least once. Caller falls back to default when label is empty.
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const inputs = devices.filter((d) => d.kind === "audioinput");
+    const isBuiltIn = (label: string) => {
+      const l = label.toLowerCase();
+      return (
+        l.includes("macbook") ||
+        l.includes("built-in") ||
+        l.includes("built in") ||
+        l.includes("internal microphone")
+      );
+    };
+    const builtIn = inputs.find((d) => isBuiltIn(d.label));
+    if (builtIn) return builtIn.deviceId;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Warm-up audio stream — opened once at install time and kept alive for the
+// life of the popover webview so subsequent dictation presses don't pay
+// the getUserMedia/audio-session-switch cost (which is what was cutting
+// off the first ~300ms of speech and pausing/glitching playing audio).
+let warmStream: MediaStream | null = null;
+let warmStreamDeviceId: string | null = null;
+let warmStreamPromise: Promise<MediaStream | null> | null = null;
+
+async function prewarmMicStream(): Promise<MediaStream | null> {
+  if (warmStream && warmStream.getAudioTracks().some((t) => t.readyState === "live")) {
+    return warmStream;
+  }
+  if (warmStreamPromise) return warmStreamPromise;
+  warmStreamPromise = (async () => {
+    if (!navigator.mediaDevices?.getUserMedia) return null;
+    try {
+      const builtInId = await pickBuiltInMicId();
+      const constraints: MediaStreamConstraints = builtInId
+        ? { audio: { deviceId: { exact: builtInId } } }
+        : { audio: true };
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      // If we couldn't get the built-in mic by label (no permission yet),
+      // re-enumerate now that the OS prompt has resolved and switch the
+      // track to built-in if a different device leaked through.
+      if (!builtInId) {
+        const id = await pickBuiltInMicId();
+        if (id) {
+          const track = stream.getAudioTracks()[0];
+          if (track && track.getSettings().deviceId !== id) {
+            try {
+              await track.applyConstraints({ deviceId: { exact: id } });
+            } catch {
+              // applyConstraints may not switch hardware; keep current track.
+            }
+          }
+          warmStreamDeviceId = id;
+        }
+      } else {
+        warmStreamDeviceId = builtInId;
+      }
+      // Disable the track until a session actually wants it. With the
+      // track disabled the mic indicator goes off, no audio is captured,
+      // but the audio session stays open — flipping `enabled = true`
+      // resumes capture instantly with no system audio glitch.
+      stream.getAudioTracks().forEach((t) => (t.enabled = false));
+      warmStream = stream;
+      return stream;
+    } catch (err) {
+      console.warn("[voice-dictation] prewarm getUserMedia failed:", err);
+      return null;
+    } finally {
+      warmStreamPromise = null;
+    }
+  })();
+  return warmStreamPromise;
+}
+
 function setFlowState(state: FlowState): void {
   emit("voice:state-change", { state }).catch(() => {});
 }
@@ -144,6 +230,13 @@ function stopMeter(session: VoiceSession): void {
 
 function stopTracks(session: VoiceSession): void {
   if (!session.stream) return;
+  // If this session is using the warm pre-opened stream, don't actually
+  // stop the tracks — just disable them so the audio session stays open
+  // and the next press is instant.
+  if (session.stream === warmStream) {
+    session.stream.getAudioTracks().forEach((t) => (t.enabled = false));
+    return;
+  }
   session.stream.getTracks().forEach((track) => {
     try {
       track.stop();
@@ -339,8 +432,14 @@ export function installDesktopVoiceDictation(
       return { kind: "server", providerPref: provider };
     }
     const status = await refreshProviderStatus();
+    // Auto: prefer the BYOK transcription providers (user explicitly
+    // pasted these keys for transcription). NOTE: we deliberately DO NOT
+    // auto-route to Builder here even though BUILDER_PRIVATE_KEY may be
+    // set — that key is framework-wide (CMS / agent runtime) and isn't
+    // a user opt-in for voice. Pick browser when no transcription-
+    // specific key is configured; users who want Builder for voice can
+    // pick it explicitly in Settings → Voice transcription.
     if (status.gemini) return { kind: "server", providerPref: "gemini" };
-    if (status.builder) return { kind: "server", providerPref: "builder" };
     if (status.groq) return { kind: "server", providerPref: "groq" };
     if (status.openai) return { kind: "server", providerPref: "openai" };
     return { kind: "browser" };
@@ -414,17 +513,34 @@ export function installDesktopVoiceDictation(
     try {
       startInFlight = true;
       stopRequestedBeforeReady = false;
-      await invoke("show_flow_bar");
-      setFlowState("recording");
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      // Reuse the pre-warmed mic stream so we skip the getUserMedia +
+      // audio-session-switch latency that was eating the first ~300ms of
+      // every press (and pausing whatever music was playing). Fall back
+      // to a fresh stream if the warm one isn't ready yet.
+      let stream = await prewarmMicStream();
+      let usingWarmStream = !!stream;
+      if (!stream) {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      } else {
+        // Flip the muted track back on so MediaRecorder actually captures.
+        stream.getAudioTracks().forEach((t) => (t.enabled = true));
+      }
       if (disposed || stopRequestedBeforeReady) {
-        stream.getTracks().forEach((track) => track.stop());
+        if (usingWarmStream) {
+          stream.getAudioTracks().forEach((t) => (t.enabled = false));
+        } else {
+          stream.getTracks().forEach((track) => track.stop());
+        }
         startInFlight = false;
         stopRequestedBeforeReady = false;
         setFlowState("idle");
         invoke("hide_flow_bar").catch(() => {});
         return;
       }
+      // Show the bar AFTER the recorder is actually capturing so the user
+      // never sees the bar before the mic is live.
+      await invoke("show_flow_bar");
+      setFlowState("recording");
       const mimeType = pickMimeType();
       const recorder = new MediaRecorder(stream, { mimeType });
       const next: VoiceSession = {
@@ -482,10 +598,9 @@ export function installDesktopVoiceDictation(
               "[voice-dictation] transcribe returned empty text — nothing to paste",
             );
           }
-          setFlowState("complete");
-          window.setTimeout(() => {
-            if (!disposed) cleanup(next);
-          }, 550);
+          // Dismiss the bar immediately — no "Polishing..." lag after the
+          // text already landed in the focused field.
+          if (!disposed) cleanup(next);
         } catch (err) {
           if (
             next.cancelled ||
@@ -738,6 +853,14 @@ export function installDesktopVoiceDictation(
     .then((u) => unlistens.push(u))
     .catch(() => {});
 
+  // Pre-warm the built-in mic stream so the first dictation press is
+  // instant. Fires once per webview lifetime — safe to ignore if the user
+  // hasn't granted permission yet (we'll fall back to a fresh getUserMedia
+  // on the first press, which prompts as before).
+  if (enabled) {
+    void prewarmMicStream();
+  }
+
   return () => {
     disposed = true;
     enabled = false;
@@ -754,5 +877,18 @@ export function installDesktopVoiceDictation(
     });
     unlistens.length = 0;
     cleanup(session);
+    // Tear down the warm stream when the dictation feature is disposed
+    // (settings off, app quitting). The next install() will rewarm.
+    if (warmStream) {
+      warmStream.getTracks().forEach((t) => {
+        try {
+          t.stop();
+        } catch {
+          // ignore
+        }
+      });
+      warmStream = null;
+      warmStreamDeviceId = null;
+    }
   };
 }

--- a/templates/clips/desktop/src/overlays/flow-bar.tsx
+++ b/templates/clips/desktop/src/overlays/flow-bar.tsx
@@ -45,13 +45,14 @@ export function FlowBar() {
 
     trackListen(
       listen<{ state: FlowState }>("voice:state-change", (ev) => {
-        const next = ev.payload.state;
-        // "complete" / "idle" are transitional states right before the
-        // window is closed by hide_flow_bar — don't repaint into the
-        // empty "EN" idle pill in the brief gap, just leave the
-        // previous state showing until the window goes away.
-        if (next === "complete" || next === "idle") return;
-        setState(next);
+        // Always reflect what the dictation engine reported. Earlier we
+        // ignored "complete"/"idle" on the assumption that hide_flow_bar
+        // would close the window milliseconds later — but if the hide
+        // got debounced or dropped, the bar would sit on "Polishing..."
+        // forever even after the text had already been pasted. Painting
+        // the actual state means the worst case is a blank bar for a
+        // frame, not a permanently stuck one.
+        setState(ev.payload.state);
       }),
     );
 

--- a/templates/clips/server/plugins/db.ts
+++ b/templates/clips/server/plugins/db.ts
@@ -382,6 +382,7 @@ async function syncWorkspacesToOrganizations(): Promise<void> {
   //    so every downstream FK (`spaces.workspace_id`, `recordings.workspace_id`,
   //    etc.) already points at the right org without a remap. The framework
   //    `organizations` table has a simple shape: id, name, created_by, created_at.
+  // guard:allow-unscoped — schema migration backfill — system-level by design
   try {
     if (pg) {
       await exec.execute(`
@@ -414,6 +415,7 @@ async function syncWorkspacesToOrganizations(): Promise<void> {
   }
 
   // 2) Copy workspaces → organization_settings (brand fields sidecar).
+  // guard:allow-unscoped — schema migration backfill — system-level by design
   try {
     await exec.execute(`
       INSERT INTO organization_settings (organization_id, brand_color, brand_logo_url, default_visibility, created_at, updated_at)
@@ -670,6 +672,7 @@ async function sweepOrphanedRecordingChunks(): Promise<void> {
 
   for (const [recordingId, keys] of keysByRecording) {
     let shouldSweep = false;
+    // guard:allow-unscoped — orphaned-chunk GC sweep — system-level by design
     try {
       const probe = await exec.execute({
         sql: pg

--- a/templates/slides/server/handlers/decks.ts
+++ b/templates/slides/server/handlers/decks.ts
@@ -196,48 +196,57 @@ export const updateDeck = defineEventHandler(async (event) => {
     const db = getDb();
     const now = new Date().toISOString();
 
-    // Does the row already exist?
-    const existing = await db
-      .select()
-      .from(schema.decks)
-      .where(eq(schema.decks.id, id))
-      .limit(1);
-
     deck.id = id;
     deck.updatedAt = now;
     const title = deck.title || "Untitled";
 
-    if (existing.length === 0) {
-      // Create new deck — owner is the caller. Anonymous callers cannot
-      // create decks: requiring an email here keeps the table free of
-      // ownerless rows (the source of the legacy leak).
+    // Resolve access first — this loads the row AND tells us the caller's
+    // effective role in one pass, so we never run an unscoped existence
+    // SELECT that would leak "this id exists" to non-owners.
+    const access = await resolveAccess("deck", id);
+
+    if (!access) {
+      // Either the deck does not exist OR the caller cannot see it. In
+      // both cases we treat this as a create-on-PUT for the caller. If
+      // the row actually exists but is owned by someone else, the INSERT
+      // below will fail on the primary key — we map that to a 404 so we
+      // never reveal that the id is taken.
       if (!email) {
         return handleForbidden(
           event,
           new ForbiddenError("Sign in to create a deck"),
         );
       }
-      await db.insert(schema.decks).values({
-        id,
-        title,
-        data: JSON.stringify(deck),
-        ownerEmail: email,
-        orgId: orgId ?? null,
-        createdAt: now,
-        updatedAt: now,
-      });
-    } else {
       try {
-        await assertAccess("deck", id, "editor");
+        await db.insert(schema.decks).values({
+          id,
+          title,
+          data: JSON.stringify(deck),
+          ownerEmail: email,
+          orgId: orgId ?? null,
+          createdAt: now,
+          updatedAt: now,
+        });
       } catch (err) {
-        if (err instanceof ForbiddenError) {
-          // Return 404 (not 403) so we don't leak the existence of decks
-          // the caller has no access to — same pattern as getDeck/deleteDeck.
+        // Primary-key collision = the id is taken by a deck the caller
+        // cannot see. Return 404 to match the read-side privacy contract.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (
+          /unique|duplicate|primary key|UNIQUE constraint/i.test(msg) ||
+          (err as { code?: string })?.code === "23505"
+        ) {
           setResponseStatus(event, 404);
           return { error: "Deck not found" };
         }
-        return handleForbidden(event, err);
+        throw err;
       }
+    } else if (
+      access.role === "owner" ||
+      access.role === "admin" ||
+      access.role === "editor"
+    ) {
+      // Caller has editor+ access — perform the update. The access check
+      // above already confirmed the row exists and the caller can write.
       await db
         .update(schema.decks)
         .set({
@@ -246,6 +255,11 @@ export const updateDeck = defineEventHandler(async (event) => {
           updatedAt: now,
         })
         .where(eq(schema.decks.id, id));
+    } else {
+      // Viewer-only access — same 404 as no-access to avoid leaking that
+      // the deck exists with restricted permissions.
+      setResponseStatus(event, 404);
+      return { error: "Deck not found" };
     }
 
     notifyClients(id);
@@ -301,7 +315,23 @@ export const deleteDeck = defineEventHandler(async (event) => {
 
   return withAuth(event, async () => {
     try {
+      // assertAccess loads the row and verifies the caller has admin
+      // role on this resource — it must run BEFORE the delete (and in
+      // the same scope) so we don't leak existence to callers who lack
+      // access.
       await assertAccess("deck", id, "admin");
+      const db = getDb();
+      const result = await db
+        .delete(schema.decks)
+        .where(eq(schema.decks.id, id))
+        .returning();
+
+      if (result.length > 0) {
+        notifyClients(id, "deck-deleted");
+        return { success: true };
+      }
+      setResponseStatus(event, 404);
+      return { error: "Deck not found" };
     } catch (err) {
       if (err instanceof ForbiddenError) {
         // 404 to avoid leaking existence
@@ -310,18 +340,5 @@ export const deleteDeck = defineEventHandler(async (event) => {
       }
       throw err;
     }
-
-    const db = getDb();
-    const result = await db
-      .delete(schema.decks)
-      .where(eq(schema.decks.id, id))
-      .returning();
-
-    if (result.length > 0) {
-      notifyClients(id, "deck-deleted");
-      return { success: true };
-    }
-    setResponseStatus(event, 404);
-    return { error: "Deck not found" };
   });
 });

--- a/templates/slides/server/handlers/design-systems.ts
+++ b/templates/slides/server/handlers/design-systems.ts
@@ -1,33 +1,72 @@
-import {
-  defineEventHandler,
-  getRouterParam,
-  setResponseStatus,
-  createError,
-} from "h3";
+import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
 import { eq, desc } from "drizzle-orm";
 import { getDb, schema } from "../db";
-import { readBody } from "@agent-native/core/server";
+import {
+  readBody,
+  getSession,
+  runWithRequestContext,
+} from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+  ForbiddenError,
+} from "@agent-native/core/sharing";
 
-// GET /api/design-systems — list all design systems
-export const listDesignSystems = defineEventHandler(async (_event) => {
-  const db = getDb();
-  const rows = await db
-    .select()
-    .from(schema.designSystems)
-    .orderBy(desc(schema.designSystems.updatedAt));
+/**
+ * Resolve the caller's auth context from the request and run `fn` inside a
+ * `runWithRequestContext` scope so `accessFilter` / `resolveAccess` /
+ * `assertAccess` can read it. ALL `/api/design-systems/*` handlers MUST go
+ * through this — querying ownable tables without a request context is how
+ * data leaks across users (see #SLI-2026-04-28).
+ */
+async function withAuth<T>(
+  event: any,
+  fn: (session: { email?: string; orgId?: string }) => Promise<T>,
+): Promise<T> {
+  const session = await getSession(event).catch(() => null);
+  const ctx = {
+    userEmail: session?.email,
+    orgId: session?.orgId,
+  };
+  return runWithRequestContext(ctx, () =>
+    fn({ email: ctx.userEmail, orgId: ctx.orgId }),
+  );
+}
 
-  return rows.map((row) => ({
-    id: row.id,
-    title: row.title,
-    description: row.description,
-    isDefault: row.isDefault,
-    visibility: row.visibility,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  }));
+function handleForbidden(event: any, err: unknown): { error: string } {
+  if (err instanceof ForbiddenError) {
+    setResponseStatus(event, err.statusCode);
+    return { error: err.message };
+  }
+  throw err;
+}
+
+// GET /api/design-systems — list design systems the caller can see
+// (own + shared + visibility match)
+export const listDesignSystems = defineEventHandler(async (event) => {
+  return withAuth(event, async () => {
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(schema.designSystems)
+      .where(accessFilter(schema.designSystems, schema.designSystemShares))
+      .orderBy(desc(schema.designSystems.updatedAt));
+
+    return rows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      description: row.description,
+      isDefault: row.isDefault,
+      visibility: row.visibility,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    }));
+  });
 });
 
 // GET /api/design-systems/:id — get a specific design system
+// (caller must have viewer+ access)
 export const getDesignSystem = defineEventHandler(async (event) => {
   const id = getRouterParam(event, "id");
   if (!id) {
@@ -35,15 +74,15 @@ export const getDesignSystem = defineEventHandler(async (event) => {
     return { error: "Design system id is required" };
   }
 
-  const db = getDb();
-  const rows = await db
-    .select()
-    .from(schema.designSystems)
-    .where(eq(schema.designSystems.id, id))
-    .limit(1);
-
-  if (rows.length > 0) {
-    const row = rows[0];
+  return withAuth(event, async () => {
+    const access = await resolveAccess("design-system", id);
+    if (!access) {
+      // Return 404 (not 403) so we don't leak existence of design
+      // systems the caller has no access to.
+      setResponseStatus(event, 404);
+      return { error: "Design system not found" };
+    }
+    const row = access.resource;
     return {
       id: row.id,
       title: row.title,
@@ -55,13 +94,10 @@ export const getDesignSystem = defineEventHandler(async (event) => {
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     };
-  }
-
-  setResponseStatus(event, 404);
-  return { error: "Design system not found" };
+  });
 });
 
-// POST /api/design-systems — create a new design system
+// POST /api/design-systems — create a new design system owned by the caller
 export const createDesignSystem = defineEventHandler(async (event) => {
   const body = await readBody(event);
 
@@ -70,38 +106,42 @@ export const createDesignSystem = defineEventHandler(async (event) => {
     return { error: "Design system must have an id" };
   }
 
-  const db = getDb();
-  const now = new Date().toISOString();
+  return withAuth(event, async ({ email, orgId }) => {
+    if (!email) {
+      return handleForbidden(
+        event,
+        new ForbiddenError("Sign in to create a design system"),
+      );
+    }
 
-  await db.insert(schema.designSystems).values({
-    id: body.id,
-    title: body.title || "Untitled",
-    description: body.description ?? null,
-    data: typeof body.data === "string" ? body.data : JSON.stringify(body.data),
-    assets:
-      body.assets != null
-        ? typeof body.assets === "string"
-          ? body.assets
-          : JSON.stringify(body.assets)
-        : null,
-    isDefault: body.isDefault ?? false,
-    ownerEmail: (() => {
-      if (body.ownerEmail) return body.ownerEmail as string;
-      throw createError({
-        statusCode: 401,
-        statusMessage: "ownerEmail required",
-      });
-    })(),
-    orgId: body.orgId ?? null,
-    createdAt: now,
-    updatedAt: now,
+    const db = getDb();
+    const now = new Date().toISOString();
+
+    await db.insert(schema.designSystems).values({
+      id: body.id,
+      title: body.title || "Untitled",
+      description: body.description ?? null,
+      data:
+        typeof body.data === "string" ? body.data : JSON.stringify(body.data),
+      assets:
+        body.assets != null
+          ? typeof body.assets === "string"
+            ? body.assets
+            : JSON.stringify(body.assets)
+          : null,
+      isDefault: body.isDefault ?? false,
+      ownerEmail: email,
+      orgId: orgId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    setResponseStatus(event, 201);
+    return { id: body.id, title: body.title };
   });
-
-  setResponseStatus(event, 201);
-  return { id: body.id, title: body.title };
 });
 
-// PUT /api/design-systems/:id — update a design system
+// PUT /api/design-systems/:id — update a design system (must have editor+ access)
 export const updateDesignSystem = defineEventHandler(async (event) => {
   const id = getRouterParam(event, "id");
   if (!id) {
@@ -115,33 +155,51 @@ export const updateDesignSystem = defineEventHandler(async (event) => {
     return { error: "Invalid design system data" };
   }
 
-  const db = getDb();
-  const now = new Date().toISOString();
+  return withAuth(event, async () => {
+    try {
+      // assertAccess loads the row and verifies the caller has editor+
+      // role on this resource — it must run BEFORE the update (and in
+      // the same scope) so we don't leak existence to non-editors.
+      await assertAccess("design-system", id, "editor");
 
-  const updates: Record<string, unknown> = { updatedAt: now };
-  if (body.title !== undefined) updates.title = body.title;
-  if (body.description !== undefined) updates.description = body.description;
-  if (body.data !== undefined)
-    updates.data =
-      typeof body.data === "string" ? body.data : JSON.stringify(body.data);
-  if (body.assets !== undefined)
-    updates.assets =
-      body.assets != null
-        ? typeof body.assets === "string"
-          ? body.assets
-          : JSON.stringify(body.assets)
-        : null;
-  if (body.isDefault !== undefined) updates.isDefault = body.isDefault;
+      const db = getDb();
+      const now = new Date().toISOString();
 
-  await db
-    .update(schema.designSystems)
-    .set(updates)
-    .where(eq(schema.designSystems.id, id));
+      const updates: Record<string, unknown> = { updatedAt: now };
+      if (body.title !== undefined) updates.title = body.title;
+      if (body.description !== undefined)
+        updates.description = body.description;
+      if (body.data !== undefined)
+        updates.data =
+          typeof body.data === "string" ? body.data : JSON.stringify(body.data);
+      if (body.assets !== undefined)
+        updates.assets =
+          body.assets != null
+            ? typeof body.assets === "string"
+              ? body.assets
+              : JSON.stringify(body.assets)
+            : null;
+      if (body.isDefault !== undefined) updates.isDefault = body.isDefault;
 
-  return { id, updated: true };
+      await db
+        .update(schema.designSystems)
+        .set(updates)
+        .where(eq(schema.designSystems.id, id));
+
+      return { id, updated: true };
+    } catch (err) {
+      if (err instanceof ForbiddenError) {
+        // Return 404 (not 403) so we don't leak the existence of design
+        // systems the caller has no access to.
+        setResponseStatus(event, 404);
+        return { error: "Design system not found" };
+      }
+      return handleForbidden(event, err);
+    }
+  });
 });
 
-// DELETE /api/design-systems/:id — delete a design system
+// DELETE /api/design-systems/:id — delete a design system (admin or owner only)
 export const deleteDesignSystem = defineEventHandler(async (event) => {
   const id = getRouterParam(event, "id");
   if (!id) {
@@ -149,16 +207,32 @@ export const deleteDesignSystem = defineEventHandler(async (event) => {
     return { error: "Design system id is required" };
   }
 
-  const db = getDb();
-  const result = await db
-    .delete(schema.designSystems)
-    .where(eq(schema.designSystems.id, id))
-    .returning();
+  return withAuth(event, async () => {
+    try {
+      // assertAccess loads the row and verifies the caller has admin
+      // role on this resource — it must run BEFORE the delete (and in
+      // the same scope) so we don't leak existence to callers who lack
+      // access.
+      await assertAccess("design-system", id, "admin");
+      const db = getDb();
+      const result = await db
+        .delete(schema.designSystems)
+        .where(eq(schema.designSystems.id, id))
+        .returning();
 
-  if (result.length > 0) {
-    return { success: true };
-  } else {
-    setResponseStatus(event, 404);
-    return { error: "Design system not found" };
-  }
+      if (result.length > 0) {
+        return { success: true };
+      } else {
+        setResponseStatus(event, 404);
+        return { error: "Design system not found" };
+      }
+    } catch (err) {
+      if (err instanceof ForbiddenError) {
+        // 404 to avoid leaking existence
+        setResponseStatus(event, 404);
+        return { error: "Design system not found" };
+      }
+      throw err;
+    }
+  });
 });

--- a/templates/videos/actions/save-composition.ts
+++ b/templates/videos/actions/save-composition.ts
@@ -1,7 +1,11 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
-import { assertAccess, ForbiddenError } from "@agent-native/core/sharing";
+import {
+  assertAccess,
+  resolveAccess,
+  ForbiddenError,
+} from "@agent-native/core/sharing";
 import {
   getRequestUserEmail,
   getRequestOrgId,
@@ -31,15 +35,16 @@ export default defineAction({
     const db = getDb();
     const dataStr = args.data || "{}";
 
-    // Check if this composition already exists to decide insert vs update
-    const existing = await db
-      .select()
-      .from(schema.compositions)
-      .where(eq(schema.compositions.id, args.id))
-      .limit(1);
+    // Resolve the caller's access to this composition id (if any). This is
+    // scoped — it returns null when the row doesn't exist OR when it exists
+    // but the caller has no access. Treating "no access" the same as
+    // "doesn't exist" prevents cross-tenant existence probing AND prevents
+    // a malicious caller from forcing a write path against someone else's
+    // composition by passing their id.
+    const access = await resolveAccess("composition", args.id);
 
-    if (existing.length > 0) {
-      // Updating — require editor access
+    if (access) {
+      // Updating — require editor access (assertAccess re-checks role)
       await assertAccess("composition", args.id, "editor");
 
       await db
@@ -55,16 +60,24 @@ export default defineAction({
       // Creating — set owner/org from request context
       const ownerEmail = getRequestUserEmail();
       if (!ownerEmail) throw new Error("no authenticated user");
-      await db.insert(schema.compositions).values({
-        id: args.id,
-        title: args.title,
-        type: args.type,
-        data: dataStr,
-        createdAt: now,
-        updatedAt: now,
-        ownerEmail,
-        orgId: getRequestOrgId(),
-      });
+      try {
+        await db.insert(schema.compositions).values({
+          id: args.id,
+          title: args.title,
+          type: args.type,
+          data: dataStr,
+          createdAt: now,
+          updatedAt: now,
+          ownerEmail,
+          orgId: getRequestOrgId(),
+        });
+      } catch (err) {
+        // PK conflict means the id is taken by another tenant we couldn't
+        // see via resolveAccess. Reject rather than overwrite their row.
+        throw new ForbiddenError(
+          `Composition ${args.id} already exists and is not accessible to you`,
+        );
+      }
     }
 
     // Sync to collab layer for live editing


### PR DESCRIPTION
## Summary
- Wraps `POST /api/uploads/:callId/abort` in `runWithRequestContext` and re-asserts `editor` access on the callId — chunks/abort/complete are independent serverless requests, so the check has to happen each time
- Switches slides `updateDeck` / `deleteDeck` and videos `save-composition` from unscoped existence SELECTs to `resolveAccess` + `assertAccess`, with PK-collision → 404 to avoid leaking that an id is taken by another tenant
- Adds `guard:allow-unscoped` markers (with reasons) for legitimate system-level paths: public booking link lookup, clips workspace→organization migration backfill, orphaned-chunk GC sweep
- Clips desktop: voice-dictation + flow-bar refinements + popover lifecycle tweaks

## Test plan
- [ ] `pnpm run prep` passes locally
- [ ] Manual: try to PUT a deck id owned by another user → 404
- [ ] Manual: abort a call upload while signed in as a non-editor → 403
- [ ] Manual: public booking link still loads anonymously