### PR TITLE
fix(slides): color picker popup overflowing palette button container

### DIFF
--- a/templates/slides/app/components/editor/BlockBubbleMenu.tsx
+++ b/templates/slides/app/components/editor/BlockBubbleMenu.tsx
@@ -185,14 +185,14 @@ export function BlockBubbleMenu({ editingEl, onChange }: BlockBubbleMenuProps) {
           active={showColors}
         />
         {showColors && (
-          <div className="absolute top-full left-0 mt-1 p-2 rounded-lg bg-popover border border-border shadow-2xl shadow-black/60 grid grid-cols-6 gap-1">
+          <div className="absolute top-full left-0 mt-1 p-3 rounded-lg bg-popover border border-border shadow-2xl shadow-black/60 grid grid-cols-6 gap-2 w-max">
             {COLORS.map((c) => (
               <button
                 key={c}
                 type="button"
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={() => applyColor(c)}
-                className="w-5 h-5 rounded border border-border hover:scale-110 transition-transform"
+                className="w-7 h-7 rounded-md border border-foreground/25 hover:scale-110 transition-transform"
                 style={{ background: c }}
                 title={c}
                 aria-label={`Set color ${c}`}


### PR DESCRIPTION
## Summary

The text-block bubble menu's color picker was rendering with squished, overflowing swatches:

- The popup is `position: absolute` inside a ~28px-wide palette button wrapper.
- With `width: auto`, CSS shrink-to-fit collapsed the popup to ~120px.
- `grid-cols-6` then squeezed each column to ~10px, but the swatches had explicit `w-5` (20px) widths — so they overflowed their own columns. The rightmost swatches rendered outside the popup's dark background entirely.

Fix: force the popup to size to its content with `w-max` so the 6-column grid gets the room it needs, regardless of how narrow the absolutely-positioned containing block is.

While there:
- Bumped swatches 20px → 28px (`w-5` → `w-7`) and gap 4px → 8px so they're no longer cramped.
- Switched border from `border-border` to `border-foreground/25` so white/light-gray/black swatches stop blurring into the dark popover background.

## Test plan

- [ ] Open a deck, click into a text block, select some text, click the palette icon — color picker should be ~232px wide with all 11 swatches sitting in a clean 6+5 grid inside the popup.
- [ ] Hover a swatch — `hover:scale-110` should still fire without overlap.
- [ ] Click a swatch — color applies to the selected text and popup closes.
- [ ] Verify in both light and dark themes that all swatches (especially `#FFFFFF`, `#E5E7EB`, `#000000`) are clearly visible against the popover background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)