### PR TITLE
fix(slides): inline text selection + format commands now work

### DIFF
--- a/templates/slides/app/components/editor/BlockBubbleMenu.tsx
+++ b/templates/slides/app/components/editor/BlockBubbleMenu.tsx
@@ -120,9 +120,11 @@ export function BlockBubbleMenu({ editingEl }: BlockBubbleMenuProps) {
 
   const runCommand = (cmd: string, value?: string) => {
     if (!restoreSelection()) return;
-    // Don't sync to React state per-command: it would re-run SlideRenderer's
-    // dangerouslySetInnerHTML and wipe the contentEditable attribute. Edit
-    // exit captures the final DOM via slideContent.innerHTML.
+    // Force <span style="..."> output so colors survive sanitizeSlideHtml,
+    // which strips <font> tags and would silently lose foreColor on save.
+    document.execCommand("styleWithCSS", false, "true");
+    // No state sync per-command — would re-run dangerouslySetInnerHTML and
+    // wipe contentEditable. Final DOM is captured by exitInlineEdit.
     document.execCommand(cmd, false, value);
   };
 
@@ -183,6 +185,9 @@ export function BlockBubbleMenu({ editingEl }: BlockBubbleMenuProps) {
           icon={IconPalette}
           title="Color"
           onClick={() => {
+            // Imperative set BEFORE state change — useEffect runs after the
+            // input's autoFocus has already fired selectionchange, too late.
+            if (!showColors) interactingRef.current = true;
             setShowColors((v) => !v);
             setShowLinkInput(false);
           }}
@@ -209,6 +214,7 @@ export function BlockBubbleMenu({ editingEl }: BlockBubbleMenuProps) {
         icon={IconLink}
         title="Link"
         onClick={() => {
+          if (!showLinkInput) interactingRef.current = true;
           setShowLinkInput((v) => !v);
           setShowColors(false);
         }}

--- a/templates/slides/app/components/editor/BlockBubbleMenu.tsx
+++ b/templates/slides/app/components/editor/BlockBubbleMenu.tsx
@@ -14,8 +14,6 @@ import {
 interface BlockBubbleMenuProps {
   /** The element currently in contentEditable mode. Menu only shows while selection is inside it. */
   editingEl: HTMLElement | null;
-  /** Called when formatting changes, so the parent can persist the updated HTML. */
-  onChange?: () => void;
 }
 
 interface Position {
@@ -45,12 +43,18 @@ const COLORS = [
  * the DOM. Designed to work with the in-place per-block editing in
  * SlideEditor — it never mutates anything outside the editing element.
  */
-export function BlockBubbleMenu({ editingEl, onChange }: BlockBubbleMenuProps) {
+export function BlockBubbleMenu({ editingEl }: BlockBubbleMenuProps) {
   const [pos, setPos] = useState<Position | null>(null);
   const [showColors, setShowColors] = useState(false);
   const [showLinkInput, setShowLinkInput] = useState(false);
   const [linkValue, setLinkValue] = useState("");
   const savedRangeRef = useRef<Range | null>(null);
+  // True while a popup/input has the user's focus — keeps the menu pinned
+  // even when the contentEditable selection collapses behind the scenes.
+  const interactingRef = useRef(false);
+  useEffect(() => {
+    interactingRef.current = showColors || showLinkInput;
+  }, [showColors, showLinkInput]);
 
   // Hide menu when the editing element changes
   useEffect(() => {
@@ -64,6 +68,7 @@ export function BlockBubbleMenu({ editingEl, onChange }: BlockBubbleMenuProps) {
     if (!editingEl) return;
 
     const updatePosition = () => {
+      if (interactingRef.current) return;
       const sel = window.getSelection();
       if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
         setPos(null);
@@ -115,11 +120,10 @@ export function BlockBubbleMenu({ editingEl, onChange }: BlockBubbleMenuProps) {
 
   const runCommand = (cmd: string, value?: string) => {
     if (!restoreSelection()) return;
-    // execCommand is deprecated but still the simplest way to apply
-    // inline formatting inside a contentEditable region. We scope all
-    // commands to the editing element by restoring its selection first.
+    // Don't sync to React state per-command: it would re-run SlideRenderer's
+    // dangerouslySetInnerHTML and wipe the contentEditable attribute. Edit
+    // exit captures the final DOM via slideContent.innerHTML.
     document.execCommand(cmd, false, value);
-    onChange?.();
   };
 
   const applyColor = (color: string) => {

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -375,34 +375,16 @@ export default function SlideEditor({
     });
   }, []);
 
-  /** Save the current slide content without exiting edit mode (called from bubble menu). */
-  const saveBlockContent = useCallback(() => {
-    const slideContent = containerRef.current?.querySelector(
-      ".slide-content",
-    ) as HTMLElement | null;
-    if (!slideContent) return;
-    const html = stripBuilderIds(slideContent.innerHTML);
-    onUpdateSlideRef.current({ content: html });
-  }, []);
-
   /** Enter edit mode on a smart block (text leaf or smart group) */
   const enterInlineEdit = useCallback((el: HTMLElement) => {
     el.contentEditable = "true";
     el.setAttribute("data-editing-block", "true");
-    el.focus();
-    // If the block is a simple text leaf, pre-select its content so typing
-    // replaces it. For smart groups (bullet lists, etc.) don't select all —
-    // the user usually wants to edit just one part, so we place the caret
-    // at the click location instead (which contentEditable does by default).
-    const isSimpleLeaf =
-      isTextLeaf(el) && el.children.length === 0 && !!el.textContent?.trim();
-    if (isSimpleLeaf) {
-      const range = document.createRange();
-      range.selectNodeContents(el);
-      const sel = window.getSelection();
-      sel?.removeAllRanges();
-      sel?.addRange(range);
-    }
+    // Don't override the selection. The browser's native double-click
+    // word-select (or single-click caret) is already on the element from the
+    // user's gesture; re-selecting from JS clobbers it. focus() on an
+    // element that already contains the selection preserves it in modern
+    // browsers, so it's safe to keep for keyboard delivery.
+    el.focus({ preventScroll: true });
     setEditingEl(el);
   }, []);
 
@@ -997,7 +979,7 @@ export default function SlideEditor({
         onSendToAgent={sendSelectionToAgent}
       />
 
-      <BlockBubbleMenu editingEl={editingEl} onChange={saveBlockContent} />
+      <BlockBubbleMenu editingEl={editingEl} />
 
       {pendingUpdateCount > 0 && (
         <div className="absolute top-4 right-4 z-50">


### PR DESCRIPTION
## Summary

Three interlocking bugs were breaking the in-place text editor in the slides template:

1. **Double-click selected the whole block instead of a word.** `enterInlineEdit` called `range.selectNodeContents(el)` on every entry, *after* the browser had already done its native double-click word-selection. The JS selection clobbered the gesture's selection.
2. **Color / link commands appeared not to apply.** `runCommand` synced to React state via `onChange` -> `saveBlockContent` -> `onUpdateSlide({ content })` after every \`execCommand\`. That re-rendered `SlideRenderer`; `BlankSlideContent`'s `useMemo` invalidated on the new `content`, and React re-assigned `innerHTML` — wiping the imperative `contentEditable=true`. \`editingEl\` ended up pointing at a detached node, so the very next interaction silently broke. There's a comment in \`SlideRenderer.tsx:113-119\` warning about exactly this failure mode for same-content re-renders, but \`runCommand\` deliberately *changed* the content so the memo couldn't help.
3. **The link input disappeared the moment it autofocused.** \`selectionchange\` saw the contentEditable selection collapse when focus moved to the URL field and called \`setPos(null)\`, unmounting the menu before the user could type.

## Fixes

- **\`SlideEditor.tsx\`** — drop the \`selectNodeContents\` block in \`enterInlineEdit\`. The browser's own click/double-click selection survives. Keep \`focus()\` (with \`preventScroll: true\`) so keyboard events still go to the contentEditable.
- **\`BlockBubbleMenu.tsx\`**
  - \`runCommand\` no longer calls \`onChange\`. \`exitInlineEdit\` already captures the final DOM via \`slideContent.innerHTML\` on Esc / Enter / click-outside / slide-switch, so no data is lost.
  - Track popup/input activity via \`interactingRef\`. While the user is in the color popup or the URL input, \`updatePosition\` short-circuits, so the menu stays pinned even when the contentEditable selection appears to collapse.
- Removes the now-dead \`onChange\` prop and the \`saveBlockContent\` callback rather than leaving no-op shims.

## Test plan

- [ ] Open a deck, double-click a word inside a heading or paragraph → only the word should be selected (not the whole block).
- [ ] Drag-select a fraction of a word → the selection should follow the drag.
- [ ] With a word selected, click the palette → pick a color → the word's color should change and the selection should remain so you can apply another command.
- [ ] With a word selected, click the link icon → the URL input should appear and remain visible. Type \`example.com\`, press Enter → the word becomes a link.
- [ ] Click outside the block (or press Esc) → edit mode exits and the formatting is persisted (re-open the deck and confirm).
- [ ] Switching slides while editing → formatting persists.
- [ ] Bold / italic / underline / strikethrough still work the same way they did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)