### PR TITLE
Add node-pty to starter template dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3981,6 +3981,9 @@ importers:
       isbot:
         specifier: ^5
         version: 5.1.37
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6

--- a/templates/starter/package.json
+++ b/templates/starter/package.json
@@ -17,6 +17,7 @@
     "@tabler/icons-react": "^3.40.0",
     "h3": "^2.0.1-rc.20",
     "isbot": "^5",
+    "node-pty": "^1.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
### Summary
Adds `node-pty` as a dependency to the starter template to resolve "node-pty not installed" errors encountered by users.

### Problem
Users were getting `node-pty not installed` errors when using the starter template, because `node-pty` was not listed as a dependency in the template's `package.json`.

### Solution
Added `node-pty@^1.1.0` to the `dependencies` section of the starter template's `package.json` and updated the `pnpm-lock.yaml` accordingly.

### Key Changes
- Added `node-pty: ^1.1.0` to `templates/starter/package.json` dependencies
- Updated `pnpm-lock.yaml` to include the resolved `node-pty` version (`1.1.0`)


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/sparkle-conduit-ugmm28gu"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-sparkle-conduit-ugmm28gu_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 387`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>sparkle-conduit-ugmm28gu</branchName>-->