### PR TITLE
Fix "Builder keys not configured" and duplicate paste bug

### DIFF
--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -642,7 +642,16 @@ export function TiptapComposer({
 
         event.preventDefault();
         void Promise.all(
-          files.map((file) => composerRuntime.addAttachment(file)),
+          files.map((file) => {
+            // SimpleImageAttachmentAdapter uses file.name as the attachment id.
+            // Clipboard images (e.g. screenshots) are typically all named
+            // "image.png", so a second paste would replace the first instead of
+            // appending. Prepend a unique token so each paste gets a distinct id.
+            const uniqueName = `${Date.now()}-${Math.random().toString(36).slice(2)}-${file.name}`;
+            return composerRuntime.addAttachment(
+              new File([file], uniqueName, { type: file.type }),
+            );
+          }),
         ).catch((error) => {
           console.error("Error adding pasted attachment:", error);
         });

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -571,32 +571,40 @@ export function createCoreRoutesPlugin(
           return { error: "A signed-in user is required to run Builder" };
         }
         const userEmail = session.email;
-        const { resolveBuilderCredential: resolveBuilderCred } =
-          await import("./credential-provider.js");
-        const builderUserId =
-          (await resolveBuilderCred("BUILDER_USER_ID")) || undefined;
-        // Server-controlled projectId — don't let clients target arbitrary
-        // Builder projects with our private key. When this feature graduates
-        // past the hardcoded preview, the projectId will come from
-        // workspace/org config, still resolved server-side.
-        try {
-          const result = await runBuilderAgent({
-            prompt,
-            projectId: DEFAULT_BUILDER_PROJECT_ID,
-            branchName:
-              typeof body?.branchName === "string"
-                ? body.branchName
-                : undefined,
-            userEmail,
-            userId: builderUserId,
-          });
-          return result;
-        } catch (e) {
-          setResponseStatus(event, 500);
-          return {
-            error: e instanceof Error ? e.message : "Builder run failed",
-          };
-        }
+        // Wrap in runWithRequestContext so resolveBuilderCredential() inside
+        // runBuilderAgent() resolves per-user app_secrets rather than falling
+        // through to process.env — the same pattern the /builder/status endpoint
+        // uses. Without this, per-user Builder keys stored in app_secrets are
+        // invisible to the run path and the call throws "Builder keys are not
+        // configured" even though the status endpoint correctly reports configured=true.
+        return runWithRequestContext({ userEmail }, async () => {
+          const { resolveBuilderCredential: resolveBuilderCred } =
+            await import("./credential-provider.js");
+          const builderUserId =
+            (await resolveBuilderCred("BUILDER_USER_ID")) || undefined;
+          // Server-controlled projectId — don't let clients target arbitrary
+          // Builder projects with our private key. When this feature graduates
+          // past the hardcoded preview, the projectId will come from
+          // workspace/org config, still resolved server-side.
+          try {
+            const result = await runBuilderAgent({
+              prompt,
+              projectId: DEFAULT_BUILDER_PROJECT_ID,
+              branchName:
+                typeof body?.branchName === "string"
+                  ? body.branchName
+                  : undefined,
+              userEmail,
+              userId: builderUserId,
+            });
+            return result;
+          } catch (e) {
+            setResponseStatus(event, 500);
+            return {
+              error: e instanceof Error ? e.message : "Builder run failed",
+            };
+          }
+        });
       }),
     );
 


### PR DESCRIPTION
### Summary
Fixes two bugs: Builder API keys appearing unconfigured on the run path despite being correctly set, and pasted clipboard screenshots replacing each other instead of appending in the composer.

### Problem
1. **Builder keys not configured**: The `/builder/run` endpoint was resolving credentials outside of `runWithRequestContext`, causing per-user `app_secrets` keys to be invisible. The status endpoint correctly reported `configured=true`, but the run path threw "Builder keys are not configured" because it fell through to `process.env` instead of reading per-user secrets.
2. **Duplicate paste replacement**: When pasting multiple clipboard screenshots (e.g. `image.png`), each image shared the same filename. Since `SimpleImageAttachmentAdapter` uses `file.name` as the attachment ID, each new paste replaced the previous one instead of appending.

### Solution
1. Wrapped the Builder run handler in `runWithRequestContext({ userEmail }, ...)` — the same pattern already used by the `/builder/status` endpoint — so per-user credential resolution works correctly on the run path.
2. Prepend a unique token (`Date.now()` + random string) to the filename of each pasted file before calling `addAttachment`, ensuring every paste gets a distinct attachment ID.

### Key Changes
- **`core-routes-plugin.ts`**: Wrapped the `/builder/run` handler body in `runWithRequestContext` so `resolveBuilderCredential()` correctly resolves per-user `app_secrets` instead of falling back to `process.env`.
- **`TiptapComposer.tsx`**: On paste, each file is wrapped in a new `File` object with a unique name prefix (`${Date.now()}-${random}-${file.name}`) to prevent ID collisions when multiple clipboard images share the same filename.


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/frozen-track-dntta4xi"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-frozen-track-dntta4xi_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

💬 [View Slack Thread](https://slack.com/app_redirect?team=T0GCV21GE&channel=C0ATH3CCZT4&message_ts=1777555160.763289)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 375`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>frozen-track-dntta4xi</branchName>-->