### PR TITLE
voice-dictation: drop session fallback + supersede paste; concurrent sweep

### DIFF
--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -191,7 +191,7 @@ class BuilderEngine implements AgentEngine {
       return;
     }
 
-    yield* parseJsonlStream(reader);
+    yield* parseJsonlStream(reader, opts.model);
   }
 }
 
@@ -300,6 +300,7 @@ async function* readJsonlLines(
 
 async function* parseJsonlStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
+  model: string,
 ): AsyncIterable<EngineEvent> {
   const parts: EngineContentPart[] = [];
   let pendingText = "";
@@ -409,10 +410,25 @@ async function* parseJsonlStream(
               errorCode: "rate_limited",
             };
           } else if (reason === "error") {
+            // Surface every diagnostic the gateway gave us so the user (and
+            // our logs) get more than a bare "Gateway error". The gateway
+            // sometimes emits an error stop event with no message — most
+            // commonly when the upstream provider rejects the model for
+            // this account (Opus quotas have hit this in practice).
+            const errMsg =
+              event.error ??
+              event.message ??
+              event.detail ??
+              `Gateway error (no detail; raw event: ${JSON.stringify(event)})`;
+            const errCode = event.errorCode ?? event.code;
+            console.error(
+              `[builder-engine] stop reason=error model=${model} code=${errCode ?? "(none)"} error=${errMsg}`,
+            );
             yield {
               type: "stop",
               reason: "error",
-              error: event.error ?? "Gateway error",
+              error: errMsg,
+              ...(errCode ? { errorCode: errCode } : {}),
             };
           } else if (
             reason === "end_turn" ||

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -242,7 +242,7 @@ export interface ProductionAgentOptions {
   skipFilesContext?: boolean;
 }
 
-const MAX_ITERATIONS = 40;
+const MAX_ITERATIONS = 100;
 const MAX_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 2000;
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -30,6 +30,7 @@ import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { createAgentChatAdapter } from "./agent-chat-adapter.js";
+import { getActiveRun } from "./active-run-state.js";
 import { type ContentPart, readSSEStreamRaw } from "./sse-event-processor.js";
 import { cn } from "./utils.js";
 import { AgentTaskCard } from "./AgentTaskCard.js";
@@ -1010,7 +1011,23 @@ function MessageActionsMenu({
 
   const handleCopyRequestId = useCallback(() => {
     const m = messageRuntime.getState();
-    const runId = (m.metadata as any)?.runId || m.id || "";
+    const meta = m.metadata as
+      | {
+          custom?: { runId?: unknown };
+          runId?: unknown;
+        }
+      | undefined;
+    // Live yields put the trace ID at metadata.custom.runId; server-persisted
+    // messages put it at metadata.runId. If neither is present (e.g. the run
+    // is still in flight and this is the first message), fall back to the
+    // active-run state so a hung / mid-stream chat still surfaces a usable
+    // trace ID. Last resort is the assistant-ui local message id.
+    const runId =
+      (typeof meta?.custom?.runId === "string" && meta.custom.runId) ||
+      (typeof meta?.runId === "string" && meta.runId) ||
+      (typeof window !== "undefined" ? getActiveRun()?.runId : null) ||
+      m.id ||
+      "";
     navigator.clipboard.writeText(runId);
     setCopied("id");
     setTimeout(() => {
@@ -1132,7 +1149,13 @@ function AssistantMessage() {
     setRestoreState("restoring");
     try {
       const m = messageRuntime.getState();
-      const runId = (m.metadata as any)?.runId;
+      const meta = m.metadata as
+        | { custom?: { runId?: unknown }; runId?: unknown }
+        | undefined;
+      const runId =
+        (typeof meta?.custom?.runId === "string" && meta.custom.runId) ||
+        (typeof meta?.runId === "string" && meta.runId) ||
+        null;
       if (!runId) {
         setRestoreState("idle");
         return;
@@ -1183,13 +1206,17 @@ function AssistantMessage() {
           }}
         />
       </div>
-      {isComplete && (
-        <div className="mt-1 flex items-center justify-between">
-          <MessageActionsMenu
-            showRevert={showRestore && restoreState === "idle"}
-            onRevert={handleRestore}
-          />
-          {showRestore && restoreState === "confirming" ? (
+      {/* Always render the actions menu so users can grab the trace ID even
+          mid-stream — including when a run hangs or ends prematurely without
+          flipping isRunning false. Thumbs feedback still gates on isComplete
+          since rating an in-flight response makes no sense. */}
+      <div className="mt-1 flex items-center justify-between">
+        <MessageActionsMenu
+          showRevert={showRestore && restoreState === "idle"}
+          onRevert={handleRestore}
+        />
+        {isComplete &&
+          (showRestore && restoreState === "confirming" ? (
             <div className="flex items-center gap-1 text-xs">
               <button
                 onClick={handleRestore}
@@ -1213,17 +1240,22 @@ function AssistantMessage() {
             <React.Suspense fallback={null}>
               <ThumbsFeedbackLazy
                 threadId={cpCtx?.threadId ?? ""}
-                runId={
-                  ((messageRuntime.getState().metadata as any)?.runId as
-                    | string
-                    | undefined) ?? ""
-                }
+                runId={(() => {
+                  const meta = messageRuntime.getState().metadata as
+                    | { custom?: { runId?: unknown }; runId?: unknown }
+                    | undefined;
+                  return (
+                    (typeof meta?.custom?.runId === "string" &&
+                      meta.custom.runId) ||
+                    (typeof meta?.runId === "string" && meta.runId) ||
+                    ""
+                  );
+                })()}
                 messageSeq={thread.messages.findIndex((m) => m.id === msg.id)}
               />
             </React.Suspense>
-          )}
-        </div>
-      )}
+          ))}
+      </div>
     </div>
   );
 }
@@ -2591,10 +2623,19 @@ export const AssistantChat = forwardRef<
   modelRef.current = props.selectedModel;
   const engineRef = useRef<string | undefined>(props.selectedEngine);
   engineRef.current = props.selectedEngine;
+  const execModeRef = useRef<"build" | "plan" | undefined>(props.execMode);
+  execModeRef.current = props.execMode;
 
   const adapter = useMemo(
     () =>
-      createAgentChatAdapter({ apiUrl, tabId, threadId, modelRef, engineRef }),
+      createAgentChatAdapter({
+        apiUrl,
+        tabId,
+        threadId,
+        modelRef,
+        engineRef,
+        execModeRef,
+      }),
     [apiUrl, tabId, threadId],
   );
   const attachmentAdapter = useMemo(

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -693,14 +693,6 @@ export function MultiTabAssistantChat({
 
   // Listen for builder.submitChat postMessages
   useEffect(() => {
-    const execModeKey = `agent-native-exec-mode${keyPrefix}`;
-    const PLAN_MODE_INSTRUCTION =
-      `PLAN MODE ACTIVE: Before making any changes, you MUST:\n` +
-      `1. Explore the codebase to understand what's needed\n` +
-      `2. Write a plan to \`.builder/plans/YYYY-MM-DD-<topic>.md\`\n` +
-      `3. Present your approach clearly and wait for the user's explicit approval\n` +
-      `Do NOT edit any files, run any scripts, or make any changes until the user says to proceed.`;
-
     const handler = (event: MessageEvent) => {
       if (!isTrustedFrameMessage(event)) return;
       if (event.data?.type !== "agentNative.submitChat") return;
@@ -718,22 +710,12 @@ export function MultiTabAssistantChat({
         window.dispatchEvent(new CustomEvent("agent-panel:open"));
       }
 
-      const isPlanMode = (() => {
-        if (!props.execMode) return false;
-        try {
-          return localStorage.getItem(execModeKey) === "plan";
-        } catch {
-          return false;
-        }
-      })();
-
-      const baseMessage = context
+      // Plan-mode instruction prefix is injected by the chat adapter at
+      // request time (see agent-chat-adapter.ts). The user-visible message
+      // text stays clean here so it doesn't appear in the chat history.
+      const fullMessage = context
         ? `${message}\n\n<context>\n${context}\n</context>`
         : message;
-
-      const fullMessage = isPlanMode
-        ? `${PLAN_MODE_INSTRUCTION}\n\n${baseMessage}`
-        : baseMessage;
 
       const sendToTab = (threadId: string) => {
         // If a model override was specified, apply it only if we recognize it
@@ -777,7 +759,7 @@ export function MultiTabAssistantChat({
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [keyPrefix, availableModels, createThread, switchThread]);
+  }, [availableModels, createThread, switchThread]);
 
   // Process pending sends when refs mount
   useEffect(() => {

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createAgentChatAdapter } from "./agent-chat-adapter.js";
+import {
+  PLAN_MODE_INSTRUCTION,
+  createAgentChatAdapter,
+} from "./agent-chat-adapter.js";
 
 function sseResponse(events: unknown[]): Response {
   const body = events.map((event) => `data: ${JSON.stringify(event)}\n\n`);
@@ -175,5 +178,65 @@ describe("createAgentChatAdapter", () => {
         detail: { isRunning: false, tabId: "chat-qa" },
       }),
     );
+  });
+
+  it("prepends the plan-mode instruction to the request body when execMode is plan", async () => {
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(sseResponse([{ type: "done" }]));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const execModeRef: { current: "build" | "plan" | undefined } = {
+      current: "plan",
+    };
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      execModeRef,
+    });
+
+    await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "make a button blue" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.message).toBe(`${PLAN_MODE_INSTRUCTION}\n\nmake a button blue`);
+
+    // Switching back to build mode skips the prefix
+    execModeRef.current = "build";
+    fetchSpy.mockClear();
+    fetchSpy.mockResolvedValueOnce(sseResponse([{ type: "done" }]));
+
+    await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "make a button blue" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    const body2 = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body2.message).toBe("make a button blue");
   });
 });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -8,6 +8,19 @@ import { type ContentPart, readSSEStream } from "./sse-event-processor.js";
 import { agentNativePath } from "./api-path.js";
 
 /**
+ * Instruction prefixed to the outgoing user message when the composer's
+ * exec mode is "plan". Lives in the request body only — not in the
+ * displayed chat history — so the user's bubble stays clean while the
+ * LLM still sees the planning constraint on every plan-mode turn.
+ */
+export const PLAN_MODE_INSTRUCTION =
+  `PLAN MODE ACTIVE: Before making any changes, you MUST:\n` +
+  `1. Explore the codebase to understand what's needed\n` +
+  `2. Write a plan to \`.builder/plans/YYYY-MM-DD-<topic>.md\`\n` +
+  `3. Present your approach clearly and wait for the user's explicit approval\n` +
+  `Do NOT edit any files, run any scripts, or make any changes until the user says to proceed.`;
+
+/**
  * Creates a ChatModelAdapter that connects to the agent-native
  * `/_agent-native/agent-chat` SSE endpoint. Supports reconnection via run-manager.
  */
@@ -17,6 +30,7 @@ export function createAgentChatAdapter(options?: {
   threadId?: string;
   modelRef?: { current: string | undefined };
   engineRef?: { current: string | undefined };
+  execModeRef?: { current: "build" | "plan" | undefined };
 }): ChatModelAdapter {
   const apiUrl =
     options?.apiUrl ?? agentNativePath("/_agent-native/agent-chat");
@@ -24,6 +38,7 @@ export function createAgentChatAdapter(options?: {
   const threadId = options?.threadId;
   const modelRef = options?.modelRef;
   const engineRef = options?.engineRef;
+  const execModeRef = options?.execModeRef;
 
   return {
     async *run({ messages, abortSignal, runConfig }) {
@@ -35,11 +50,20 @@ export function createAgentChatAdapter(options?: {
           break;
         }
       }
-      const messageText =
+      const rawMessageText =
         lastUserMsg?.content
           .filter((p): p is { type: "text"; text: string } => p.type === "text")
           .map((p) => p.text)
           .join("\n") ?? "";
+
+      // Prepend the plan-mode instruction to the LLM-bound message when the
+      // composer's exec mode is "plan". The chat UI keeps the original text
+      // (rendered from `lastUserMsg.content`), so the user's bubble stays
+      // clean — only the request body carries the prefix.
+      const messageText =
+        execModeRef?.current === "plan"
+          ? `${PLAN_MODE_INSTRUCTION}\n\n${rawMessageText}`
+          : rawMessageText;
 
       // Extract attachments (images as base64, text as content).
       // assistant-ui puts user attachments on msg.attachments (not on content);
@@ -244,6 +268,7 @@ export function createAgentChatAdapter(options?: {
               updateActiveRunSeq(seq);
             }
           },
+          runId,
         );
 
         // Run completed normally — clear active run state
@@ -303,6 +328,7 @@ export function createAgentChatAdapter(options?: {
                     updateActiveRunSeq(seq);
                   }
                 },
+                runId,
               );
               reconnected = true;
               clearActiveRun();
@@ -336,6 +362,7 @@ export function createAgentChatAdapter(options?: {
             type: "incomplete" as const,
             reason: "error" as const,
           },
+          ...(runId ? { metadata: { custom: { runId } } } : {}),
         };
       } finally {
         if (typeof window !== "undefined") {

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -256,6 +256,11 @@ export function processEvent(
 /**
  * Read and process SSE events from a ReadableStream response body.
  * Yields ChatModelRunResult for each meaningful event.
+ *
+ * When `runId` is provided, every yielded result carries
+ * `metadata.custom.runId` so the UI can expose the trace ID via
+ * "Copy Request ID" — including mid-stream, so users can grab it before
+ * the run completes (or if the run hangs / ends prematurely).
  */
 export async function* readSSEStream(
   body: ReadableStream<Uint8Array>,
@@ -263,10 +268,14 @@ export async function* readSSEStream(
   toolCallCounter: { value: number },
   tabId: string | undefined,
   onSeq?: (seq: number) => void,
+  runId?: string | null,
 ): AsyncGenerator<ChatModelRunResult> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buf = "";
+
+  const withRunId = (r: ChatModelRunResult): ChatModelRunResult =>
+    runId ? { ...r, metadata: { ...r.metadata, custom: { runId } } } : r;
 
   try {
     while (true) {
@@ -301,7 +310,7 @@ export async function* readSSEStream(
           tabId,
         );
 
-        if (result) yield result;
+        if (result) yield withRunId(result);
         if (
           action === "done" ||
           action === "error" ||
@@ -317,7 +326,7 @@ export async function* readSSEStream(
 
   // Stream ended without explicit done event
   if (content.length > 0) {
-    yield { content: [...content] } as ChatModelRunResult;
+    yield withRunId({ content: [...content] } as ChatModelRunResult);
   }
 }
 

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -29,6 +29,18 @@ Every raw number, record, sequence ID, or underlying value you present MUST orig
 
 **Why this matters:** Users make business decisions based on the data you present. Fabricated data is not a helpful approximation — it is actively harmful. Admitting "I can't get that right now" is always the right answer when you cannot query the actual source.
 
+## TOOL AVAILABILITY — DO NOT GASLIGHT YOURSELF
+
+Your warehouse query tool is named `bigquery` and is **always registered** in this app's agent runtime — it is a first-class native tool, not an MCP add-on, and ships with every analytics deploy. The same is true for `ga4-report`, `hubspot-deals`, `amplitude-events`, `posthog-events`, `mixpanel-events`, `jira-search`, `jira-analytics`, `pylon-issues`, `gong-calls`, `apollo-search`, `commonroom-members`, `github-prs`, `seo-top-keywords`, `seo-page-keywords`, `seo-blog-pages`, and the dashboard / data-dictionary / analysis actions listed below.
+
+**Never tell the user "the bigquery tool is not registered" or "I can't see the BigQuery execution tool" or "it may be a configuration issue with this agent session".** Those statements are false. If you reached for `bigquery` and got back a tool-result that looks like an error, the failure is one of:
+
+- **Credentials not configured** — the action returns a structured `{ error: "bigquery_not_configured", message, settingsPath }` payload. Surface that message verbatim to the user and point them at Settings → Data sources.
+- **SQL error** (unknown column, syntax, permission) — the BigQuery API returns the message in the error string. Show it to the user and offer to fix the SQL.
+- **Quota / network blip** — say so and offer to retry.
+
+If, despite the above, you genuinely cannot find `bigquery` in your tool list, the correct response is to **call it anyway and report the actual tool-result back to the user** — not to invent a "the tool isn't registered" excuse. The runtime returns a clear "Unknown tool" error if a tool truly doesn't exist; absence of that error means the tool ran.
+
 **Core philosophy:** The agent and UI have full parity. Everything the user can see, the agent can see via `view-screen`. Everything the user can do, the agent can do via actions. The agent is always context-aware — it knows what the user is looking at before acting.
 
 The current screen state is automatically included with each message as a `<current-screen>` block. You don't need to call `view-screen` before every action — use it only when you need a refreshed snapshot mid-conversation.

--- a/templates/analytics/actions/bigquery.ts
+++ b/templates/analytics/actions/bigquery.ts
@@ -4,12 +4,31 @@ import { runQuery } from "../server/lib/bigquery";
 
 export default defineAction({
   description:
-    "Query the BigQuery data warehouse. Use this for ALL warehouse tables and any table NOT in the app's own SQL database. Pass standard SQL. Do NOT use db-query for BigQuery data — it only reaches the app database.",
+    "Query the BigQuery data warehouse. Always-available native tool — call this directly for any `dbt_analytics.*`, `dbt_mart.*`, or other warehouse table. Pass standard SQL via the `sql` arg. Do NOT use `db-query` for warehouse data (it only reaches the app's own SQL database). If credentials aren't configured, this returns a clear error with the settings path — surface that to the user; never claim the tool is missing or unregistered.",
   schema: z.object({
     sql: z.string().describe("SQL query to execute"),
   }),
   http: false,
   run: async (args) => {
-    return await runQuery(args.sql);
+    try {
+      return await runQuery(args.sql);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (
+        /GOOGLE_APPLICATION_CREDENTIALS_JSON not configured/i.test(msg) ||
+        /BIGQUERY_PROJECT_ID/i.test(msg) ||
+        /service account/i.test(msg) ||
+        /Token exchange failed/i.test(msg)
+      ) {
+        return {
+          error: "bigquery_not_configured",
+          message:
+            "BigQuery isn't connected for this workspace yet. Ask the user to open Settings → Data sources and add BIGQUERY_PROJECT_ID + GOOGLE_APPLICATION_CREDENTIALS_JSON (a service-account JSON key). Once those are saved, retry the query.",
+          settingsPath: "/data-sources",
+          underlying: msg,
+        };
+      }
+      throw err;
+    }
   },
 });

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -59,17 +59,32 @@ export default createAgentChatPlugin({
     return ctx.orgId;
   },
   extraContext: async (event) => {
+    // Always inject the warehouse-tool reminder, even if the data-dictionary
+    // lookup throws. Katya hit a recurring issue where the agent hallucinated
+    // that `bigquery` wasn't registered (Slack #product-agent-native-feedback,
+    // 2026-04-27 + 2026-04-30) — in reality the tool is always present and
+    // either succeeds, returns a structured credentials-missing payload, or
+    // returns a BigQuery API error. None of those are "tool not registered".
+    const toolAssertion =
+      "<warehouse-tools>\n" +
+      "Your native tool registry ALWAYS includes `bigquery(sql)` for warehouse queries (dbt_analytics.*, dbt_mart.*, builder-3b0a2.*, etc.) plus `ga4-report`, `hubspot-deals`, `hubspot-metrics`, `hubspot-pipelines`, `amplitude-events`, `posthog-events`, `mixpanel-events`, `jira-search`, `jira-analytics`, `pylon-issues`, `gong-calls`, `apollo-search`, `commonroom-members`, `github-prs`, and `seo-*`. Do NOT tell the user that any of these are unregistered or unavailable in your session — they are part of every analytics deploy. " +
+      'If `bigquery` returns `{ error: "bigquery_not_configured", message, settingsPath }`, surface that message and the settings path to the user. ' +
+      "If it returns a BigQuery API error (unknown column, permission, syntax), show that error and offer to fix the SQL. " +
+      "Never substitute fabricated numbers for a failed query.\n" +
+      "</warehouse-tools>";
+
     try {
       const scope = await resolveSettingsScope(event);
       const all = await listScopedSettingRecords(scope, DATA_DICT_PREFIX);
       const entries = Object.values(all) as Array<Record<string, unknown>>;
-      return renderDataDictionary(entries);
+      const dict = renderDataDictionary(entries);
+      return dict ? `${toolAssertion}\n\n${dict}` : toolAssertion;
     } catch (err) {
       console.warn(
         "[analytics] data dictionary context failed:",
         err instanceof Error ? err.message : err,
       );
-      return null;
+      return toolAssertion;
     }
   },
   mentionProviders: {

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -1198,10 +1198,16 @@ export function installDesktopVoiceDictation(
           );
           window.setTimeout(() => {
             if (disposed) return;
+            // If a new Fn-tap took over during tail-capture, mark the
+            // old session cancelled BEFORE aborting so its `onend`
+            // handler skips the paste (otherwise abort() fires onend
+            // synchronously and complete_voice_dictation pastes the
+            // stale transcript into the new session's focused field).
+            const supersededByNewSession = !!session && session !== lingering;
+            if (supersededByNewSession) lingering.cancelled = true;
             // Always release the lingering session's mic + recognizer
-            // — even if cancelled or replaced by a newer session.
-            // Skipping the abort/stopTracks would leave the old
-            // recognizer listening and the mic stream open.
+            // — even if cancelled or superseded. Skipping abort/stopTracks
+            // would leave the old recognizer listening and the mic open.
             try {
               lingering.recognition?.abort();
             } catch {
@@ -1209,11 +1215,7 @@ export function installDesktopVoiceDictation(
             }
             stopTracks(lingering);
             if (lingering.cancelled) return;
-            // A new Fn-tap during tail-capture starts a fresh session
-            // that owns the flow-bar now. Don't paste this lingering
-            // session's text against it, and don't wipe its UI on
-            // dismiss. Mirrors the native finalize guard above.
-            if (session && session !== lingering) return;
+            if (supersededByNewSession) return;
             const finalText = lingering.browserTranscript.trim();
             lingering.browserTranscript = "";
             if (finalText) {
@@ -1270,20 +1272,16 @@ export function installDesktopVoiceDictation(
     .then((u) => unlistens.push(u))
     .catch(() => {});
   listen<{ text: string }>("voice:final-transcript", (ev) => {
-    // After stop() in the native path, `session` has been cleared so a
-    // rapid restart can take it; the lingering session that's waiting
-    // for the final transcript lives on `lingeringSession`. Prefer
-    // `lingeringSession` here — the final-transcript event we're
-    // routing was emitted by Rust's `endAudio()` from the lingering
-    // session's stop(); the brand-new `session` is still ramping up
-    // and won't see a final until its own stop() fires. Only if there
-    // is no lingering one do we fall back to the active session.
+    // Final transcripts are ONLY emitted by Rust after `endAudio()`,
+    // which we call in stop(). At that point the session has been
+    // moved from `session` to `lingeringSession`, so route there
+    // exclusively. Do NOT fall back to the active `session`: a
+    // late-arriving final from the previous session would otherwise
+    // overwrite the new session's transcript with stale text.
     const current =
       lingeringSession && lingeringSession.kind === "native"
         ? lingeringSession
-        : session && session.kind === "native"
-          ? session
-          : null;
+        : null;
     if (!current) return;
     if (current.cancelled) return;
     // Final beats partial — overwrite so a `complete_voice_dictation`


### PR DESCRIPTION
## Summary

Addresses the 2 deferred 🟡 review comments from PR #388, plus a concurrent agent sweep.

### Bot review fixes
- **Tail-capture cleanup pastes superseded session after recognizer abort** — \`recognition.abort()\` fires \`onend\` synchronously, and \`onend\` calls \`complete_voice_dictation()\` if the session still has a non-empty transcript. When a new session has taken over, this pasted the old session's text into the new session's focused field. Now we mark \`lingering.cancelled = true\` before aborting, so \`onend\` skips the paste.
- **Clearing lingeringSession lets late native finals misroute** — final transcripts are ONLY emitted by Rust after \`endAudio()\`, which only runs in \`stop()\`; by that point the session has moved from \`session\` to \`lingeringSession\`. Removed the fallback to \`session\` in the listener so a late-arriving final from the previous session can never overwrite the new session's transcript.

### Concurrent sweep
- packages/core agent engine + chat adapters + SSE processor updates
- analytics template BigQuery action + agent-chat plugin updates

## Test plan
- [ ] CI: Lint, Test, Typecheck, Build, Scaffold E2E, Guard all green
- [ ] Rapid Fn-tap during browser tail-capture: no stale paste from old session
- [ ] Native final after stop(): pastes through lingeringSession, not into a brand-new active session