### PR TITLE
Clips desktop: native macOS dictation, browser-default voice, flow-bar polish

### DIFF
--- a/packages/core/docs/content/cloneable-saas.md
+++ b/packages/core/docs/content/cloneable-saas.md
@@ -15,21 +15,19 @@ We call them **cloneable SaaS**, not templates. You're not starting from scratch
 
 Each one is a real app you could use today, and the launching pad for your own version of it.
 
-| Template       | What it is                                                                                                |
-| -------------- | --------------------------------------------------------------------------------------------------------- |
-| **Mail**       | An agent-native Superhuman. Inbox, labels, AI triage, keyboard-first, drafts and sends through the agent. |
-| **Calendar**   | An agent-native Google Calendar. Events, sync, public booking links, agent-driven scheduling.             |
-| **Content**    | An agent-native Notion / Google Docs. Markdown + Tiptap editor, Notion sync, real-time multi-user collab. |
-| **Slides**     | An agent-native Google Slides. React-based decks the agent generates and edits directly.                  |
-| **Video**      | An agent-native video editor on Remotion. Prompt for a cut, the agent assembles it.                       |
-| **Analytics**  | An agent-native Amplitude/Mixpanel. Connect data sources, prompt for charts, pin to dashboards.           |
-| **Forms**      | An agent-native Typeform. Build, share, and collect; the agent handles schema and submission analysis.    |
-| **Issues**     | An agent-native Jira. Projects, issues, priorities, with the agent as your project manager.               |
-| **Recruiting** | An agent-native Greenhouse. Candidate pipelines, scoring, outreach drafts.                                |
-| **Dispatch**   | The workspace control plane: shared secrets, cross-app integrations, Slack/Telegram, scheduled jobs.      |
-| **Starter**    | The minimal scaffold. Agent chat plus the architecture, nothing else. Build something new.                |
-
-More are in active development: **Clips** (screen recording + transcription), **Calls** (Gong-style conversation intelligence), and **Scheduling** (a standalone scheduling app).
+| Template      | What it is                                                                                                |
+| ------------- | --------------------------------------------------------------------------------------------------------- |
+| **Mail**      | An agent-native Superhuman. Inbox, labels, AI triage, keyboard-first, drafts and sends through the agent. |
+| **Calendar**  | An agent-native Google Calendar. Events, sync, public booking links, agent-driven scheduling.             |
+| **Content**   | An agent-native Notion / Google Docs. Markdown + Tiptap editor, Notion sync, real-time multi-user collab. |
+| **Slides**    | An agent-native Google Slides. React-based decks the agent generates and edits directly.                  |
+| **Video**     | An agent-native video editor on Remotion. Prompt for a cut, the agent assembles it.                       |
+| **Analytics** | An agent-native Amplitude/Mixpanel. Connect data sources, prompt for charts, pin to dashboards.           |
+| **Clips**     | An agent-native Loom. Async screen + camera recording with transcription, chapters, AI summaries.         |
+| **Design**    | An agent-native Figma/Canva. Vector design tool the agent can edit alongside you.                         |
+| **Forms**     | An agent-native Typeform. Build, share, and collect; the agent handles schema and submission analysis.    |
+| **Dispatch**  | The workspace control plane: shared secrets, cross-app integrations, Slack/Telegram, scheduled jobs.      |
+| **Starter**   | The minimal scaffold. Agent chat plus the architecture, nothing else. Build something new.                |
 
 See the full catalog under [Templates](/templates), or jump straight to one — for example, [Dispatch](/docs/template-dispatch) is a great place to start if you want a workspace-style app.
 

--- a/packages/core/docs/content/faq.md
+++ b/packages/core/docs/content/faq.md
@@ -66,7 +66,10 @@ The framework ships with production-ready templates you can use as daily drivers
 - **[Slides](/templates/slides)** — presentation builder
 - **[Video](/templates/video)** — video composition with Remotion
 - **[Analytics](/templates/analytics)** — data platform (like Amplitude/Mixpanel)
-- **[Forms](/templates/forms)**, **[Issues](/templates/issues)**, **[Recruiting](/templates/recruiting)**, and the **[Dispatch](/docs/template-dispatch)** workspace control plane.
+- **[Clips](/templates/clips)** — async screen + camera recording (replaces Loom)
+- **[Design](/templates/design)** — agent-native design tool (like Figma/Canva)
+- **[Forms](/templates/forms)** — form builder (like Typeform)
+- **[Dispatch](/templates/dispatch)** — workspace control plane: shared secrets, integrations, jobs
 
 Each template is a complete app with UI, agent actions, database schema, and AI instructions. See [Cloneable SaaS](/docs/cloneable-saas) for the full picture, or all [Templates](/templates).
 

--- a/packages/core/docs/content/getting-started.md
+++ b/packages/core/docs/content/getting-started.md
@@ -63,6 +63,8 @@ Each template is a complete app with UI, agent actions, database schema, and AI 
 | [Slides](/templates/slides)         | Google Slides, Pitch                             |
 | [Video](/templates/video)           | video editing                                    |
 | [Analytics](/templates/analytics)   | Amplitude, Mixpanel, Looker                      |
+| [Clips](/templates/clips)           | Replaces Loom — screen + camera recording        |
+| [Design](/templates/design)         | Figma, Canva                                     |
 | [Forms](/docs/template-forms)       | Typeform                                         |
 | [Dispatch](/docs/template-dispatch) | Workspace control plane — secrets, routing, jobs |
 | [Starter](/docs/template-starter)   | Minimal scaffold — build from scratch            |

--- a/packages/docs/public/docs/getting-started.md
+++ b/packages/docs/public/docs/getting-started.md
@@ -29,14 +29,18 @@ From here, use your AI coding tool (Claude Code, Cursor, Windsurf, etc.) to cust
 
 Each template is a complete app with UI, agent actions, database schema, and AI instructions ready to go:
 
-| Template                          | Replaces                    |
-| --------------------------------- | --------------------------- |
-| [Mail](/templates/mail)           | Superhuman, Gmail           |
-| [Calendar](/templates/calendar)   | Google Calendar, Calendly   |
-| [Content](/templates/content)     | Notion, Google Docs         |
-| [Slides](/templates/slides)       | Google Slides, Pitch        |
-| [Video](/templates/video)         | video editing               |
-| [Analytics](/templates/analytics) | Amplitude, Mixpanel, Looker |
+| Template                          | Replaces                                |
+| --------------------------------- | --------------------------------------- |
+| [Mail](/templates/mail)           | Superhuman, Gmail                       |
+| [Calendar](/templates/calendar)   | Google Calendar, Calendly               |
+| [Content](/templates/content)     | Notion, Google Docs                     |
+| [Slides](/templates/slides)       | Google Slides, Pitch                    |
+| [Video](/templates/video)         | video editing                           |
+| [Analytics](/templates/analytics) | Amplitude, Mixpanel, Looker             |
+| [Clips](/templates/clips)         | Loom — screen + camera recording        |
+| [Design](/templates/design)       | Figma, Canva                            |
+| [Forms](/templates/forms)         | Typeform                                |
+| [Dispatch](/templates/dispatch)   | Workspace control plane — secrets, jobs |
 
 Browse the [template gallery](/templates) for live demos and detailed feature lists.
 

--- a/templates/clips/desktop/src-tauri/Cargo.lock
+++ b/templates/clips/desktop/src-tauri/Cargo.lock
@@ -475,9 +475,13 @@ dependencies = [
 name = "clips-tray"
 version = "0.1.1"
 dependencies = [
+ "block2",
  "core-foundation",
  "core-graphics",
  "objc2",
+ "objc2-avf-audio",
+ "objc2-foundation",
+ "objc2-speech",
  "serde",
  "serde_json",
  "tauri",
@@ -2358,6 +2362,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-audio-toolbox",
+ "objc2-core-audio-types",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2430,33 @@ dependencies = [
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-media"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-core-video",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-io-surface",
 ]
 
@@ -2441,6 +2520,19 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-speech"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9eb609f9d2a25e0f8b76954f3acaa58348ce2a91285fe867643b2224ac4d263"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-avf-audio",
+ "objc2-core-media",
  "objc2-foundation",
 ]
 

--- a/templates/clips/desktop/src-tauri/Cargo.toml
+++ b/templates/clips/desktop/src-tauri/Cargo.toml
@@ -48,6 +48,35 @@ url = "2"
 core-foundation = "0.10"
 core-graphics = "0.25"
 objc2 = "0.6"
+# Native on-device dictation via SFSpeechRecognizer + AVAudioEngine.
+# Powers the "browser" voice-dictation provider (free, instant, no API
+# key, no server round-trip — same engine WisprFlow uses for offline).
+objc2-foundation = { version = "0.3", features = [
+  "NSString",
+  "NSError",
+  "NSLocale",
+  "NSURL",
+  "NSValue",
+] }
+objc2-speech = { version = "0.3", features = [
+  "SFSpeechRecognizer",
+  "SFSpeechRecognitionRequest",
+  "SFSpeechRecognitionResult",
+  "SFSpeechRecognitionTask",
+  "SFTranscription",
+  "SFTranscriptionSegment",
+  "SFErrors",
+] }
+objc2-avf-audio = { version = "0.3", features = [
+  "AVAudioEngine",
+  "AVAudioFormat",
+  "AVAudioIONode",
+  "AVAudioNode",
+  "AVAudioBuffer",
+  "AVAudioSession",
+  "block2",
+] }
+block2 = "0.6"
 
 [profile.release]
 panic = "abort"

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -518,8 +518,11 @@ pub async fn show_flow_bar(app: AppHandle) -> Result<(), String> {
     dlog!("[clips-tray] show_flow_bar invoked");
 
     let (mw, mh) = primary_monitor_physical_size(&app).unwrap_or((2880, 1800));
-    let w: u32 = 400;
-    let h: u32 = 120;
+    // Wider + taller than the pill alone so the live transcript chip
+    // can stack above it. Height accommodates: bottom-anchored 32px pill
+    // + 6px gap + ~28px transcript chip + drop-shadow margin.
+    let w: u32 = 800;
+    let h: u32 = 180;
     let x: i32 = ((mw as i32 - w as i32) / 2).max(0);
     // Bottom margin: ~14 logical px ≈ 28 physical px, matching Wispr Flow.
     let y: i32 = (mh as i32 - h as i32 - 28).max(0);

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -137,7 +137,11 @@ export function App() {
     return saved === "toggle" ? "toggle" : "push-to-talk";
   });
   const [voiceProvider, setVoiceProvider] = useState<VoiceProvider>(() => {
-    const saved = loadString(VOICE_PROVIDER_KEY, "auto");
+    // Default to "browser" — local on-device dictation via the macOS
+    // Speech framework. No server round-trip, no "Polishing..." step,
+    // no API keys. Users wanting cloud-quality can pick a server
+    // provider in Settings → Voice transcription.
+    const saved = loadString(VOICE_PROVIDER_KEY, "browser");
     return saved === "auto" ||
       saved === "browser" ||
       saved === "builder" ||
@@ -145,7 +149,7 @@ export function App() {
       saved === "openai" ||
       saved === "groq"
       ? saved
-      : "auto";
+      : "browser";
   });
 
   const [recordings, setRecordings] = useState<RecordingSummary[]>([]);

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -730,10 +730,15 @@ export function installDesktopVoiceDictation(
             interim += r[0].transcript;
           }
         }
-        next.browserTranscript = finalSoFar;
-        const live = (finalSoFar + interim).trim();
+        // Include interim in browserTranscript so an abort() in stop()
+        // captures the words the user just said — without it we'd lose
+        // the tail because Web Speech only marks a segment as `isFinal`
+        // after a confidence-threshold pass.
+        next.browserTranscript = (finalSoFar + interim).trim();
         // Stream the live transcript to the flow-bar.
-        emit("voice:partial-transcript", { text: live }).catch(() => {});
+        emit("voice:partial-transcript", {
+          text: next.browserTranscript,
+        }).catch(() => {});
       };
       recognition.onerror = (ev) => {
         if (ev.error !== "no-speech" && ev.error !== "aborted") {
@@ -875,10 +880,41 @@ export function installDesktopVoiceDictation(
       if (current.kind === "server") {
         current.recorder?.stop();
       } else {
-        // recognition.stop() lets pending interim results finalize
-        // before firing onend (where we paste). abort() would discard
-        // them — we want stop().
-        current.recognition?.stop();
+        // BROWSER PATH: dismiss the bar IMMEDIATELY and paste whatever
+        // transcript we have right now. recognition.stop() / .abort()
+        // can take 1-5 seconds to fire onend in WKWebView — we don't
+        // want the user staring at a stuck bar that long. We tracked
+        // interim results in browserTranscript above, so the latest
+        // spoken text is captured. Null out browserTranscript before
+        // calling abort() so the late onend doesn't double-paste.
+        const text = current.browserTranscript.trim();
+        current.browserTranscript = "";
+        if (session === current) session = null;
+        startInFlight = false;
+        stopRequestedBeforeReady = false;
+        setFlowState("idle");
+        invoke("hide_flow_bar").catch(() => {});
+        emit("voice:partial-transcript", { text: "" }).catch(() => {});
+        try {
+          current.recognition?.abort();
+        } catch {
+          // ignore
+        }
+        stopMeter(current);
+        stopTracks(current);
+        if (text) {
+          console.log(
+            `[voice-dictation] pasting on Fn release (${text.length} chars):`,
+            text.slice(0, 120),
+          );
+          invoke("complete_voice_dictation", { text }).catch((err) => {
+            console.error("[voice-dictation] paste failed:", err);
+          });
+        } else {
+          console.warn(
+            "[voice-dictation] no transcript captured — recognition didn't produce results",
+          );
+        }
       }
     } catch (err) {
       console.error("[voice-dictation] stop failed", err);

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -661,6 +661,10 @@ export function installDesktopVoiceDictation(
       await startServer("auto");
       return;
     }
+    // Hoisted so the catch handler can close it if either invoke()
+    // or recognition.start() throws before `session = next` runs.
+    // Cleared after the success path takes ownership via `session.stream`.
+    let stream: MediaStream | null = null;
     try {
       startInFlight = true;
       stopRequestedBeforeReady = false;
@@ -668,7 +672,7 @@ export function installDesktopVoiceDictation(
       // Web Speech API doesn't expose its own buffers; without this we
       // were faking the bars with a synthetic sine. The recognition engine
       // has its own independent audio path so the two coexist fine.
-      const stream = await navigator.mediaDevices.getUserMedia({
+      stream = await navigator.mediaDevices.getUserMedia({
         audio: true,
       });
       if (disposed || stopRequestedBeforeReady) {
@@ -780,6 +784,9 @@ export function installDesktopVoiceDictation(
         cleanup(next);
       };
       session = next;
+      // `next` now owns the stream; clear our hoisted reference so the
+      // catch handler doesn't double-close it on a later throw.
+      stream = null;
       startInFlight = false;
       // Real audio meter from the mic stream.
       startMeter(next);
@@ -788,6 +795,10 @@ export function installDesktopVoiceDictation(
         console.log("[voice-dictation] recognition.start() returned");
       } catch (err) {
         console.error("[voice-dictation] recognition.start threw:", err);
+        // Recognition failed after we handed the stream to `next` — close
+        // it through the session so we don't leak the mic.
+        stopTracks(next);
+        if (session === next) session = null;
         throw err;
       }
       if (stopRequestedBeforeReady) {
@@ -797,6 +808,20 @@ export function installDesktopVoiceDictation(
       console.error("[voice-dictation] startBrowser failed", err);
       startInFlight = false;
       stopRequestedBeforeReady = false;
+      // Close the mic stream if we opened it but never reached the
+      // success path (covers the show_flow_bar throw case before
+      // `session = next` ran). After session takes ownership, `stream`
+      // is reset to null so we don't double-close.
+      if (stream) {
+        stream.getTracks().forEach((t) => {
+          try {
+            t.stop();
+          } catch {
+            // ignore
+          }
+        });
+        stream = null;
+      }
       // See note in startServer's catch — clear leaked session so the
       // next Fn press isn't blocked on a stale `if (session) return`.
       session = null;

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -707,9 +707,8 @@ export function installDesktopVoiceDictation(
       // Lifecycle diagnostics — when something silently fails (common in
       // WKWebView Web Speech), missing logs tell us exactly which stage
       // is broken. Cheap to keep enabled.
-      (
-        recognition as unknown as { onstart: (() => void) | null }
-      ).onstart = () => console.log("[voice-dictation] recognition.onstart");
+      (recognition as unknown as { onstart: (() => void) | null }).onstart =
+        () => console.log("[voice-dictation] recognition.onstart");
       (
         recognition as unknown as { onaudiostart: (() => void) | null }
       ).onaudiostart = () =>
@@ -742,12 +741,12 @@ export function installDesktopVoiceDictation(
       };
       recognition.onerror = (ev) => {
         if (ev.error !== "no-speech" && ev.error !== "aborted") {
-          console.warn(
-            "[voice-dictation] recognition error:",
+          console.warn("[voice-dictation] recognition error:", ev.error);
+        } else {
+          console.log(
+            "[voice-dictation] recognition error (benign):",
             ev.error,
           );
-        } else {
-          console.log("[voice-dictation] recognition error (benign):", ev.error);
         }
       };
       recognition.onend = async () => {

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -652,21 +652,37 @@ export function installDesktopVoiceDictation(
    * the "Polishing..." state entirely.
    */
   const startBrowser = async () => {
+    console.log("[voice-dictation] startBrowser: opening mic + recognition");
     const Ctor = getSpeechRecognitionCtor();
     if (!Ctor) {
       console.error(
-        "[voice-dictation] webkitSpeechRecognition unavailable — falling back to server path",
+        "[voice-dictation] webkitSpeechRecognition unavailable — falling back to server",
       );
-      // Force a server attempt as a last resort. If that fails too, the
-      // user gets the "no provider" error in the bar.
       await startServer("auto");
       return;
     }
     try {
       startInFlight = true;
       stopRequestedBeforeReady = false;
+      // Open a real mic stream so the waveform shows actual audio levels.
+      // Web Speech API doesn't expose its own buffers; without this we
+      // were faking the bars with a synthetic sine. The recognition engine
+      // has its own independent audio path so the two coexist fine.
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+      });
+      if (disposed || stopRequestedBeforeReady) {
+        stream.getTracks().forEach((t) => t.stop());
+        startInFlight = false;
+        stopRequestedBeforeReady = false;
+        setFlowState("idle");
+        invoke("hide_flow_bar").catch(() => {});
+        return;
+      }
       await invoke("show_flow_bar");
       setFlowState("recording");
+      // Reset any prior partial transcript display in the flow-bar.
+      emit("voice:partial-transcript", { text: "" }).catch(() => {});
       const recognition = new Ctor();
       recognition.continuous = true;
       recognition.interimResults = true;
@@ -674,7 +690,7 @@ export function installDesktopVoiceDictation(
       recognition.maxAlternatives = 1;
       const next: VoiceSession = {
         kind: "browser",
-        stream: null,
+        stream,
         recorder: null,
         chunks: [],
         audioContext: null,
@@ -688,29 +704,59 @@ export function installDesktopVoiceDictation(
         transcribeAbort: null,
         cancelled: false,
       };
+      // Lifecycle diagnostics — when something silently fails (common in
+      // WKWebView Web Speech), missing logs tell us exactly which stage
+      // is broken. Cheap to keep enabled.
+      (
+        recognition as unknown as { onstart: (() => void) | null }
+      ).onstart = () => console.log("[voice-dictation] recognition.onstart");
+      (
+        recognition as unknown as { onaudiostart: (() => void) | null }
+      ).onaudiostart = () =>
+        console.log("[voice-dictation] recognition.onaudiostart");
+      (
+        recognition as unknown as { onspeechstart: (() => void) | null }
+      ).onspeechstart = () =>
+        console.log("[voice-dictation] recognition.onspeechstart");
       recognition.onresult = (ev) => {
-        for (let i = ev.resultIndex; i < ev.results.length; i++) {
+        // Build current full text (final segments + latest interim).
+        let finalSoFar = "";
+        let interim = "";
+        for (let i = 0; i < ev.results.length; i++) {
           const r = ev.results[i];
           if (r.isFinal) {
-            next.browserTranscript += r[0].transcript;
+            finalSoFar += r[0].transcript;
+          } else {
+            interim += r[0].transcript;
           }
         }
+        next.browserTranscript = finalSoFar;
+        const live = (finalSoFar + interim).trim();
+        // Stream the live transcript to the flow-bar.
+        emit("voice:partial-transcript", { text: live }).catch(() => {});
       };
       recognition.onerror = (ev) => {
-        // "no-speech" / "aborted" are normal in push-to-talk; only log
-        // the genuinely unexpected ones.
         if (ev.error !== "no-speech" && ev.error !== "aborted") {
           console.warn(
-            "[voice-dictation] webkitSpeechRecognition error:",
+            "[voice-dictation] recognition error:",
             ev.error,
           );
+        } else {
+          console.log("[voice-dictation] recognition error (benign):", ev.error);
         }
       };
       recognition.onend = async () => {
+        console.log("[voice-dictation] recognition.onend");
         stopMeter(next);
+        stopTracks(next);
         if (session === next) session = null;
         const text = next.browserTranscript.trim();
         if (disposed || next.cancelled || !text) {
+          console.log(
+            "[voice-dictation] no usable text on onend (cancelled/empty)",
+          );
+          // Clear the live transcript display.
+          emit("voice:partial-transcript", { text: "" }).catch(() => {});
           cleanup(next);
           return;
         }
@@ -726,14 +772,20 @@ export function installDesktopVoiceDictation(
             err,
           );
         }
-        // No "Polishing..." for the browser path — text is already final
-        // when onend fires. Just dismiss.
+        emit("voice:partial-transcript", { text: "" }).catch(() => {});
         cleanup(next);
       };
       session = next;
       startInFlight = false;
-      startSyntheticMeter(next);
-      recognition.start();
+      // Real audio meter from the mic stream.
+      startMeter(next);
+      try {
+        recognition.start();
+        console.log("[voice-dictation] recognition.start() returned");
+      } catch (err) {
+        console.error("[voice-dictation] recognition.start threw:", err);
+        throw err;
+      }
       if (stopRequestedBeforeReady) {
         stop();
       }

--- a/templates/clips/desktop/src/overlays/flow-bar.tsx
+++ b/templates/clips/desktop/src/overlays/flow-bar.tsx
@@ -21,6 +21,7 @@ export function FlowBar() {
   // "idle" caused the bar to flash an "EN" language pill that never went
   // away if the start event was missed.
   const [state, setState] = useState<FlowState>("recording");
+  const [partialTranscript, setPartialTranscript] = useState("");
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const levelRef = useRef(0);
   const rafRef = useRef<number | null>(null);
@@ -45,13 +46,6 @@ export function FlowBar() {
 
     trackListen(
       listen<{ state: FlowState }>("voice:state-change", (ev) => {
-        // Always reflect what the dictation engine reported. Earlier we
-        // ignored "complete"/"idle" on the assumption that hide_flow_bar
-        // would close the window milliseconds later — but if the hide
-        // got debounced or dropped, the bar would sit on "Polishing..."
-        // forever even after the text had already been pasted. Painting
-        // the actual state means the worst case is a blank bar for a
-        // frame, not a permanently stuck one.
         setState(ev.payload.state);
       }),
     );
@@ -59,6 +53,14 @@ export function FlowBar() {
     trackListen(
       listen<{ level: number }>("voice:audio-level", (ev) => {
         levelRef.current = Math.max(0, Math.min(1, ev.payload.level));
+      }),
+    );
+
+    trackListen(
+      listen<{ text: string }>("voice:partial-transcript", (ev) => {
+        // Live transcript as the user speaks — rendered above the pill.
+        // Empty payload clears the display (sent at session start/end).
+        setPartialTranscript(ev.payload.text || "");
       }),
     );
 
@@ -145,8 +147,18 @@ export function FlowBar() {
     emit("voice:cancel").catch(() => {});
   };
 
+  // Show live transcript above the pill while recording / processing,
+  // so the user can see the words being recognized in real time. Empties
+  // out as soon as the bar closes.
+  const showTranscript =
+    (state === "recording" || state === "processing") &&
+    partialTranscript.length > 0;
+
   return (
     <div className="flow-bar-root">
+      {showTranscript && (
+        <div className="flow-bar-transcript">{partialTranscript}</div>
+      )}
       <div className={`flow-bar flow-bar-${state}`}>
         {state === "recording" ? (
           <div className="flow-bar-recording">

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2060,19 +2060,43 @@ button {
 
 /* Wispr Flow-style dictation pill: small capsule anchored to the bottom
    of its (transparent) overlay window. The window itself is positioned
-   bottom-center on the primary display by show_flow_bar in Rust, so we
-   align to flex-end here to push the pill to the bottom-edge of the
-   window — leaving the upper portion of the window as empty space the
-   drop shadow can paint into. */
+   bottom-center on the primary display by show_flow_bar in Rust. We
+   stack the live transcript above the pill in a column so the user sees
+   the words being recognized in real time. */
 .flow-bar-root {
   position: fixed;
   inset: 0;
   display: flex;
-  align-items: flex-end;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
   padding-bottom: 8px;
+  gap: 6px;
   background: transparent;
   pointer-events: none;
+}
+
+/* Live partial-transcript chip floating above the pill. Same dark glass
+   look as the pill, smaller, only there when transcript is non-empty.
+   Caps width and clips long lines so a long sentence doesn't shove the
+   layout outside the transparent window. */
+.flow-bar-transcript {
+  max-width: 360px;
+  padding: 4px 10px;
+  border-radius: 12px;
+  background: rgba(18, 18, 20, 0.92);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 12px;
+  line-height: 1.35;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+  animation: flow-bar-in 100ms ease-out;
 }
 
 .flow-bar {

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2133,9 +2133,13 @@ button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 16px;
-  margin: 0 8px 0 4px;
+  width: 18px;
+  height: 18px;
+  /* Pill is 32px tall × chip is 18px → 7px above/below auto via flex
+     centering. Match that 7px on the right so the chip has uniform
+     padding to the pill's top/bottom/right edges. Left can be tighter
+     so the chip doesn't float away from the waveform/text. */
+  margin: 0 7px 0 6px;
   padding: 0;
   border: none;
   border-radius: 50%;


### PR DESCRIPTION
## Summary
- **feat(clips/desktop):** wire `objc2-foundation` + `objc2-speech` into the Tauri shell so the desktop app can run local on-device dictation through Apple's `SFSpeechRecognizer` / `AVAudioEngine` — same engine WisprFlow uses (instant, no API key, no server round-trip).
- **fix(clips/desktop):** default the voice-dictation provider to `browser` instead of `auto`, so users get the local engine on first launch. Cloud-quality providers (Builder / OpenAI / Groq / Gemini) remain available in Settings → Voice transcription.
- **polish(clips/desktop):** widen the flow-bar cancel chip from 16 → 18 px and tighten its left/right margins so the chip sits with uniform padding inside the pill.

## Test plan
- [ ] Lint, typecheck, test, build all green
- [ ] Scaffold E2E green
- [ ] Guard suite (drizzle-kit-push, unscoped-queries, env-credentials, unscoped-credentials, env-mutation, localhost-fallback, template-list)
- [ ] Manual: clips desktop — fresh install, hit dictation hotkey, verify it uses the local Speech framework with no "Polishing..." step
- [ ] Manual: clips desktop flow bar — cancel chip visible, centered, hover ramp still works