### PR TITLE
Remove per-user usage limit checks (keep tracking)

### DIFF
--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -129,9 +129,9 @@ function isMultiTenantDeploy(): boolean {
  * In multi-tenant deploys we deliberately refuse the deploy-level
  * deploy-level fallback for authenticated users. Without that gate any
  * signed-in user who hasn't configured their own provider key would silently
- * inherit the deployment's key (free-tier abuse, billing
- * mis-attribution, prompt logging tied to the deployment owner) — exactly
- * the prior-incident pattern we hit on 2026-04-29.
+ * inherit the deployment's key (uncapped billing on the owner's account,
+ * prompt logging tied to the deployment owner) — exactly the prior-incident
+ * pattern we hit on 2026-04-29.
  *
  * Single-tenant (local-dev, self-hosted SQLite) keeps the env fallback.
  *
@@ -233,10 +233,6 @@ export interface ProductionAgentOptions {
   onEngineResolved?: (engine: AgentEngine, model: string) => void;
   /** Resolve the owner email from the H3 event (for usage tracking) */
   resolveOwnerEmail?: (event: any) => string | Promise<string>;
-  /** Enable per-user usage limit checking and token tracking */
-  trackUsage?: boolean;
-  /** Usage limit in cents (default: 100 = $1.00) */
-  usageLimitCents?: number;
   /**
    * Skip auto-injecting the workspace files/skills/agents inventory on the
    * first message of a conversation. Useful for minimal/voice apps where
@@ -732,9 +728,8 @@ export function createProductionAgentHandler(
     }
 
     // Resolve owner first so we can look up a per-owner API key. Users
-    // who bring their own key bypass the platform's free-tier usage limit
-    // and use their key for this request (which is also durable across
-    // serverless cold starts via the settings table).
+    // who bring their own key use their key for this request (durable
+    // across serverless cold starts via the settings table).
     let ownerEmail: string | null = null;
     if (options.resolveOwnerEmail) {
       try {
@@ -825,43 +820,6 @@ export function createProductionAgentHandler(
           controller.close();
         },
       });
-    }
-
-    // Check usage limit before starting a run (production hosted mode).
-    // Skip when the user has provided their own key — they're paying
-    // Anthropic directly, so the platform's free tier doesn't apply.
-    if (
-      !userApiKey &&
-      options.trackUsage &&
-      options.resolveOwnerEmail &&
-      ownerEmail &&
-      ownerEmail !== DEV_MODE_USER_EMAIL
-    ) {
-      try {
-        const { checkUsageLimit } = await import("../usage/store.js");
-        const result = await checkUsageLimit(
-          ownerEmail,
-          options.usageLimitCents,
-        );
-        if (!result.allowed) {
-          setResponseHeader(event, "Content-Type", "text/event-stream");
-          setResponseHeader(event, "Cache-Control", "no-cache");
-          setResponseHeader(event, "Connection", "keep-alive");
-          const encoder = new TextEncoder();
-          return new ReadableStream({
-            start(controller) {
-              controller.enqueue(
-                encoder.encode(
-                  `data: ${JSON.stringify({ type: "usage_limit_reached", usageCents: result.usageCents, limitCents: result.limitCents })}\n\n`,
-                ),
-              );
-              controller.close();
-            },
-          });
-        }
-      } catch {
-        // Usage check failed — allow the request to proceed
-      }
     }
 
     // Run all independent pre-send steps in parallel. Each of these hits
@@ -1412,10 +1370,8 @@ export function createProductionAgentHandler(
           loopUsage = await runAgentLoop(agentLoopOpts);
         }
 
-        // Record token usage for cost monitoring. Always on (not gated by
-        // trackUsage) so the Usage panel in settings works in every mode,
-        // including local dev. `trackUsage` only controls the pre-request
-        // *limit check*; recording happens unconditionally.
+        // Record token usage for cost monitoring so the Usage panel in
+        // settings works in every mode, including local dev.
         try {
           const ownerEmail = options.resolveOwnerEmail
             ? await options.resolveOwnerEmail(event)

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -156,7 +156,6 @@ export function startRun(
           (last.event.type !== "done" &&
             last.event.type !== "error" &&
             last.event.type !== "missing_api_key" &&
-            last.event.type !== "usage_limit_reached" &&
             last.event.type !== "loop_limit")
         ) {
           run.events.push(terminal);
@@ -294,7 +293,6 @@ function subscribeInMemory(
             event.event.type === "done" ||
             event.event.type === "error" ||
             event.event.type === "missing_api_key" ||
-            event.event.type === "usage_limit_reached" ||
             event.event.type === "loop_limit"
           ) {
             run.subscribers.delete(subscriberRef!);
@@ -356,7 +354,6 @@ function subscribeFromSQL(
               parsed.type === "done" ||
               parsed.type === "error" ||
               parsed.type === "missing_api_key" ||
-              parsed.type === "usage_limit_reached" ||
               parsed.type === "loop_limit"
             ) {
               controller.close();

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -115,7 +115,6 @@ export type AgentChatEvent =
       upgradeUrl?: string;
     }
   | { type: "missing_api_key" }
-  | { type: "usage_limit_reached"; usageCents: number; limitCents: number }
   | { type: "loop_limit" }
   | { type: "clear" };
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1434,160 +1434,6 @@ function ApiKeySetupCard({ apiUrl }: { apiUrl: string }) {
   );
 }
 
-// ─── Builder.io CTA Card (usage limit / code changes / CLI) ─────────────────
-
-export function BuilderCtaCard({
-  reason,
-  usageCents,
-  limitCents,
-  apiUrl = agentNativePath("/_agent-native/agent-chat"),
-}: {
-  reason: "usage_limit" | "code_changes" | "cli_tab";
-  usageCents?: number;
-  limitCents?: number;
-  apiUrl?: string;
-}) {
-  const appName =
-    typeof window !== "undefined"
-      ? window.location.hostname.split(".")[0]
-      : "app";
-  const cloneCommand = `npx agent-native create ${appName}`;
-
-  const [apiKey, setApiKey] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleSave = async () => {
-    if (!apiKey.trim()) return;
-    setSaving(true);
-    setError(null);
-    try {
-      const res = await fetch(`${apiUrl}/save-key`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ key: apiKey.trim(), provider: "anthropic" }),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || "Failed to save");
-      }
-      setSaved(true);
-      setTimeout(() => window.location.reload(), 1000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const title =
-    reason === "usage_limit"
-      ? "Free usage limit reached"
-      : reason === "code_changes"
-        ? "Code changes require a local setup"
-        : "Get full access";
-
-  const description =
-    reason === "usage_limit"
-      ? null
-      : reason === "code_changes"
-        ? "This app is running in hosted mode. To make code changes, add your own Anthropic API key or clone and run locally."
-        : "This hosted app has limited AI features. Add your own Anthropic API key for the full experience, or clone and run locally.";
-
-  if (saved) {
-    return (
-      <div className="mx-4 my-6 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4">
-        <div className="flex items-center gap-2 text-sm text-emerald-400">
-          <IconCheck className="h-4 w-4" />
-          API key saved. Reloading...
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="mx-4 my-6 rounded-lg border border-border bg-card p-5">
-      <div className="flex items-center gap-3 mb-4">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted">
-          <IconMessage className="h-4.5 w-4.5 text-muted-foreground" />
-        </div>
-        <div>
-          <h3 className="text-sm font-medium text-foreground">{title}</h3>
-          {description && (
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {description}
-            </p>
-          )}
-        </div>
-      </div>
-
-      <div className="space-y-3">
-        <div className="rounded-md bg-muted/50 px-3 py-2.5 text-xs text-muted-foreground leading-relaxed">
-          <p>
-            Paste an Anthropic API key (
-            <a
-              href="https://console.anthropic.com/settings/keys"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline text-foreground/80 hover:text-foreground"
-            >
-              console.anthropic.com/settings/keys
-            </a>
-            ) to skip the free-tier limit.
-          </p>
-        </div>
-
-        <input
-          type="password"
-          value={apiKey}
-          onChange={(e) => {
-            setApiKey(e.target.value);
-            setError(null);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") handleSave();
-          }}
-          placeholder="sk-ant-..."
-          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
-          autoComplete="off"
-        />
-
-        {error && <p className="text-xs text-destructive">{error}</p>}
-
-        <button
-          onClick={handleSave}
-          disabled={saving || !apiKey.trim()}
-          className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          {saving ? "Saving..." : "Save API key"}
-        </button>
-
-        <div className="relative">
-          <div className="absolute inset-0 flex items-center">
-            <span className="w-full border-t border-border" />
-          </div>
-          <div className="relative flex justify-center text-xs">
-            <span className="bg-card px-2 text-muted-foreground">or</span>
-          </div>
-        </div>
-
-        <div className="rounded-md bg-muted/50 px-3 py-2.5">
-          <p className="text-xs text-muted-foreground mb-1.5">
-            Clone and run locally:
-          </p>
-          <code className="block text-xs text-foreground/80 font-mono break-all select-all">
-            {cloneCommand}
-          </code>
-        </div>
-
-        {/* Builder CTA — live Connect flow, replaces the old waitlist link. */}
-        <BuilderConnectCta variant="compact" />
-      </div>
-    </div>
-  );
-}
-
 // ─── Main Component ─────────────────────────────────────────────────────────
 
 export interface AssistantChatHandle {
@@ -1734,10 +1580,6 @@ const AssistantChatInner = forwardRef<
   const [missingApiKey, setMissingApiKey] = useState(false);
   const [authError, setAuthError] = useState<{
     sessionExpired?: boolean;
-  } | null>(null);
-  const [usageLimitReached, setUsageLimitReached] = useState<{
-    usageCents: number;
-    limitCents: number;
   } | null>(null);
   const [queuedMessages, setQueuedMessages] = useState<
     Array<{
@@ -2225,20 +2067,6 @@ const AssistantChatInner = forwardRef<
     return () => window.removeEventListener("agent-chat:auth-error", handler);
   }, []);
 
-  // Listen for usage limit reached events from the adapter
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent).detail;
-      setUsageLimitReached({
-        usageCents: detail?.usageCents ?? 0,
-        limitCents: detail?.limitCents ?? 100,
-      });
-    };
-    window.addEventListener("agent-chat:usage-limit-reached", handler);
-    return () =>
-      window.removeEventListener("agent-chat:usage-limit-reached", handler);
-  }, []);
-
   // Listen for loop-limit events from the adapter
   useEffect(() => {
     const handler = (e: Event) => {
@@ -2527,15 +2355,6 @@ const AssistantChatInner = forwardRef<
               ) : missingApiKey ? (
                 <div className="flex flex-col items-center justify-center h-full px-2">
                   <ApiKeySetupCard apiUrl={apiUrl} />
-                </div>
-              ) : usageLimitReached ? (
-                <div className="flex flex-col items-center justify-center h-full px-2">
-                  <BuilderCtaCard
-                    reason="usage_limit"
-                    usageCents={usageLimitReached.usageCents}
-                    limitCents={usageLimitReached.limitCents}
-                    apiUrl={apiUrl}
-                  />
                 </div>
               ) : isRestoring ? (
                 <div className="flex flex-col gap-3 p-4">

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -44,7 +44,6 @@ export {
 } from "./frame.js";
 export {
   AssistantChat,
-  BuilderCtaCard,
   clearChatStorage,
   type AssistantChatProps,
   type AssistantChatHandle,

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -29,9 +29,6 @@ export interface SSEEvent {
   preview?: string;
   currentStep?: string;
   summary?: string;
-  // Usage limit fields
-  usageCents?: number;
-  limitCents?: number;
   // Structured error metadata — Builder gateway sets these on 402/403 so the
   // UI can render an upgrade CTA alongside the error text.
   errorCode?: string;
@@ -48,13 +45,7 @@ export function processEvent(
   toolCallCounter: { value: number },
   tabId: string | undefined,
 ): {
-  action:
-    | "continue"
-    | "done"
-    | "yield"
-    | "error"
-    | "missing_api_key"
-    | "usage_limit_reached";
+  action: "continue" | "done" | "yield" | "error" | "missing_api_key";
   result?: ChatModelRunResult;
 } {
   if (ev.type === "clear") {
@@ -203,27 +194,6 @@ export function processEvent(
     };
   }
 
-  if (ev.type === "usage_limit_reached") {
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(
-        new CustomEvent("agent-chat:usage-limit-reached", {
-          detail: {
-            usageCents: ev.usageCents,
-            limitCents: ev.limitCents,
-          },
-        }),
-      );
-    }
-    content.push({ type: "text", text: "" });
-    return {
-      action: "usage_limit_reached",
-      result: {
-        content: [...content],
-        status: { type: "incomplete" as const, reason: "error" as const },
-      } as ChatModelRunResult,
-    };
-  }
-
   if (ev.type === "loop_limit") {
     content.push({
       type: "text",
@@ -335,8 +305,7 @@ export async function* readSSEStream(
         if (
           action === "done" ||
           action === "error" ||
-          action === "missing_api_key" ||
-          action === "usage_limit_reached"
+          action === "missing_api_key"
         ) {
           return;
         }
@@ -397,16 +366,14 @@ export async function readSSEStreamRaw(
           action === "yield" ||
           action === "done" ||
           action === "error" ||
-          action === "missing_api_key" ||
-          action === "usage_limit_reached"
+          action === "missing_api_key"
         ) {
           updated = true;
         }
         if (
           action === "done" ||
           action === "error" ||
-          action === "missing_api_key" ||
-          action === "usage_limit_reached"
+          action === "missing_api_key"
         ) {
           onUpdate([...content]);
           return;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,7 +70,6 @@ export {
   recordUsage,
   getUsageSummary,
   getUserUsageCents,
-  checkUsageLimit,
   calculateCost,
   type UsageRecord,
   type UsageSummary,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -3111,9 +3111,9 @@ export function createAgentChatPlugin(
           return (
             runCtx?.engine ??
             createAnthropicEngine({
-              // Sub-agents must inherit the parent run's resolved key so a
-              // BYO-key user can't bypass the free-tier check on the parent
-              // run and then have agent-teams spawn delegations bill the platform key.
+              // Sub-agents must inherit the parent run's resolved key so
+              // delegations spawned by agent-teams don't silently fall back
+              // to the platform key while the parent uses BYO credentials.
               apiKey:
                 runCtx?.userApiKey ??
                 options?.apiKey ??
@@ -3183,7 +3183,7 @@ export function createAgentChatPlugin(
       });
 
       // Always build the production handler (includes resource tools + call-agent + team tools)
-      // In production mode (!canToggle), enable usage tracking and limits
+      // In production mode (!canToggle), resolve the owner from the request session.
       const isHostedProd = !canToggle;
       const resolveExtraContext = async (
         event: any,
@@ -3274,8 +3274,7 @@ export function createAgentChatPlugin(
           if (threadId) _runSendByThread.delete(threadId);
           await onRunComplete(run, threadId);
         },
-        // Usage tracking for hosted production deployments
-        trackUsage: isHostedProd,
+        // Resolve owner from session for usage attribution in hosted prod
         resolveOwnerEmail: isHostedProd ? getOwnerFromEvent : undefined,
       });
 

--- a/packages/core/src/usage/store.ts
+++ b/packages/core/src/usage/store.ts
@@ -9,9 +9,6 @@
  */
 import { getDbExec, intType, isPostgres } from "../db/client.js";
 
-/** Default usage limit per user in cents ($1.00) for hosted prod mode */
-export const DEFAULT_USAGE_LIMIT_CENTS = 100;
-
 /**
  * Per-million-token pricing in cents. Cache read is typically ~10% of
  * input; cache write (5m TTL) is ~125%. Pricing is best-effort — keep
@@ -225,22 +222,6 @@ export async function getUserUsageCents(ownerEmail: string): Promise<number> {
   });
   const total = Number((rows[0] as { total?: number })?.total ?? 0);
   return total / 100;
-}
-
-export async function checkUsageLimit(
-  ownerEmail: string,
-  limitCents?: number,
-): Promise<
-  | { allowed: true; usageCents: number; limitCents: number }
-  | { allowed: false; usageCents: number; limitCents: number }
-> {
-  const limit = limitCents ?? DEFAULT_USAGE_LIMIT_CENTS;
-  const usageCents = await getUserUsageCents(ownerEmail);
-  return {
-    allowed: usageCents < limit,
-    usageCents,
-    limitCents: limit,
-  };
 }
 
 // ─── Admin / UI queries ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Drops the platform-side free-tier usage cap that 403'd hosted users when they hit \$1.00 of consumption.
- Removes the pre-request limit check, the \`usage_limit_reached\` SSE event type, the \`UsageLimitReachedNotice\` client component, and the \`createProductionAgent\` options that wired it up (\`trackUsage\`, \`usageLimitCents\`).
- Usage **recording** stays — the Usage panel in settings still shows per-user spend, both in hosted and local-dev modes.

## Test plan
- [ ] Lint, typecheck, test, build all green
- [ ] Scaffold E2E green
- [ ] Guard suite (drizzle-kit-push, unscoped-queries, env-credentials, unscoped-credentials, env-mutation, localhost-fallback, template-list)
- [ ] Manual: hit a hosted deploy as a fresh user, run several agent turns, confirm no 403 is returned and that the Usage panel reflects the spend