### PR TITLE
Daily branch: analytics first-party tracking + onboarding + clips/slides polish

### DIFF
--- a/.agents/skills/tracking/SKILL.md
+++ b/.agents/skills/tracking/SKILL.md
@@ -75,9 +75,12 @@ Set the env var and the provider auto-registers at startup. No SDK dependencies 
 | PostHog    | `POSTHOG_API_KEY` (required), `POSTHOG_HOST` (optional, defaults to `https://us.i.posthog.com`) |
 | Mixpanel   | `MIXPANEL_TOKEN`                                          |
 | Amplitude  | `AMPLITUDE_API_KEY`                                       |
+| Agent Native Analytics | `AGENT_NATIVE_ANALYTICS_PUBLIC_KEY` (server), `AGENT_NATIVE_ANALYTICS_ENDPOINT` (optional, defaults to `https://analytics.agent-native.com/track`) |
 | Webhook    | `TRACKING_WEBHOOK_URL` (required), `TRACKING_WEBHOOK_AUTH` (optional, sent as `Authorization` header) |
 
 Multiple providers can be active simultaneously. All receive every event.
+
+Browser-side `trackEvent()` also forwards to Agent Native Analytics when `VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY` is present. Use `VITE_AGENT_NATIVE_ANALYTICS_ENDPOINT` to override the default browser endpoint.
 
 ## Provider Interface
 
@@ -109,7 +112,7 @@ interface TrackingEvent {
 | File                                           | Purpose                                     |
 | ---------------------------------------------- | ------------------------------------------- |
 | `packages/core/src/tracking/registry.ts`       | `track()`, `identify()`, `registerTrackingProvider()`, `flushTracking()` |
-| `packages/core/src/tracking/providers.ts`      | Built-in providers (PostHog, Mixpanel, Amplitude, Webhook) and `registerBuiltinProviders()` |
+| `packages/core/src/tracking/providers.ts`      | Built-in providers (PostHog, Mixpanel, Amplitude, Agent Native Analytics, Webhook) and `registerBuiltinProviders()` |
 | `packages/core/src/tracking/types.ts`          | `TrackingEvent` and `TrackingProvider` interfaces |
 
 ## Related Skills

--- a/.agents/skills/tracking/SKILL.md
+++ b/.agents/skills/tracking/SKILL.md
@@ -80,7 +80,7 @@ Set the env var and the provider auto-registers at startup. No SDK dependencies 
 
 Multiple providers can be active simultaneously. All receive every event.
 
-Browser-side `trackEvent()` also forwards to Agent Native Analytics when `VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY` is present. Use `VITE_AGENT_NATIVE_ANALYTICS_ENDPOINT` to override the default browser endpoint.
+Browser-side `trackEvent()` also forwards to Agent Native Analytics when `VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY` is present. Use `VITE_AGENT_NATIVE_ANALYTICS_ENDPOINT` to override the default browser endpoint. The built-in Agent Native Analytics sender is quiet on localhost/local dev by default; set `AGENT_NATIVE_ANALYTICS_ALLOW_LOCALHOST=true` only for an intentional local ingestion test.
 
 ## Provider Interface
 

--- a/packages/core/docs/content/onboarding.md
+++ b/packages/core/docs/content/onboarding.md
@@ -1,9 +1,9 @@
 # Onboarding
 
 When you first open an app built on the agent-native framework, you'll see a
-**Setup** checklist in the agent sidebar. Each item is something the app needs
-from you — connect an AI engine, paste an API key, configure email delivery —
-before the agent can do its full job.
+**Setup** checklist in the agent sidebar. It keeps first-run configuration close
+to the agent chat: connect an AI engine, optionally point the app at shared
+infrastructure, and add providers only when you need them.
 
 ## For end users
 
@@ -11,9 +11,9 @@ before the agent can do its full job.
 
 - A **Setup** panel above the agent chat with a checklist like "Connect an AI
   engine", "Email delivery", etc.
-- A counter at the top (e.g. "1 of 4") shows how many steps are done.
-- The current step is expanded; finished steps collapse with a green check;
-  remaining steps sit dimmed below.
+- A counter at the top (e.g. "1 of 4") shows how many steps are ready.
+- The current step is expanded; finished steps show a green check and stay
+  readable if you open them.
 - Required steps show a small red **required** pill. The panel stays visible
   until every required step is complete.
 - Once everything required is done, the panel hides itself automatically.
@@ -23,14 +23,14 @@ before the agent can do its full job.
 ### How to complete each step
 
 Steps offer one or more **methods** — different ways to satisfy the same
-requirement. The recommended option is highlighted in blue; alternatives sit
-below it.
+requirement. The primary path is shown first; secondary paths are kept compact
+behind a picker or disclosure when a step has several equivalent providers.
 
 - **Connect a service (one click)** — e.g. _Connect Builder_ for the managed
   AI gateway. Click the button, a window opens, you sign in, the window closes,
   and the step is marked complete. No keys to copy.
-- **Paste an API key or fill a form** — e.g. _Use your Anthropic API key_,
-  _Use Resend_ for email. Click the method, paste the value(s), click **Save**.
+- **Paste an API key or fill a form** — e.g. choose an LLM provider, database,
+  OAuth provider, or email provider, paste the value(s), click **Save**.
   Secret fields use a password input so the value isn't shown on screen. Saved
   values go into your local `.env` (or workspace settings) — see
   [Secrets](/docs/secrets) for where they live.
@@ -42,14 +42,16 @@ below it.
 
 ### The built-in steps you'll usually see
 
-- **Connect an AI engine** (required) — the only mandatory step. Either
-  connect Builder for a one-click managed gateway, or paste a key for
-  Anthropic, OpenAI, Google Gemini, or OpenRouter.
+- **Connect an AI engine** (required) — the only mandatory step. Connect
+  Builder for a one-click managed gateway, or open the secondary provider-key
+  picker and paste your own LLM key.
+- **Database** (optional) — set `DATABASE_URL` when you want to use a specific
+  SQL database connection string.
+- **Authentication** (optional) — built-in email/password accounts work by
+  default. Add OAuth or access-token sign-in only when you want those paths.
 - **Email delivery** (optional) — needed for password resets and team
-  invitations. Resend or SendGrid; without it, reset emails just log to the
-  server console.
-- **Database** and **Authentication** — only shown in local dev mode.
-  Production deployments configure these via environment variables.
+  invitations. Use the provider you already use; without one, local/dev reset
+  emails log to the server console.
 
 Templates can add their own steps on top of these — e.g. a CRM template might
 add "Connect Gmail", a docs template might add "Pick a default workspace". See
@@ -127,23 +129,23 @@ export default defineNitroPlugin(() => {
 
 ### Method kinds
 
-| Kind               | Payload                   | Use for                                   |
-| ------------------ | ------------------------- | ----------------------------------------- |
-| `link`             | `{ url, external? }`      | Send user to an OAuth flow or docs page   |
-| `form`             | `{ fields, writeScope? }` | Collect env vars (keys, secrets, URLs)    |
-| `builder-cli-auth` | `{ scope: "browser" }`    | Connect Builder (unlocks shared infra)    |
-| `agent-task`       | `{ prompt }`              | Send a prompt to the agent chat to handle |
+| Kind               | Payload                         | Use for                                   |
+| ------------------ | ------------------------------- | ----------------------------------------- |
+| `link`             | `{ url, external? }`            | Send user to an OAuth flow or docs page   |
+| `form`             | `{ fields, writeScope? }`       | Collect env vars (keys, secrets, URLs)    |
+| `builder-cli-auth` | `{ scope: "llm" \| "browser" }` | Connect Builder (unlocks shared infra)    |
+| `agent-task`       | `{ prompt }`                    | Send a prompt to the agent chat to handle |
 
 The `primary: true` flag marks a method as the big CTA for its step.
 
 ### Built-in steps
 
-| ID         | Required | Description                                   |
-| ---------- | -------- | --------------------------------------------- |
-| `llm`      | yes      | ANTHROPIC_API_KEY or Builder connection       |
-| `database` | no       | SQLite default or a DATABASE_URL for Postgres |
-| `auth`     | no       | Local dev mode, Google OAuth, or access token |
-| `email`    | no       | Resend or SendGrid for transactional email    |
+| ID         | Required | Description                                       |
+| ---------- | -------- | ------------------------------------------------- |
+| `llm`      | yes      | Builder connection or a provider LLM key          |
+| `database` | no       | Default database or any SQL `DATABASE_URL`        |
+| `auth`     | no       | Built-in accounts, optional OAuth or access token |
+| `email`    | no       | Resend or SendGrid for transactional email        |
 
 Any of these can be overridden by re-registering with the same `id` after the
 defaults load.

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -19,6 +19,18 @@ let _sentryInitialized = false;
 const AGENT_NATIVE_ANALYTICS_DEFAULT_ENDPOINT =
   "https://analytics.agent-native.com/track";
 
+function isLocalAnalyticsHostname(hostname: string | undefined): boolean {
+  const h = (hostname || "").toLowerCase();
+  return (
+    h === "localhost" ||
+    h === "127.0.0.1" ||
+    h === "::1" ||
+    h === "[::1]" ||
+    h.endsWith(".localhost") ||
+    h.endsWith(".local")
+  );
+}
+
 function ensureAmplitude(): boolean {
   if (_amplitudeInitialized) return true;
   const key = (import.meta.env as Record<string, string | undefined>)
@@ -135,6 +147,8 @@ function sendAgentNativeAnalytics(
   name: string,
   properties: Record<string, unknown>,
 ): void {
+  if (isLocalAnalyticsHostname(window.location.hostname)) return;
+
   const publicKey = (import.meta.env as Record<string, string | undefined>)
     ?.VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY;
   if (!publicKey) return;

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -16,6 +16,9 @@ let _getDefaultProps: GetDefaultProps | null = null;
 let _amplitudeInitialized = false;
 let _sentryInitialized = false;
 
+const AGENT_NATIVE_ANALYTICS_DEFAULT_ENDPOINT =
+  "https://analytics.agent-native.com/track";
+
 function ensureAmplitude(): boolean {
   if (_amplitudeInitialized) return true;
   const key = (import.meta.env as Record<string, string | undefined>)
@@ -128,6 +131,44 @@ function resolveProps(
   return _getDefaultProps ? _getDefaultProps(name, base) : base;
 }
 
+function sendAgentNativeAnalytics(
+  name: string,
+  properties: Record<string, unknown>,
+): void {
+  const publicKey = (import.meta.env as Record<string, string | undefined>)
+    ?.VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY;
+  if (!publicKey) return;
+
+  const endpoint =
+    (import.meta.env as Record<string, string | undefined>)
+      ?.VITE_AGENT_NATIVE_ANALYTICS_ENDPOINT ||
+    AGENT_NATIVE_ANALYTICS_DEFAULT_ENDPOINT;
+  const userId =
+    typeof properties.userId === "string" ? properties.userId : undefined;
+  const body = JSON.stringify({
+    publicKey,
+    event: name,
+    properties,
+    userId,
+    timestamp: new Date().toISOString(),
+  });
+
+  try {
+    if (navigator.sendBeacon) {
+      const sent = navigator.sendBeacon(endpoint, body);
+      if (sent) return;
+    }
+    fetch(endpoint, {
+      method: "POST",
+      body,
+      keepalive: true,
+      headers: { "Content-Type": "text/plain;charset=UTF-8" },
+    }).catch(() => {});
+  } catch {
+    // best-effort
+  }
+}
+
 export function trackEvent(
   name: string,
   params?: Record<string, string | number | boolean>,
@@ -139,6 +180,7 @@ export function trackEvent(
   if (ensureAmplitude()) {
     amplitude.track(name, props);
   }
+  sendAgentNativeAnalytics(name, props);
 }
 
 export function trackSessionStatus(signedIn: boolean): void {

--- a/packages/core/src/client/onboarding/OnboardingPanel.tsx
+++ b/packages/core/src/client/onboarding/OnboardingPanel.tsx
@@ -15,6 +15,7 @@ import {
   IconChevronRight,
   IconChevronUp,
   IconExternalLink,
+  IconKey,
   IconLoader2,
 } from "@tabler/icons-react";
 import { useOnboarding } from "./use-onboarding.js";
@@ -26,6 +27,8 @@ import type {
   OnboardingMethod,
   OnboardingStepStatus,
 } from "../../onboarding/types.js";
+
+type FormOnboardingMethod = Extract<OnboardingMethod, { kind: "form" }>;
 
 interface OnboardingPanelProps {
   /** Optional extra styles / classes for the wrapper. */
@@ -176,6 +179,10 @@ function StepCard({
     return a.primary ? -1 : 1;
   });
 
+  const handleCompleted = async () => {
+    await onRefresh();
+  };
+
   return (
     <div
       style={{
@@ -212,21 +219,201 @@ function StepCard({
       {expanded && (
         <div style={styles.cardBody}>
           <p style={styles.cardDesc}>{step.description}</p>
-          <div style={styles.methods}>
-            {sortedMethods.map((method) => (
-              <MethodBlock
-                key={method.id}
-                method={method}
-                stepId={step.id}
-                onCompleted={async () => {
-                  await onRefresh();
-                }}
-                onMarkManualComplete={onMarkComplete}
-              />
-            ))}
-          </div>
+          <StepMethods
+            step={step}
+            methods={sortedMethods}
+            onCompleted={handleCompleted}
+            onMarkManualComplete={onMarkComplete}
+          />
         </div>
       )}
+    </div>
+  );
+}
+
+function isFormMethod(
+  method: OnboardingMethod,
+): method is FormOnboardingMethod {
+  return method.kind === "form";
+}
+
+function StepMethods({
+  step,
+  methods,
+  onCompleted,
+  onMarkManualComplete,
+}: {
+  step: OnboardingStepStatus;
+  methods: OnboardingMethod[];
+  onCompleted: () => Promise<void>;
+  onMarkManualComplete: () => void;
+}) {
+  const formMethods = methods.filter(isFormMethod);
+
+  if (step.id === "llm") {
+    return (
+      <LlmMethodGroup
+        methods={methods}
+        formMethods={formMethods}
+        stepId={step.id}
+        onCompleted={onCompleted}
+        onMarkManualComplete={onMarkManualComplete}
+      />
+    );
+  }
+
+  if (methods.length > 1 && formMethods.length === methods.length) {
+    const pickerLabel = step.id === "auth" ? "Sign-in path" : "Provider";
+    return (
+      <div style={styles.methods}>
+        <FormMethodPicker
+          methods={formMethods}
+          label={pickerLabel}
+          onCompleted={onCompleted}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.methods}>
+      {methods.map((method) => (
+        <MethodBlock
+          key={method.id}
+          method={method}
+          stepId={step.id}
+          onCompleted={onCompleted}
+          onMarkManualComplete={onMarkManualComplete}
+        />
+      ))}
+    </div>
+  );
+}
+
+function LlmMethodGroup({
+  methods,
+  formMethods,
+  stepId,
+  onCompleted,
+  onMarkManualComplete,
+}: {
+  methods: OnboardingMethod[];
+  formMethods: FormOnboardingMethod[];
+  stepId: string;
+  onCompleted: () => Promise<void>;
+  onMarkManualComplete: () => void;
+}) {
+  const [showKeyForm, setShowKeyForm] = useState(false);
+  const primaryMethod =
+    methods.find((method) => method.kind === "builder-cli-auth") ??
+    methods.find((method) => method.primary);
+  const otherMethods = methods.filter(
+    (method) => method !== primaryMethod && !isFormMethod(method),
+  );
+
+  return (
+    <div style={styles.methods}>
+      {primaryMethod && (
+        <MethodBlock
+          method={primaryMethod}
+          stepId={stepId}
+          onCompleted={onCompleted}
+          onMarkManualComplete={onMarkManualComplete}
+        />
+      )}
+
+      {formMethods.length > 0 && (
+        <div style={styles.secondaryPanel}>
+          <button
+            type="button"
+            onClick={() => setShowKeyForm((value) => !value)}
+            style={styles.secondaryToggle}
+            aria-expanded={showKeyForm}
+          >
+            <span style={styles.secondaryToggleLeft}>
+              <IconKey size={13} aria-hidden />
+              <span>Add your own provider key</span>
+            </span>
+            <span style={styles.chevron}>
+              {showKeyForm ? (
+                <IconChevronDown size={14} />
+              ) : (
+                <IconChevronRight size={14} />
+              )}
+            </span>
+          </button>
+          {showKeyForm && (
+            <FormMethodPicker
+              methods={formMethods}
+              label="Provider"
+              onCompleted={onCompleted}
+              embedded
+            />
+          )}
+        </div>
+      )}
+
+      {otherMethods.map((method) => (
+        <MethodBlock
+          key={method.id}
+          method={method}
+          stepId={stepId}
+          onCompleted={onCompleted}
+          onMarkManualComplete={onMarkManualComplete}
+        />
+      ))}
+    </div>
+  );
+}
+
+function FormMethodPicker({
+  methods,
+  label,
+  onCompleted,
+  embedded,
+}: {
+  methods: FormOnboardingMethod[];
+  label: string;
+  onCompleted: () => Promise<void>;
+  embedded?: boolean;
+}) {
+  const [selectedId, setSelectedId] = useState(methods[0]?.id ?? "");
+
+  useEffect(() => {
+    if (!methods.some((method) => method.id === selectedId)) {
+      setSelectedId(methods[0]?.id ?? "");
+    }
+  }, [methods, selectedId]);
+
+  const selectedMethod =
+    methods.find((method) => method.id === selectedId) ?? methods[0];
+
+  if (!selectedMethod) return null;
+
+  return (
+    <div style={embedded ? styles.methodPickerEmbedded : styles.method}>
+      <label style={styles.pickerLabel}>
+        <span style={styles.formLabelText}>{label}</span>
+        <select
+          value={selectedMethod.id}
+          onChange={(event) => setSelectedId(event.target.value)}
+          style={styles.select}
+        >
+          {methods.map((method) => (
+            <option key={method.id} value={method.id}>
+              {method.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      {selectedMethod.description && (
+        <p style={styles.methodDesc}>{selectedMethod.description}</p>
+      )}
+      <FormMethod
+        key={selectedMethod.id}
+        method={selectedMethod}
+        onCompleted={onCompleted}
+      />
     </div>
   );
 }
@@ -584,7 +771,8 @@ const styles: Record<string, React.CSSProperties> = {
     background: "hsl(var(--muted, 0 0% 0%) / 0.12)",
   },
   cardDone: {
-    opacity: 0.55,
+    borderColor: "rgba(34,197,94,0.12)",
+    background: "rgba(34,197,94,0.025)",
   },
   cardHeader: {
     width: "100%",
@@ -607,9 +795,13 @@ const styles: Record<string, React.CSSProperties> = {
   cardTitle: {
     fontSize: 12,
     fontWeight: 500,
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    minWidth: 0,
+    flexWrap: "wrap" as const,
   },
   requiredPill: {
-    marginLeft: 6,
     fontSize: 10,
     padding: "1px 5px",
     borderRadius: 4,
@@ -672,9 +864,52 @@ const styles: Record<string, React.CSSProperties> = {
   methodHeader: { display: "flex", alignItems: "center" },
   methodLabel: { fontSize: 12, fontWeight: 500 },
   methodDesc: { margin: 0, opacity: 0.6, fontSize: 11, lineHeight: 1.4 },
+  secondaryPanel: {
+    paddingTop: 2,
+  },
+  secondaryToggle: {
+    width: "100%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 8,
+    padding: "7px 8px",
+    borderRadius: 6,
+    border: "1px solid rgba(255,255,255,0.08)",
+    background: "rgba(255,255,255,0.025)",
+    color: "inherit",
+    cursor: "pointer",
+    fontSize: 11,
+    fontWeight: 500,
+    textAlign: "left" as const,
+  },
+  secondaryToggleLeft: {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    minWidth: 0,
+  },
+  methodPickerEmbedded: {
+    paddingTop: 8,
+    display: "flex",
+    flexDirection: "column",
+    gap: 6,
+  },
+  pickerLabel: { display: "flex", flexDirection: "column", gap: 3 },
   form: { display: "flex", flexDirection: "column", gap: 6 },
   formLabel: { display: "flex", flexDirection: "column", gap: 2 },
   formLabelText: { fontSize: 11, opacity: 0.6 },
+  select: {
+    width: "100%",
+    padding: "6px 8px",
+    fontSize: 12,
+    borderRadius: 5,
+    border: "1px solid rgba(255,255,255,0.1)",
+    background: "rgba(0,0,0,0.25)",
+    color: "inherit",
+    outline: "none",
+    boxSizing: "border-box" as const,
+  },
   input: {
     width: "100%",
     padding: "6px 8px",

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -964,7 +964,9 @@ function EmailSectionInner({
   const [fromAddr, setFromAddr] = useState("");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
-  const [showSendgrid, setShowSendgrid] = useState(false);
+  const [emailProvider, setEmailProvider] = useState<"resend" | "sendgrid">(
+    "resend",
+  );
   const [envLoaded, setEnvLoaded] = useState(false);
 
   useEffect(() => {
@@ -982,6 +984,12 @@ function EmailSectionInner({
   const fromConfigured =
     envKeys.find((k) => k.key === "EMAIL_FROM")?.configured ?? false;
   const anyConfigured = resendConfigured || sendgridConfigured;
+
+  useEffect(() => {
+    if (sendgridConfigured && !resendConfigured) {
+      setEmailProvider("sendgrid");
+    }
+  }, [resendConfigured, sendgridConfigured]);
 
   const save = async (vars: Array<{ key: string; value: string }>) => {
     setSaving(true);
@@ -1034,64 +1042,48 @@ function EmailSectionInner({
         <SettingsSkeleton lines={2} />
       ) : (
         <div className="space-y-2">
-          <ManualSetupCard
-            hint="Paste a Resend API key to start sending real emails."
-            docsUrl="https://resend.com/api-keys"
-            docsLabel="Get a Resend key"
-          >
-            {resendConfigured ? (
-              <div className="flex items-center gap-1.5 text-[10px] text-green-500 mb-1">
-                <IconCheck size={10} />
-                RESEND_API_KEY configured
-              </div>
-            ) : (
-              <div className="flex gap-1.5 mb-1">
-                <input
-                  type="password"
-                  value={resendKey}
-                  onChange={(e) => setResendKey(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") saveResend();
-                  }}
-                  placeholder="re_..."
-                  className="flex-1 rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                />
-                <button
-                  onClick={saveResend}
-                  disabled={!resendKey.trim() || saving}
-                  className="rounded bg-accent px-2 py-1 text-[10px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40"
-                >
-                  {saving ? (
-                    <IconLoader2 size={10} className="animate-spin" />
-                  ) : saved ? (
-                    <IconCheck size={10} />
-                  ) : (
-                    "Save"
-                  )}
-                </button>
-              </div>
-            )}
-            {fromConfigured ? (
-              <div className="flex items-center gap-1.5 text-[10px] text-green-500">
-                <IconCheck size={10} />
-                EMAIL_FROM configured
-              </div>
-            ) : (
-              <div className="flex gap-1.5">
-                <input
-                  type="text"
-                  value={fromAddr}
-                  onChange={(e) => setFromAddr(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") saveResend();
-                  }}
-                  placeholder="From address — e.g. Acme <hi@acme.com>"
-                  className="flex-1 rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                />
-                {!resendConfigured ? null : (
+          <label className="block space-y-1">
+            <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              Provider
+            </span>
+            <select
+              value={emailProvider}
+              onChange={(e) =>
+                setEmailProvider(e.target.value as "resend" | "sendgrid")
+              }
+              className="w-full rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none focus:ring-1 focus:ring-accent"
+            >
+              <option value="resend">Resend</option>
+              <option value="sendgrid">SendGrid</option>
+            </select>
+          </label>
+
+          {emailProvider === "resend" ? (
+            <ManualSetupCard
+              hint="Use Resend for transactional email."
+              docsUrl="https://resend.com/api-keys"
+              docsLabel="Get a Resend key"
+            >
+              {resendConfigured ? (
+                <div className="mb-1 flex items-center gap-1.5 text-[10px] text-green-500">
+                  <IconCheck size={10} />
+                  RESEND_API_KEY configured
+                </div>
+              ) : (
+                <div className="mb-1 flex gap-1.5">
+                  <input
+                    type="password"
+                    value={resendKey}
+                    onChange={(e) => setResendKey(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") saveResend();
+                    }}
+                    placeholder="re_..."
+                    className="flex-1 rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                  />
                   <button
                     onClick={saveResend}
-                    disabled={!fromAddr.trim() || saving}
+                    disabled={!resendKey.trim() || saving}
                     className="rounded bg-accent px-2 py-1 text-[10px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40"
                   >
                     {saving ? (
@@ -1102,32 +1094,56 @@ function EmailSectionInner({
                       "Save"
                     )}
                   </button>
-                )}
-              </div>
-            )}
-          </ManualSetupCard>
-
-          {!sendgridConfigured && !showSendgrid ? (
-            <button
-              type="button"
-              onClick={() => setShowSendgrid(true)}
-              className="text-[10px] text-muted-foreground hover:text-foreground"
-            >
-              Use SendGrid instead
-            </button>
+                </div>
+              )}
+              {fromConfigured ? (
+                <div className="flex items-center gap-1.5 text-[10px] text-green-500">
+                  <IconCheck size={10} />
+                  EMAIL_FROM configured
+                </div>
+              ) : (
+                <div className="flex gap-1.5">
+                  <input
+                    type="text"
+                    value={fromAddr}
+                    onChange={(e) => setFromAddr(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") saveResend();
+                    }}
+                    placeholder="From address - e.g. Acme <hi@acme.com>"
+                    className="flex-1 rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                  />
+                  {!resendConfigured ? null : (
+                    <button
+                      onClick={saveResend}
+                      disabled={!fromAddr.trim() || saving}
+                      className="rounded bg-accent px-2 py-1 text-[10px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40"
+                    >
+                      {saving ? (
+                        <IconLoader2 size={10} className="animate-spin" />
+                      ) : saved ? (
+                        <IconCheck size={10} />
+                      ) : (
+                        "Save"
+                      )}
+                    </button>
+                  )}
+                </div>
+              )}
+            </ManualSetupCard>
           ) : (
             <ManualSetupCard
-              hint="SendGrid alternative — requires a verified sender address (set EMAIL_FROM above)."
+              hint="Use SendGrid for transactional email. SendGrid requires a verified from address."
               docsUrl="https://app.sendgrid.com/settings/api_keys"
               docsLabel="Get a SendGrid key"
             >
               {sendgridConfigured ? (
-                <div className="flex items-center gap-1.5 text-[10px] text-green-500">
+                <div className="mb-1 flex items-center gap-1.5 text-[10px] text-green-500">
                   <IconCheck size={10} />
                   SENDGRID_API_KEY configured
                 </div>
               ) : (
-                <div className="flex gap-1.5">
+                <div className="mb-1 flex gap-1.5">
                   <input
                     type="password"
                     value={sendgridKey}
@@ -1151,6 +1167,40 @@ function EmailSectionInner({
                       "Save"
                     )}
                   </button>
+                </div>
+              )}
+              {fromConfigured ? (
+                <div className="flex items-center gap-1.5 text-[10px] text-green-500">
+                  <IconCheck size={10} />
+                  EMAIL_FROM configured
+                </div>
+              ) : (
+                <div className="flex gap-1.5">
+                  <input
+                    type="text"
+                    value={fromAddr}
+                    onChange={(e) => setFromAddr(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") saveSendgrid();
+                    }}
+                    placeholder="From address - e.g. Acme <hi@acme.com>"
+                    className="flex-1 rounded border border-border bg-background px-2 py-1 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                  />
+                  {!sendgridConfigured ? null : (
+                    <button
+                      onClick={saveSendgrid}
+                      disabled={!fromAddr.trim() || saving}
+                      className="rounded bg-accent px-2 py-1 text-[10px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40"
+                    >
+                      {saving ? (
+                        <IconLoader2 size={10} className="animate-spin" />
+                      ) : saved ? (
+                        <IconCheck size={10} />
+                      ) : (
+                        "Save"
+                      )}
+                    </button>
+                  )}
                 </div>
               )}
             </ManualSetupCard>

--- a/packages/core/src/client/transcription/BuilderTranscriptionCta.tsx
+++ b/packages/core/src/client/transcription/BuilderTranscriptionCta.tsx
@@ -7,12 +7,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  IconBolt,
-  IconCheck,
-  IconExternalLink,
-  IconLoader2,
-} from "@tabler/icons-react";
+import { IconBolt, IconExternalLink, IconLoader2 } from "@tabler/icons-react";
 import { agentNativePath } from "../api-path.js";
 import { getCallbackOrigin } from "../frame.js";
 
@@ -99,7 +94,7 @@ export function BuilderTranscriptionCta() {
         <span className="text-destructive text-[10px]">{error}</span>
       ) : connecting ? (
         <IconLoader2 size={12} className="shrink-0 animate-spin" />
-      ) : configured === false ? (
+      ) : (
         <button
           type="button"
           onClick={handleConnect}
@@ -108,11 +103,6 @@ export function BuilderTranscriptionCta() {
           Connect
           <IconExternalLink size={10} />
         </button>
-      ) : (
-        <span className="ml-auto flex items-center gap-1 text-[10px] text-green-600">
-          <IconCheck size={10} />
-          Connected
-        </span>
       )}
     </div>
   );

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import { pathToFileURL } from "url";
 import { afterEach, describe, expect, it } from "vitest";
-import { generateWorkerEntry } from "./build.js";
+import { generateWorkerEntry, getNodeBuiltinNames } from "./build.js";
 
 const tempDirs: string[] = [];
 
@@ -233,5 +233,11 @@ export default {
       ok: true,
       echo: { hello: "again" },
     });
+  });
+});
+
+describe("Cloudflare deploy builtins", () => {
+  it("externalizes node:sqlite references from optional runtime probes", () => {
+    expect(getNodeBuiltinNames()).toContain("sqlite");
   });
 });

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -757,6 +757,7 @@ const NODE_BUILTINS = [
   "querystring",
   "readline",
   "repl",
+  "sqlite",
   "stream",
   "stream/web",
   "string_decoder",
@@ -774,7 +775,7 @@ const NODE_BUILTINS = [
   "zlib",
 ];
 
-function getNodeBuiltinNames(): string[] {
+export function getNodeBuiltinNames(): string[] {
   return NODE_BUILTINS;
 }
 
@@ -1213,6 +1214,7 @@ export default bundle;
             "child_process",
             "module",
             "process",
+            "sqlite",
             "worker_threads",
             "querystring",
             "zlib",
@@ -1401,6 +1403,7 @@ export default bundle;
           "child_process",
           "module",
           "process",
+          "sqlite",
           "worker_threads",
           "string_decoder",
           "diagnostics_channel",

--- a/packages/core/src/onboarding/default-steps.ts
+++ b/packages/core/src/onboarding/default-steps.ts
@@ -27,27 +27,44 @@ const LLM_KEY_METHODS: LlmKeyMethod[] = [
   {
     provider: "anthropic",
     id: "anthropic-key",
-    label: "Use your Anthropic API key",
-    description: "Paste a key — stored locally in your .env file.",
+    label: "Anthropic",
+    description: "Claude models with your own Anthropic key.",
   },
   {
     provider: "openai",
     id: "openai-key",
-    label: "Use your OpenAI API key",
-    description: "GPT models via the ai-sdk:openai engine.",
+    label: "OpenAI",
+    description: "GPT models with your own OpenAI key.",
   },
   {
     provider: "google",
     id: "google-key",
-    label: "Use your Google Gemini API key",
-    description: "Gemini models via the ai-sdk:google engine.",
+    label: "Google Gemini",
+    description: "Gemini models with your own Google AI key.",
   },
   {
     provider: "openrouter",
     id: "openrouter-key",
-    label: "Use your OpenRouter API key",
-    description:
-      "One key, 300+ models via openrouter.ai — the ai-sdk:openrouter engine.",
+    label: "OpenRouter",
+    description: "OpenRouter models with your own OpenRouter key.",
+  },
+  {
+    provider: "groq",
+    id: "groq-key",
+    label: "Groq",
+    description: "Groq-hosted models with your own Groq key.",
+  },
+  {
+    provider: "mistral",
+    id: "mistral-key",
+    label: "Mistral",
+    description: "Mistral models with your own Mistral key.",
+  },
+  {
+    provider: "cohere",
+    id: "cohere-key",
+    label: "Cohere",
+    description: "Cohere models with your own Cohere key.",
   },
 ];
 
@@ -56,8 +73,19 @@ const llmStep: OnboardingStep = {
   order: 10,
   required: true,
   title: "Connect an AI engine",
-  description: "Agent-native needs an LLM to power the agent chat.",
+  description: "Use Builder's managed gateway, or bring your own provider key.",
   methods: [
+    {
+      id: "builder",
+      kind: "builder-cli-auth",
+      label: "Connect Builder",
+      description:
+        "One click, no API key needed. Builder routes Claude, GPT, Gemini, and more.",
+      primary: true,
+      payload: {
+        scope: "llm",
+      },
+    },
     ...LLM_KEY_METHODS.map(({ provider, id, label, description, primary }) => {
       const meta = PROVIDER_ENV_META[provider];
       return {
@@ -79,17 +107,6 @@ const llmStep: OnboardingStep = {
         },
       };
     }),
-    {
-      id: "builder",
-      kind: "builder-cli-auth",
-      label: "Connect Builder",
-      description:
-        "One click, no API key needed. Claude, GPT, Gemini, and more via Builder's managed gateway.",
-      primary: true,
-      payload: {
-        scope: "llm",
-      },
-    },
   ],
   isComplete: async () => {
     try {
@@ -108,64 +125,56 @@ const llmStep: OnboardingStep = {
   },
 };
 
-/** Step 2 — where application data lives. SQLite default means non-blocking. */
+/** Step 2 — where application data lives. The default DB is non-blocking. */
 const databaseStep: OnboardingStep = {
   id: "database",
   order: 20,
   required: false,
   title: "Database",
-  description: "Where your app data lives.",
+  description:
+    "Agent-native stores app data in SQL. Set DATABASE_URL when you want to point this app at a specific database.",
   methods: [
     {
-      id: "sqlite-default",
-      kind: "link",
-      label: "Use SQLite (default)",
-      description: "Zero setup, local dev only.",
-      primary: true,
-      payload: { url: "#" },
-    },
-    {
-      id: "postgres-url",
+      id: "database-url",
       kind: "form",
-      label: "Use Postgres / Neon",
-      description: "Paste a DATABASE_URL for any SQL-compatible provider.",
+      label: "Set DATABASE_URL",
+      description: "Paste the SQL connection string this app should use.",
       payload: {
         writeScope: "workspace",
         fields: [
           {
             key: "DATABASE_URL",
             label: "DATABASE_URL",
-            placeholder: "postgres://user:pass@host/db",
+            placeholder: "postgres://..., libsql://..., file:./data/app.db",
+          },
+          {
+            key: "DATABASE_AUTH_TOKEN",
+            label: "DATABASE_AUTH_TOKEN (if needed)",
+            placeholder: "Token for providers such as Turso/libSQL",
+            secret: true,
           },
         ],
       },
     },
   ],
-  // SQLite default means this step is always satisfied — never blocks setup.
+  // The default local database means this step is always satisfied.
   isComplete: () => true,
 };
 
-/** Step 3 — how users sign in. Dev-mode keeps solo local workflows easy. */
+/** Step 3 — how users sign in. Built-in account auth is non-blocking. */
 const authStep: OnboardingStep = {
   id: "auth",
   order: 30,
   required: false,
   title: "Authentication",
-  description: "How users sign in. Dev mode is fine for local work.",
+  description:
+    "Built-in email/password accounts work by default. Add OAuth or access tokens only if you want another sign-in path.",
   methods: [
     {
-      id: "local-dev",
-      kind: "link",
-      label: "Use local mode (dev)",
-      description: "Solo dev with no login step.",
-      primary: true,
-      payload: { url: "#" },
-    },
-    {
-      id: "better-auth-google",
+      id: "google-oauth",
       kind: "form",
-      label: "Sign in with Google",
-      description: "Paste Google OAuth credentials (client ID + secret).",
+      label: "Google OAuth",
+      description: "Add Google as an optional sign-in provider.",
       payload: {
         writeScope: "workspace",
         fields: [
@@ -178,12 +187,42 @@ const authStep: OnboardingStep = {
         ],
       },
     },
+    {
+      id: "github-oauth",
+      kind: "form",
+      label: "GitHub OAuth",
+      description: "Add GitHub as an optional sign-in provider.",
+      payload: {
+        writeScope: "workspace",
+        fields: [
+          { key: "GITHUB_CLIENT_ID", label: "GITHUB_CLIENT_ID" },
+          {
+            key: "GITHUB_CLIENT_SECRET",
+            label: "GITHUB_CLIENT_SECRET",
+            secret: true,
+          },
+        ],
+      },
+    },
+    {
+      id: "access-token",
+      kind: "form",
+      label: "Shared access token",
+      description: "Use a simple token gate for private deployments.",
+      payload: {
+        writeScope: "workspace",
+        fields: [
+          {
+            key: "ACCESS_TOKEN",
+            label: "ACCESS_TOKEN",
+            placeholder: "Paste a strong shared token",
+            secret: true,
+          },
+        ],
+      },
+    },
   ],
-  isComplete: () => {
-    if (process.env.AUTH_MODE === "local") return true;
-    if (process.env.ACCESS_TOKEN || process.env.ACCESS_TOKENS) return true;
-    return !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
-  },
+  isComplete: () => true,
 };
 
 /** Step 4 — transactional email (password resets, invitations). Optional. */
@@ -193,15 +232,13 @@ const emailStep: OnboardingStep = {
   required: false,
   title: "Email delivery",
   description:
-    "Needed to send password reset links and future invitation emails. Without a provider, reset emails are logged to the server console.",
+    "Optional provider for password resets and invitations. Without one, local/dev emails are logged to the server console.",
   methods: [
     {
       id: "resend",
       kind: "form",
-      label: "Use Resend",
-      description: "Paste an API key from resend.com.",
-      primary: true,
-      badge: "recommended",
+      label: "Resend",
+      description: "Use Resend for transactional email.",
       payload: {
         writeScope: "workspace",
         fields: [
@@ -227,8 +264,8 @@ const emailStep: OnboardingStep = {
     {
       id: "sendgrid",
       kind: "form",
-      label: "Use SendGrid",
-      description: "Paste an API key from sendgrid.com.",
+      label: "SendGrid",
+      description: "Use SendGrid for transactional email.",
       payload: {
         writeScope: "workspace",
         fields: [

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -4,6 +4,7 @@ import {
   setResponseStatus,
   setResponseHeader,
   getMethod,
+  getHeader,
 } from "h3";
 import type { H3Event } from "h3";
 import path from "node:path";
@@ -514,20 +515,58 @@ export function createCoreRoutesPlugin(
     // callback minutes later.
     const BUILDER_CONNECT_PENDING_TTL_MS = 10 * 60 * 1000; // 10 min
 
+    // Decide whether a /builder/connect navigation originated from this
+    // app's own UI (allowed) or from a foreign origin (cross-site CSRF
+    // attempt — rejected). Sec-Fetch-Site is the modern signal:
+    //   - "same-origin": user clicked Connect from our own pages — allow
+    //   - "none": typed in URL bar / bookmark / browser extension — allow
+    //   - "same-site" / "cross-site" / missing-but-with-foreign-Origin
+    //     all map to reject.
+    // For older browsers without Sec-Fetch-* we fall back to Origin and
+    // then Referer, comparing against the request's resolved origin.
+    function isSameOriginConnect(event: H3Event): boolean {
+      const fetchSite = getHeader(event, "sec-fetch-site");
+      if (fetchSite === "same-origin" || fetchSite === "none") return true;
+      if (fetchSite) return false; // browser told us it's cross-site/same-site
+      const expected = getOrigin(event).replace(/\/+$/, "");
+      const origin = getHeader(event, "origin");
+      if (origin) return origin.replace(/\/+$/, "") === expected;
+      const referer = getHeader(event, "referer");
+      if (referer) {
+        try {
+          return new URL(referer).origin === expected;
+        } catch {
+          return false;
+        }
+      }
+      // No Sec-Fetch-Site, no Origin, no Referer — pre-2020 browser
+      // making a top-level navigation. Allow; cookies are still
+      // session-bound so the worst case degrades to the prior behavior.
+      return true;
+    }
+
     // Lightweight 302 to the Builder CLI-auth URL. Lets clients do
     // `window.open('/_agent-native/builder/connect', '_blank')` synchronously
     // inside a click handler, avoiding the popup-blocker downgrade that
     // happens when an await sits before window.open.
     //
-    // We record a server-side pending-connect token in the settings table
-    // (keyed by session email) rather than embedding a signed CSRF state in
-    // the redirect_url query string. The URL-embedded approach broke because
-    // Builder's /cli-auth page strips existing query params from redirect_url
-    // when it appends p-key/api-key/etc., so _an_state was always null when
-    // the callback fired. The server-side row is keyed by the session that
-    // started the flow, so it still provides equivalent CSRF protection
-    // (the callback requires a valid session cookie) without depending on
-    // Builder preserving arbitrary URL query params.
+    // CSRF protection here is two-layer because session cookies are
+    // SameSite=None;Secure (so the editor iframe can ride along) — that
+    // means a session cookie alone does NOT prevent cross-origin
+    // window.open from initiating a connect flow on the victim's behalf:
+    //   1. Sec-Fetch-Site header — modern browsers stamp every request
+    //      with the navigation context. We only allow `same-origin` or
+    //      `none` (typed/bookmark/extension); cross-site / same-site are
+    //      rejected. The previous "URL-embedded signed state" was dropped
+    //      because Builder's /cli-auth strips arbitrary query params; this
+    //      replaces that defense with a browser-native one.
+    //   2. Pending row keyed by session email + bound nonce — the callback
+    //      requires both a valid session and a one-time row that this
+    //      handler wrote during the same flow. Without the same-origin
+    //      check above, an attacker could prime the row from cross-site
+    //      and then trick the victim into hitting a callback URL with
+    //      attacker-controlled p-key/api-key, hijacking the victim's
+    //      account. With the check, the attacker can't prime the row.
     getH3App(nitroApp).use(
       `${P}/builder/connect`,
       defineEventHandler(async (event) => {
@@ -536,23 +575,50 @@ export function createCoreRoutesPlugin(
           setResponseStatus(event, 401);
           return { error: "Authentication required" };
         }
+
+        // Same-origin gate. Sec-Fetch-Site is the primary signal; fall
+        // back to Origin/Referer for older browsers. Reject any context
+        // that isn't this exact app's origin — including same-site
+        // subdomains, since a compromised subdomain shouldn't be able
+        // to mint Builder credential writes for users of the main app.
+        if (!isSameOriginConnect(event)) {
+          setResponseStatus(event, 403);
+          return { error: "Cross-origin connect requests are not allowed" };
+        }
+
+        // Clear any prior failure row from a previous attempt — otherwise
+        // useBuilderStatus polling sees the stale error and aborts the
+        // new attempt before it can complete.
+        try {
+          await deleteSetting(`builder-connect-error:${session.email}`);
+        } catch {
+          // No prior error row — fine
+        }
+
         // Store a short-lived pending row. If the DB is unavailable we
-        // return a clear error rather than silently issuing a callback
-        // that can never be verified.
+        // surface a popup-renderable error page that signals the parent
+        // via BroadcastChannel, rather than letting the popup show raw
+        // JSON and the parent poll for 5 minutes.
         try {
           await putSetting(`builder-pending-connect:${session.email}`, {
             expiresAt: Date.now() + BUILDER_CONNECT_PENDING_TTL_MS,
           });
         } catch (err) {
+          const msg =
+            "Could not initiate Builder connect — storage unavailable. Try again.";
           console.error(
             "[builder] Could not store pending-connect state:",
             (err as Error)?.message ?? err,
           );
+          // Best-effort: also write the error row so the parent's
+          // /builder/status poll picks it up if BroadcastChannel doesn't.
+          await putSetting(`builder-connect-error:${session.email}`, {
+            message: msg,
+            at: Date.now(),
+          }).catch(() => {});
           setResponseStatus(event, 503);
-          return {
-            error:
-              "Could not initiate Builder connect — storage unavailable. Try again.",
-          };
+          setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
+          return createBuilderBrowserCallbackErrorPage(msg);
         }
         // Build the cli-auth URL without embedding state in redirect_url:
         // Builder's /cli-auth appends params directly to redirect_url and
@@ -646,9 +712,12 @@ export function createCoreRoutesPlugin(
           return { error: "Method not allowed" };
         }
 
-        // Session blocks anonymous callers; the signed state below blocks
-        // CSRF (session cookies are SameSite=None;Secure for the iframe
-        // editor, so they ride along on attacker-crafted top-level links).
+        // Session blocks anonymous callers; the pending-row check below
+        // (combined with the same-origin gate on /builder/connect) blocks
+        // CSRF. Session cookies are SameSite=None;Secure for the iframe
+        // editor, so they ride along on attacker-crafted top-level links —
+        // the SameSite=None concession is exactly why the connect flow
+        // can't rely on session-cookie identity alone.
         const session = await getSession(event).catch(() => null);
         if (!session?.email) {
           setResponseStatus(event, 401);
@@ -664,7 +733,15 @@ export function createCoreRoutesPlugin(
         // /builder/connect route stored. This replaces the old URL-embedded
         // signed CSRF state (_an_state) which Builder's /cli-auth page was
         // stripping from the redirect_url query string.
+        //
+        // The delete must succeed before we proceed — otherwise a DB blip
+        // leaves the row in place and the same callback URL can be
+        // replayed against the same session for up to 10 minutes (the
+        // TTL window). Treat a delete failure as a hard failure: the
+        // user retries, the next /builder/connect call rewrites the
+        // pending row.
         let pendingValid = false;
+        let pendingError: string | null = null;
         try {
           const pending = (await getSetting(
             `builder-pending-connect:${session.email}`,
@@ -672,17 +749,34 @@ export function createCoreRoutesPlugin(
           if (
             pending &&
             typeof pending.expiresAt === "number" &&
-            Date.now() <= pending.expiresAt
+            Date.now() < pending.expiresAt
           ) {
-            pendingValid = true;
-            // One-time use — delete immediately so the same callback URL
-            // can't be replayed even within the TTL window.
-            await deleteSetting(
-              `builder-pending-connect:${session.email}`,
-            ).catch(() => {});
+            try {
+              await deleteSetting(`builder-pending-connect:${session.email}`);
+              pendingValid = true;
+            } catch (err) {
+              pendingError =
+                "Could not consume pending-connect token (storage error). Please retry.";
+              console.error(
+                "[builder] deleteSetting failed for pending-connect — refusing to proceed (replay risk):",
+                (err as Error)?.message ?? err,
+              );
+            }
           }
         } catch {
           // DB temporarily unavailable — treat as missing.
+        }
+
+        if (pendingError) {
+          // Best-effort signal to the parent's poll loop, then render the
+          // popup-friendly error page so the BroadcastChannel notify fires.
+          await putSetting(`builder-connect-error:${session.email}`, {
+            message: pendingError,
+            at: Date.now(),
+          }).catch(() => {});
+          setResponseStatus(event, 503);
+          setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
+          return createBuilderBrowserCallbackErrorPage(pendingError);
         }
 
         if (!pendingValid) {
@@ -707,8 +801,19 @@ export function createCoreRoutesPlugin(
         const publicKey = requestUrl.searchParams.get("api-key");
 
         if (!privateKey || !publicKey) {
+          // Render the popup-friendly error page (and write a status row)
+          // instead of bare JSON, so the parent tab's poll loop terminates
+          // immediately via BroadcastChannel rather than hanging until the
+          // 5-minute timeout.
+          const msg =
+            "Builder didn't return credentials. Restart the connect flow from settings.";
+          await putSetting(`builder-connect-error:${session.email}`, {
+            message: msg,
+            at: Date.now(),
+          }).catch(() => {});
           setResponseStatus(event, 400);
-          return { error: "Missing Builder credentials in callback" };
+          setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
+          return createBuilderBrowserCallbackErrorPage(msg);
         }
 
         const userId = requestUrl.searchParams.get("user-id");

--- a/packages/core/src/server/security-headers.ts
+++ b/packages/core/src/server/security-headers.ts
@@ -22,6 +22,9 @@
  *     embedded in the same-origin app shell can opt out by setting its own
  *     header inside the route handler — h3's `setResponseHeader` overwrites,
  *     so a route emitting `SAMEORIGIN` wins over our middleware default.
+ *     We skip this header entirely in dev (NODE_ENV !== "production") so the
+ *     desktop app's local dev frame (localhost:3334) can iframe templates
+ *     running on other localhost ports (e.g. mail at 8085).
  *   - `Referrer-Policy: strict-origin-when-cross-origin` — strips path/query
  *     from outbound Referer headers when the request crosses origin, so a
  *     public-share viewer's outbound link clicks never leak the share token.
@@ -76,9 +79,12 @@ function isHttpsRequest(event: any): boolean {
  * `setResponseHeader` after this runs — the latest write wins.
  */
 export function createSecurityHeadersMiddleware() {
+  const isProduction = process.env.NODE_ENV === "production";
   return defineEventHandler((event) => {
     setResponseHeader(event, "X-Content-Type-Options", "nosniff");
-    setResponseHeader(event, "X-Frame-Options", "DENY");
+    if (isProduction) {
+      setResponseHeader(event, "X-Frame-Options", "DENY");
+    }
     setResponseHeader(
       event,
       "Referrer-Policy",

--- a/packages/core/src/tracking/providers.spec.ts
+++ b/packages/core/src/tracking/providers.spec.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function freshTrackingModules() {
+  vi.resetModules();
+  const registry = await import("./registry.js");
+  registry.unregisterTrackingProvider("agent-native-analytics");
+  registry.unregisterTrackingProvider("posthog");
+  registry.unregisterTrackingProvider("mixpanel");
+  registry.unregisterTrackingProvider("amplitude");
+  registry.unregisterTrackingProvider("webhook");
+  const providers = await import("./providers.js");
+  return { ...registry, ...providers };
+}
+
+describe("tracking providers", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not register Agent Native Analytics without a public key", async () => {
+    vi.stubEnv("AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "");
+    const { listTrackingProviders, registerBuiltinProviders } =
+      await freshTrackingModules();
+
+    registerBuiltinProviders();
+
+    expect(listTrackingProviders()).not.toContain("agent-native-analytics");
+  });
+
+  it("sends track events to Agent Native Analytics when configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}"));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
+    vi.stubEnv(
+      "AGENT_NATIVE_ANALYTICS_ENDPOINT",
+      "https://analytics.example.test/track",
+    );
+    const { flushTracking, registerBuiltinProviders, track } =
+      await freshTrackingModules();
+
+    registerBuiltinProviders();
+    track("qa.event", { app: "qa", signed_in: true }, { userId: "u1" });
+    await flushTracking();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://analytics.example.test/track");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toMatchObject({
+      publicKey: "anpk_test",
+      event: "qa.event",
+      properties: { app: "qa", signed_in: true },
+      userId: "u1",
+    });
+  });
+});

--- a/packages/core/src/tracking/providers.spec.ts
+++ b/packages/core/src/tracking/providers.spec.ts
@@ -55,4 +55,27 @@ describe("tracking providers", () => {
       userId: "u1",
     });
   });
+
+  it("does not register Agent Native Analytics for localhost app URLs", async () => {
+    vi.stubEnv("AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
+    vi.stubEnv("APP_URL", "http://localhost:3000");
+    const { listTrackingProviders, registerBuiltinProviders } =
+      await freshTrackingModules();
+
+    registerBuiltinProviders();
+
+    expect(listTrackingProviders()).not.toContain("agent-native-analytics");
+  });
+
+  it("allows an explicit localhost override for Agent Native Analytics", async () => {
+    vi.stubEnv("AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
+    vi.stubEnv("APP_URL", "http://localhost:3000");
+    vi.stubEnv("AGENT_NATIVE_ANALYTICS_ALLOW_LOCALHOST", "true");
+    const { listTrackingProviders, registerBuiltinProviders } =
+      await freshTrackingModules();
+
+    registerBuiltinProviders();
+
+    expect(listTrackingProviders()).toContain("agent-native-analytics");
+  });
 });

--- a/packages/core/src/tracking/providers.ts
+++ b/packages/core/src/tracking/providers.ts
@@ -7,6 +7,7 @@
  * POSTHOG_API_KEY + POSTHOG_HOST  → PostHog
  * MIXPANEL_TOKEN                  → Mixpanel
  * AMPLITUDE_API_KEY               → Amplitude
+ * AGENT_NATIVE_ANALYTICS_PUBLIC_KEY → Agent Native Analytics
  *
  * Call `registerBuiltinProviders()` at server startup (done
  * automatically by the core-routes plugin).
@@ -16,6 +17,8 @@ import { registerTrackingProvider } from "./registry.js";
 import type { TrackingProvider, TrackingEvent } from "./types.js";
 
 const POSTHOG_DEFAULT_HOST = "https://us.i.posthog.com";
+const AGENT_NATIVE_ANALYTICS_DEFAULT_ENDPOINT =
+  "https://analytics.agent-native.com/track";
 const BATCH_INTERVAL_MS = 10_000;
 const MAX_BATCH_SIZE = 50;
 
@@ -235,6 +238,45 @@ function createWebhookProvider(
   };
 }
 
+// ─── Agent Native Analytics ───────────────────────────────────────────────
+
+function createAgentNativeAnalyticsProvider(
+  publicKey: string,
+  endpoint: string,
+): TrackingProvider {
+  return {
+    name: "agent-native-analytics",
+    track(event: TrackingEvent) {
+      enqueue(
+        endpoint,
+        JSON.stringify({
+          publicKey,
+          event: event.name,
+          properties: event.properties ?? {},
+          userId: event.userId,
+          timestamp: event.timestamp,
+        }),
+      );
+    },
+    identify(userId, traits) {
+      enqueue(
+        endpoint,
+        JSON.stringify({
+          publicKey,
+          event: "$identify",
+          userId,
+          properties: traits ?? {},
+          timestamp: new Date().toISOString(),
+        }),
+      );
+    },
+    flush: () => {
+      drainQueue();
+      return Promise.resolve();
+    },
+  };
+}
+
 // ─── Auto-registration ────────────────────────────────────────────────────
 
 let _registered = false;
@@ -260,6 +302,19 @@ export function registerBuiltinProviders(): void {
   const amplitudeKey = process.env.AMPLITUDE_API_KEY;
   if (amplitudeKey) {
     registerTrackingProvider(createAmplitudeProvider(amplitudeKey));
+  }
+
+  const agentNativeAnalyticsKey = process.env.AGENT_NATIVE_ANALYTICS_PUBLIC_KEY;
+  if (agentNativeAnalyticsKey) {
+    registerTrackingProvider(
+      createAgentNativeAnalyticsProvider(
+        agentNativeAnalyticsKey,
+        (
+          process.env.AGENT_NATIVE_ANALYTICS_ENDPOINT ||
+          AGENT_NATIVE_ANALYTICS_DEFAULT_ENDPOINT
+        ).replace(/\/+$/, ""),
+      ),
+    );
   }
 
   const webhookUrl = process.env.TRACKING_WEBHOOK_URL;

--- a/packages/core/src/tracking/providers.ts
+++ b/packages/core/src/tracking/providers.ts
@@ -86,6 +86,43 @@ function drainQueue(): void {
   }
 }
 
+function isLocalhostUrl(value: string | undefined): boolean {
+  if (!value || !value.trim()) return false;
+  const raw = value.trim();
+  const withProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw)
+    ? raw
+    : `https://${raw}`;
+  try {
+    const { hostname } = new URL(withProtocol);
+    const h = hostname.toLowerCase();
+    return (
+      h === "localhost" ||
+      h === "127.0.0.1" ||
+      h === "::1" ||
+      h === "[::1]" ||
+      h.endsWith(".localhost") ||
+      h.endsWith(".local")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function shouldSkipAgentNativeAnalyticsForLocalhost(): boolean {
+  if (process.env.AGENT_NATIVE_ANALYTICS_ALLOW_LOCALHOST === "true") {
+    return false;
+  }
+  if (process.env.NODE_ENV === "development") return true;
+  return [
+    process.env.APP_URL,
+    process.env.BETTER_AUTH_URL,
+    process.env.URL,
+    process.env.DEPLOY_URL,
+    process.env.VERCEL_PROJECT_PRODUCTION_URL,
+    process.env.VERCEL_URL,
+  ].some(isLocalhostUrl);
+}
+
 // ─── PostHog ───────────────────────────────────────────────────────────────
 
 function createPostHogProvider(apiKey: string, host: string): TrackingProvider {
@@ -305,7 +342,10 @@ export function registerBuiltinProviders(): void {
   }
 
   const agentNativeAnalyticsKey = process.env.AGENT_NATIVE_ANALYTICS_PUBLIC_KEY;
-  if (agentNativeAnalyticsKey) {
+  if (
+    agentNativeAnalyticsKey &&
+    !shouldSkipAgentNativeAnalyticsForLocalhost()
+  ) {
     registerTrackingProvider(
       createAgentNativeAnalyticsProvider(
         agentNativeAnalyticsKey,

--- a/templates/analytics/.agents/skills/data-querying/SKILL.md
+++ b/templates/analytics/.agents/skills/data-querying/SKILL.md
@@ -16,6 +16,8 @@ The analytics app connects to multiple data sources. This skill covers general p
 3. **Write ad-hoc scripts** — if no existing script covers the question, create one in `actions/`
 4. **Present data in chat** — don't just say "check the dashboard" — actually query, get the data, and present it
 
+For events recorded by the analytics template itself via `analytics.agent-native.com/track`, use `pnpm action query-agent-native-analytics --sql "SELECT ... FROM analytics_events ..."`. Do not use `db-query` for first-party analytics questions; `db-query` is only for internal app tables and will confuse data-source analysis.
+
 ## Built-in Filtering
 
 All scripts that use `output()` support universal flags:
@@ -78,6 +80,7 @@ export default async function main(args: string[]) {
 For complete answers, combine data from multiple sources:
 
 - **BigQuery** for analytics events, signups, pageviews
+- **First-party Analytics** (`query-agent-native-analytics`) for events collected through `/track`
 - **HubSpot** for CRM data — deals, contacts, revenue
 - **Jira** for engineering metrics — tickets, sprints
 - **GitHub** for code metrics — PRs, reviews

--- a/templates/analytics/.agents/skills/data-querying/SKILL.md
+++ b/templates/analytics/.agents/skills/data-querying/SKILL.md
@@ -16,7 +16,7 @@ The analytics app connects to multiple data sources. This skill covers general p
 3. **Write ad-hoc scripts** — if no existing script covers the question, create one in `actions/`
 4. **Present data in chat** — don't just say "check the dashboard" — actually query, get the data, and present it
 
-For events recorded by the analytics template itself via `analytics.agent-native.com/track`, use `pnpm action query-agent-native-analytics --sql "SELECT ... FROM analytics_events ..."`. Do not use `db-query` for first-party analytics questions; `db-query` is only for internal app tables and will confuse data-source analysis.
+For events recorded by the analytics template itself via `analytics.agent-native.com/track`, use `pnpm action query-agent-native-analytics --sql "SELECT ... FROM analytics_events ..."`. Do not use `db-query` for first-party analytics questions; `db-query` is only for internal app tables and will confuse data-source analysis. The shipped `agent-native-templates-first-party` SQL dashboard is the template engagement dashboard for this source.
 
 ## Built-in Filtering
 

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -144,6 +144,15 @@ Dashboard configs, explorer configs, and theme settings are stored in SQL via th
 
 Solo-mode dashboards/configs are user-scoped. Org dashboards/views are org-scoped. Legacy global rows still load as a fallback, and the Team-page upgrade flow can move those legacy rows onto the signed-in user during migration from local mode.
 
+First-party analytics events live in SQL tables managed by this template:
+
+| Table                   | Contents                                                            |
+| ----------------------- | ------------------------------------------------------------------- |
+| `analytics_public_keys` | Public write keys used by hosted apps to send events to `/track`    |
+| `analytics_events`      | Event rows recorded by `/track`, scoped to the key owner's user/org |
+
+Use the `first-party` dashboard source or `query-agent-native-analytics` action for these events. Do **not** use `db-query` for user analytics questions unless the user explicitly asks to inspect the app's internal tables.
+
 ### Sharing
 
 Dashboards and analyses are **private by default**. The framework's sharing primitive is wired up:
@@ -235,7 +244,9 @@ A `<data-dictionary>` block is injected into your system prompt with the approve
 5. Obey `knownGotchas` from any entry you use — note them to the user if the data has limitations.
 6. The dashboard save endpoint now dry-runs every panel's SQL through BigQuery before persisting. If a panel fails validation you'll get a 400 with the BigQuery error text (e.g. `Unrecognized name: is_closed; Did you mean hs_is_closed?`) — fix the SQL and retry; never try to persist broken SQL.
 
-**Panel `source` is a backend, not a table.** The `source` field on every panel must be exactly `"bigquery"`, `"app-db"`, `"ga4"`, or `"amplitude"` — it selects _which backend_ the query runs against. For `bigquery` / `app-db` the `sql` is literal SQL; for `ga4` the `sql` is a JSON descriptor of a GA4 Data API call (e.g. `{"metrics":["activeUsers"],"dimensions":["date"],"days":30}`); for `amplitude` the `sql` is a JSON descriptor of an Amplitude query. Table/dataset references (e.g. `dbt_intermediate.uf_pageviews`) go inside the `sql` string. Writing the table name into `source` produces `Invalid source` errors on every render.
+**Panel `source` is a backend, not a table.** The `source` field on every panel must be exactly `"bigquery"`, `"ga4"`, `"amplitude"`, or `"first-party"` — it selects _which backend_ the query runs against. For `bigquery` the `sql` is literal warehouse SQL; for `ga4` the `sql` is a JSON descriptor of a GA4 Data API call (e.g. `{"metrics":["activeUsers"],"dimensions":["date"],"days":30}`); for `amplitude` the `sql` is a JSON descriptor of an Amplitude query; for `first-party` the `sql` is read-only SQL over `analytics_events` only. Table/dataset references (e.g. `dbt_intermediate.uf_pageviews`) go inside the `sql` string. Writing the table name into `source` produces `Invalid source` errors on every render.
+
+**First-party analytics is a data source, not raw app DB access.** When the user asks about events collected by `analytics.agent-native.com/track`, use `query-agent-native-analytics` or a dashboard panel with `source: "first-party"`. Do not use `db-query`; that tool is for internal app tables and caused past confusion.
 
 **Populating the dictionary:** When the user has existing metric definitions elsewhere (team docs, Confluence, Notion, dbt descriptions, a Google Sheet, a wiki), fetch them with whatever tools you have — generic `WebFetch`, an MCP server the user has configured, a CSV import, or asking the user to paste — then upsert each via `save-data-dictionary-entry`. The dictionary itself is source-agnostic.
 
@@ -252,36 +263,40 @@ A `<data-dictionary>` block is injected into your system prompt with the approve
 
 ### Data Source Scripts
 
-| Action                    | Args / Flags                | Use For                                                                                                                     |
-| ------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `github-prs`              | `--org`, `--query`          | PR & issue search                                                                                                           |
-| `hubspot-deals`           |                             | CRM deals, pipelines                                                                                                        |
-| `hubspot-metrics`         |                             | CRM metrics summary                                                                                                         |
-| `hubspot-pipelines`       |                             | Pipeline stages                                                                                                             |
-| `jira-search`             | `--jql`, `--fields`         | Ticket search                                                                                                               |
-| `jira-analytics`          |                             | Sprint tracking, velocity                                                                                                   |
-| `pylon-issues`            | `--account`, `--state`      | Support tickets                                                                                                             |
-| `gong-calls`              | `--company`, `--days`       | Sales call recordings                                                                                                       |
-| `apollo-search`           | `--query`                   | Contact/company enrichment                                                                                                  |
-| `seo-top-keywords`        | `--limit`                   | Keyword rankings                                                                                                            |
-| `seo-page-keywords`       | `--url`                     | Keywords for a specific page                                                                                                |
-| `seo-blog-pages`          |                             | Blog page SEO metrics                                                                                                       |
-| `ga4-report`              | `--metrics`, `--dimensions` | Google Analytics reports                                                                                                    |
-| `bigquery`                | `--sql`                     | Ad-hoc BigQuery queries (**also available as a native callable agent tool** — call it directly; don't use HTTP workarounds) |
-| `mixpanel-events`         |                             | Mixpanel event data                                                                                                         |
-| `posthog-events`          |                             | PostHog event data                                                                                                          |
-| `amplitude-events`        |                             | Amplitude event data                                                                                                        |
-| `commonroom-members`      | `--query`, `--email`        | Community member lookup                                                                                                     |
-| `twitter-tweets`          |                             | Tweet engagement                                                                                                            |
-| `generate-chart`          | `--type`, `--data`          | Generate inline charts for chat                                                                                             |
-| `top-amplitude-events`    | `[--days N]`                | Top 20 Amplitude events by count from BigQuery (default 90 days)                                                            |
-| `bigquery-table-info`     |                             | Return embedded BigQuery table schema reference (no network call)                                                           |
-| `content-calendar`        |                             | Get all entries from the Notion content calendar                                                                            |
-| `content-calendar-schema` |                             | Return content calendar field schema                                                                                        |
-| `check-form-schema`       |                             | Show the inbound forms table schema in the app database                                                                     |
-| `query-inbound-forms`     | `[--limit N]`               | Query inbound form submissions from the app database                                                                        |
-| `check-contact-signup`    |                             | Check contacts with signup timestamps from BigQuery dim_hs_contacts                                                         |
-| `onboarding-events`       | `[--days N]`                | Onboarding funnel events from BigQuery                                                                                      |
+| Action                         | Args / Flags                | Use For                                                                                                                     |
+| ------------------------------ | --------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `github-prs`                   | `--org`, `--query`          | PR & issue search                                                                                                           |
+| `hubspot-deals`                |                             | CRM deals, pipelines                                                                                                        |
+| `hubspot-metrics`              |                             | CRM metrics summary                                                                                                         |
+| `hubspot-pipelines`            |                             | Pipeline stages                                                                                                             |
+| `jira-search`                  | `--jql`, `--fields`         | Ticket search                                                                                                               |
+| `jira-analytics`               |                             | Sprint tracking, velocity                                                                                                   |
+| `pylon-issues`                 | `--account`, `--state`      | Support tickets                                                                                                             |
+| `gong-calls`                   | `--company`, `--days`       | Sales call recordings                                                                                                       |
+| `apollo-search`                | `--query`                   | Contact/company enrichment                                                                                                  |
+| `seo-top-keywords`             | `--limit`                   | Keyword rankings                                                                                                            |
+| `seo-page-keywords`            | `--url`                     | Keywords for a specific page                                                                                                |
+| `seo-blog-pages`               |                             | Blog page SEO metrics                                                                                                       |
+| `ga4-report`                   | `--metrics`, `--dimensions` | Google Analytics reports                                                                                                    |
+| `bigquery`                     | `--sql`                     | Ad-hoc BigQuery queries (**also available as a native callable agent tool** — call it directly; don't use HTTP workarounds) |
+| `query-agent-native-analytics` | `--sql`                     | Query first-party `analytics_events` recorded via `/track` (use instead of `db-query` for this datasource)                  |
+| `create-analytics-public-key`  | `[--name <label>]`          | Generate a public write key for hosted apps to send events to `analytics.agent-native.com/track`                            |
+| `list-analytics-public-keys`   |                             | List active/revoked first-party analytics write keys                                                                        |
+| `revoke-analytics-public-key`  | `--id <keyId>`              | Revoke a first-party analytics write key                                                                                    |
+| `mixpanel-events`              |                             | Mixpanel event data                                                                                                         |
+| `posthog-events`               |                             | PostHog event data                                                                                                          |
+| `amplitude-events`             |                             | Amplitude event data                                                                                                        |
+| `commonroom-members`           | `--query`, `--email`        | Community member lookup                                                                                                     |
+| `twitter-tweets`               |                             | Tweet engagement                                                                                                            |
+| `generate-chart`               | `--type`, `--data`          | Generate inline charts for chat                                                                                             |
+| `top-amplitude-events`         | `[--days N]`                | Top 20 Amplitude events by count from BigQuery (default 90 days)                                                            |
+| `bigquery-table-info`          |                             | Return embedded BigQuery table schema reference (no network call)                                                           |
+| `content-calendar`             |                             | Get all entries from the Notion content calendar                                                                            |
+| `content-calendar-schema`      |                             | Return content calendar field schema                                                                                        |
+| `check-form-schema`            |                             | Show the inbound forms table schema in the app database                                                                     |
+| `query-inbound-forms`          | `[--limit N]`               | Query inbound form submissions from the app database                                                                        |
+| `check-contact-signup`         |                             | Check contacts with signup timestamps from BigQuery dim_hs_contacts                                                         |
+| `onboarding-events`            | `[--days N]`                | Onboarding funnel events from BigQuery                                                                                      |
 
 ### Action-Specific Filtering
 
@@ -330,7 +345,7 @@ Two ways to show charts inline in chat:
    ```
    ````
 
-   The `SqlPanel` shape is the same one used by `update-dashboard` (see `app/pages/adhoc/sql-dashboard/types.ts`). Required fields: `id`, `title`, `sql`, `source` (`"bigquery" | "app-db" | "ga4" | "amplitude"`), `chartType` (`"line" | "area" | "bar" | "metric" | "table" | "pie"`), `width` (`1` or `2`). Optional `config` for axis keys, formatting, pivots.
+   The `SqlPanel` shape is the same one used by `update-dashboard` (see `app/pages/adhoc/sql-dashboard/types.ts`). Required fields: `id`, `title`, `sql`, `source` (`"bigquery" | "ga4" | "amplitude" | "first-party"`), `chartType` (`"line" | "area" | "bar" | "metric" | "table" | "pie"`), `width` (`1` or `2`). Optional `config` for axis keys, formatting, pivots.
 
    Keep the JSON compact — URLs are capped around 4KB. If the SQL is long, consider persisting it as a saved dashboard panel instead and linking to that dashboard.
 

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -146,10 +146,10 @@ Solo-mode dashboards/configs are user-scoped. Org dashboards/views are org-scope
 
 First-party analytics events live in SQL tables managed by this template:
 
-| Table                   | Contents                                                            |
-| ----------------------- | ------------------------------------------------------------------- |
-| `analytics_public_keys` | Public write keys used by hosted apps to send events to `/track`    |
-| `analytics_events`      | Event rows recorded by `/track`, scoped to the key owner's user/org |
+| Table                   | Contents                                                                                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `analytics_public_keys` | Public write keys used by hosted apps to send events to `/track`                                                                                              |
+| `analytics_events`      | Event rows recorded by `/track`, scoped to the key owner's user/org. Common dimensions include `event_name`, `timestamp`, `app`, `template`, and `signed_in`. |
 
 Use the `first-party` dashboard source or `query-agent-native-analytics` action for these events. Do **not** use `db-query` for user analytics questions unless the user explicitly asks to inspect the app's internal tables.
 

--- a/templates/analytics/actions/create-analytics-public-key.ts
+++ b/templates/analytics/actions/create-analytics-public-key.ts
@@ -1,0 +1,27 @@
+import { defineAction } from "@agent-native/core";
+import {
+  getRequestOrgId,
+  getRequestUserEmail,
+} from "@agent-native/core/server";
+import { z } from "zod";
+import { createAnalyticsPublicKey } from "../server/lib/first-party-analytics.js";
+
+function resolveScope() {
+  const userEmail = getRequestUserEmail();
+  if (!userEmail) throw new Error("no authenticated user");
+  return { userEmail, orgId: getRequestOrgId() || null };
+}
+
+export default defineAction({
+  description:
+    "Generate a public write key for first-party analytics ingestion. Use this when the user wants hosted apps to send events to analytics.agent-native.com/track. The returned publicKey is shown once and should be put in AGENT_NATIVE_ANALYTICS_PUBLIC_KEY / VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY on the emitting app.",
+  schema: z.object({
+    name: z
+      .string()
+      .optional()
+      .describe("Human label for this key, e.g. 'Hosted templates'."),
+  }),
+  run: async (args) => {
+    return createAnalyticsPublicKey(resolveScope(), args.name ?? "Default key");
+  },
+});

--- a/templates/analytics/actions/list-analytics-public-keys.ts
+++ b/templates/analytics/actions/list-analytics-public-keys.ts
@@ -1,0 +1,23 @@
+import { defineAction } from "@agent-native/core";
+import {
+  getRequestOrgId,
+  getRequestUserEmail,
+} from "@agent-native/core/server";
+import { z } from "zod";
+import { listAnalyticsPublicKeys } from "../server/lib/first-party-analytics.js";
+
+function resolveScope() {
+  const userEmail = getRequestUserEmail();
+  if (!userEmail) throw new Error("no authenticated user");
+  return { userEmail, orgId: getRequestOrgId() || null };
+}
+
+export default defineAction({
+  description:
+    "List first-party analytics public write keys for the current user/org. Returns prefixes and status only, not full key values.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  run: async () => {
+    return listAnalyticsPublicKeys(resolveScope());
+  },
+});

--- a/templates/analytics/actions/query-agent-native-analytics.ts
+++ b/templates/analytics/actions/query-agent-native-analytics.ts
@@ -1,0 +1,29 @@
+import { defineAction } from "@agent-native/core";
+import {
+  getRequestOrgId,
+  getRequestUserEmail,
+} from "@agent-native/core/server";
+import { z } from "zod";
+import { queryFirstPartyAnalytics } from "../server/lib/first-party-analytics.js";
+
+function resolveScope() {
+  const userEmail = getRequestUserEmail();
+  if (!userEmail) throw new Error("no authenticated user");
+  return { userEmail, orgId: getRequestOrgId() || null };
+}
+
+export default defineAction({
+  description:
+    "Query first-party Agent Native analytics events recorded through analytics.agent-native.com/track. Use this data-source-specific action instead of db-query. SQL may read analytics_events only; reads are automatically scoped to the current user/org.",
+  schema: z.object({
+    sql: z
+      .string()
+      .describe(
+        "Read-only SQL over analytics_events, e.g. SELECT event_name, COUNT(*) AS count FROM analytics_events GROUP BY event_name",
+      ),
+  }),
+  http: false,
+  run: async (args) => {
+    return queryFirstPartyAnalytics(args.sql, resolveScope());
+  },
+});

--- a/templates/analytics/actions/revoke-analytics-public-key.ts
+++ b/templates/analytics/actions/revoke-analytics-public-key.ts
@@ -1,0 +1,24 @@
+import { defineAction } from "@agent-native/core";
+import {
+  getRequestOrgId,
+  getRequestUserEmail,
+} from "@agent-native/core/server";
+import { z } from "zod";
+import { revokeAnalyticsPublicKey } from "../server/lib/first-party-analytics.js";
+
+function resolveScope() {
+  const userEmail = getRequestUserEmail();
+  if (!userEmail) throw new Error("no authenticated user");
+  return { userEmail, orgId: getRequestOrgId() || null };
+}
+
+export default defineAction({
+  description:
+    "Revoke a first-party analytics public write key. Future /track calls with that key will be rejected.",
+  schema: z.object({
+    id: z.string().describe("Public key row id to revoke."),
+  }),
+  run: async (args) => {
+    return revokeAnalyticsPublicKey(resolveScope(), args.id);
+  },
+});

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { getDashboard, upsertDashboard } from "../server/lib/dashboards-store";
 import { dryRunQuery } from "../server/lib/bigquery";
 import { interpolate } from "../app/pages/adhoc/sql-dashboard/interpolate";
+import { validateFirstPartyAnalyticsSql } from "../server/lib/first-party-analytics.js";
 import {
   hasCollabState,
   applyText,
@@ -190,7 +191,7 @@ function validateDashboardConfig(
   if (!Array.isArray(panels)) {
     return "config.panels must be an array (use [] for an empty dashboard)";
   }
-  const validSources = new Set(["bigquery", "app-db", "ga4", "amplitude"]);
+  const validSources = new Set(["bigquery", "ga4", "amplitude", "first-party"]);
   for (let i = 0; i < panels.length; i++) {
     const p = panels[i] as Record<string, unknown> | null;
     if (!p || typeof p !== "object") {
@@ -215,7 +216,7 @@ function validateDashboardConfig(
       }
     }
     if (!validSources.has(p.source as string)) {
-      return `panel[${i}].source must be 'bigquery', 'app-db', 'ga4', or 'amplitude' (got '${p.source}'). source selects the backend — put the table name in sql, not here.`;
+      return `panel[${i}].source must be 'bigquery', 'ga4', 'amplitude', or 'first-party' (got '${p.source}'). source selects the backend — put the table name in sql, not here.`;
     }
   }
   return null;
@@ -244,6 +245,17 @@ async function validatePanelSql(
           }
         } catch (e: any) {
           return `panel[${i}] "${p.title || p.id}" Amplitude descriptor is not valid JSON: ${e?.message}`;
+        }
+      }
+      continue;
+    }
+    if (p.source === "first-party") {
+      const raw = typeof p.sql === "string" ? p.sql : "";
+      if (raw.trim()) {
+        try {
+          validateFirstPartyAnalyticsSql(interpolate(raw, vars));
+        } catch (e: any) {
+          return `panel[${i}] "${p.title || p.id}" first-party analytics SQL is invalid: ${e?.message ?? e}`;
         }
       }
       continue;

--- a/templates/analytics/actions/view-screen.ts
+++ b/templates/analytics/actions/view-screen.ts
@@ -6,6 +6,7 @@ import {
 } from "@agent-native/core/server";
 import { readAppState } from "@agent-native/core/application-state";
 import { getDashboard } from "../server/lib/dashboards-store";
+import { listAnalyticsPublicKeys } from "../server/lib/first-party-analytics.js";
 
 export default defineAction({
   description:
@@ -64,6 +65,23 @@ export default defineAction({
       screen.page = "query";
     } else if (nav?.view === "data-sources") {
       screen.page = "data-sources";
+      const email = getRequestUserEmail();
+      if (email) {
+        const keys = await listAnalyticsPublicKeys({
+          userEmail: email,
+          orgId: getRequestOrgId() || null,
+        });
+        screen.firstPartyAnalytics = {
+          activeKeys: keys.filter((key: any) => !key.revokedAt).length,
+          keys: keys.map((key: any) => ({
+            id: key.id,
+            name: key.name,
+            publicKeyPrefix: key.publicKeyPrefix,
+            revokedAt: key.revokedAt,
+            lastUsedAt: key.lastUsedAt,
+          })),
+        };
+      }
     } else if (nav?.view === "settings") {
       screen.page = "settings";
     }

--- a/templates/analytics/app/components/layout/NewDashboardDialog.tsx
+++ b/templates/analytics/app/components/layout/NewDashboardDialog.tsx
@@ -23,9 +23,10 @@ export function NewDashboardDialog() {
         "The user wants to create a new analytics dashboard. " +
         "Create a SQL-driven dashboard by saving a JSON config via PUT /api/sql-dashboards/{id}. " +
         "The config shape is: { name: string, panels: [{ id, title, sql, source, chartType, width, config? }] }. " +
-        "Each panel needs: id (unique string), title, sql (the query), source ('bigquery' | 'app-db' | 'ga4'), " +
+        "Each panel needs: id (unique string), title, sql (the query), source ('bigquery' | 'ga4' | 'amplitude' | 'first-party'), " +
         "chartType ('line' | 'area' | 'bar' | 'metric' | 'table' | 'pie'), width (1 or 2). " +
         "Optional config: { xKey, yKey, yKeys, color, colors, yFormatter ('number'|'currency'|'percent'), description }. " +
+        "For first-party analytics, source is 'first-party' and sql may read analytics_events only; do not use db-query for datasource panels. " +
         "First check /_agent-native/env-status to see which data sources are connected. " +
         "Refer to .builder/skills/<provider>/SKILL.md for SQL patterns and table names. " +
         "NO code files need to be created — only the dashboard config JSON via the API. " +

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -22,6 +22,8 @@ import {
   IconTrash,
   IconSearch,
   IconPlus,
+  IconKey,
+  IconCopy,
 } from "@tabler/icons-react";
 import { getIdToken } from "@/lib/auth";
 import {
@@ -32,13 +34,28 @@ import {
   type DataSourceCategory,
   type WalkthroughStep,
 } from "@/lib/data-sources";
-import { appApiPath, useSendToAgentChat } from "@agent-native/core/client";
+import {
+  appApiPath,
+  useActionMutation,
+  useActionQuery,
+  useSendToAgentChat,
+} from "@agent-native/core/client";
 
 interface EnvKeyStatus {
   key: string;
   label: string;
   required: boolean;
   configured: boolean;
+}
+
+interface AnalyticsPublicKeyRow {
+  id: string;
+  name: string;
+  publicKeyPrefix: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+  revokedAt: string | null;
+  orgId: string | null;
 }
 
 async function fetchEnvStatus(): Promise<EnvKeyStatus[]> {
@@ -774,6 +791,190 @@ function AddDataSourceCTA() {
   );
 }
 
+function FirstPartyAnalyticsCard() {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("Hosted templates");
+  const [createdKey, setCreatedKey] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const { data, isLoading } = useActionQuery(
+    "list-analytics-public-keys",
+    undefined,
+    { staleTime: 10_000 },
+  );
+  const keys = ((data as AnalyticsPublicKeyRow[] | undefined) ?? []).filter(
+    (key) => !key.revokedAt,
+  );
+
+  const createKey = useActionMutation("create-analytics-public-key", {
+    onSuccess: (result: any) => {
+      setCreatedKey(result.publicKey);
+      setCopied(false);
+      queryClient.invalidateQueries({
+        queryKey: ["action", "list-analytics-public-keys"],
+      });
+    },
+  });
+
+  const revokeKey = useActionMutation("revoke-analytics-public-key", {
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["action", "list-analytics-public-keys"],
+      });
+    },
+  });
+
+  const copyCreatedKey = async () => {
+    if (!createdKey) return;
+    await navigator.clipboard?.writeText(createdKey);
+    setCopied(true);
+  };
+
+  return (
+    <Card className="bg-card border-border/50">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <IconKey className="h-5 w-5" />
+            </div>
+            <div>
+              <CardTitle className="text-sm font-medium">
+                First-party Analytics
+              </CardTitle>
+              <CardDescription className="text-xs mt-0.5">
+                Receive product events at analytics.agent-native.com and query
+                them as a dashboard data source.
+              </CardDescription>
+            </div>
+          </div>
+          {isLoading ? (
+            <Skeleton className="h-4 w-20 rounded-full" />
+          ) : keys.length > 0 ? (
+            <span className="flex items-center gap-1.5 text-xs text-emerald-500 font-medium whitespace-nowrap">
+              <IconCheck className="h-3.5 w-3.5" />
+              {keys.length} active
+            </span>
+          ) : (
+            <span className="flex items-center gap-1.5 text-xs text-muted-foreground whitespace-nowrap">
+              <IconCircle className="h-3 w-3" />
+              No keys
+            </span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-2 rounded-md border border-border/50 bg-muted/20 p-3 text-xs">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-muted-foreground">Endpoint</span>
+            <code className="truncate font-mono">
+              https://analytics.agent-native.com/track
+            </code>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-muted-foreground">Server env</span>
+            <code className="truncate font-mono">
+              AGENT_NATIVE_ANALYTICS_PUBLIC_KEY
+            </code>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-muted-foreground">Browser env</span>
+            <code className="truncate font-mono">
+              VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY
+            </code>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="flex min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 text-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
+            placeholder="Key name"
+          />
+          <Button
+            size="sm"
+            onClick={() => createKey.mutate({ name })}
+            disabled={createKey.isPending}
+            className="text-xs"
+          >
+            {createKey.isPending ? (
+              <>
+                <IconLoader2 className="h-3 w-3 animate-spin mr-1.5" />
+                Generating...
+              </>
+            ) : (
+              <>
+                <IconPlus className="h-3 w-3 mr-1.5" />
+                Generate Key
+              </>
+            )}
+          </Button>
+        </div>
+
+        {createdKey && (
+          <div className="space-y-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 p-3">
+            <p className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+              New key generated
+            </p>
+            <div className="flex gap-2">
+              <input
+                readOnly
+                value={createdKey}
+                className="flex min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+              />
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={copyCreatedKey}
+                className="text-xs"
+              >
+                <IconCopy className="h-3 w-3 mr-1.5" />
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {keys.length > 0 && (
+          <div className="space-y-2 border-t border-border/30 pt-3">
+            {keys.map((key) => (
+              <div
+                key={key.id}
+                className="flex items-center justify-between gap-3 text-xs"
+              >
+                <div className="min-w-0">
+                  <div className="font-medium truncate">{key.name}</div>
+                  <div className="text-muted-foreground font-mono">
+                    {key.publicKeyPrefix}...
+                    {key.lastUsedAt
+                      ? ` last used ${new Date(key.lastUsedAt).toLocaleDateString()}`
+                      : " never used"}
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => revokeKey.mutate({ id: key.id })}
+                  disabled={revokeKey.isPending}
+                  className="text-xs text-destructive hover:text-destructive"
+                >
+                  {revokeKey.isPending ? (
+                    <IconLoader2 className="h-3 w-3 animate-spin mr-1.5" />
+                  ) : (
+                    <IconTrash className="h-3 w-3 mr-1.5" />
+                  )}
+                  Revoke
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function DataSources() {
   const queryClient = useQueryClient();
   const [search, setSearch] = useState("");
@@ -823,6 +1024,8 @@ export default function DataSources() {
           className="flex w-full rounded-md border border-input bg-background pl-9 pr-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
         />
       </div>
+
+      {!search && <FirstPartyAnalyticsCard />}
 
       {/* Filtered results */}
       {filteredSources !== null ? (

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
@@ -34,9 +34,9 @@ const CHART_TYPES: { value: ChartType; label: string }[] = [
 
 const SOURCES: { value: DataSourceType; label: string }[] = [
   { value: "bigquery", label: "BigQuery" },
-  { value: "app-db", label: "App DB" },
   { value: "ga4", label: "Google Analytics" },
   { value: "amplitude", label: "Amplitude" },
+  { value: "first-party", label: "First-party Analytics" },
 ];
 
 function generatePanelId(title: string): string {
@@ -175,8 +175,9 @@ export function PanelEditorDialog({
         `The user wants to add a new panel to SQL dashboard "${dashboardId}". ${titlesLine} ` +
         `Use the \`update-dashboard\` action with ops=[{op:'insert', path:'/panels/-', value: <panel>}] ` +
         `to append, or an appropriate index to place the panel in the right spot. ` +
-        `Panel shape: { id (unique slug), title, sql, source ('bigquery'|'app-db'|'ga4'|'amplitude'), chartType ('line'|'area'|'bar'|'metric'|'table'|'pie'), width (1 half | 2 full), config? }. ` +
+        `Panel shape: { id (unique slug), title, sql, source ('bigquery'|'ga4'|'amplitude'|'first-party'), chartType ('line'|'area'|'bar'|'metric'|'table'|'pie'), width (1 half | 2 full), config? }. ` +
         `For amplitude panels, sql is a JSON descriptor: {"event":"event name","groupBy":"property","days":30}. ` +
+        `For first-party panels, sql is read-only SQL over analytics_events only; use source 'first-party' and do not call db-query for this datasource. ` +
         `Config is optional: { xKey, yKey, yKeys, yFormatter ('number'|'currency'|'percent'), description, columns, pivot, limit }. ` +
         `Consult the data dictionary first via \`list-data-dictionary --search <topic>\`, then read the relevant \`.builder/skills/<provider>/SKILL.md\` before writing SQL. ` +
         `Every BigQuery panel is dry-run validated on save — if columns/tables are wrong the save returns a 400 with the BQ error and you must fix the SQL and retry. ` +

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/types.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/types.ts
@@ -1,4 +1,4 @@
-export type DataSourceType = "bigquery" | "app-db" | "ga4" | "amplitude";
+export type DataSourceType = "bigquery" | "ga4" | "amplitude" | "first-party";
 
 export type ChartType = "line" | "area" | "bar" | "metric" | "table" | "pie";
 

--- a/templates/analytics/app/routes/chart.tsx
+++ b/templates/analytics/app/routes/chart.tsx
@@ -15,13 +15,9 @@ const VALID_CHART_TYPES = new Set([
   "table",
   "pie",
 ]);
-// `app-db` intentionally excluded from embed URLs — the base64 panel param
-// lets the caller control the SQL, and running arbitrary SELECTs against
-// the app DB would let an assistant-crafted chart URL read the `settings`
-// table (which stores provider credentials). Saved dashboards still run
-// app-db panels via /api/sql-query; only the URL-driven embed path is
-// restricted to external data sources.
-const VALID_SOURCES = new Set(["bigquery", "ga4", "amplitude"]);
+// Embed URLs accept external sources plus the restricted first-party analytics
+// source. They intentionally do not expose arbitrary app database querying.
+const VALID_SOURCES = new Set(["bigquery", "ga4", "amplitude", "first-party"]);
 
 function decodePanel(raw: string): SqlPanel | { error: string } {
   try {
@@ -38,8 +34,7 @@ function decodePanel(raw: string): SqlPanel | { error: string } {
     }
     if (typeof p.source !== "string" || !VALID_SOURCES.has(p.source)) {
       return {
-        error:
-          "Panel source must be bigquery or ga4. app-db panels cannot be rendered in embed URLs.",
+        error: "Panel source must be bigquery, ga4, amplitude, or first-party.",
       };
     }
     if (

--- a/templates/analytics/seeds/dashboards/agent-native-templates-first-party.json
+++ b/templates/analytics/seeds/dashboards/agent-native-templates-first-party.json
@@ -1,0 +1,151 @@
+{
+  "name": "Agent Native Templates (First-party)",
+  "description": "Template engagement and per-app activity recorded through analytics.agent-native.com/track. Source: first-party analytics_events.",
+  "panels": [
+    {
+      "id": "total-template-clicks",
+      "title": "Template Clicks",
+      "chartType": "metric",
+      "source": "first-party",
+      "width": 1,
+      "sql": "SELECT COUNT(*) AS count FROM analytics_events WHERE event_name = 'click template'",
+      "config": {
+        "yKey": "count",
+        "yFormatter": "number",
+        "description": "First-party events"
+      }
+    },
+    {
+      "id": "total-demo-clicks",
+      "title": "Demo Clicks",
+      "chartType": "metric",
+      "source": "first-party",
+      "width": 1,
+      "sql": "SELECT COUNT(*) AS count FROM analytics_events WHERE event_name = 'click try demo'",
+      "config": {
+        "yKey": "count",
+        "yFormatter": "number",
+        "description": "First-party events"
+      }
+    },
+    {
+      "id": "total-cli-copies",
+      "title": "CLI Copies",
+      "chartType": "metric",
+      "source": "first-party",
+      "width": 1,
+      "sql": "SELECT COUNT(*) AS count FROM analytics_events WHERE event_name = 'copy cli command'",
+      "config": {
+        "yKey": "count",
+        "yFormatter": "number",
+        "description": "First-party events"
+      }
+    },
+    {
+      "id": "template-interest-over-time",
+      "title": "Template Interest Over Time",
+      "chartType": "area",
+      "source": "first-party",
+      "width": 2,
+      "sql": "SELECT substr(timestamp, 1, 10) AS date, COUNT(*) AS count FROM analytics_events WHERE event_name = 'click template' GROUP BY substr(timestamp, 1, 10) ORDER BY date",
+      "config": {
+        "xKey": "date",
+        "yKey": "count",
+        "color": "#6366f1"
+      }
+    },
+    {
+      "id": "clicks-by-template",
+      "title": "Clicks by Template",
+      "chartType": "bar",
+      "source": "first-party",
+      "width": 1,
+      "sql": "SELECT COALESCE(NULLIF(template, ''), 'unknown') AS template, COUNT(*) AS count FROM analytics_events WHERE event_name = 'click template' GROUP BY COALESCE(NULLIF(template, ''), 'unknown') ORDER BY count DESC LIMIT 20",
+      "config": {
+        "xKey": "template",
+        "yKey": "count",
+        "color": "#6366f1"
+      }
+    },
+    {
+      "id": "demo-clicks-by-template",
+      "title": "Try-Demo Clicks by Template",
+      "chartType": "bar",
+      "source": "first-party",
+      "width": 1,
+      "sql": "SELECT COALESCE(NULLIF(template, ''), 'unknown') AS template, COUNT(*) AS count FROM analytics_events WHERE event_name = 'click try demo' GROUP BY COALESCE(NULLIF(template, ''), 'unknown') ORDER BY count DESC LIMIT 20",
+      "config": {
+        "xKey": "template",
+        "yKey": "count",
+        "color": "#8b5cf6"
+      }
+    },
+    {
+      "id": "cli-copies-by-template",
+      "title": "CLI Copies by Template",
+      "chartType": "bar",
+      "source": "first-party",
+      "width": 1,
+      "sql": "SELECT COALESCE(NULLIF(template, ''), 'unknown') AS template, COUNT(*) AS count FROM analytics_events WHERE event_name = 'copy cli command' GROUP BY COALESCE(NULLIF(template, ''), 'unknown') ORDER BY count DESC LIMIT 20",
+      "config": {
+        "xKey": "template",
+        "yKey": "count",
+        "color": "#06b6d4"
+      }
+    },
+    {
+      "id": "cli-copies-over-time",
+      "title": "CLI Copies Over Time",
+      "chartType": "area",
+      "source": "first-party",
+      "width": 2,
+      "sql": "SELECT substr(timestamp, 1, 10) AS date, COUNT(*) AS count FROM analytics_events WHERE event_name = 'copy cli command' GROUP BY substr(timestamp, 1, 10) ORDER BY date",
+      "config": {
+        "xKey": "date",
+        "yKey": "count",
+        "color": "#06b6d4"
+      }
+    },
+    {
+      "id": "sessions-by-app",
+      "title": "Sessions by Agent-Native App",
+      "chartType": "bar",
+      "source": "first-party",
+      "width": 2,
+      "sql": "SELECT COALESCE(NULLIF(app, ''), 'unknown') AS app, COUNT(*) AS count FROM analytics_events WHERE event_name = 'session status' GROUP BY COALESCE(NULLIF(app, ''), 'unknown') ORDER BY count DESC LIMIT 20",
+      "config": {
+        "xKey": "app",
+        "yKey": "count",
+        "color": "#10b981",
+        "description": "Per-template-site session activity (mail, calendar, slides, ...). Each tab fires session status once."
+      }
+    },
+    {
+      "id": "signed-in-vs-anon",
+      "title": "Signed-In vs Anonymous Sessions",
+      "chartType": "bar",
+      "source": "first-party",
+      "width": 1,
+      "sql": "SELECT COALESCE(NULLIF(signed_in, ''), 'unknown') AS signed_in, COUNT(*) AS count FROM analytics_events WHERE event_name = 'session status' GROUP BY COALESCE(NULLIF(signed_in, ''), 'unknown') ORDER BY signed_in",
+      "config": {
+        "xKey": "signed_in",
+        "yKey": "count",
+        "color": "#f59e0b",
+        "description": "true = signed in, false = anonymous. Best proxy for total signups per period (still includes returning users)."
+      }
+    },
+    {
+      "id": "sessions-over-time",
+      "title": "Sessions Over Time",
+      "chartType": "area",
+      "source": "first-party",
+      "width": 1,
+      "sql": "SELECT substr(timestamp, 1, 10) AS date, COUNT(*) AS count FROM analytics_events WHERE event_name = 'session status' GROUP BY substr(timestamp, 1, 10) ORDER BY date",
+      "config": {
+        "xKey": "date",
+        "yKey": "count",
+        "color": "#10b981"
+      }
+    }
+  ]
+}

--- a/templates/analytics/seeds/dashboards/agent-native-templates-ga4.json
+++ b/templates/analytics/seeds/dashboards/agent-native-templates-ga4.json
@@ -82,7 +82,7 @@
     },
     {
       "id": "demo-clicks-by-template",
-      "title": "Demo Clicks by Template",
+      "title": "Try-Demo Clicks by Template",
       "chartType": "bar",
       "source": "ga4",
       "width": 1,
@@ -117,6 +117,47 @@
         "xKey": "date",
         "yKey": "eventCount",
         "color": "#06b6d4"
+      }
+    },
+    {
+      "id": "sessions-by-app",
+      "title": "Sessions by Agent-Native App",
+      "chartType": "bar",
+      "source": "ga4",
+      "width": 2,
+      "sql": "{\"metrics\":[\"eventCount\"],\"dimensions\":[\"customEvent:app\"],\"days\":{{days}},\"filter\":{\"filter\":{\"fieldName\":\"eventName\",\"stringFilter\":{\"value\":\"session_status\",\"matchType\":\"EXACT\"}}}}",
+      "config": {
+        "xKey": "customEvent:app",
+        "yKey": "eventCount",
+        "color": "#10b981",
+        "description": "Per-template-site session activity (mail, calendar, slides, ...). Each tab fires session_status once."
+      }
+    },
+    {
+      "id": "signed-in-vs-anon",
+      "title": "Signed-In vs Anonymous Sessions",
+      "chartType": "bar",
+      "source": "ga4",
+      "width": 1,
+      "sql": "{\"metrics\":[\"eventCount\"],\"dimensions\":[\"customEvent:signed_in\"],\"days\":{{days}},\"filter\":{\"filter\":{\"fieldName\":\"eventName\",\"stringFilter\":{\"value\":\"session_status\",\"matchType\":\"EXACT\"}}}}",
+      "config": {
+        "xKey": "customEvent:signed_in",
+        "yKey": "eventCount",
+        "color": "#f59e0b",
+        "description": "true = signed in, false = anonymous. Best proxy for total signups per period (still includes returning users)."
+      }
+    },
+    {
+      "id": "sessions-over-time",
+      "title": "Sessions Over Time",
+      "chartType": "area",
+      "source": "ga4",
+      "width": 1,
+      "sql": "{\"metrics\":[\"eventCount\"],\"dimensions\":[\"date\"],\"days\":{{days}},\"filter\":{\"filter\":{\"fieldName\":\"eventName\",\"stringFilter\":{\"value\":\"session_status\",\"matchType\":\"EXACT\"}}}}",
+      "config": {
+        "xKey": "date",
+        "yKey": "eventCount",
+        "color": "#10b981"
       }
     }
   ]

--- a/templates/analytics/seeds/dashboards/agent-native-templates.json
+++ b/templates/analytics/seeds/dashboards/agent-native-templates.json
@@ -1,6 +1,6 @@
 {
   "name": "Agent Native Templates",
-  "description": "Template engagement from the docs site — clicks, demo tries, and CLI copies tracked via Amplitude",
+  "description": "Template engagement and per-app activity. Source: Amplitude.",
   "filters": [
     {
       "id": "days",
@@ -82,7 +82,7 @@
     },
     {
       "id": "demo-clicks-by-template",
-      "title": "Demo Clicks by Template",
+      "title": "Try-Demo Clicks by Template",
       "chartType": "bar",
       "source": "amplitude",
       "width": 1,
@@ -117,6 +117,47 @@
         "xKey": "date",
         "yKey": "count",
         "color": "#06b6d4"
+      }
+    },
+    {
+      "id": "sessions-by-app",
+      "title": "Sessions by Agent-Native App",
+      "chartType": "bar",
+      "source": "amplitude",
+      "width": 2,
+      "sql": "{\"event\":\"session status\",\"groupBy\":\"app\",\"days\":{{days}}}",
+      "config": {
+        "xKey": "app",
+        "yKey": "count",
+        "color": "#10b981",
+        "description": "Per-template-site session activity (mail, calendar, slides, ...). Each tab fires session status once."
+      }
+    },
+    {
+      "id": "signed-in-vs-anon",
+      "title": "Signed-In vs Anonymous Sessions",
+      "chartType": "bar",
+      "source": "amplitude",
+      "width": 1,
+      "sql": "{\"event\":\"session status\",\"groupBy\":\"signed_in\",\"days\":{{days}}}",
+      "config": {
+        "xKey": "signed_in",
+        "yKey": "count",
+        "color": "#f59e0b",
+        "description": "true = signed in, false = anonymous. Best proxy for total signups per period (still includes returning users)."
+      }
+    },
+    {
+      "id": "sessions-over-time",
+      "title": "Sessions Over Time",
+      "chartType": "area",
+      "source": "amplitude",
+      "width": 1,
+      "sql": "{\"event\":\"session status\",\"days\":{{days}}}",
+      "config": {
+        "xKey": "date",
+        "yKey": "count",
+        "color": "#10b981"
       }
     }
   ]

--- a/templates/analytics/server/db/schema.ts
+++ b/templates/analytics/server/db/schema.ts
@@ -120,6 +120,7 @@ export const analyticsEvents = table("analytics_events", {
   referrer: text("referrer"),
   app: text("app"),
   template: text("template"),
+  signedIn: text("signed_in"),
   properties: text("properties").notNull().default("{}"),
   context: text("context").notNull().default("{}"),
   ownerEmail: text("owner_email").notNull().default("local@localhost"),

--- a/templates/analytics/server/db/schema.ts
+++ b/templates/analytics/server/db/schema.ts
@@ -82,3 +82,46 @@ export const bigqueryCache = table("bigquery_cache", {
   createdAt: text("created_at").notNull(),
   expiresAt: text("expires_at").notNull(),
 });
+
+/**
+ * Public write keys for the first-party analytics ingestion endpoint.
+ * The key is intentionally public/write-only: it can create events for the
+ * owning user/org but grants no read or admin access.
+ */
+export const analyticsPublicKeys = table("analytics_public_keys", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  publicKey: text("public_key").notNull(),
+  publicKeyPrefix: text("public_key_prefix").notNull(),
+  createdAt: text("created_at").notNull().default(now()),
+  lastUsedAt: text("last_used_at"),
+  revokedAt: text("revoked_at"),
+  ownerEmail: text("owner_email").notNull().default("local@localhost"),
+  orgId: text("org_id"),
+});
+
+/**
+ * First-party product analytics events recorded via /track.
+ * Common dimensions are mirrored as columns so dashboards can group/filter
+ * without dialect-specific JSON operators.
+ */
+export const analyticsEvents = table("analytics_events", {
+  id: text("id").primaryKey(),
+  publicKeyId: text("public_key_id").notNull(),
+  eventName: text("event_name").notNull(),
+  userId: text("user_id"),
+  anonymousId: text("anonymous_id"),
+  sessionId: text("session_id"),
+  timestamp: text("timestamp").notNull(),
+  receivedAt: text("received_at").notNull().default(now()),
+  url: text("url"),
+  path: text("path"),
+  hostname: text("hostname"),
+  referrer: text("referrer"),
+  app: text("app"),
+  template: text("template"),
+  properties: text("properties").notNull().default("{}"),
+  context: text("context").notNull().default("{}"),
+  ownerEmail: text("owner_email").notNull().default("local@localhost"),
+  orgId: text("org_id"),
+});

--- a/templates/analytics/server/handlers/first-party-analytics.ts
+++ b/templates/analytics/server/handlers/first-party-analytics.ts
@@ -1,0 +1,54 @@
+import {
+  defineEventHandler,
+  getHeader,
+  setResponseHeader,
+  setResponseStatus,
+} from "h3";
+import { readBody } from "@agent-native/core/server";
+import {
+  parseAnalyticsTrackPayload,
+  recordAnalyticsEvents,
+} from "../lib/first-party-analytics.js";
+
+function setCors(event: any): void {
+  setResponseHeader(event, "Access-Control-Allow-Origin", "*");
+  setResponseHeader(event, "Access-Control-Allow-Methods", "POST, OPTIONS");
+  setResponseHeader(
+    event,
+    "Access-Control-Allow-Headers",
+    "content-type, x-agent-native-analytics-key",
+  );
+  setResponseHeader(event, "Access-Control-Max-Age", "86400");
+}
+
+export const handleAnalyticsTrackOptions = defineEventHandler((event) => {
+  setCors(event);
+  setResponseStatus(event, 204);
+  return "";
+});
+
+export const handleAnalyticsTrack = defineEventHandler(async (event) => {
+  setCors(event);
+  try {
+    const headerKey = getHeader(event, "x-agent-native-analytics-key");
+    let body = await readBody(event);
+    if (headerKey) {
+      if (typeof body === "string" && body.trim()) {
+        body = { ...JSON.parse(body), publicKey: headerKey };
+      } else if (body && typeof body === "object" && !Array.isArray(body)) {
+        body = { ...(body as Record<string, unknown>), publicKey: headerKey };
+      } else {
+        body = { publicKey: headerKey };
+      }
+    }
+    const parsed = parseAnalyticsTrackPayload(body);
+    const result = await recordAnalyticsEvents(parsed.publicKey, parsed.events);
+    setResponseStatus(event, 202);
+    return { success: true, accepted: result.accepted };
+  } catch (err: any) {
+    const message = err?.message || String(err);
+    const invalidKey = /invalid analytics public key/i.test(message);
+    setResponseStatus(event, invalidKey ? 401 : 400);
+    return { error: message };
+  }
+});

--- a/templates/analytics/server/handlers/sql-dashboards.ts
+++ b/templates/analytics/server/handlers/sql-dashboards.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/dashboards-store";
 import { dryRunQuery } from "../lib/bigquery";
 import { interpolate } from "../../app/pages/adhoc/sql-dashboard/interpolate";
+import { validateFirstPartyAnalyticsSql } from "../lib/first-party-analytics";
 
 async function ctxFromEvent(event: any) {
   const ctx = await getOrgContext(event);
@@ -106,12 +107,12 @@ export const saveSqlDashboard = defineEventHandler(async (event) => {
         setResponseStatus(event, 400);
         return { error: validation };
       }
+      const ctx = await ctxFromEvent(event);
       const sqlError = await validatePanelSql(body);
       if (sqlError) {
         setResponseStatus(event, 400);
         return { error: sqlError };
       }
-      const ctx = await ctxFromEvent(event);
       await upsertDashboard(id, "sql", body, ctx);
       return { id, success: true };
     } catch (err: any) {
@@ -152,6 +153,15 @@ async function validatePanelSql(
       const err = validateAmplitudePanelShape(interpolate(raw, vars));
       if (err) {
         return `panel[${i}] "${p.title || p.id}" Amplitude descriptor is invalid: ${err}`;
+      }
+      continue;
+    }
+
+    if (p.source === "first-party") {
+      try {
+        validateFirstPartyAnalyticsSql(interpolate(raw, vars));
+      } catch (e: any) {
+        return `panel[${i}] "${p.title || p.id}" first-party analytics SQL is invalid: ${e?.message ?? e}`;
       }
       continue;
     }
@@ -248,7 +258,12 @@ function validateDashboardConfig(
   }
   if (Array.isArray(panels)) {
     const requiredStrings = ["id", "title", "sql", "source", "chartType"];
-    const validSources = new Set(["bigquery", "app-db", "ga4", "amplitude"]);
+    const validSources = new Set([
+      "bigquery",
+      "ga4",
+      "amplitude",
+      "first-party",
+    ]);
     for (let i = 0; i < panels.length; i++) {
       const p = panels[i] as Record<string, unknown> | null;
       if (!p || typeof p !== "object") return `panel[${i}] must be an object`;
@@ -259,7 +274,7 @@ function validateDashboardConfig(
         }
       }
       if (!validSources.has(p.source as string)) {
-        return `panel[${i}].source must be 'bigquery', 'app-db', 'ga4', or 'amplitude' (got '${p.source}'). The table name belongs in the panel's sql, not in source — source selects the backend, not the table.`;
+        return `panel[${i}].source must be 'bigquery', 'ga4', 'amplitude', or 'first-party' (got '${p.source}'). The table name belongs in the panel's sql, not in source — source selects the backend, not the table.`;
       }
       if (p.width !== 1 && p.width !== 2) {
         return `panel[${i}].width must be 1 or 2`;

--- a/templates/analytics/server/handlers/sql-query.ts
+++ b/templates/analytics/server/handlers/sql-query.ts
@@ -7,6 +7,7 @@ import { runQuery } from "../lib/bigquery";
 import { runReport } from "../lib/google-analytics";
 import { getUserSegmentation, queryEvents } from "../lib/amplitude";
 import { readBody } from "@agent-native/core/server";
+import { queryFirstPartyAnalytics } from "../lib/first-party-analytics";
 
 /**
  * ga4 panels carry a JSON blob in `sql` describing the GA4 Data API call.
@@ -245,7 +246,7 @@ function flattenAmplitudeResponse(
 }
 
 export const handleSqlQuery = defineEventHandler(async (event) => {
-  return runApiHandlerWithContext(event, async () => {
+  return runApiHandlerWithContext(event, async (ctx) => {
     const { query, source } = await readBody(event);
 
     if (!query || typeof query !== "string") {
@@ -253,10 +254,14 @@ export const handleSqlQuery = defineEventHandler(async (event) => {
       return { error: "Missing or invalid query" };
     }
 
-    if (!source || !["bigquery", "ga4", "amplitude"].includes(source)) {
+    if (
+      !source ||
+      !["bigquery", "ga4", "amplitude", "first-party"].includes(source)
+    ) {
       setResponseStatus(event, 400);
       return {
-        error: "Invalid source. Must be 'bigquery', 'ga4', or 'amplitude'",
+        error:
+          "Invalid source. Must be 'bigquery', 'ga4', 'amplitude', or 'first-party'",
       };
     }
 
@@ -302,6 +307,13 @@ export const handleSqlQuery = defineEventHandler(async (event) => {
         );
         if (missingSecret) return missingSecret;
         return await runAmplitudePanel(query);
+      }
+
+      if (source === "first-party") {
+        return await queryFirstPartyAnalytics(query, {
+          userEmail: ctx.userEmail,
+          orgId: ctx.orgId ?? null,
+        });
       }
 
       setResponseStatus(event, 400);

--- a/templates/analytics/server/lib/first-party-analytics.ts
+++ b/templates/analytics/server/lib/first-party-analytics.ts
@@ -1,0 +1,485 @@
+import { and, eq, isNull, or } from "drizzle-orm";
+import { getDbExec } from "@agent-native/core/db";
+import { getDb, schema } from "../db/index.js";
+
+export interface AnalyticsScope {
+  userEmail: string;
+  orgId: string | null;
+}
+
+export interface IncomingAnalyticsEvent {
+  event: string;
+  properties?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  userId?: string | null;
+  anonymousId?: string | null;
+  sessionId?: string | null;
+  timestamp?: string | number | Date | null;
+}
+
+export interface AnalyticsQueryResult {
+  rows: Record<string, unknown>[];
+  schema: { name: string; type: string }[];
+}
+
+const MAX_EVENTS_PER_REQUEST = 100;
+const MAX_QUERY_ROWS = 5_000;
+const RESERVED_ALIAS_WORDS = new Set([
+  "where",
+  "on",
+  "group",
+  "order",
+  "limit",
+  "join",
+  "left",
+  "right",
+  "inner",
+  "outer",
+  "cross",
+  "full",
+  "having",
+  "union",
+]);
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function randomHex(bytes: number): string {
+  const arr = new Uint8Array(bytes);
+  if (!globalThis.crypto?.getRandomValues) {
+    throw new Error("Secure random generation is unavailable");
+  }
+  globalThis.crypto.getRandomValues(arr);
+  return Array.from(arr, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function id(prefix: string): string {
+  return `${prefix}_${randomHex(12)}`;
+}
+
+export function generateAnalyticsPublicKey(): string {
+  return `anpk_${randomHex(24)}`;
+}
+
+export async function createAnalyticsPublicKey(
+  scope: AnalyticsScope,
+  name: string,
+): Promise<Record<string, unknown>> {
+  const db = getDb() as any;
+  const publicKey = generateAnalyticsPublicKey();
+  const createdAt = nowIso();
+  const row = {
+    id: id("apk"),
+    name: name.trim() || "Default key",
+    publicKey,
+    publicKeyPrefix: publicKey.slice(0, 13),
+    createdAt,
+    ownerEmail: scope.userEmail,
+    orgId: scope.orgId,
+  };
+  await db.insert(schema.analyticsPublicKeys).values(row);
+  return {
+    id: row.id,
+    name: row.name,
+    publicKey,
+    publicKeyPrefix: row.publicKeyPrefix,
+    createdAt,
+    orgId: row.orgId,
+    revokedAt: null,
+    lastUsedAt: null,
+  };
+}
+
+export async function listAnalyticsPublicKeys(
+  scope: AnalyticsScope,
+): Promise<Record<string, unknown>[]> {
+  const db = getDb() as any;
+  const where = scope.orgId
+    ? or(
+        eq(schema.analyticsPublicKeys.orgId, scope.orgId),
+        and(
+          eq(schema.analyticsPublicKeys.ownerEmail, scope.userEmail),
+          isNull(schema.analyticsPublicKeys.orgId),
+        ),
+      )
+    : and(
+        eq(schema.analyticsPublicKeys.ownerEmail, scope.userEmail),
+        isNull(schema.analyticsPublicKeys.orgId),
+      );
+  const rows = await db
+    .select()
+    .from(schema.analyticsPublicKeys)
+    .where(where)
+    .orderBy(schema.analyticsPublicKeys.createdAt);
+
+  return rows.map((row: any) => ({
+    id: row.id,
+    name: row.name,
+    publicKeyPrefix: row.publicKeyPrefix,
+    createdAt: row.createdAt,
+    lastUsedAt: row.lastUsedAt ?? null,
+    revokedAt: row.revokedAt ?? null,
+    orgId: row.orgId ?? null,
+  }));
+}
+
+export async function revokeAnalyticsPublicKey(
+  scope: AnalyticsScope,
+  keyId: string,
+): Promise<{ id: string; revokedAt: string }> {
+  const db = getDb() as any;
+  const where = scope.orgId
+    ? and(
+        eq(schema.analyticsPublicKeys.id, keyId),
+        or(
+          eq(schema.analyticsPublicKeys.orgId, scope.orgId),
+          and(
+            eq(schema.analyticsPublicKeys.ownerEmail, scope.userEmail),
+            isNull(schema.analyticsPublicKeys.orgId),
+          ),
+        ),
+      )
+    : and(
+        eq(schema.analyticsPublicKeys.id, keyId),
+        eq(schema.analyticsPublicKeys.ownerEmail, scope.userEmail),
+        isNull(schema.analyticsPublicKeys.orgId),
+      );
+  const revokedAt = nowIso();
+  const updated = await db
+    .update(schema.analyticsPublicKeys)
+    .set({ revokedAt })
+    .where(where)
+    .returning();
+  if (!updated.length) {
+    throw new Error("Analytics public key not found");
+  }
+  return { id: keyId, revokedAt };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
+}
+
+function normalizeTimestamp(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number") {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? nowIso() : d.toISOString();
+  }
+  if (typeof value === "string" && value.trim()) {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? nowIso() : d.toISOString();
+  }
+  return nowIso();
+}
+
+function urlParts(url: string | null): {
+  url: string | null;
+  path: string | null;
+  hostname: string | null;
+} {
+  if (!url) return { url: null, path: null, hostname: null };
+  try {
+    const parsed = new URL(url, "https://placeholder.agent-native.local");
+    const relative = !/^https?:\/\//i.test(url);
+    return {
+      url: relative ? `${parsed.pathname}${parsed.search}${parsed.hash}` : url,
+      path: parsed.pathname,
+      hostname: relative ? null : parsed.hostname,
+    };
+  } catch {
+    return { url, path: null, hostname: null };
+  }
+}
+
+export function parseAnalyticsTrackPayload(raw: unknown): {
+  publicKey: string;
+  events: IncomingAnalyticsEvent[];
+} {
+  const body =
+    typeof raw === "string" && raw.trim() ? JSON.parse(raw) : asRecord(raw);
+  const publicKey =
+    asString((body as any).publicKey) ||
+    asString((body as any).writeKey) ||
+    asString((body as any).apiKey);
+  if (!publicKey) {
+    throw new Error("Missing publicKey");
+  }
+
+  const rawEvents = Array.isArray((body as any).events)
+    ? (body as any).events
+    : [body];
+  if (rawEvents.length === 0) {
+    throw new Error("No events provided");
+  }
+  if (rawEvents.length > MAX_EVENTS_PER_REQUEST) {
+    throw new Error(`At most ${MAX_EVENTS_PER_REQUEST} events are accepted`);
+  }
+
+  const events = rawEvents.map((rawEvent: unknown) => {
+    const obj = asRecord(rawEvent);
+    const eventName =
+      asString((obj as any).event) || asString((obj as any).name);
+    if (!eventName) throw new Error("Each event requires an event name");
+    return {
+      event: eventName,
+      properties: asRecord((obj as any).properties),
+      context: asRecord((obj as any).context),
+      userId: asString((obj as any).userId),
+      anonymousId: asString((obj as any).anonymousId),
+      sessionId: asString((obj as any).sessionId),
+      timestamp: (obj as any).timestamp,
+    };
+  });
+
+  return { publicKey, events };
+}
+
+export async function recordAnalyticsEvents(
+  publicKey: string,
+  events: IncomingAnalyticsEvent[],
+): Promise<{ accepted: number; keyId: string }> {
+  const db = getDb() as any;
+  // guard:allow-unscoped -- public ingestion must resolve the owning tenant from the submitted write key before it can scope inserts.
+  const [key] = await db
+    .select()
+    .from(schema.analyticsPublicKeys)
+    .where(
+      and(
+        eq(schema.analyticsPublicKeys.publicKey, publicKey),
+        isNull(schema.analyticsPublicKeys.revokedAt),
+      ),
+    )
+    .limit(1);
+  if (!key) {
+    throw new Error("Invalid analytics public key");
+  }
+
+  const receivedAt = nowIso();
+  const rows = events.map((event) => {
+    const properties = event.properties ?? {};
+    const context = event.context ?? {};
+    const url =
+      asString(properties.url) ||
+      asString((context as any).url) ||
+      asString((properties as any).href);
+    const parts = urlParts(url);
+    const hostname =
+      parts.hostname ||
+      asString(properties.hostname) ||
+      asString((context as any).hostname);
+    const app =
+      asString(properties.app) ||
+      asString((context as any).app) ||
+      (hostname ? hostname.split(".")[0] : null);
+    const template =
+      asString(properties.template) ||
+      asString((properties as any).templateId) ||
+      app;
+
+    return {
+      id: id("evt"),
+      publicKeyId: key.id,
+      eventName: event.event,
+      userId: event.userId ?? asString((properties as any).userId),
+      anonymousId:
+        event.anonymousId ??
+        asString((properties as any).anonymousId) ??
+        asString((properties as any).distinctId),
+      sessionId: event.sessionId ?? asString((properties as any).sessionId),
+      timestamp: normalizeTimestamp(event.timestamp),
+      receivedAt,
+      url: parts.url,
+      path: parts.path ?? asString(properties.path),
+      hostname,
+      referrer:
+        asString(properties.referrer) || asString((context as any).referrer),
+      app,
+      template,
+      properties: JSON.stringify(properties),
+      context: JSON.stringify(context),
+      ownerEmail: key.ownerEmail,
+      orgId: key.orgId ?? null,
+    };
+  });
+
+  if (rows.length) {
+    await db.insert(schema.analyticsEvents).values(rows);
+    await db
+      .update(schema.analyticsPublicKeys)
+      .set({ lastUsedAt: receivedAt })
+      .where(eq(schema.analyticsPublicKeys.id, key.id));
+  }
+
+  return { accepted: rows.length, keyId: key.id };
+}
+
+function stripSqlLiterals(sql: string): string {
+  let out = "";
+  let i = 0;
+  let inSingle = false;
+  let inDouble = false;
+  while (i < sql.length) {
+    const ch = sql[i];
+    const next = sql[i + 1];
+    if (!inSingle && !inDouble && ch === "-" && next === "-") {
+      while (i < sql.length && sql[i] !== "\n") i++;
+      out += " ";
+      continue;
+    }
+    if (!inSingle && !inDouble && ch === "/" && next === "*") {
+      i += 2;
+      while (i < sql.length && !(sql[i] === "*" && sql[i + 1] === "/")) i++;
+      i += 2;
+      out += " ";
+      continue;
+    }
+    if (!inDouble && ch === "'") {
+      out += " ";
+      if (inSingle && next === "'") {
+        i += 2;
+        continue;
+      }
+      inSingle = !inSingle;
+      i++;
+      continue;
+    }
+    if (!inSingle && ch === '"') {
+      out += " ";
+      inDouble = !inDouble;
+      i++;
+      continue;
+    }
+    out += inSingle || inDouble ? " " : ch;
+    i++;
+  }
+  return out;
+}
+
+export function validateFirstPartyAnalyticsSql(sql: string): void {
+  const stripped = stripSqlLiterals(sql).trim();
+  const lowered = stripped.toLowerCase();
+  if (!/^(select|with)\b/.test(lowered)) {
+    throw new Error(
+      "First-party analytics queries must start with SELECT or WITH",
+    );
+  }
+  if (stripped.includes(";")) {
+    throw new Error("Only a single SELECT statement is allowed");
+  }
+  if (
+    /\b(insert|update|delete|drop|alter|truncate|create|replace|pragma|attach|detach|vacuum|grant|revoke)\b/i.test(
+      stripped,
+    )
+  ) {
+    throw new Error("Only read-only SELECT queries are allowed");
+  }
+  if (stripped.includes("?")) {
+    throw new Error("Bind placeholders are not supported in dashboard SQL");
+  }
+
+  const cteNames = new Set<string>();
+  const cteRe = /\b([a-zA-Z_][a-zA-Z0-9_]*)\s+as\s*\(/gi;
+  for (const match of stripped.matchAll(cteRe)) {
+    cteNames.add(match[1].toLowerCase());
+  }
+
+  let usesAnalyticsEvents = false;
+  const tableRe =
+    /\b(?:from|join)\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)?)/gi;
+  for (const match of stripped.matchAll(tableRe)) {
+    const ref = match[1].toLowerCase();
+    if (ref === "analytics_events") {
+      usesAnalyticsEvents = true;
+      continue;
+    }
+    if (cteNames.has(ref)) continue;
+    throw new Error(
+      `First-party analytics queries can only read analytics_events (found ${match[1]})`,
+    );
+  }
+  if (!usesAnalyticsEvents) {
+    throw new Error("Query must read from analytics_events");
+  }
+}
+
+function scopeClause(scope: AnalyticsScope): {
+  sql: string;
+  args: Array<string | null>;
+} {
+  if (scope.orgId) {
+    return {
+      sql: "(org_id = ? OR (org_id IS NULL AND owner_email = ?))",
+      args: [scope.orgId, scope.userEmail],
+    };
+  }
+  return {
+    sql: "(org_id IS NULL AND owner_email = ?)",
+    args: [scope.userEmail],
+  };
+}
+
+function scopedAnalyticsSql(
+  sql: string,
+  scope: AnalyticsScope,
+): { sql: string; args: Array<string | null> } {
+  const args: Array<string | null> = [];
+  const aliasRe =
+    /\b(from|join)\s+analytics_events\b(\s+(?:as\s+)?(?!where\b|on\b|group\b|order\b|limit\b|join\b|left\b|right\b|inner\b|outer\b|cross\b|full\b|having\b|union\b)([a-zA-Z_][a-zA-Z0-9_]*))?/gi;
+  const rewritten = sql.replace(aliasRe, (full, keyword, aliasPart, alias) => {
+    const normalizedAlias =
+      typeof alias === "string" ? alias.toLowerCase() : "";
+    const usableAlias =
+      aliasPart && normalizedAlias && !RESERVED_ALIAS_WORDS.has(normalizedAlias)
+        ? aliasPart
+        : " AS analytics_events";
+    const scopeDef = scopeClause(scope);
+    args.push(...scopeDef.args);
+    return `${keyword} (SELECT * FROM analytics_events WHERE ${scopeDef.sql})${usableAlias}`;
+  });
+  return { sql: rewritten, args };
+}
+
+function valueType(value: unknown): string {
+  if (typeof value === "number") return "number";
+  if (typeof value === "boolean") return "boolean";
+  return "string";
+}
+
+function inferSchema(rows: Record<string, unknown>[]): {
+  name: string;
+  type: string;
+}[] {
+  const first = rows.find((row) => row && typeof row === "object");
+  if (!first) return [];
+  return Object.entries(first).map(([name, value]) => ({
+    name,
+    type: valueType(value),
+  }));
+}
+
+export async function queryFirstPartyAnalytics(
+  sql: string,
+  scope: AnalyticsScope,
+): Promise<AnalyticsQueryResult> {
+  validateFirstPartyAnalyticsSql(sql);
+  const scoped = scopedAnalyticsSql(sql, scope);
+  const exec = getDbExec();
+  const result = await exec.execute({
+    sql: `SELECT * FROM (${scoped.sql}) AS first_party_analytics_query LIMIT ${MAX_QUERY_ROWS}`,
+    args: scoped.args,
+  });
+  const rows = result.rows as Record<string, unknown>[];
+  return { rows, schema: inferSchema(rows) };
+}

--- a/templates/analytics/server/lib/first-party-analytics.ts
+++ b/templates/analytics/server/lib/first-party-analytics.ts
@@ -287,6 +287,11 @@ export async function recordAnalyticsEvents(
       asString(properties.template) ||
       asString((properties as any).templateId) ||
       app;
+    const signedIn =
+      asString((properties as any).signed_in) ||
+      asString((properties as any).signedIn) ||
+      asString((context as any).signed_in) ||
+      asString((context as any).signedIn);
 
     return {
       id: id("evt"),
@@ -307,6 +312,7 @@ export async function recordAnalyticsEvents(
         asString(properties.referrer) || asString((context as any).referrer),
       app,
       template,
+      signedIn,
       properties: JSON.stringify(properties),
       context: JSON.stringify(context),
       ownerEmail: key.ownerEmail,

--- a/templates/analytics/server/plugins/db.ts
+++ b/templates/analytics/server/plugins/db.ts
@@ -103,6 +103,63 @@ export default runMigrations(
       version: 10,
       sql: `CREATE INDEX IF NOT EXISTS dashboard_views_dashboard_idx ON dashboard_views (dashboard_id)`,
     },
+    {
+      version: 11,
+      sql: `CREATE TABLE IF NOT EXISTS analytics_public_keys (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      public_key TEXT NOT NULL,
+      public_key_prefix TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      last_used_at TEXT,
+      revoked_at TEXT,
+      owner_email TEXT NOT NULL DEFAULT 'local@localhost',
+      org_id TEXT
+    )`,
+    },
+    {
+      version: 12,
+      sql: `CREATE UNIQUE INDEX IF NOT EXISTS analytics_public_keys_key_idx ON analytics_public_keys (public_key)`,
+    },
+    {
+      version: 13,
+      sql: `CREATE INDEX IF NOT EXISTS analytics_public_keys_owner_idx ON analytics_public_keys (owner_email, org_id)`,
+    },
+    {
+      version: 14,
+      sql: `CREATE TABLE IF NOT EXISTS analytics_events (
+      id TEXT PRIMARY KEY,
+      public_key_id TEXT NOT NULL,
+      event_name TEXT NOT NULL,
+      user_id TEXT,
+      anonymous_id TEXT,
+      session_id TEXT,
+      timestamp TEXT NOT NULL,
+      received_at TEXT NOT NULL DEFAULT (datetime('now')),
+      url TEXT,
+      path TEXT,
+      hostname TEXT,
+      referrer TEXT,
+      app TEXT,
+      template TEXT,
+      properties TEXT NOT NULL DEFAULT '{}',
+      context TEXT NOT NULL DEFAULT '{}',
+      owner_email TEXT NOT NULL DEFAULT 'local@localhost',
+      org_id TEXT
+    )`,
+    },
+    {
+      version: 15,
+      sql: `CREATE INDEX IF NOT EXISTS analytics_events_scope_time_idx ON analytics_events (org_id, owner_email, timestamp)`,
+    },
+    {
+      version: 16,
+      sql: `CREATE INDEX IF NOT EXISTS analytics_events_event_time_idx ON analytics_events (event_name, timestamp)`,
+    },
+    {
+      version: 17,
+      sql: `CREATE INDEX IF NOT EXISTS analytics_events_key_idx ON analytics_events (public_key_id)`,
+    },
   ],
   { table: "analytics_migrations" },
 );

--- a/templates/analytics/server/plugins/db.ts
+++ b/templates/analytics/server/plugins/db.ts
@@ -142,6 +142,7 @@ export default runMigrations(
       referrer TEXT,
       app TEXT,
       template TEXT,
+      signed_in TEXT,
       properties TEXT NOT NULL DEFAULT '{}',
       context TEXT NOT NULL DEFAULT '{}',
       owner_email TEXT NOT NULL DEFAULT 'local@localhost',
@@ -159,6 +160,10 @@ export default runMigrations(
     {
       version: 17,
       sql: `CREATE INDEX IF NOT EXISTS analytics_events_key_idx ON analytics_events (public_key_id)`,
+    },
+    {
+      version: 18,
+      sql: `ALTER TABLE analytics_events ADD COLUMN IF NOT EXISTS signed_in TEXT`,
     },
   ],
   { table: "analytics_migrations" },

--- a/templates/analytics/server/routes/api/analytics/track.options.ts
+++ b/templates/analytics/server/routes/api/analytics/track.options.ts
@@ -1,0 +1,1 @@
+export { handleAnalyticsTrackOptions as default } from "../../../handlers/first-party-analytics";

--- a/templates/analytics/server/routes/api/analytics/track.post.ts
+++ b/templates/analytics/server/routes/api/analytics/track.post.ts
@@ -1,0 +1,1 @@
+export { handleAnalyticsTrack as default } from "../../../handlers/first-party-analytics";

--- a/templates/analytics/server/routes/track.options.ts
+++ b/templates/analytics/server/routes/track.options.ts
@@ -1,0 +1,1 @@
+export { handleAnalyticsTrackOptions as default } from "../handlers/first-party-analytics";

--- a/templates/analytics/server/routes/track.post.ts
+++ b/templates/analytics/server/routes/track.post.ts
@@ -1,0 +1,1 @@
+export { handleAnalyticsTrack as default } from "../handlers/first-party-analytics";

--- a/templates/clips/app/components/player/transcript-panel.tsx
+++ b/templates/clips/app/components/player/transcript-panel.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { msToClock } from "./scrubber";
-import { agentNativePath } from "@agent-native/core/client";
+import { agentNativePath, getCallbackOrigin } from "@agent-native/core/client";
 
 export interface TranscriptSegment {
   startMs: number;
@@ -303,6 +303,7 @@ function TranscriptSetupCard({
     kind: "ok" | "err";
     text: string;
   } | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -319,6 +320,7 @@ function TranscriptSetupCard({
     return () => {
       mountedRef.current = false;
       if (pollRef.current) clearInterval(pollRef.current);
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
     };
   }, []);
 
@@ -327,10 +329,11 @@ function TranscriptSetupCard({
     setConnecting(true);
     setConnectError(null);
 
+    const origin = getCallbackOrigin() || window.location.origin;
     window.open(
       new URL(
         agentNativePath("/_agent-native/builder/connect"),
-        window.location.origin,
+        origin,
       ).toString(),
       "_blank",
       "noopener,noreferrer",
@@ -380,11 +383,13 @@ function TranscriptSetupCard({
           body: JSON.stringify({ value: apiKey.trim() }),
         },
       );
+      if (!mountedRef.current) return;
       if (!res.ok) {
         const err = await res
           .json()
           .then((j: { error?: string }) => j.error)
           .catch(() => null);
+        if (!mountedRef.current) return;
         setSaveToast({
           kind: "err",
           text: err ?? `Save failed (${res.status})`,
@@ -394,9 +399,13 @@ function TranscriptSetupCard({
       setApiKey("");
       setSaveToast({ kind: "ok", text: "Saved. Retrying transcription…" });
       onRetry?.();
-      setTimeout(() => setSaveToast(null), 2500);
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = setTimeout(() => {
+        if (mountedRef.current) setSaveToast(null);
+        toastTimerRef.current = null;
+      }, 2500);
     } finally {
-      setSaving(false);
+      if (mountedRef.current) setSaving(false);
     }
   }
 
@@ -484,91 +493,95 @@ function TranscriptSetupCard({
           )}
         </div>
 
-        {/* BYOK — secondary option, collapsed by default */}
-        {!builderConfigured && (
-          <div>
-            <button
-              type="button"
-              onClick={() => setShowByok((v) => !v)}
-              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <IconKey className="h-3.5 w-3.5" />
-              {isProviderError
-                ? "Update your API key"
+        {/* BYOK — secondary option, collapsed by default. Shown even when
+            Builder is connected so users can fall back if Builder
+            transcription itself fails (quota / outage / unsupported audio
+            format) — the failure message tells them to add a key, so the
+            input must be reachable. */}
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowByok((v) => !v)}
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <IconKey className="h-3.5 w-3.5" />
+            {isProviderError
+              ? "Update your API key"
+              : builderConfigured
+                ? "Add a fallback API key (Groq / OpenAI)"
                 : "Or use your own API key (Groq / OpenAI)"}
-              {showByok ? (
-                <IconChevronUp className="h-3 w-3" />
-              ) : (
-                <IconChevronDown className="h-3 w-3" />
-              )}
-            </button>
-
-            {showByok && (
-              <div className="mt-2 space-y-2 pl-1">
-                <p className="text-[11px] text-muted-foreground">
-                  Groq key starts with <code className="font-mono">gsk_</code>{" "}
-                  (fast, recommended) or OpenAI starts with{" "}
-                  <code className="font-mono">sk-</code>.
-                </p>
-                <div className="flex gap-1.5">
-                  <Input
-                    type="password"
-                    value={apiKey}
-                    onChange={(e) => setApiKey(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") saveApiKey();
-                    }}
-                    placeholder="gsk_… or sk-…"
-                    className="h-8 text-xs"
-                  />
-                  <Button
-                    size="sm"
-                    onClick={saveApiKey}
-                    disabled={!apiKey.trim() || saving}
-                  >
-                    {saving ? (
-                      <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      "Save"
-                    )}
-                  </Button>
-                </div>
-                <div className="flex items-center gap-3">
-                  <a
-                    href="https://console.groq.com/keys"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
-                  >
-                    Get Groq key
-                    <IconExternalLink className="h-3 w-3" />
-                  </a>
-                  <a
-                    href="https://platform.openai.com/api-keys"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
-                  >
-                    Get OpenAI key
-                    <IconExternalLink className="h-3 w-3" />
-                  </a>
-                </div>
-                {saveToast && (
-                  <p
-                    className={cn(
-                      "text-[11px]",
-                      saveToast.kind === "ok"
-                        ? "text-green-600"
-                        : "text-destructive",
-                    )}
-                  >
-                    {saveToast.text}
-                  </p>
-                )}
-              </div>
+            {showByok ? (
+              <IconChevronUp className="h-3 w-3" />
+            ) : (
+              <IconChevronDown className="h-3 w-3" />
             )}
-          </div>
-        )}
+          </button>
+
+          {showByok && (
+            <div className="mt-2 space-y-2 pl-1">
+              <p className="text-[11px] text-muted-foreground">
+                Groq key starts with <code className="font-mono">gsk_</code>{" "}
+                (fast, recommended) or OpenAI starts with{" "}
+                <code className="font-mono">sk-</code>.
+              </p>
+              <div className="flex gap-1.5">
+                <Input
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") saveApiKey();
+                  }}
+                  placeholder="gsk_… or sk-…"
+                  className="h-8 text-xs"
+                />
+                <Button
+                  size="sm"
+                  onClick={saveApiKey}
+                  disabled={!apiKey.trim() || saving}
+                >
+                  {saving ? (
+                    <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    "Save"
+                  )}
+                </Button>
+              </div>
+              <div className="flex items-center gap-3">
+                <a
+                  href="https://console.groq.com/keys"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+                >
+                  Get Groq key
+                  <IconExternalLink className="h-3 w-3" />
+                </a>
+                <a
+                  href="https://platform.openai.com/api-keys"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+                >
+                  Get OpenAI key
+                  <IconExternalLink className="h-3 w-3" />
+                </a>
+              </div>
+              {saveToast && (
+                <p
+                  className={cn(
+                    "text-[11px]",
+                    saveToast.kind === "ok"
+                      ? "text-green-600"
+                      : "text-destructive",
+                  )}
+                >
+                  {saveToast.text}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -137,13 +137,19 @@ export function App() {
     return saved === "toggle" ? "toggle" : "push-to-talk";
   });
   const [voiceProvider, setVoiceProvider] = useState<VoiceProvider>(() => {
-    // Default to "browser" — local on-device dictation via the macOS
-    // Speech framework. No server round-trip, no "Polishing..." step,
-    // no API keys. Users wanting cloud-quality can pick a server
-    // provider in Settings → Voice transcription.
-    const saved = loadString(VOICE_PROVIDER_KEY, "browser");
     const isMac =
       typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+    // Default: macOS gets the native path (SFSpeechRecognizer +
+    // AVAudioEngine driven from Rust) — cleanly releases the mic on
+    // stop, no "Polishing..." step, no API keys. WKWebView's
+    // webkitSpeechRecognition keeps the orange mic indicator on after
+    // abort, so we route Mac users away from it by default. Windows /
+    // Linux fall back to the browser path until we add a native
+    // equivalent there.
+    const saved = loadString(
+      VOICE_PROVIDER_KEY,
+      isMac ? "macos-native" : "browser",
+    );
     // `macos-native` calls into native_speech_start which only works on
     // macOS; on Windows/Linux a saved selection would be permanently
     // broken. Coerce back to "browser" if we're not on a Mac.
@@ -156,7 +162,9 @@ export function App() {
       saved === "openai" ||
       saved === "groq"
       ? saved
-      : "browser";
+      : isMac
+        ? "macos-native"
+        : "browser";
   });
 
   const [recordings, setRecordings] = useState<RecordingSummary[]>([]);

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -686,46 +686,26 @@ export function installDesktopVoiceDictation(
     try {
       startInFlight = true;
       stopRequestedBeforeReady = false;
-      // Open a parallel mic stream JUST for the live audio meter. This
-      // is safe with the native path because SFSpeechRecognizer's audio
-      // capture lives in Rust (AVAudioEngine, separate bus) — multiple
-      // mic consumers coexist fine on macOS. We deliberately don't do
-      // this on the browser path because webkitSpeechRecognition fights
-      // a sibling getUserMedia in WKWebView.
-      //
-      // Disable echoCancellation / noiseSuppression / autoGainControl so
-      // we stay in standard mic mode. With them ON, macOS may switch
-      // into voice-call mode which conflicts with AVAudioEngine's
-      // input bus and causes getUserMedia to silently return a dead
-      // stream that produces no audio levels.
-      const meterStream = await navigator.mediaDevices
-        .getUserMedia({
-          audio: {
-            echoCancellation: false,
-            noiseSuppression: false,
-            autoGainControl: false,
-          },
-        })
-        .catch((err) => {
-          console.warn(
-            `[voice-dictation] meter getUserMedia failed (${(err as Error)?.name ?? "Error"}): ${(err as Error)?.message ?? String(err)} — falling back to synthetic meter`,
-          );
-          return null;
-        });
-      if (meterStream) {
-        const tracks = meterStream.getAudioTracks();
-        console.log(
-          `[voice-dictation] meter mic ready: ${tracks.length} track(s)`,
-          tracks[0]?.label || "unlabeled",
-        );
-      }
+      // No parallel meter mic — Rust's AVAudioEngine is the only mic
+      // consumer in this path. We previously opened a sibling
+      // getUserMedia stream so the AnalyserNode could drive a voice-
+      // tracking waveform, but having two consumers on macOS turned out
+      // to (a) sometimes return a dead stream that produced flat zero
+      // levels (so the waveform looked frozen), and (b) keep the orange
+      // mic indicator lit after teardown — `track.stop()` didn't fully
+      // release once the stream entered the degraded state. The
+      // synthetic meter pulses the bars at a low amplitude so the bar
+      // still reads as "listening". Voice-tracking levels can come back
+      // later by having Rust compute RMS in the installTapOnBus block
+      // and emit `voice:audio-level` events from there — single mic
+      // consumer = clean release + real levels.
       await invoke("show_flow_bar");
       setFlowState("recording");
       // Reset any prior partial transcript display in the flow-bar.
       emit("voice:partial-transcript", { text: "" }).catch(() => {});
       const next: VoiceSession = {
         kind: "native",
-        stream: meterStream,
+        stream: null,
         recorder: null,
         chunks: [],
         audioContext: null,
@@ -741,15 +721,7 @@ export function installDesktopVoiceDictation(
       };
       session = next;
       startInFlight = false;
-      // Real audio meter from the parallel mic stream — bars bounce with
-      // the user's voice + volume. Falls back to synthetic if the mic
-      // stream couldn't be opened (e.g. permission denied just for
-      // getUserMedia).
-      if (meterStream) {
-        startMeter(next);
-      } else {
-        startSyntheticMeter(next);
-      }
+      startSyntheticMeter(next);
       try {
         await invoke("native_speech_start", {
           locale: navigator.language || "en-US",

--- a/templates/slides/app/components/deck/SlideRenderer.tsx
+++ b/templates/slides/app/components/deck/SlideRenderer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Slide } from "@/context/DeckContext";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -110,8 +110,6 @@ const markdownComponents = {
 
 /** Renders blank slide HTML content and applies white filter to logo images */
 function BlankSlideContent({ content }: { content: string }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-
   // Memoize derived strings + the dangerouslySetInnerHTML object on `content` so
   // the prop value has a stable reference across re-renders. React 19 only checks
   // reference equality on `dangerouslySetInnerHTML` and unconditionally re-assigns
@@ -168,7 +166,6 @@ function BlankSlideContent({ content }: { content: string }) {
 
   return (
     <div
-      ref={containerRef}
       className="slide-content text-white/90 w-full block h-full"
       dangerouslySetInnerHTML={dangerousHtml}
     />

--- a/templates/slides/app/components/design-system/DesignSystemSetup.tsx
+++ b/templates/slides/app/components/design-system/DesignSystemSetup.tsx
@@ -222,6 +222,15 @@ export function DesignSystemSetup({
       return;
     }
 
+    // Cap inlined file content so a giant pasted README doesn't blow the
+    // prompt budget. Append a marker so the agent doesn't treat the
+    // truncation point as the end of the document.
+    const TEXT_INLINE_MAX = 5000;
+    const inlineText = (text: string) =>
+      text.length > TEXT_INLINE_MAX
+        ? `${text.slice(0, TEXT_INLINE_MAX)}\n…[truncated, ${text.length - TEXT_INLINE_MAX} more chars]`
+        : text;
+
     const parts: string[] = [];
     parts.push(
       "Set up a design system from the following sources. Analyze each source, extract design tokens (colors, fonts, spacing, borders), and create a cohesive design system for my slide decks.",
@@ -251,7 +260,7 @@ export function DesignSystemSetup({
         );
         for (const f of withContent) {
           parts.push(
-            `\n### ${f.name}\n\`\`\`\n${f.textContent!.slice(0, 5000)}\n\`\`\``,
+            `\n### ${f.name}\n\`\`\`\n${inlineText(f.textContent!)}\n\`\`\``,
           );
         }
       }
@@ -266,7 +275,7 @@ export function DesignSystemSetup({
         );
         for (const f of inlined) {
           parts.push(
-            `\n### ${f.name}\n\`\`\`\n${f.textContent!.slice(0, 5000)}\n\`\`\``,
+            `\n### ${f.name}\n\`\`\`\n${inlineText(f.textContent!)}\n\`\`\``,
           );
         }
       }


### PR DESCRIPTION
## Summary

Concurrent agent sweep — substantial updates across analytics, framework core, and templates.

### Analytics
- First-party analytics tracking pipeline (\`templates/analytics/server/lib/first-party-analytics.ts\`, new track endpoints, dashboard seed)
- SQL handlers + dashboards updates
- New \`agent-native-templates-first-party.json\` dashboard seed
- BigQuery / data-querying skill docs updated

### Framework core
- Tracking providers refactor + tests
- Onboarding panel + default-steps updates
- Settings panel + Builder transcription CTA polish
- Core routes plugin + security headers tweaks
- Deploy build path adjustments

### Clips desktop + slides
- Voice-dictation refinements
- Player transcript panel polish
- Slides renderer + design-system setup

## Test plan
- [ ] CI: Lint, Test, Typecheck, Build, Scaffold E2E, Guard all green
- [ ] Analytics first-party tracking endpoint receives events
- [ ] Onboarding panel still renders correctly
- [ ] Voice dictation still works