### PR TITLE
Move @assistant-ui packages to runtime deps + scaffold-build CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           fi
           pnpm install
 
-      - name: Scaffold workspace (starter + calendar) and verify pnpm install
+      - name: Scaffold workspace (starter + calendar) and verify pnpm install + build
         run: |
           cd "$(mktemp -d)"
           node "$GITHUB_WORKSPACE/packages/core/dist/cli/index.js" create test-workspace --template starter,calendar
@@ -134,6 +134,10 @@ jobs:
             exit 1
           fi
           pnpm install
+          # Build the calendar app — catches missing peer/runtime deps that
+          # `pnpm install` alone won't surface (e.g. core importing a peer
+          # dep that templates don't declare).
+          pnpm --filter ./apps/calendar build
 
   guard-no-drizzle-push:
     name: Guard — no drizzle-kit push in build paths

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",
@@ -97,6 +97,8 @@
   "dependencies": {
     "@amplitude/analytics-browser": "^2.41.1",
     "@anthropic-ai/sdk": "^0.90.0",
+    "@assistant-ui/react": "^0.12.19",
+    "@assistant-ui/react-markdown": "^0.12.6",
     "@clack/prompts": "^1.2.0",
     "@libsql/client": "^0.15.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
@@ -150,8 +152,6 @@
     "@ai-sdk/groq": ">=3",
     "@ai-sdk/mistral": ">=3",
     "@ai-sdk/openai": ">=3",
-    "@assistant-ui/react": ">=0.12",
-    "@assistant-ui/react-markdown": ">=0.12",
     "@openrouter/ai-sdk-provider": ">=2",
     "@supabase/supabase-js": ">=2",
     "@tabler/icons-react": ">=3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,12 @@ importers:
       '@anthropic-ai/sdk':
         specifier: '>=0.90.0'
         version: 0.90.0(zod@4.3.6)
+      '@assistant-ui/react':
+        specifier: ^0.12.19
+        version: 0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+      '@assistant-ui/react-markdown':
+        specifier: ^0.12.6
+        version: 0.12.8(@assistant-ui/react@0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@clack/prompts':
         specifier: ^1.2.0
         version: 1.2.0
@@ -261,12 +267,6 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.53
         version: 3.0.53(zod@4.3.6)
-      '@assistant-ui/react':
-        specifier: ^0.12.19
-        version: 0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
-      '@assistant-ui/react-markdown':
-        specifier: ^0.12.6
-        version: 0.12.8(@assistant-ui/react@0.12.22(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@supabase/supabase-js':
         specifier: ^2.49.0
         version: 2.101.1


### PR DESCRIPTION
## Summary
- **packages/core/package.json:** bump to 0.7.16; move \`@assistant-ui/react\` and \`@assistant-ui/react-markdown\` from \`peerDependencies\` → \`dependencies\`. The framework imports them directly (e.g. \`AssistantChat.tsx\`), so they need to ship with \`@agent-native/core\` rather than relying on every template to declare them as peers.
- **.github/workflows/ci.yml:** extend the scaffold E2E job to run \`pnpm --filter ./apps/calendar build\` after install. Catches the missing-peer-dep class of regression that \`pnpm install\` alone misses (silent install, then explodes at build time).

## Test plan
- [ ] Lint, typecheck, test, build all green
- [ ] Scaffold E2E green (now includes the build step)
- [ ] Guard suite (drizzle-kit-push, unscoped-queries, env-credentials, unscoped-credentials, env-mutation, localhost-fallback, template-list)