### PR TITLE
Gate macos-native voice provider + concurrent sweep

### DIFF
--- a/packages/core/src/client/org/TeamPage.tsx
+++ b/packages/core/src/client/org/TeamPage.tsx
@@ -34,8 +34,10 @@ import {
   useSetOrgDomain,
   useSetA2ASecret,
   useSyncA2ASecret,
+  useJoinByDomain,
   type SyncA2ASecretResult,
 } from "./hooks.js";
+import type { DomainMatchOrg } from "../../org/types.js";
 
 export interface TeamPageProps {
   /**
@@ -111,6 +113,55 @@ function PendingInvitationsCard() {
         </div>
       ))}
       <ErrorText error={acceptInvitation.error} />
+    </section>
+  );
+}
+
+function JoinByDomainCard({ matches }: { matches: DomainMatchOrg[] }) {
+  const joinByDomain = useJoinByDomain();
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <h3 className="text-sm font-medium">Join your team</h3>
+      <p className="text-sm text-muted-foreground">
+        {matches.length === 1
+          ? `An organization matching your email domain already exists. Join it to collaborate with your teammates.`
+          : `Organizations matching your email domain already exist. Join one to collaborate with your teammates.`}
+      </p>
+      <div className="space-y-2">
+        {matches.map((m) => (
+          <div
+            key={m.orgId}
+            className="flex items-center justify-between rounded-md border border-border p-3"
+          >
+            <div className="flex items-center gap-2.5">
+              <div className="flex h-8 w-8 items-center justify-center rounded-md bg-blue-600/10">
+                <IconBuilding className="h-4 w-4 text-blue-600" />
+              </div>
+              <div className="text-sm font-medium">{m.orgName}</div>
+            </div>
+            <button
+              type="button"
+              disabled={joinByDomain.isPending && pendingId === m.orgId}
+              onClick={() => {
+                setPendingId(m.orgId);
+                joinByDomain.mutate(m.orgId, {
+                  onSettled: () => setPendingId(null),
+                });
+              }}
+              className="rounded-md bg-foreground px-3 py-1.5 text-xs font-medium text-background hover:opacity-90 disabled:opacity-50"
+            >
+              {joinByDomain.isPending && pendingId === m.orgId ? (
+                <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                "Join"
+              )}
+            </button>
+          </div>
+        ))}
+      </div>
+      <ErrorText error={joinByDomain.error} />
     </section>
   );
 }
@@ -1031,7 +1082,12 @@ export function TeamPage({
         <>
           <PendingInvitationsCard />
           {!org?.orgId ? (
-            <CreateOrgCard description={createOrgDescription} />
+            <>
+              {org?.domainMatches && org.domainMatches.length > 0 && (
+                <JoinByDomainCard matches={org.domainMatches} />
+              )}
+              <CreateOrgCard description={createOrgDescription} />
+            </>
           ) : (
             <MembersCard />
           )}

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -571,33 +571,13 @@ export function oauthCallbackResponse(
   }
 
   // Web: redirect to the requested return path (validated same-origin) or
-  // "/" if no return was supplied / the return failed validation.
-  //
-  // Why we don't use `sendRedirect` or return an HTTPResponse: h3 v2's
-  // `prepareResponse` skips the header-merge for any response with
-  // `!val.ok` — redirects (302/3xx) qualify, so the new HTTPResponse it
-  // builds drops the `Set-Cookie` headers that `createOAuthSession`
-  // wrote to `event.res.headers` via `setCookie(event, ...)`. Returning
-  // a plain string body keeps the response on h3's `prepareResponseBody`
-  // → `FastResponse` path, which DOES merge the prepared event headers
-  // (Location + Set-Cookie). The body is a meta-refresh fallback in case
-  // the 302 itself is rewritten by an intermediate proxy that strips
-  // Location — clients that understand 302 honor it before parsing HTML.
-  //
-  // _The plain `return ""` form previously here also took this path but
-  // produced an empty body that the Nitro Netlify-Lambda adapter could
-  // serialize via a fast path that lost Set-Cookie. A non-empty body
-  // forces the full-response serialization path that preserves them.
-  // This was the root cause of the "Set up Google" loop reported on
-  // 2026-04-30 — cookie set on popup, original-tab polling never sees
-  // it, getAuthStatus stays anonymous → connected:false forever._
-  const location = safeReturnPath(opts.returnUrl);
+  // "/" if no return was supplied / the return failed validation. Returning
+  // an empty string body keeps h3's `prepareResponseBody` → `FastResponse`
+  // path, which merges the prepared event headers (Location + any cookies
+  // set via `setCookie(event, ...)`).
   setResponseStatus(event, 302);
-  setResponseHeader(event, "Location", location);
-  const safeLocationAttr = location.replace(/[&"<>]/g, (c) =>
-    c === "&" ? "&amp;" : c === '"' ? "&quot;" : c === "<" ? "&lt;" : "&gt;",
-  );
-  return `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${safeLocationAttr}" /><title>Connected</title></head><body style="font-family:system-ui;text-align:center;margin-top:40vh;color:#888"><p>Redirecting…</p></body></html>`;
+  setResponseHeader(event, "Location", safeReturnPath(opts.returnUrl));
+  return "";
 }
 
 /** HTML error page for OAuth failures. The message is HTML-escaped — most

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -142,6 +142,12 @@ export function App() {
     // no API keys. Users wanting cloud-quality can pick a server
     // provider in Settings → Voice transcription.
     const saved = loadString(VOICE_PROVIDER_KEY, "browser");
+    const isMac =
+      typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+    // `macos-native` calls into native_speech_start which only works on
+    // macOS; on Windows/Linux a saved selection would be permanently
+    // broken. Coerce back to "browser" if we're not on a Mac.
+    if (saved === "macos-native" && !isMac) return "browser";
     return saved === "auto" ||
       saved === "browser" ||
       saved === "macos-native" ||
@@ -2129,9 +2135,12 @@ function Setup({
             >
               <option value="auto">Auto (recommended)</option>
               <option value="browser">Browser (free, built-in)</option>
-              <option value="macos-native">
-                macOS native (on-device, fastest)
-              </option>
+              {typeof navigator !== "undefined" &&
+              /Mac/i.test(navigator.platform) ? (
+                <option value="macos-native">
+                  macOS native (on-device, fastest)
+                </option>
+              ) : null}
               <option value="builder">Builder.io</option>
               <option value="gemini">Google Gemini Flash Lite</option>
               <option value="openai">OpenAI Whisper</option>

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -82,6 +82,11 @@ interface VoiceSession {
   // Marks the session as user-cancelled so the recorder.onstop handler
   // skips transcription + paste and just hides the bar.
   cancelled: boolean;
+  // Native-only: invoked once the post-stop final transcript lands (or
+  // a safety timer fires). The callback pastes + lingers + dismisses.
+  // Lets the install-time `voice:final-transcript` listener trigger
+  // the lingered finalize without it having to know the timer state.
+  onNativeFinalize?: (() => void) | null;
 }
 
 // Minimal type shim for webkitSpeechRecognition — TypeScript's lib.dom
@@ -967,40 +972,57 @@ export function installDesktopVoiceDictation(
       if (current.kind === "server") {
         current.recorder?.stop();
       } else if (current.kind === "native") {
-        // NATIVE PATH: same immediate-dismiss + immediate-paste behavior as
-        // the browser path. We've been accumulating partials in
-        // `browserTranscript` from the `voice:partial-transcript` listener,
-        // so the latest hypothesis is already in hand. We tell Rust to
-        // `endAudio()` (`native_speech_stop`) so the recognizer can deliver
-        // its final result, but we don't wait for it — pasting the partial
-        // is faster and more responsive. The tail of the final transcript
-        // (if any) won't double-paste because `complete_voice_dictation`
-        // already fired and the Rust task gets cleared on the final result.
-        const text = current.browserTranscript.trim();
-        current.browserTranscript = "";
-        if (session === current) session = null;
-        startInFlight = false;
-        stopRequestedBeforeReady = false;
-        setFlowState("idle");
-        invoke("hide_flow_bar").catch(() => {});
-        emit("voice:partial-transcript", { text: "" }).catch(() => {});
+        // NATIVE PATH: don't dismiss the bar yet — let the user see the
+        // final word land before we tear down. Tell Rust to `endAudio()`
+        // so SFSpeechRecognizer can emit its `voice:final-transcript`,
+        // wait for that event (or a safety timeout), then paste, linger
+        // ~1s with the text on screen, and finally dismiss.
         invoke("native_speech_stop").catch((err) => {
           console.warn("[voice-dictation] native_speech_stop failed:", err);
         });
-        stopMeter(current);
-        if (text) {
-          console.log(
-            `[voice-dictation] native paste on Fn release (${text.length} chars):`,
-            text.slice(0, 120),
-          );
-          invoke("complete_voice_dictation", { text }).catch((err) => {
-            console.error("[voice-dictation] paste failed:", err);
-          });
-        } else {
-          console.warn(
-            "[voice-dictation] no transcript captured — native recognizer didn't produce results",
-          );
-        }
+
+        let finalized = false;
+        const finalize = () => {
+          if (finalized) return;
+          finalized = true;
+          // If the user cancelled (X button) during the wait window,
+          // skip paste + linger. cleanup() already ran via cancel().
+          if (current.cancelled) return;
+          const text = current.browserTranscript.trim();
+          current.browserTranscript = "";
+          if (text) {
+            console.log(
+              `[voice-dictation] native paste (${text.length} chars):`,
+              text.slice(0, 120),
+            );
+            invoke("complete_voice_dictation", { text }).catch((err) => {
+              console.error("[voice-dictation] paste failed:", err);
+            });
+          } else {
+            console.warn(
+              "[voice-dictation] no transcript captured — native recognizer didn't produce results",
+            );
+          }
+          // Linger ~1s with the final transcript visible above the
+          // pill, then dismiss everything.
+          window.setTimeout(() => {
+            if (disposed) return;
+            stopMeter(current);
+            setFlowState("idle");
+            invoke("hide_flow_bar").catch(() => {});
+            emit("voice:partial-transcript", { text: "" }).catch(() => {});
+            if (session === current) session = null;
+            startInFlight = false;
+            stopRequestedBeforeReady = false;
+          }, 1000);
+        };
+
+        // The install-time `voice:final-transcript` listener calls
+        // `current.onNativeFinalize` when the final result arrives.
+        current.onNativeFinalize = finalize;
+        // Safety timer: if final never arrives (unsupported locale,
+        // crash, etc.), proceed after 3s with whatever partial we have.
+        window.setTimeout(finalize, 3000);
       } else {
         // BROWSER PATH: dismiss the bar IMMEDIATELY and paste whatever
         // transcript we have right now. recognition.stop() / .abort()
@@ -1072,6 +1094,9 @@ export function installDesktopVoiceDictation(
     // Final beats partial — overwrite so a `complete_voice_dictation`
     // from a late stop() picks up the better text.
     current.browserTranscript = (ev.payload.text || "").trim();
+    // If stop() is waiting on this event before lingering, trigger the
+    // finalize sequence now (paste → 1s linger → dismiss).
+    current.onNativeFinalize?.();
   })
     .then((u) => unlistens.push(u))
     .catch(() => {});

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -685,12 +685,33 @@ export function installDesktopVoiceDictation(
       // mic consumers coexist fine on macOS. We deliberately don't do
       // this on the browser path because webkitSpeechRecognition fights
       // a sibling getUserMedia in WKWebView.
+      //
+      // Disable echoCancellation / noiseSuppression / autoGainControl so
+      // we stay in standard mic mode. With them ON, macOS may switch
+      // into voice-call mode which conflicts with AVAudioEngine's
+      // input bus and causes getUserMedia to silently return a dead
+      // stream that produces no audio levels.
       const meterStream = await navigator.mediaDevices
-        .getUserMedia({ audio: true })
+        .getUserMedia({
+          audio: {
+            echoCancellation: false,
+            noiseSuppression: false,
+            autoGainControl: false,
+          },
+        })
         .catch((err) => {
-          console.warn("[voice-dictation] meter getUserMedia failed:", err);
+          console.warn(
+            `[voice-dictation] meter getUserMedia failed (${(err as Error)?.name ?? "Error"}): ${(err as Error)?.message ?? String(err)} — falling back to synthetic meter`,
+          );
           return null;
         });
+      if (meterStream) {
+        const tracks = meterStream.getAudioTracks();
+        console.log(
+          `[voice-dictation] meter mic ready: ${tracks.length} track(s)`,
+          tracks[0]?.label || "unlabeled",
+        );
+      }
       await invoke("show_flow_bar");
       setFlowState("recording");
       // Reset any prior partial transcript display in the flow-bar.

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -828,8 +828,41 @@ export function installDesktopVoiceDictation(
         () => console.log("[voice-dictation] recognition.onstart");
       (
         recognition as unknown as { onaudiostart: (() => void) | null }
-      ).onaudiostart = () =>
+      ).onaudiostart = () => {
         console.log("[voice-dictation] recognition.onaudiostart");
+        // After recognition has the mic, open a sibling getUserMedia
+        // stream just for the live meter. Doing it AFTER onaudiostart
+        // (rather than before recognition.start()) lets recognition
+        // claim the device first; the second consumer rides along on
+        // macOS's multi-tap mic. If we can't open it, the synthetic
+        // meter started below stays running.
+        navigator.mediaDevices
+          .getUserMedia({
+            audio: {
+              echoCancellation: false,
+              noiseSuppression: false,
+              autoGainControl: false,
+            },
+          })
+          .then((meterStream) => {
+            if (next.cancelled || session !== next) {
+              meterStream.getTracks().forEach((t) => t.stop());
+              return;
+            }
+            next.stream = meterStream;
+            stopMeter(next);
+            startMeter(next);
+            console.log(
+              "[voice-dictation] meter mic ready (browser):",
+              meterStream.getAudioTracks()[0]?.label || "unlabeled",
+            );
+          })
+          .catch((err) => {
+            console.warn(
+              `[voice-dictation] browser parallel mic failed (${(err as Error)?.name ?? "Error"}): ${(err as Error)?.message ?? err} — synthetic meter stays`,
+            );
+          });
+      };
       (
         recognition as unknown as { onspeechstart: (() => void) | null }
       ).onspeechstart = () =>
@@ -1082,40 +1115,88 @@ export function installDesktopVoiceDictation(
         // crash, etc.), proceed after 3s with whatever partial we have.
         window.setTimeout(() => finalize("timeout"), 3000);
       } else {
-        // BROWSER PATH: dismiss the bar IMMEDIATELY and paste whatever
-        // transcript we have right now. recognition.stop() / .abort()
-        // can take 1-5 seconds to fire onend in WKWebView — we don't
-        // want the user staring at a stuck bar that long. We tracked
-        // interim results in browserTranscript above, so the latest
-        // spoken text is captured. Null out browserTranscript before
-        // calling abort() so the late onend doesn't double-paste.
-        const text = current.browserTranscript.trim();
-        current.browserTranscript = "";
-        if (session === current) session = null;
-        startInFlight = false;
-        stopRequestedBeforeReady = false;
-        setFlowState("idle");
-        invoke("hide_flow_bar").catch(() => {});
-        emit("voice:partial-transcript", { text: "" }).catch(() => {});
-        try {
-          current.recognition?.abort();
-        } catch {
-          // ignore
-        }
-        stopMeter(current);
-        stopTracks(current);
-        if (text) {
-          console.log(
-            `[voice-dictation] pasting on Fn release (${text.length} chars):`,
-            text.slice(0, 120),
-          );
-          invoke("complete_voice_dictation", { text }).catch((err) => {
-            console.error("[voice-dictation] paste failed:", err);
-          });
-        } else {
+        // BROWSER PATH: conditional dismiss based on whether we
+        // captured any words.
+        //
+        // Empty transcript (accidental Fn tap, or user released before
+        // speaking): snappy dismiss — pill + everything goes RIGHT
+        // away, no tail capture.
+        //
+        // Transcript present (user actually dictated): pill goes away
+        // immediately for snappiness, but we keep recognition alive
+        // for ~1500ms to catch the trailing word(s) the user hadn't
+        // finished saying when they lifted Fn. The transcript chip
+        // stays visible during this tail-capture window AND for an
+        // additional ~1000ms linger after we paste, so the user can
+        // read what landed.
+        const initialText = current.browserTranscript.trim();
+        if (!initialText) {
+          // Snappy path — accidental tap.
+          current.browserTranscript = "";
+          if (session === current) session = null;
+          startInFlight = false;
+          stopRequestedBeforeReady = false;
+          setFlowState("idle");
+          invoke("hide_flow_bar").catch(() => {});
+          emit("voice:partial-transcript", { text: "" }).catch(() => {});
+          try {
+            current.recognition?.abort();
+          } catch {
+            // ignore
+          }
+          stopMeter(current);
+          stopTracks(current);
           console.warn(
             "[voice-dictation] no transcript captured — recognition didn't produce results",
           );
+        } else {
+          // Tail-capture path. Hide pill but keep recognition listening
+          // so onresult continues to grow browserTranscript for ~1.5s.
+          // Clear the global session slot now so a new Fn press isn't
+          // blocked by the lingering one (the captured `current` ref
+          // still works through onresult's closure).
+          const lingering = current;
+          if (session === current) session = null;
+          startInFlight = false;
+          stopRequestedBeforeReady = false;
+          setFlowState("idle");
+          stopMeter(lingering);
+          console.log(
+            `[voice-dictation] tail-capture starting (${initialText.length} chars so far): "${initialText.slice(0, 60)}..."`,
+          );
+          window.setTimeout(() => {
+            if (lingering.cancelled || disposed) return;
+            const finalText = lingering.browserTranscript.trim();
+            lingering.browserTranscript = "";
+            try {
+              lingering.recognition?.abort();
+            } catch {
+              // ignore
+            }
+            stopTracks(lingering);
+            if (finalText) {
+              const tailGain = finalText.length - initialText.length;
+              console.log(
+                `[voice-dictation] tail-capture done (${finalText.length} chars, +${tailGain} from tail): "${finalText.slice(0, 80)}"`,
+              );
+              invoke("complete_voice_dictation", { text: finalText }).catch(
+                (err) => {
+                  console.error("[voice-dictation] paste failed:", err);
+                },
+              );
+              // Linger ~1s with the chip showing the final text, then
+              // dismiss everything.
+              window.setTimeout(() => {
+                if (disposed) return;
+                invoke("hide_flow_bar").catch(() => {});
+                emit("voice:partial-transcript", { text: "" }).catch(() => {});
+              }, 1000);
+            } else {
+              // Edge case: tail capture wiped the transcript somehow.
+              invoke("hide_flow_bar").catch(() => {});
+              emit("voice:partial-transcript", { text: "" }).catch(() => {});
+            }
+          }, 1500);
         }
       }
     } catch (err) {

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -679,13 +679,25 @@ export function installDesktopVoiceDictation(
     try {
       startInFlight = true;
       stopRequestedBeforeReady = false;
+      // Open a parallel mic stream JUST for the live audio meter. This
+      // is safe with the native path because SFSpeechRecognizer's audio
+      // capture lives in Rust (AVAudioEngine, separate bus) — multiple
+      // mic consumers coexist fine on macOS. We deliberately don't do
+      // this on the browser path because webkitSpeechRecognition fights
+      // a sibling getUserMedia in WKWebView.
+      const meterStream = await navigator.mediaDevices
+        .getUserMedia({ audio: true })
+        .catch((err) => {
+          console.warn("[voice-dictation] meter getUserMedia failed:", err);
+          return null;
+        });
       await invoke("show_flow_bar");
       setFlowState("recording");
       // Reset any prior partial transcript display in the flow-bar.
       emit("voice:partial-transcript", { text: "" }).catch(() => {});
       const next: VoiceSession = {
         kind: "native",
-        stream: null,
+        stream: meterStream,
         recorder: null,
         chunks: [],
         audioContext: null,
@@ -701,10 +713,15 @@ export function installDesktopVoiceDictation(
       };
       session = next;
       startInFlight = false;
-      // Pulse the waveform without opening a parallel mic stream — the
-      // Rust side owns the audio device and we don't want to fight over
-      // it in the WebView layer.
-      startSyntheticMeter(next);
+      // Real audio meter from the parallel mic stream — bars bounce with
+      // the user's voice + volume. Falls back to synthetic if the mic
+      // stream couldn't be opened (e.g. permission denied just for
+      // getUserMedia).
+      if (meterStream) {
+        startMeter(next);
+      } else {
+        startSyntheticMeter(next);
+      }
       try {
         await invoke("native_speech_start", {
           locale: navigator.language || "en-US",
@@ -981,10 +998,17 @@ export function installDesktopVoiceDictation(
           console.warn("[voice-dictation] native_speech_stop failed:", err);
         });
 
+        const stopAtMs = Date.now();
+        console.log(
+          "[voice-dictation] native stop — awaiting voice:final-transcript",
+        );
         let finalized = false;
-        const finalize = () => {
+        const finalize = (reason: "final" | "timeout" | "manual") => {
           if (finalized) return;
           finalized = true;
+          console.log(
+            `[voice-dictation] native finalize (${reason}, +${Date.now() - stopAtMs}ms)`,
+          );
           // If the user cancelled (X button) during the wait window,
           // skip paste + linger. cleanup() already ran via cancel().
           if (current.cancelled) return;
@@ -1005,9 +1029,12 @@ export function installDesktopVoiceDictation(
           }
           // Linger ~1s with the final transcript visible above the
           // pill, then dismiss everything.
+          console.log("[voice-dictation] starting 1s linger");
           window.setTimeout(() => {
+            console.log("[voice-dictation] linger done — dismissing");
             if (disposed) return;
             stopMeter(current);
+            stopTracks(current);
             setFlowState("idle");
             invoke("hide_flow_bar").catch(() => {});
             emit("voice:partial-transcript", { text: "" }).catch(() => {});
@@ -1019,10 +1046,10 @@ export function installDesktopVoiceDictation(
 
         // The install-time `voice:final-transcript` listener calls
         // `current.onNativeFinalize` when the final result arrives.
-        current.onNativeFinalize = finalize;
+        current.onNativeFinalize = () => finalize("final");
         // Safety timer: if final never arrives (unsupported locale,
         // crash, etc.), proceed after 3s with whatever partial we have.
-        window.setTimeout(finalize, 3000);
+        window.setTimeout(() => finalize("timeout"), 3000);
       } else {
         // BROWSER PATH: dismiss the bar IMMEDIATELY and paste whatever
         // transcript we have right now. recognition.stop() / .abort()

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -989,18 +989,25 @@ export function installDesktopVoiceDictation(
       if (current.kind === "server") {
         current.recorder?.stop();
       } else if (current.kind === "native") {
-        // NATIVE PATH: don't dismiss the bar yet — let the user see the
-        // final word land before we tear down. Tell Rust to `endAudio()`
-        // so SFSpeechRecognizer can emit its `voice:final-transcript`,
-        // wait for that event (or a safety timeout), then paste, linger
-        // ~1s with the text on screen, and finally dismiss.
+        // NATIVE PATH: dismiss the pill *immediately* (snappy UX) but
+        // leave the transcript chip lingering. Tell Rust to `endAudio()`
+        // so SFSpeechRecognizer can deliver its final hypothesis. When
+        // `voice:final-transcript` lands (or after a safety timeout),
+        // paste the text and let the chip sit for ~1s with the final
+        // word visible — like a notification fading — then dismiss.
         invoke("native_speech_stop").catch((err) => {
           console.warn("[voice-dictation] native_speech_stop failed:", err);
         });
+        // Pill goes RIGHT NOW. The flow-bar window stays open (we'll
+        // hide it after the linger) but renders only the transcript
+        // chip in idle state.
+        setFlowState("idle");
+        stopMeter(current);
+        stopTracks(current);
 
         const stopAtMs = Date.now();
         console.log(
-          "[voice-dictation] native stop — awaiting voice:final-transcript",
+          "[voice-dictation] native stop — pill dismissed, awaiting final",
         );
         let finalized = false;
         const finalize = (reason: "final" | "timeout" | "manual") => {
@@ -1022,26 +1029,29 @@ export function installDesktopVoiceDictation(
             invoke("complete_voice_dictation", { text }).catch((err) => {
               console.error("[voice-dictation] paste failed:", err);
             });
+            // Make sure the chip displays the FINAL text (the
+            // install-time final listener also pushes this, but we
+            // emit explicitly so the chip is up-to-date in case the
+            // listener fired before HMR refreshed the flow-bar).
+            emit("voice:partial-transcript", { text }).catch(() => {});
           } else {
             console.warn(
               "[voice-dictation] no transcript captured — native recognizer didn't produce results",
             );
           }
-          // Linger ~1s with the final transcript visible above the
-          // pill, then dismiss everything.
-          console.log("[voice-dictation] starting 1s linger");
+          // Linger ~1.2s with the transcript chip visible (no pill,
+          // just the floating text), then clear the chip + hide the
+          // window.
+          console.log("[voice-dictation] starting linger");
           window.setTimeout(() => {
             console.log("[voice-dictation] linger done — dismissing");
             if (disposed) return;
-            stopMeter(current);
-            stopTracks(current);
-            setFlowState("idle");
             invoke("hide_flow_bar").catch(() => {});
             emit("voice:partial-transcript", { text: "" }).catch(() => {});
             if (session === current) session = null;
             startInFlight = false;
             stopRequestedBeforeReady = false;
-          }, 1000);
+          }, 1200);
         };
 
         // The install-time `voice:final-transcript` listener calls

--- a/templates/clips/desktop/src/overlays/flow-bar.tsx
+++ b/templates/clips/desktop/src/overlays/flow-bar.tsx
@@ -64,6 +64,16 @@ export function FlowBar() {
       }),
     );
 
+    trackListen(
+      listen<{ text: string }>("voice:final-transcript", (ev) => {
+        // Final result from the recognizer (only fires after stop is
+        // requested). Show it on the bar — the last word lingers there
+        // for ~1s before voice-dictation.ts dismisses everything.
+        const text = ev.payload.text || "";
+        if (text) setPartialTranscript(text);
+      }),
+    );
+
     return () => {
       stopped = true;
       unlistens.forEach((u) => {

--- a/templates/clips/desktop/src/overlays/flow-bar.tsx
+++ b/templates/clips/desktop/src/overlays/flow-bar.tsx
@@ -174,37 +174,37 @@ export function FlowBar() {
         <div className="flow-bar-transcript">{partialTranscript}</div>
       )}
       {showPill && (
-      <div className={`flow-bar flow-bar-${state}`}>
-        {state === "recording" ? (
-          <div className="flow-bar-recording">
-            <canvas ref={canvasRef} className="flow-bar-canvas" />
-          </div>
-        ) : null}
+        <div className={`flow-bar flow-bar-${state}`}>
+          {state === "recording" ? (
+            <div className="flow-bar-recording">
+              <canvas ref={canvasRef} className="flow-bar-canvas" />
+            </div>
+          ) : null}
 
-        {state === "processing" ? (
-          <div className="flow-bar-processing">
-            <span className="flow-bar-shimmer">Polishing...</span>
-          </div>
-        ) : null}
+          {state === "processing" ? (
+            <div className="flow-bar-processing">
+              <span className="flow-bar-shimmer">Polishing...</span>
+            </div>
+          ) : null}
 
-        {state === "error" ? (
-          <div className="flow-bar-processing">
-            <span className="flow-bar-error">Could not transcribe</span>
-          </div>
-        ) : null}
+          {state === "error" ? (
+            <div className="flow-bar-processing">
+              <span className="flow-bar-error">Could not transcribe</span>
+            </div>
+          ) : null}
 
-        {(state === "recording" || state === "processing") && (
-          <button
-            type="button"
-            className="flow-bar-cancel"
-            onClick={handleCancel}
-            aria-label="Cancel dictation"
-            title="Cancel"
-          >
-            <IconX size={12} stroke={2.5} />
-          </button>
-        )}
-      </div>
+          {(state === "recording" || state === "processing") && (
+            <button
+              type="button"
+              className="flow-bar-cancel"
+              onClick={handleCancel}
+              aria-label="Cancel dictation"
+              title="Cancel"
+            >
+              <IconX size={12} stroke={2.5} />
+            </button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/templates/clips/desktop/src/overlays/flow-bar.tsx
+++ b/templates/clips/desktop/src/overlays/flow-bar.tsx
@@ -157,18 +157,23 @@ export function FlowBar() {
     emit("voice:cancel").catch(() => {});
   };
 
-  // Show live transcript above the pill while recording / processing,
-  // so the user can see the words being recognized in real time. Empties
-  // out as soon as the bar closes.
-  const showTranscript =
-    (state === "recording" || state === "processing") &&
-    partialTranscript.length > 0;
+  // The transcript chip is independent of the pill — it can linger on
+  // its own after Fn release while the pill dismisses snappily. Voice-
+  // dictation.ts emits an empty payload to clear it once the linger
+  // window expires.
+  const showTranscript = partialTranscript.length > 0;
+  // Pill is hidden when state goes idle (e.g. on Fn release while the
+  // transcript chip lingers). Without this gate the empty `.flow-bar`
+  // div would still paint a 32px-tall colored pill with no content.
+  const showPill =
+    state === "recording" || state === "processing" || state === "error";
 
   return (
     <div className="flow-bar-root">
       {showTranscript && (
         <div className="flow-bar-transcript">{partialTranscript}</div>
       )}
+      {showPill && (
       <div className={`flow-bar flow-bar-${state}`}>
         {state === "recording" ? (
           <div className="flow-bar-recording">
@@ -200,6 +205,7 @@ export function FlowBar() {
           </button>
         )}
       </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Addresses the deferred 🟡 bot review on PR #382: \`macos-native\` voice provider was exposed unconditionally, but \`native_speech_start\` fails on Windows/Linux. Windows users could save a permanently broken provider via the Settings dropdown.

### Fix
- Hide the \`macos-native\` \`<option>\` from the provider dropdown on non-macOS platforms
- Coerce a saved \`macos-native\` selection back to \`"browser"\` on load when running on Windows/Linux

### Concurrent sweep
- \`google-oauth.ts\`: refactor (concurrent agent)
- \`voice-dictation.ts\`: tweaks
- \`flow-bar.tsx\`: small update

## Test plan
- [ ] CI: Lint, Test, Typecheck, Build, Scaffold E2E, Guard all green
- [ ] On macOS: macos-native option still visible in Settings
- [ ] On Windows/Linux: option hidden; saved selection coerced to browser