### PR TITLE
Auto-open browser on dev server start

### DIFF
--- a/templates/starter/package.json
+++ b/templates/starter/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "agent-native dev",
+    "dev": "agent-native dev --open",
     "build": "agent-native build",
     "start": "agent-native start",
     "typecheck": "agent-native typecheck",


### PR DESCRIPTION
### Summary
Adds the `--open` flag to the starter template's `dev` script so that running `pnpm run dev` automatically opens (or focuses and refreshes) the localhost URL in the browser.

### Problem
Previously, starting the dev server required manually navigating to the localhost URL in a browser tab every time, adding unnecessary friction to the development workflow.

### Solution
Pass the `--open` flag to the `agent-native dev` command in the starter template's `package.json`, which instructs the dev server to automatically open the app in the default browser (or refresh an existing tab) on startup.

### Key Changes
- Updated `templates/starter/package.json`: changed `"dev": "agent-native dev"` to `"dev": "agent-native dev --open"`


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/semi-watt-6r9p6yfk"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-semi-watt-6r9p6yfk_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 386`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>semi-watt-6r9p6yfk</branchName>-->