### PR TITLE
Move Starter template to top of CLI picker

### DIFF
--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -17,6 +17,17 @@ const __dirname = path.dirname(__filename);
 const REPO = "BuilderIO/agent-native";
 const TEMPLATES_DIR = "templates";
 
+/**
+ * Move "starter" to the top of the list so it lines up with clack's default
+ * highlight on the first option — otherwise users have to scroll to see that
+ * Starter is pre-selected.
+ */
+function starterFirst(templates: TemplateMeta[]): TemplateMeta[] {
+  const starter = templates.find((t) => t.name === "starter");
+  if (!starter) return templates;
+  return [starter, ...templates.filter((t) => t.name !== "starter")];
+}
+
 /** Blank scaffold option appended to every picker. */
 const BLANK_OPTION = {
   name: "blank",
@@ -334,7 +345,7 @@ async function createStandaloneApp(
     const picked = await clack.select({
       message: "Which template would you like to use?",
       options: [
-        ...coreTemplates().map((t) => ({
+        ...starterFirst(coreTemplates()).map((t) => ({
           value: t.name,
           label: t.label,
           hint: t.hint,
@@ -661,7 +672,7 @@ async function promptTemplatePicker(
   opts?: { excludeNames?: string[]; message?: string },
 ): Promise<string[]> {
   const excluded = new Set(opts?.excludeNames ?? []);
-  const options = coreTemplates()
+  const options = starterFirst(coreTemplates())
     .filter((t) => !excluded.has(t.name))
     .map((t) => ({
       value: t.name,


### PR DESCRIPTION
### Summary
Ensures the "Starter" template always appears first in the CLI template picker, making it immediately visible and clearly pre-selected without requiring the user to scroll.

### Problem
When launching the CLI, the "Starter" template was automatically pre-selected but appeared further down the list. Users had to scroll to see it, making it unclear that any default selection had been made at all.

### Solution
Introduce a `starterFirst` helper that moves the "starter" template to the front of the template list before it is passed to the clack picker. This aligns the default highlight (first item) with the intended default choice.

### Key Changes
- Added `starterFirst(templates)` utility function that finds the `"starter"` entry and moves it to index 0, leaving all other templates in their original order
- Applied `starterFirst` in both the standalone app template picker (`createStandaloneApp`) and the shared `promptTemplatePicker` helper so the ordering is consistent across all CLI flows


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/mage-ohm-qf41d6sc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-mage-ohm-qf41d6sc_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 385`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>mage-ohm-qf41d6sc</branchName>-->