### PR TITLE
Daily branch: tool-search agent + analytics tests + auth refinements

### DIFF
--- a/.agents/skills/tracking/SKILL.md
+++ b/.agents/skills/tracking/SKILL.md
@@ -82,6 +82,24 @@ Multiple providers can be active simultaneously. All receive every event.
 
 Browser-side `trackEvent()` also forwards to Agent Native Analytics when `VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY` is present. Use `VITE_AGENT_NATIVE_ANALYTICS_ENDPOINT` to override the default browser endpoint. The built-in Agent Native Analytics sender is quiet on localhost/local dev by default; set `AGENT_NATIVE_ANALYTICS_ALLOW_LOCALHOST=true` only for an intentional local ingestion test.
 
+## Default Baseline Events
+
+Template roots call `configureTracking()` once during app startup. That installs default browser pageview tracking for hosted apps:
+
+- Event: `pageview`
+- Fires on initial load, `history.pushState`, `history.replaceState`, and `popstate`
+- De-dupes repeated events for the same URL
+- Includes `url`, `path`, `hostname`, `referrer`, `title`, `navigation_type`, `app`, and inferred `template`
+- Does not send first-party events from localhost/local dev
+
+Other framework-level baseline events:
+
+- `session status` from `useSession()`, with `signed_in`
+- `signup` from Better Auth user creation, with `auth_provider` and `auth_user_id`
+- `builder connect started`, `builder connect succeeded`, `builder connect failed`, `builder disconnect succeeded`, and `builder disconnect failed` from the Builder connection routes
+
+For new lifecycle events, call `track()` server-side when the server is the source of truth, and `trackEvent()` client-side only for browser interactions.
+
 ## Provider Interface
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Create and edit visual designs by prompt or by hand, with the agent as your co-d
 
 **Mission control for agent-native apps**
 
-Centralized messaging and management for every agent in your stack. Talk to your agents from Slack, Telegram, or the web; route jobs, hold memory, approve actions, and delegate across apps.
+Message, manage, and delegate to agents from Slack, Telegram, or the web, with routing, memory, and approvals built in.
 
 </td>
 </tr>

--- a/packages/core/docs/content/mcp-clients.md
+++ b/packages/core/docs/content/mcp-clients.md
@@ -49,7 +49,7 @@ On next app start you'll see:
 [mcp-client] connected to filesystem: 4 tools
 ```
 
-The tools are registered in the agent's tool registry with the prefix `mcp__<server-id>__<tool-name>` so they can't collide with your template's actions.
+The tools are registered in the agent's tool registry with the prefix `mcp__<server-id>__<tool-name>` so they can't collide with your template's actions. They are also included in `tool-search`, so agents can discover newly connected MCP capabilities by intent instead of needing the exact prefixed name up front.
 
 ## Config precedence {#precedence}
 
@@ -95,7 +95,7 @@ Two scopes are supported:
 - **Personal** — only the signed-in user gets the tools. Stored as a user-scope setting.
 - **Team** — everyone in the active organization gets the tools. Owners and admins can add; members see the list read-only. Stored as an org-scope setting.
 
-Adds and removes hot-reload into the running MCP manager — no process restart, and no server restart. The new `mcp__<scope>-<name>__*` tools appear to the agent on the next message.
+Adds and removes hot-reload into the running MCP manager — no process restart, and no server restart. The new `mcp__<scope>-<name>__*` tools appear to the agent on the next message and are searchable via `tool-search`.
 
 HTTPS URLs are accepted everywhere; plain `http://` is only allowed for `localhost` during development. Optional auth goes in as a Bearer token that's sent via `Authorization: Bearer …` on every request.
 

--- a/packages/core/src/agent/tool-search.spec.ts
+++ b/packages/core/src/agent/tool-search.spec.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ActionEntry } from "./production-agent.js";
+import { attachToolSearch, searchToolRegistry } from "./tool-search.js";
+
+function action(
+  description: string,
+  properties: Record<string, unknown> = {},
+  required: string[] = [],
+): ActionEntry {
+  return {
+    tool: {
+      description,
+      parameters: {
+        type: "object",
+        properties,
+        required,
+      },
+    },
+    http: false,
+    readOnly: true,
+    run: async () => "(ok)",
+  };
+}
+
+describe("tool-search", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("searches action names, descriptions, and parameter metadata", () => {
+    const registry = {
+      "send-email": action(
+        "Send an email message",
+        {
+          to: { type: "string", description: "Recipient email address" },
+          subject: { type: "string", description: "Email subject line" },
+        },
+        ["to"],
+      ),
+      "list-events": action("List calendar events"),
+    };
+
+    const result = searchToolRegistry(registry, {
+      query: "email subject",
+      limit: 1,
+    });
+
+    expect(result.count).toBe(1);
+    expect(result.results[0]).toMatchObject({
+      name: "send-email",
+      kind: "action",
+      parameters: [
+        {
+          name: "to",
+          type: "string",
+          required: true,
+        },
+        {
+          name: "subject",
+          type: "string",
+          required: false,
+        },
+      ],
+    });
+  });
+
+  it("includes connected MCP tools and reports their source server", async () => {
+    const registry = attachToolSearch({
+      mcp__zapier__send_slack_message: action(
+        "Send a Slack message through Zapier",
+        {
+          channel: { type: "string", description: "Slack channel" },
+          text: { type: "string", description: "Message body" },
+        },
+        ["channel", "text"],
+      ),
+    });
+
+    const result = await registry["tool-search"].run({
+      query: "zapier slack",
+      includeSchemas: "true",
+    } as any);
+
+    expect(result.results[0]).toMatchObject({
+      name: "mcp__zapier__send_slack_message",
+      kind: "mcp",
+      source: "zapier",
+    });
+    expect(result.results[0].inputSchema).toMatchObject({
+      properties: {
+        channel: { type: "string" },
+      },
+    });
+  });
+
+  it("searches the live registry after MCP tools are added", async () => {
+    const registry = attachToolSearch({
+      "list-documents": action("List documents"),
+    });
+
+    expect(
+      await registry["tool-search"].run({ query: "browser screenshot" } as any),
+    ).toMatchObject({ count: 0 });
+
+    registry["mcp__chrome__take_screenshot"] = action(
+      "Take a browser screenshot",
+    );
+
+    const result = await registry["tool-search"].run({
+      query: "browser screenshot",
+    } as any);
+
+    expect(result.results.map((tool) => tool.name)).toContain(
+      "mcp__chrome__take_screenshot",
+    );
+  });
+
+  it("honors MCP request visibility for scoped connected servers", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const registry = {
+      mcp__user_deadbeef00_zapier__send_slack_message: action(
+        "Send a Slack message through Zapier",
+      ),
+    };
+
+    const result = searchToolRegistry(registry, {
+      query: "zapier slack",
+    });
+
+    expect(result).toMatchObject({ totalTools: 0, count: 0, results: [] });
+  });
+});

--- a/packages/core/src/agent/tool-search.ts
+++ b/packages/core/src/agent/tool-search.ts
@@ -1,0 +1,281 @@
+import type { ActionEntry } from "./production-agent.js";
+import { parseMcpToolName } from "../mcp-client/manager.js";
+import { isMcpToolAllowedForRequest } from "../mcp-client/visibility.js";
+
+export const TOOL_SEARCH_ACTION_NAME = "tool-search";
+
+type ToolSearchArgs = {
+  query?: unknown;
+  limit?: unknown;
+  includeSchemas?: unknown;
+};
+
+type ToolParameterSummary = {
+  name: string;
+  type?: string;
+  required: boolean;
+  description?: string;
+  enum?: string[];
+};
+
+type ToolSearchResult = {
+  name: string;
+  kind: "action" | "mcp";
+  source?: string;
+  description: string;
+  score: number;
+  parameters: ToolParameterSummary[];
+  inputSchema?: unknown;
+};
+
+type ToolSearchOptions = {
+  defaultLimit?: number;
+  maxLimit?: number;
+};
+
+const DEFAULT_LIMIT = 8;
+const MAX_LIMIT = 25;
+
+export function createToolSearchEntry(
+  getRegistry: () => Record<string, ActionEntry>,
+  options: ToolSearchOptions = {},
+): ActionEntry {
+  return {
+    tool: {
+      description:
+        "Search the live registry of callable tools/actions, including connected MCP server tools named `mcp__<server>__<tool>`. Use this when you need a capability but are not sure which tool to call, especially after users connect new MCP servers. Returns exact tool names and parameter summaries so you can call the matching tool directly.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "What capability to find, e.g. `send slack message`, `create calendar event`, `zapier gmail`, or `browser screenshot`.",
+          },
+          limit: {
+            type: "number",
+            description: `Maximum results to return. Defaults to ${options.defaultLimit ?? DEFAULT_LIMIT}.`,
+          } as any,
+          includeSchemas: {
+            type: "boolean",
+            description:
+              "When true, include each matching tool's full input schema. Default false.",
+          } as any,
+        },
+        required: ["query"],
+      },
+    },
+    http: false,
+    readOnly: true,
+    run: async (args: Record<string, string>) =>
+      searchToolRegistry(getRegistry(), args, options),
+  };
+}
+
+export function attachToolSearch(
+  registry: Record<string, ActionEntry>,
+  options: ToolSearchOptions = {},
+): Record<string, ActionEntry> {
+  registry[TOOL_SEARCH_ACTION_NAME] = createToolSearchEntry(
+    () => registry,
+    options,
+  );
+  return registry;
+}
+
+export function searchToolRegistry(
+  registry: Record<string, ActionEntry>,
+  args: ToolSearchArgs = {},
+  options: ToolSearchOptions = {},
+): {
+  query: string;
+  totalTools: number;
+  count: number;
+  results: ToolSearchResult[];
+} {
+  const query = String(args.query ?? "").trim();
+  const includeSchemas = parseBoolean(args.includeSchemas);
+  const limit = parseLimit(
+    args.limit,
+    options.defaultLimit ?? DEFAULT_LIMIT,
+    options.maxLimit ?? MAX_LIMIT,
+  );
+  const queryTokens = tokenize(query);
+
+  const candidates: ToolSearchResult[] = [];
+  let totalTools = 0;
+
+  for (const [name, entry] of Object.entries(registry)) {
+    if (!entry?.tool || name === TOOL_SEARCH_ACTION_NAME) continue;
+    if (name.startsWith("mcp__") && !isMcpToolAllowedForRequest(name)) {
+      continue;
+    }
+
+    totalTools++;
+    const description = normalizeWhitespace(entry.tool.description ?? "");
+    const parameters = summarizeParameters(entry.tool.parameters);
+    const parsedMcp = parseMcpToolName(name);
+    const kind = parsedMcp ? "mcp" : "action";
+    const source = parsedMcp?.serverId;
+    const score = scoreTool({
+      query,
+      queryTokens,
+      name,
+      source,
+      description,
+      parameters,
+      kind,
+    });
+
+    if (queryTokens.length > 0 && score <= 0) continue;
+
+    candidates.push({
+      name,
+      kind,
+      ...(source ? { source } : {}),
+      description,
+      score,
+      parameters,
+      ...(includeSchemas ? { inputSchema: entry.tool.parameters ?? {} } : {}),
+    });
+  }
+
+  candidates.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.name.localeCompare(b.name);
+  });
+
+  return {
+    query,
+    totalTools,
+    count: Math.min(candidates.length, limit),
+    results: candidates.slice(0, limit),
+  };
+}
+
+function parseLimit(value: unknown, fallback: number, max: number): number {
+  const n =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : fallback;
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.max(1, Math.min(max, Math.floor(n)));
+}
+
+function parseBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "true" || normalized === "1" || normalized === "yes";
+}
+
+function summarizeParameters(schema: unknown): ToolParameterSummary[] {
+  if (!schema || typeof schema !== "object") return [];
+  const obj = schema as {
+    properties?: Record<string, unknown>;
+    required?: unknown;
+  };
+  const properties = obj.properties;
+  if (!properties || typeof properties !== "object") return [];
+  const required = new Set(
+    Array.isArray(obj.required)
+      ? obj.required.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [],
+  );
+
+  return Object.entries(properties).map(([name, raw]) => {
+    const prop =
+      raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+    const enumValues = Array.isArray(prop.enum)
+      ? prop.enum.map((value) => String(value)).slice(0, 20)
+      : undefined;
+    return {
+      name,
+      type: summarizeType(prop.type),
+      required: required.has(name),
+      description:
+        typeof prop.description === "string"
+          ? normalizeWhitespace(prop.description)
+          : undefined,
+      ...(enumValues && enumValues.length > 0 ? { enum: enumValues } : {}),
+    };
+  });
+}
+
+function summarizeType(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    const parts = value.filter((v): v is string => typeof v === "string");
+    return parts.length > 0 ? parts.join(" | ") : undefined;
+  }
+  return undefined;
+}
+
+function scoreTool(input: {
+  query: string;
+  queryTokens: string[];
+  name: string;
+  source?: string;
+  description: string;
+  parameters: ToolParameterSummary[];
+  kind: "action" | "mcp";
+}): number {
+  if (input.queryTokens.length === 0) return 1;
+
+  const name = searchableText(input.name);
+  const source = searchableText(input.source ?? "");
+  const description = searchableText(input.description);
+  const params = searchableText(
+    input.parameters
+      .map((p) => `${p.name} ${p.type ?? ""} ${p.description ?? ""}`)
+      .join(" "),
+  );
+  const all = `${name} ${source} ${description} ${params} ${input.kind}`;
+  const phrase = searchableText(input.query);
+
+  let score = 0;
+  if (name.includes(phrase)) score += 14;
+  if (source && source.includes(phrase)) score += 10;
+  if (description.includes(phrase)) score += 8;
+  if (params.includes(phrase)) score += 5;
+
+  for (const token of input.queryTokens) {
+    if (name.split(" ").includes(token)) score += 9;
+    else if (name.includes(token)) score += 6;
+
+    if (source) {
+      if (source.split(" ").includes(token)) score += 6;
+      else if (source.includes(token)) score += 3;
+    }
+
+    if (description.includes(token)) score += 3;
+    if (params.includes(token)) score += 2;
+    if (all.includes(token)) score += 1;
+  }
+
+  return score;
+}
+
+function tokenize(value: string): string[] {
+  const seen = new Set<string>();
+  for (const token of searchableText(value).split(" ")) {
+    if (token.length > 0) seen.add(token);
+  }
+  return Array.from(seen);
+}
+
+function searchableText(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -9,6 +9,7 @@ import { isTrustedFrameMessage } from "./frame.js";
 import { cn } from "./utils.js";
 import { useChatThreads, type ChatThreadSummary } from "./use-chat-threads.js";
 import { agentNativePath } from "./api-path.js";
+import { DEFAULT_MODEL } from "../agent/default-model.js";
 
 interface EngineModelGroup {
   engine: string;
@@ -331,7 +332,7 @@ export function MultiTabAssistantChat({
   const [availableModels, setAvailableModels] = useState<EngineModelGroup[]>(
     [],
   );
-  const [defaultModel, setDefaultModel] = useState("claude-sonnet-4-6");
+  const [defaultModel, setDefaultModel] = useState(DEFAULT_MODEL);
   const threadModelRef = useRef<Map<string, { model: string; engine: string }>>(
     new Map(),
   );
@@ -480,7 +481,7 @@ export function MultiTabAssistantChat({
             });
         }
         setAvailableModels(groups);
-        setDefaultModel(currentModel ?? "claude-sonnet-4-6");
+        setDefaultModel(currentModel ?? DEFAULT_MODEL);
       })
       .catch(() => {});
   }, []);

--- a/packages/core/src/client/analytics.spec.ts
+++ b/packages/core/src/client/analytics.spec.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const pageviewStateKey = Symbol.for("agent-native.client.pageviewTracking");
+
+function resetPageviewState() {
+  delete (globalThis as any)[pageviewStateKey];
+}
+
+function setLocation(
+  location: {
+    href: string;
+    origin: string;
+    hostname: string;
+    pathname: string;
+    search: string;
+    hash: string;
+  },
+  next: string,
+) {
+  const url = new URL(next, location.href);
+  location.href = url.href;
+  location.origin = url.origin;
+  location.hostname = url.hostname;
+  location.pathname = url.pathname;
+  location.search = url.search;
+  location.hash = url.hash;
+}
+
+async function tick() {
+  await Promise.resolve();
+}
+
+async function freshAnalytics() {
+  vi.resetModules();
+  return import("./analytics.js");
+}
+
+function installBrowser(url = "https://mail.agent-native.com/inbox") {
+  const parsed = new URL(url);
+  const location = {
+    href: parsed.href,
+    origin: parsed.origin,
+    hostname: parsed.hostname,
+    pathname: parsed.pathname,
+    search: parsed.search,
+    hash: parsed.hash,
+  };
+  const listeners: Record<string, Array<() => void>> = {};
+  const history = {
+    pushState: vi.fn((_state: unknown, _title: string, next?: string | URL) => {
+      if (next !== undefined) setLocation(location, String(next));
+    }),
+    replaceState: vi.fn(
+      (_state: unknown, _title: string, next?: string | URL) => {
+        if (next !== undefined) setLocation(location, String(next));
+      },
+    ),
+  };
+  const windowMock = {
+    location,
+    history,
+    gtag: vi.fn(),
+    addEventListener: vi.fn((event: string, listener: () => void) => {
+      listeners[event] = [...(listeners[event] ?? []), listener];
+    }),
+    setTimeout,
+  };
+  vi.stubGlobal("window", windowMock);
+  vi.stubGlobal("document", {
+    referrer: "https://builder.io/start?token=secret&utm=ok",
+    title: "Inbox",
+  });
+  vi.stubGlobal("navigator", { sendBeacon: vi.fn(() => false) });
+
+  return {
+    fetchMock: vi.fn().mockResolvedValue(new Response("{}")),
+    history,
+    listeners,
+    location,
+  };
+}
+
+describe("browser analytics pageviews", () => {
+  afterEach(() => {
+    resetPageviewState();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("emits a default pageview with useful browser context", async () => {
+    const { fetchMock } = installBrowser();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
+    vi.stubEnv(
+      "VITE_AGENT_NATIVE_ANALYTICS_ENDPOINT",
+      "https://analytics.example.test/track",
+    );
+    const { configureTracking } = await freshAnalytics();
+
+    configureTracking({
+      getDefaultProps: (_name, properties) => ({
+        ...properties,
+        app: "agent-native-mail",
+      }),
+    });
+    await tick();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://analytics.example.test/track");
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({
+      publicKey: "anpk_test",
+      event: "pageview",
+      properties: {
+        app: "agent-native-mail",
+        template: "mail",
+        url: "https://mail.agent-native.com/inbox",
+        path: "/inbox",
+        hostname: "mail.agent-native.com",
+        referrer: "https://builder.io/start?token=%3Credacted%3E&utm=ok",
+        title: "Inbox",
+        navigation_type: "load",
+      },
+    });
+  });
+
+  it("tracks client-side URL changes once per URL", async () => {
+    const { fetchMock, history } = installBrowser();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
+    const { configureTracking } = await freshAnalytics();
+
+    configureTracking({});
+    await tick();
+    history.pushState({}, "", "/sent");
+    await tick();
+    history.replaceState({}, "", "/sent");
+    await tick();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const events = fetchMock.mock.calls.map(([, init]) =>
+      JSON.parse(init.body),
+    );
+    expect(events.map((event) => event.properties.path)).toEqual([
+      "/inbox",
+      "/sent",
+    ]);
+    expect(events[1].properties.navigation_type).toBe("pushState");
+  });
+
+  it("keeps Agent Native Analytics quiet on localhost", async () => {
+    const { fetchMock } = installBrowser("http://localhost:3000/inbox");
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY", "anpk_test");
+    const { configureTracking } = await freshAnalytics();
+
+    configureTracking({});
+    await tick();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -12,12 +12,20 @@ type GetDefaultProps = (
   properties: Record<string, unknown>,
 ) => Record<string, unknown>;
 
+type PageviewTrackingState = {
+  installed: boolean;
+  lastPageviewKey: string | null;
+};
+
 let _getDefaultProps: GetDefaultProps | null = null;
 let _amplitudeInitialized = false;
 let _sentryInitialized = false;
 
 const AGENT_NATIVE_ANALYTICS_DEFAULT_ENDPOINT =
   "https://analytics.agent-native.com/track";
+const PAGEVIEW_TRACKING_STATE_KEY = Symbol.for(
+  "agent-native.client.pageviewTracking",
+);
 
 function isLocalAnalyticsHostname(hostname: string | undefined): boolean {
   const h = (hostname || "").toLowerCase();
@@ -118,6 +126,19 @@ function ensureSentry(): void {
   _sentryInitialized = true;
 }
 
+function getPageviewTrackingState(): PageviewTrackingState {
+  const g = globalThis as typeof globalThis & {
+    [PAGEVIEW_TRACKING_STATE_KEY]?: PageviewTrackingState;
+  };
+  if (!g[PAGEVIEW_TRACKING_STATE_KEY]) {
+    g[PAGEVIEW_TRACKING_STATE_KEY] = {
+      installed: false,
+      lastPageviewKey: null,
+    };
+  }
+  return g[PAGEVIEW_TRACKING_STATE_KEY];
+}
+
 export function configureTracking(options: {
   getDefaultProps?: GetDefaultProps;
 }): void {
@@ -127,12 +148,28 @@ export function configureTracking(options: {
   if (typeof window !== "undefined") {
     ensureSentry();
     ensureAmplitude();
+    installPageviewTracking();
   }
+}
+
+function inferTemplateName(properties: Record<string, unknown>): string | null {
+  const envTemplate =
+    (import.meta.env as Record<string, string | undefined>)
+      ?.VITE_AGENT_NATIVE_TEMPLATE ||
+    (import.meta.env as Record<string, string | undefined>)?.VITE_APP_TEMPLATE;
+  if (envTemplate) return envTemplate;
+
+  const app = typeof properties.app === "string" ? properties.app.trim() : "";
+  if (!app || app === "localhost") return null;
+  if (app.startsWith("agent-native-")) {
+    return app.slice("agent-native-".length);
+  }
+  return app;
 }
 
 function resolveProps(
   name: string,
-  params?: Record<string, string | number | boolean>,
+  params?: Record<string, unknown>,
 ): Record<string, unknown> {
   if (typeof window === "undefined") return { ...params };
   const base: Record<string, unknown> = {
@@ -140,7 +177,82 @@ function resolveProps(
     app: window.location.hostname.split(".")[0] || "localhost",
     ...params,
   };
-  return _getDefaultProps ? _getDefaultProps(name, base) : base;
+  const props = _getDefaultProps ? _getDefaultProps(name, base) : base;
+  if (props.template === undefined) {
+    const template = inferTemplateName(props);
+    if (template) {
+      return { ...props, template };
+    }
+  }
+  return props;
+}
+
+function pageviewKey(): string {
+  return window.location.href;
+}
+
+function pageviewProperties(reason: string): Record<string, unknown> {
+  const properties: Record<string, unknown> = {
+    url: scrubUrl(window.location.href),
+    path: window.location.pathname,
+    hostname: window.location.hostname,
+    navigation_type: reason,
+  };
+  if (window.location.search) {
+    properties.search = scrubUrl(window.location.search);
+  }
+  if (typeof document !== "undefined") {
+    if (document.referrer) {
+      properties.referrer = scrubUrl(document.referrer);
+    }
+    if (document.title) {
+      properties.title = document.title;
+    }
+  }
+  return properties;
+}
+
+function emitPageview(reason: string): void {
+  if (isLocalAnalyticsHostname(window.location.hostname)) return;
+  const state = getPageviewTrackingState();
+  const key = pageviewKey();
+  if (state.lastPageviewKey === key) return;
+  state.lastPageviewKey = key;
+  trackEvent("pageview", pageviewProperties(reason));
+}
+
+function schedulePageview(reason: string): void {
+  const run = () => emitPageview(reason);
+  if (typeof queueMicrotask === "function") {
+    queueMicrotask(run);
+    return;
+  }
+  window.setTimeout(run, 0);
+}
+
+function installPageviewTracking(): void {
+  const state = getPageviewTrackingState();
+  if (state.installed) return;
+  state.installed = true;
+
+  schedulePageview("load");
+
+  const originalPushState = window.history.pushState;
+  const originalReplaceState = window.history.replaceState;
+
+  window.history.pushState = function pushState(...args) {
+    const result = originalPushState.apply(this, args);
+    schedulePageview("pushState");
+    return result;
+  };
+
+  window.history.replaceState = function replaceState(...args) {
+    const result = originalReplaceState.apply(this, args);
+    schedulePageview("replaceState");
+    return result;
+  };
+
+  window.addEventListener("popstate", () => schedulePageview("popstate"));
 }
 
 function sendAgentNativeAnalytics(
@@ -185,7 +297,7 @@ function sendAgentNativeAnalytics(
 
 export function trackEvent(
   name: string,
-  params?: Record<string, string | number | boolean>,
+  params?: Record<string, unknown>,
 ): void {
   if (typeof window === "undefined") return;
   ensureSentry();

--- a/packages/core/src/client/tools/ToolsListPage.tsx
+++ b/packages/core/src/client/tools/ToolsListPage.tsx
@@ -11,6 +11,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "../components/ui/popover.js";
+import {
+  TOOLS_ORDER_CHANGE_EVENT,
+  applyToolsOrder,
+  getToolsOrder,
+} from "./tool-order.js";
 
 interface Tool {
   id: string;
@@ -81,6 +86,9 @@ function CreateToolInput({
 export function ToolsListPage() {
   const [showCreate, setShowCreate] = useState(false);
   const [createPrompt, setCreatePrompt] = useState("");
+  const [toolOrderState, setToolOrderState] = useState<string[]>(() =>
+    typeof window !== "undefined" ? getToolsOrder() : [],
+  );
 
   useEffect(() => {
     fetch(agentNativePath("/_agent-native/application-state/navigation"), {
@@ -88,6 +96,17 @@ export function ToolsListPage() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ value: { view: "tools" } }),
     }).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const syncOrder = () => setToolOrderState(getToolsOrder());
+    window.addEventListener(TOOLS_ORDER_CHANGE_EVENT, syncOrder);
+    window.addEventListener("storage", syncOrder);
+    return () => {
+      window.removeEventListener(TOOLS_ORDER_CHANGE_EVENT, syncOrder);
+      window.removeEventListener("storage", syncOrder);
+    };
   }, []);
 
   const { data: tools, isLoading } = useQuery<Tool[]>({
@@ -99,7 +118,10 @@ export function ToolsListPage() {
     },
   });
 
-  const toolList = tools ?? [];
+  const toolList =
+    toolOrderState.length > 0
+      ? applyToolsOrder(tools ?? [], toolOrderState)
+      : (tools ?? []);
 
   const handleCreate = () => {
     if (!createPrompt.trim()) return;

--- a/packages/core/src/client/tools/ToolsSidebarSection.tsx
+++ b/packages/core/src/client/tools/ToolsSidebarSection.tsx
@@ -20,11 +20,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "../components/ui/popover.js";
-import {
-  applyToolsOrder,
-  getToolsOrder,
-  setToolsOrder,
-} from "./tool-order.js";
+import { applyToolsOrder, getToolsOrder, setToolsOrder } from "./tool-order.js";
 
 interface Tool {
   id: string;

--- a/packages/core/src/client/tools/ToolsSidebarSection.tsx
+++ b/packages/core/src/client/tools/ToolsSidebarSection.tsx
@@ -11,6 +11,7 @@ import {
   IconDots,
   IconHelpCircle,
   IconPencil,
+  IconGripVertical,
 } from "@tabler/icons-react";
 import { cn } from "../utils.js";
 import { sendToAgentChat } from "../agent-chat.js";
@@ -19,6 +20,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "../components/ui/popover.js";
+import {
+  applyToolsOrder,
+  getToolsOrder,
+  setToolsOrder,
+} from "./tool-order.js";
 
 interface Tool {
   id: string;
@@ -60,6 +66,11 @@ export function ToolsSidebarSection() {
   const [renameValue, setRenameValue] = useState("");
   const [showCreate, setShowCreate] = useState(false);
   const [createPrompt, setCreatePrompt] = useState("");
+  const [toolOrderState, setToolOrderState] = useState<string[]>(() =>
+    typeof window !== "undefined" ? getToolsOrder() : [],
+  );
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dragOverId, setDragOverId] = useState<string | null>(null);
 
   const { data: tools, isLoading } = useQuery<Tool[]>({
     queryKey: ["tools"],
@@ -104,6 +115,11 @@ export function ToolsSidebarSection() {
           const next = new Set(prev);
           next.delete(toolId);
           saveFavorites(next);
+          return next;
+        });
+        setToolOrderState((prev) => {
+          const next = prev.filter((id) => id !== toolId);
+          if (next.length !== prev.length) setToolsOrder(next);
           return next;
         });
         if (
@@ -165,13 +181,33 @@ export function ToolsSidebarSection() {
 
   const sortedTools = useMemo(() => {
     if (!tools) return [];
-    return [...tools].sort((a, b) => {
+    const defaultSorted = [...tools].sort((a, b) => {
       const aFav = favoriteIds.has(a.id) ? 0 : 1;
       const bFav = favoriteIds.has(b.id) ? 0 : 1;
       if (aFav !== bFav) return aFav - bFav;
       return a.name.localeCompare(b.name);
     });
-  }, [tools, favoriteIds]);
+    return toolOrderState.length > 0
+      ? applyToolsOrder(defaultSorted, toolOrderState)
+      : defaultSorted;
+  }, [tools, favoriteIds, toolOrderState]);
+
+  const reorderTool = useCallback(
+    (activeId: string, overId: string) => {
+      if (activeId === overId) return;
+      const ids = sortedTools.map((tool) => tool.id);
+      const oldIndex = ids.indexOf(activeId);
+      const newIndex = ids.indexOf(overId);
+      if (oldIndex === -1 || newIndex === -1) return;
+      const next = [...ids];
+      const [moved] = next.splice(oldIndex, 1);
+      if (!moved) return;
+      next.splice(newIndex, 0, moved);
+      setToolsOrder(next);
+      setToolOrderState(next);
+    },
+    [sortedTools],
+  );
 
   const handleCreate = () => {
     if (!createPrompt.trim()) return;
@@ -275,11 +311,58 @@ export function ToolsSidebarSection() {
             const isRenamingThis = renamingId === tool.id;
 
             return (
-              <div key={tool.id} className="group/tool relative">
+              <div
+                key={tool.id}
+                onDragOver={(e) => {
+                  if (!draggingId || draggingId === tool.id) return;
+                  e.preventDefault();
+                  e.dataTransfer.dropEffect = "move";
+                  setDragOverId(tool.id);
+                }}
+                onDragLeave={() => {
+                  setDragOverId((current) =>
+                    current === tool.id ? null : current,
+                  );
+                }}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  const activeId =
+                    draggingId || e.dataTransfer.getData("text/plain");
+                  setDraggingId(null);
+                  setDragOverId(null);
+                  if (activeId) reorderTool(activeId, tool.id);
+                }}
+                className={cn(
+                  "group/tool relative flex items-center min-w-0 rounded-md",
+                  draggingId === tool.id && "opacity-50",
+                  dragOverId === tool.id &&
+                    draggingId !== tool.id &&
+                    "bg-accent/60",
+                )}
+              >
+                <button
+                  type="button"
+                  draggable
+                  onDragStart={(e) => {
+                    setDraggingId(tool.id);
+                    setDragOverId(null);
+                    e.dataTransfer.effectAllowed = "move";
+                    e.dataTransfer.setData("text/plain", tool.id);
+                  }}
+                  onDragEnd={() => {
+                    setDraggingId(null);
+                    setDragOverId(null);
+                  }}
+                  className="-ml-2 cursor-grab rounded p-0.5 text-muted-foreground/30 opacity-0 transition-colors hover:text-muted-foreground/70 active:cursor-grabbing group-hover/tool:opacity-100 group-focus-within/tool:opacity-100"
+                  aria-label={`Reorder ${tool.name}`}
+                  title="Drag to reorder"
+                >
+                  <IconGripVertical className="h-3 w-3" />
+                </button>
                 <Link
                   to={`/tools/${tool.id}`}
                   className={cn(
-                    "flex items-center rounded-md px-2 py-1.5 text-xs transition-colors",
+                    "flex min-w-0 flex-1 items-center rounded-md px-2 py-1.5 pr-12 text-xs transition-colors",
                     isActive
                       ? "bg-accent text-accent-foreground font-medium"
                       : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",

--- a/packages/core/src/client/tools/ToolsSidebarSection.tsx
+++ b/packages/core/src/client/tools/ToolsSidebarSection.tsx
@@ -305,6 +305,7 @@ export function ToolsSidebarSection() {
               location.pathname === `/tools/${tool.id}/edit`;
             const isFav = favoriteIds.has(tool.id);
             const isRenamingThis = renamingId === tool.id;
+            const actionsVisible = menuOpenId === tool.id || isRenamingThis;
 
             return (
               <div
@@ -358,7 +359,8 @@ export function ToolsSidebarSection() {
                 <Link
                   to={`/tools/${tool.id}`}
                   className={cn(
-                    "flex min-w-0 flex-1 items-center rounded-md px-2 py-1.5 pr-12 text-xs transition-colors",
+                    "flex min-w-0 flex-1 items-center rounded-md px-2 py-1.5 pr-12 text-xs transition-[padding,color,background-color] md:pr-2 md:group-hover/tool:pr-12 md:group-focus-within/tool:pr-12",
+                    actionsVisible && "md:pr-12",
                     isActive
                       ? "bg-accent text-accent-foreground font-medium"
                       : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
@@ -378,14 +380,19 @@ export function ToolsSidebarSection() {
                         e.preventDefault();
                         e.stopPropagation();
                       }}
-                      className="flex-1 min-w-0 truncate text-xs bg-transparent border-b border-primary outline-none py-0 px-0"
+                      className="min-w-0 flex-1 truncate border-b border-primary bg-transparent px-0 py-0 text-xs outline-none"
                     />
                   ) : (
-                    <span className="truncate">{tool.name}</span>
+                    <span className="block truncate">{tool.name}</span>
                   )}
                 </Link>
 
-                <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+                <div
+                  className={cn(
+                    "pointer-events-none absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-100 transition-opacity md:opacity-0 md:group-hover/tool:opacity-100 md:group-focus-within/tool:opacity-100",
+                    actionsVisible && "md:opacity-100",
+                  )}
+                >
                   <button
                     type="button"
                     onClick={(e) => {
@@ -394,10 +401,10 @@ export function ToolsSidebarSection() {
                       toggleFavorite(tool.id);
                     }}
                     className={cn(
-                      "cursor-pointer rounded p-0.5",
+                      "pointer-events-auto cursor-pointer rounded p-0.5 transition-colors",
                       isFav
                         ? "text-yellow-500"
-                        : "text-muted-foreground/40 opacity-100 hover:text-yellow-500 md:opacity-0 md:group-hover/tool:opacity-100 md:group-focus-within/tool:opacity-100",
+                        : "text-muted-foreground/40 hover:text-yellow-500",
                     )}
                     aria-label={isFav ? "Unfavorite" : "Favorite"}
                   >
@@ -416,7 +423,7 @@ export function ToolsSidebarSection() {
                         e.stopPropagation();
                         setMenuOpenId(menuOpenId === tool.id ? null : tool.id);
                       }}
-                      className="cursor-pointer rounded p-0.5 text-muted-foreground/40 opacity-100 hover:text-foreground md:opacity-0 md:group-hover/tool:opacity-100 md:group-focus-within/tool:opacity-100"
+                      className="pointer-events-auto cursor-pointer rounded p-0.5 text-muted-foreground/40 transition-colors hover:text-foreground"
                       aria-label="Tool actions"
                     >
                       <IconDots className="h-3 w-3" />

--- a/packages/core/src/client/tools/tool-order.ts
+++ b/packages/core/src/client/tools/tool-order.ts
@@ -1,0 +1,49 @@
+export const TOOLS_ORDER_CHANGE_EVENT = "tools-order-change";
+
+const TOOLS_ORDER_KEY = "tools-order";
+
+export function getToolsOrder(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(TOOLS_ORDER_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((id) => typeof id === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function setToolsOrder(order: string[]) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(TOOLS_ORDER_KEY, JSON.stringify(order));
+    window.dispatchEvent(
+      new CustomEvent(TOOLS_ORDER_CHANGE_EVENT, { detail: order }),
+    );
+  } catch {
+    // localStorage unavailable / quota — ignore, order is best-effort
+  }
+}
+
+export function applyToolsOrder<T extends { id: string }>(
+  items: T[],
+  savedOrder: string[],
+): T[] {
+  if (savedOrder.length === 0) return items;
+  const idToItem = new Map(items.map((item) => [item.id, item]));
+  const ordered: T[] = [];
+  for (const id of savedOrder) {
+    const item = idToItem.get(id);
+    if (item) {
+      ordered.push(item);
+      idToItem.delete(id);
+    }
+  }
+  for (const item of idToItem.values()) {
+    ordered.push(item);
+  }
+  return ordered;
+}

--- a/packages/core/src/oauth-tokens/index.ts
+++ b/packages/core/src/oauth-tokens/index.ts
@@ -1,5 +1,6 @@
 export {
   getOAuthTokens,
+  OAuthAccountOwnedByOtherUserError,
   saveOAuthTokens,
   deleteOAuthTokens,
   listOAuthAccounts,

--- a/packages/core/src/oauth-tokens/store.spec.ts
+++ b/packages/core/src/oauth-tokens/store.spec.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface ExecCall {
+  sql: string;
+  args: unknown[];
+}
+
+const execCalls: ExecCall[] = [];
+let existingOwner: string | null = null;
+
+const mockDb = {
+  execute: vi.fn(async (input: string | { sql: string; args?: unknown[] }) => {
+    const sql = typeof input === "string" ? input : input.sql;
+    const args = typeof input === "string" ? [] : (input.args ?? []);
+    execCalls.push({ sql, args });
+
+    if (/SELECT owner, display_name FROM oauth_tokens/i.test(sql)) {
+      return {
+        rows: existingOwner
+          ? [{ owner: existingOwner, display_name: null }]
+          : [],
+        rowsAffected: 0,
+      };
+    }
+
+    return { rows: [], rowsAffected: 0 };
+  }),
+};
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => mockDb,
+  intType: () => "INTEGER",
+  isPostgres: () => false,
+}));
+
+const { saveOAuthTokens } = await import("./store.js");
+
+function lastInsert(): ExecCall {
+  const inserts = execCalls.filter((c) => /^\s*INSERT\b/i.test(c.sql));
+  if (inserts.length === 0) throw new Error("no INSERT was executed");
+  return inserts[inserts.length - 1];
+}
+
+describe("oauth token store", () => {
+  beforeEach(() => {
+    execCalls.length = 0;
+    existingOwner = null;
+    vi.clearAllMocks();
+  });
+
+  it("repairs legacy local ownership when the Google account reconnects", async () => {
+    existingOwner = "local@localhost";
+
+    await saveOAuthTokens(
+      "google",
+      "steve@builder.io",
+      { access_token: "new-token" },
+      "steve@builder.io",
+    );
+
+    expect(lastInsert().args[2]).toBe("steve@builder.io");
+  });
+
+  it("still refuses to rebind a Google account owned by a real user", async () => {
+    existingOwner = "other@example.com";
+
+    await expect(
+      saveOAuthTokens(
+        "google",
+        "steve@builder.io",
+        { access_token: "new-token" },
+        "steve@builder.io",
+      ),
+    ).rejects.toMatchObject({
+      name: "OAuthAccountOwnedByOtherUserError",
+      existingOwner: "other@example.com",
+      attemptedOwner: "steve@builder.io",
+    });
+  });
+});

--- a/packages/core/src/oauth-tokens/store.ts
+++ b/packages/core/src/oauth-tokens/store.ts
@@ -131,6 +131,11 @@ export async function saveOAuthTokens(
   if (!owner) {
     // Token-refresh path: keep the existing owner/displayName unchanged.
     if (existingOwner) resolvedOwner = existingOwner;
+  } else if (existingOwner === "local@localhost" && sanitizedOwner) {
+    // Legacy dev rows from older OAuth flows were sometimes stored under the
+    // synthetic local user. A successful OAuth callback proves control of the
+    // Google account, so let the reconnect repair that owner in place.
+    resolvedOwner = sanitizedOwner;
   } else if (
     existingOwner &&
     sanitizedOwner &&

--- a/packages/core/src/scripts/agent-engines/list-agent-engines.ts
+++ b/packages/core/src/scripts/agent-engines/list-agent-engines.ts
@@ -10,6 +10,7 @@ import {
   getAgentEngineEntry,
   isStoredEngineUsable,
 } from "../../agent/engine/index.js";
+import { DEFAULT_MODEL } from "../../agent/default-model.js";
 import { getSetting } from "../../settings/index.js";
 
 export const tool: ActionTool = {
@@ -64,10 +65,7 @@ export async function run(): Promise<string> {
     })),
     current: {
       engine: currentEngineName,
-      model:
-        currentModel ??
-        currentEntry?.defaultModel ??
-        "claude-haiku-4-5-20251001",
+      model: currentModel ?? currentEntry?.defaultModel ?? DEFAULT_MODEL,
     },
   };
 

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -26,6 +26,7 @@ import type {
   MentionProvider,
   MentionProviderItem,
 } from "../agent/types.js";
+import { attachToolSearch } from "../agent/tool-search.js";
 import type { ActionHttpConfig } from "../action.js";
 import {
   McpClientManager,
@@ -1284,6 +1285,7 @@ const FRAMEWORK_CORE_COMPACT = `
 8. **\`db-*\` tools are internal only** — \`db-query\`, \`db-exec\`, \`db-patch\` ONLY access the app's own SQL database (settings, application_state, template tables). They CANNOT reach BigQuery, HubSpot, GA4, Jira, or any external data source. If the user asks about a table that is NOT in the app schema (e.g. \`dbt_analytics.*\`, \`dbt_mart.*\`, or any fully-qualified \`project.dataset.table\`), use the appropriate template action instead — \`bigquery\` for warehouse tables, \`ga4-report\` for Google Analytics, \`hubspot-deals\` for HubSpot, etc. **Never use \`db-query\` for external data — it will fail.**
 9. **Never fabricate data** — Do NOT invent numbers, metrics, records, or query results. Do NOT present estimated or example data as if it were real. If a data source is unavailable (missing credentials, connection error, tool failure), say so clearly, note the gap, and work with whatever data you do have. If no data can be retrieved at all, say "I can't retrieve this data right now" and explain why. Presenting made-up data as real is a critical failure — it is worse than admitting the limitation.
 10. **Never fabricate success from tool errors** — When any tool call returns an error (marked \`isError: true\`, contains "Command failed", "Error:", or non-zero exit output), the operation FAILED. Do NOT synthesize a success narrative or describe what the action "would have" produced. Report the failure verbatim from the tool output. This applies especially to \`shell(command="pnpm action ...")\` calls: if the action threw, it did NOT succeed.
+11. **Find tools when unsure** — Use \`tool-search\` to find the exact action/tool for a capability. It searches the live registry, including connected MCP server tools.
 
 ### Resources
 
@@ -1460,6 +1462,7 @@ const FRAMEWORK_CORE = `
 8. **\`db-*\` tools are internal only** — \`db-query\`, \`db-exec\`, \`db-patch\` ONLY access the app's own SQL database (settings, application_state, template tables). They CANNOT reach BigQuery, HubSpot, GA4, Jira, or any external data source. If the user asks about a table that is NOT in the app schema (e.g. \`dbt_analytics.*\`, \`dbt_mart.*\`, or any fully-qualified \`project.dataset.table\`), use the appropriate template action instead — \`bigquery\` for warehouse tables, \`ga4-report\` for Google Analytics, \`hubspot-deals\` for HubSpot, etc. **Never use \`db-query\` for external data — it will fail.**
 9. **Never fabricate data** — Do NOT invent numbers, metrics, records, or query results. Do NOT present estimated or example data as if it were real. If a data source is unavailable (missing credentials, connection error, tool failure), say so clearly, note the gap, and work with whatever data you do have. If no data can be retrieved at all, say "I can't retrieve this data right now" and explain why. Presenting made-up data as real is a critical failure — it is worse than admitting the limitation.
 10. **Never fabricate success from tool errors** — When any tool call returns an error (marked \`isError: true\`, contains "Command failed", "Error:", or non-zero exit output), the operation FAILED. Do NOT synthesize a success narrative, format a result table, or describe what the action "would have" produced. Report the failure verbatim from the tool output. This applies especially to \`shell(command="pnpm action ...")\` calls: if the underlying action threw (visible in the error text), the action did NOT succeed — report the error, do not describe a successful outcome.
+11. **Find tools when unsure** — Use \`tool-search\` to find the exact action/tool for a capability. It searches the live registry, including connected MCP server tools added through config, settings, or the MCP hub.
 
 ### Resources
 
@@ -2427,41 +2430,43 @@ export function createAgentChatPlugin(
       // This avoids degenerate empty-object tool calls that Anthropic models
       // sometimes emit for actions with complex schemas. Production keeps the
       // native registration since it has no shell access.
-      const allScripts = canToggle
-        ? {
-            ...resourceScripts,
-            ...docsScripts,
-            ...(lazyContext ? frameworkContextTool : {}),
-            ...urlTools,
-            ...chatScripts,
-            ...callAgentScript,
-            ...automationTools,
-            ...notificationTools,
-            ...progressTools,
-            ...fetchTool,
-            ...toolActions,
-            ...browserTools,
-            ...devScriptsForA2A,
-          }
-        : {
-            ...discoveredActions,
-            ...templateScripts,
-            ...resourceScripts,
-            ...docsScripts,
-            ...dbScripts,
-            ...refreshScreenTool,
-            ...(lazyContext ? frameworkContextTool : {}),
-            ...urlTools,
-            ...chatScripts,
-            ...callAgentScript,
-            ...automationTools,
-            ...notificationTools,
-            ...progressTools,
-            ...fetchTool,
-            ...toolActions,
-            ...browserTools,
-            ...devScriptsForA2A,
-          };
+      const allScripts = attachToolSearch(
+        canToggle
+          ? {
+              ...resourceScripts,
+              ...docsScripts,
+              ...(lazyContext ? frameworkContextTool : {}),
+              ...urlTools,
+              ...chatScripts,
+              ...callAgentScript,
+              ...automationTools,
+              ...notificationTools,
+              ...progressTools,
+              ...fetchTool,
+              ...toolActions,
+              ...browserTools,
+              ...devScriptsForA2A,
+            }
+          : {
+              ...discoveredActions,
+              ...templateScripts,
+              ...resourceScripts,
+              ...docsScripts,
+              ...dbScripts,
+              ...refreshScreenTool,
+              ...(lazyContext ? frameworkContextTool : {}),
+              ...urlTools,
+              ...chatScripts,
+              ...callAgentScript,
+              ...automationTools,
+              ...notificationTools,
+              ...progressTools,
+              ...fetchTool,
+              ...toolActions,
+              ...browserTools,
+              ...devScriptsForA2A,
+            },
+      );
 
       const { mountA2A } = await import("../a2a/server.js");
       mountA2A(nitroApp, {
@@ -2630,29 +2635,31 @@ export function createAgentChatPlugin(
           // to prevent infinite recursive A2A loops (agent calling itself).
           // In dev mode, template actions are invoked via shell (not native tools),
           // so they're omitted from the tool registry — see allScripts comment.
-          const a2aActions = devActive
-            ? {
-                ...resourceScripts,
-                ...docsScripts,
-                ...(lazyContext ? frameworkContextTool : {}),
-                ...urlTools,
-                ...chatScripts,
-                ...toolActions,
-                ...browserTools,
-                ...devScriptsForA2A,
-              }
-            : {
-                ...templateScripts,
-                ...resourceScripts,
-                ...docsScripts,
-                ...dbScripts,
-                ...refreshScreenTool,
-                ...(lazyContext ? frameworkContextTool : {}),
-                ...urlTools,
-                ...chatScripts,
-                ...toolActions,
-                ...browserTools,
-              };
+          const a2aActions = attachToolSearch(
+            devActive
+              ? {
+                  ...resourceScripts,
+                  ...docsScripts,
+                  ...(lazyContext ? frameworkContextTool : {}),
+                  ...urlTools,
+                  ...chatScripts,
+                  ...toolActions,
+                  ...browserTools,
+                  ...devScriptsForA2A,
+                }
+              : {
+                  ...templateScripts,
+                  ...resourceScripts,
+                  ...docsScripts,
+                  ...dbScripts,
+                  ...refreshScreenTool,
+                  ...(lazyContext ? frameworkContextTool : {}),
+                  ...urlTools,
+                  ...chatScripts,
+                  ...toolActions,
+                  ...browserTools,
+                },
+          );
 
           const a2aTools = actionsToEngineTools(a2aActions);
 
@@ -2767,27 +2774,29 @@ export function createAgentChatPlugin(
           // Same actions as A2A — without call-agent to prevent loops.
           // In dev mode, template actions go through shell, not native tools.
           const devActiveMcp = isDevMode();
-          const mcpActions = devActiveMcp
-            ? {
-                ...resourceScripts,
-                ...docsScripts,
-                ...(lazyContext ? frameworkContextTool : {}),
-                ...urlTools,
-                ...chatScripts,
-                ...toolActions,
-                ...devScriptsForA2A,
-              }
-            : {
-                ...templateScripts,
-                ...resourceScripts,
-                ...docsScripts,
-                ...dbScripts,
-                ...refreshScreenTool,
-                ...(lazyContext ? frameworkContextTool : {}),
-                ...urlTools,
-                ...chatScripts,
-                ...toolActions,
-              };
+          const mcpActions = attachToolSearch(
+            devActiveMcp
+              ? {
+                  ...resourceScripts,
+                  ...docsScripts,
+                  ...(lazyContext ? frameworkContextTool : {}),
+                  ...urlTools,
+                  ...chatScripts,
+                  ...toolActions,
+                  ...devScriptsForA2A,
+                }
+              : {
+                  ...templateScripts,
+                  ...resourceScripts,
+                  ...docsScripts,
+                  ...dbScripts,
+                  ...refreshScreenTool,
+                  ...(lazyContext ? frameworkContextTool : {}),
+                  ...urlTools,
+                  ...chatScripts,
+                  ...toolActions,
+                },
+          );
 
           const mcpTools = actionsToEngineTools(mcpActions);
 
@@ -3144,16 +3153,16 @@ export function createAgentChatPlugin(
       // progress, call-agent, and MCP entries to keep the tool list tight and
       // prevent the LLM from reaching for web-request instead of the
       // template's native actions (e.g. log-meal).
-      const leanActions = {
+      const leanActions = attachToolSearch({
         ...templateScripts,
         ...resourceScripts,
         ...refreshScreenTool,
         ...urlTools,
         ...chatScripts,
         ...toolActions,
-      };
+      });
 
-      const prodActions = {
+      const prodActions = attachToolSearch({
         ...templateScripts,
         ...resourceScripts,
         ...docsScripts,
@@ -3172,7 +3181,7 @@ export function createAgentChatPlugin(
         ...toolActions,
         ...browserTools,
         ...mcpActionEntries,
-      };
+      });
 
       // Keep the prod action dict's MCP entries in sync when the manager's
       // server set changes at runtime (e.g. a user adds a remote MCP server
@@ -3294,27 +3303,29 @@ export function createAgentChatPlugin(
         // template's actions as native tools instead of routing through shell.
         // Templates with structured-arg actions (objects/arrays) need this to
         // avoid round-tripping JSON through the CLI parser.
-        const devActions = leanPrompt
-          ? leanActions
-          : devNative
-            ? prodActions
-            : {
-                ...resourceScripts,
-                ...docsScripts,
-                ...(lazyContext ? frameworkContextTool : {}),
-                ...chatScripts,
-                ...callAgentScript,
-                ...teamTools,
-                ...jobTools,
-                ...automationTools,
-                ...notificationTools,
-                ...progressTools,
-                ...fetchTool,
-                ...toolActions,
-                ...browserTools,
-                ...mcpActionEntries,
-                ...(await createDevScriptRegistry()),
-              };
+        const devActions = attachToolSearch(
+          leanPrompt
+            ? leanActions
+            : devNative
+              ? prodActions
+              : {
+                  ...resourceScripts,
+                  ...docsScripts,
+                  ...(lazyContext ? frameworkContextTool : {}),
+                  ...chatScripts,
+                  ...callAgentScript,
+                  ...teamTools,
+                  ...jobTools,
+                  ...automationTools,
+                  ...notificationTools,
+                  ...progressTools,
+                  ...fetchTool,
+                  ...toolActions,
+                  ...browserTools,
+                  ...mcpActionEntries,
+                  ...(await createDevScriptRegistry()),
+                },
+        );
         // Keep dev action dict in sync with runtime MCP additions. When
         // native-actions mode is on (lean or `nativeActionsInDev`), devActions
         // === prodActions so the prod listener already covers it.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -455,6 +455,64 @@ describe("server/auth", () => {
       );
     });
 
+    it("desktop exchange can deliver OAuth errors to the app surface", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      delete process.env.AUTH_DISABLED;
+      delete process.env.AUTH_MODE;
+
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: vi.fn(async () => ({ rows: [] })) }),
+        isPostgres: () => false,
+        isLocalDatabase: () => false,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(async () => new Response("{}")),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+            listOrganizations: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
+
+      const { autoMountAuth, setDesktopExchangeError } =
+        await import("./auth.js");
+      const app = createMockApp();
+      await autoMountAuth(app);
+      setDesktopExchangeError("flow-error", {
+        message: "Sign out and try again.",
+        code: "account_owner_mismatch",
+        accountId: "steve@builder.io",
+        attemptedOwner: "other@example.com",
+      });
+
+      const exchangeHandler = app.use.mock.calls.find(
+        (call: any[]) => call[0] === "/_agent-native/auth/desktop-exchange",
+      )?.[1];
+      const result = await exchangeHandler(
+        createMockEvent({
+          path: "/_agent-native/auth/desktop-exchange",
+          query: { flow_id: "flow-error" },
+        }),
+      );
+
+      expect(result).toEqual({
+        error: "Sign out and try again.",
+        message: "Sign out and try again.",
+        code: "account_owner_mismatch",
+        accountId: "steve@builder.io",
+        attemptedOwner: "other@example.com",
+      });
+    });
+
     it("strips APP_BASE_PATH before forwarding requests to Better Auth", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("APP_BASE_PATH", "/docs");

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -10,6 +10,7 @@ describe("server/auth", () => {
   afterEach(() => {
     process.env = originalEnv;
     vi.doUnmock("./better-auth-instance.js");
+    vi.doUnmock("../db/client.js");
     vi.resetModules();
   });
 
@@ -390,6 +391,70 @@ describe("server/auth", () => {
       expect(result).toEqual({ error: "Not authenticated" });
     });
 
+    it("desktop exchange establishes the session cookie when redeeming a token", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      delete process.env.AUTH_DISABLED;
+      delete process.env.AUTH_MODE;
+
+      const mockExecute = vi.fn().mockImplementation(({ sql, args }: any) => {
+        if (
+          typeof sql === "string" &&
+          sql.includes("DELETE FROM sessions") &&
+          args?.[0] === "dex:flow-1"
+        ) {
+          return {
+            rows: [{ email: "session-token-abc::user@gmail.com" }],
+          };
+        }
+        return { rows: [] };
+      });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => false,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+      vi.doMock("./better-auth-instance.js", () => ({
+        getBetterAuth: vi.fn(async () => ({
+          handler: vi.fn(async () => new Response("{}")),
+          api: {
+            getSession: vi.fn(async () => null),
+            signInEmail: vi.fn(),
+            signUpEmail: vi.fn(),
+            signOut: vi.fn(),
+            listOrganizations: vi.fn(),
+          },
+        })),
+        getBetterAuthSync: vi.fn(() => undefined),
+      }));
+
+      const { autoMountAuth } = await import("./auth.js");
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const exchangeHandler = app.use.mock.calls.find(
+        (call: any[]) => call[0] === "/_agent-native/auth/desktop-exchange",
+      )?.[1];
+      expect(exchangeHandler).toBeTypeOf("function");
+
+      const event = createMockEvent({
+        path: "/_agent-native/auth/desktop-exchange",
+        query: { flow_id: "flow-1" },
+      });
+      const result = await exchangeHandler(event);
+
+      expect(result).toEqual({
+        token: "session-token-abc",
+        email: "user@gmail.com",
+      });
+      expect(event.res.headers.get("set-cookie")).toContain(
+        "session-token-abc",
+      );
+    });
+
     it("strips APP_BASE_PATH before forwarding requests to Better Auth", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("APP_BASE_PATH", "/docs");
@@ -542,6 +607,42 @@ describe("server/auth", () => {
       const event = createMockEvent();
       const session = await getSession(event);
       expect(session).toEqual({ email: "local@localhost" });
+    });
+
+    it("promotes _session query tokens even while AUTH_MODE=local is active", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("AUTH_MODE", "local");
+
+      const mockExecute = vi.fn().mockImplementation(({ sql, args }: any) => {
+        if (
+          typeof sql === "string" &&
+          sql.includes("SELECT") &&
+          args?.[0] === "mobile-token-abc"
+        ) {
+          return {
+            rows: [{ email: "user@gmail.com", created_at: Date.now() }],
+          };
+        }
+        return { rows: [] };
+      });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => true,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+
+      const { getSession } = await import("./auth.js");
+      const event = createMockEvent({
+        query: { _session: "mobile-token-abc" },
+      });
+
+      expect(await getSession(event)).toEqual({
+        email: "user@gmail.com",
+        token: "mobile-token-abc",
+      });
+      expect(event.res.headers.get("set-cookie")).toContain("mobile-token-abc");
     });
 
     it("still returns local session in dev after AUTH_MODE=local is cleared (dev fallback)", async () => {
@@ -732,6 +833,17 @@ describe("server/auth", () => {
       expect(decoded.returnUrl).toBe("/share/abc?x=1");
     });
 
+    it("encodes and decodes app id through signed state for frame routing", async () => {
+      const { encodeOAuthState, decodeOAuthState } =
+        await import("./google-oauth.js");
+      const state = encodeOAuthState({
+        redirectUri: "http://x/cb",
+        app: "mail",
+      });
+      const decoded = decodeOAuthState(state, "http://x/cb");
+      expect(decoded.app).toBe("mail");
+    });
+
     it("produces undefined returnUrl when none was encoded (backwards compat)", async () => {
       const { encodeOAuthState, decodeOAuthState } =
         await import("./google-oauth.js");
@@ -782,6 +894,50 @@ describe("server/auth", () => {
       // But safeReturnPath would catch this:
       const { safeReturnPath } = await import("./auth.js");
       expect(safeReturnPath(decoded.returnUrl)).toBe("/");
+    });
+  });
+
+  describe("OAuth callback copy", () => {
+    it("uses the requested app name for desktop exchange completion", async () => {
+      const { oauthCallbackResponse } = await import("./google-oauth.js");
+      const response = await Promise.resolve(
+        oauthCallbackResponse(createMockEvent(), "steve@example.com", {
+          desktop: true,
+          flowId: "flow-1",
+          sessionToken: "token-1",
+          appName: "Mail",
+        }),
+      );
+      expect(response).toBeInstanceOf(Response);
+      const html = await (response as Response).text();
+      expect(html).toContain("return to Mail");
+      expect(html).not.toContain("return to Clips");
+    });
+
+    it("uses a deep link for Electron desktop exchange completion", async () => {
+      const { oauthCallbackResponse } = await import("./google-oauth.js");
+      const response = await Promise.resolve(
+        oauthCallbackResponse(
+          createMockEvent({
+            headers: { "user-agent": "Agent Native Electron" },
+            query: { state: "state-1" },
+          }),
+          "steve@example.com",
+          {
+            desktop: true,
+            flowId: "flow-1",
+            sessionToken: "token-1",
+            appName: "Mail",
+          },
+        ),
+      );
+
+      expect(response).toBeInstanceOf(Response);
+      const html = await (response as Response).text();
+      expect(html).toContain("agentnative://oauth-complete");
+      expect(html).toContain("token=token-1");
+      expect(html).toContain("state=state-1");
+      expect(html).not.toContain("return to Mail");
     });
   });
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -566,10 +566,20 @@ function areGenericGoogleOAuthRoutesEnabled(app: H3App): boolean {
 // durability (Cloudflare Workers, multi-region deployments). The value stored
 // in the `email` column is "{realToken}::{userEmail}" so both can be recovered
 // from a single DB lookup.
-const _desktopExchanges = new Map<
-  string,
-  { token: string; email: string; expiresAt: number }
->();
+export interface DesktopExchangeErrorPayload {
+  message: string;
+  code?: string;
+  accountId?: string;
+  existingOwner?: string;
+  attemptedOwner?: string;
+}
+
+type DesktopExchangeEntry =
+  | { token: string; email: string; expiresAt: number }
+  | { error: DesktopExchangeErrorPayload; expiresAt: number };
+
+const _desktopExchanges = new Map<string, DesktopExchangeEntry>();
+const DESKTOP_EXCHANGE_ERROR_PREFIX = "__error__::";
 
 // 5-minute TTL for exchange entries (short — single-use tokens).
 const DESKTOP_EXCHANGE_TTL_MS = 5 * 60 * 1000;
@@ -588,6 +598,17 @@ export function setDesktopExchange(
   // templates call this helper directly instead of going through the OAuth
   // callback path).
   void persistDesktopExchangeToDB(flowId, token, email);
+}
+
+export function setDesktopExchangeError(
+  flowId: string,
+  error: DesktopExchangeErrorPayload,
+) {
+  _desktopExchanges.set(flowId, {
+    error,
+    expiresAt: Date.now() + DESKTOP_EXCHANGE_TTL_MS,
+  });
+  void persistDesktopExchangeErrorToDB(flowId, error);
 }
 
 /**
@@ -610,13 +631,28 @@ async function persistDesktopExchangeToDB(
   }
 }
 
+async function persistDesktopExchangeErrorToDB(
+  flowId: string,
+  error: DesktopExchangeErrorPayload,
+): Promise<void> {
+  try {
+    const payload = Buffer.from(JSON.stringify(error)).toString("base64url");
+    await addSession(
+      `dex:${flowId}`,
+      `${DESKTOP_EXCHANGE_ERROR_PREFIX}${payload}`,
+    );
+  } catch {
+    // non-fatal — in-memory Map is the primary path
+  }
+}
+
 /**
  * Retrieve and consume a desktop exchange entry from the DB fallback.
  * Returns null if not found or already consumed.
  */
 async function consumeDesktopExchangeFromDB(
   flowId: string,
-): Promise<{ token: string; email: string } | null> {
+): Promise<Omit<DesktopExchangeEntry, "expiresAt"> | null> {
   try {
     // Atomic DELETE...RETURNING prevents token replay: two concurrent polls
     // cannot both retrieve the token because only one DELETE will match the row.
@@ -632,6 +668,12 @@ async function consumeDesktopExchangeFromDB(
     if (rows.length === 0) return null;
     const packed = (rows[0].email ?? rows[0][0]) as string | null;
     if (!packed) return null;
+    if (packed.startsWith(DESKTOP_EXCHANGE_ERROR_PREFIX)) {
+      const raw = packed.slice(DESKTOP_EXCHANGE_ERROR_PREFIX.length);
+      return {
+        error: JSON.parse(Buffer.from(raw, "base64url").toString()),
+      };
+    }
     const sepIdx = packed.indexOf("::");
     if (sepIdx === -1) return null;
     return { token: packed.slice(0, sepIdx), email: packed.slice(sepIdx + 2) };
@@ -1583,8 +1625,7 @@ async function mountBetterAuthRoutes(
           return { pending: true };
         }
         entry = {
-          token: fromDb.token,
-          email: fromDb.email,
+          ...fromDb,
           expiresAt: Date.now() + 1, // already consumed from DB
         };
       }
@@ -1592,6 +1633,9 @@ async function mountBetterAuthRoutes(
       // Also wipe the DB-persisted entry so it cannot be replayed via the
       // DB fallback path after in-memory consumption.
       void removeSession(`dex:${flowId}`);
+      if ("error" in entry) {
+        return { error: entry.error.message, ...entry.error };
+      }
       // Make the exchange itself establish the app session. Older clients
       // still make a follow-up /auth/session?_session=... request, but the
       // OAuth handoff should not depend on that second request succeeding.

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -212,6 +212,15 @@ const APP_NAME_SLUG = (process.env.APP_NAME || "")
 export const COOKIE_NAME = APP_NAME_SLUG
   ? `an_session_${APP_NAME_SLUG}`
   : "an_session";
+function getOAuthStateAppId(): string | undefined {
+  const raw = process.env.APP_NAME || process.env.npm_package_name;
+  if (!raw) return undefined;
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || undefined;
+}
 const DEFAULT_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 const LOCAL_MODE_MARKER_PATH = path.resolve(
   process.cwd(),
@@ -945,6 +954,9 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
       // Better Auth not initialized yet
     }
 
+    const querySession = await promoteQuerySession(event);
+    if (querySession) return querySession;
+
     return LOCAL_SESSION;
   }
 
@@ -1016,20 +1028,8 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
   }
 
   // 6. Mobile WebView bridge — _session query param
-  const qToken = getQuery(event)?._session as string | undefined;
-  if (qToken) {
-    const email = await getSessionEmail(qToken);
-    if (email) {
-      setCookie(event, COOKIE_NAME, qToken, {
-        httpOnly: true,
-        ...crossSiteCookieAttrs(event),
-        path: "/",
-        maxAge: sessionMaxAge,
-      });
-      setResponseHeader(event, "Referrer-Policy", "no-referrer");
-      return { email, token: qToken };
-    }
-  }
+  const querySession = await promoteQuerySession(event);
+  if (querySession) return querySession;
 
   // 7. Dev-mode safety net — in development on a local SQLite database, fall
   // back to local@localhost so the app is usable without any auth configuration.
@@ -1061,6 +1061,18 @@ export async function getSession(event: H3Event): Promise<AuthSession | null> {
   }
 
   return null;
+}
+
+async function promoteQuerySession(
+  event: H3Event,
+): Promise<AuthSession | null> {
+  const qToken = getQuery(event)?._session as string | undefined;
+  if (!qToken) return null;
+  const email = await getSessionEmail(qToken);
+  if (!email) return null;
+  setFrameworkSessionCookie(event, qToken);
+  setResponseHeader(event, "Referrer-Policy", "no-referrer");
+  return { email, token: qToken };
 }
 
 /**
@@ -1121,6 +1133,15 @@ function crossSiteCookieAttrs(event: H3Event): {
   return isHttpsRequest(event)
     ? { sameSite: "none", secure: true }
     : { sameSite: "lax", secure: false };
+}
+
+function setFrameworkSessionCookie(event: H3Event, token: string): void {
+  setCookie(event, COOKIE_NAME, token, {
+    httpOnly: true,
+    ...crossSiteCookieAttrs(event),
+    path: "/",
+    maxAge: sessionMaxAge,
+  });
 }
 
 function isHttpsRequest(event: H3Event): boolean {
@@ -1408,15 +1429,14 @@ async function mountBetterAuthRoutes(
         const validated =
           typeof returnQuery === "string" ? safeReturnPath(returnQuery) : "/";
         const returnUrl = validated !== "/" ? validated : undefined;
-        const state = encodeOAuthState(
+        const state = encodeOAuthState({
           redirectUri,
-          undefined,
           desktop,
-          false,
-          undefined,
+          addAccount: false,
+          app: getOAuthStateAppId(),
           returnUrl,
           flowId,
-        );
+        });
         const params = new URLSearchParams({
           client_id: process.env.GOOGLE_CLIENT_ID!,
           redirect_uri: redirectUri,
@@ -1572,6 +1592,11 @@ async function mountBetterAuthRoutes(
       // Also wipe the DB-persisted entry so it cannot be replayed via the
       // DB fallback path after in-memory consumption.
       void removeSession(`dex:${flowId}`);
+      // Make the exchange itself establish the app session. Older clients
+      // still make a follow-up /auth/session?_session=... request, but the
+      // OAuth handoff should not depend on that second request succeeding.
+      setFrameworkSessionCookie(event, entry.token);
+      setResponseHeader(event, "Referrer-Policy", "no-referrer");
       return { token: entry.token, email: entry.email };
     }),
   );

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -577,6 +577,9 @@ export interface DesktopExchangeErrorPayload {
 type DesktopExchangeEntry =
   | { token: string; email: string; expiresAt: number }
   | { error: DesktopExchangeErrorPayload; expiresAt: number };
+type DesktopExchangeStoredEntry =
+  | { token: string; email: string }
+  | { error: DesktopExchangeErrorPayload };
 
 const _desktopExchanges = new Map<string, DesktopExchangeEntry>();
 const DESKTOP_EXCHANGE_ERROR_PREFIX = "__error__::";
@@ -652,7 +655,7 @@ async function persistDesktopExchangeErrorToDB(
  */
 async function consumeDesktopExchangeFromDB(
   flowId: string,
-): Promise<Omit<DesktopExchangeEntry, "expiresAt"> | null> {
+): Promise<DesktopExchangeStoredEntry | null> {
   try {
     // Atomic DELETE...RETURNING prevents token replay: two concurrent polls
     // cannot both retrieve the token because only one DELETE will match the row.
@@ -1624,10 +1627,14 @@ async function mountBetterAuthRoutes(
         if (!fromDb) {
           return { pending: true };
         }
-        entry = {
-          ...fromDb,
-          expiresAt: Date.now() + 1, // already consumed from DB
-        };
+        entry =
+          "error" in fromDb
+            ? { error: fromDb.error, expiresAt: Date.now() + 1 }
+            : {
+                token: fromDb.token,
+                email: fromDb.email,
+                expiresAt: Date.now() + 1,
+              };
       }
       _desktopExchanges.delete(flowId);
       // Also wipe the DB-persisted entry so it cannot be replayed via the

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -22,6 +22,7 @@ import { getAppProductionUrl } from "./app-url.js";
 import { getDbExec, isPostgres } from "../db/client.js";
 import { acceptPendingInvitationsForEmail } from "../org/accept-pending.js";
 import { saveOAuthTokens } from "../oauth-tokens/store.js";
+import { identify, track } from "../tracking/index.js";
 import {
   getDialect,
   getDatabaseUrl,
@@ -688,13 +689,30 @@ async function createBetterAuthInstance(
     databaseHooks: {
       user: {
         create: {
-          after: async (user: { email?: string }) => {
+          after: async (user: {
+            id?: string;
+            email?: string;
+            name?: string | null;
+          }) => {
             // When a newly-created user's email has pending org invitations
             // (common when someone is invited *before* they've signed up),
             // auto-accept them so the user lands in the org on their very
             // first page load instead of a blank-slate workspace.
             const email = user?.email;
             if (!email) return;
+            identify(email, {
+              email,
+              name: user.name ?? undefined,
+              authUserId: user.id,
+            });
+            track(
+              "signup",
+              {
+                auth_provider: "better-auth",
+                auth_user_id: user.id,
+              },
+              { userId: email },
+            );
             try {
               await acceptPendingInvitationsForEmail(email);
             } catch (err) {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -57,6 +57,7 @@ import {
 } from "../secrets/routes.js";
 import { registerFrameworkSecrets } from "../secrets/register-framework-secrets.js";
 import { registerBuiltinProviders } from "../tracking/providers.js";
+import { track } from "../tracking/index.js";
 import { registerBuiltinNotificationChannels } from "../notifications/channels.js";
 import { createNotificationsHandler } from "../notifications/routes.js";
 import { createProgressHandler } from "../progress/routes.js";
@@ -97,6 +98,22 @@ export const FRAMEWORK_ROUTE_PREFIX = "/_agent-native";
 function isEnvVarWriteAllowed(): boolean {
   if (process.env.AGENT_NATIVE_ALLOW_ENV_VAR_WRITES === "1") return true;
   return isDevEnvironment() && isLocalDatabase();
+}
+
+function trackBuilderLifecycle(
+  name: string,
+  userEmail: string | undefined | null,
+  properties: Record<string, unknown> = {},
+): void {
+  if (!userEmail) return;
+  track(
+    name,
+    {
+      feature: "builder",
+      ...properties,
+    },
+    { userId: userEmail },
+  );
 }
 
 function normalizeAppBasePath(value: string | undefined): string {
@@ -582,6 +599,10 @@ export function createCoreRoutesPlugin(
         // subdomains, since a compromised subdomain shouldn't be able
         // to mint Builder credential writes for users of the main app.
         if (!isSameOriginConnect(event)) {
+          trackBuilderLifecycle("builder connect failed", session.email, {
+            reason: "cross_origin",
+            stage: "connect",
+          });
           setResponseStatus(event, 403);
           return { error: "Cross-origin connect requests are not allowed" };
         }
@@ -604,6 +625,10 @@ export function createCoreRoutesPlugin(
             expiresAt: Date.now() + BUILDER_CONNECT_PENDING_TTL_MS,
           });
         } catch (err) {
+          trackBuilderLifecycle("builder connect failed", session.email, {
+            reason: "pending_storage_unavailable",
+            stage: "connect",
+          });
           const msg =
             "Could not initiate Builder connect — storage unavailable. Try again.";
           console.error(
@@ -620,6 +645,9 @@ export function createCoreRoutesPlugin(
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
           return createBuilderBrowserCallbackErrorPage(msg);
         }
+        trackBuilderLifecycle("builder connect started", session.email, {
+          stage: "connect",
+        });
         // Build the cli-auth URL without embedding state in redirect_url:
         // Builder's /cli-auth appends params directly to redirect_url and
         // does not preserve any pre-existing query string we put there.
@@ -768,6 +796,10 @@ export function createCoreRoutesPlugin(
         }
 
         if (pendingError) {
+          trackBuilderLifecycle("builder connect failed", session.email, {
+            reason: "pending_consume_storage_error",
+            stage: "callback",
+          });
           // Best-effort signal to the parent's poll loop, then render the
           // popup-friendly error page so the BroadcastChannel notify fires.
           await putSetting(`builder-connect-error:${session.email}`, {
@@ -780,6 +812,10 @@ export function createCoreRoutesPlugin(
         }
 
         if (!pendingValid) {
+          trackBuilderLifecycle("builder connect failed", session.email, {
+            reason: "missing_pending_connect",
+            stage: "callback",
+          });
           const msg =
             "No active connect flow found. Restart the Builder connect flow from Settings.";
           // Write an error signal so the polling loop in the parent tab
@@ -801,6 +837,10 @@ export function createCoreRoutesPlugin(
         const publicKey = requestUrl.searchParams.get("api-key");
 
         if (!privateKey || !publicKey) {
+          trackBuilderLifecycle("builder connect failed", session.email, {
+            reason: "missing_credentials",
+            stage: "callback",
+          });
           // Render the popup-friendly error page (and write a status row)
           // instead of bare JSON, so the parent tab's poll loop terminates
           // immediately via BroadcastChannel rather than hanging until the
@@ -851,6 +891,10 @@ export function createCoreRoutesPlugin(
         }
 
         if (writeError) {
+          trackBuilderLifecycle("builder connect failed", session.email, {
+            reason: "credential_write_failed",
+            stage: "callback",
+          });
           // Best-effort signal to /builder/status. If putSetting also fails
           // (entire DB unreachable) the popup's postMessage still notifies
           // the parent. If both fail the parent times out at 5min as today.
@@ -887,6 +931,11 @@ export function createCoreRoutesPlugin(
           requestUrl.searchParams.get("preview-url"),
           event,
         );
+        trackBuilderLifecycle("builder connect succeeded", session.email, {
+          stage: "callback",
+          has_preview_url: Boolean(previewUrl),
+          org_kind: orgKind || undefined,
+        });
         setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
         return createBuilderBrowserCallbackPage(previewUrl);
       }),
@@ -917,6 +966,9 @@ export function createCoreRoutesPlugin(
             await import("./credential-provider.js");
           await deleteBuilderCredentials(session.email);
         } catch (err) {
+          trackBuilderLifecycle("builder disconnect failed", session.email, {
+            reason: "credential_delete_failed",
+          });
           setResponseStatus(event, 500);
           return {
             ok: false,
@@ -926,6 +978,7 @@ export function createCoreRoutesPlugin(
           };
         }
 
+        trackBuilderLifecycle("builder disconnect succeeded", session.email);
         return { ok: true };
       }),
     );

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -610,6 +610,15 @@ export function oauthErrorPage(message: string): Response {
   );
 }
 
+export function oauthDesktopExchangePage(
+  message = "Returning to the app...",
+): Response {
+  const safe = escapeHtml(message);
+  return htmlResponse(
+    `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Returning</title></head><body style="background:#111;color:#aaa;font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0"><p style="font-size:14px">${safe}</p><script>window.close()</script></body></html>`,
+  );
+}
+
 // ─── Internal ────────────────────────────────────────────────────────────────
 
 function resolveOAuthAppName(explicit?: string): string {

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -23,6 +23,7 @@ import {
   getSessionMaxAge,
   safeReturnPath,
 } from "./auth.js";
+import { getAppName } from "./app-name.js";
 import { writeDesktopSso } from "./desktop-sso.js";
 
 // ─── Platform Detection ─────────────────────────────────────────────────────
@@ -222,6 +223,7 @@ export interface OAuthStatePayload {
   owner?: string;
   desktop?: boolean;
   addAccount?: boolean;
+  app?: string;
   /**
    * Same-origin path to redirect to after a successful web-flow sign-in.
    * Threaded through the (HMAC-signed) state so it survives the round trip
@@ -391,6 +393,7 @@ export function decodeOAuthState(
         owner: parsed.o || undefined,
         desktop: !!parsed.d,
         addAccount: !!parsed.a,
+        app: typeof parsed.app === "string" ? parsed.app : undefined,
         // Pass returnUrl through as-is — same-origin validation runs at the
         // consumer (oauthCallbackResponse → safeReturnPath). The state is
         // HMAC-signed, but we still validate at consumption as defence in
@@ -509,6 +512,7 @@ export function oauthCallbackResponse(
      */
     returnUrl?: string;
     flowId?: string;
+    appName?: string;
   },
 ): Response | string | unknown | Promise<Response | string | unknown> {
   const mobile = isMobile(event);
@@ -533,19 +537,28 @@ export function oauthCallbackResponse(
   // to ensure no deep link fires and the existing session is never switched).
   if (opts.desktop && opts.addAccount) {
     const safeEmail = email ? escapeHtml(email) : "";
+    const safeAppName = escapeHtml(resolveOAuthAppName(opts.appName));
     const msg = safeEmail ? `Connected ${safeEmail}!` : "Connected!";
     return htmlResponse(
-      `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Connected</title></head><body style="background:#111;color:#ccc;font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;flex-direction:column;gap:8px"><p style="font-size:16px">${msg}</p><p style="font-size:13px;color:#888">You can close this tab and return to Agent Native.</p></body></html>`,
+      `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Connected</title></head><body style="background:#111;color:#ccc;font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;flex-direction:column;gap:8px"><p style="font-size:16px">${msg}</p><p style="font-size:13px;color:#888">You can close this tab and return to ${safeAppName}.</p></body></html>`,
     );
   }
 
-  // Desktop exchange flow (Tauri tray app): the tray app polls the
+  // Electron desktop exchange flow: mail/calendar still pass a flow id so the
+  // renderer can poll as a fallback, but the main handoff should use the
+  // protocol deep link so the popup returns focus to the desktop app.
+  if (opts.desktop && opts.flowId && isElectron(event) && opts.sessionToken) {
+    return desktopSuccessPage(event, email, opts.sessionToken, callbackState);
+  }
+
+  // Desktop exchange flow (non-Electron tray app): the tray app polls the
   // desktop-exchange endpoint for the token — no deep link needed.
   if (opts.desktop && opts.flowId) {
     const safeEmail = email ? escapeHtml(email) : "";
+    const safeAppName = escapeHtml(resolveOAuthAppName(opts.appName));
     const msg = safeEmail ? `Signed in as ${safeEmail}!` : "Signed in!";
     return htmlResponse(
-      `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Connected</title></head><body style="background:#111;color:#ccc;font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;flex-direction:column;gap:8px"><p style="font-size:16px">${msg}</p><p style="font-size:13px;color:#888">You can close this tab and return to Clips.</p></body></html>`,
+      `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Connected</title></head><body style="background:#111;color:#ccc;font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;flex-direction:column;gap:8px"><p style="font-size:16px">${msg}</p><p style="font-size:13px;color:#888">You can close this tab and return to ${safeAppName}.</p></body></html>`,
     );
   }
 
@@ -598,6 +611,16 @@ export function oauthErrorPage(message: string): Response {
 }
 
 // ─── Internal ────────────────────────────────────────────────────────────────
+
+function resolveOAuthAppName(explicit?: string): string {
+  const raw = explicit || getAppName() || "Agent Native";
+  if (!/^[a-z0-9_-]+$/.test(raw)) return raw;
+  return raw
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(" ");
+}
 
 function buildOAuthCompleteDeepLink(
   sessionToken?: string,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -16,8 +16,10 @@ export {
   getSessionEmail,
   runAuthGuard,
   setDesktopExchange,
+  setDesktopExchangeError,
   DEV_MODE_USER_EMAIL,
   safeReturnPath,
+  type DesktopExchangeErrorPayload,
   type AuthSession,
   type AuthOptions,
 } from "./auth.js";

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -173,6 +173,7 @@ export {
   createOAuthSession,
   oauthCallbackResponse,
   oauthErrorPage,
+  oauthDesktopExchangePage,
   type OAuthStatePayload,
   type OAuthOwnerResult,
   type OAuthSessionResult,

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -712,9 +712,7 @@ function openOAuthWindow(
       // Detect the OAuth callback (works for both /api/google/callback and
       // /_agent-native/google/callback).
       if (parsed.pathname.includes(provider.callbackPathFragment)) {
-        // Google success pages close via the agentnative:// handoff below.
-        // Error pages do not deep-link, so keep the popup open for the user.
-        if (provider.name !== "google") scheduleClose();
+        scheduleClose();
       }
       // Detect agentnative:// deep link — handle it and close the popup.
       if (parsed.protocol === `${DEEP_LINK_PROTOCOL}:`) {

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -552,7 +552,10 @@ interface OAuthProvider {
 const OAUTH_PROVIDERS: OAuthProvider[] = [
   {
     name: "google",
-    matches: (u) => u.hostname === "accounts.google.com",
+    matches: (u) =>
+      u.hostname === "accounts.google.com" ||
+      u.pathname.endsWith("/_agent-native/google/auth-url") ||
+      u.pathname.endsWith("/_agent-native/google/add-account/auth-url"),
     callbackPathFragment: "google/callback",
   },
   {
@@ -640,6 +643,12 @@ function openOAuthWindow(
   const onNavigate = (_event: Electron.Event, navUrl: string) => {
     try {
       const parsed = new URL(navUrl);
+      if (
+        (parsed.protocol === "https:" || parsed.protocol === "http:") &&
+        provider.matches(parsed)
+      ) {
+        rememberOAuthState(navUrl);
+      }
       // Detect the OAuth callback (works for both /api/google/callback and
       // /_agent-native/google/callback).
       if (parsed.pathname.includes(provider.callbackPathFragment)) {

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -712,7 +712,9 @@ function openOAuthWindow(
       // Detect the OAuth callback (works for both /api/google/callback and
       // /_agent-native/google/callback).
       if (parsed.pathname.includes(provider.callbackPathFragment)) {
-        scheduleClose();
+        // Google success pages close via the agentnative:// handoff below.
+        // Error pages do not deep-link, so keep the popup open for the user.
+        if (provider.name !== "google") scheduleClose();
       }
       // Detect agentnative:// deep link — handle it and close the popup.
       if (parsed.protocol === `${DEEP_LINK_PROTOCOL}:`) {

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -544,9 +544,13 @@ ipcMain.on(IPC.INTER_APP_SEND, (event: IpcMainEvent, msg: InterAppMessage) => {
 // never touch the webview/renderer. See credential-provider.ts.
 interface OAuthProvider {
   name: string;
-  matches: (url: URL) => boolean;
+  matches: (url: URL, context?: OAuthMatchContext) => boolean;
   /** Substring to look for in the navigation URL to detect callback arrival. */
   callbackPathFragment: string;
+}
+
+interface OAuthMatchContext {
+  sourceUrl?: string;
 }
 
 function isLoopbackHost(hostname: string): boolean {
@@ -565,12 +569,30 @@ function isGoogleOAuthStarterPath(pathname: string): boolean {
   );
 }
 
+function getUrlOrigin(url: string | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isTrustedGoogleOAuthStarter(
+  url: URL,
+  context?: OAuthMatchContext,
+): boolean {
+  if (!isGoogleOAuthStarterPath(url.pathname)) return false;
+  if (isLoopbackHost(url.hostname)) return true;
+  return getUrlOrigin(context?.sourceUrl) === url.origin;
+}
+
 const OAUTH_PROVIDERS: OAuthProvider[] = [
   {
     name: "google",
-    matches: (u) =>
+    matches: (u, context) =>
       u.hostname === "accounts.google.com" ||
-      (isLoopbackHost(u.hostname) && isGoogleOAuthStarterPath(u.pathname)),
+      isTrustedGoogleOAuthStarter(u, context),
     callbackPathFragment: "google/callback",
   },
   {
@@ -599,10 +621,13 @@ const OAUTH_PROVIDERS: OAuthProvider[] = [
   },
 ];
 
-function matchOAuthProvider(urlString: string): OAuthProvider | null {
+function matchOAuthProvider(
+  urlString: string,
+  context?: OAuthMatchContext,
+): OAuthProvider | null {
   try {
     const parsed = new URL(urlString);
-    return OAUTH_PROVIDERS.find((p) => p.matches(parsed)) ?? null;
+    return OAUTH_PROVIDERS.find((p) => p.matches(parsed, context)) ?? null;
   } catch {
     return null;
   }
@@ -619,12 +644,26 @@ function shouldRememberOAuthStateFromNavigation(
   return provider.matches(url);
 }
 
+function rememberOAuthStateFromNavigation(
+  provider: OAuthProvider,
+  url: string,
+) {
+  try {
+    const parsed = new URL(url);
+    if (shouldRememberOAuthStateFromNavigation(provider, parsed)) {
+      rememberOAuthState(url);
+    }
+  } catch {
+    // Malformed URL — ignore
+  }
+}
+
 function openOAuthWindow(
   url: string,
   sourceSession: Electron.Session | undefined,
   provider: OAuthProvider,
 ) {
-  rememberOAuthState(url);
+  rememberOAuthStateFromNavigation(provider, url);
   const mainWin = BrowserWindow.getAllWindows()[0];
 
   // Critical: the popup MUST share the source webview's session so the
@@ -669,9 +708,7 @@ function openOAuthWindow(
   const onNavigate = (_event: Electron.Event, navUrl: string) => {
     try {
       const parsed = new URL(navUrl);
-      if (shouldRememberOAuthStateFromNavigation(provider, parsed)) {
-        rememberOAuthState(navUrl);
-      }
+      rememberOAuthStateFromNavigation(provider, navUrl);
       // Detect the OAuth callback (works for both /api/google/callback and
       // /_agent-native/google/callback).
       if (parsed.pathname.includes(provider.callbackPathFragment)) {
@@ -730,7 +767,7 @@ app.on("web-contents-created", (_event, contents) => {
           if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
             return { action: "deny" as const };
           }
-          const provider = matchOAuthProvider(url);
+          const provider = matchOAuthProvider(url, { sourceUrl: wc.getURL() });
           if (provider) {
             openOAuthWindow(url, wc.session, provider);
           } else {
@@ -751,7 +788,9 @@ app.on("web-contents-created", (_event, contents) => {
       if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
         return { action: "deny" };
       }
-      const provider = matchOAuthProvider(url);
+      const provider = matchOAuthProvider(url, {
+        sourceUrl: contents.getURL(),
+      });
       if (provider) {
         openOAuthWindow(url, contents.session, provider);
       } else {

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -549,13 +549,28 @@ interface OAuthProvider {
   callbackPathFragment: string;
 }
 
+function isLoopbackHost(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "[::1]"
+  );
+}
+
+function isGoogleOAuthStarterPath(pathname: string): boolean {
+  return (
+    pathname.endsWith("/_agent-native/google/auth-url") ||
+    pathname.endsWith("/_agent-native/google/add-account/auth-url")
+  );
+}
+
 const OAUTH_PROVIDERS: OAuthProvider[] = [
   {
     name: "google",
     matches: (u) =>
       u.hostname === "accounts.google.com" ||
-      u.pathname.endsWith("/_agent-native/google/auth-url") ||
-      u.pathname.endsWith("/_agent-native/google/add-account/auth-url"),
+      (isLoopbackHost(u.hostname) && isGoogleOAuthStarterPath(u.pathname)),
     callbackPathFragment: "google/callback",
   },
   {
@@ -591,6 +606,17 @@ function matchOAuthProvider(urlString: string): OAuthProvider | null {
   } catch {
     return null;
   }
+}
+
+function shouldRememberOAuthStateFromNavigation(
+  provider: OAuthProvider,
+  url: URL,
+): boolean {
+  if (url.protocol !== "https:" && url.protocol !== "http:") return false;
+  if (provider.name === "google") {
+    return url.hostname === "accounts.google.com";
+  }
+  return provider.matches(url);
 }
 
 function openOAuthWindow(
@@ -643,10 +669,7 @@ function openOAuthWindow(
   const onNavigate = (_event: Electron.Event, navUrl: string) => {
     try {
       const parsed = new URL(navUrl);
-      if (
-        (parsed.protocol === "https:" || parsed.protocol === "http:") &&
-        provider.matches(parsed)
-      ) {
+      if (shouldRememberOAuthStateFromNavigation(provider, parsed)) {
         rememberOAuthState(navUrl);
       }
       // Detect the OAuth callback (works for both /api/google/callback and

--- a/scripts/dev-electron.ts
+++ b/scripts/dev-electron.ts
@@ -51,6 +51,7 @@ if (hasFlag("--help") || hasFlag("-h")) {
 }
 
 const dryRun = hasFlag("--dry-run");
+const FRAME_PORT = 3334;
 
 // ── App port assignments ───────────────────────────────────────
 // Parsed from packages/shared-app-config/templates.ts (same approach
@@ -84,6 +85,7 @@ const requestedApps = appsArg
 const portsToUse = requestedApps
   .map((a) => PORT_MAP[a])
   .filter(Boolean) as number[];
+portsToUse.push(FRAME_PORT);
 
 function tryKillPort(port: number) {
   try {
@@ -116,9 +118,15 @@ requestedApps.forEach((appName, i) => {
   // both the frontend and all /api/* routes on the one port.
   // PORT pins the dev server port (Nitro's vite plugin reads process.env.PORT
   // first when resolving the dev server port).
-  commands.push(`PORT=${port} pnpm --dir templates/${appName} exec vite`);
+  commands.push(
+    `APP_NAME=${appName} PORT=${port} pnpm --dir templates/${appName} exec vite`,
+  );
   colors.push(appColors[i % appColors.length]);
 });
+
+names.push("frame");
+commands.push("pnpm --filter @agent-native/frame dev");
+colors.push("magenta");
 
 // Electron shell dev (starts electron-vite which starts renderer + main + Electron)
 names.push("electron");

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -153,6 +153,15 @@ First-party analytics events live in SQL tables managed by this template:
 
 Use the `first-party` dashboard source or `query-agent-native-analytics` action for these events. Do **not** use `db-query` for user analytics questions unless the user explicitly asks to inspect the app's internal tables.
 
+Collector endpoints:
+
+- Hosted collector: `POST https://analytics.agent-native.com/track`
+- Self-hosted collector: `POST https://<your-analytics-domain>/api/analytics/track`
+- Body: `{ "publicKey": "anpk_...", "event": "click template", "properties": { "app": "docs", "template": "mail", "signed_in": true } }`
+- Batch body: `{ "publicKey": "anpk_...", "events": [{ "event": "click template", "properties": { "template": "mail" } }] }`
+- Header alternative: `x-agent-native-analytics-key: anpk_...`
+- Max batch size: 100 events.
+
 ### Sharing
 
 Dashboards and analyses are **private by default**. The framework's sharing primitive is wired up:

--- a/templates/analytics/actions/rename-analysis.ts
+++ b/templates/analytics/actions/rename-analysis.ts
@@ -1,0 +1,30 @@
+import { defineAction } from "@agent-native/core";
+import {
+  getRequestUserEmail,
+  getRequestOrgId,
+} from "@agent-native/core/server";
+import { z } from "zod";
+import { upsertAnalysis } from "../server/lib/dashboards-store";
+
+function resolveScope() {
+  const orgId = getRequestOrgId() || null;
+  const email = getRequestUserEmail();
+  if (!email) throw new Error("no authenticated user");
+  return { orgId, email };
+}
+
+export default defineAction({
+  description: "Rename a saved ad-hoc analysis by ID.",
+  schema: z.object({
+    id: z.string().describe("The analysis ID to rename"),
+    name: z.string().describe("The new analysis name"),
+  }),
+  run: async (args) => {
+    const name = args.name.trim();
+    if (!name) throw new Error("name is required");
+
+    const ctx = resolveScope();
+    const analysis = await upsertAnalysis(args.id, { name }, ctx);
+    return { id: analysis.id, name: analysis.name };
+  },
+});

--- a/templates/analytics/actions/rename-dashboard.ts
+++ b/templates/analytics/actions/rename-dashboard.ts
@@ -4,10 +4,7 @@ import {
   getRequestOrgId,
 } from "@agent-native/core/server";
 import { z } from "zod";
-import {
-  getDashboard,
-  upsertDashboard,
-} from "../server/lib/dashboards-store";
+import { getDashboard, upsertDashboard } from "../server/lib/dashboards-store";
 import {
   hasCollabState,
   applyText,

--- a/templates/analytics/actions/rename-dashboard.ts
+++ b/templates/analytics/actions/rename-dashboard.ts
@@ -1,0 +1,60 @@
+import { defineAction } from "@agent-native/core";
+import {
+  getRequestUserEmail,
+  getRequestOrgId,
+} from "@agent-native/core/server";
+import { z } from "zod";
+import {
+  getDashboard,
+  upsertDashboard,
+} from "../server/lib/dashboards-store";
+import {
+  hasCollabState,
+  applyText,
+  seedFromText,
+} from "@agent-native/core/collab";
+
+function resolveScope() {
+  const orgId = getRequestOrgId() || null;
+  const email = getRequestUserEmail();
+  if (!email) throw new Error("no authenticated user");
+  return { orgId, email };
+}
+
+async function syncToCollab(
+  dashboardId: string,
+  config: Record<string, unknown>,
+): Promise<void> {
+  const docId = `dash-${dashboardId}`;
+  const configStr = JSON.stringify(config);
+  try {
+    if (await hasCollabState(docId)) {
+      await applyText(docId, configStr, "content", "agent");
+    } else {
+      await seedFromText(docId, configStr);
+    }
+  } catch {
+    // Best-effort: SQL remains the source of truth.
+  }
+}
+
+export default defineAction({
+  description: "Rename a saved analytics dashboard by ID.",
+  schema: z.object({
+    id: z.string().describe("The dashboard ID to rename"),
+    name: z.string().describe("The new dashboard name"),
+  }),
+  run: async (args) => {
+    const name = args.name.trim();
+    if (!name) throw new Error("name is required");
+
+    const ctx = resolveScope();
+    const dashboard = await getDashboard(args.id, ctx);
+    if (!dashboard) throw new Error("Dashboard not found");
+
+    const config = { ...dashboard.config, name };
+    const updated = await upsertDashboard(args.id, dashboard.kind, config, ctx);
+    await syncToCollab(args.id, config);
+    return { id: updated.id, name: updated.title };
+  },
+});

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -308,20 +308,18 @@ function SortableDashboardItem({
   isActive,
   location,
   favoriteIds,
-  deletingId,
   onToggleFavorite,
-  setDeletingId,
   onDelete,
+  onRename,
   views,
 }: {
   d: SidebarDashboard;
   isActive: boolean;
   location: ReturnType<typeof useLocation>;
   favoriteIds: Set<string>;
-  deletingId: string | null;
   onToggleFavorite: (id: string) => void;
-  setDeletingId: (id: string | null) => void;
   onDelete: (d: SidebarDashboard) => Promise<void>;
+  onRename: (d: SidebarDashboard, name: string) => Promise<void>;
   views?: DashboardView[];
 }) {
   const href = `/adhoc/${d.id}`;
@@ -365,15 +363,13 @@ function SortableDashboardItem({
     <SortableRow
       id={d.id}
       favoriteKey={d.id}
-      deleteKey={d.id}
       name={d.name}
       href={href}
       isActive={isActive}
       favoriteIds={favoriteIds}
       onToggleFavorite={onToggleFavorite}
-      deletingId={deletingId}
-      setDeletingId={setDeletingId}
       onDelete={() => onDelete(d)}
+      onRename={(name) => onRename(d, name)}
     >
       {isActive && allSubviews.length > 0 && (
         <div className="ml-6 mt-0.5 space-y-0.5">
@@ -529,6 +525,42 @@ function setAnalysisOrder(order: string[]): void {
   }
 }
 
+const STATIC_DASHBOARD_RENAMES_KEY = "dashboard-name-overrides";
+
+function getStaticDashboardRenames(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  try {
+    const parsed = JSON.parse(
+      window.localStorage.getItem(STATIC_DASHBOARD_RENAMES_KEY) || "{}",
+    );
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, string] =>
+          typeof entry[0] === "string" &&
+          typeof entry[1] === "string" &&
+          entry[1].trim().length > 0,
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function setStaticDashboardRenames(renames: Record<string, string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      STATIC_DASHBOARD_RENAMES_KEY,
+      JSON.stringify(renames),
+    );
+  } catch {
+    // localStorage unavailable / quota — ignore, rename is best-effort
+  }
+}
+
 async function fetchSqlDashboards(): Promise<{ id: string; name: string }[]> {
   const token = await getIdToken();
   const res = await fetch(appApiPath("/api/sql-dashboards"), {
@@ -596,16 +628,22 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       .catch(() => {});
   }, []);
   const [logoutOpen, setLogoutOpen] = useState(false);
+  const { mutateAsync: renameDashboard } = useActionMutation(
+    "rename-dashboard",
+  );
+  const { mutateAsync: renameAnalysis } = useActionMutation("rename-analysis");
   const [sidebarWidth, setSidebarWidth] = useState(() => {
     if (typeof window === "undefined") return 256;
     const saved = localStorage.getItem("sidebar-width");
     return saved ? Math.max(180, Math.min(480, Number(saved))) : 256;
   });
   const isResizing = useRef(false);
-  const [deletingId, setDeletingId] = useState<string | null>(null);
   const [hiddenIds, setHiddenIds] = useState(() =>
     typeof window === "undefined" ? new Set<string>() : getHiddenDashboards(),
   );
+  const [staticDashboardRenames, setStaticDashboardRenamesState] = useState<
+    Record<string, string>
+  >(() => (typeof window === "undefined" ? {} : getStaticDashboardRenames()));
   const [dashboardOrderState, setDashboardOrderState] = useState(() =>
     typeof window === "undefined" ? [] : getDashboardOrder(),
   );
@@ -686,7 +724,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       .filter((d) => !hiddenIds.has(d.id))
       .map((d) => ({
         id: d.id,
-        name: d.name,
+        name: staticDashboardRenames[d.id] ?? d.name,
         subviews: d.subviews,
         source: "static",
       }));
@@ -709,7 +747,14 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       });
     }
     return applyOrder(all, dashboardOrderState);
-  }, [hiddenIds, favoriteIds, dashboardOrderState, sqlDashboards, popularity]);
+  }, [
+    hiddenIds,
+    staticDashboardRenames,
+    favoriteIds,
+    dashboardOrderState,
+    sqlDashboards,
+    popularity,
+  ]);
 
   const displayedDashboards = useMemo(
     () =>

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -799,6 +799,44 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
     [queryClient],
   );
 
+  const handleDashboardRename = useCallback(
+    async (d: SidebarDashboard, name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed || trimmed === d.name) return;
+
+      if (d.source === "static") {
+        setStaticDashboardRenamesState((prev) => {
+          const next = { ...prev, [d.id]: trimmed };
+          setStaticDashboardRenames(next);
+          return next;
+        });
+        return;
+      }
+
+      const queryKey = ["sql-dashboards-sidebar"] as const;
+      const prev =
+        queryClient.getQueryData<{ id: string; name: string }[]>(queryKey);
+      queryClient.setQueryData<{ id: string; name: string }[]>(
+        queryKey,
+        (old) =>
+          (old ?? []).map((item) =>
+            item.id === d.id ? { ...item, name: trimmed } : item,
+          ),
+      );
+      try {
+        await renameDashboard({ id: d.id, name: trimmed });
+        queryClient.invalidateQueries({ queryKey });
+        queryClient.invalidateQueries({
+          queryKey: ["sql-dashboards-palette"],
+        });
+      } catch (err) {
+        if (prev) queryClient.setQueryData(queryKey, prev);
+        throw err;
+      }
+    },
+    [queryClient, renameDashboard],
+  );
+
   const handleAnalysisDelete = useCallback(
     async (a: { id: string; name: string }) => {
       const queryKey = ["analyses-sidebar"] as const;
@@ -825,6 +863,50 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       }
     },
     [queryClient],
+  );
+
+  const handleAnalysisRename = useCallback(
+    async (a: { id: string; name: string }, name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed || trimmed === a.name) return;
+
+      const sidebarKey = ["analyses-sidebar"] as const;
+      const listKey = ["analyses-list"] as const;
+      const detailKey = ["analysis-detail", a.id] as const;
+      const prevSidebar =
+        queryClient.getQueryData<{ id: string; name: string }[]>(sidebarKey);
+      const prevList = queryClient.getQueryData<any[]>(listKey);
+      const prevDetail = queryClient.getQueryData<any>(detailKey);
+
+      queryClient.setQueryData<{ id: string; name: string }[]>(
+        sidebarKey,
+        (old) =>
+          (old ?? []).map((item) =>
+            item.id === a.id ? { ...item, name: trimmed } : item,
+          ),
+      );
+      queryClient.setQueryData<any[]>(listKey, (old) =>
+        (old ?? []).map((item) =>
+          item.id === a.id ? { ...item, name: trimmed } : item,
+        ),
+      );
+      queryClient.setQueryData<any>(detailKey, (old) =>
+        old ? { ...old, name: trimmed } : old,
+      );
+
+      try {
+        await renameAnalysis({ id: a.id, name: trimmed });
+        queryClient.invalidateQueries({ queryKey: sidebarKey });
+        queryClient.invalidateQueries({ queryKey: listKey });
+        queryClient.invalidateQueries({ queryKey: detailKey });
+      } catch (err) {
+        if (prevSidebar) queryClient.setQueryData(sidebarKey, prevSidebar);
+        if (prevList) queryClient.setQueryData(listKey, prevList);
+        if (prevDetail) queryClient.setQueryData(detailKey, prevDetail);
+        throw err;
+      }
+    },
+    [queryClient, renameAnalysis],
   );
 
   const sensors = useSensors(
@@ -1002,10 +1084,9 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
                       isActive={location.pathname === `/adhoc/${d.id}`}
                       location={location}
                       favoriteIds={favoriteIds}
-                      deletingId={deletingId}
                       onToggleFavorite={toggleFavorite}
-                      setDeletingId={setDeletingId}
                       onDelete={handleDashboardDelete}
+                      onRename={handleDashboardRename}
                       views={allViewsMap[d.id]}
                     />
                   ))}
@@ -1075,15 +1156,13 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
                       key={a.id}
                       id={a.id}
                       favoriteKey={`analysis:${a.id}`}
-                      deleteKey={`analysis:${a.id}`}
                       name={a.name}
                       href={`/analyses/${a.id}`}
                       isActive={location.pathname === `/analyses/${a.id}`}
                       favoriteIds={favoriteIds}
                       onToggleFavorite={toggleFavorite}
-                      deletingId={deletingId}
-                      setDeletingId={setDeletingId}
                       onDelete={() => handleAnalysisDelete(a)}
+                      onRename={(name) => handleAnalysisRename(a, name)}
                     />
                   ))}
                   {sortedAnalyses.length > SIDEBAR_PREVIEW_COUNT && (

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -263,14 +263,14 @@ function SortableRow({
           </button>
           <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
             <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              className="pointer-events-auto rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-foreground"
-              title={`${name} actions`}
-              aria-label={`${name} actions`}
-            >
-              <IconDots className="h-3 w-3" />
-            </button>
+              <button
+                type="button"
+                className="pointer-events-auto rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-foreground"
+                title={`${name} actions`}
+                aria-label={`${name} actions`}
+              >
+                <IconDots className="h-3 w-3" />
+              </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent side="right" align="start" className="w-36">
               <DropdownMenuItem
@@ -628,9 +628,8 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       .catch(() => {});
   }, []);
   const [logoutOpen, setLogoutOpen] = useState(false);
-  const { mutateAsync: renameDashboard } = useActionMutation(
-    "rename-dashboard",
-  );
+  const { mutateAsync: renameDashboard } =
+    useActionMutation("rename-dashboard");
   const { mutateAsync: renameAnalysis } = useActionMutation("rename-analysis");
   const [sidebarWidth, setSidebarWidth] = useState(() => {
     if (typeof window === "undefined") return 256;

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -12,8 +12,10 @@ import {
   IconMoon,
   IconInfoCircle,
   IconTrash,
+  IconDots,
   IconLoader2,
   IconStar,
+  IconPencil,
   IconSettings,
   IconGripVertical,
   IconBook2,
@@ -50,9 +52,19 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton, appApiPath } from "@agent-native/core/client";
+import {
+  FeedbackButton,
+  appApiPath,
+  useActionMutation,
+} from "@agent-native/core/client";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
 import { NewDashboardDialog } from "./NewDashboardDialog";
 import { NewAnalysisDialog } from "./NewAnalysisDialog";
@@ -116,28 +128,24 @@ function applyOrder<T extends { id: string }>(
 function SortableRow({
   id,
   favoriteKey,
-  deleteKey,
   name,
   href,
   isActive,
   favoriteIds,
   onToggleFavorite,
-  deletingId,
-  setDeletingId,
   onDelete,
+  onRename,
   children,
 }: {
   id: string;
   favoriteKey: string;
-  deleteKey: string;
   name: string;
   href: string;
   isActive: boolean;
   favoriteIds: Set<string>;
   onToggleFavorite: (key: string) => void;
-  deletingId: string | null;
-  setDeletingId: (id: string | null) => void;
   onDelete: () => Promise<void> | void;
+  onRename: (name: string) => Promise<void> | void;
   children?: React.ReactNode;
 }) {
   const {
@@ -155,82 +163,138 @@ function SortableRow({
     opacity: isDragging ? 0.5 : 1,
   };
   const isFav = favoriteIds.has(favoriteKey);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState(name);
+
+  useEffect(() => {
+    if (!isRenaming) setRenameValue(name);
+  }, [isRenaming, name]);
+
+  const submitRename = useCallback(async () => {
+    const trimmed = renameValue.trim();
+    setIsRenaming(false);
+    if (!trimmed || trimmed === name) {
+      setRenameValue(name);
+      return;
+    }
+    try {
+      await onRename(trimmed);
+    } catch (e) {
+      setRenameValue(name);
+      toast.error(
+        e instanceof Error
+          ? `Couldn't rename ${name}: ${e.message}`
+          : `Couldn't rename ${name}`,
+      );
+    }
+  }, [name, onRename, renameValue]);
+
+  const runDelete = useCallback(async () => {
+    setMenuOpen(false);
+    try {
+      await onDelete();
+    } catch (e) {
+      toast.error(
+        e instanceof Error
+          ? `Couldn't delete ${name}: ${e.message}`
+          : `Couldn't delete ${name}`,
+      );
+    }
+  }, [name, onDelete]);
+
   return (
     <div ref={setNodeRef} style={style} className="group/item relative min-w-0">
-      <div className="flex items-center min-w-0">
-        <button
-          className="-ml-3 p-1 cursor-grab active:cursor-grabbing text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors shrink-0 opacity-0 group-hover/item:opacity-100"
-          {...attributes}
-          {...listeners}
-        >
-          <IconGripVertical className="h-3 w-3" />
-        </button>
-        <Link
-          to={href}
-          className={cn(
-            "flex-1 min-w-0 flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs transition-all hover:text-primary",
-            isActive
-              ? "bg-sidebar-accent text-sidebar-accent-foreground"
-              : "text-muted-foreground hover:bg-sidebar-accent/50",
-          )}
-        >
-          <span className="truncate">{name}</span>
-        </Link>
-        <button
-          onClick={() => onToggleFavorite(favoriteKey)}
-          className={cn(
-            "p-1 rounded transition-all shrink-0",
-            isFav
-              ? "text-yellow-500 opacity-100"
-              : "opacity-0 group-hover/item:opacity-100 text-muted-foreground/50 hover:text-yellow-500",
-          )}
-          title={isFav ? "Unfavorite" : "Favorite"}
-        >
-          <IconStar className={cn("h-3 w-3", isFav && "fill-current")} />
-        </button>
-        <Popover
-          open={deletingId === deleteKey}
-          onOpenChange={(open) => setDeletingId(open ? deleteKey : null)}
-        >
-          <PopoverTrigger asChild>
+      <button
+        type="button"
+        className="absolute -left-4 top-1/2 z-10 -translate-y-1/2 cursor-grab rounded p-1 text-muted-foreground/30 opacity-0 transition-colors hover:text-muted-foreground/60 group-hover/item:opacity-100 active:cursor-grabbing"
+        aria-label={`Drag ${name}`}
+        {...attributes}
+        {...listeners}
+      >
+        <IconGripVertical className="h-3 w-3" />
+      </button>
+      <div
+        className={cn(
+          "relative flex min-w-0 items-center rounded-lg transition-colors",
+          isActive
+            ? "bg-sidebar-accent text-sidebar-accent-foreground"
+            : "text-muted-foreground hover:bg-sidebar-accent/50 group-hover/item:text-primary",
+        )}
+      >
+        {isRenaming ? (
+          <input
+            autoFocus
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            onBlur={submitRename}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submitRename();
+              if (e.key === "Escape") {
+                setRenameValue(name);
+                setIsRenaming(false);
+              }
+            }}
+            className="min-w-0 flex-1 bg-transparent px-2 py-1.5 pr-12 text-xs outline-none"
+          />
+        ) : (
+          <Link
+            to={href}
+            title={name}
+            className="min-w-0 flex-1 px-2 py-1.5 pr-12 text-xs transition-[padding] md:pr-2 md:group-hover/item:pr-12 md:group-focus-within/item:pr-12"
+          >
+            <span className="block truncate">{name}</span>
+          </Link>
+        )}
+        <div className="pointer-events-none absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-100 transition-opacity md:opacity-0 md:group-hover/item:opacity-100 md:group-focus-within/item:opacity-100">
+          <button
+            type="button"
+            onClick={() => onToggleFavorite(favoriteKey)}
+            className={cn(
+              "pointer-events-auto rounded p-0.5 transition-colors",
+              isFav
+                ? "text-yellow-500"
+                : "text-muted-foreground/50 hover:text-yellow-500",
+            )}
+            title={isFav ? "Unfavorite" : "Favorite"}
+            aria-label={isFav ? "Unfavorite" : "Favorite"}
+          >
+            <IconStar className={cn("h-3 w-3", isFav && "fill-current")} />
+          </button>
+          <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+            <DropdownMenuTrigger asChild>
             <button
-              className="opacity-0 group-hover/item:opacity-100 p-1 rounded text-muted-foreground/50 hover:text-foreground transition-all shrink-0 mr-1"
-              title={`Remove ${name}`}
+              type="button"
+              className="pointer-events-auto rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-foreground"
+              title={`${name} actions`}
+              aria-label={`${name} actions`}
             >
-              <IconTrash className="h-3 w-3" />
+              <IconDots className="h-3 w-3" />
             </button>
-          </PopoverTrigger>
-          <PopoverContent className="w-52 p-3" side="right" align="start">
-            <p className="text-sm mb-3">
-              Remove <strong>{name}</strong>?
-            </p>
-            <div className="flex gap-2">
-              <button
-                onClick={async () => {
-                  try {
-                    await onDelete();
-                    setDeletingId(null);
-                  } catch (e) {
-                    toast.error(
-                      e instanceof Error
-                        ? `Couldn't remove ${name}: ${e.message}`
-                        : `Couldn't remove ${name}`,
-                    );
-                  }
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="right" align="start" className="w-36">
+              <DropdownMenuItem
+                onSelect={() => {
+                  setRenameValue(name);
+                  setIsRenaming(true);
                 }}
-                className="flex-1 rounded-md bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 transition-colors"
               >
-                Remove
-              </button>
-              <button
-                onClick={() => setDeletingId(null)}
-                className="flex-1 rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-sidebar-accent/50 transition-colors"
+                <IconPencil className="mr-2 h-3.5 w-3.5" />
+                Rename
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault();
+                  void runDelete();
+                }}
+                className="text-destructive focus:text-destructive"
               >
-                Cancel
-              </button>
-            </div>
-          </PopoverContent>
-        </Popover>
+                <IconTrash className="mr-2 h-3.5 w-3.5" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
       {children}
     </div>

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactElement, type ReactNode } from "react";
 import { useSendToAgentChat } from "@agent-native/core/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,8 +9,12 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
 } from "@/components/ui/dialog";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -117,14 +121,32 @@ interface PanelEditorDialogProps {
   existingPanelTitles: string[];
 }
 
-export function PanelEditorDialog({
+interface PanelEditorContentProps extends PanelEditorDialogProps {}
+
+function EditorFooter({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`flex flex-col-reverse gap-2 sm:flex-row sm:justify-end ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+function PanelEditorContent({
   open,
   onOpenChange,
   panel,
   onSave,
   dashboardId,
   existingPanelTitles,
-}: PanelEditorDialogProps) {
+}: PanelEditorContentProps) {
   const [form, setForm] = useState<PanelFormValues>(() => panelToForm(panel));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -308,119 +330,169 @@ export function PanelEditorDialog({
     </div>
   );
 
+  if (isEdit) {
+    return (
+      <>
+        {manualForm}
+        <EditorFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!canSave || saving}
+          >
+            {saving ? "Saving..." : "Save changes"}
+          </Button>
+        </EditorFooter>
+      </>
+    );
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Tabs value={tab} onValueChange={(v) => setTab(v as "describe" | "manual")}>
+      <TabsList className="grid w-full grid-cols-2">
+        <TabsTrigger value="describe">Describe</TabsTrigger>
+        <TabsTrigger value="manual">Manual</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="describe" className="mt-4">
+        <div className="grid gap-3">
+          <Label htmlFor="panel-prompt">What do you want to chart?</Label>
+          <Textarea
+            id="panel-prompt"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder="e.g. Weekly signups by channel over the last 6 months, stacked area"
+            className="min-h-[140px] resize-y text-sm"
+            autoFocus
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                handleDescribe();
+              }
+            }}
+          />
+          <p className="text-xs text-muted-foreground">
+            The agent will consult the data dictionary, write the SQL, and
+            append the panel. Press{" "}
+            <kbd className="px-1 rounded border bg-muted font-mono text-[10px]">
+              ⌘ ↵
+            </kbd>{" "}
+            to send.
+          </p>
+        </div>
+        <EditorFooter className="mt-4">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={isGenerating}
+          >
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleDescribe} disabled={!canGenerate}>
+            {isGenerating ? (
+              <>
+                <IconLoader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                Generating...
+              </>
+            ) : (
+              "Generate"
+            )}
+          </Button>
+        </EditorFooter>
+      </TabsContent>
+
+      <TabsContent value="manual" className="mt-2">
+        {manualForm}
+        <EditorFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!canSave || saving}
+          >
+            {saving ? "Saving..." : "Add panel"}
+          </Button>
+        </EditorFooter>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+export function PanelEditorDialog(props: PanelEditorDialogProps) {
+  if (!props.panel) return null;
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent className="sm:max-w-[640px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>{isEdit ? "Edit panel" : "Add panel"}</DialogTitle>
+          <DialogTitle>Edit panel</DialogTitle>
         </DialogHeader>
 
-        {isEdit ? (
-          <>
-            {manualForm}
-            <DialogFooter>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => onOpenChange(false)}
-                disabled={saving}
-              >
-                Cancel
-              </Button>
-              <Button
-                size="sm"
-                onClick={handleSubmit}
-                disabled={!canSave || saving}
-              >
-                {saving ? "Saving..." : "Save changes"}
-              </Button>
-            </DialogFooter>
-          </>
-        ) : (
-          <Tabs
-            value={tab}
-            onValueChange={(v) => setTab(v as "describe" | "manual")}
-          >
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="describe">Describe</TabsTrigger>
-              <TabsTrigger value="manual">Manual</TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="describe" className="mt-4">
-              <div className="grid gap-3">
-                <Label htmlFor="panel-prompt">What do you want to chart?</Label>
-                <Textarea
-                  id="panel-prompt"
-                  value={prompt}
-                  onChange={(e) => setPrompt(e.target.value)}
-                  placeholder="e.g. Weekly signups by channel over the last 6 months, stacked area"
-                  className="min-h-[140px] resize-y text-sm"
-                  autoFocus
-                  onKeyDown={(e) => {
-                    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                      e.preventDefault();
-                      handleDescribe();
-                    }
-                  }}
-                />
-                <p className="text-xs text-muted-foreground">
-                  The agent will consult the data dictionary, write the SQL, and
-                  append the panel. Press{" "}
-                  <kbd className="px-1 rounded border bg-muted font-mono text-[10px]">
-                    ⌘ ↵
-                  </kbd>{" "}
-                  to send.
-                </p>
-              </div>
-              <DialogFooter className="mt-4">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => onOpenChange(false)}
-                  disabled={isGenerating}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  size="sm"
-                  onClick={handleDescribe}
-                  disabled={!canGenerate}
-                >
-                  {isGenerating ? (
-                    <>
-                      <IconLoader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-                      Generating...
-                    </>
-                  ) : (
-                    "Generate"
-                  )}
-                </Button>
-              </DialogFooter>
-            </TabsContent>
-
-            <TabsContent value="manual" className="mt-2">
-              {manualForm}
-              <DialogFooter>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => onOpenChange(false)}
-                  disabled={saving}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  size="sm"
-                  onClick={handleSubmit}
-                  disabled={!canSave || saving}
-                >
-                  {saving ? "Saving..." : "Add panel"}
-                </Button>
-              </DialogFooter>
-            </TabsContent>
-          </Tabs>
-        )}
+        <PanelEditorContent {...props} />
       </DialogContent>
     </Dialog>
+  );
+}
+
+interface AddPanelPopoverProps {
+  children: ReactElement;
+  onSave: (panel: SqlPanel) => Promise<void>;
+  dashboardId: string;
+  existingPanelTitles: string[];
+  align?: "start" | "center" | "end";
+  side?: "top" | "right" | "bottom" | "left";
+}
+
+export function AddPanelPopover({
+  children,
+  onSave,
+  dashboardId,
+  existingPanelTitles,
+  align = "end",
+  side = "bottom",
+}: AddPanelPopoverProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent
+        align={align}
+        side={side}
+        sideOffset={8}
+        aria-label="Add panel"
+        className="w-[calc(100vw-2rem)] sm:w-[640px] max-h-[var(--radix-popover-content-available-height)] overflow-y-auto p-5"
+      >
+        <div className="mb-4">
+          <h2 className="text-base font-semibold leading-none tracking-tight">
+            Add panel
+          </h2>
+        </div>
+        <PanelEditorContent
+          open={open}
+          onOpenChange={setOpen}
+          panel={null}
+          onSave={onSave}
+          dashboardId={dashboardId}
+          existingPanelTitles={existingPanelTitles}
+        />
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -39,7 +39,7 @@ import {
   resolveFilterVars,
 } from "./DashboardFilterBar";
 import { interpolate } from "./interpolate";
-import { PanelEditorDialog } from "./PanelEditorDialog";
+import { AddPanelPopover, PanelEditorDialog } from "./PanelEditorDialog";
 import { ViewsMenu } from "./ViewsMenu";
 import type { SqlDashboardConfig, SqlPanel } from "./types";
 import { useUserPref } from "@/hooks/use-user-pref";
@@ -128,7 +128,7 @@ export default function SqlDashboardPage() {
   const [descriptionInput, setDescriptionInput] = useState("");
   const [loaded, setLoaded] = useState(false);
 
-  // Panel editor dialog state
+  // Panel edit dialog state
   const [editorOpen, setEditorOpen] = useState(false);
   const [editingPanel, setEditingPanel] = useState<SqlPanel | null>(null);
 
@@ -404,12 +404,6 @@ export default function SqlDashboardPage() {
     [dashboard, persistThrow],
   );
 
-  const openAddPanel = useCallback(() => {
-    setEditingPanel(null);
-    setEditorOpen(true);
-    awareness?.setLocalStateField("editingPanelId", null);
-  }, [awareness]);
-
   const openEditPanel = useCallback(
     (panel: SqlPanel) => {
       setEditingPanel(panel);
@@ -548,10 +542,17 @@ export default function SqlDashboardPage() {
             variant="compact"
           />
         ) : null}
-        <Button size="sm" variant="outline" onClick={openAddPanel}>
-          <IconPlus className="h-4 w-4 mr-1" />
-          Add panel
-        </Button>
+        <AddPanelPopover
+          onSave={handleSavePanel}
+          dashboardId={dashboardId ?? ""}
+          existingPanelTitles={dashboard.panels.map((p) => p.title)}
+          align="end"
+        >
+          <Button size="sm" variant="outline">
+            <IconPlus className="h-4 w-4 mr-1" />
+            Add panel
+          </Button>
+        </AddPanelPopover>
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
@@ -661,10 +662,17 @@ export default function SqlDashboardPage() {
         <Card>
           <CardContent className="flex flex-col items-center justify-center h-64 text-muted-foreground text-sm gap-3">
             <p>This dashboard has no panels yet.</p>
-            <Button size="sm" variant="outline" onClick={openAddPanel}>
-              <IconPlus className="h-4 w-4 mr-1" />
-              Add your first panel
-            </Button>
+            <AddPanelPopover
+              onSave={handleSavePanel}
+              dashboardId={dashboardId ?? ""}
+              existingPanelTitles={dashboard.panels.map((p) => p.title)}
+              align="center"
+            >
+              <Button size="sm" variant="outline">
+                <IconPlus className="h-4 w-4 mr-1" />
+                Add your first panel
+              </Button>
+            </AddPanelPopover>
           </CardContent>
         </Card>
       ) : (

--- a/templates/analytics/docs/schemas/README.md
+++ b/templates/analytics/docs/schemas/README.md
@@ -5,6 +5,7 @@ This directory contains technical documentation for BigQuery tables and schemas.
 - **[analytics-events-partitioned.md](./analytics-events-partitioned.md)** - App-level events table structure
 - **[metrics-events.md](./metrics-events.md)** - Metrics events schema
 - **[tracked-events.md](./tracked-events.md)** - Event tracking reference
+- **[first-party-analytics.md](./first-party-analytics.md)** - Public `/track` ingestion endpoint and `analytics_events` query source
 - **[query-metrics-api.md](./query-metrics-api.md)** - Query API documentation
 - **[other-tables.md](./other-tables.md)** - Additional table references
 

--- a/templates/analytics/docs/schemas/first-party-analytics.md
+++ b/templates/analytics/docs/schemas/first-party-analytics.md
@@ -84,19 +84,19 @@ Invalid keys return `401`; malformed payloads return `400`.
 
 Events are stored in `analytics_events`. Common query columns include:
 
-| Column | Description |
-| ------ | ----------- |
-| `event_name` | Event name |
-| `timestamp` | Client event timestamp |
-| `received_at` | Collector receive time |
-| `user_id` | Identified user, when supplied |
-| `anonymous_id` | Anonymous/distinct visitor id |
-| `session_id` | Session id |
-| `app` | App/site name, usually from `properties.app` |
-| `template` | Template dimension, usually from `properties.template` |
-| `signed_in` | Signed-in state copied from `signed_in` or `signedIn` |
-| `url`, `path`, `hostname`, `referrer` | Page context |
-| `properties`, `context` | Original JSON objects |
+| Column                                | Description                                            |
+| ------------------------------------- | ------------------------------------------------------ |
+| `event_name`                          | Event name                                             |
+| `timestamp`                           | Client event timestamp                                 |
+| `received_at`                         | Collector receive time                                 |
+| `user_id`                             | Identified user, when supplied                         |
+| `anonymous_id`                        | Anonymous/distinct visitor id                          |
+| `session_id`                          | Session id                                             |
+| `app`                                 | App/site name, usually from `properties.app`           |
+| `template`                            | Template dimension, usually from `properties.template` |
+| `signed_in`                           | Signed-in state copied from `signed_in` or `signedIn`  |
+| `url`, `path`, `hostname`, `referrer` | Page context                                           |
+| `properties`, `context`               | Original JSON objects                                  |
 
 Example dashboard panel:
 

--- a/templates/analytics/docs/schemas/first-party-analytics.md
+++ b/templates/analytics/docs/schemas/first-party-analytics.md
@@ -1,0 +1,113 @@
+# First-Party Analytics
+
+The analytics template can collect events into its own SQL database and query them as the `first-party` dashboard data source. This is separate from general app DB querying: use `source: "first-party"` in dashboard panels or the `query-agent-native-analytics` action, not `db-query`.
+
+## Create a public key
+
+Generate a public write key from **Data Sources > First-party Analytics**, or ask the agent to run `create-analytics-public-key --name "<label>"`.
+
+Set the key on emitting apps:
+
+```sh
+AGENT_NATIVE_ANALYTICS_PUBLIC_KEY=anpk_...
+VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY=anpk_...
+```
+
+The core `track()` and browser `trackEvent()` helpers automatically send to `https://analytics.agent-native.com/track` when those env vars are present. Localhost is skipped by default.
+
+## Endpoint
+
+Use either endpoint shape:
+
+```txt
+POST https://analytics.agent-native.com/track
+POST https://your-analytics-domain.com/api/analytics/track
+```
+
+Headers:
+
+```txt
+Content-Type: application/json
+x-agent-native-analytics-key: anpk_...  # optional; can also be in the body
+```
+
+Single-event body:
+
+```json
+{
+  "publicKey": "anpk_...",
+  "event": "click template",
+  "userId": "steve@builder.io",
+  "anonymousId": "anon_123",
+  "sessionId": "session_123",
+  "timestamp": "2026-05-01T12:00:00.000Z",
+  "properties": {
+    "app": "docs",
+    "template": "mail",
+    "signed_in": true,
+    "url": "https://agent-native.com/templates/mail"
+  },
+  "context": {
+    "source": "docs"
+  }
+}
+```
+
+Batch body:
+
+```json
+{
+  "publicKey": "anpk_...",
+  "events": [
+    {
+      "event": "click template",
+      "properties": {
+        "app": "docs",
+        "template": "mail"
+      }
+    }
+  ]
+}
+```
+
+Batches may include up to 100 events. Event names may be sent as `event` or `name`; keys may be sent as `publicKey`, `writeKey`, `apiKey`, or the `x-agent-native-analytics-key` header.
+
+Successful requests return:
+
+```json
+{ "success": true, "accepted": 1 }
+```
+
+Invalid keys return `401`; malformed payloads return `400`.
+
+## Stored fields
+
+Events are stored in `analytics_events`. Common query columns include:
+
+| Column | Description |
+| ------ | ----------- |
+| `event_name` | Event name |
+| `timestamp` | Client event timestamp |
+| `received_at` | Collector receive time |
+| `user_id` | Identified user, when supplied |
+| `anonymous_id` | Anonymous/distinct visitor id |
+| `session_id` | Session id |
+| `app` | App/site name, usually from `properties.app` |
+| `template` | Template dimension, usually from `properties.template` |
+| `signed_in` | Signed-in state copied from `signed_in` or `signedIn` |
+| `url`, `path`, `hostname`, `referrer` | Page context |
+| `properties`, `context` | Original JSON objects |
+
+Example dashboard panel:
+
+```json
+{
+  "id": "clicks-by-template",
+  "title": "Clicks by Template",
+  "source": "first-party",
+  "chartType": "bar",
+  "width": 1,
+  "sql": "SELECT COALESCE(NULLIF(template, ''), 'unknown') AS template, COUNT(*) AS count FROM analytics_events WHERE event_name = 'click template' GROUP BY COALESCE(NULLIF(template, ''), 'unknown') ORDER BY count DESC LIMIT 20",
+  "config": { "xKey": "template", "yKey": "count" }
+}
+```

--- a/templates/analytics/seeds/dashboards/agent-native-templates-ga4.json
+++ b/templates/analytics/seeds/dashboards/agent-native-templates-ga4.json
@@ -121,30 +121,30 @@
     },
     {
       "id": "sessions-by-app",
-      "title": "Sessions by Agent-Native App",
+      "title": "Sessions by Agent-Native Template",
       "chartType": "bar",
       "source": "ga4",
       "width": 2,
-      "sql": "{\"metrics\":[\"eventCount\"],\"dimensions\":[\"customEvent:app\"],\"days\":{{days}},\"filter\":{\"filter\":{\"fieldName\":\"eventName\",\"stringFilter\":{\"value\":\"session_status\",\"matchType\":\"EXACT\"}}}}",
+      "sql": "{\"metrics\":[\"eventCount\"],\"dimensions\":[\"customEvent:template\"],\"days\":{{days}},\"filter\":{\"filter\":{\"fieldName\":\"eventName\",\"stringFilter\":{\"value\":\"session_status\",\"matchType\":\"EXACT\"}}}}",
       "config": {
-        "xKey": "customEvent:app",
+        "xKey": "customEvent:template",
         "yKey": "eventCount",
         "color": "#10b981",
-        "description": "Per-template-site session activity (mail, calendar, slides, ...). Each tab fires session_status once."
+        "description": "Per-template session activity. GA4 exposes template as a registered event dimension."
       }
     },
     {
       "id": "signed-in-vs-anon",
-      "title": "Signed-In vs Anonymous Sessions",
-      "chartType": "bar",
+      "title": "Session Status Events",
+      "chartType": "metric",
       "source": "ga4",
       "width": 1,
-      "sql": "{\"metrics\":[\"eventCount\"],\"dimensions\":[\"customEvent:signed_in\"],\"days\":{{days}},\"filter\":{\"filter\":{\"fieldName\":\"eventName\",\"stringFilter\":{\"value\":\"session_status\",\"matchType\":\"EXACT\"}}}}",
+      "sql": "{\"metrics\":[\"eventCount\"],\"dimensions\":[],\"days\":{{days}},\"filter\":{\"filter\":{\"fieldName\":\"eventName\",\"stringFilter\":{\"value\":\"session_status\",\"matchType\":\"EXACT\"}}}}",
       "config": {
-        "xKey": "customEvent:signed_in",
         "yKey": "eventCount",
+        "yFormatter": "number",
         "color": "#f59e0b",
-        "description": "true = signed in, false = anonymous. Best proxy for total signups per period (still includes returning users)."
+        "description": "Signed-in split is available in first-party analytics; GA4 needs signed_in registered as a custom dimension before it can segment this panel."
       }
     },
     {

--- a/templates/analytics/server/plugins/auth.ts
+++ b/templates/analytics/server/plugins/auth.ts
@@ -1,6 +1,7 @@
 import { createAuthPlugin } from "@agent-native/core/server";
 
 export default createAuthPlugin({
+  publicPaths: ["/track", "/api/analytics/track"],
   marketing: {
     appName: "Agent-Native Analytics",
     tagline:

--- a/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
+++ b/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
@@ -8,6 +8,8 @@ import {
   IconLoader2,
   IconChevronUp,
   IconUpload,
+  IconAlertTriangle,
+  IconLogout,
 } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import { agentNativePath, getCallbackOrigin } from "@agent-native/core/client";
@@ -60,6 +62,15 @@ interface GoogleConnectBannerProps {
   variant?: "banner" | "hero";
 }
 
+interface DesktopAuthIssue {
+  error?: string;
+  message?: string;
+  code?: string;
+  accountId?: string;
+  existingOwner?: string;
+  attemptedOwner?: string;
+}
+
 export function GoogleConnectBanner({
   variant = "banner",
 }: GoogleConnectBannerProps) {
@@ -67,6 +78,8 @@ export function GoogleConnectBanner({
   const [wantAddAccount, setWantAddAccount] = useState(false);
   const [dismissed, setDismissed] = useState(false);
   const [showWizard, setShowWizard] = useState(false);
+  const [desktopAuthIssue, setDesktopAuthIssue] =
+    useState<DesktopAuthIssue | null>(null);
   const googleStatus = useGoogleAuthStatus();
   const authUrl = useGoogleAuthUrl(wantAuthUrl);
   const addAccountUrl = useGoogleAddAccountUrl(wantAddAccount);
@@ -88,6 +101,7 @@ export function GoogleConnectBanner({
   }, []);
 
   function signInViaDesktopBrowser(addAccount = false) {
+    setDesktopAuthIssue(null);
     const flowId =
       crypto.randomUUID?.() ||
       Math.random().toString(36).slice(2) + Date.now().toString(36);
@@ -112,7 +126,11 @@ export function GoogleConnectBanner({
           ),
         );
         const data = await res.json();
-        if (data?.token) {
+        if (data?.error) {
+          clearInterval(desktopPollRef.current!);
+          desktopPollRef.current = null;
+          setDesktopAuthIssue(data);
+        } else if (data?.token) {
           clearInterval(desktopPollRef.current!);
           desktopPollRef.current = null;
           await fetch(
@@ -212,6 +230,18 @@ export function GoogleConnectBanner({
   const allConfigured =
     envStatus.length > 0 && envStatus.every((k) => k.configured);
 
+  const handleSignOutForGoogle = useCallback(async () => {
+    try {
+      await fetch(agentNativePath("/_agent-native/auth/logout"), {
+        method: "POST",
+        credentials: "include",
+      });
+    } catch {
+      // Reload below still lands on the auth screen if the local cookie changed.
+    }
+    window.location.reload();
+  }, []);
+
   // When add-account URL is ready, open it and poll for new account.
   // Same retry-intent rationale as the connect effect — `wantAddAccount`
   // is in the deps so a second click rerun the effect; the polling
@@ -245,6 +275,7 @@ export function GoogleConnectBanner({
   }, [wantAddAccount, addAccountUrl.data]);
 
   function handleConnect() {
+    setDesktopAuthIssue(null);
     if (isElectron) {
       signInViaDesktopBrowser();
       return;
@@ -340,6 +371,13 @@ export function GoogleConnectBanner({
                 ? "Connect Google"
                 : "Set up Google"}
         </Button>
+
+        <GoogleAuthIssuePanel
+          issue={desktopAuthIssue}
+          onSignOut={handleSignOutForGoogle}
+          onDismiss={() => setDesktopAuthIssue(null)}
+          className="mt-5 w-full max-w-md"
+        />
 
         {hasAccounts && (
           <div className="mt-4 flex items-center gap-2 flex-wrap justify-center">
@@ -480,6 +518,13 @@ export function GoogleConnectBanner({
           </Button>
         </div>
       </div>
+
+      <GoogleAuthIssuePanel
+        issue={desktopAuthIssue}
+        onSignOut={handleSignOutForGoogle}
+        onDismiss={() => setDesktopAuthIssue(null)}
+        className="mx-4 mb-3"
+      />
 
       {/* Inline setup wizard */}
       {showWizard && !allConfigured && (

--- a/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
+++ b/templates/calendar/app/components/calendar/GoogleConnectBanner.tsx
@@ -456,6 +456,12 @@ export function GoogleConnectBanner({
             <IconX className="h-3 w-3" />
           </Button>
         </div>
+        <GoogleAuthIssuePanel
+          issue={desktopAuthIssue}
+          onSignOut={handleSignOutForGoogle}
+          onDismiss={() => setDesktopAuthIssue(null)}
+          className="mx-4 mb-3"
+        />
       </div>
     );
   }
@@ -548,6 +554,75 @@ export function GoogleConnectBanner({
           />
         </div>
       )}
+    </div>
+  );
+}
+
+function GoogleAuthIssuePanel({
+  issue,
+  onSignOut,
+  onDismiss,
+  className = "",
+}: {
+  issue: DesktopAuthIssue | null;
+  onSignOut: () => void;
+  onDismiss: () => void;
+  className?: string;
+}) {
+  if (!issue) return null;
+  const account = issue.accountId || "that Google account";
+  const detail =
+    issue.message ||
+    issue.error ||
+    `Sign out, then sign back in with ${account}.`;
+  const shouldOfferSignOut =
+    issue.code === "account_owner_mismatch" ||
+    Boolean(issue.existingOwner || issue.attemptedOwner || issue.accountId);
+
+  return (
+    <div
+      className={`rounded-lg border border-amber-500/25 bg-amber-500/[0.07] p-3 text-left ${className}`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-amber-500/15 text-amber-300">
+          <IconAlertTriangle className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-foreground">
+            Use the matching Agent Native login
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            {detail}
+          </p>
+          {shouldOfferSignOut && (
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                className="h-8 gap-1.5 px-3 text-xs font-medium"
+                onClick={onSignOut}
+              >
+                <IconLogout className="h-3.5 w-3.5" />
+                Sign out
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground"
+                onClick={onDismiss}
+              >
+                Dismiss
+              </Button>
+            </div>
+          )}
+        </div>
+        <button
+          className="shrink-0 rounded p-1 text-muted-foreground hover:bg-white/5 hover:text-foreground"
+          onClick={onDismiss}
+          aria-label="Dismiss Google sign-in notice"
+        >
+          <IconX className="h-3.5 w-3.5" />
+        </button>
+      </div>
     </div>
   );
 }

--- a/templates/calendar/server/handlers/google-auth.ts
+++ b/templates/calendar/server/handlers/google-auth.ts
@@ -16,8 +16,10 @@ import {
   resolveOAuthOwner,
   createOAuthSession,
   oauthCallbackResponse,
+  oauthDesktopExchangePage,
   oauthErrorPage,
   setDesktopExchange,
+  setDesktopExchangeError,
   DEV_MODE_USER_EMAIL,
 } from "@agent-native/core/server";
 import {
@@ -28,29 +30,67 @@ import {
 } from "../lib/google-calendar.js";
 import { OAuthAccountOwnedByOtherUserError } from "@agent-native/core/oauth-tokens";
 
-function googleOAuthErrorMessage(
+function googleOAuthErrorPayload(
   error: any,
   prefix = "Connection failed",
-): string {
+): {
+  message: string;
+  code?: string;
+  accountId?: string;
+  existingOwner?: string;
+  attemptedOwner?: string;
+} {
   if (
     error instanceof OAuthAccountOwnedByOtherUserError ||
     error?.name === "OAuthAccountOwnedByOtherUserError"
   ) {
     const account = error.accountId || "This Google account";
+    const existingOwner = error.existingOwner || undefined;
+    const attemptedOwner = error.attemptedOwner || undefined;
     const owner =
       error.existingOwner === DEV_MODE_USER_EMAIL
         ? "a previous local session"
         : error.existingOwner || "another user";
-    return `${account} is already connected to ${owner}. Sign in as that user or disconnect the Google account there first.`;
+    const message =
+      attemptedOwner && attemptedOwner !== existingOwner
+        ? `You selected ${account}, but Calendar is currently signed in as ${attemptedOwner}. Sign out, then sign back in with ${account}.`
+        : `${account} is already connected to ${owner}. Sign in as that user or disconnect the Google account there first.`;
+    return {
+      message,
+      code: "account_owner_mismatch",
+      accountId: error.accountId,
+      existingOwner,
+      attemptedOwner,
+    };
   }
 
   const msg = error?.message || "Unknown error";
   const isPermission =
     msg.includes("Insufficient Permission") ||
     msg.includes("insufficient_scope");
-  return isPermission
-    ? "This account wasn't granted the required permissions. Make sure you check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
-    : `${prefix}: ${msg}`;
+  return {
+    message: isPermission
+      ? "This account wasn't granted the required permissions. Make sure you check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
+      : `${prefix}: ${msg}`,
+    code: isPermission ? "missing_google_permissions" : "google_oauth_failed",
+  };
+}
+
+function googleOAuthErrorMessage(error: any, prefix = "Connection failed") {
+  return googleOAuthErrorPayload(error, prefix).message;
+}
+
+function googleOAuthErrorResponse(
+  event: H3Event,
+  error: any,
+  opts: { desktop?: boolean; flowId?: string; prefix?: string } = {},
+) {
+  const payload = googleOAuthErrorPayload(error, opts.prefix);
+  if (opts.desktop && opts.flowId) {
+    setDesktopExchangeError(opts.flowId, payload);
+    return oauthDesktopExchangePage("Returning to Calendar...");
+  }
+  return oauthErrorPage(payload.message);
 }
 
 export const getGoogleAuthUrl = defineEventHandler(async (event: H3Event) => {

--- a/templates/calendar/server/handlers/google-auth.ts
+++ b/templates/calendar/server/handlers/google-auth.ts
@@ -26,6 +26,32 @@ import {
   getAuthStatus,
   disconnect,
 } from "../lib/google-calendar.js";
+import { OAuthAccountOwnedByOtherUserError } from "@agent-native/core/oauth-tokens";
+
+function googleOAuthErrorMessage(
+  error: any,
+  prefix = "Connection failed",
+): string {
+  if (
+    error instanceof OAuthAccountOwnedByOtherUserError ||
+    error?.name === "OAuthAccountOwnedByOtherUserError"
+  ) {
+    const account = error.accountId || "This Google account";
+    const owner =
+      error.existingOwner === DEV_MODE_USER_EMAIL
+        ? "a previous local session"
+        : error.existingOwner || "another user";
+    return `${account} is already connected to ${owner}. Sign in as that user or disconnect the Google account there first.`;
+  }
+
+  const msg = error?.message || "Unknown error";
+  const isPermission =
+    msg.includes("Insufficient Permission") ||
+    msg.includes("insufficient_scope");
+  return isPermission
+    ? "This account wasn't granted the required permissions. Make sure you check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
+    : `${prefix}: ${msg}`;
+}
 
 export const getGoogleAuthUrl = defineEventHandler(async (event: H3Event) => {
   if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
@@ -128,14 +154,7 @@ export const handleGoogleCallback = defineEventHandler(
         appName: "Calendar",
       });
     } catch (error: any) {
-      const msg = error.message || "Unknown error";
-      const isPermission =
-        msg.includes("Insufficient Permission") ||
-        msg.includes("insufficient_scope");
-      const userMessage = isPermission
-        ? "This account wasn't granted the required permissions. Make sure you check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
-        : `Connection failed: ${msg}`;
-      return oauthErrorPage(userMessage);
+      return oauthErrorPage(googleOAuthErrorMessage(error));
     }
   },
 );
@@ -221,14 +240,9 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
         appName: "Calendar",
       });
     } catch (error: any) {
-      const msg = error.message || "Unknown error";
-      const isPermission =
-        msg.includes("Insufficient Permission") ||
-        msg.includes("insufficient_scope");
-      const userMessage = isPermission
-        ? "This account wasn't granted the required permissions. Make sure you check all the permission boxes on the consent screen."
-        : `Failed to add account: ${msg}`;
-      return oauthErrorPage(userMessage);
+      return oauthErrorPage(
+        googleOAuthErrorMessage(error, "Failed to add account"),
+      );
     }
   },
 );

--- a/templates/calendar/server/handlers/google-auth.ts
+++ b/templates/calendar/server/handlers/google-auth.ts
@@ -76,10 +76,6 @@ function googleOAuthErrorPayload(
   };
 }
 
-function googleOAuthErrorMessage(error: any, prefix = "Connection failed") {
-  return googleOAuthErrorPayload(error, prefix).message;
-}
-
 function googleOAuthErrorResponse(
   event: H3Event,
   error: any,
@@ -260,17 +256,35 @@ export const getGoogleAddAccountUrl = defineEventHandler(
 
 export const handleGoogleAddAccountCallback = defineEventHandler(
   async (event: H3Event) => {
+    let desktop = false;
+    let flowId: string | undefined;
     try {
       const session = await getSession(event);
       const query = getQuery(event);
-      const {
-        redirectUri,
-        owner: stateOwner,
-        desktop,
-      } = decodeOAuthState(
+      const state = decodeOAuthState(
         query.state as string | undefined,
         getAppUrl(event, "/_agent-native/google/add-account/callback"),
       );
+      desktop = state.desktop;
+      flowId = state.flowId;
+
+      const googleError = query.error as string | undefined;
+      if (googleError) {
+        const errorDesc =
+          (query.error_description as string | undefined) || googleError;
+        const isPermission =
+          googleError === "access_denied" ||
+          errorDesc.includes("Insufficient Permission");
+        const userMessage = isPermission
+          ? "Access was denied. Make sure to check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
+          : `Connection failed: ${errorDesc}`;
+        return googleOAuthErrorResponse(event, new Error(userMessage), {
+          desktop,
+          flowId,
+        });
+      }
+
+      const { redirectUri, owner: stateOwner } = state;
 
       const ownerEmail = session?.email || stateOwner;
       if (!ownerEmail) {
@@ -296,9 +310,11 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
         appName: "Calendar",
       });
     } catch (error: any) {
-      return oauthErrorPage(
-        googleOAuthErrorMessage(error, "Failed to add account"),
-      );
+      return googleOAuthErrorResponse(event, error, {
+        desktop,
+        flowId,
+        prefix: "Failed to add account",
+      });
     }
   },
 );

--- a/templates/calendar/server/handlers/google-auth.ts
+++ b/templates/calendar/server/handlers/google-auth.ts
@@ -138,24 +138,40 @@ export const getGoogleAuthUrl = defineEventHandler(async (event: H3Event) => {
 
 export const handleGoogleCallback = defineEventHandler(
   async (event: H3Event) => {
+    let desktop = false;
+    let flowId: string | undefined;
     try {
       const query = getQuery(event);
+      const state = decodeOAuthState(
+        query.state as string | undefined,
+        getAppUrl(event, "/_agent-native/google/callback"),
+      );
+      desktop = state.desktop;
+      flowId = state.flowId;
+
+      const googleError = query.error as string | undefined;
+      if (googleError) {
+        const errorDesc =
+          (query.error_description as string | undefined) || googleError;
+        const isPermission =
+          googleError === "access_denied" ||
+          errorDesc.includes("Insufficient Permission");
+        const userMessage = isPermission
+          ? "Access was denied. Make sure to check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
+          : `Connection failed: ${errorDesc}`;
+        return googleOAuthErrorResponse(event, new Error(userMessage), {
+          desktop,
+          flowId,
+        });
+      }
+
       const code = query.code as string;
       if (!code) {
         setResponseStatus(event, 400);
         return { error: "Missing authorization code" };
       }
 
-      const {
-        redirectUri,
-        owner: stateOwner,
-        desktop,
-        addAccount,
-        flowId,
-      } = decodeOAuthState(
-        query.state as string | undefined,
-        getAppUrl(event, "/_agent-native/google/callback"),
-      );
+      const { redirectUri, owner: stateOwner, addAccount } = state;
 
       // 1. Resolve owner (needs session context, before exchangeCode)
       const { owner, hasProductionSession } = await resolveOAuthOwner(
@@ -194,7 +210,7 @@ export const handleGoogleCallback = defineEventHandler(
         appName: "Calendar",
       });
     } catch (error: any) {
-      return oauthErrorPage(googleOAuthErrorMessage(error));
+      return googleOAuthErrorResponse(event, error, { desktop, flowId });
     }
   },
 );

--- a/templates/calendar/server/handlers/google-auth.ts
+++ b/templates/calendar/server/handlers/google-auth.ts
@@ -125,6 +125,7 @@ export const handleGoogleCallback = defineEventHandler(
         desktop,
         addAccount: isAddAccount,
         flowId,
+        appName: "Calendar",
       });
     } catch (error: any) {
       const msg = error.message || "Unknown error";
@@ -217,6 +218,7 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
       return oauthCallbackResponse(event, addedEmail, {
         desktop,
         addAccount: true,
+        appName: "Calendar",
       });
     } catch (error: any) {
       const msg = error.message || "Unknown error";

--- a/templates/calls/actions/request-transcript.ts
+++ b/templates/calls/actions/request-transcript.ts
@@ -51,7 +51,7 @@ import {
   getRequestUserEmail,
   getCredentialContext,
 } from "@agent-native/core/server/request-context";
-import { hasBuilderPrivateKey } from "@agent-native/core/server";
+import { resolveHasBuilderPrivateKey } from "@agent-native/core/server";
 import { transcribeWithBuilder } from "@agent-native/core/transcription/builder";
 import { transcribeWithDeepgram } from "../server/lib/transcription/deepgram.js";
 import { labelSpeakers } from "../server/lib/transcription/diarize-speakers.js";
@@ -72,10 +72,11 @@ export default defineAction({
     const userEmail = getRequestUserEmail() ?? ownerEmail;
 
     // ── Builder transcription (highest priority) ──────────────────────
-    // Builder proxy is available when BUILDER_PRIVATE_KEY is set. It
-    // provides high-quality diarized transcription without requiring a
-    // separate Deepgram key.
-    if (hasBuilderPrivateKey()) {
+    // Builder proxy is available when the current user has connected
+    // Builder via OAuth (per-user app_secrets) OR when BUILDER_PRIVATE_KEY
+    // is set at the deployment level. Use the per-user-aware resolver so
+    // a sidebar OAuth connection actually wires through to transcription.
+    if (await resolveHasBuilderPrivateKey()) {
       await upsertTranscriptRow(db, {
         callId: args.callId,
         ownerEmail,

--- a/templates/clips/actions/request-transcript.ts
+++ b/templates/clips/actions/request-transcript.ts
@@ -43,7 +43,7 @@ import {
   getRequestUserEmail,
   getCredentialContext,
 } from "@agent-native/core/server/request-context";
-import { hasBuilderPrivateKey } from "@agent-native/core/server";
+import { resolveHasBuilderPrivateKey } from "@agent-native/core/server";
 import { transcribeWithBuilder } from "@agent-native/core/transcription/builder";
 import regenerateTitle from "./regenerate-title.js";
 
@@ -153,10 +153,11 @@ export default defineAction({
     let builderError: string | null = null;
 
     // ── Builder transcription (highest priority) ──────────────────────
-    // Builder proxy is available when BUILDER_PRIVATE_KEY is set. It
-    // provides high-quality transcription without requiring a separate
-    // Groq or OpenAI key.
-    if (hasBuilderPrivateKey()) {
+    // Builder proxy is available when the current user has connected
+    // Builder via OAuth (per-user app_secrets) OR when BUILDER_PRIVATE_KEY
+    // is set at the deployment level. Use the per-user-aware resolver so
+    // a sidebar OAuth connection actually wires through to transcription.
+    if (await resolveHasBuilderPrivateKey()) {
       await upsertTranscriptRow(db, {
         recordingId: args.recordingId,
         ownerEmail,

--- a/templates/mail/app/components/GoogleConnectBanner.tsx
+++ b/templates/mail/app/components/GoogleConnectBanner.tsx
@@ -862,6 +862,75 @@ export function GoogleConnectBanner({
   );
 }
 
+function GoogleAuthIssuePanel({
+  issue,
+  onSignOut,
+  onDismiss,
+  className = "",
+}: {
+  issue: DesktopAuthIssue | null;
+  onSignOut: () => void;
+  onDismiss: () => void;
+  className?: string;
+}) {
+  if (!issue) return null;
+  const account = issue.accountId || "that Google account";
+  const detail =
+    issue.message ||
+    issue.error ||
+    `Sign out, then sign back in with ${account}.`;
+  const shouldOfferSignOut =
+    issue.code === "account_owner_mismatch" ||
+    Boolean(issue.existingOwner || issue.attemptedOwner || issue.accountId);
+
+  return (
+    <div
+      className={`rounded-lg border border-amber-500/25 bg-amber-500/[0.07] p-3 text-left ${className}`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-amber-500/15 text-amber-300">
+          <IconAlertTriangle className="h-4 w-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-foreground">
+            Use the matching Agent Native login
+          </p>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            {detail}
+          </p>
+          {shouldOfferSignOut && (
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <Button
+                size="sm"
+                className="h-8 gap-1.5 bg-white px-3 text-xs font-medium text-black hover:bg-white/90"
+                onClick={onSignOut}
+              >
+                <IconLogout className="h-3.5 w-3.5" />
+                Sign out
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground"
+                onClick={onDismiss}
+              >
+                Dismiss
+              </Button>
+            </div>
+          )}
+        </div>
+        <button
+          className="shrink-0 rounded p-1 text-muted-foreground hover:bg-white/5 hover:text-foreground"
+          onClick={onDismiss}
+          aria-label="Dismiss Google sign-in notice"
+        >
+          <IconX className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function GoogleIcon({ className = "h-4 w-4" }: { className?: string }) {
   return (
     <svg viewBox="0 0 24 24" className={className} aria-hidden="true">

--- a/templates/mail/app/components/GoogleConnectBanner.tsx
+++ b/templates/mail/app/components/GoogleConnectBanner.tsx
@@ -623,6 +623,12 @@ export function GoogleConnectBanner({
             <IconX className="h-3 w-3" />
           </Button>
         </div>
+        <GoogleAuthIssuePanel
+          issue={desktopAuthIssue}
+          onSignOut={handleSignOutForGoogle}
+          onDismiss={() => setDesktopAuthIssue(null)}
+          className="mx-4 mb-3"
+        />
       </div>
     );
   }

--- a/templates/mail/app/components/GoogleConnectBanner.tsx
+++ b/templates/mail/app/components/GoogleConnectBanner.tsx
@@ -9,6 +9,8 @@ import {
   IconChevronDown,
   IconChevronUp,
   IconUpload,
+  IconAlertTriangle,
+  IconLogout,
 } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import { agentNativePath, getCallbackOrigin } from "@agent-native/core/client";
@@ -68,6 +70,15 @@ interface GoogleConnectBannerProps {
   variant?: "banner" | "hero";
 }
 
+interface DesktopAuthIssue {
+  error?: string;
+  message?: string;
+  code?: string;
+  accountId?: string;
+  existingOwner?: string;
+  attemptedOwner?: string;
+}
+
 export function GoogleConnectBanner({
   variant = "banner",
 }: GoogleConnectBannerProps) {
@@ -75,6 +86,8 @@ export function GoogleConnectBanner({
   const [wantAddAccount, setWantAddAccount] = useState(false);
   const [dismissed, setDismissed] = useState(false);
   const [showWizard, setShowWizard] = useState(false);
+  const [desktopAuthIssue, setDesktopAuthIssue] =
+    useState<DesktopAuthIssue | null>(null);
   const googleStatus = useGoogleAuthStatus();
   const authUrl = useGoogleAuthUrl(wantAuthUrl);
   const addAccountUrl = useGoogleAddAccountUrl(wantAddAccount);
@@ -96,6 +109,7 @@ export function GoogleConnectBanner({
   }, []);
 
   function signInViaDesktopBrowser(addAccount = false) {
+    setDesktopAuthIssue(null);
     const flowId =
       crypto.randomUUID?.() ||
       Math.random().toString(36).slice(2) + Date.now().toString(36);
@@ -120,7 +134,11 @@ export function GoogleConnectBanner({
           ),
         );
         const data = await res.json();
-        if (data?.token) {
+        if (data?.error) {
+          clearInterval(desktopPollRef.current!);
+          desktopPollRef.current = null;
+          setDesktopAuthIssue(data);
+        } else if (data?.token) {
           clearInterval(desktopPollRef.current!);
           desktopPollRef.current = null;
           await fetch(
@@ -235,6 +253,18 @@ export function GoogleConnectBanner({
   const allConfigured =
     envStatus.length > 0 && envStatus.every((k) => k.configured);
 
+  const handleSignOutForGoogle = useCallback(async () => {
+    try {
+      await fetch(agentNativePath("/_agent-native/auth/logout"), {
+        method: "POST",
+        credentials: "include",
+      });
+    } catch {
+      // Reload below still lands on the auth screen if the local cookie changed.
+    }
+    window.location.reload();
+  }, []);
+
   // When add-account URL is ready, open it and poll for new account.
   // Same retry-intent rationale as the connect effect — `wantAddAccount`
   // is in the deps so a second click rerun the effect; the polling
@@ -276,6 +306,7 @@ export function GoogleConnectBanner({
   }, [wantAddAccount, addAccountUrl.data]);
 
   function handleConnect() {
+    setDesktopAuthIssue(null);
     if (isElectron) {
       signInViaDesktopBrowser();
       return;
@@ -377,6 +408,13 @@ export function GoogleConnectBanner({
               ? "Sign in with Google"
               : "Set up Google"}
         </Button>
+
+        <GoogleAuthIssuePanel
+          issue={desktopAuthIssue}
+          onSignOut={handleSignOutForGoogle}
+          onDismiss={() => setDesktopAuthIssue(null)}
+          className="mt-5 w-full max-w-md"
+        />
 
         {authError && allConfigured && (
           <p className="mt-3 text-xs text-red-400">{authError}</p>
@@ -649,6 +687,13 @@ export function GoogleConnectBanner({
           </Button>
         </div>
       </div>
+
+      <GoogleAuthIssuePanel
+        issue={desktopAuthIssue}
+        onSignOut={handleSignOutForGoogle}
+        onDismiss={() => setDesktopAuthIssue(null)}
+        className="mx-4 mb-3"
+      />
 
       {/* Inline setup wizard */}
       {showWizard && !allConfigured && (

--- a/templates/mail/server/handlers/google-auth.ts
+++ b/templates/mail/server/handlers/google-auth.ts
@@ -30,7 +30,35 @@ import {
 } from "../lib/google-auth.js";
 import { googleFetch } from "../lib/google-api.js";
 import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
-import { setOAuthDisplayName } from "@agent-native/core/oauth-tokens";
+import {
+  OAuthAccountOwnedByOtherUserError,
+  setOAuthDisplayName,
+} from "@agent-native/core/oauth-tokens";
+
+function googleOAuthErrorMessage(
+  error: any,
+  prefix = "Connection failed",
+): string {
+  if (
+    error instanceof OAuthAccountOwnedByOtherUserError ||
+    error?.name === "OAuthAccountOwnedByOtherUserError"
+  ) {
+    const account = error.accountId || "This Google account";
+    const owner =
+      error.existingOwner === DEV_MODE_USER_EMAIL
+        ? "a previous local session"
+        : error.existingOwner || "another user";
+    return `${account} is already connected to ${owner}. Sign in as that user or disconnect the Google account there first.`;
+  }
+
+  const msg = error?.message || "Unknown error";
+  const isPermission =
+    msg.includes("Insufficient Permission") ||
+    msg.includes("insufficient_scope");
+  return isPermission
+    ? "This account wasn't granted the required permissions. Make sure you check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
+    : `${prefix}: ${msg}`;
+}
 
 export const getGoogleAuthUrl = defineEventHandler(async (event: H3Event) => {
   if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
@@ -180,14 +208,7 @@ export const handleGoogleCallback = defineEventHandler(
         appName: "Mail",
       });
     } catch (error: any) {
-      const msg = error.message || "Unknown error";
-      const isPermission =
-        msg.includes("Insufficient Permission") ||
-        msg.includes("insufficient_scope");
-      const userMessage = isPermission
-        ? "This account wasn't granted the required permissions. Make sure you check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
-        : `Connection failed: ${msg}`;
-      return oauthErrorPage(userMessage);
+      return oauthErrorPage(googleOAuthErrorMessage(error));
     }
   },
 );
@@ -288,14 +309,9 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
         appName: "Mail",
       });
     } catch (error: any) {
-      const msg = error.message || "Unknown error";
-      const isPermission =
-        msg.includes("Insufficient Permission") ||
-        msg.includes("insufficient_scope");
-      const userMessage = isPermission
-        ? "This account wasn't granted the required permissions. Make sure you check all the permission boxes on the consent screen."
-        : `Failed to add account: ${msg}`;
-      return oauthErrorPage(userMessage);
+      return oauthErrorPage(
+        googleOAuthErrorMessage(error, "Failed to add account"),
+      );
     }
   },
 );

--- a/templates/mail/server/handlers/google-auth.ts
+++ b/templates/mail/server/handlers/google-auth.ts
@@ -16,8 +16,10 @@ import {
   resolveOAuthOwner,
   createOAuthSession,
   oauthCallbackResponse,
+  oauthDesktopExchangePage,
   oauthErrorPage,
   setDesktopExchange,
+  setDesktopExchangeError,
   DEV_MODE_USER_EMAIL,
 } from "@agent-native/core/server";
 import {
@@ -35,29 +37,67 @@ import {
   setOAuthDisplayName,
 } from "@agent-native/core/oauth-tokens";
 
-function googleOAuthErrorMessage(
+function googleOAuthErrorPayload(
   error: any,
   prefix = "Connection failed",
-): string {
+): {
+  message: string;
+  code?: string;
+  accountId?: string;
+  existingOwner?: string;
+  attemptedOwner?: string;
+} {
   if (
     error instanceof OAuthAccountOwnedByOtherUserError ||
     error?.name === "OAuthAccountOwnedByOtherUserError"
   ) {
     const account = error.accountId || "This Google account";
+    const existingOwner = error.existingOwner || undefined;
+    const attemptedOwner = error.attemptedOwner || undefined;
     const owner =
       error.existingOwner === DEV_MODE_USER_EMAIL
         ? "a previous local session"
         : error.existingOwner || "another user";
-    return `${account} is already connected to ${owner}. Sign in as that user or disconnect the Google account there first.`;
+    const message =
+      attemptedOwner && attemptedOwner !== existingOwner
+        ? `You selected ${account}, but Mail is currently signed in as ${attemptedOwner}. Sign out, then sign back in with ${account}.`
+        : `${account} is already connected to ${owner}. Sign in as that user or disconnect the Google account there first.`;
+    return {
+      message,
+      code: "account_owner_mismatch",
+      accountId: error.accountId,
+      existingOwner,
+      attemptedOwner,
+    };
   }
 
   const msg = error?.message || "Unknown error";
   const isPermission =
     msg.includes("Insufficient Permission") ||
     msg.includes("insufficient_scope");
-  return isPermission
-    ? "This account wasn't granted the required permissions. Make sure you check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
-    : `${prefix}: ${msg}`;
+  return {
+    message: isPermission
+      ? "This account wasn't granted the required permissions. Make sure you check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
+      : `${prefix}: ${msg}`,
+    code: isPermission ? "missing_google_permissions" : "google_oauth_failed",
+  };
+}
+
+function googleOAuthErrorMessage(error: any, prefix = "Connection failed") {
+  return googleOAuthErrorPayload(error, prefix).message;
+}
+
+function googleOAuthErrorResponse(
+  event: H3Event,
+  error: any,
+  opts: { desktop?: boolean; flowId?: string; prefix?: string } = {},
+) {
+  const payload = googleOAuthErrorPayload(error, opts.prefix);
+  if (opts.desktop && opts.flowId) {
+    setDesktopExchangeError(opts.flowId, payload);
+    return oauthDesktopExchangePage("Returning to Mail...");
+  }
+  return oauthErrorPage(payload.message);
 }
 
 export const getGoogleAuthUrl = defineEventHandler(async (event: H3Event) => {

--- a/templates/mail/server/handlers/google-auth.ts
+++ b/templates/mail/server/handlers/google-auth.ts
@@ -83,10 +83,6 @@ function googleOAuthErrorPayload(
   };
 }
 
-function googleOAuthErrorMessage(error: any, prefix = "Connection failed") {
-  return googleOAuthErrorPayload(error, prefix).message;
-}
-
 function googleOAuthErrorResponse(
   event: H3Event,
   error: any,
@@ -300,9 +296,17 @@ export const getGoogleAddAccountUrl = defineEventHandler(
 
 export const handleGoogleAddAccountCallback = defineEventHandler(
   async (event: H3Event) => {
+    let desktop = false;
+    let flowId: string | undefined;
     try {
       const session = await getSession(event);
       const query = getQuery(event);
+      const state = decodeOAuthState(
+        query.state as string | undefined,
+        getAppUrl(event, "/_agent-native/google/add-account/callback"),
+      );
+      desktop = state.desktop;
+      flowId = state.flowId;
 
       // Handle Google authorization errors (e.g. user denied access, invalid client)
       const googleError = query.error as string | undefined;
@@ -315,17 +319,13 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
         const userMessage = isPermission
           ? "Access was denied. Make sure to check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
           : `Connection failed: ${errorDesc}`;
-        return oauthErrorPage(userMessage);
+        return googleOAuthErrorResponse(event, new Error(userMessage), {
+          desktop,
+          flowId,
+        });
       }
 
-      const {
-        redirectUri,
-        owner: stateOwner,
-        desktop,
-      } = decodeOAuthState(
-        query.state as string | undefined,
-        getAppUrl(event, "/_agent-native/google/add-account/callback"),
-      );
+      const { redirectUri, owner: stateOwner } = state;
 
       const ownerEmail = session?.email || stateOwner;
       if (!ownerEmail) {
@@ -351,9 +351,11 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
         appName: "Mail",
       });
     } catch (error: any) {
-      return oauthErrorPage(
-        googleOAuthErrorMessage(error, "Failed to add account"),
-      );
+      return googleOAuthErrorResponse(event, error, {
+        desktop,
+        flowId,
+        prefix: "Failed to add account",
+      });
     }
   },
 );

--- a/templates/mail/server/handlers/google-auth.ts
+++ b/templates/mail/server/handlers/google-auth.ts
@@ -62,6 +62,7 @@ export const getGoogleAuthUrl = defineEventHandler(async (event: H3Event) => {
       owner,
       desktop,
       addAccount: false,
+      app: "mail",
       flowId,
     });
     const url = getAuthUrl(undefined, redirectUri, state);
@@ -176,6 +177,7 @@ export const handleGoogleCallback = defineEventHandler(
         desktop,
         addAccount: isAddAccount,
         flowId,
+        appName: "Mail",
       });
     } catch (error: any) {
       const msg = error.message || "Unknown error";
@@ -218,6 +220,7 @@ export const getGoogleAddAccountUrl = defineEventHandler(
         owner: session.email,
         desktop,
         addAccount: true,
+        app: "mail",
         flowId,
       });
       const url = getAuthUrl(undefined, redirectUri, state);
@@ -282,6 +285,7 @@ export const handleGoogleAddAccountCallback = defineEventHandler(
       return oauthCallbackResponse(event, addedEmail, {
         desktop,
         addAccount: true,
+        appName: "Mail",
       });
     } catch (error: any) {
       const msg = error.message || "Unknown error";

--- a/templates/mail/server/handlers/google-auth.ts
+++ b/templates/mail/server/handlers/google-auth.ts
@@ -146,8 +146,16 @@ export const getGoogleAuthUrl = defineEventHandler(async (event: H3Event) => {
 
 export const handleGoogleCallback = defineEventHandler(
   async (event: H3Event) => {
+    let desktop = false;
+    let flowId: string | undefined;
     try {
       const query = getQuery(event);
+      const state = decodeOAuthState(
+        query.state as string | undefined,
+        getAppUrl(event, "/_agent-native/google/callback"),
+      );
+      desktop = state.desktop;
+      flowId = state.flowId;
 
       // Handle Google authorization errors (e.g. user denied access, invalid client)
       const googleError = query.error as string | undefined;
@@ -160,7 +168,10 @@ export const handleGoogleCallback = defineEventHandler(
         const userMessage = isPermission
           ? "Access was denied. Make sure to check all the permission boxes on the consent screen. If the app is in testing mode, add this email as a test user in Google Cloud Console."
           : `Connection failed: ${errorDesc}`;
-        return oauthErrorPage(userMessage);
+        return googleOAuthErrorResponse(event, new Error(userMessage), {
+          desktop,
+          flowId,
+        });
       }
 
       const code = query.code as string;
@@ -169,16 +180,7 @@ export const handleGoogleCallback = defineEventHandler(
         return { error: "Missing authorization code" };
       }
 
-      const {
-        redirectUri,
-        owner: stateOwner,
-        desktop,
-        addAccount,
-        flowId,
-      } = decodeOAuthState(
-        query.state as string | undefined,
-        getAppUrl(event, "/_agent-native/google/callback"),
-      );
+      const { redirectUri, owner: stateOwner, addAccount } = state;
 
       // 1. Resolve owner (needs session context, before exchangeCode)
       const { owner, hasProductionSession } = await resolveOAuthOwner(
@@ -248,7 +250,7 @@ export const handleGoogleCallback = defineEventHandler(
         appName: "Mail",
       });
     } catch (error: any) {
-      return oauthErrorPage(googleOAuthErrorMessage(error));
+      return googleOAuthErrorResponse(event, error, { desktop, flowId });
     }
   },
 );


### PR DESCRIPTION
## Summary

Concurrent agent sweep on \`updates-220\`.

### New
- \`packages/core/src/agent/tool-search.ts\` + spec — agent tool search
- \`packages/core/src/client/analytics.spec.ts\` — analytics test coverage
- \`templates/analytics/docs/schemas/first-party-analytics.md\` — first-party schema docs

### Modified
- Tracking skill docs
- MCP clients doc
- Client analytics module
- Server agent-chat plugin
- Auth + better-auth instance
- Core routes plugin
- Google OAuth (core + mail + calendar handlers)
- Desktop app main process + dev-electron script

### Plus
- Analytics first-party schema docs
- GA4 dashboard seed updates
- Auth plugin tweak

## Test plan
- [ ] CI: Lint, Test, Typecheck, Build, Scaffold E2E, Guard all green
- [ ] tool-search agent works end-to-end
- [ ] Analytics tracking still works