### PR TITLE
Fix native voice-dictation: rapid restart + stale session race

### DIFF
--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -1056,9 +1056,19 @@ export function installDesktopVoiceDictation(
         // hide it after the linger) but renders only the transcript
         // chip in idle state.
         setFlowState("idle");
+        // Free the global session-startup guards immediately, matching the
+        // browser paths below. Deferring these to the end of the 1.2s
+        // linger meant a rapid second Fn tap during linger silently no-op'd
+        // because `start()` early-returns while `startInFlight` is true.
+        // The captured `current` ref is what `finalize()` and the timers
+        // operate on, so detaching `session`/flags from it here is safe.
+        if (session === current) session = null;
+        startInFlight = false;
+        stopRequestedBeforeReady = false;
         stopMeter(current);
         stopTracks(current);
 
+        const lingering = current;
         const stopAtMs = Date.now();
         console.log(
           "[voice-dictation] native stop — pill dismissed, awaiting final",
@@ -1070,11 +1080,16 @@ export function installDesktopVoiceDictation(
           console.log(
             `[voice-dictation] native finalize (${reason}, +${Date.now() - stopAtMs}ms)`,
           );
-          // If the user cancelled (X button) during the wait window,
-          // skip paste + linger. cleanup() already ran via cancel().
-          if (current.cancelled) return;
-          const text = current.browserTranscript.trim();
-          current.browserTranscript = "";
+          // If the user cancelled (X button) during the wait window or a
+          // brand-new session has started (Fn re-tapped during linger),
+          // skip paste + linger. cleanup() already ran via cancel() in the
+          // cancelled case; in the new-session case the new `session` owns
+          // the flow-bar now and we'd otherwise paste stale text against
+          // it.
+          if (lingering.cancelled) return;
+          if (session && session !== lingering) return;
+          const text = lingering.browserTranscript.trim();
+          lingering.browserTranscript = "";
           if (text) {
             console.log(
               `[voice-dictation] native paste (${text.length} chars):`,
@@ -1095,22 +1110,20 @@ export function installDesktopVoiceDictation(
           }
           // Linger ~1.2s with the transcript chip visible (no pill,
           // just the floating text), then clear the chip + hide the
-          // window.
+          // window. Don't clobber a new session's flow-bar if one started.
           console.log("[voice-dictation] starting linger");
           window.setTimeout(() => {
             console.log("[voice-dictation] linger done — dismissing");
             if (disposed) return;
+            if (session && session !== lingering) return;
             invoke("hide_flow_bar").catch(() => {});
             emit("voice:partial-transcript", { text: "" }).catch(() => {});
-            if (session === current) session = null;
-            startInFlight = false;
-            stopRequestedBeforeReady = false;
           }, 1200);
         };
 
         // The install-time `voice:final-transcript` listener calls
         // `current.onNativeFinalize` when the final result arrives.
-        current.onNativeFinalize = () => finalize("final");
+        lingering.onNativeFinalize = () => finalize("final");
         // Safety timer: if final never arrives (unsupported locale,
         // crash, etc.), proceed after 3s with whatever partial we have.
         window.setTimeout(() => finalize("timeout"), 3000);

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -1179,6 +1179,11 @@ export function installDesktopVoiceDictation(
           );
           window.setTimeout(() => {
             if (lingering.cancelled || disposed) return;
+            // A new Fn-tap during tail-capture starts a fresh session that
+            // owns the flow-bar now. Don't paste this lingering session's
+            // text against it, and don't wipe its UI on dismiss. Mirrors
+            // the native finalize guard above.
+            if (session && session !== lingering) return;
             const finalText = lingering.browserTranscript.trim();
             lingering.browserTranscript = "";
             try {
@@ -1201,6 +1206,7 @@ export function installDesktopVoiceDictation(
               // dismiss everything.
               window.setTimeout(() => {
                 if (disposed) return;
+                if (session && session !== lingering) return;
                 invoke("hide_flow_bar").catch(() => {});
                 emit("voice:partial-transcript", { text: "" }).catch(() => {});
               }, 1000);

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -362,6 +362,13 @@ export function installDesktopVoiceDictation(
 ): () => void {
   let disposed = false;
   let session: VoiceSession | null = null;
+  // After stop() in the native path, `session` is cleared immediately so
+  // a rapid second Fn tap can start fresh. But the install-time
+  // `voice:final-transcript` listener still needs to find the lingering
+  // session so it can fire `onNativeFinalize` and run the paste. This
+  // ref holds that session through the wait + linger window; cleared
+  // once the linger callback completes.
+  let lingeringSession: VoiceSession | null = null;
   let serverUrl = options.serverUrl;
   let enabled = options.enabled;
   let shortcut = options.shortcut;
@@ -1059,16 +1066,18 @@ export function installDesktopVoiceDictation(
         // Free the global session-startup guards immediately, matching the
         // browser paths below. Deferring these to the end of the 1.2s
         // linger meant a rapid second Fn tap during linger silently no-op'd
-        // because `start()` early-returns while `startInFlight` is true.
-        // The captured `current` ref is what `finalize()` and the timers
-        // operate on, so detaching `session`/flags from it here is safe.
+        // because `start()` early-returns on a non-null `session`. We
+        // park the lingering session in `lingeringSession` so the
+        // install-time `voice:final-transcript` listener can still route
+        // the final event to `onNativeFinalize` while a brand-new
+        // `session` is being set up by the next tap.
+        const lingering = current;
+        lingeringSession = current;
         if (session === current) session = null;
         startInFlight = false;
         stopRequestedBeforeReady = false;
         stopMeter(current);
         stopTracks(current);
-
-        const lingering = current;
         const stopAtMs = Date.now();
         console.log(
           "[voice-dictation] native stop — pill dismissed, awaiting final",
@@ -1114,6 +1123,7 @@ export function installDesktopVoiceDictation(
           console.log("[voice-dictation] starting linger");
           window.setTimeout(() => {
             console.log("[voice-dictation] linger done — dismissing");
+            if (lingeringSession === lingering) lingeringSession = null;
             if (disposed) return;
             if (session && session !== lingering) return;
             invoke("hide_flow_bar").catch(() => {});
@@ -1246,8 +1256,18 @@ export function installDesktopVoiceDictation(
     .then((u) => unlistens.push(u))
     .catch(() => {});
   listen<{ text: string }>("voice:final-transcript", (ev) => {
-    const current = session;
-    if (!current || current.kind !== "native") return;
+    // After stop() in the native path, `session` has been cleared so a
+    // rapid restart can take it; the lingering session that's waiting
+    // for the final transcript lives on `lingeringSession`. Prefer the
+    // active session when both exist (we'd be receiving partials for a
+    // brand-new session).
+    const current =
+      session && session.kind === "native"
+        ? session
+        : lingeringSession && lingeringSession.kind === "native"
+          ? lingeringSession
+          : null;
+    if (!current) return;
     if (current.cancelled) return;
     // Final beats partial — overwrite so a `complete_voice_dictation`
     // from a late stop() picks up the better text.

--- a/templates/clips/desktop/src/overlays/flow-bar.tsx
+++ b/templates/clips/desktop/src/overlays/flow-bar.tsx
@@ -162,50 +162,48 @@ export function FlowBar() {
   // dictation.ts emits an empty payload to clear it once the linger
   // window expires.
   const showTranscript = partialTranscript.length > 0;
-  // Pill is hidden when state goes idle (e.g. on Fn release while the
-  // transcript chip lingers). Without this gate the empty `.flow-bar`
-  // div would still paint a 32px-tall colored pill with no content.
-  const showPill =
-    state === "recording" || state === "processing" || state === "error";
 
   return (
     <div className="flow-bar-root">
       {showTranscript && (
         <div className="flow-bar-transcript">{partialTranscript}</div>
       )}
-      {showPill && (
-        <div className={`flow-bar flow-bar-${state}`}>
-          {state === "recording" ? (
-            <div className="flow-bar-recording">
-              <canvas ref={canvasRef} className="flow-bar-canvas" />
-            </div>
-          ) : null}
+      {/* Pill is ALWAYS mounted — when state goes idle we fade the
+          opacity to 0 (see CSS) instead of removing it from the DOM,
+          so the transcript chip above doesn't reflow when the pill
+          "goes away". Inner content keeps its last frame rendered
+          during the fade so the canvas doesn't pop. */}
+      <div className={`flow-bar flow-bar-${state}`}>
+        {(state === "recording" || state === "idle") && (
+          <div className="flow-bar-recording">
+            <canvas ref={canvasRef} className="flow-bar-canvas" />
+          </div>
+        )}
 
-          {state === "processing" ? (
-            <div className="flow-bar-processing">
-              <span className="flow-bar-shimmer">Polishing...</span>
-            </div>
-          ) : null}
+        {state === "processing" ? (
+          <div className="flow-bar-processing">
+            <span className="flow-bar-shimmer">Polishing...</span>
+          </div>
+        ) : null}
 
-          {state === "error" ? (
-            <div className="flow-bar-processing">
-              <span className="flow-bar-error">Could not transcribe</span>
-            </div>
-          ) : null}
+        {state === "error" ? (
+          <div className="flow-bar-processing">
+            <span className="flow-bar-error">Could not transcribe</span>
+          </div>
+        ) : null}
 
-          {(state === "recording" || state === "processing") && (
-            <button
-              type="button"
-              className="flow-bar-cancel"
-              onClick={handleCancel}
-              aria-label="Cancel dictation"
-              title="Cancel"
-            >
-              <IconX size={12} stroke={2.5} />
-            </button>
-          )}
-        </div>
-      )}
+        {(state === "recording" || state === "processing") && (
+          <button
+            type="button"
+            className="flow-bar-cancel"
+            onClick={handleCancel}
+            aria-label="Cancel dictation"
+            title="Cancel"
+          >
+            <IconX size={12} stroke={2.5} />
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -2116,6 +2116,21 @@ button {
   pointer-events: auto;
   /* Subtle fade-in so the pill doesn't hard-pop on appear. */
   animation: flow-bar-in 140ms ease-out;
+  /* Fade out to opacity 0 when state goes idle (after Fn release).
+     Keeping the pill in the DOM means the transcript chip above
+     doesn't reflow when the pill "goes away" — important for the
+     linger UX where the chip stays put while the pill dissolves. */
+  transition: opacity 220ms ease-out;
+}
+
+/* When the dictation engine reports idle (e.g. mid-linger after Fn
+   release on the browser path), fade the pill out without unmounting
+   it. The canvas keeps its last-frame so the user sees the waveform
+   smoothly fade rather than pop into nothing. Pointer-events go off
+   so the now-invisible chip can't catch clicks. */
+.flow-bar-idle {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .flow-bar-recording {


### PR DESCRIPTION
## Summary

Addresses the 4 deferred bot review comments from PR #383 about \`templates/clips/desktop/src/lib/voice-dictation.ts\`:

### 🔴 Rapid Fn-tap during linger silently no-op'd
The native path deferred \`startInFlight = false; stopRequestedBeforeReady = false;\` to inside the 1.2s linger \`setTimeout\`. Browser paths reset them immediately after \`setFlowState(\"idle\")\`. While the linger ran, a second Fn tap hit \`start()\`'s early-return guard and silently failed.

**Fix:** reset the global guards immediately after \`setFlowState(\"idle\")\` in the native path. Capture the session as \`lingering\` so the deferred \`finalize()\` and linger callbacks still operate on the right session ref.

### 🟡 Stale session paste / flow-bar wipe
\`finalize()\` and the linger \`setTimeout\` accessed session state without checking whether a new session had started. A rapid restart could have pasted stale text against the new session or wiped the new session's flow-bar.

**Fix:** add \`if (session && session !== lingering) return;\` guards before the paste in \`finalize()\` and before \`hide_flow_bar\` in the linger callback.

### Plus
- \`flow-bar.tsx\`: concurrent agent tweak
- \`styles.css\`: concurrent agent update

## Test plan
- [ ] CI: Lint, Test, Typecheck, Build, Scaffold E2E, Guard all green
- [ ] Single Fn dictation works (paste happens, chip lingers, dismisses)
- [ ] Rapid Fn-tap during linger: second session starts cleanly
- [ ] X-button cancel during wait window: no paste