### PR TITLE
Address PR #380 review: OAuth retry effects + getClients failure surfacing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -595,6 +595,19 @@ function postProcessStandalone(name: string, targetDir: string): void {
           }
         }
       }
+      // Ensure pnpm.onlyBuiltDependencies is set so native packages
+      // (better-sqlite3, esbuild, node-pty) compile their postinstall scripts
+      // under pnpm 10+ without prompting for `pnpm approve-builds`.
+      const requiredBuilt = ["better-sqlite3", "esbuild", "node-pty"];
+      if (!pkg.pnpm || typeof pkg.pnpm !== "object") {
+        pkg.pnpm = {};
+      }
+      const existing = Array.isArray(pkg.pnpm.onlyBuiltDependencies)
+        ? pkg.pnpm.onlyBuiltDependencies
+        : [];
+      pkg.pnpm.onlyBuiltDependencies = Array.from(
+        new Set([...existing, ...requiredBuilt]),
+      );
       fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
     } catch {}
   }

--- a/packages/core/src/scripts/utils.ts
+++ b/packages/core/src/scripts/utils.ts
@@ -16,7 +16,8 @@ export function loadEnv(envPath?: string): void {
   const appEnv = envPath ?? path.join(process.cwd(), ".env");
   // App-level .env first. Dotenv won't clobber already-set process.env, so
   // values that are already present (e.g. set by the shell) still win.
-  dotenv.config({ path: appEnv });
+  // `quiet: true` suppresses the dotenv tip line on every load (v17+).
+  dotenv.config({ path: appEnv, quiet: true });
 
   // Then workspace root, if any — but only fill in keys the app didn't
   // define. Setting `override: false` is dotenv's default.
@@ -24,7 +25,7 @@ export function loadEnv(envPath?: string): void {
   if (workspaceRoot) {
     const wsEnv = path.join(workspaceRoot, ".env");
     if (fs.existsSync(wsEnv) && wsEnv !== appEnv) {
-      dotenv.config({ path: wsEnv });
+      dotenv.config({ path: wsEnv, quiet: true });
     }
   }
 }

--- a/packages/core/src/terminal/terminal-plugin.ts
+++ b/packages/core/src/terminal/terminal-plugin.ts
@@ -67,6 +67,13 @@ export interface TerminalPluginOptions {
   authCheck?: (req: any) => boolean | Promise<boolean>;
 }
 
+// Vite's dev server can initialize Nitro plugins more than once during boot.
+// Module-scope flags ensure the "node-pty not installed" / "Disabled in
+// production" / "Frame detected" notices each fire at most once per process.
+let _ptyMissingLogged = false;
+let _disabledLogged = false;
+let _frameDetectedLogged = false;
+
 export function createTerminalPlugin(options: TerminalPluginOptions = {}) {
   return async (nitroApp: any) => {
     // Terminal requires Node.js (PTY, child_process) — skip on edge runtimes
@@ -96,7 +103,10 @@ export function createTerminalPlugin(options: TerminalPluginOptions = {}) {
 
     // Skip if running inside a frame
     if (process.env.FRAME_PORT) {
-      console.log("[terminal] Frame detected, skipping embedded terminal");
+      if (!_frameDetectedLogged) {
+        console.log("[terminal] Frame detected, skipping embedded terminal");
+        _frameDetectedLogged = true;
+      }
       return;
     }
 
@@ -106,9 +116,12 @@ export function createTerminalPlugin(options: TerminalPluginOptions = {}) {
       (process.env.AGENT_TERMINAL_ENABLED === "true" || !isProd);
 
     if (!enabled) {
-      console.log(
-        "[terminal] Disabled in production (set AGENT_TERMINAL_ENABLED=true to enable)",
-      );
+      if (!_disabledLogged) {
+        console.log(
+          "[terminal] Disabled in production (set AGENT_TERMINAL_ENABLED=true to enable)",
+        );
+        _disabledLogged = true;
+      }
       // Mount a disabled info endpoint
       getH3App(nitroApp).use(
         "/_agent-native/agent-terminal-info",
@@ -212,10 +225,13 @@ export function createTerminalPlugin(options: TerminalPluginOptions = {}) {
       const missingPty =
         code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
       if (missingPty) {
-        console.log(
-          "[terminal] node-pty not installed — embedded terminal disabled. " +
-            "Install with `pnpm add node-pty` to enable.",
-        );
+        if (!_ptyMissingLogged) {
+          console.log(
+            "[terminal] node-pty not installed — embedded terminal disabled. " +
+              "Install with `pnpm add node-pty` to enable.",
+          );
+          _ptyMissingLogged = true;
+        }
       } else {
         console.error("[terminal] Failed to start PTY server:", err);
         console.error(

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -791,6 +791,10 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
       dotenv.config({
         path: path.join(workspaceRoot, ".env"),
         override: false,
+        // Suppress the dotenv v17 tip line — this loader fires alongside
+        // utils.ts loadEnv() during dev startup and would otherwise emit a
+        // duplicate "[dotenv] injecting env" message.
+        quiet: true,
       });
     } catch {}
   }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "inlineSources": true,
     "outDir": "dist",
     "rootDir": "src",
     "strict": false,

--- a/templates/analytics/actions/helpers.ts
+++ b/templates/analytics/actions/helpers.ts
@@ -1,6 +1,10 @@
 // Load .env in CLI mode (not needed when running via Vite dev server)
 try {
-  await import("dotenv/config");
+  // Use the programmatic form with `quiet: true` to suppress dotenv v17's
+  // "tip" banner on every load. The bare `dotenv/config` import would print
+  // it.
+  const dotenv = await import("dotenv");
+  dotenv.config({ quiet: true });
 } catch {
   // dotenv not available in Vite SSR context — env is already loaded
 }

--- a/templates/analytics/package.json
+++ b/templates/analytics/package.json
@@ -106,5 +106,12 @@
     "vite": "catalog:",
     "vitest": "^4.1.5"
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
+  }
 }

--- a/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
+++ b/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
@@ -77,9 +77,13 @@ export function GoogleConnectBanner({
 
   const isElectron = useMemo(() => /Electron/i.test(navigator.userAgent), []);
   const desktopPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const authPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const addAccountPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   useEffect(() => {
     return () => {
       if (desktopPollRef.current) clearInterval(desktopPollRef.current);
+      if (authPollRef.current) clearInterval(authPollRef.current);
+      if (addAccountPollRef.current) clearInterval(addAccountPollRef.current);
     };
   }, []);
 
@@ -166,37 +170,35 @@ export function GoogleConnectBanner({
   }, [fetchStatus]);
 
   // When auth URL is ready, open it and poll for connection.
-  // Gate on wantAuthUrl so a cached/refetched URL doesn't open a second
-  // popup behind the first when React Query returns stale data immediately
-  // and then refetches in the background.
   //
-  // `wantAuthUrl` is intentionally NOT in the deps array. Including it would
-  // re-run the effect when we flip it false on the line below, which runs
-  // the cleanup (clearInterval) within ~16ms — long before the 2-second
-  // poll ever fires. The early-return guard above still prevents double-
-  // opening when React Query refetches a stale URL in the background.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // `wantAuthUrl` is the user's retry intent and must be in the deps so a
+  // second click after closing the popup re-runs this effect (the cached
+  // authUrl.data won't change on its own). The interval lives in a ref so
+  // flipping wantAuthUrl false below doesn't tear down an already-running
+  // poll; cleanup happens on unmount via the dedicated effect above.
   useEffect(() => {
     if (!wantAuthUrl || !authUrl.data?.url) return;
     setWantAuthUrl(false);
     window.open(authUrl.data.url, "_blank");
 
-    const interval = setInterval(async () => {
+    if (authPollRef.current) clearInterval(authPollRef.current);
+    authPollRef.current = setInterval(async () => {
       const res = await fetch(
         agentNativePath("/_agent-native/google/status"),
       ).catch(() => null);
       if (res?.ok) {
         const data = await res.json();
         if (data.connected) {
-          clearInterval(interval);
+          if (authPollRef.current) {
+            clearInterval(authPollRef.current);
+            authPollRef.current = null;
+          }
           setDismissed(true);
           window.location.reload();
         }
       }
     }, 2000);
-
-    return () => clearInterval(interval);
-  }, [authUrl.data]);
+  }, [wantAuthUrl, authUrl.data]);
 
   // When auth URL fails with missing credentials, show wizard
   useEffect(() => {
@@ -211,31 +213,33 @@ export function GoogleConnectBanner({
     envStatus.length > 0 && envStatus.every((k) => k.configured);
 
   // When add-account URL is ready, open it and poll for new account.
-  // Same dep-list rationale as the connect effect above — `wantAddAccount`
-  // is intentionally omitted so flipping it false doesn't tear down the
-  // poll interval before it fires.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Same retry-intent rationale as the connect effect — `wantAddAccount`
+  // is in the deps so a second click rerun the effect; the polling
+  // interval lives in a ref so flipping wantAddAccount false here doesn't
+  // tear down the running poll.
   useEffect(() => {
     if (!wantAddAccount || !addAccountUrl.data?.url) return;
     window.open(addAccountUrl.data.url, "_blank");
     setWantAddAccount(false);
 
     const prevCount = accounts.length;
-    const interval = setInterval(async () => {
+    if (addAccountPollRef.current) clearInterval(addAccountPollRef.current);
+    addAccountPollRef.current = setInterval(async () => {
       const res = await fetch(
         agentNativePath("/_agent-native/google/status"),
       ).catch(() => null);
       if (res?.ok) {
         const data = await res.json();
         if (data.accounts?.length > prevCount) {
-          clearInterval(interval);
+          if (addAccountPollRef.current) {
+            clearInterval(addAccountPollRef.current);
+            addAccountPollRef.current = null;
+          }
           window.location.reload();
         }
       }
     }, 2000);
-
-    return () => clearInterval(interval);
-  }, [addAccountUrl.data, accounts.length]);
+  }, [wantAddAccount, addAccountUrl.data, accounts.length]);
 
   function handleConnect() {
     if (isElectron) {

--- a/templates/calendar/package.json
+++ b/templates/calendar/package.json
@@ -95,5 +95,12 @@
     "vite": "catalog:",
     "vitest": "^4.1.5"
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
+  }
 }

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -109,6 +109,14 @@ async function getValidAccessToken(
         // Drop the dead row so isOAuthConnected returns false and the UI
         // surfaces the connect banner instead of a stale-token illusion.
         await deleteOAuthTokens("google", accountId);
+        throw err;
+      }
+      // Transient failure (network hiccup, 5xx, timeout). If the existing
+      // token hasn't actually expired yet — we only entered this path
+      // because we're inside the 5-minute pre-expiry buffer — fall back to
+      // it so a flaky moment doesn't 502 the calendar.
+      if (tokens.access_token && tokens.expiry_date > Date.now()) {
+        return tokens.access_token;
       }
       throw err;
     }
@@ -183,7 +191,12 @@ export async function getClient(
 export async function getClients(
   forEmail?: string,
 ): Promise<Array<{ email: string; accessToken: string }>> {
-  const { clients } = await getClientsWithErrors(forEmail);
+  const { clients, errors } = await getClientsWithErrors(forEmail);
+  if (clients.length === 0 && errors.length > 0) {
+    throw new Error(
+      `All Google accounts failed to refresh: ${errors[0].error}`,
+    );
+  }
   return clients;
 }
 
@@ -396,12 +409,13 @@ export async function listOverlayEvents(
   events: CalendarEvent[];
   errors: Array<{ email: string; error: string }>;
 }> {
-  const clients = await getClients(forEmail);
-  if (clients.length === 0) return { events: [], errors: [] };
+  const { clients, errors: refreshErrors } =
+    await getClientsWithErrors(forEmail);
+  const errors: Array<{ email: string; error: string }> = [...refreshErrors];
+  if (clients.length === 0) return { events: [], errors };
 
   // Use the first available token to query other people's calendars
   const { accessToken } = clients[0];
-  const errors: Array<{ email: string; error: string }> = [];
 
   const allResults = await Promise.all(
     overlayEmails.map(async (overlayEmail) => {

--- a/templates/calls/package.json
+++ b/templates/calls/package.json
@@ -80,5 +80,12 @@
     "typescript": "^6.0.3",
     "vaul": "^1.1.2",
     "vite": "catalog:"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
   }
 }

--- a/templates/clips/package.json
+++ b/templates/clips/package.json
@@ -88,5 +88,12 @@
     "typescript": "^6.0.3",
     "vaul": "^1.1.2",
     "vite": "catalog:"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
   }
 }

--- a/templates/content/package.json
+++ b/templates/content/package.json
@@ -93,5 +93,12 @@
     "vite": "catalog:",
     "vitest": "^4.1.5"
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
+  }
 }

--- a/templates/design/package.json
+++ b/templates/design/package.json
@@ -85,5 +85,12 @@
     "typescript": "^6.0.3",
     "vaul": "^1.1.2",
     "vite": "catalog:"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
   }
 }

--- a/templates/dispatch/package.json
+++ b/templates/dispatch/package.json
@@ -80,5 +80,12 @@
     "typescript": "^6.0.3",
     "vaul": "^1.1.2",
     "vite": "catalog:"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
   }
 }

--- a/templates/forms/package.json
+++ b/templates/forms/package.json
@@ -87,5 +87,12 @@
     "typescript": "^6.0.3",
     "vite": "catalog:"
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
+  }
 }

--- a/templates/issues/package.json
+++ b/templates/issues/package.json
@@ -78,5 +78,12 @@
     "typescript": "^6.0.3",
     "vite": "catalog:",
     "vitest": "^4.1.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
   }
 }

--- a/templates/macros/package.json
+++ b/templates/macros/package.json
@@ -87,5 +87,12 @@
     "vite": "catalog:",
     "vitest": "^4.1.5"
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
+  }
 }

--- a/templates/mail/actions/helpers.ts
+++ b/templates/mail/actions/helpers.ts
@@ -1,6 +1,10 @@
 // Load .env in CLI mode (not needed when running via Vite dev server)
 try {
-  await import("dotenv/config");
+  // Use the programmatic form with `quiet: true` to suppress dotenv v17's
+  // "tip" banner on every load. The bare `dotenv/config` import would print
+  // it.
+  const dotenv = await import("dotenv");
+  dotenv.config({ quiet: true });
 } catch {
   // dotenv not available in Vite SSR context — env is already loaded
 }

--- a/templates/mail/app/components/GoogleConnectBanner.tsx
+++ b/templates/mail/app/components/GoogleConnectBanner.tsx
@@ -85,9 +85,13 @@ export function GoogleConnectBanner({
 
   const isElectron = useMemo(() => /Electron/i.test(navigator.userAgent), []);
   const desktopPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const authPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const addAccountPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   useEffect(() => {
     return () => {
       if (desktopPollRef.current) clearInterval(desktopPollRef.current);
+      if (authPollRef.current) clearInterval(authPollRef.current);
+      if (addAccountPollRef.current) clearInterval(addAccountPollRef.current);
     };
   }, []);
 
@@ -177,18 +181,12 @@ export function GoogleConnectBanner({
   }, [fetchStatus]);
 
   // When auth URL is ready, open it and poll for connection.
-  // Gate on wantAuthUrl so a cached/refetched URL doesn't open a second
-  // popup behind the first when React Query returns stale data immediately
-  // and then refetches in the background.
   //
-  // `wantAuthUrl` is intentionally NOT in the deps array. Including it would
-  // re-run the effect when we flip it false on line below, which runs the
-  // cleanup (clearInterval) within ~16ms — long before the 2-second poll
-  // ever fires. The early-return guard above still prevents double-opening
-  // when React Query refetches a stale URL in the background. _This dep-list
-  // bug, alongside the Netlify-Lambda Set-Cookie drop in the OAuth callback,
-  // is what produced the "Set up Google" loop reported on 2026-04-30._
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // `wantAuthUrl` is the user's retry intent and must be in the deps so a
+  // second click after closing the popup re-runs this effect (the cached
+  // authUrl.data won't change on its own). The interval lives in a ref so
+  // flipping wantAuthUrl false below doesn't tear down an already-running
+  // poll. Cleanup happens on unmount via the dedicated effect above.
   useEffect(() => {
     if (!wantAuthUrl || !authUrl.data?.url) return;
     const url = authUrl.data.url;
@@ -204,22 +202,23 @@ export function GoogleConnectBanner({
     }
     window.open(url, "_blank");
 
-    // Poll for connection status while user completes OAuth in other tab.
-    const interval = setInterval(async () => {
+    if (authPollRef.current) clearInterval(authPollRef.current);
+    authPollRef.current = setInterval(async () => {
       const res = await fetch(
         agentNativePath("/_agent-native/google/status"),
       ).catch(() => null);
       if (res?.ok) {
         const data = await res.json();
         if (data.connected) {
-          clearInterval(interval);
+          if (authPollRef.current) {
+            clearInterval(authPollRef.current);
+            authPollRef.current = null;
+          }
           window.location.reload();
         }
       }
     }, 2000);
-
-    return () => clearInterval(interval);
-  }, [authUrl.data]);
+  }, [wantAuthUrl, authUrl.data]);
 
   // When auth URL fails, show wizard (for missing credentials) or an error message
   useEffect(() => {
@@ -237,10 +236,10 @@ export function GoogleConnectBanner({
     envStatus.length > 0 && envStatus.every((k) => k.configured);
 
   // When add-account URL is ready, open it and poll for new account.
-  // Same dep-list rationale as the connect effect above — `wantAddAccount`
-  // is intentionally omitted so flipping it false doesn't tear down the
-  // poll interval before it fires.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Same retry-intent rationale as the connect effect — `wantAddAccount`
+  // is in the deps so a second click rerun the effect; the polling
+  // interval lives in a ref so flipping wantAddAccount false here doesn't
+  // tear down the running poll.
   useEffect(() => {
     if (!wantAddAccount || !addAccountUrl.data?.url) return;
     const isNativeWebView =
@@ -252,24 +251,26 @@ export function GoogleConnectBanner({
     }
     setWantAddAccount(false);
 
-    if (!isNativeWebView) {
-      const prevCount = accounts.length;
-      const interval = setInterval(async () => {
-        const res = await fetch(
-          agentNativePath("/_agent-native/google/status"),
-        ).catch(() => null);
-        if (res?.ok) {
-          const data = await res.json();
-          if (data.accounts?.length > prevCount) {
-            clearInterval(interval);
-            window.location.reload();
-          }
-        }
-      }, 2000);
+    if (isNativeWebView) return;
 
-      return () => clearInterval(interval);
-    }
-  }, [addAccountUrl.data, accounts.length]);
+    const prevCount = accounts.length;
+    if (addAccountPollRef.current) clearInterval(addAccountPollRef.current);
+    addAccountPollRef.current = setInterval(async () => {
+      const res = await fetch(
+        agentNativePath("/_agent-native/google/status"),
+      ).catch(() => null);
+      if (res?.ok) {
+        const data = await res.json();
+        if (data.accounts?.length > prevCount) {
+          if (addAccountPollRef.current) {
+            clearInterval(addAccountPollRef.current);
+            addAccountPollRef.current = null;
+          }
+          window.location.reload();
+        }
+      }
+    }, 2000);
+  }, [wantAddAccount, addAccountUrl.data, accounts.length]);
 
   function handleConnect() {
     if (isElectron) {

--- a/templates/mail/package.json
+++ b/templates/mail/package.json
@@ -104,5 +104,12 @@
     "vite": "catalog:",
     "vitest": "^4.1.5"
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
+  }
 }

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -115,6 +115,18 @@ async function getValidAccessToken(
       // Drop the dead row so isOAuthConnected returns false and the UI
       // surfaces the connect banner instead of an empty-inbox illusion.
       await deleteOAuthTokens("google", accountId);
+      throw err;
+    }
+    // Transient failure (network hiccup, 5xx, timeout). If the existing
+    // token hasn't actually expired yet — we only entered this path
+    // because we're inside the 5-minute pre-expiry buffer — fall back to
+    // it so a flaky moment doesn't 502 the inbox.
+    if (
+      tokens.access_token &&
+      tokens.expiry_date &&
+      Date.now() < tokens.expiry_date
+    ) {
+      return tokens.access_token;
     }
     throw err;
   }
@@ -297,17 +309,22 @@ export async function getClientFromAccount(account: {
  * Get OAuth credentials. When `forEmail` is provided, returns only that
  * user's credentials (multi-user mode). Otherwise returns an empty array.
  *
- * Refresh failures are swallowed per-account here — callers that need to
- * surface "all your tokens are dead" to the UI should use
- * `getClientsWithErrors`. Without that signal, a fully-broken account
- * silently looks like an empty inbox.
+ * If the user has accounts connected but every refresh failed, this
+ * throws — otherwise an inbox with all dead tokens would render as
+ * "empty inbox" instead of prompting a reconnect. Callers that need
+ * per-account success/failure detail should use `getClientsWithErrors`.
  */
 export async function getClients(
   forEmail?: string,
 ): Promise<
   Array<{ email: string; accessToken: string; refreshToken: string }>
 > {
-  const { clients } = await getClientsWithErrors(forEmail);
+  const { clients, errors } = await getClientsWithErrors(forEmail);
+  if (clients.length === 0 && errors.length > 0) {
+    throw new Error(
+      `All Google accounts failed to refresh: ${errors[0].error}`,
+    );
+  }
   return clients;
 }
 

--- a/templates/mail/server/plugins/mail-jobs.ts
+++ b/templates/mail/server/plugins/mail-jobs.ts
@@ -18,6 +18,10 @@ import { z } from "zod";
 const INTERVAL_MS = 60_000; // 1 minute
 const WATCH_RENEW_INTERVAL_MS = 12 * 60 * 60_000;
 let lastWatchRenewalAt = 0;
+// Vite's dev server initializes Nitro plugins more than once during boot
+// (initial load + post-init). Module-scope flag ensures the "skipping" log
+// fires at most once per process.
+let skippingLogged = false;
 
 async function renewAllWatches(): Promise<void> {
   if (!process.env.GMAIL_WATCH_TOPIC) return;
@@ -110,9 +114,12 @@ export default () => {
   const flag = process.env.RUN_BACKGROUND_JOBS;
   const enabled = flag === "1" || (isProd && flag !== "0");
   if (!enabled) {
-    console.log(
-      "[mail-jobs] Skipping background cron (set RUN_BACKGROUND_JOBS=1 to enable in dev; on by default in production)",
-    );
+    if (!skippingLogged) {
+      console.log(
+        "[mail-jobs] Skipping background cron (set RUN_BACKGROUND_JOBS=1 to enable in dev; on by default in production)",
+      );
+      skippingLogged = true;
+    }
     return;
   }
 

--- a/templates/meeting-notes/package.json
+++ b/templates/meeting-notes/package.json
@@ -64,5 +64,12 @@
     "tsx": "^4.20.3",
     "typescript": "^6.0.3",
     "vite": "catalog:"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
   }
 }

--- a/templates/recruiting/actions/helpers.ts
+++ b/templates/recruiting/actions/helpers.ts
@@ -1,6 +1,10 @@
 // Load .env in CLI mode (not needed when running via Vite dev server)
 try {
-  await import("dotenv/config");
+  // Use the programmatic form with `quiet: true` to suppress dotenv v17's
+  // "tip" banner on every load. The bare `dotenv/config` import would print
+  // it.
+  const dotenv = await import("dotenv");
+  dotenv.config({ quiet: true });
 } catch {
   // dotenv not available in Vite SSR context — env is already loaded
 }

--- a/templates/recruiting/package.json
+++ b/templates/recruiting/package.json
@@ -70,5 +70,12 @@
     "tsx": "^4.20.3",
     "typescript": "^6.0.3",
     "vite": "catalog:"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
   }
 }

--- a/templates/scheduling/package.json
+++ b/templates/scheduling/package.json
@@ -78,5 +78,12 @@
     "typescript": "^6.0.3",
     "vite": "catalog:",
     "vitest": "^4.1.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
   }
 }

--- a/templates/slides/package.json
+++ b/templates/slides/package.json
@@ -135,5 +135,12 @@
     "vite": "catalog:",
     "vitest": "^4.1.5"
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
+  }
 }

--- a/templates/starter/package.json
+++ b/templates/starter/package.json
@@ -79,5 +79,12 @@
     "typescript": "^6.0.3",
     "vaul": "^1.1.2",
     "vite": "catalog:"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
   }
 }

--- a/templates/videos/package.json
+++ b/templates/videos/package.json
@@ -108,5 +108,12 @@
     "vite": "catalog:",
     "vitest": "^4.1.5"
   },
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
+  }
 }

--- a/templates/voice/package.json
+++ b/templates/voice/package.json
@@ -62,5 +62,12 @@
     "tsx": "^4.20.3",
     "typescript": "^6.0.3",
     "vite": "catalog:"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "node-pty"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Addresses the 5 deferred bot review comments from PR #380, plus a sweep of concurrent local changes.

### Bot review fixes

- **GoogleConnectBanner (mail + calendar)** — \`wantAuthUrl\`/\`wantAddAccount\` are now in the effect deps so a second click after closing the popup actually re-runs the effect. Polling intervals moved into refs so flipping the intent flag back to false on the same tick doesn't tear down the running poll. Cleanup runs on unmount.
- **\`getClients()\` (mail + calendar)** — now throws when accounts are connected but every refresh failed. Previously the wrapper discarded the \`errors\` array from \`getClientsWithErrors()\`, so callers couldn't distinguish \"no accounts\" from \"all tokens broken\" — the inbox/calendar would silently render empty. Per-account detail is still available via \`getClientsWithErrors\`.
- **\`getValidAccessToken()\` (mail + calendar)** — on transient refresh failures (network hiccup, 5xx, timeout), fall back to the existing \`access_token\` if it hasn't actually expired yet. We only enter the refresh path while inside the 5-minute pre-expiry buffer, so the existing token is still valid. Permanent errors (\`invalid_grant\`, \`unauthorized_client\`, \`invalid_client\`) still drop the row and throw.
- **\`listOverlayEvents()\` (calendar)** — switched to \`getClientsWithErrors\` so the new \`getClients\` throw doesn't crash overlay queries; refresh errors now flow into the returned \`errors\` array.

### Plus

- Concurrent agent changes swept across \`packages/core\` (CLI, terminal plugin, vite client) and template package metadata.

## Test plan

- [ ] CI: Lint, Test, Typecheck, Build, Scaffold E2E, Guard all green
- [ ] Mail/calendar OAuth retry: close popup, click Connect again — popup reopens
- [ ] All-dead-tokens case: inbox surfaces an error instead of empty list
- [ ] Transient refresh failure: token still works within 5-min buffer