### PR TITLE
fix(mail): include filtered messages in search

### DIFF
--- a/docs/plans/2026-05-01-001-feat-builder-managed-email-plan.md
+++ b/docs/plans/2026-05-01-001-feat-builder-managed-email-plan.md
@@ -1,0 +1,223 @@
+---
+title: "feat: Builder-managed transactional email"
+type: feat
+status: blocked
+date: 2026-05-01
+---
+
+# Builder-Managed Transactional Email
+
+## Overview
+
+Add Builder as a first-class email provider for agent-native apps. This is not an email implementation plan for Resend, SendGrid, or SES inside the framework. It is the agent-native integration plan for an ai-services managed email backend.
+
+The user-facing shape should match the setup direction we want elsewhere:
+
+- Builder-managed is the primary path.
+- Bring-your-own provider keys are secondary.
+- Local development should work without email provider setup.
+- Production/deploy flows should clearly prompt users to enable email before flows like password reset, invite, verification, or app notifications depend on it.
+
+## Status: Blocked
+
+Blocked on ai-services shipping the managed email control plane and send plane described in:
+
+`/Users/steve/Projects/builder/ai-services/packages/docs/content/tech-specs/managed-transactional-email.mdx`
+
+Agent-native should not call SES directly. The framework should only call Builder's managed email API with a scoped send token minted by ai-services.
+
+## Product Defaults
+
+- Email providers are not required for local mode.
+- Local/dev auth can continue using existing no-provider behavior.
+- Managed email is optional until deploy or until the app uses production email features.
+- Setup copy should say email is needed before production features like password resets, verification, invites, and notifications can send.
+- Do not recommend Resend over SendGrid or SendGrid over Resend. Both are BYO secondary options.
+- Builder-managed email should appear as the primary option when available.
+- BYO Resend/SendGrid remains available for users who already have an email provider.
+
+## Backend Contract Expected From ai-services
+
+Agent-native expects these ai-services routes:
+
+| Method | Route                                                     | Purpose                                                                 |
+| ------ | --------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `GET`  | `/agent-native/managed-email/v1/status`                   | Get enablement, default sender, custom-domain state, and credit status. |
+| `POST` | `/agent-native/managed-email/v1/enable`                   | Provision or fetch the managed email tenant and default sender.         |
+| `POST` | `/agent-native/managed-email/v1/tokens`                   | Mint a scoped runtime send token for the deployed app.                  |
+| `POST` | `/agent-native/managed-email/v1/send`                     | Send a transactional email with the scoped token.                       |
+| `GET`  | `/agent-native/managed-email/v1/domains`                  | List sender domains and DNS status.                                     |
+| `POST` | `/agent-native/managed-email/v1/domains`                  | Start custom sender-domain verification.                                |
+| `POST` | `/agent-native/managed-email/v1/domains/:domainId/verify` | Refresh DNS/SES verification status.                                    |
+
+The runtime app should never receive a Builder private key. It should receive only a send-only token scoped to owner/project/app/environment/sender.
+
+## Runtime Configuration
+
+Add a Builder provider mode to framework email config:
+
+```env
+BUILDER_EMAIL_PROVIDER=builder
+BUILDER_EMAIL_TOKEN=bme_...
+BUILDER_EMAIL_API_BASE_URL=https://ai.builder.io
+BUILDER_EMAIL_FROM=notifications@app.example.com
+```
+
+Provider resolution order:
+
+1. `BUILDER_EMAIL_PROVIDER=builder` and `BUILDER_EMAIL_TOKEN` means use Builder-managed email.
+2. `RESEND_API_KEY` means use Resend.
+3. `SENDGRID_API_KEY` means use SendGrid.
+4. No provider means dev/no-email behavior.
+
+Do not depend on per-user Builder OAuth credentials for sending email. Password reset routes and other public auth flows can run without a logged-in user, so the app needs a tenant-scoped send token stored as deployment env/workspace secret.
+
+## Setup UX
+
+Replace the current provider-card-heavy email setup with a compact primary/secondary shape:
+
+- Primary row: "Use Builder-managed email"
+  - Copy: "Builder sends transactional email for this app. Best for password resets, invites, verification, and production notifications."
+  - Button: "Enable"
+  - Status states: `not enabled`, `enabling`, `enabled`, `credits paused`, `domain pending`, `domain verified`.
+
+- Secondary row: "Use your own provider"
+  - Provider selector: Resend or SendGrid.
+  - Neutral copy: "Paste an existing provider key if you already manage email elsewhere."
+  - Required env fields shown only for the selected BYO provider.
+
+Setup copy should not imply email is required for local work. A better checklist message:
+
+> Email is optional for local development. Enable it before deploy if this app sends password resets, verification emails, invites, or notifications.
+
+## Deploy-Gated Enablement
+
+Managed email should be created only when clearly needed. Acceptable enable triggers:
+
+- User clicks "Enable Builder-managed email" in setup.
+- User enters deploy flow and the app uses auth/email-dependent features.
+- Agent detects a production email requirement and asks to enable managed email.
+
+Do not auto-provision email tenants for every created project.
+
+## Framework Email Behavior
+
+Extend the existing framework email abstraction so `sendEmail()` can use Builder-managed email. The app-level email call should stay provider-agnostic.
+
+Expected behavior:
+
+- `isEmailConfigured()` returns true when Builder provider env is present and token is non-empty.
+- Password reset sends through Builder provider when configured.
+- Verification sends through Builder provider when configured.
+- Organization invites and share notifications send through Builder provider when configured.
+- If credits are exhausted, the provider returns a structured error and the caller surfaces a clear message.
+- Existing Resend and SendGrid behavior remains unchanged.
+
+Do not add feature-specific email code paths. Auth, organizations, sharing, and app notifications should continue to call the framework email helper.
+
+## Credit-Exhausted UX
+
+When ai-services returns 402:
+
+- Do not claim that email was sent.
+- Show a quiet but visible message near the relevant flow.
+- Suggested copy:
+
+> Email is enabled for this app, but Builder credits are currently exhausted. Emails will resume when credits are available.
+
+In the setup checklist, show email as connected but paused:
+
+- Connected provider: Builder
+- Status: Paused, credits required
+- Action: link to Builder billing/credits page when available
+
+## Custom Domain UX
+
+v1 agent-native setup should expose only the minimum domain status needed:
+
+- Default Builder-managed sender is available.
+- Custom sender domain is not configured.
+- Custom sender domain is pending DNS.
+- Custom sender domain is verified.
+- Custom sender domain is restricted or disabled.
+
+DNS record editing can live in Builder-hosted management UI if that is easier for v1. Agent-native only needs a status card and a link/button to manage sender domain.
+
+## BYO Provider Fallback
+
+Keep BYO Resend and SendGrid:
+
+```env
+RESEND_API_KEY=...
+RESEND_FROM_EMAIL=...
+SENDGRID_API_KEY=...
+SENDGRID_FROM_EMAIL=...
+```
+
+Provider UI should be neutral:
+
+- Do not describe one provider as preferred.
+- Do not use "recommended" badges for BYO providers.
+- Do not show large cards for every possible provider.
+- Use one compact provider selector and reveal only relevant env fields.
+
+## Docs Updates
+
+After backend exists, update:
+
+- `packages/core/docs/content/onboarding.md`
+- `packages/core/docs/content/authentication.md`
+- `packages/core/docs/content/deployment.md`
+- `packages/core/docs/content/notifications.md`
+
+Docs should say:
+
+- Local mode does not require email.
+- Production password reset, verification, invites, and notifications need an email provider.
+- Builder-managed email is the easiest hosted path.
+- Resend and SendGrid are BYO alternatives.
+
+## Test Plan
+
+Unit tests:
+
+- Email provider resolution chooses Builder when `BUILDER_EMAIL_PROVIDER=builder`.
+- Resend and SendGrid continue to resolve as before.
+- No-provider local/dev behavior is unchanged.
+- Builder provider maps normal send success.
+- Builder provider maps 402 to a structured credit error.
+- Builder provider maps retryable server errors without losing original context.
+
+UI tests:
+
+- Email setup shows Builder-managed as primary.
+- BYO provider selector reveals only selected provider fields.
+- Local/dev copy does not say email is required.
+- Connected but credit-paused state is visually distinct from disconnected state.
+
+Manual QA:
+
+- Local app with no provider can still run auth in dev mode.
+- Deployed app with Builder provider sends password reset.
+- Organization invite sends through Builder provider.
+- Credits exhausted path blocks send and shows the quiet notice.
+- Switching to BYO Resend/SendGrid still works.
+
+## Sequencing
+
+1. ai-services managed email spec approved.
+2. ai-services hidden endpoints ship behind flags.
+3. Agent-native adds Builder provider support in the email abstraction.
+4. Agent-native setup UI makes Builder-managed email primary.
+5. Deploy flow offers managed email enablement only when needed.
+6. Builder internal usage surfaces show `email:*` credit spend.
+7. Roll out to internal projects, then allowlist, then general hosted deployments.
+
+## Out Of Scope
+
+- Direct SES usage from agent-native apps.
+- Marketing email.
+- Email template builder.
+- Attachments.
+- Inbound email.
+- Replacing BYO provider support.

--- a/docs/plans/2026-05-01-002-research-managed-app-platform-gaps.md
+++ b/docs/plans/2026-05-01-002-research-managed-app-platform-gaps.md
@@ -1,0 +1,293 @@
+---
+title: "research: managed app platform gaps after db/auth/email/llm/hosting"
+type: research
+status: done
+date: 2026-05-01
+---
+
+# Managed App Platform Gaps After DB/Auth/Email/LLM/Hosting
+
+## Summary
+
+If Builder has managed database, auth, email, LLM, and hosting, the biggest remaining "get apps live" gaps are not payments or ecommerce. The most important missing primitives are the operational platform pieces around a live app:
+
+1. File/object storage.
+2. Custom domains, DNS, SSL, and primary-domain UX.
+3. Production secrets and environment management.
+4. Logs, monitoring, and deploy diagnostics.
+5. Basic app analytics.
+6. Background jobs and workflow runs.
+7. Preview/share controls.
+8. Git/export/import.
+9. Rollback and production safety.
+10. Security and verification checks before publish.
+
+Payments and ecommerce are lower priority. Once secrets, server actions/functions, webhooks, and jobs are solid, Stripe and Shopify are mostly integration/template work rather than core platform blockers.
+
+## Competitive Baseline
+
+### Lovable
+
+Lovable's current surface is broader than app generation plus publish. Lovable Cloud positions itself as a managed runtime with database, auth, storage, edge functions, app connectors, secrets, custom email, usage/cost management, and AI. It also has publish snapshots, custom domains, GitHub sync/export, preview links, project analytics, file generation, browser testing, testing tools, security scanning, collaboration, project comments, workspace knowledge, cross-project references, design systems, and enterprise governance.
+
+Useful lessons:
+
+- Managed cloud should feel like a complete app envelope, not a bag of separate integrations.
+- Security and browser verification are part of the publish loop, not optional debugging tools.
+- Runtime app connectors and build-time MCP/context connectors should be separate concepts.
+- Publish snapshots reduce accidental production changes.
+- Direct visual editing and project comments are strong bridges for non-developers.
+
+Avoid copying:
+
+- Brittle GitHub coupling where repo moves/renames break sync.
+- Half-stable environment separation. Lovable's Test/Live environment docs say new Cloud projects no longer get that feature after March 24, 2026.
+- Connector sprawl without deep typed contracts, auth, observability, and agent/UI parity.
+
+### Bolt
+
+Bolt Cloud is close to Lovable's all-in-one beginner launch story. It bundles hosting, domains, database, auth, file storage, server functions, analytics, and Stripe. Bolt also has `.bolt.host` URLs, domain purchase/connect flows, secrets, logs, file storage buckets, hosting analytics, sharing/collaboration roles, version history, export/download/GitHub restore, and an Expo/mobile path.
+
+Useful lessons:
+
+- Beginner launch products benefit from one visible checklist that includes URL, storage, secrets, logs, and analytics.
+- File storage has to exist even if the admin UI starts simple.
+- Mobile is a visible competitive surface, but probably not day-one critical for Builder's web-first app path.
+
+### Replit
+
+Replit is strongest on operational deployment. It has Autoscale, Static, Reserved VM, and Scheduled deployments; custom domains with TLS; encrypted secrets; Scheduled Deployments for cron/background jobs; object storage built on GCS; deployment monitoring; logs; resource usage; checkpoints and rollbacks; imports from GitHub, ZIP, Vercel, Bolt, Lovable, and Figma; and a strong native mobile/Expo story.
+
+Useful lessons:
+
+- Logs and monitoring are core deploy product, not support tooling.
+- Scheduled jobs are a first-class deployment type.
+- Import/export matters for portability and competitive switching.
+- Rollback needs a clear story for both code and data.
+
+## Priority Platform Pieces
+
+### P0: File/Object Storage
+
+This is the biggest gap after DB/auth/email/LLM/hosting. Real apps need avatars, uploads, documents, attachments, generated exports, images, videos, and user files.
+
+Builder should provide:
+
+- Per-app buckets.
+- Public and private objects.
+- Signed upload and download URLs.
+- Access-policy helpers integrated with agent-native auth/orgs.
+- Agent-friendly helpers for file upload, read, list, delete, and generate.
+- Storage usage shown in credits/usage eventually.
+- A simple file browser in hosted management UI.
+
+This should be treated as a platform primitive, not a template feature.
+
+### P0: Domains, DNS, SSL, And Primary Domain
+
+Every competitor makes "real URL" part of launch. Builder hosting should include:
+
+- Default `*.builder.cloud` or equivalent app URL.
+- Custom domain connect.
+- DNS verification status.
+- Automatic TLS.
+- Primary domain selection.
+- Redirects from secondary domains.
+- Troubleshooting when DNS is wrong.
+- Future optional domain purchase.
+
+Email sender-domain verification should align with app-domain setup where possible, but app domain and email domain should remain separately understandable.
+
+### P0: Secrets And Environment Management
+
+Users will paste Stripe, Shopify, Slack, Twilio, custom API, and other keys. The platform needs:
+
+- Per-app secrets.
+- Per-environment secrets.
+- Server-only visibility.
+- Rotation and deletion.
+- Secret-safe collaboration.
+- Agent prompts when a feature requires a key.
+- A path from "user pasted key" to "server action/function uses key" without leaking it to browser code.
+
+This is the foundation that makes payments and most integrations easy later.
+
+### P0: Logs And Monitoring
+
+Once an app is public, debugging without logs is miserable. Builder should expose:
+
+- Runtime request logs.
+- Action/function logs.
+- Auth logs.
+- Database errors.
+- Job logs.
+- Deploy/build logs.
+- Email send events.
+- LLM gateway errors.
+- Agent-readable logs for debugging.
+
+Start with simple filtered logs and error summaries. Advanced APM can wait.
+
+### P1: Analytics
+
+Basic analytics have high perceived value and low product complexity:
+
+- Visitors.
+- Pageviews.
+- Top pages.
+- Referrers.
+- Countries/devices.
+- 404s.
+- Request status/duration.
+- Simple real-time view.
+
+This can be framed as "is anyone using my app?" rather than a full analytics product.
+
+### P1: Background Jobs And Workflows
+
+Agent-native already has recurring jobs, automations, and queue-like integration patterns. The hosted product needs a live surface:
+
+- Schedule editor.
+- Natural-language schedule if feasible.
+- Manual "run now".
+- Run history.
+- Logs.
+- Retries.
+- Failure alerts.
+- Secret/env support.
+- Credit/usage accounting later.
+
+This matters for notifications, syncs, reports, reminders, billing tasks, and integrations.
+
+### P1: Preview, Sharing, And Collaboration
+
+Builder should support:
+
+- Temporary public preview links for the running app only.
+- Private/internal published app access.
+- Collaborator roles.
+- Secret-safe behavior for viewers.
+- Comments or feedback tied to UI/screens where possible.
+
+Do not expose code, chat, or secrets through preview links.
+
+### P1: Git, Export, And Import
+
+Portability is central to Builder's positioning. Support:
+
+- ZIP export.
+- GitHub sync/export.
+- Reconnect after repo rename/move.
+- Import from GitHub and ZIP.
+- Later: import from Vercel, Bolt, Lovable, Replit, and Figma where practical.
+
+Lovable's two-way GitHub sync is useful but brittle. Builder should make repo mobility boring.
+
+### P1: Rollback And Production Safety
+
+Agent-native apps can modify code and database schema, so rollback is not optional.
+
+Needed:
+
+- Code checkpoints.
+- Deploy snapshots.
+- Clear rollback to previous deploy.
+- Clear distinction between code rollback and data rollback.
+- Pre-publish checks.
+- Additive-schema guidance surfaced in agent/deploy flows.
+- Optional database backup before risky deploys.
+
+### P1: Security And Verification Before Publish
+
+Copy the spirit of Lovable's publish gate:
+
+- Browser test before publish.
+- Console/network error checks.
+- Dependency/security audit.
+- Secret leak scan.
+- Auth/access-policy checks.
+- Database access-scope checks.
+- Email/domain/reputation checks where relevant.
+
+Do not overclaim "secure." Present checks as automated guardrails plus residual risk.
+
+### P2: Mobile
+
+Bolt and Replit both have credible Expo/mobile stories. This is a visible competitive gap if "end-to-end app building" includes app-store distribution.
+
+For Builder, mobile can wait behind web deploy essentials. A later path could be:
+
+- Expo template support.
+- Phone preview.
+- Shared backend/auth/storage/email services.
+- Guided TestFlight/App Store/Play Store checklist.
+
+## What Not To Prioritize For V1
+
+- Stripe as a platform primitive. A Stripe key plus server actions, secrets, webhooks, and agent guidance is enough for most early apps.
+- Shopify/ecommerce as a core blocker.
+- Huge connector catalog before typed actions, auth, logs, and secrets are solid.
+- Enterprise governance before the base deploy surface works.
+- Full staging/live environments unless Builder can make them stable and understandable from day one.
+
+## Recommended Roadmap Shape
+
+### Managed Platform V1
+
+- Hosting with default domain.
+- Managed database.
+- Managed auth.
+- Managed LLM gateway.
+- Managed transactional email.
+- Secrets/env vars.
+- File/object storage.
+- Logs.
+- Basic custom domains.
+- Publish snapshots and rollback.
+
+### Managed Platform V1.5
+
+- Background jobs/workflows.
+- Basic analytics.
+- Security and browser verification checks before publish.
+- Preview/share links.
+- GitHub sync/export.
+- Email/custom-domain polish.
+- Credits view for email/storage/hosting/db usage categories.
+
+### Managed Platform V2
+
+- Stable staging/prod environments.
+- Domain purchase.
+- Mobile/Expo path.
+- Import from competitor tools.
+- Team comments/design systems/governance.
+- More runtime app connectors with typed contracts.
+
+## Sources
+
+- [Lovable Cloud](https://docs.lovable.dev/integrations/cloud)
+- [Lovable Publish](https://docs.lovable.dev/features/publish)
+- [Lovable Custom Domains](https://docs.lovable.dev/features/custom-domain)
+- [Lovable GitHub integration](https://docs.lovable.dev/integrations/github)
+- [Lovable Analytics](https://docs.lovable.dev/features/analytics)
+- [Lovable Browser Testing](https://docs.lovable.dev/features/browser-testing)
+- [Lovable Testing Tools](https://docs.lovable.dev/features/testing)
+- [Lovable Security](https://docs.lovable.dev/features/security)
+- [Lovable Collaboration](https://docs.lovable.dev/features/collaboration)
+- [Lovable Test and Live Environments](https://docs.lovable.dev/features/environments)
+- [Bolt Cloud](https://support.bolt.new/cloud/bolt-cloud)
+- [Bolt Hosting](https://support.bolt.new/cloud/hosting)
+- [Bolt Domains](https://support.bolt.new/cloud/domains)
+- [Bolt Secrets](https://support.bolt.new/cloud/database/secrets)
+- [Bolt Logs](https://support.bolt.new/cloud/database/logs)
+- [Bolt File Storage](https://support.bolt.new/cloud/database/file-storage)
+- [Bolt Rollback and Backup](https://support.bolt.new/building/using-bolt/rollback-backup)
+- [Replit Deployments](https://docs.replit.com/category/replit-deployments)
+- [Replit Custom Domains](https://docs.replit.com/cloud-services/deployments/custom-domains)
+- [Replit Secrets](https://docs.replit.com/core-concepts/project-editor/app-setup/secrets)
+- [Replit Scheduled Deployments](https://docs.replit.com/cloud-services/deployments/scheduled-deployments)
+- [Replit Object Storage](https://docs.replit.com/cloud-services/storage-and-databases/object-storage)
+- [Replit Deployment Monitoring](https://docs.replit.com/cloud-services/deployments/monitoring-a-deployment)
+- [Replit Checkpoints and Rollbacks](https://docs.replit.com/core-concepts/agent/checkpoints-and-rollbacks)
+- [Replit Import](https://docs.replit.com/core-concepts/project-editor/app-setup/import)

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -286,8 +286,8 @@ export function useEmails(
   const data = useMemo(() => {
     if (!q.data) return undefined;
     const all = q.data.pages.flatMap((p: EmailsPage) => p.emails);
-    return applyOverrides(filterSuppressed(all, view));
-  }, [q.data, view]);
+    return applyOverrides(search ? all : filterSuppressed(all, view));
+  }, [q.data, search, view]);
 
   return {
     data,

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -311,7 +311,7 @@ export function InboxPage() {
       );
       return filtered.filter((e) => qualifiedThreadIds.has(e.threadId || e.id));
     }
-    if (view === "inbox" && pinnedUserLabels.length > 0) {
+    if (!searchQuery && view === "inbox" && pinnedUserLabels.length > 0) {
       // Inbox: filter out emails that belong to a pinned label
       // Compute short names for each pinned label so we match email labelIds
       const pinnedShortNames = pinnedUserLabels.map((l) =>
@@ -334,6 +334,7 @@ export function InboxPage() {
   }, [
     rawEmails,
     view,
+    searchQuery,
     activeLabel,
     pinnedUserLabels,
     activeAccounts,


### PR DESCRIPTION
## Summary
- Keep suppressed/pinned-label filtering out of Mail search results so search can find messages that are hidden from the normal inbox view
- Include the search query in inbox memo dependencies so label filtering updates correctly when searching
- Add managed email and managed app platform planning notes

## Verification
- npx prettier --write templates/mail/app/hooks/use-emails.ts templates/mail/app/pages/InboxPage.tsx
- pnpm --dir templates/mail typecheck
- git diff --check
- npx prettier --write docs/plans/2026-05-01-001-feat-builder-managed-email-plan.md docs/plans/2026-05-01-002-research-managed-app-platform-gaps.md
- git diff --cached --check