### PR TITLE
fix(slides): inline text editing — memoize dangerouslySetInnerHTML object

### DIFF
--- a/templates/slides/app/components/deck/SlideRenderer.tsx
+++ b/templates/slides/app/components/deck/SlideRenderer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Slide } from "@/context/DeckContext";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -112,33 +112,48 @@ const markdownComponents = {
 function BlankSlideContent({ content }: { content: string }) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Apply white filter to all logo images (brandfetch, logo.dev, etc.) for dark backgrounds
-  const processedContent = sanitizeSlideHtml(
-    content.replace(
-      /(<img\s+(?=[^>]*src="[^"]*(?:brandfetch|logo\.dev)[^"]*")[^>]*)(\/?>)/gi,
-      (_match, before, close) => {
-        if (before.includes('style="')) {
-          return (
-            before.replace(
-              'style="',
-              'style="filter:brightness(0) invert(1);',
-            ) + close
-          );
-        }
-        return before + ' style="filter:brightness(0) invert(1);"' + close;
-      },
-    ),
-  );
+  // Memoize derived strings + the dangerouslySetInnerHTML object on `content` so
+  // the prop value has a stable reference across re-renders. React 19 only checks
+  // reference equality on `dangerouslySetInnerHTML` and unconditionally re-assigns
+  // `domElement.innerHTML` when the object reference differs — a fresh `{ __html }`
+  // literal each render therefore wipes any DOM mutations made on children. That
+  // includes the per-block `contentEditable="true"` set by SlideEditor's
+  // double-click-to-edit flow, which made inline text editing appear to do nothing.
+  const { mermaidBlocks, htmlWithPlaceholders, dangerousHtml } = useMemo(() => {
+    // Apply white filter to all logo images (brandfetch, logo.dev, etc.) for dark backgrounds
+    const processed = sanitizeSlideHtml(
+      content.replace(
+        /(<img\s+(?=[^>]*src="[^"]*(?:brandfetch|logo\.dev)[^"]*")[^>]*)(\/?>)/gi,
+        (_match, before, close) => {
+          if (before.includes('style="')) {
+            return (
+              before.replace(
+                'style="',
+                'style="filter:brightness(0) invert(1);',
+              ) + close
+            );
+          }
+          return before + ' style="filter:brightness(0) invert(1);"' + close;
+        },
+      ),
+    );
 
-  // Extract mermaid blocks from HTML content for React-based rendering
-  const mermaidBlocks: string[] = [];
-  const htmlWithPlaceholders = processedContent.replace(
-    /<div\s+class="mermaid"[^>]*>([\s\S]*?)<\/div>/gi,
-    (_, definition) => {
-      mermaidBlocks.push(definition.trim());
-      return `<div data-mermaid-index="${mermaidBlocks.length - 1}"></div>`;
-    },
-  );
+    // Extract mermaid blocks from HTML content for React-based rendering
+    const blocks: string[] = [];
+    const withPlaceholders = processed.replace(
+      /<div\s+class="mermaid"[^>]*>([\s\S]*?)<\/div>/gi,
+      (_, definition) => {
+        blocks.push(definition.trim());
+        return `<div data-mermaid-index="${blocks.length - 1}"></div>`;
+      },
+    );
+
+    return {
+      mermaidBlocks: blocks,
+      htmlWithPlaceholders: withPlaceholders,
+      dangerousHtml: { __html: processed },
+    };
+  }, [content]);
 
   if (mermaidBlocks.length > 0) {
     return (
@@ -155,7 +170,7 @@ function BlankSlideContent({ content }: { content: string }) {
     <div
       ref={containerRef}
       className="slide-content text-white/90 w-full block h-full"
-      dangerouslySetInnerHTML={{ __html: processedContent }}
+      dangerouslySetInnerHTML={dangerousHtml}
     />
   );
 }


### PR DESCRIPTION
## Summary

- Inline text editing on the deck canvas was silently broken under React 19: double-clicking a heading or paragraph would briefly toggle `contentEditable="true"`, then the slide DOM got rebuilt within the same event-loop turn and the edit was wiped — symptom: nothing happens on click.
- Root cause is that react-dom 19's `updateProperties` only checks reference equality on the `dangerouslySetInnerHTML` prop and unconditionally re-assigns `domElement.innerHTML`. `BlankSlideContent` was passing a fresh `{ __html: ... }` literal every render, so every parent re-render destroyed any DOM mutations the SlideEditor had made on children.
- Fix derives the processed HTML + mermaid extraction + the `dangerouslySetInnerHTML` object inside a single `useMemo([content])`. Stable identity → React diff sees `prev === next` → `innerHTML` is left alone → contentEditable persists.
- Reproduced and verified locally; user confirmed editing works.

## Why this surfaced now

Two recent things converged: per-deck aspect ratio (PR #346) made the editor canvas re-render more often as `aspectRatio`/`isHoveringText` flow changed, and React 19's stricter prop-diff for `dangerouslySetInnerHTML` doesn't compare `__html` strings the way older versions effectively did via memoization paths. The file's own comment at \`SlideEditor.tsx:273-281\` already flagged this risk for keystrokes mid-edit; it also blocked the entry into edit mode.

## Diff scope

One file: \`templates/slides/app/components/deck/SlideRenderer.tsx\`. Behaviour for content rendering is unchanged — the only difference is that derived strings + the inner-HTML wrapper object are computed once per content string instead of once per render.

## Test plan

- [x] \`npx tsc --noEmit -p .\` passes (clean, no slides errors)
- [x] \`prettier --write\` clean
- [x] Manually reproduced the bug before the fix (Playwright traced the contentEditable being set then immediately wiped within the same event-loop turn)
- [x] Manually verified after the fix: dev-server inline editing works
- [ ] Open a deck with a normal \`fmd-slide\` content slide; hover text → "Double-click any text to edit" pill appears; double-click → caret enters block; type → text appears; Escape → exits and persists. Repeat for layouts: title, content (bullets), section, statement, blank.
- [ ] Switch deck aspect ratio (gear menu) to 1:1, 9:16, 4:5 — editing still works at each ratio.
- [ ] Switch slides mid-deck after editing, switch back — content survives.
- [ ] Sanity check on a slide that contains a mermaid block (uses the alternate \`MermaidHtmlContent\` branch — also memoized in this change).

## Out of scope (follow-ups)

- The \`SlideEditor\` "save only on explicit exit" mitigation is no longer load-bearing now that the DOM survives re-renders, but I'm not changing that policy in this PR — keep diff minimal.
- Markdown-rendered slides (without \`class="fmd-slide"\` / not in the raw-HTML layout list) still silently can't be inline-edited, and the "Double-click any text to edit" hint is shown regardless. Separate UX bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)