### PR TITLE
Default tools to org visibility + voice-dictation rapid-restart cleanups

### DIFF
--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -213,6 +213,50 @@ describe("server/auth", () => {
       expect(paths).toContain("/_agent-native/auth/ba");
     });
 
+    it("passes through an already-mounted generic Google route when a template opts out later", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("GOOGLE_CLIENT_ID", "google-client");
+      vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-secret");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      delete process.env.AUTH_DISABLED;
+      delete process.env.AUTH_MODE;
+
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(async () => new Response("{}")),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+            listOrganizations: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
+
+      const { autoMountAuth } = await import("./auth.js");
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const authUrlHandler = app.use.mock.calls.find(
+        (call: any[]) => call[0] === "/_agent-native/google/auth-url",
+      )?.[1];
+      expect(authUrlHandler).toBeTypeOf("function");
+
+      await autoMountAuth(app, {
+        googleOnly: true,
+        mountGoogleOAuthRoutes: false,
+      });
+
+      expect(
+        await authUrlHandler(
+          createMockEvent({ path: "/_agent-native/google/auth-url" }),
+        ),
+      ).toBeUndefined();
+    });
+
     it("mounts auth when ACCESS_TOKEN is set in production", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("ACCESS_TOKEN", "my-secret");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -2375,6 +2375,9 @@ export async function autoMountAuth(
   // H3 app, empty middleware) would short-circuit here and end up with no
   // auth routes mounted at all.
   if (_authGuardFn && _mountedApp === app) {
+    if (options.mountGoogleOAuthRoutes === false) {
+      setGenericGoogleOAuthRoutesEnabled(app, false);
+    }
     // A custom getSession always wins — even if the default auth plugin
     // mounted first (which happens in production where bootstrapDefaultPlugins
     // can't see the template's server/plugins/ dir and auto-mounts defaults).

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -533,6 +533,20 @@ interface AuthGuardConfig {
   publicPaths: string[];
 }
 let _authGuardConfig: AuthGuardConfig | null = null;
+const _genericGoogleOAuthRoutesEnabled = new WeakMap<object, boolean>();
+
+function setGenericGoogleOAuthRoutesEnabled(
+  app: H3App,
+  enabled: boolean,
+): void {
+  if (app && typeof app === "object") {
+    _genericGoogleOAuthRoutesEnabled.set(app, enabled);
+  }
+}
+
+function areGenericGoogleOAuthRoutesEnabled(app: H3App): boolean {
+  return _genericGoogleOAuthRoutesEnabled.get(app as object) !== false;
+}
 
 // Desktop OAuth exchange store — holds session tokens keyed by a unique flow
 // ID so native apps (Tauri, Electron) that open OAuth in the system browser
@@ -1350,6 +1364,7 @@ async function mountBetterAuthRoutes(
     process.env.GOOGLE_CLIENT_SECRET &&
     options.mountGoogleOAuthRoutes !== false
   ) {
+    setGenericGoogleOAuthRoutesEnabled(app, true);
     for (const gp of [
       "/_agent-native/google/callback",
       "/_agent-native/google/auth-url",
@@ -1366,6 +1381,7 @@ async function mountBetterAuthRoutes(
     app.use(
       "/_agent-native/google/auth-url",
       defineEventHandler((event) => {
+        if (!areGenericGoogleOAuthRoutesEnabled(app)) return undefined;
         if (getMethod(event) !== "GET") {
           setResponseStatus(event, 405);
           return { error: "Method not allowed" };
@@ -1421,6 +1437,7 @@ async function mountBetterAuthRoutes(
     app.use(
       "/_agent-native/google/callback",
       defineEventHandler(async (event) => {
+        if (!areGenericGoogleOAuthRoutesEnabled(app)) return undefined;
         if (getMethod(event) !== "GET") {
           setResponseStatus(event, 405);
           return { error: "Method not allowed" };

--- a/packages/core/src/tools/store.ts
+++ b/packages/core/src/tools/store.ts
@@ -194,7 +194,12 @@ export async function createTool(data: CreateToolData): Promise<ToolRow> {
     updatedAt: now,
     ownerEmail: userEmail,
     orgId: orgId ?? null,
-    visibility: "private",
+    // Default to org-visibility when the user has an active organization so
+    // teammates see the tool in their sidebar — matching how analytics
+    // dashboards/analyses are scoped (`templates/analytics/server/lib/
+    // dashboards-store.ts:356`). Solo users (no org) get the private
+    // default. Owners can still flip back to private via update-tool.
+    visibility: orgId ? "org" : "private",
   };
   await db.insert(tools).values(row);
   return row;

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -1095,8 +1095,17 @@ export function installDesktopVoiceDictation(
           // cancelled case; in the new-session case the new `session` owns
           // the flow-bar now and we'd otherwise paste stale text against
           // it.
-          if (lingering.cancelled) return;
-          if (session && session !== lingering) return;
+          if (lingering.cancelled) {
+            if (lingeringSession === lingering) lingeringSession = null;
+            return;
+          }
+          if (session && session !== lingering) {
+            // A new session took over during the wait window. Drop the
+            // lingering ref so it doesn't outlive its 3s safety timer
+            // and accidentally route a late final-transcript here.
+            if (lingeringSession === lingering) lingeringSession = null;
+            return;
+          }
           const text = lingering.browserTranscript.trim();
           lingering.browserTranscript = "";
           if (text) {
@@ -1188,20 +1197,25 @@ export function installDesktopVoiceDictation(
             `[voice-dictation] tail-capture starting (${initialText.length} chars so far): "${initialText.slice(0, 60)}..."`,
           );
           window.setTimeout(() => {
-            if (lingering.cancelled || disposed) return;
-            // A new Fn-tap during tail-capture starts a fresh session that
-            // owns the flow-bar now. Don't paste this lingering session's
-            // text against it, and don't wipe its UI on dismiss. Mirrors
-            // the native finalize guard above.
-            if (session && session !== lingering) return;
-            const finalText = lingering.browserTranscript.trim();
-            lingering.browserTranscript = "";
+            if (disposed) return;
+            // Always release the lingering session's mic + recognizer
+            // — even if cancelled or replaced by a newer session.
+            // Skipping the abort/stopTracks would leave the old
+            // recognizer listening and the mic stream open.
             try {
               lingering.recognition?.abort();
             } catch {
               // ignore
             }
             stopTracks(lingering);
+            if (lingering.cancelled) return;
+            // A new Fn-tap during tail-capture starts a fresh session
+            // that owns the flow-bar now. Don't paste this lingering
+            // session's text against it, and don't wipe its UI on
+            // dismiss. Mirrors the native finalize guard above.
+            if (session && session !== lingering) return;
+            const finalText = lingering.browserTranscript.trim();
+            lingering.browserTranscript = "";
             if (finalText) {
               const tailGain = finalText.length - initialText.length;
               console.log(
@@ -1258,14 +1272,17 @@ export function installDesktopVoiceDictation(
   listen<{ text: string }>("voice:final-transcript", (ev) => {
     // After stop() in the native path, `session` has been cleared so a
     // rapid restart can take it; the lingering session that's waiting
-    // for the final transcript lives on `lingeringSession`. Prefer the
-    // active session when both exist (we'd be receiving partials for a
-    // brand-new session).
+    // for the final transcript lives on `lingeringSession`. Prefer
+    // `lingeringSession` here — the final-transcript event we're
+    // routing was emitted by Rust's `endAudio()` from the lingering
+    // session's stop(); the brand-new `session` is still ramping up
+    // and won't see a final until its own stop() fires. Only if there
+    // is no lingering one do we fall back to the active session.
     const current =
-      session && session.kind === "native"
-        ? session
-        : lingeringSession && lingeringSession.kind === "native"
-          ? lingeringSession
+      lingeringSession && lingeringSession.kind === "native"
+        ? lingeringSession
+        : session && session.kind === "native"
+          ? session
           : null;
     if (!current) return;
     if (current.cancelled) return;


### PR DESCRIPTION
## Summary

### Tools default visibility — \"if people can see tools in sidebar they should be able to open it\"
\`createTool()\` now defaults \`visibility: \"org\"\` when the user has an active organization, falling back to \`\"private\"\` only for solo users. Matches how analytics dashboards/analyses already scope themselves (\`templates/analytics/server/lib/dashboards-store.ts:356\`).

**Why:** a teammate who joined the Builder.io org reported seeing all dashboards and analyses but **none of the tools**. The framework's \`createTool\` was hardcoding \`visibility: \"private\"\` regardless of org context, so every tool ended up owner-only. Org-shared dashboards that embed those tools also broke for the teammate (the embedded tool fetch returned 404 via \`resolveAccess\`).

Owners can still flip back to private via \`update-tool\` or the share dialog.

### voice-dictation rapid-restart cleanups (3 items deferred from PR #384)
- 🟡 \`finalize()\` early-returns now clear \`lingeringSession\` so a new session that takes over during the wait window doesn't leave a stale ref behind for the 3s safety timer to chase.
- 🔴 \`voice:final-transcript\` listener prefers \`lingeringSession\` over \`session\` — the final event we route was emitted by the lingering session's \`stop()\`, not the brand-new active session.
- 🟡 Browser tail-capture now releases the lingering session's recognizer + mic tracks before the stale-session early return, so a rapid restart never leaves the old recognizer listening.

## Test plan
- [ ] CI: Lint, Test, Typecheck, Build, Scaffold E2E, Guard all green
- [ ] New tool created by an org user is visible in teammates' sidebars (visibility=org)
- [ ] Solo user (no org) tools still default to private
- [ ] Existing tools unchanged (no migration; only affects new tools)
- [ ] Rapid Fn-tap during native linger: new session takes over cleanly, no stale paste
- [ ] Rapid Fn-tap during browser tail-capture: old recognizer/mic released