### PR TITLE
Content: import prosemirror-markdown directly

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1723,12 +1723,18 @@ importers:
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
+      prosemirror-markdown:
+        specifier: ^1.13.4
+        version: 1.13.4
       tiptap-markdown:
         specifier: ^0.9.0
         version: 0.9.0(@tiptap/core@3.22.2(@tiptap/pm@3.22.2))
       y-protocols:
         specifier: ^1.0.7
         version: 1.0.7(yjs@13.6.30)
+      yjs:
+        specifier: ^13.6.30
+        version: 13.6.30
       zod:
         specifier: ^4.3.6
         version: 4.3.6

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -13,7 +13,7 @@ import { TableRow } from "@tiptap/extension-table-row";
 import { TableCell } from "@tiptap/extension-table-cell";
 import { TableHeader } from "@tiptap/extension-table-header";
 import { Markdown } from "tiptap-markdown";
-import { defaultMarkdownSerializer } from "@tiptap/pm/markdown";
+import { defaultMarkdownSerializer } from "prosemirror-markdown";
 import {
   Plugin,
   PluginKey,

--- a/templates/content/app/components/editor/extensions/ImageNode.ts
+++ b/templates/content/app/components/editor/extensions/ImageNode.ts
@@ -1,7 +1,7 @@
 import Image, { type ImageOptions } from "@tiptap/extension-image";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import { ImageBlock } from "./ImageBlock";
-import { defaultMarkdownSerializer } from "@tiptap/pm/markdown";
+import { defaultMarkdownSerializer } from "prosemirror-markdown";
 
 // Override the default image serializer to treat images as block elements
 defaultMarkdownSerializer.nodes.image = function (state: any, node: any) {

--- a/templates/content/package.json
+++ b/templates/content/package.json
@@ -51,8 +51,10 @@
     "highlight.js": "^11.11.1",
     "isbot": "^5",
     "lowlight": "^3.3.0",
+    "prosemirror-markdown": "^1.13.4",
     "tiptap-markdown": "^0.9.0",
     "y-protocols": "^1.0.7",
+    "yjs": "^13.6.30",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Switch \`templates/content\` from \`@tiptap/pm/markdown\` (tiptap's re-export) to importing \`prosemirror-markdown\` directly. The re-export went through tiptap's peer-dep resolution, which gave bundlers two copies of \`prosemirror-markdown\` in the hoisted graph — so the override on \`defaultMarkdownSerializer.nodes.image\` only patched one of them and the editor sometimes serialized images inline instead of as a block.

- \`templates/content/package.json\`: add \`prosemirror-markdown@^1.13.4\` and \`yjs@^13.6.30\` as direct deps (yjs has the same hoisting concern).
- \`templates/content/app/components/editor/VisualEditor.tsx\` and \`extensions/ImageNode.ts\`: update the import.
- \`pnpm-lock.yaml\`: regenerated.

## Test plan
- [ ] Lint, typecheck, test, build all green
- [ ] Scaffold E2E green
- [ ] Guard suite (drizzle-kit-push, unscoped-queries, env-credentials, unscoped-credentials, env-mutation, localhost-fallback, template-list)
- [ ] Manual: open a content doc with an image, save, verify markdown output renders the image as a block (own line, not inline)