### PR TITLE
Address PR #381 review: revert getClients throw + drop accounts.length dep

### DIFF
--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -141,6 +141,78 @@ describe("server/auth", () => {
       errorSpy.mockRestore();
     });
 
+    it("mounts generic Google OAuth routes by default when credentials are configured", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("GOOGLE_CLIENT_ID", "google-client");
+      vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-secret");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      delete process.env.AUTH_DISABLED;
+      delete process.env.AUTH_MODE;
+
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(async () => new Response("{}")),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+            listOrganizations: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
+
+      const { autoMountAuth } = await import("./auth.js");
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const paths = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .filter((path: unknown): path is string => typeof path === "string");
+      expect(paths).toContain("/_agent-native/google/auth-url");
+      expect(paths).toContain("/_agent-native/google/callback");
+    });
+
+    it("lets templates own Google OAuth routes when opted out", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("GOOGLE_CLIENT_ID", "google-client");
+      vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-secret");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      delete process.env.AUTH_DISABLED;
+      delete process.env.AUTH_MODE;
+
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(async () => new Response("{}")),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+            listOrganizations: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
+
+      const { autoMountAuth } = await import("./auth.js");
+      const app = createMockApp();
+      await autoMountAuth(app, {
+        googleOnly: true,
+        mountGoogleOAuthRoutes: false,
+      });
+
+      const paths = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .filter((path: unknown): path is string => typeof path === "string");
+      expect(paths).not.toContain("/_agent-native/google/auth-url");
+      expect(paths).not.toContain("/_agent-native/google/callback");
+      expect(paths).toContain("/_agent-native/auth/ba");
+    });
+
     it("mounts auth when ACCESS_TOKEN is set in production", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("ACCESS_TOKEN", "my-secret");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -145,6 +145,14 @@ export interface AuthOptions {
    */
   googleOnly?: boolean;
   /**
+   * Mount the framework's generic Google sign-in routes.
+   *
+   * Set this to false when a template owns `/_agent-native/google/auth-url`
+   * and `/_agent-native/google/callback` itself because it needs broader
+   * product scopes and persisted API tokens, not just identity sign-in.
+   */
+  mountGoogleOAuthRoutes?: boolean;
+  /**
    * Product marketing content shown alongside the sign-in form.
    * When provided, the page uses a split layout: marketing on the left,
    * sign-in form on the right.
@@ -1313,10 +1321,14 @@ async function mountBetterAuthRoutes(
     if (!publicPaths.includes(pp)) publicPaths.push(pp);
   }
 
-  // Auto-add Google OAuth routes when credentials are configured.
-  // Templates can override by defining their own Nitro routes at the same
-  // paths (e.g. mail/calendar need broader scopes for API access).
-  if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+  // Auto-add Google OAuth routes when credentials are configured. Templates
+  // that need broader product scopes (mail/calendar) opt out and provide
+  // their own Nitro routes at these paths.
+  if (
+    process.env.GOOGLE_CLIENT_ID &&
+    process.env.GOOGLE_CLIENT_SECRET &&
+    options.mountGoogleOAuthRoutes !== false
+  ) {
     for (const gp of [
       "/_agent-native/google/callback",
       "/_agent-native/google/auth-url",

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -153,6 +153,27 @@ export interface AuthOptions {
    */
   mountGoogleOAuthRoutes?: boolean;
   /**
+   * Additional Google OAuth scopes to request beyond the default identity
+   * scopes (`openid`, `email`, `profile`). When set, Better Auth's Google
+   * social provider asks for these up front, requests a refresh token
+   * (`access_type=offline`), and forces the consent screen so the refresh
+   * token is reissued on every sign-in.
+   *
+   * Tokens land in Better Auth's `account` table, and a database hook
+   * mirrors them into `oauth_tokens` so template code (mail's Gmail client,
+   * calendar's events fetcher, etc.) can pick them up without a separate
+   * "Connect Google" round-trip.
+   *
+   * Example for the mail template:
+   * ```ts
+   * googleScopes: [
+   *   "https://www.googleapis.com/auth/gmail.readonly",
+   *   "https://www.googleapis.com/auth/gmail.send",
+   * ],
+   * ```
+   */
+  googleScopes?: string[];
+  /**
    * Product marketing content shown alongside the sign-in form.
    * When provided, the page uses a split layout: marketing on the left,
    * sign-in form on the right.
@@ -1540,8 +1561,15 @@ async function mountBetterAuthRoutes(
 
   const accessTokens = getAccessTokens();
 
-  // Initialize Better Auth
-  const auth = await getBetterAuth(options.betterAuth);
+  // Initialize Better Auth. Forward `googleScopes` into the BetterAuthConfig
+  // so the social provider requests the broader product scopes (Gmail,
+  // Calendar, etc.) up front during the primary sign-in — eliminating the
+  // need for a separate "Connect Google" page.
+  const betterAuthConfig: BetterAuthConfig = {
+    ...(options.betterAuth ?? {}),
+    ...(options.googleScopes ? { googleScopes: options.googleScopes } : {}),
+  };
+  const auth = await getBetterAuth(betterAuthConfig);
 
   // Mount Better Auth catch-all handler at /_agent-native/auth/ba/*
   app.use(

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -21,6 +21,7 @@ import {
 import { getAppProductionUrl } from "./app-url.js";
 import { getDbExec, isPostgres } from "../db/client.js";
 import { acceptPendingInvitationsForEmail } from "../org/accept-pending.js";
+import { saveOAuthTokens } from "../oauth-tokens/store.js";
 import {
   getDialect,
   getDatabaseUrl,
@@ -210,6 +211,21 @@ export interface BetterAuthConfig {
   socialProviders?: BetterAuthOptions["socialProviders"];
   /** Additional Better Auth plugins */
   plugins?: BetterAuthOptions["plugins"];
+  /**
+   * Additional Google OAuth scopes (Gmail, Calendar, etc.) to request
+   * up front during the primary "Sign in with Google" flow, beyond the
+   * default identity scopes (`openid`, `email`, `profile`).
+   *
+   * When set, the Google social provider also opts into:
+   * - `accessType: "offline"` — so a refresh token is issued
+   * - `prompt: "consent"` — so the refresh token is reissued every sign-in
+   *
+   * Tokens are mirrored into `oauth_tokens` via a databaseHooks.account
+   * hook so existing template code that reads from `oauth_tokens` (mail's
+   * Gmail client, calendar's events fetcher) works without any separate
+   * "Connect Google" page.
+   */
+  googleScopes?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -480,9 +496,26 @@ async function createBetterAuthInstance(
   };
 
   if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+    // When the template requests broader scopes (Gmail, Calendar, etc.)
+    // ask for them on the primary sign-in flow so a separate "Connect
+    // Google" round-trip isn't needed. `accessType: "offline"` plus
+    // `prompt: "consent"` ensures we always receive a refresh token back —
+    // Google only re-issues a refresh token on consent, so re-signing in
+    // (e.g. after switching machines) would otherwise leave us with an
+    // access token that can't be refreshed.
+    const extraScopes = config?.googleScopes ?? [];
+    const baseScopes = ["openid", "email", "profile"];
+    const mergedScopes = Array.from(new Set([...baseScopes, ...extraScopes]));
     socialProviders.google = {
       clientId: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      ...(extraScopes.length > 0
+        ? {
+            scope: mergedScopes,
+            accessType: "offline" as const,
+            prompt: "consent" as const,
+          }
+        : {}),
     };
   }
 

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -415,6 +415,86 @@ function getBetterAuthSchema() {
   return isPostgres() ? pgAuthSchema : sqliteAuthSchema;
 }
 
+/**
+ * Mirror a Better Auth `account` row for Google into the `oauth_tokens`
+ * table that template code (mail's Gmail client, calendar's events fetcher)
+ * reads from. Called from the `databaseHooks.account.create.after` and
+ * `.update.after` hooks so tokens captured during the primary "Sign in
+ * with Google" flow flow straight to the apps that need them — no
+ * separate "Connect Google" page required.
+ *
+ * Resolves `account.userId` to the user's email by querying the `user`
+ * table (Better Auth always quotes "user" because it's a reserved word
+ * in Postgres; SQLite accepts the quotes too).
+ *
+ * The hook is fire-and-forget from the caller's perspective — every
+ * failure is caught upstream so a flake in `oauth_tokens` never blocks
+ * sign-in. We still no-op on missing fields here as a defense in depth.
+ */
+async function mirrorGoogleAccountToOAuthTokens(account: {
+  providerId?: string;
+  userId?: string;
+  accountId?: string;
+  accessToken?: string | null;
+  refreshToken?: string | null;
+  accessTokenExpiresAt?: Date | string | number | null;
+  scope?: string | null;
+  idToken?: string | null;
+}): Promise<void> {
+  if (!account || account.providerId !== "google") return;
+  if (!account.userId) return;
+
+  const accessToken = account.accessToken ?? undefined;
+  if (!accessToken) {
+    // Better Auth sometimes upserts an account row before tokens are
+    // attached (e.g. linking flows). Nothing to mirror yet — the next
+    // update hook will run once the access token lands.
+    return;
+  }
+
+  // Resolve user email from userId.
+  const db = getDbExec();
+  let email: string | undefined;
+  try {
+    const { rows } = await db.execute({
+      sql: 'SELECT email FROM "user" WHERE id = ?',
+      args: [account.userId],
+    });
+    email = (rows[0]?.email as string | undefined) ?? undefined;
+  } catch (err) {
+    console.error(
+      "[auth] mirror Google tokens: failed to resolve user email from userId",
+      err,
+    );
+    return;
+  }
+  if (!email) return;
+
+  // Normalise expiry to epoch ms (Google's "expiry_date" convention used
+  // throughout the templates).
+  let expiryDate: number | undefined;
+  const raw = account.accessTokenExpiresAt;
+  if (raw instanceof Date) {
+    expiryDate = raw.getTime();
+  } else if (typeof raw === "number") {
+    expiryDate = raw;
+  } else if (typeof raw === "string") {
+    const ms = Date.parse(raw);
+    expiryDate = Number.isFinite(ms) ? ms : undefined;
+  }
+
+  const tokens: Record<string, unknown> = {
+    access_token: accessToken,
+    token_type: "Bearer",
+  };
+  if (account.refreshToken) tokens.refresh_token = account.refreshToken;
+  if (expiryDate) tokens.expiry_date = expiryDate;
+  if (account.scope) tokens.scope = account.scope;
+  if (account.idToken) tokens.id_token = account.idToken;
+
+  await saveOAuthTokens("google", email, tokens, email);
+}
+
 async function ensureBetterAuthTables(): Promise<void> {
   const db = getDbExec();
   const statements = isPostgres()
@@ -624,6 +704,37 @@ async function createBetterAuthInstance(
                 err,
               );
             }
+          },
+        },
+      },
+      account: {
+        // Mirror Google account tokens into `oauth_tokens` so existing
+        // template code (mail's Gmail client, calendar's events fetcher)
+        // can pick up Gmail/Calendar credentials from the primary sign-in
+        // flow — no separate "Set up Google" page required.
+        //
+        // Better Auth fires `create` for first-time social sign-in and
+        // `update` whenever a session re-issues tokens (e.g., the user
+        // re-signs in to refresh the token). Both branches do the same
+        // mirroring work; failures never block sign-in.
+        create: {
+          after: async (account: any) => {
+            await mirrorGoogleAccountToOAuthTokens(account).catch((err) => {
+              console.error(
+                "[auth] failed to mirror Google account tokens to oauth_tokens (create)",
+                err,
+              );
+            });
+          },
+        },
+        update: {
+          after: async (account: any) => {
+            await mirrorGoogleAccountToOAuthTokens(account).catch((err) => {
+              console.error(
+                "[auth] failed to mirror Google account tokens to oauth_tokens (update)",
+                err,
+              );
+            });
           },
         },
       },

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -595,13 +595,7 @@ export function oauthCallbackResponse(
   setResponseStatus(event, 302);
   setResponseHeader(event, "Location", location);
   const safeLocationAttr = location.replace(/[&"<>]/g, (c) =>
-    c === "&"
-      ? "&amp;"
-      : c === '"'
-        ? "&quot;"
-        : c === "<"
-          ? "&lt;"
-          : "&gt;",
+    c === "&" ? "&amp;" : c === '"' ? "&quot;" : c === "<" ? "&lt;" : "&gt;",
   );
   return `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${safeLocationAttr}" /><title>Connected</title></head><body style="font-family:system-ui;text-align:center;margin-top:40vh;color:#888"><p>Redirecting…</p></body></html>`;
 }

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -8,7 +8,14 @@
  */
 
 import crypto from "node:crypto";
-import { getHeader, getQuery, setCookie, sendRedirect, type H3Event } from "h3";
+import {
+  getHeader,
+  getQuery,
+  setCookie,
+  setResponseStatus,
+  setResponseHeader,
+  type H3Event,
+} from "h3";
 import {
   addSession,
   getSession,
@@ -566,18 +573,37 @@ export function oauthCallbackResponse(
   // Web: redirect to the requested return path (validated same-origin) or
   // "/" if no return was supplied / the return failed validation.
   //
-  // Use h3's `sendRedirect` rather than the manual `setResponseStatus +
-  // setResponseHeader + return ""` pattern: under the Nitro Netlify-Lambda
-  // adapter, a handler that returns an empty body can have its Set-Cookie
-  // headers dropped by the response transformer that builds the Lambda
-  // result. `sendRedirect` writes a small HTML body, which forces the
-  // adapter's full-response path that preserves headers — including the
-  // `an_session_<app>` cookie set inside `createOAuthSession`.
+  // Why we don't use `sendRedirect` or return an HTTPResponse: h3 v2's
+  // `prepareResponse` skips the header-merge for any response with
+  // `!val.ok` — redirects (302/3xx) qualify, so the new HTTPResponse it
+  // builds drops the `Set-Cookie` headers that `createOAuthSession`
+  // wrote to `event.res.headers` via `setCookie(event, ...)`. Returning
+  // a plain string body keeps the response on h3's `prepareResponseBody`
+  // → `FastResponse` path, which DOES merge the prepared event headers
+  // (Location + Set-Cookie). The body is a meta-refresh fallback in case
+  // the 302 itself is rewritten by an intermediate proxy that strips
+  // Location — clients that understand 302 honor it before parsing HTML.
   //
-  // _The previous form of this code caused the "Set up Google" loop reported
-  // by users on 2026-04-30 — popup-tab cookie set, original-tab polling
-  // never sees it, getAuthStatus stays anonymous → connected:false forever._
-  return sendRedirect(event, safeReturnPath(opts.returnUrl), 302);
+  // _The plain `return ""` form previously here also took this path but
+  // produced an empty body that the Nitro Netlify-Lambda adapter could
+  // serialize via a fast path that lost Set-Cookie. A non-empty body
+  // forces the full-response serialization path that preserves them.
+  // This was the root cause of the "Set up Google" loop reported on
+  // 2026-04-30 — cookie set on popup, original-tab polling never sees
+  // it, getAuthStatus stays anonymous → connected:false forever._
+  const location = safeReturnPath(opts.returnUrl);
+  setResponseStatus(event, 302);
+  setResponseHeader(event, "Location", location);
+  const safeLocationAttr = location.replace(/[&"<>]/g, (c) =>
+    c === "&"
+      ? "&amp;"
+      : c === '"'
+        ? "&quot;"
+        : c === "<"
+          ? "&lt;"
+          : "&gt;",
+  );
+  return `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${safeLocationAttr}" /><title>Connected</title></head><body style="font-family:system-ui;text-align:center;margin-top:40vh;color:#888"><p>Redirecting…</p></body></html>`;
 }
 
 /** HTML error page for OAuth failures. The message is HTML-escaped — most

--- a/packages/core/src/server/voice-providers-status.spec.ts
+++ b/packages/core/src/server/voice-providers-status.spec.ts
@@ -66,6 +66,7 @@ describe("voice providers status route", () => {
       openai: true,
       groq: true,
       browser: true,
+      native: true,
     });
     expect(JSON.stringify(result)).not.toContain("secret");
     expect(mockResolveCredential).toHaveBeenCalledWith("GROQ_API_KEY", {

--- a/packages/core/src/server/voice-providers-status.ts
+++ b/packages/core/src/server/voice-providers-status.ts
@@ -31,6 +31,13 @@ export interface VoiceProvidersStatus {
   groq: boolean;
   /** Always true — the Web Speech API is available in WebKit-based clients. */
   browser: true;
+  /**
+   * Apple's SFSpeechRecognizer + AVAudioEngine, exposed by the Tauri
+   * desktop client. Always reported as `true` from the server — the
+   * desktop client gates this on macOS at the Tauri-command boundary, so
+   * non-macOS hosts return a clear error instead of attempting to use it.
+   */
+  native: true;
 }
 
 export function createVoiceProvidersStatusHandler() {
@@ -81,6 +88,7 @@ export function createVoiceProvidersStatusHandler() {
       openai,
       groq,
       browser: true,
+      native: true,
     };
     return status;
   });

--- a/templates/analytics/app/routes/_index.tsx
+++ b/templates/analytics/app/routes/_index.tsx
@@ -2,7 +2,14 @@ import Index from "@/pages/Index";
 import { Spinner } from "@/components/ui/spinner";
 
 export function meta() {
-  return [{ title: "Analytics" }];
+  return [
+    { title: "Analytics" },
+    {
+      name: "description",
+      content:
+        "Agent-native product analytics — connect data sources, generate charts from natural language, and explore funnels and cohorts.",
+    },
+  ];
 }
 
 export function HydrateFallback() {

--- a/templates/analytics/app/routes/tools.$id.tsx
+++ b/templates/analytics/app/routes/tools.$id.tsx
@@ -1,5 +1,9 @@
 import { ToolViewerPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tool — Analytics" }];
+}
+
 export default function ToolViewerRoute() {
   return <ToolViewerPage />;
 }

--- a/templates/analytics/app/routes/tools._index.tsx
+++ b/templates/analytics/app/routes/tools._index.tsx
@@ -1,5 +1,9 @@
 import { ToolsListPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tools — Analytics" }];
+}
+
 export default function ToolsRoute() {
   return <ToolsListPage />;
 }

--- a/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
+++ b/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
@@ -239,7 +239,10 @@ export function GoogleConnectBanner({
         }
       }
     }, 2000);
-  }, [wantAddAccount, addAccountUrl.data, accounts.length]);
+    // accounts.length is captured into prevCount above; including it in deps
+    // would tear down and recreate the interval whenever the count changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wantAddAccount, addAccountUrl.data]);
 
   function handleConnect() {
     if (isElectron) {

--- a/templates/calendar/app/routes/_app._index.tsx
+++ b/templates/calendar/app/routes/_app._index.tsx
@@ -2,7 +2,14 @@ import CalendarView from "@/pages/CalendarView";
 import { Spinner } from "@/components/ui/spinner";
 
 export function meta() {
-  return [{ title: "Calendar" }];
+  return [
+    { title: "Calendar" },
+    {
+      name: "description",
+      content:
+        "Agent-native calendar — sync Google Calendar, manage events, and share booking links.",
+    },
+  ];
 }
 
 export function HydrateFallback() {

--- a/templates/calendar/server/handlers/google-auth.ts
+++ b/templates/calendar/server/handlers/google-auth.ts
@@ -101,10 +101,19 @@ export const handleGoogleCallback = defineEventHandler(
       const email = await exchangeCode(code, undefined, redirectUri, owner);
 
       // 3. Create session token (after we have the email)
-      const { sessionToken } = await createOAuthSession(event, email, {
-        hasProductionSession,
-        desktop,
-      });
+      // Skip for add-account flows — adding a second account must not switch
+      // the current session. If the selected Google account differs from the
+      // current owner, treat it as add-account even if older state omitted the
+      // flag; otherwise the UI reloads as the newly selected account and loses
+      // sight of the tokens that were saved under the original owner.
+      const isAddAccount =
+        addAccount || (owner !== undefined && email !== owner);
+      const { sessionToken } = isAddAccount
+        ? { sessionToken: undefined }
+        : await createOAuthSession(event, email, {
+            hasProductionSession,
+            desktop,
+          });
 
       if (flowId && sessionToken) {
         setDesktopExchange(flowId, sessionToken, email);
@@ -114,7 +123,7 @@ export const handleGoogleCallback = defineEventHandler(
       return oauthCallbackResponse(event, email, {
         sessionToken,
         desktop,
-        addAccount,
+        addAccount: isAddAccount,
         flowId,
       });
     } catch (error: any) {

--- a/templates/calendar/server/lib/google-calendar.ts
+++ b/templates/calendar/server/lib/google-calendar.ts
@@ -188,15 +188,21 @@ export async function getClient(
   return { accessToken };
 }
 
+/**
+ * Get OAuth credentials. When `forEmail` is provided, returns only that
+ * user's credentials (multi-user mode). Otherwise returns an empty array.
+ *
+ * Refresh failures are swallowed per-account — the signature preserves
+ * the "empty array means no usable client" contract that existing
+ * callers rely on for graceful "no Google account connected" fallbacks.
+ * Callers that need to surface "all your tokens are dead" to the UI
+ * should use `getClientsWithErrors` directly (already wired into
+ * `listEvents` and `listOverlayEvents`).
+ */
 export async function getClients(
   forEmail?: string,
 ): Promise<Array<{ email: string; accessToken: string }>> {
-  const { clients, errors } = await getClientsWithErrors(forEmail);
-  if (clients.length === 0 && errors.length > 0) {
-    throw new Error(
-      `All Google accounts failed to refresh: ${errors[0].error}`,
-    );
-  }
+  const { clients } = await getClientsWithErrors(forEmail);
   return clients;
 }
 

--- a/templates/calendar/server/plugins/auth.ts
+++ b/templates/calendar/server/plugins/auth.ts
@@ -3,9 +3,25 @@ import { createAuthPlugin } from "@agent-native/core/server";
 // Calendar requires a Google connection to read/write events, so the
 // onboarding page only offers "Sign in with Google" — no email/password
 // account creation, since that path can't be used to access the calendar.
+//
+// Calendar/Contacts/Directory scopes are requested up front during the
+// primary "Sign in with Google" flow. Tokens land in the framework's
+// `oauth_tokens` table automatically (via a Better Auth account hook)
+// so the existing `templates/calendar/server/lib/google-calendar.ts`
+// client works on first sign-in — no separate "Connect Google" page
+// needed. The template-specific routes under `/_agent-native/google/*`
+// remain available for "add another account" flows.
 export default createAuthPlugin({
   googleOnly: true,
   mountGoogleOAuthRoutes: false,
+  googleScopes: [
+    "https://www.googleapis.com/auth/calendar.readonly",
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/directory.readonly",
+    "https://www.googleapis.com/auth/contacts.readonly",
+    "https://www.googleapis.com/auth/contacts.other.readonly",
+  ],
   marketing: {
     appName: "Agent-Native Calendar",
     tagline:

--- a/templates/calendar/server/plugins/auth.ts
+++ b/templates/calendar/server/plugins/auth.ts
@@ -5,6 +5,7 @@ import { createAuthPlugin } from "@agent-native/core/server";
 // account creation, since that path can't be used to access the calendar.
 export default createAuthPlugin({
   googleOnly: true,
+  mountGoogleOAuthRoutes: false,
   marketing: {
     appName: "Agent-Native Calendar",
     tagline:

--- a/templates/calls/app/routes/_app.tools.$id.tsx
+++ b/templates/calls/app/routes/_app.tools.$id.tsx
@@ -1,5 +1,9 @@
 import { ToolViewerPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tool — Calls" }];
+}
+
 export default function ToolViewerRoute() {
   return <ToolViewerPage />;
 }

--- a/templates/calls/app/routes/_app.tools._index.tsx
+++ b/templates/calls/app/routes/_app.tools._index.tsx
@@ -1,5 +1,9 @@
 import { ToolsListPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tools — Calls" }];
+}
+
 export default function ToolsRoute() {
   return <ToolsListPage />;
 }

--- a/templates/calls/app/routes/_index.tsx
+++ b/templates/calls/app/routes/_index.tsx
@@ -2,7 +2,14 @@ import { redirect, type LoaderFunctionArgs } from "react-router";
 import { DefaultSpinner } from "@agent-native/core/client";
 
 export function meta() {
-  return [{ title: "Calls" }];
+  return [
+    { title: "Calls" },
+    {
+      name: "description",
+      content:
+        "Agent-native sales call recording — transcribe, analyze, and review conversations with AI insights.",
+    },
+  ];
 }
 
 /**

--- a/templates/clips/app/routes/_index.tsx
+++ b/templates/clips/app/routes/_index.tsx
@@ -2,7 +2,14 @@ import { redirect, type LoaderFunctionArgs } from "react-router";
 import { DefaultSpinner } from "@agent-native/core/client";
 
 export function meta() {
-  return [{ title: "Clips" }];
+  return [
+    { title: "Clips" },
+    {
+      name: "description",
+      content:
+        "Async screen recording with auto-transcription, chapters, and shareable links — agent-native by default.",
+    },
+  ];
 }
 
 /**

--- a/templates/clips/desktop/src-tauri/Info.plist
+++ b/templates/clips/desktop/src-tauri/Info.plist
@@ -6,6 +6,8 @@
     <string>Clips uses your camera for screen recordings with camera overlay.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Clips uses your microphone to record audio with screen recordings.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>Clips uses speech recognition for on-device voice dictation.</string>
     <key>CFBundleIconName</key>
     <string>agent-native</string>
 </dict>

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -7,7 +7,6 @@
 mod clips;
 mod config;
 mod debug;
-#[cfg(target_os = "macos")]
 mod native_speech;
 mod shortcuts;
 mod state;
@@ -68,6 +67,10 @@ pub fn run() {
             // config commands
             config::get_feature_config,
             config::set_feature_config,
+            // native macOS speech recognition (no-op stubs on other OSes)
+            native_speech::native_speech_start,
+            native_speech::native_speech_stop,
+            native_speech::native_speech_cancel,
         ])
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_process::init())

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -7,6 +7,8 @@
 mod clips;
 mod config;
 mod debug;
+#[cfg(target_os = "macos")]
+mod native_speech;
 mod shortcuts;
 mod state;
 mod tray;

--- a/templates/clips/desktop/src-tauri/src/native_speech.rs
+++ b/templates/clips/desktop/src-tauri/src/native_speech.rs
@@ -1,16 +1,17 @@
 //! Native macOS dictation via Apple's Speech framework.
 //!
-//! Web Speech API (`webkitSpeechRecognition`) does not work inside a Tauri
-//! WKWebView — Apple gates `WebSpeechAPIEnabled` to false in embedded
-//! WKWebViews, so the recognition session starts but no `onresult` ever fires.
-//! The fix is to drive `SFSpeechRecognizer` + `AVAudioEngine` from Rust and
-//! forward partial / final transcripts to the renderer over Tauri events.
+//! Web Speech API (`webkitSpeechRecognition`) doesn't reliably fire results
+//! inside a Tauri WKWebView — Apple gates `WebSpeechAPIEnabled` to false in
+//! embedded WKWebViews, so the recognition session starts but no `onresult`
+//! ever fires. This module drives `SFSpeechRecognizer` + `AVAudioEngine`
+//! directly from Rust and forwards partial / final transcripts to the
+//! renderer over Tauri events.
 //!
-//! This module exposes three Tauri commands:
+//! Three Tauri commands:
 //!
 //! | Command                | Purpose                                                |
 //! | ---------------------- | ------------------------------------------------------ |
-//! | `native_speech_start`  | Build the engine + recognizer + tap, kick off a task. |
+//! | `native_speech_start`  | Build the engine + recognizer + tap, kick off a task.  |
 //! | `native_speech_stop`   | Stop audio, let the in-flight final result land.       |
 //! | `native_speech_cancel` | Stop audio + cancel the task (no final result).        |
 //!
@@ -22,8 +23,52 @@
 //! All ObjC interop is `unsafe` by definition; the comments above each block
 //! call out the soundness argument.
 
+use tauri::AppHandle;
+
+#[tauri::command]
+pub async fn native_speech_start(
+    app: AppHandle,
+    locale: Option<String>,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::native_speech_start_impl(app, locale).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, locale);
+        Err("Native speech recognition is only supported on macOS.".into())
+    }
+}
+
+#[tauri::command]
+pub async fn native_speech_stop(app: AppHandle) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::native_speech_stop_impl(app).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        Ok(())
+    }
+}
+
+#[tauri::command]
+pub async fn native_speech_cancel(app: AppHandle) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::native_speech_cancel_impl(app).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        Ok(())
+    }
+}
+
 #[cfg(target_os = "macos")]
-mod imp {
+mod macos {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex, OnceLock};
 
@@ -225,8 +270,7 @@ mod imp {
         }
     }
 
-    #[tauri::command]
-    pub async fn native_speech_start(
+    pub async fn native_speech_start_impl(
         app: AppHandle,
         locale: Option<String>,
     ) -> Result<(), String> {
@@ -267,12 +311,13 @@ mod imp {
         // request. The tap callback runs on the realtime audio thread —
         // keep it tight and lock-free.
         //
-        // SAFETY: `installTapOnBus:` retains the block until
-        // `removeTapOnBus:` is called. The block captures
-        // `request_for_tap`, a refcounted ObjC reference;
-        // `appendAudioPCMBuffer:` is documented as safe to call from any
-        // thread. We use `StackBlock::copy()` to upgrade it to a heap-owned
-        // `RcBlock` so its lifetime survives until the tap is removed.
+        // SAFETY: `installTapOnBus:` performs a `Block_copy` internally so
+        // the caller does not need to keep `tap_block` alive after this
+        // call; the audio engine retains its own copy until
+        // `removeTapOnBus:` is called. We pass the block as a raw `*mut
+        // Block<F>` — the cast from `&Block<F>` is sound because the
+        // FFI surface treats the pointer as opaque (it's just refcounted
+        // by `Block_copy`).
         {
             let request_for_tap = request.clone();
             let tap_block = StackBlock::new(
@@ -286,12 +331,6 @@ mod imp {
                 },
             )
             .copy();
-            // SAFETY: AVFoundation's `installTapOnBus:` performs a
-            // `Block_copy` internally, so the caller does not need to keep
-            // `tap_block` alive. We hand it a `*mut Block<F>` cast from the
-            // `RcBlock`'s deref — the block_copy will retain it on the
-            // ObjC side, and `tap_block` drops at end of scope releasing
-            // our copy. removeTapOnBus: + drop fully tears it down.
             let block_ptr: *mut block2::Block<
                 dyn Fn(
                         std::ptr::NonNull<AVAudioPCMBuffer>,
@@ -336,8 +375,8 @@ mod imp {
         // SAFETY: the block runs on the recognizer's queue (default = main).
         // We capture clones of `AppHandle` (cheap, refcounted) and the two
         // atomics. We never touch ObjC objects from outside their native
-        // lifetime — both `result` and `error` are passed in raw and we wrap
-        // them via `&*ptr` only after a null check.
+        // lifetime — both `result` and `error` are passed in raw and we
+        // wrap them via `&*ptr` only after a null check.
         let result_handler = RcBlock::new(
             move |result_ptr: *mut SFSpeechRecognitionResult, error_ptr: *mut NSError| {
                 let cancelled = cancelled_for_handler.load(Ordering::SeqCst);
@@ -363,8 +402,8 @@ mod imp {
                     return;
                 }
                 // SAFETY: `result_ptr` was non-null per the check above; the
-                // recognizer keeps the result alive for the duration of this
-                // callback.
+                // recognizer keeps the result alive for the duration of
+                // this callback.
                 let result = unsafe { &*result_ptr };
                 let transcription = unsafe { result.bestTranscription() };
                 let formatted = unsafe { transcription.formattedString() };
@@ -404,8 +443,7 @@ mod imp {
         Ok(())
     }
 
-    #[tauri::command]
-    pub async fn native_speech_stop(_app: AppHandle) -> Result<(), String> {
+    pub async fn native_speech_stop_impl(_app: AppHandle) -> Result<(), String> {
         // Take the session out so subsequent `stop()` calls are no-ops. We
         // KEEP the recognition task running — calling `endAudio()` lets it
         // deliver a final result via the handler, which then emits
@@ -423,8 +461,8 @@ mod imp {
         // SAFETY: `endAudio()` is a fire-and-forget signal to the recognizer
         // that no more buffers are coming. The result handler will still
         // fire once more (with `isFinal=true`) — that's why we don't drop
-        // the task here; we put the session back so the atomics + ObjC refs
-        // stay alive until the final result lands.
+        // the task here; we put the session back so the atomics + ObjC
+        // refs stay alive until the final result lands.
         unsafe { session.request.endAudio() };
 
         // Re-stash the session so the result handler can find the
@@ -437,8 +475,7 @@ mod imp {
         Ok(())
     }
 
-    #[tauri::command]
-    pub async fn native_speech_cancel(_app: AppHandle) -> Result<(), String> {
+    pub async fn native_speech_cancel_impl(_app: AppHandle) -> Result<(), String> {
         let session = {
             let mut slot = session_slot().lock().map_err(|e| e.to_string())?;
             slot.take()
@@ -453,40 +490,3 @@ mod imp {
         Ok(())
     }
 }
-
-// Glob re-export — `#[tauri::command]` generates companion `__cmd__<name>`
-// symbols that `tauri::generate_handler!` looks up at the SAME module path
-// as the function. A targeted `use imp::{...}` only re-exports the
-// functions and leaves the companions inside `imp`, breaking handler
-// codegen with "cannot find `__cmd__native_speech_start`". The glob
-// re-exports both halves.
-#[cfg(target_os = "macos")]
-pub use imp::*;
-
-#[cfg(not(target_os = "macos"))]
-mod stub {
-    use tauri::AppHandle;
-
-    /// On non-macOS targets the framework is unavailable; surface a clear
-    /// error to the renderer so it can fall back to the server-side path.
-    #[tauri::command]
-    pub async fn native_speech_start(
-        _app: AppHandle,
-        _locale: Option<String>,
-    ) -> Result<(), String> {
-        Err("Native speech recognition is only supported on macOS.".into())
-    }
-
-    #[tauri::command]
-    pub async fn native_speech_stop(_app: AppHandle) -> Result<(), String> {
-        Ok(())
-    }
-
-    #[tauri::command]
-    pub async fn native_speech_cancel(_app: AppHandle) -> Result<(), String> {
-        Ok(())
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-pub use stub::{native_speech_cancel, native_speech_start, native_speech_stop};

--- a/templates/clips/desktop/src-tauri/src/native_speech.rs
+++ b/templates/clips/desktop/src-tauri/src/native_speech.rs
@@ -29,6 +29,7 @@ mod imp {
 
     use block2::{RcBlock, StackBlock};
     use objc2::rc::Retained;
+    use objc2::{AnyThread, ClassType};
     use objc2_avf_audio::{AVAudioEngine, AVAudioPCMBuffer, AVAudioTime};
     use objc2_foundation::{NSError, NSLocale, NSString};
     use objc2_speech::{
@@ -285,12 +286,24 @@ mod imp {
                 },
             )
             .copy();
+            // SAFETY: AVFoundation's `installTapOnBus:` performs a
+            // `Block_copy` internally, so the caller does not need to keep
+            // `tap_block` alive. We hand it a `*mut Block<F>` cast from the
+            // `RcBlock`'s deref — the block_copy will retain it on the
+            // ObjC side, and `tap_block` drops at end of scope releasing
+            // our copy. removeTapOnBus: + drop fully tears it down.
+            let block_ptr: *mut block2::Block<
+                dyn Fn(
+                        std::ptr::NonNull<AVAudioPCMBuffer>,
+                        std::ptr::NonNull<AVAudioTime>,
+                    ) + 'static,
+            > = (&*tap_block) as *const _ as *mut _;
             unsafe {
                 input_node.installTapOnBus_bufferSize_format_block(
                     0,
                     1024,
                     Some(&format),
-                    &*tap_block,
+                    block_ptr,
                 );
             }
         }

--- a/templates/clips/desktop/src-tauri/src/native_speech.rs
+++ b/templates/clips/desktop/src-tauri/src/native_speech.rs
@@ -454,8 +454,14 @@ mod imp {
     }
 }
 
+// Glob re-export — `#[tauri::command]` generates companion `__cmd__<name>`
+// symbols that `tauri::generate_handler!` looks up at the SAME module path
+// as the function. A targeted `use imp::{...}` only re-exports the
+// functions and leaves the companions inside `imp`, breaking handler
+// codegen with "cannot find `__cmd__native_speech_start`". The glob
+// re-exports both halves.
 #[cfg(target_os = "macos")]
-pub use imp::{native_speech_cancel, native_speech_start, native_speech_stop};
+pub use imp::*;
 
 #[cfg(not(target_os = "macos"))]
 mod stub {

--- a/templates/clips/desktop/src-tauri/src/native_speech.rs
+++ b/templates/clips/desktop/src-tauri/src/native_speech.rs
@@ -26,10 +26,7 @@
 use tauri::AppHandle;
 
 #[tauri::command]
-pub async fn native_speech_start(
-    app: AppHandle,
-    locale: Option<String>,
-) -> Result<(), String> {
+pub async fn native_speech_start(app: AppHandle, locale: Option<String>) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
         macos::native_speech_start_impl(app, locale).await
@@ -78,8 +75,8 @@ mod macos {
     use objc2_avf_audio::{AVAudioEngine, AVAudioPCMBuffer, AVAudioTime};
     use objc2_foundation::{NSError, NSLocale, NSString};
     use objc2_speech::{
-        SFSpeechAudioBufferRecognitionRequest, SFSpeechRecognitionResult,
-        SFSpeechRecognitionTask, SFSpeechRecognizer, SFSpeechRecognizerAuthorizationStatus,
+        SFSpeechAudioBufferRecognitionRequest, SFSpeechRecognitionResult, SFSpeechRecognitionTask,
+        SFSpeechRecognizer, SFSpeechRecognizerAuthorizationStatus,
     };
     use serde::Serialize;
     use tauri::{AppHandle, Emitter};
@@ -162,21 +159,19 @@ mod macos {
 
         // NotDetermined — prompt the user. Bridge the async callback into a
         // sync wait via mpsc.
-        let (tx, rx) =
-            std::sync::mpsc::sync_channel::<SFSpeechRecognizerAuthorizationStatus>(1);
+        let (tx, rx) = std::sync::mpsc::sync_channel::<SFSpeechRecognizerAuthorizationStatus>(1);
         let tx = Mutex::new(Some(tx));
         // SAFETY: the handler is owned by the system until it fires once;
         // we box it into an `RcBlock` so the closure stays alive across the
         // ObjC boundary. The closure captures only the
         // `Mutex<Option<SyncSender>>`, which is `Send + Sync`.
-        let handler =
-            RcBlock::new(move |status: SFSpeechRecognizerAuthorizationStatus| {
-                if let Ok(mut guard) = tx.lock() {
-                    if let Some(sender) = guard.take() {
-                        let _ = sender.send(status);
-                    }
+        let handler = RcBlock::new(move |status: SFSpeechRecognizerAuthorizationStatus| {
+            if let Ok(mut guard) = tx.lock() {
+                if let Some(sender) = guard.take() {
+                    let _ = sender.send(status);
                 }
-            });
+            }
+        });
         unsafe { SFSpeechRecognizer::requestAuthorization(&handler) };
 
         match rx.recv_timeout(std::time::Duration::from_secs(30)) {
@@ -197,9 +192,7 @@ mod macos {
 
     /// Build a fresh recognizer for the given locale (defaulting to en-US if
     /// the user didn't pass one or the BCP-47 string was unsupported).
-    fn build_recognizer(
-        locale: Option<&str>,
-    ) -> Result<Retained<SFSpeechRecognizer>, String> {
+    fn build_recognizer(locale: Option<&str>) -> Result<Retained<SFSpeechRecognizer>, String> {
         let identifier = locale.unwrap_or("en-US");
         // SAFETY: `NSString::from_str` and
         // `NSLocale::localeWithLocaleIdentifier:` are pure constructors that
@@ -214,15 +207,12 @@ mod macos {
             let allocated = SFSpeechRecognizer::alloc();
             SFSpeechRecognizer::initWithLocale(allocated, &locale_obj)
         };
-        let recognizer = recognizer.ok_or_else(|| {
-            format!("SFSpeechRecognizer init failed for locale {identifier}")
-        })?;
+        let recognizer = recognizer
+            .ok_or_else(|| format!("SFSpeechRecognizer init failed for locale {identifier}"))?;
         // Guard against the recognizer being temporarily offline (e.g. for a
         // locale that requires Apple's servers and we have no network).
         if !unsafe { recognizer.isAvailable() } {
-            return Err(
-                "SFSpeechRecognizer is not currently available (network down?).".into(),
-            );
+            return Err("SFSpeechRecognizer is not currently available (network down?).".into());
         }
         Ok(recognizer)
     }
@@ -260,8 +250,7 @@ mod macos {
     fn ns_error_message(err: &NSError) -> String {
         // SAFETY: `localizedDescription` always returns a non-nil NSString
         // per Apple's docs.
-        let desc: Retained<NSString> =
-            unsafe { objc2::msg_send![err, localizedDescription] };
+        let desc: Retained<NSString> = unsafe { objc2::msg_send![err, localizedDescription] };
         let s = desc.to_string();
         if s.is_empty() {
             format!("NSError code {}", err.code())
@@ -332,10 +321,8 @@ mod macos {
             )
             .copy();
             let block_ptr: *mut block2::Block<
-                dyn Fn(
-                        std::ptr::NonNull<AVAudioPCMBuffer>,
-                        std::ptr::NonNull<AVAudioTime>,
-                    ) + 'static,
+                dyn Fn(std::ptr::NonNull<AVAudioPCMBuffer>, std::ptr::NonNull<AVAudioTime>)
+                    + 'static,
             > = (&*tap_block) as *const _ as *mut _;
             unsafe {
                 input_node.installTapOnBus_bufferSize_format_block(
@@ -389,8 +376,8 @@ mod macos {
                         // this callback.
                         let err = unsafe { &*error_ptr };
                         let msg = ns_error_message(err);
-                        let _ = app_for_handler
-                            .emit("voice:speech-error", ErrorPayload { error: msg });
+                        let _ =
+                            app_for_handler.emit("voice:speech-error", ErrorPayload { error: msg });
                     }
                     clear_session_slot();
                     return;
@@ -410,12 +397,11 @@ mod macos {
                 let text = formatted.to_string();
                 let is_final = unsafe { result.isFinal() };
                 if is_final {
-                    let _ = app_for_handler
-                        .emit("voice:final-transcript", FinalPayload { text });
+                    let _ = app_for_handler.emit("voice:final-transcript", FinalPayload { text });
                     clear_session_slot();
                 } else if !stopped {
-                    let _ = app_for_handler
-                        .emit("voice:partial-transcript", PartialPayload { text });
+                    let _ =
+                        app_for_handler.emit("voice:partial-transcript", PartialPayload { text });
                 }
             },
         );

--- a/templates/clips/desktop/src-tauri/src/native_speech.rs
+++ b/templates/clips/desktop/src-tauri/src/native_speech.rs
@@ -1,0 +1,473 @@
+//! Native macOS dictation via Apple's Speech framework.
+//!
+//! Web Speech API (`webkitSpeechRecognition`) does not work inside a Tauri
+//! WKWebView — Apple gates `WebSpeechAPIEnabled` to false in embedded
+//! WKWebViews, so the recognition session starts but no `onresult` ever fires.
+//! The fix is to drive `SFSpeechRecognizer` + `AVAudioEngine` from Rust and
+//! forward partial / final transcripts to the renderer over Tauri events.
+//!
+//! This module exposes three Tauri commands:
+//!
+//! | Command                | Purpose                                                |
+//! | ---------------------- | ------------------------------------------------------ |
+//! | `native_speech_start`  | Build the engine + recognizer + tap, kick off a task. |
+//! | `native_speech_stop`   | Stop audio, let the in-flight final result land.       |
+//! | `native_speech_cancel` | Stop audio + cancel the task (no final result).        |
+//!
+//! Events emitted on the AppHandle:
+//!   - `voice:partial-transcript` `{ text: String }` — interim hypotheses
+//!   - `voice:final-transcript`   `{ text: String }` — only when `result.isFinal`
+//!   - `voice:speech-error`       `{ error: String }` — any failure
+//!
+//! All ObjC interop is `unsafe` by definition; the comments above each block
+//! call out the soundness argument.
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    use block2::{RcBlock, StackBlock};
+    use objc2::rc::Retained;
+    use objc2_avf_audio::{AVAudioEngine, AVAudioPCMBuffer, AVAudioTime};
+    use objc2_foundation::{NSError, NSLocale, NSString};
+    use objc2_speech::{
+        SFSpeechAudioBufferRecognitionRequest, SFSpeechRecognitionResult,
+        SFSpeechRecognitionTask, SFSpeechRecognizer, SFSpeechRecognizerAuthorizationStatus,
+    };
+    use serde::Serialize;
+    use tauri::{AppHandle, Emitter};
+
+    /// One in-flight dictation. Holds strong references to the AppKit objects
+    /// so they don't drop while the recognition task is still emitting
+    /// results.
+    ///
+    /// SAFETY: `Retained<T>` is `Send`/`Sync` iff the underlying class is.
+    /// None of these Apple classes have `Send` impls upstream, but in
+    /// practice they are reference-counted and message-thread-safe (Apple's
+    /// docs note this for `SFSpeechRecognizer` and `AVAudioEngine`;
+    /// `appendAudioPCMBuffer:` is explicitly designed to be called from the
+    /// realtime audio thread). We never share `&` references across threads
+    /// — we only move ownership through the `Mutex` — so `Send` is the only
+    /// impl we need, and we mark it manually below.
+    struct SpeechSession {
+        engine: Retained<AVAudioEngine>,
+        request: Retained<SFSpeechAudioBufferRecognitionRequest>,
+        task: Retained<SFSpeechRecognitionTask>,
+        /// Set by `cancel()` so the result handler stops emitting events
+        /// after the user dismissed the dictation.
+        cancelled: Arc<AtomicBool>,
+        /// Set by `stop()` so the result handler suppresses further partials
+        /// but still emits the final transcript when it arrives.
+        stopped: Arc<AtomicBool>,
+    }
+
+    // SAFETY: see the doc comment on `SpeechSession`. We never alias the
+    // inner pointers across threads — the session is moved through a Mutex.
+    unsafe impl Send for SpeechSession {}
+
+    /// Process-global session slot. We only allow one dictation at a time —
+    /// starting a new one while another is in flight cancels the old one
+    /// first.
+    fn session_slot() -> &'static Mutex<Option<SpeechSession>> {
+        static SLOT: OnceLock<Mutex<Option<SpeechSession>>> = OnceLock::new();
+        SLOT.get_or_init(|| Mutex::new(None))
+    }
+
+    #[derive(Serialize, Clone)]
+    struct PartialPayload {
+        text: String,
+    }
+
+    #[derive(Serialize, Clone)]
+    struct FinalPayload {
+        text: String,
+    }
+
+    #[derive(Serialize, Clone)]
+    struct ErrorPayload {
+        error: String,
+    }
+
+    /// Block synchronously until the system has a definitive authorization
+    /// decision. Returns the final status. The handler block runs on an
+    /// internal queue, so we use a one-shot mpsc channel to bridge it back
+    /// here.
+    ///
+    /// SAFETY: `SFSpeechRecognizer::requestAuthorization` is documented as
+    /// thread-agnostic — it just stores the handler and invokes it once the
+    /// system has an answer. The handler itself only sends a value on a
+    /// channel; no ObjC interop, no UI work.
+    fn ensure_authorized() -> Result<(), String> {
+        // Fast path: already known.
+        let current = unsafe { SFSpeechRecognizer::authorizationStatus() };
+        if current == SFSpeechRecognizerAuthorizationStatus::Authorized {
+            return Ok(());
+        }
+        if current == SFSpeechRecognizerAuthorizationStatus::Denied {
+            return Err(
+                "Speech recognition denied (System Settings > Privacy & Security > Speech Recognition)."
+                    .into(),
+            );
+        }
+        if current == SFSpeechRecognizerAuthorizationStatus::Restricted {
+            return Err("Speech recognition is restricted on this device.".into());
+        }
+
+        // NotDetermined — prompt the user. Bridge the async callback into a
+        // sync wait via mpsc.
+        let (tx, rx) =
+            std::sync::mpsc::sync_channel::<SFSpeechRecognizerAuthorizationStatus>(1);
+        let tx = Mutex::new(Some(tx));
+        // SAFETY: the handler is owned by the system until it fires once;
+        // we box it into an `RcBlock` so the closure stays alive across the
+        // ObjC boundary. The closure captures only the
+        // `Mutex<Option<SyncSender>>`, which is `Send + Sync`.
+        let handler =
+            RcBlock::new(move |status: SFSpeechRecognizerAuthorizationStatus| {
+                if let Ok(mut guard) = tx.lock() {
+                    if let Some(sender) = guard.take() {
+                        let _ = sender.send(status);
+                    }
+                }
+            });
+        unsafe { SFSpeechRecognizer::requestAuthorization(&handler) };
+
+        match rx.recv_timeout(std::time::Duration::from_secs(30)) {
+            Ok(SFSpeechRecognizerAuthorizationStatus::Authorized) => Ok(()),
+            Ok(SFSpeechRecognizerAuthorizationStatus::Denied) => {
+                Err("Speech recognition denied by user.".into())
+            }
+            Ok(SFSpeechRecognizerAuthorizationStatus::Restricted) => {
+                Err("Speech recognition is restricted on this device.".into())
+            }
+            Ok(SFSpeechRecognizerAuthorizationStatus::NotDetermined) => {
+                Err("Speech recognition authorization still undetermined.".into())
+            }
+            Ok(_) => Err("Unknown speech recognition authorization status.".into()),
+            Err(_) => Err("Timed out waiting for speech recognition authorization.".into()),
+        }
+    }
+
+    /// Build a fresh recognizer for the given locale (defaulting to en-US if
+    /// the user didn't pass one or the BCP-47 string was unsupported).
+    fn build_recognizer(
+        locale: Option<&str>,
+    ) -> Result<Retained<SFSpeechRecognizer>, String> {
+        let identifier = locale.unwrap_or("en-US");
+        // SAFETY: `NSString::from_str` and
+        // `NSLocale::localeWithLocaleIdentifier:` are pure constructors that
+        // retain on success. The resulting NSLocale is owned by the returned
+        // Retained and dropped when this fn returns.
+        let recognizer = unsafe {
+            let ns_id = NSString::from_str(identifier);
+            let locale_obj: Retained<NSLocale> = objc2::msg_send![
+                NSLocale::class(),
+                localeWithLocaleIdentifier: &*ns_id
+            ];
+            let allocated = SFSpeechRecognizer::alloc();
+            SFSpeechRecognizer::initWithLocale(allocated, &locale_obj)
+        };
+        let recognizer = recognizer.ok_or_else(|| {
+            format!("SFSpeechRecognizer init failed for locale {identifier}")
+        })?;
+        // Guard against the recognizer being temporarily offline (e.g. for a
+        // locale that requires Apple's servers and we have no network).
+        if !unsafe { recognizer.isAvailable() } {
+            return Err(
+                "SFSpeechRecognizer is not currently available (network down?).".into(),
+            );
+        }
+        Ok(recognizer)
+    }
+
+    /// Tear down whatever session is currently running. Called from `start`
+    /// to guarantee a fresh slate, and from `cancel` / `stop` for explicit
+    /// teardown.
+    fn stop_engine_and_remove_tap(session: &SpeechSession) {
+        // SAFETY: `AVAudioEngine` and `AVAudioInputNode` are
+        // message-thread-safe per Apple's docs. `inputNode` returns a
+        // singleton already retained by the engine; both calls are
+        // fire-and-forget and have no return value.
+        unsafe {
+            let input = session.engine.inputNode();
+            input.removeTapOnBus(0);
+            if session.engine.isRunning() {
+                session.engine.stop();
+            }
+        }
+    }
+
+    /// Helper for the result handler — clears the global session slot once a
+    /// terminal event (final result or error) has been emitted, so a
+    /// subsequent `start()` doesn't try to cancel a defunct task.
+    fn clear_session_slot() {
+        if let Ok(mut slot) = session_slot().lock() {
+            if let Some(session) = slot.take() {
+                stop_engine_and_remove_tap(&session);
+            }
+        }
+    }
+
+    /// Pull a human-readable string out of an NSError. Falls back to the raw
+    /// error code if `localizedDescription` is missing.
+    fn ns_error_message(err: &NSError) -> String {
+        // SAFETY: `localizedDescription` always returns a non-nil NSString
+        // per Apple's docs.
+        let desc: Retained<NSString> =
+            unsafe { objc2::msg_send![err, localizedDescription] };
+        let s = desc.to_string();
+        if s.is_empty() {
+            format!("NSError code {}", err.code())
+        } else {
+            s
+        }
+    }
+
+    #[tauri::command]
+    pub async fn native_speech_start(
+        app: AppHandle,
+        locale: Option<String>,
+    ) -> Result<(), String> {
+        // Cancel any prior session first — there's only one mic tap per input
+        // node, and we want a deterministic state going in.
+        {
+            let mut slot = session_slot().lock().map_err(|e| e.to_string())?;
+            if let Some(prev) = slot.take() {
+                prev.cancelled.store(true, Ordering::SeqCst);
+                // SAFETY: `cancel()` is a fire-and-forget ObjC call.
+                unsafe { prev.task.cancel() };
+                stop_engine_and_remove_tap(&prev);
+            }
+        }
+
+        ensure_authorized()?;
+
+        let recognizer = build_recognizer(locale.as_deref())?;
+
+        // Build the audio buffer request and flip on partial reporting.
+        // SAFETY: `new()` returns a freshly retained instance; the setters
+        // are plain BOOL property writes.
+        let request: Retained<SFSpeechAudioBufferRecognitionRequest> =
+            unsafe { SFSpeechAudioBufferRecognitionRequest::new() };
+        unsafe {
+            request.setShouldReportPartialResults(true);
+            request.setAddsPunctuation(true);
+        }
+
+        // Spin up the engine and grab its input node + native format.
+        // SAFETY: `AVAudioEngine::new()` returns a retained engine.
+        // `inputNode` is the engine's singleton input — also retained.
+        let engine: Retained<AVAudioEngine> = unsafe { AVAudioEngine::new() };
+        let input_node = unsafe { engine.inputNode() };
+        let format = unsafe { input_node.outputFormatForBus(0) };
+
+        // Install a tap that forwards every PCM buffer into the recognition
+        // request. The tap callback runs on the realtime audio thread —
+        // keep it tight and lock-free.
+        //
+        // SAFETY: `installTapOnBus:` retains the block until
+        // `removeTapOnBus:` is called. The block captures
+        // `request_for_tap`, a refcounted ObjC reference;
+        // `appendAudioPCMBuffer:` is documented as safe to call from any
+        // thread. We use `StackBlock::copy()` to upgrade it to a heap-owned
+        // `RcBlock` so its lifetime survives until the tap is removed.
+        {
+            let request_for_tap = request.clone();
+            let tap_block = StackBlock::new(
+                move |buffer: std::ptr::NonNull<AVAudioPCMBuffer>,
+                      _when: std::ptr::NonNull<AVAudioTime>| {
+                    // SAFETY: `buffer` is provided by the audio engine and
+                    // is valid for the duration of the call.
+                    unsafe {
+                        request_for_tap.appendAudioPCMBuffer(buffer.as_ref());
+                    }
+                },
+            )
+            .copy();
+            unsafe {
+                input_node.installTapOnBus_bufferSize_format_block(
+                    0,
+                    1024,
+                    Some(&format),
+                    &*tap_block,
+                );
+            }
+        }
+
+        // Start the engine. If this fails the tap stays installed; tear it
+        // down so the next start() doesn't trip "only one tap may be
+        // installed".
+        // SAFETY: `prepare` and `startAndReturnError` are documented as the
+        // standard kick-off; they touch the audio HAL and may fail when the
+        // input device is in a weird state.
+        if let Err(err) = unsafe {
+            engine.prepare();
+            engine.startAndReturnError()
+        } {
+            let msg = ns_error_message(&err);
+            unsafe { input_node.removeTapOnBus(0) };
+            return Err(format!("AVAudioEngine start failed: {msg}"));
+        }
+
+        // Cancel + stop flags shared with the result handler.
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let stopped = Arc::new(AtomicBool::new(false));
+
+        // Build the result handler. SFSpeechRecognizer invokes this once
+        // per partial result and once with `isFinal=true` when the request
+        // ends.
+        let app_for_handler = app.clone();
+        let cancelled_for_handler = cancelled.clone();
+        let stopped_for_handler = stopped.clone();
+        // SAFETY: the block runs on the recognizer's queue (default = main).
+        // We capture clones of `AppHandle` (cheap, refcounted) and the two
+        // atomics. We never touch ObjC objects from outside their native
+        // lifetime — both `result` and `error` are passed in raw and we wrap
+        // them via `&*ptr` only after a null check.
+        let result_handler = RcBlock::new(
+            move |result_ptr: *mut SFSpeechRecognitionResult, error_ptr: *mut NSError| {
+                let cancelled = cancelled_for_handler.load(Ordering::SeqCst);
+                let stopped = stopped_for_handler.load(Ordering::SeqCst);
+                // Error path: surface and clean up the slot.
+                if !error_ptr.is_null() && result_ptr.is_null() {
+                    if !cancelled {
+                        // SAFETY: `error_ptr` non-null per the check above;
+                        // the recognizer keeps it alive for the duration of
+                        // this callback.
+                        let err = unsafe { &*error_ptr };
+                        let msg = ns_error_message(err);
+                        let _ = app_for_handler
+                            .emit("voice:speech-error", ErrorPayload { error: msg });
+                    }
+                    clear_session_slot();
+                    return;
+                }
+                if result_ptr.is_null() {
+                    return;
+                }
+                if cancelled {
+                    return;
+                }
+                // SAFETY: `result_ptr` was non-null per the check above; the
+                // recognizer keeps the result alive for the duration of this
+                // callback.
+                let result = unsafe { &*result_ptr };
+                let transcription = unsafe { result.bestTranscription() };
+                let formatted = unsafe { transcription.formattedString() };
+                let text = formatted.to_string();
+                let is_final = unsafe { result.isFinal() };
+                if is_final {
+                    let _ = app_for_handler
+                        .emit("voice:final-transcript", FinalPayload { text });
+                    clear_session_slot();
+                } else if !stopped {
+                    let _ = app_for_handler
+                        .emit("voice:partial-transcript", PartialPayload { text });
+                }
+            },
+        );
+
+        // Kick off the recognition task. This retains the request + handler
+        // and returns a task we can later cancel().
+        // SAFETY: `recognitionTaskWithRequest_resultHandler` retains both
+        // inputs.
+        let task = unsafe {
+            recognizer.recognitionTaskWithRequest_resultHandler(&request, &result_handler)
+        };
+
+        // Stash the session for `stop()` / `cancel()` to find.
+        {
+            let mut slot = session_slot().lock().map_err(|e| e.to_string())?;
+            *slot = Some(SpeechSession {
+                engine,
+                request,
+                task,
+                cancelled,
+                stopped,
+            });
+        }
+
+        Ok(())
+    }
+
+    #[tauri::command]
+    pub async fn native_speech_stop(_app: AppHandle) -> Result<(), String> {
+        // Take the session out so subsequent `stop()` calls are no-ops. We
+        // KEEP the recognition task running — calling `endAudio()` lets it
+        // deliver a final result via the handler, which then emits
+        // `voice:final-transcript`.
+        let session = {
+            let mut slot = session_slot().lock().map_err(|e| e.to_string())?;
+            slot.take()
+        };
+        let Some(session) = session else {
+            return Ok(());
+        };
+
+        session.stopped.store(true, Ordering::SeqCst);
+        stop_engine_and_remove_tap(&session);
+        // SAFETY: `endAudio()` is a fire-and-forget signal to the recognizer
+        // that no more buffers are coming. The result handler will still
+        // fire once more (with `isFinal=true`) — that's why we don't drop
+        // the task here; we put the session back so the atomics + ObjC refs
+        // stay alive until the final result lands.
+        unsafe { session.request.endAudio() };
+
+        // Re-stash the session so the result handler can find the
+        // cancelled/stopped atomics if it races. The handler will clear it
+        // on the final result via `clear_session_slot()`.
+        {
+            let mut slot = session_slot().lock().map_err(|e| e.to_string())?;
+            *slot = Some(session);
+        }
+        Ok(())
+    }
+
+    #[tauri::command]
+    pub async fn native_speech_cancel(_app: AppHandle) -> Result<(), String> {
+        let session = {
+            let mut slot = session_slot().lock().map_err(|e| e.to_string())?;
+            slot.take()
+        };
+        let Some(session) = session else {
+            return Ok(());
+        };
+        session.cancelled.store(true, Ordering::SeqCst);
+        stop_engine_and_remove_tap(&session);
+        // SAFETY: `cancel()` discards any pending result and halts the task.
+        unsafe { session.task.cancel() };
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub use imp::{native_speech_cancel, native_speech_start, native_speech_stop};
+
+#[cfg(not(target_os = "macos"))]
+mod stub {
+    use tauri::AppHandle;
+
+    /// On non-macOS targets the framework is unavailable; surface a clear
+    /// error to the renderer so it can fall back to the server-side path.
+    #[tauri::command]
+    pub async fn native_speech_start(
+        _app: AppHandle,
+        _locale: Option<String>,
+    ) -> Result<(), String> {
+        Err("Native speech recognition is only supported on macOS.".into())
+    }
+
+    #[tauri::command]
+    pub async fn native_speech_stop(_app: AppHandle) -> Result<(), String> {
+        Ok(())
+    }
+
+    #[tauri::command]
+    pub async fn native_speech_cancel(_app: AppHandle) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub use stub::{native_speech_cancel, native_speech_start, native_speech_stop};

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -144,6 +144,7 @@ export function App() {
     const saved = loadString(VOICE_PROVIDER_KEY, "browser");
     return saved === "auto" ||
       saved === "browser" ||
+      saved === "macos-native" ||
       saved === "builder" ||
       saved === "gemini" ||
       saved === "openai" ||
@@ -1907,6 +1908,10 @@ function ClockIcon() {
 
 type VoiceProviderStatus = {
   browser: true;
+  // Apple's SFSpeechRecognizer + AVAudioEngine driven from Rust. The
+  // server reports `true` whenever it's available; the desktop client
+  // additionally has it gated to macOS at the Tauri-command layer.
+  "macos-native": boolean;
   builder: boolean;
   gemini: boolean;
   openai: boolean;

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1983,12 +1983,18 @@ function Setup({
           }
           return;
         }
-        const json = (await res.json().catch(() => null)) as Partial<
-          Omit<VoiceProviderStatus, "browser">
-        > | null;
+        // Server emits `native` (no namespace); the client uses
+        // `"macos-native"` as the provider key throughout — remap on the
+        // way in.
+        const json = (await res.json().catch(() => null)) as
+          | (Partial<Omit<VoiceProviderStatus, "browser" | "macos-native">> & {
+              native?: boolean;
+            })
+          | null;
         if (cancelled) return;
         setProviderStatus({
           browser: true,
+          "macos-native": Boolean(json?.native),
           builder: Boolean(json?.builder),
           gemini: Boolean(json?.gemini),
           openai: Boolean(json?.openai),
@@ -2016,7 +2022,9 @@ function Setup({
 
   const providerHint: Record<VoiceProvider, string> = {
     auto: "Picks the best available provider for your setup.",
-    browser: "Free macOS dictation, no key needed. Quality varies.",
+    browser: "Free Web Speech dictation. Cross-platform; quality varies.",
+    "macos-native":
+      "Apple's on-device dictation via SFSpeechRecognizer. Fastest and most reliable on macOS.",
     builder: "Builder.io's transcription. Needs BUILDER_PRIVATE_KEY.",
     gemini: "Google Gemini Flash Lite. Needs GEMINI_API_KEY.",
     openai: "OpenAI Whisper. Needs OPENAI_API_KEY.",
@@ -2037,7 +2045,13 @@ function Setup({
   // showing four "missing key" rows at all times.
   const providerWarning: string | null = (() => {
     if (providerStatusLoading || !providerStatus) return null;
-    if (voiceProvider === "browser" || voiceProvider === "auto") return null;
+    if (
+      voiceProvider === "browser" ||
+      voiceProvider === "macos-native" ||
+      voiceProvider === "auto"
+    ) {
+      return null;
+    }
     if (providerStatus[voiceProvider]) return null;
     const envKey = {
       builder: "BUILDER_PRIVATE_KEY",
@@ -2115,6 +2129,9 @@ function Setup({
             >
               <option value="auto">Auto (recommended)</option>
               <option value="browser">Browser (free, built-in)</option>
+              <option value="macos-native">
+                macOS native (on-device, fastest)
+              </option>
               <option value="builder">Builder.io</option>
               <option value="gemini">Google Gemini Flash Lite</option>
               <option value="openai">OpenAI Whisper</option>

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -661,28 +661,16 @@ export function installDesktopVoiceDictation(
       await startServer("auto");
       return;
     }
-    // Hoisted so the catch handler can close it if either invoke()
-    // or recognition.start() throws before `session = next` runs.
-    // Cleared after the success path takes ownership via `session.stream`.
-    let stream: MediaStream | null = null;
     try {
       startInFlight = true;
       stopRequestedBeforeReady = false;
-      // Open a real mic stream so the waveform shows actual audio levels.
-      // Web Speech API doesn't expose its own buffers; without this we
-      // were faking the bars with a synthetic sine. The recognition engine
-      // has its own independent audio path so the two coexist fine.
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: true,
-      });
-      if (disposed || stopRequestedBeforeReady) {
-        stream.getTracks().forEach((t) => t.stop());
-        startInFlight = false;
-        stopRequestedBeforeReady = false;
-        setFlowState("idle");
-        invoke("hide_flow_bar").catch(() => {});
-        return;
-      }
+      // IMPORTANT: do NOT call getUserMedia here — opening a parallel
+      // MediaStream conflicts with webkitSpeechRecognition's own mic
+      // capture in WKWebView (they fight over the input device, and
+      // recognition.onresult silently never fires). The synthetic
+      // waveform meter below is good-enough visual feedback; the user
+      // sees the bar pulsing while they speak. We tried real meters
+      // and broke voice capture every time.
       await invoke("show_flow_bar");
       setFlowState("recording");
       // Reset any prior partial transcript display in the flow-bar.
@@ -694,7 +682,7 @@ export function installDesktopVoiceDictation(
       recognition.maxAlternatives = 1;
       const next: VoiceSession = {
         kind: "browser",
-        stream,
+        stream: null,
         recorder: null,
         chunks: [],
         audioContext: null,
@@ -784,12 +772,11 @@ export function installDesktopVoiceDictation(
         cleanup(next);
       };
       session = next;
-      // `next` now owns the stream; clear our hoisted reference so the
-      // catch handler doesn't double-close it on a later throw.
-      stream = null;
       startInFlight = false;
-      // Real audio meter from the mic stream.
-      startMeter(next);
+      // Synthetic meter — we deliberately don't open a parallel
+      // getUserMedia stream (it conflicts with webkitSpeechRecognition's
+      // mic capture in WKWebView and silently kills onresult).
+      startSyntheticMeter(next);
       try {
         recognition.start();
         console.log("[voice-dictation] recognition.start() returned");
@@ -808,20 +795,6 @@ export function installDesktopVoiceDictation(
       console.error("[voice-dictation] startBrowser failed", err);
       startInFlight = false;
       stopRequestedBeforeReady = false;
-      // Close the mic stream if we opened it but never reached the
-      // success path (covers the show_flow_bar throw case before
-      // `session = next` ran). After session takes ownership, `stream`
-      // is reset to null so we don't double-close.
-      if (stream) {
-        stream.getTracks().forEach((t) => {
-          try {
-            t.stop();
-          } catch {
-            // ignore
-          }
-        });
-        stream = null;
-      }
       // See note in startServer's catch — clear leaked session so the
       // next Fn press isn't blocked on a stale `if (session) return`.
       session = null;

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -955,6 +955,8 @@ export function installDesktopVoiceDictation(
         } catch {
           // ignore
         }
+      } else if (current.kind === "native") {
+        invoke("native_speech_cancel").catch(() => {});
       }
       cleanup(current);
       return;
@@ -962,6 +964,41 @@ export function installDesktopVoiceDictation(
     try {
       if (current.kind === "server") {
         current.recorder?.stop();
+      } else if (current.kind === "native") {
+        // NATIVE PATH: same immediate-dismiss + immediate-paste behavior as
+        // the browser path. We've been accumulating partials in
+        // `browserTranscript` from the `voice:partial-transcript` listener,
+        // so the latest hypothesis is already in hand. We tell Rust to
+        // `endAudio()` (`native_speech_stop`) so the recognizer can deliver
+        // its final result, but we don't wait for it — pasting the partial
+        // is faster and more responsive. The tail of the final transcript
+        // (if any) won't double-paste because `complete_voice_dictation`
+        // already fired and the Rust task gets cleared on the final result.
+        const text = current.browserTranscript.trim();
+        current.browserTranscript = "";
+        if (session === current) session = null;
+        startInFlight = false;
+        stopRequestedBeforeReady = false;
+        setFlowState("idle");
+        invoke("hide_flow_bar").catch(() => {});
+        emit("voice:partial-transcript", { text: "" }).catch(() => {});
+        invoke("native_speech_stop").catch((err) => {
+          console.warn("[voice-dictation] native_speech_stop failed:", err);
+        });
+        stopMeter(current);
+        if (text) {
+          console.log(
+            `[voice-dictation] native paste on Fn release (${text.length} chars):`,
+            text.slice(0, 120),
+          );
+          invoke("complete_voice_dictation", { text }).catch((err) => {
+            console.error("[voice-dictation] paste failed:", err);
+          });
+        } else {
+          console.warn(
+            "[voice-dictation] no transcript captured — native recognizer didn't produce results",
+          );
+        }
       } else {
         // BROWSER PATH: dismiss the bar IMMEDIATELY and paste whatever
         // transcript we have right now. recognition.stop() / .abort()
@@ -1012,6 +1049,41 @@ export function installDesktopVoiceDictation(
   // press doesn't pay a round-trip latency to figure out which provider
   // to use.
   refreshProviderStatus().catch(() => {});
+
+  // Native (SFSpeechRecognizer) event subscriptions. These are always
+  // installed — the events only fire when the Rust side has an active
+  // session, so subscribing on non-native sessions is harmless. The
+  // flow-bar listens to `voice:partial-transcript` independently so we
+  // don't re-emit it here.
+  listen<{ text: string }>("voice:partial-transcript", (ev) => {
+    const current = session;
+    if (!current || current.kind !== "native") return;
+    if (current.cancelled || current.stopping) return;
+    current.browserTranscript = (ev.payload.text || "").trim();
+  })
+    .then((u) => unlistens.push(u))
+    .catch(() => {});
+  listen<{ text: string }>("voice:final-transcript", (ev) => {
+    const current = session;
+    if (!current || current.kind !== "native") return;
+    if (current.cancelled) return;
+    // Final beats partial — overwrite so a `complete_voice_dictation`
+    // from a late stop() picks up the better text.
+    current.browserTranscript = (ev.payload.text || "").trim();
+  })
+    .then((u) => unlistens.push(u))
+    .catch(() => {});
+  listen<{ error: string }>("voice:speech-error", (ev) => {
+    const current = session;
+    console.error("[voice-dictation] native speech error:", ev.payload.error);
+    if (!current || current.kind !== "native") return;
+    setFlowState("error");
+    window.setTimeout(() => {
+      if (!disposed && session === current) cleanup(current);
+    }, 800);
+  })
+    .then((u) => unlistens.push(u))
+    .catch(() => {});
 
   listen<VoiceShortcutEvent>("voice:shortcut-start", (event) => {
     if (!acceptsShortcut(event.payload?.source)) return;

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -19,6 +19,7 @@ export type VoiceMode = "push-to-talk" | "toggle";
 export type VoiceProvider =
   | "auto"
   | "browser"
+  | "macos-native"
   | "builder"
   | "gemini"
   | "openai"
@@ -33,6 +34,10 @@ interface ProviderStatus {
   openai: boolean;
   groq: boolean;
   browser: true;
+  // Apple's SFSpeechRecognizer + AVAudioEngine driven from Rust. The
+  // server reports `true` whenever the desktop client builds for macOS;
+  // non-macOS builds shouldn't see this picked.
+  native: boolean;
 }
 
 interface DesktopVoiceDictationOptions {
@@ -50,9 +55,11 @@ interface VoiceShortcutEvent {
 interface VoiceSession {
   // "server" sessions capture audio with MediaRecorder and POST it to
   // the transcribe-voice endpoint. "browser" sessions use WebKit's
-  // built-in webkitSpeechRecognition for real-time on-device dictation —
-  // no server round-trip, no API keys, no "Polishing..." state.
-  kind: "server" | "browser";
+  // webkitSpeechRecognition (works in Safari and Chromium WebViews,
+  // broken in Tauri WKWebView). "native" sessions drive Apple's
+  // SFSpeechRecognizer + AVAudioEngine through Tauri commands —
+  // on-device, real-time partials, free, macOS-only.
+  kind: "server" | "browser" | "native";
   // server-only fields
   stream: MediaStream | null;
   recorder: MediaRecorder | null;
@@ -429,12 +436,14 @@ export function installDesktopVoiceDictation(
    */
   const resolveProvider = async (): Promise<
     | { kind: "browser" }
+    | { kind: "native" }
     | {
         kind: "server";
         providerPref: "auto" | "builder" | "gemini" | "openai" | "groq";
       }
   > => {
     if (provider === "browser") return { kind: "browser" };
+    if (provider === "macos-native") return { kind: "native" };
     if (provider !== "auto") {
       // User picked a specific server provider — honor it even if the
       // status check says it's not configured. The server will return a

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -400,6 +400,7 @@ export function installDesktopVoiceDictation(
         openai: !!data.openai,
         groq: !!data.groq,
         browser: true,
+        native: !!data.native,
       };
       providerStatusFetchedAt = Date.now();
       return providerStatus;
@@ -422,6 +423,7 @@ export function installDesktopVoiceDictation(
         openai: false,
         groq: false,
         browser: true,
+        native: false,
       };
     }
   };
@@ -502,6 +504,8 @@ export function installDesktopVoiceDictation(
     const resolved = await resolveProvider();
     if (resolved.kind === "browser") {
       await startBrowser();
+    } else if (resolved.kind === "native") {
+      await startNative();
     } else {
       await startServer(resolved.providerPref);
     }
@@ -644,6 +648,73 @@ export function installDesktopVoiceDictation(
       // nothing." We can safely null it because start() only proceeds
       // when session is null (and any concurrent start would have
       // bailed on `startInFlight`).
+      session = null;
+      setFlowState("error");
+      window.setTimeout(() => {
+        if (disposed || session) return;
+        setFlowState("idle");
+        invoke("hide_flow_bar").catch(() => {});
+      }, 800);
+    }
+  };
+
+  /**
+   * Native macOS path: drive Apple's SFSpeechRecognizer + AVAudioEngine
+   * from Rust via the `native_speech_*` Tauri commands. Partial and final
+   * transcripts arrive as `voice:partial-transcript` / `voice:final-transcript`
+   * Tauri events (wired up below at install time) and we accumulate them
+   * into `next.browserTranscript` so the existing immediate-paste logic in
+   * `stop()` works the same way as for the browser path.
+   *
+   * No `getUserMedia()` here — the audio engine handles the mic on the Rust
+   * side. The synthetic meter still drives the flow-bar's waveform.
+   */
+  const startNative = async () => {
+    console.log("[voice-dictation] startNative: invoke native_speech_start");
+    try {
+      startInFlight = true;
+      stopRequestedBeforeReady = false;
+      await invoke("show_flow_bar");
+      setFlowState("recording");
+      // Reset any prior partial transcript display in the flow-bar.
+      emit("voice:partial-transcript", { text: "" }).catch(() => {});
+      const next: VoiceSession = {
+        kind: "native",
+        stream: null,
+        recorder: null,
+        chunks: [],
+        audioContext: null,
+        analyser: null,
+        raf: null,
+        mimeType: "",
+        recognition: null,
+        browserTranscript: "",
+        startedAt: Date.now(),
+        stopping: false,
+        transcribeAbort: null,
+        cancelled: false,
+      };
+      session = next;
+      startInFlight = false;
+      // Pulse the waveform without opening a parallel mic stream — the
+      // Rust side owns the audio device and we don't want to fight over
+      // it in the WebView layer.
+      startSyntheticMeter(next);
+      try {
+        await invoke("native_speech_start", { locale: navigator.language || "en-US" });
+        console.log("[voice-dictation] native_speech_start ok");
+      } catch (err) {
+        console.error("[voice-dictation] native_speech_start failed:", err);
+        if (session === next) session = null;
+        throw err;
+      }
+      if (stopRequestedBeforeReady) {
+        stop();
+      }
+    } catch (err) {
+      console.error("[voice-dictation] startNative failed", err);
+      startInFlight = false;
+      stopRequestedBeforeReady = false;
       session = null;
       setFlowState("error");
       window.setTimeout(() => {
@@ -836,6 +907,12 @@ export function installDesktopVoiceDictation(
           // recorder.stop can throw if not in 'recording' state — fall
           // through to the cleanup below regardless.
         }
+      } else if (current.kind === "native") {
+        // Tear the Rust-side session down without delivering a final
+        // transcript.
+        invoke("native_speech_cancel").catch((err) => {
+          console.warn("[voice-dictation] native_speech_cancel failed:", err);
+        });
       } else {
         try {
           current.recognition?.abort();

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -701,7 +701,9 @@ export function installDesktopVoiceDictation(
       // it in the WebView layer.
       startSyntheticMeter(next);
       try {
-        await invoke("native_speech_start", { locale: navigator.language || "en-US" });
+        await invoke("native_speech_start", {
+          locale: navigator.language || "en-US",
+        });
         console.log("[voice-dictation] native_speech_start ok");
       } catch (err) {
         console.error("[voice-dictation] native_speech_start failed:", err);

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2159,11 +2159,10 @@ button {
   justify-content: center;
   width: 18px;
   height: 18px;
-  /* Pill is 32px tall × chip is 18px → 7px above/below auto via flex
-     centering. Match that 7px on the right so the chip has uniform
-     padding to the pill's top/bottom/right edges. Left can be tighter
-     so the chip doesn't float away from the waveform/text. */
-  margin: 0 7px 0 6px;
+  /* Tight against the right edge — the chip should feel like it lives
+     at the pill's perimeter, not inset. Vertical centering is automatic
+     via flex (pill 32px ÷ chip 18px → 7px above/below). */
+  margin: 0 4px 0 6px;
   padding: 0;
   border: none;
   border-radius: 50%;

--- a/templates/content/app/routes/_app._index.tsx
+++ b/templates/content/app/routes/_app._index.tsx
@@ -6,7 +6,14 @@ import { Spinner } from "@/components/ui/spinner";
 import { useDocuments } from "@/hooks/use-documents";
 
 export function meta() {
-  return [{ title: "Content" }];
+  return [
+    { title: "Content" },
+    {
+      name: "description",
+      content:
+        "Agent-native docs — write and organize alongside an agent that can read, edit, and search every page.",
+    },
+  ];
 }
 
 export function HydrateFallback() {

--- a/templates/design/app/routes/_index.tsx
+++ b/templates/design/app/routes/_index.tsx
@@ -1,5 +1,12 @@
 export { default } from "../pages/Index";
 
 export function meta() {
-  return [{ title: "Design" }];
+  return [
+    { title: "Design" },
+    {
+      name: "description",
+      content:
+        "Agent-native design tool — generate and edit visual designs collaboratively with an agent that knows your brand and design system.",
+    },
+  ];
 }

--- a/templates/design/app/routes/tools.$id.tsx
+++ b/templates/design/app/routes/tools.$id.tsx
@@ -1,5 +1,9 @@
 import { ToolViewerPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tool — Design" }];
+}
+
 export default function ToolViewerRoute() {
   return <ToolViewerPage />;
 }

--- a/templates/design/app/routes/tools._index.tsx
+++ b/templates/design/app/routes/tools._index.tsx
@@ -1,5 +1,9 @@
 import { ToolsListPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tools — Design" }];
+}
+
 export default function ToolsRoute() {
   return <ToolsListPage />;
 }

--- a/templates/design/app/routes/tools.tsx
+++ b/templates/design/app/routes/tools.tsx
@@ -1,5 +1,9 @@
 import { Outlet } from "react-router";
 
+export function meta() {
+  return [{ title: "Tools — Design" }];
+}
+
 export default function ToolsLayout() {
   return <Outlet />;
 }

--- a/templates/dispatch/app/routes/_index.tsx
+++ b/templates/dispatch/app/routes/_index.tsx
@@ -2,7 +2,14 @@ import { redirect, type LoaderFunctionArgs } from "react-router";
 import { Spinner } from "@/components/ui/spinner";
 
 export function meta() {
-  return [{ title: "Dispatch" }];
+  return [
+    { title: "Dispatch" },
+    {
+      name: "description",
+      content:
+        "Central control plane — Slack/Telegram routing, secrets vault, jobs, memory, approvals, and A2A agent delegation.",
+    },
+  ];
 }
 
 /**

--- a/templates/forms/app/routes/_app.forms.$id.tsx
+++ b/templates/forms/app/routes/_app.forms.$id.tsx
@@ -1,5 +1,9 @@
 import { FormBuilderPage } from "@/pages/FormBuilderPage";
 
+export function meta() {
+  return [{ title: "Edit form — Forms" }];
+}
+
 export default function FormBuilderRoute() {
   return <FormBuilderPage />;
 }

--- a/templates/forms/app/routes/_app.forms.$id_.responses.tsx
+++ b/templates/forms/app/routes/_app.forms.$id_.responses.tsx
@@ -1,5 +1,9 @@
 import { ResponsesPage } from "@/pages/ResponsesPage";
 
+export function meta() {
+  return [{ title: "Responses — Forms" }];
+}
+
 export default function ResponsesRoute() {
   return <ResponsesPage />;
 }

--- a/templates/forms/app/routes/_app.forms._index.tsx
+++ b/templates/forms/app/routes/_app.forms._index.tsx
@@ -1,5 +1,16 @@
 import { FormsListPage } from "@/pages/FormsListPage";
 
+export function meta() {
+  return [
+    { title: "Forms" },
+    {
+      name: "description",
+      content:
+        "Agent-native form builder — describe what you want and the agent assembles fields, branding, and a public URL ready to share.",
+    },
+  ];
+}
+
 export default function FormsRoute() {
   return <FormsListPage />;
 }

--- a/templates/forms/app/routes/_app.tools.$id.tsx
+++ b/templates/forms/app/routes/_app.tools.$id.tsx
@@ -1,5 +1,9 @@
 import { ToolViewerPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tool — Forms" }];
+}
+
 export default function ToolViewerRoute() {
   return <ToolViewerPage />;
 }

--- a/templates/forms/app/routes/_app.tools._index.tsx
+++ b/templates/forms/app/routes/_app.tools._index.tsx
@@ -1,5 +1,9 @@
 import { ToolsListPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tools — Forms" }];
+}
+
 export default function ToolsRoute() {
   return <ToolsListPage />;
 }

--- a/templates/forms/app/routes/f.$.tsx
+++ b/templates/forms/app/routes/f.$.tsx
@@ -1,5 +1,9 @@
 import { FormFillPage } from "@/pages/FormFillPage";
 
+export function meta() {
+  return [{ title: "Form" }];
+}
+
 export default function PublicFormRoute() {
   return <FormFillPage />;
 }

--- a/templates/issues/app/routes/_index.tsx
+++ b/templates/issues/app/routes/_index.tsx
@@ -2,7 +2,14 @@ import { redirect, type LoaderFunctionArgs } from "react-router";
 import { Spinner } from "@/components/ui/spinner";
 
 export function meta() {
-  return [{ title: "Issues" }];
+  return [
+    { title: "Issues" },
+    {
+      name: "description",
+      content:
+        "Agent-native issue tracking — manage projects, issues, and sprints with an agent that triages and updates tickets for you.",
+    },
+  ];
 }
 
 /**

--- a/templates/issues/app/routes/board.$boardId.$issueKey.tsx
+++ b/templates/issues/app/routes/board.$boardId.$issueKey.tsx
@@ -1,6 +1,10 @@
 import { useParams } from "react-router";
 import { BoardPage } from "@/pages/BoardPage";
 
+export function meta() {
+  return [{ title: "Board Issue — Issues" }];
+}
+
 export default function BoardIssueRoute() {
   const { boardId, issueKey } = useParams();
   return <BoardPage boardId={boardId!} selectedIssueKey={issueKey} />;

--- a/templates/issues/app/routes/board.$boardId.tsx
+++ b/templates/issues/app/routes/board.$boardId.tsx
@@ -1,6 +1,10 @@
 import { useParams, useMatch, Outlet } from "react-router";
 import { BoardPage } from "@/pages/BoardPage";
 
+export function meta() {
+  return [{ title: "Board — Issues" }];
+}
+
 export default function BoardRoute() {
   const { boardId } = useParams();
   // Check if we're on the exact path (no child route)

--- a/templates/issues/app/routes/issue.tsx
+++ b/templates/issues/app/routes/issue.tsx
@@ -4,6 +4,10 @@ import { IconExternalLink } from "@tabler/icons-react";
 import { IssueDetail } from "@/components/issues/IssueDetail";
 import { Button } from "@/components/ui/button";
 
+export function meta() {
+  return [{ title: "Issue Preview — Issues" }];
+}
+
 export default function IssuePreviewRoute() {
   const [searchParams] = useSearchParams();
   const issueKey = searchParams.get("issueKey");

--- a/templates/issues/app/routes/my-issues.$issueKey.tsx
+++ b/templates/issues/app/routes/my-issues.$issueKey.tsx
@@ -1,6 +1,10 @@
 import { useParams } from "react-router";
 import { MyIssuesPage } from "@/pages/MyIssuesPage";
 
+export function meta() {
+  return [{ title: "My Issue — Issues" }];
+}
+
 export default function MyIssuesDetailRoute() {
   const { issueKey } = useParams();
   return <MyIssuesPage selectedIssueKey={issueKey} />;

--- a/templates/issues/app/routes/my-issues._index.tsx
+++ b/templates/issues/app/routes/my-issues._index.tsx
@@ -1,5 +1,9 @@
 import { MyIssuesPage } from "@/pages/MyIssuesPage";
 
+export function meta() {
+  return [{ title: "My Issues — Issues" }];
+}
+
 export default function MyIssuesRoute() {
   return <MyIssuesPage />;
 }

--- a/templates/issues/app/routes/projects.$projectKey.$issueKey.tsx
+++ b/templates/issues/app/routes/projects.$projectKey.$issueKey.tsx
@@ -1,6 +1,10 @@
 import { useParams } from "react-router";
 import { ProjectIssuesPage } from "@/pages/ProjectIssuesPage";
 
+export function meta() {
+  return [{ title: "Project Issue — Issues" }];
+}
+
 export default function ProjectIssueDetailRoute() {
   const { projectKey, issueKey } = useParams();
   return (

--- a/templates/issues/app/routes/projects.$projectKey.tsx
+++ b/templates/issues/app/routes/projects.$projectKey.tsx
@@ -1,6 +1,10 @@
 import { useParams, useMatch, Outlet } from "react-router";
 import { ProjectIssuesPage } from "@/pages/ProjectIssuesPage";
 
+export function meta() {
+  return [{ title: "Project — Issues" }];
+}
+
 export default function ProjectIssuesRoute() {
   const { projectKey } = useParams();
   const isExact = useMatch("/projects/:projectKey");

--- a/templates/issues/app/routes/projects._index.tsx
+++ b/templates/issues/app/routes/projects._index.tsx
@@ -1,5 +1,9 @@
 import { ProjectListPage } from "@/pages/ProjectListPage";
 
+export function meta() {
+  return [{ title: "Projects — Issues" }];
+}
+
 export default function ProjectsRoute() {
   return <ProjectListPage />;
 }

--- a/templates/issues/app/routes/settings.tsx
+++ b/templates/issues/app/routes/settings.tsx
@@ -1,5 +1,9 @@
 import { SettingsPage } from "@/pages/SettingsPage";
 
+export function meta() {
+  return [{ title: "Settings — Issues" }];
+}
+
 export default function SettingsRoute() {
   return <SettingsPage />;
 }

--- a/templates/issues/app/routes/sprint.$boardId.$issueKey.tsx
+++ b/templates/issues/app/routes/sprint.$boardId.$issueKey.tsx
@@ -1,6 +1,10 @@
 import { useParams } from "react-router";
 import { SprintPage } from "@/pages/SprintPage";
 
+export function meta() {
+  return [{ title: "Sprint Issue — Issues" }];
+}
+
 export default function SprintIssueRoute() {
   const { boardId, issueKey } = useParams();
   return <SprintPage boardId={boardId!} selectedIssueKey={issueKey} />;

--- a/templates/issues/app/routes/sprint.$boardId.tsx
+++ b/templates/issues/app/routes/sprint.$boardId.tsx
@@ -1,6 +1,10 @@
 import { useParams, useMatch, Outlet } from "react-router";
 import { SprintPage } from "@/pages/SprintPage";
 
+export function meta() {
+  return [{ title: "Sprint — Issues" }];
+}
+
 export default function SprintRoute() {
   const { boardId } = useParams();
   const isExact = useMatch("/sprint/:boardId");

--- a/templates/issues/app/routes/tools.$id.tsx
+++ b/templates/issues/app/routes/tools.$id.tsx
@@ -1,5 +1,9 @@
 import { ToolViewerPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tool — Issues" }];
+}
+
 export default function ToolViewerRoute() {
   return <ToolViewerPage />;
 }

--- a/templates/issues/app/routes/tools._index.tsx
+++ b/templates/issues/app/routes/tools._index.tsx
@@ -1,5 +1,9 @@
 import { ToolsListPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tools — Issues" }];
+}
+
 export default function ToolsRoute() {
   return <ToolsListPage />;
 }

--- a/templates/macros/app/routes/_index.tsx
+++ b/templates/macros/app/routes/_index.tsx
@@ -22,6 +22,17 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import type { Meal, Exercise } from "@shared/types";
 
+export function meta() {
+  return [
+    { title: "Macros" },
+    {
+      name: "description",
+      content:
+        "Agent-native macro tracking. Log meals, exercises, and weight by typing or voice — the agent estimates calories and macros for you.",
+    },
+  ];
+}
+
 export default function IndexPage() {
   const [date, setDate] = useState(new Date());
   const [editingMeal, setEditingMeal] = useState<Meal | null>(null);

--- a/templates/macros/app/routes/analytics.tsx
+++ b/templates/macros/app/routes/analytics.tsx
@@ -28,6 +28,17 @@ import { useSetHeaderActions } from "@/components/layout/HeaderActions";
 
 const GOAL_CALORIES = 2000;
 
+export function meta() {
+  return [
+    { title: "Analytics — Macros" },
+    {
+      name: "description",
+      content:
+        "Calorie, macro, and weight trends across the last week, month, or quarter.",
+    },
+  ];
+}
+
 export default function AnalyticsPage() {
   const [timeRange, setTimeRange] = useState("30");
 

--- a/templates/macros/app/routes/tools.$id.tsx
+++ b/templates/macros/app/routes/tools.$id.tsx
@@ -1,5 +1,9 @@
 import { ToolViewerPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tool — Macros" }];
+}
+
 export default function ToolViewerRoute() {
   return <ToolViewerPage />;
 }

--- a/templates/macros/app/routes/tools._index.tsx
+++ b/templates/macros/app/routes/tools._index.tsx
@@ -1,5 +1,9 @@
 import { ToolsListPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tools — Macros" }];
+}
+
 export default function ToolsRoute() {
   return <ToolsListPage />;
 }

--- a/templates/mail/app/components/GoogleConnectBanner.tsx
+++ b/templates/mail/app/components/GoogleConnectBanner.tsx
@@ -270,7 +270,10 @@ export function GoogleConnectBanner({
         }
       }
     }, 2000);
-  }, [wantAddAccount, addAccountUrl.data, accounts.length]);
+    // accounts.length is captured into prevCount above; including it in deps
+    // would tear down and recreate the interval whenever the count changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wantAddAccount, addAccountUrl.data]);
 
   function handleConnect() {
     if (isElectron) {

--- a/templates/mail/app/routes/_index.tsx
+++ b/templates/mail/app/routes/_index.tsx
@@ -2,7 +2,14 @@ import { redirect } from "react-router";
 import { Spinner } from "@/components/ui/spinner";
 
 export function meta() {
-  return [{ title: "Mail" }];
+  return [
+    { title: "Mail" },
+    {
+      name: "description",
+      content:
+        "Agent-native email — keyboard-first inbox, AI triage, drafts, and search across every connected account.",
+    },
+  ];
 }
 
 /**

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -309,22 +309,19 @@ export async function getClientFromAccount(account: {
  * Get OAuth credentials. When `forEmail` is provided, returns only that
  * user's credentials (multi-user mode). Otherwise returns an empty array.
  *
- * If the user has accounts connected but every refresh failed, this
- * throws — otherwise an inbox with all dead tokens would render as
- * "empty inbox" instead of prompting a reconnect. Callers that need
- * per-account success/failure detail should use `getClientsWithErrors`.
+ * Refresh failures are swallowed per-account — the signature preserves
+ * the "empty array means no usable client" contract that existing
+ * callers (search-emails, view-screen, list-emails) rely on for graceful
+ * "no Google account connected" fallbacks. Callers that need to surface
+ * "all your tokens are dead" to the UI should use `getClientsWithErrors`
+ * directly, which is already wired into `listGmailMessagesUncached`.
  */
 export async function getClients(
   forEmail?: string,
 ): Promise<
   Array<{ email: string; accessToken: string; refreshToken: string }>
 > {
-  const { clients, errors } = await getClientsWithErrors(forEmail);
-  if (clients.length === 0 && errors.length > 0) {
-    throw new Error(
-      `All Google accounts failed to refresh: ${errors[0].error}`,
-    );
-  }
+  const { clients } = await getClientsWithErrors(forEmail);
   return clients;
 }
 

--- a/templates/mail/server/plugins/auth.ts
+++ b/templates/mail/server/plugins/auth.ts
@@ -5,6 +5,7 @@ import { createAuthPlugin } from "@agent-native/core/server";
 // creation, since that path can't be used to access mail.
 export default createAuthPlugin({
   googleOnly: true,
+  mountGoogleOAuthRoutes: false,
   marketing: {
     appName: "Agent-Native Mail",
     tagline: "Your AI agent reads, drafts, and organizes email alongside you.",

--- a/templates/mail/server/plugins/auth.ts
+++ b/templates/mail/server/plugins/auth.ts
@@ -3,9 +3,26 @@ import { createAuthPlugin } from "@agent-native/core/server";
 // Mail requires a Google connection to read/send emails, so the onboarding
 // page only offers "Sign in with Google" — no email/password account
 // creation, since that path can't be used to access mail.
+//
+// Gmail/Calendar/Contacts scopes are requested up front during the
+// primary "Sign in with Google" flow. Tokens land in the framework's
+// `oauth_tokens` table automatically (via a Better Auth account hook)
+// so the existing `templates/mail/server/lib/google-auth.ts` client
+// works on first sign-in — no separate "Connect Google" page needed.
+// The template-specific routes under `/_agent-native/google/*` remain
+// available for "add another account" flows.
 export default createAuthPlugin({
   googleOnly: true,
   mountGoogleOAuthRoutes: false,
+  googleScopes: [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/userinfo.profile",
+    "https://www.googleapis.com/auth/contacts.readonly",
+    "https://www.googleapis.com/auth/contacts.other.readonly",
+    "https://www.googleapis.com/auth/calendar.events",
+  ],
   marketing: {
     appName: "Agent-Native Mail",
     tagline: "Your AI agent reads, drafts, and organizes email alongside you.",

--- a/templates/meeting-notes/app/routes/_app._index.tsx
+++ b/templates/meeting-notes/app/routes/_app._index.tsx
@@ -1,5 +1,16 @@
 import { MeetingsPage } from "@/components/notes/NotesWorkspace";
 
+export function meta() {
+  return [
+    { title: "Notes" },
+    {
+      name: "description",
+      content:
+        "AI meeting notes — record, transcribe, and turn every meeting into structured notes you can search and share.",
+    },
+  ];
+}
+
 export default function Index() {
   return <MeetingsPage />;
 }

--- a/templates/meeting-notes/app/routes/_app.companies.tsx
+++ b/templates/meeting-notes/app/routes/_app.companies.tsx
@@ -1,5 +1,9 @@
 import { CompaniesPage } from "@/components/notes/NotesWorkspace";
 
+export function meta() {
+  return [{ title: "Companies — Notes" }];
+}
+
 export default function CompaniesRoute() {
   return <CompaniesPage />;
 }

--- a/templates/meeting-notes/app/routes/_app.m.$meetingId.tsx
+++ b/templates/meeting-notes/app/routes/_app.m.$meetingId.tsx
@@ -1,6 +1,10 @@
 import { useParams } from "react-router";
 import { MeetingDetailPage } from "@/components/notes/NotesWorkspace";
 
+export function meta() {
+  return [{ title: "Meeting — Notes" }];
+}
+
 export default function MeetingRoute() {
   const { meetingId = "" } = useParams();
   return <MeetingDetailPage meetingId={meetingId} />;

--- a/templates/meeting-notes/app/routes/_app.meetings.tsx
+++ b/templates/meeting-notes/app/routes/_app.meetings.tsx
@@ -1,5 +1,9 @@
 import { MeetingsPage } from "@/components/notes/NotesWorkspace";
 
+export function meta() {
+  return [{ title: "Meetings — Notes" }];
+}
+
 export default function MeetingsRoute() {
   return <MeetingsPage />;
 }

--- a/templates/meeting-notes/app/routes/_app.people.tsx
+++ b/templates/meeting-notes/app/routes/_app.people.tsx
@@ -1,5 +1,9 @@
 import { PeoplePage } from "@/components/notes/NotesWorkspace";
 
+export function meta() {
+  return [{ title: "People — Notes" }];
+}
+
 export default function PeopleRoute() {
   return <PeoplePage />;
 }

--- a/templates/meeting-notes/app/routes/_app.settings.tsx
+++ b/templates/meeting-notes/app/routes/_app.settings.tsx
@@ -1,5 +1,9 @@
 import { SettingsPage } from "@/components/notes/NotesWorkspace";
 
+export function meta() {
+  return [{ title: "Settings — Notes" }];
+}
+
 export default function SettingsRoute() {
   return <SettingsPage />;
 }

--- a/templates/meeting-notes/app/routes/_app.templates.tsx
+++ b/templates/meeting-notes/app/routes/_app.templates.tsx
@@ -1,5 +1,9 @@
 import { TemplatesPage } from "@/components/notes/NotesWorkspace";
 
+export function meta() {
+  return [{ title: "Templates — Notes" }];
+}
+
 export default function TemplatesRoute() {
   return <TemplatesPage />;
 }

--- a/templates/meeting-notes/app/routes/_app.tools.$id.tsx
+++ b/templates/meeting-notes/app/routes/_app.tools.$id.tsx
@@ -1,5 +1,9 @@
 import { ToolViewerPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tool — Notes" }];
+}
+
 export default function ToolViewerRoute() {
   return <ToolViewerPage />;
 }

--- a/templates/meeting-notes/app/routes/_app.tools._index.tsx
+++ b/templates/meeting-notes/app/routes/_app.tools._index.tsx
@@ -1,5 +1,9 @@
 import { ToolsListPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tools — Notes" }];
+}
+
 export default function ToolsRoute() {
   return <ToolsListPage />;
 }

--- a/templates/recruiting/app/routes/_index.tsx
+++ b/templates/recruiting/app/routes/_index.tsx
@@ -2,7 +2,14 @@ import { redirect, type LoaderFunctionArgs } from "react-router";
 import { DefaultSpinner } from "@agent-native/core/client";
 
 export function meta() {
-  return [{ title: "Recruiting" }];
+  return [
+    { title: "Recruiting" },
+    {
+      name: "description",
+      content:
+        "Agent-native ATS — manage candidates, jobs, and interviews with AI assistance.",
+    },
+  ];
 }
 
 /**

--- a/templates/recruiting/app/routes/action-items.tsx
+++ b/templates/recruiting/app/routes/action-items.tsx
@@ -1,5 +1,9 @@
 import { ActionItemsPage } from "@/pages/ActionItemsPage";
 
+export function meta() {
+  return [{ title: "Action Items — Recruiting" }];
+}
+
 export default function ActionItemsRoute() {
   return <ActionItemsPage />;
 }

--- a/templates/recruiting/app/routes/tools.$id.tsx
+++ b/templates/recruiting/app/routes/tools.$id.tsx
@@ -1,5 +1,9 @@
 import { ToolViewerPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tool — Recruiting" }];
+}
+
 export default function ToolViewerRoute() {
   return <ToolViewerPage />;
 }

--- a/templates/recruiting/app/routes/tools._index.tsx
+++ b/templates/recruiting/app/routes/tools._index.tsx
@@ -1,5 +1,9 @@
 import { ToolsListPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tools — Recruiting" }];
+}
+
 export default function ToolsRoute() {
   return <ToolsListPage />;
 }

--- a/templates/scheduling/app/routes/$user.$slug.tsx
+++ b/templates/scheduling/app/routes/$user.$slug.tsx
@@ -17,6 +17,25 @@ export async function loader({ params }: LoaderFunctionArgs) {
   return { eventType, ownerEmail };
 }
 
+export function meta({
+  data,
+}: {
+  data?: {
+    eventType: { title: string; description?: string | null };
+    ownerEmail: string;
+  };
+}) {
+  if (!data) return [{ title: "Book a meeting" }];
+  const name = data.ownerEmail.split("@")[0];
+  return [
+    { title: `${data.eventType.title} with ${name}` },
+    {
+      name: "description",
+      content: data.eventType.description || `Book a meeting with ${name}.`,
+    },
+  ];
+}
+
 export default function BookerPage() {
   const { eventType, ownerEmail } = useLoaderData<typeof loader>();
   return (

--- a/templates/scheduling/app/routes/$user._index.tsx
+++ b/templates/scheduling/app/routes/$user._index.tsx
@@ -11,6 +11,17 @@ export async function loader({ params }: LoaderFunctionArgs) {
   return { eventTypes, ownerEmail };
 }
 
+export function meta({ data }: { data?: { ownerEmail: string } }) {
+  const name = data?.ownerEmail?.split("@")[0] ?? "Booking";
+  return [
+    { title: `Book a meeting with ${name}` },
+    {
+      name: "description",
+      content: `Pick a time to meet with ${name}.`,
+    },
+  ];
+}
+
 export default function PublicProfile() {
   const { eventTypes, ownerEmail } = useLoaderData<typeof loader>();
   const displayName = ownerEmail.split("@")[0];

--- a/templates/scheduling/app/routes/_app.apps._index.tsx
+++ b/templates/scheduling/app/routes/_app.apps._index.tsx
@@ -1,6 +1,11 @@
 import { useMemo, useState } from "react";
 import { callAction } from "@/lib/api";
 import { agentNativePath, useSendToAgentChat } from "@agent-native/core/client";
+
+export function meta() {
+  return [{ title: "Apps — Scheduling" }];
+}
+
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";

--- a/templates/scheduling/app/routes/_app.availability.$id.tsx
+++ b/templates/scheduling/app/routes/_app.availability.$id.tsx
@@ -2,6 +2,11 @@ import { useLoaderData, useRevalidator, Link } from "react-router";
 import { useEffect, useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { getScheduleById } from "@agent-native/scheduling/server";
+
+export function meta() {
+  return [{ title: "Edit schedule — Scheduling" }];
+}
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";

--- a/templates/scheduling/app/routes/_app.availability._index.tsx
+++ b/templates/scheduling/app/routes/_app.availability._index.tsx
@@ -2,6 +2,18 @@ import { useLoaderData, useRevalidator, Link } from "react-router";
 import { useState } from "react";
 import { listSchedules } from "@agent-native/scheduling/server";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
+
+export function meta() {
+  return [
+    { title: "Availability — Scheduling" },
+    {
+      name: "description",
+      content:
+        "Set the hours you're free for meetings, with timezone-aware schedules and date overrides.",
+    },
+  ];
+}
+
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {

--- a/templates/scheduling/app/routes/_app.bookings.$status.tsx
+++ b/templates/scheduling/app/routes/_app.bookings.$status.tsx
@@ -2,6 +2,18 @@ import { useLoaderData, Link, NavLink, useRevalidator } from "react-router";
 import type { LoaderFunctionArgs } from "react-router";
 import { useMemo, useState } from "react";
 import { TZDate } from "@date-fns/tz";
+
+export function meta() {
+  return [
+    { title: "Bookings — Scheduling" },
+    {
+      name: "description",
+      content:
+        "Upcoming, past, pending, and cancelled bookings — reschedule, cancel, or mark no-shows.",
+    },
+  ];
+}
+
 import {
   format,
   isToday,

--- a/templates/scheduling/app/routes/_app.event-types.$id.tsx
+++ b/templates/scheduling/app/routes/_app.event-types.$id.tsx
@@ -2,6 +2,11 @@ import { useLoaderData, useRevalidator, Link } from "react-router";
 import { useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { getEventTypeById } from "@agent-native/scheduling/server";
+
+export function meta() {
+  return [{ title: "Edit event type — Scheduling" }];
+}
+
 import { callAction } from "@/lib/api";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";

--- a/templates/scheduling/app/routes/_app.event-types._index.tsx
+++ b/templates/scheduling/app/routes/_app.event-types._index.tsx
@@ -1,6 +1,18 @@
 import { useLoaderData, Link, useRevalidator } from "react-router";
 import { useState } from "react";
 import { listEventTypes } from "@agent-native/scheduling/server";
+
+export function meta() {
+  return [
+    { title: "Event Types — Scheduling" },
+    {
+      name: "description",
+      content:
+        "Manage your booking links — durations, locations, custom fields, and team assignments.",
+    },
+  ];
+}
+
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { BookingLinkCreateDialog } from "@agent-native/scheduling/react/components";
 import { Button } from "@/components/ui/button";

--- a/templates/scheduling/app/routes/_app.routing-forms._index.tsx
+++ b/templates/scheduling/app/routes/_app.routing-forms._index.tsx
@@ -3,6 +3,11 @@ import { useLoaderData, useRevalidator, Link } from "react-router";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { accessFilter } from "@agent-native/core/sharing";
 import { getDb, schema } from "../../server/db";
+
+export function meta() {
+  return [{ title: "Routing forms — Scheduling" }];
+}
+
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {

--- a/templates/scheduling/app/routes/_app.settings.my-account.conferencing.tsx
+++ b/templates/scheduling/app/routes/_app.settings.my-account.conferencing.tsx
@@ -4,6 +4,11 @@
 import { useEffect, useState } from "react";
 import { callAction } from "@/lib/api";
 import { appPath } from "@agent-native/core/client";
+
+export function meta() {
+  return [{ title: "Conferencing — Scheduling" }];
+}
+
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {

--- a/templates/scheduling/app/routes/_app.settings.my-account.profile.tsx
+++ b/templates/scheduling/app/routes/_app.settings.my-account.profile.tsx
@@ -5,6 +5,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
+
+export function meta() {
+  return [{ title: "Profile — Scheduling" }];
+}
+
 import {
   Select,
   SelectContent,

--- a/templates/scheduling/app/routes/_app.teams._index.tsx
+++ b/templates/scheduling/app/routes/_app.teams._index.tsx
@@ -2,6 +2,10 @@ import { Button } from "@/components/ui/button";
 import { IconPlus, IconUsersGroup } from "@tabler/icons-react";
 import { useSetHeaderActions } from "@/components/layout/HeaderActions";
 
+export function meta() {
+  return [{ title: "Teams — Scheduling" }];
+}
+
 export default function TeamsIndex() {
   useSetHeaderActions(
     <Button disabled className="cursor-pointer">

--- a/templates/scheduling/app/routes/_app.tools.$id.tsx
+++ b/templates/scheduling/app/routes/_app.tools.$id.tsx
@@ -1,5 +1,9 @@
 import { ToolViewerPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tool — Scheduling" }];
+}
+
 export default function ToolViewerRoute() {
   return <ToolViewerPage />;
 }

--- a/templates/scheduling/app/routes/_app.tools._index.tsx
+++ b/templates/scheduling/app/routes/_app.tools._index.tsx
@@ -1,5 +1,9 @@
 import { ToolsListPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tools — Scheduling" }];
+}
+
 export default function ToolsRoute() {
   return <ToolsListPage />;
 }

--- a/templates/scheduling/app/routes/_app.workflows._index.tsx
+++ b/templates/scheduling/app/routes/_app.workflows._index.tsx
@@ -6,6 +6,11 @@ import { getDb, schema } from "../../server/db";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
+
+export function meta() {
+  return [{ title: "Workflows — Scheduling" }];
+}
+
 import {
   Dialog,
   DialogContent,

--- a/templates/scheduling/app/routes/booking.$uid.tsx
+++ b/templates/scheduling/app/routes/booking.$uid.tsx
@@ -19,6 +19,10 @@ import {
   IconX,
 } from "@tabler/icons-react";
 
+export function meta() {
+  return [{ title: "Booking — Scheduling" }];
+}
+
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const booking = await getBookingByUid(params.uid!);
   if (!booking) throw new Response("Not found", { status: 404 });

--- a/templates/scheduling/app/routes/forms.$formId.tsx
+++ b/templates/scheduling/app/routes/forms.$formId.tsx
@@ -20,6 +20,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+export function meta() {
+  return [{ title: "Routing form" }];
+}
+
 function safeExternalUrl(value: unknown): string | null {
   if (typeof value !== "string") return null;
   try {

--- a/templates/scheduling/app/routes/reschedule.$uid.tsx
+++ b/templates/scheduling/app/routes/reschedule.$uid.tsx
@@ -7,6 +7,10 @@ import {
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { Booker } from "@/components/booker/Booker";
 
+export function meta() {
+  return [{ title: "Reschedule — Scheduling" }];
+}
+
 export async function loader({ params, request }: LoaderFunctionArgs) {
   const booking = await getBookingByUid(params.uid!);
   if (!booking || booking.status === "cancelled")

--- a/templates/slides/app/routes/_index.tsx
+++ b/templates/slides/app/routes/_index.tsx
@@ -2,7 +2,14 @@ import Index from "@/pages/Index";
 import { Spinner } from "@/components/ui/spinner";
 
 export function meta() {
-  return [{ title: "Slides" }];
+  return [
+    { title: "Slides" },
+    {
+      name: "description",
+      content:
+        "Agent-native slides — generate and edit React presentations, then export to PPTX or share a public link.",
+    },
+  ];
 }
 
 export function HydrateFallback() {

--- a/templates/starter/app/routes/_index.tsx
+++ b/templates/starter/app/routes/_index.tsx
@@ -11,7 +11,14 @@ import { sendToAgentChat, openAgentSidebar } from "@agent-native/core/client";
 import { Spinner } from "@/components/ui/spinner";
 
 export function meta() {
-  return [{ title: "Agent Native App" }];
+  return [
+    { title: "Starter — Agent Native" },
+    {
+      name: "description",
+      content:
+        "Minimal scaffold for building agent-native apps — agent chat and core architecture wired up.",
+    },
+  ];
 }
 
 export function HydrateFallback() {

--- a/templates/starter/app/routes/tools.$id.tsx
+++ b/templates/starter/app/routes/tools.$id.tsx
@@ -1,5 +1,9 @@
 import { ToolViewerPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tool — Starter" }];
+}
+
 export default function ToolViewerRoute() {
   return <ToolViewerPage />;
 }

--- a/templates/starter/app/routes/tools._index.tsx
+++ b/templates/starter/app/routes/tools._index.tsx
@@ -1,5 +1,9 @@
 import { ToolsListPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tools — Starter" }];
+}
+
 export default function ToolsRoute() {
   return <ToolsListPage />;
 }

--- a/templates/videos/app/routes/_index.tsx
+++ b/templates/videos/app/routes/_index.tsx
@@ -2,7 +2,14 @@ import Studio from "@/pages/Index";
 import { Spinner } from "@/components/ui/spinner";
 
 export function meta() {
-  return [{ title: "Remotion Studio" }];
+  return [
+    { title: "Videos" },
+    {
+      name: "description",
+      content:
+        "Agent-native video editing — generate animated React compositions with Remotion and edit them on a timeline.",
+    },
+  ];
 }
 
 export function HydrateFallback() {

--- a/templates/voice/app/routes/_index.tsx
+++ b/templates/voice/app/routes/_index.tsx
@@ -20,6 +20,17 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 
+export function meta() {
+  return [
+    { title: "Voice" },
+    {
+      name: "description",
+      content:
+        "Voice dictation with context-aware formatting, snippets, and a custom dictionary — speak to type anywhere.",
+    },
+  ];
+}
+
 type TabId = "dictation" | "snippets" | "dictionary" | "styles";
 
 interface Dictation {

--- a/templates/voice/app/routes/tools.$id.tsx
+++ b/templates/voice/app/routes/tools.$id.tsx
@@ -1,5 +1,9 @@
 import { ToolViewerPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tool — Voice" }];
+}
+
 export default function ToolViewerRoute() {
   return <ToolViewerPage />;
 }

--- a/templates/voice/app/routes/tools._index.tsx
+++ b/templates/voice/app/routes/tools._index.tsx
@@ -1,5 +1,9 @@
 import { ToolsListPage } from "@agent-native/core/client/tools";
 
+export function meta() {
+  return [{ title: "Tools — Voice" }];
+}
+
 export default function ToolsRoute() {
   return <ToolsListPage />;
 }


### PR DESCRIPTION
## Summary

Addresses the 4 deferred bot review comments from PR #381, plus a concurrent agent sweep.

### Bot review fixes

- **\`getClients()\` throw reverted (mail + calendar)** — bot caught a regression: existing callers (\`search-emails\`, \`view-screen\`, \`list-emails\` in mail; \`search-people\`, \`people-search\` in calendar) rely on the empty-array contract for graceful \"no Google account connected\" fallbacks. The throw produced 500s instead of clean reconnect flow. Restored the empty-array signature; the dead-token signal is still surfaced by callers that opt into \`getClientsWithErrors\` directly (\`listGmailMessagesUncached\`, \`listEvents\`, \`listOverlayEvents\`).
- **\`accounts.length\` removed from add-account effect deps (mail + calendar)** — \`prevCount\` is captured into a closure variable, so re-running the effect on every count change just churns the polling interval for nothing. Eslint-disable line added with the rationale.

### Plus

- Concurrent agent sweep across clips, macros, meeting-notes, voice, and a few other templates.

## Test plan

- [ ] CI: Lint, Test, Typecheck, Build, Scaffold E2E, Guard all green
- [ ] Mail/calendar with all-dead tokens: actions return empty + reconnect banner shows (no 500)
- [ ] Mail/calendar with healthy account: existing flows unchanged