### PR TITLE
fix(calendar): handle booking timezones

### DIFF
--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1721,6 +1721,9 @@ export function AgentSidebar({
   // already viewport-covering, so the maximize button is hidden and the
   // mounted state ignores any persisted value.
   const effectiveFullscreen = fullscreen && !isMobile;
+  // On desktop the resize handle is also the visual divider. Avoid painting a
+  // second panel border next to it.
+  const showResizeHandle = !isMobile && !effectiveFullscreen && open;
 
   // On mobile the sidebar floats as a fixed overlay so the content below isn't
   // squashed. On desktop it participates in the flex layout as before, except
@@ -1765,15 +1768,13 @@ export function AgentSidebar({
       ...AGENT_PANEL_ROOT_STYLE,
       width,
       maxHeight: "100vh",
-      borderLeft: isLeft ? "none" : "1px solid hsl(var(--border))",
-      borderRight: isLeft ? "1px solid hsl(var(--border))" : "none",
+      borderLeft:
+        isLeft || showResizeHandle ? "none" : "1px solid hsl(var(--border))",
+      borderRight:
+        !isLeft || showResizeHandle ? "none" : "1px solid hsl(var(--border))",
       display: open ? "flex" : "none",
     };
   }
-
-  // Hide the resize handle when not draggable: mobile (overlay) or fullscreen
-  // (no width to drag — the panel covers the viewport).
-  const showResizeHandle = !isMobile && !effectiveFullscreen && open;
 
   // Always render the sidebar panel (even when closed) so MultiTabAssistantChat
   // stays mounted and can receive messages (e.g. from voice dictation) while

--- a/scripts/netlify-ignore-build.mjs
+++ b/scripts/netlify-ignore-build.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const targetName = process.argv[2];
+const repoRoot = process.cwd();
+
+const globalPaths = [
+  ".nvmrc",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "scripts/netlify-ignore-build.mjs",
+];
+
+if (!targetName) {
+  console.error("[netlify-ignore] Missing template/package name argument.");
+  process.exit(1);
+}
+
+function normalizePath(filePath) {
+  return filePath.split(path.sep).join("/").replace(/^\.\//, "");
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(path.join(repoRoot, filePath), "utf8"));
+}
+
+function packageDirsUnder(parentDir) {
+  const absParent = path.join(repoRoot, parentDir);
+
+  if (!existsSync(absParent)) {
+    return [];
+  }
+
+  return readdirSync(absParent, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `${parentDir}/${entry.name}`)
+    .filter((dir) => existsSync(path.join(repoRoot, dir, "package.json")));
+}
+
+function workspacePackages() {
+  const packages = new Map();
+
+  for (const dir of [
+    ...packageDirsUnder("packages"),
+    ...packageDirsUnder("templates"),
+  ]) {
+    const pkg = readJson(`${dir}/package.json`);
+
+    if (pkg.name) {
+      packages.set(pkg.name, { dir, pkg });
+    }
+  }
+
+  return packages;
+}
+
+function dependencyNames(pkg) {
+  return [
+    pkg.dependencies,
+    pkg.devDependencies,
+    pkg.peerDependencies,
+    pkg.optionalDependencies,
+  ].flatMap((deps) => (deps ? Object.keys(deps) : []));
+}
+
+function targetPackage(packages) {
+  if (packages.has(targetName)) {
+    return packages.get(targetName);
+  }
+
+  const templateDir = `templates/${targetName}`;
+  const match = [...packages.values()].find(({ dir }) => dir === templateDir);
+
+  return match ?? null;
+}
+
+function watchedPathsForTarget(packages, target) {
+  const watched = new Set(globalPaths);
+  const queue = [target];
+  const seen = new Set();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+
+    if (!current || seen.has(current.pkg.name)) {
+      continue;
+    }
+
+    seen.add(current.pkg.name);
+    watched.add(current.dir);
+
+    for (const dependencyName of dependencyNames(current.pkg)) {
+      const dependency = packages.get(dependencyName);
+
+      if (dependency && !seen.has(dependency.pkg.name)) {
+        queue.push(dependency);
+      }
+    }
+  }
+
+  return [...watched].sort();
+}
+
+function git(args) {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function commitExists(ref) {
+  if (!ref || /^0+$/.test(ref)) {
+    return false;
+  }
+
+  try {
+    git(["cat-file", "-e", `${ref}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function changedFiles() {
+  const cachedRef = process.env.CACHED_COMMIT_REF;
+  const commitRef = process.env.COMMIT_REF;
+
+  if (!commitExists(cachedRef) || !commitExists(commitRef)) {
+    console.log(
+      "[netlify-ignore] Build required: Netlify did not provide comparable commit refs.",
+    );
+    return null;
+  }
+
+  try {
+    return git(["diff", "--name-only", cachedRef, commitRef])
+      .split("\n")
+      .map((file) => normalizePath(file.trim()))
+      .filter(Boolean);
+  } catch (error) {
+    console.log(
+      `[netlify-ignore] Build required: git diff failed (${error.message}).`,
+    );
+    return null;
+  }
+}
+
+function pathMatches(filePath, watchedPath) {
+  return filePath === watchedPath || filePath.startsWith(`${watchedPath}/`);
+}
+
+const packages = workspacePackages();
+const target = targetPackage(packages);
+
+if (!target) {
+  console.error(`[netlify-ignore] Unknown template/package: ${targetName}`);
+  process.exit(1);
+}
+
+const watchedPaths = watchedPathsForTarget(packages, target);
+const files = changedFiles();
+
+if (!files) {
+  process.exit(1);
+}
+
+const matchedFile = files.find((file) =>
+  watchedPaths.some((watchedPath) => pathMatches(file, watchedPath)),
+);
+
+if (matchedFile) {
+  console.log(
+    `[netlify-ignore] Build required for ${target.pkg.name}: ${matchedFile} changed.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `[netlify-ignore] Skipping ${target.pkg.name}: no changes in ${watchedPaths.join(
+    ", ",
+  )}.`,
+);
+process.exit(0);

--- a/templates/analytics/netlify.toml
+++ b/templates/analytics/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs analytics"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter analytics build"
   publish = "templates/analytics/dist"
   functions = "templates/analytics/.netlify/functions-internal"

--- a/templates/calendar/actions/get-availability.ts
+++ b/templates/calendar/actions/get-availability.ts
@@ -1,27 +1,32 @@
 import { defineAction } from "@agent-native/core";
-import { getRequestUserEmail } from "@agent-native/core/server";
+import {
+  getRequestTimezone,
+  getRequestUserEmail,
+} from "@agent-native/core/server";
 import { getUserSetting } from "@agent-native/core/settings";
 import { z } from "zod";
 import type { AvailabilityConfig } from "../shared/api.js";
 import { ensureBookingUsername } from "../server/handlers/booking-usernames.js";
 
-const DEFAULT_AVAILABILITY: AvailabilityConfig = {
-  timezone: "America/New_York",
-  weeklySchedule: {
-    monday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
-    tuesday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
-    wednesday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
-    thursday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
-    friday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
-    saturday: { enabled: false, slots: [] },
-    sunday: { enabled: false, slots: [] },
-  },
-  bufferMinutes: 15,
-  minNoticeHours: 24,
-  maxAdvanceDays: 60,
-  slotDurationMinutes: 30,
-  bookingPageSlug: "book",
-};
+function createDefaultAvailability(timezone: string): AvailabilityConfig {
+  return {
+    timezone,
+    weeklySchedule: {
+      monday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      tuesday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      wednesday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      thursday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      friday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      saturday: { enabled: false, slots: [] },
+      sunday: { enabled: false, slots: [] },
+    },
+    bufferMinutes: 15,
+    minNoticeHours: 24,
+    maxAdvanceDays: 60,
+    slotDurationMinutes: 30,
+    bookingPageSlug: "book",
+  };
+}
 
 export default defineAction({
   description: "Get availability configuration",
@@ -31,9 +36,14 @@ export default defineAction({
     const email = getRequestUserEmail();
     if (!email) throw new Error("no authenticated user");
     const bookingUsername = await ensureBookingUsername(email);
+    const settings = (await getUserSetting(email, "calendar-settings")) as {
+      timezone?: string;
+    } | null;
+    const fallbackTimezone =
+      settings?.timezone || getRequestTimezone() || "America/New_York";
     const config =
       (await getUserSetting(email, "calendar-availability")) ||
-      DEFAULT_AVAILABILITY;
+      createDefaultAvailability(fallbackTimezone);
     return { ...config, bookingUsername };
   },
 });

--- a/templates/calendar/app/components/TimezoneCombobox.tsx
+++ b/templates/calendar/app/components/TimezoneCombobox.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { IconCheck, IconChevronDown } from "@tabler/icons-react";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+const FALLBACK_TIMEZONES = [
+  "UTC",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Sao_Paulo",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "Europe/Moscow",
+  "Africa/Cairo",
+  "Asia/Jerusalem",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Asia/Shanghai",
+  "Australia/Sydney",
+  "Pacific/Auckland",
+];
+
+function getSupportedTimezones(currentTimezone: string) {
+  const supported =
+    typeof Intl !== "undefined" && (Intl as any).supportedValuesOf
+      ? ((Intl as any).supportedValuesOf("timeZone") as string[])
+      : FALLBACK_TIMEZONES;
+  return Array.from(new Set([currentTimezone, ...supported].filter(Boolean)));
+}
+
+function getTimezoneCity(timezone: string) {
+  const city = timezone.split("/").pop() || timezone;
+  return city.replace(/_/g, " ");
+}
+
+function getTimezoneRegion(timezone: string) {
+  const region = timezone.split("/")[0] || "";
+  return region.replace(/_/g, " ");
+}
+
+export function TimezoneCombobox({
+  id = "timezone",
+  value,
+  onChange,
+}: {
+  id?: string;
+  value: string;
+  onChange: (timezone: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const options = getSupportedTimezones(value).map((timezone) => {
+    const city = getTimezoneCity(timezone);
+    const region = getTimezoneRegion(timezone);
+    return {
+      timezone,
+      city,
+      region,
+      searchValue: `${city} ${region} ${timezone}`.trim(),
+    };
+  });
+  const selected = options.find((option) => option.timezone === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="h-10 w-full justify-between px-3 font-normal"
+        >
+          <span className="min-w-0 truncate text-left">
+            {selected
+              ? `${selected.city} (${selected.timezone})`
+              : "Select timezone"}
+          </span>
+          <IconChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[--radix-popover-trigger-width] p-0"
+      >
+        <Command>
+          <CommandInput placeholder="Search timezone or city..." />
+          <CommandList className="max-h-[320px]">
+            <CommandEmpty>No timezone found.</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => (
+                <CommandItem
+                  key={option.timezone}
+                  value={option.searchValue}
+                  onSelect={() => {
+                    onChange(option.timezone);
+                    setOpen(false);
+                  }}
+                >
+                  <IconCheck
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === option.timezone ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <div className="min-w-0">
+                    <p className="truncate font-medium">{option.city}</p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {option.timezone}
+                    </p>
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -333,28 +333,30 @@ function GoogleAccountsSection({
   }
 
   return (
-    <div className="border-t border-border px-2.5 py-1.5">
+    <div className="border-t border-border px-1.5 py-1.5">
       <div className="mb-1 flex min-h-8 items-center justify-between px-3">
-        <div className="flex items-center gap-1.5">
-          <Link
-            to="/settings"
-            className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground"
-            title="Google Calendar settings"
-          >
-            <IconSettings className="h-3.5 w-3.5" />
-          </Link>
+        <div className="flex items-center">
           <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
             My Calendars
           </span>
         </div>
-        <button
-          type="button"
-          onClick={() => setWantAddAccount(true)}
-          className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground"
-          title="Add Google account"
-        >
-          <IconPlus className="h-3.5 w-3.5" />
-        </button>
+        <div className="flex items-center">
+          <Link
+            to="/settings"
+            className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+            title="Google Calendar settings"
+          >
+            <IconSettings className="h-3.5 w-3.5" />
+          </Link>
+          <button
+            type="button"
+            onClick={() => setWantAddAccount(true)}
+            className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+            title="Add Google account"
+          >
+            <IconPlus className="h-3.5 w-3.5" />
+          </button>
+        </div>
       </div>
 
       {accounts.map((account) => (
@@ -552,7 +554,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           <OrgSwitcher reserveSpace />
         </div>
 
-        <div className="border-t border-border px-2.5 py-1.5">
+        <div className="border-t border-border px-1.5 py-1.5">
           <ToolsSidebarSection />
         </div>
 
@@ -566,7 +568,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         )}
 
         {/* Other Calendars — people overlays + external ICS feeds combined */}
-        <div className="border-t border-border px-2.5 py-1.5">
+        <div className="border-t border-border px-1.5 py-1.5">
           <div className="flex min-h-8 items-center justify-between px-3">
             <div className="flex items-center gap-1">
               <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
@@ -591,7 +593,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                 setAddCalendarDefaultTab("people");
                 setAddCalendarOpen(true);
               }}
-              className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+              className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground"
             >
               <IconPlus className="h-3.5 w-3.5" />
             </button>
@@ -719,7 +721,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
 
         {/* Sign in prompt for local-mode users */}
         {isLocalMode && (
-          <div className="border-t border-border px-3 py-2">
+          <div className="border-t border-border px-1.5 py-2">
             <button
               type="button"
               className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
@@ -739,12 +741,12 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           </div>
         )}
 
-        <div className="px-3 py-1">
+        <div className="border-t border-border px-1.5 py-1">
           <FeedbackButton className="px-3 py-2" />
         </div>
 
         {/* Theme toggle */}
-        <div className="flex items-center gap-1 border-t border-border px-3 py-2">
+        <div className="flex items-center gap-1 border-t border-border px-1.5 py-2">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/templates/calendar/app/pages/AvailabilitySettings.tsx
+++ b/templates/calendar/app/pages/AvailabilitySettings.tsx
@@ -14,6 +14,7 @@ import {
   useAvailability,
   useUpdateAvailability,
 } from "@/hooks/use-availability";
+import { TimezoneCombobox } from "@/components/TimezoneCombobox";
 import { useDbStatus } from "@/hooks/use-db-status";
 import { CloudUpgrade } from "@/components/CloudUpgrade";
 import { toast } from "sonner";
@@ -125,6 +126,18 @@ export default function AvailabilitySettings() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          <div className="space-y-2 rounded-lg border border-border bg-muted/20 p-3">
+            <Label htmlFor="availability-timezone">Timezone</Label>
+            <TimezoneCombobox
+              id="availability-timezone"
+              value={timezone}
+              onChange={setTimezone}
+            />
+            <p className="text-xs text-muted-foreground">
+              Weekly hours like 9 AM-5 PM are interpreted in this timezone
+              before visitors see them in their own browser timezone.
+            </p>
+          </div>
           {DAYS.map(({ key, label }) => {
             const day = schedule[key];
             const slot = day.slots[0] ?? { start: "09:00", end: "17:00" };

--- a/templates/calendar/app/pages/BookingLinksPage.tsx
+++ b/templates/calendar/app/pages/BookingLinksPage.tsx
@@ -6,7 +6,6 @@ import {
   IconCalendar,
   IconChevronLeft,
   IconChevronRight,
-  IconCheck,
   IconCopy,
   IconExternalLink,
   IconLink,
@@ -100,6 +99,7 @@ import {
 } from "@/hooks/use-availability";
 import { useDbStatus } from "@/hooks/use-db-status";
 import { CloudUpgrade } from "@/components/CloudUpgrade";
+import { TimezoneCombobox } from "@/components/TimezoneCombobox";
 import BookingsList from "./BookingsList";
 import type {
   AvailabilityConfig,
@@ -1220,7 +1220,7 @@ export default function BookingLinksPage({
   }
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 px-4 py-8">
+    <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-8">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold">Booking Links</h1>
@@ -1307,7 +1307,8 @@ export default function BookingLinksPage({
                           </p>
                           {availability && (
                             <p className="mt-0.5 text-xs text-muted-foreground truncate">
-                              {formatAvailabilitySummary(availability)}
+                              {formatAvailabilitySummary(availability)} •{" "}
+                              {availability.timezone}
                             </p>
                           )}
                         </button>
@@ -1397,7 +1398,7 @@ export default function BookingLinksPage({
         </TabsContent>
 
         <TabsContent value="availability">
-          <div className="max-w-2xl space-y-6">
+          <div className="mx-auto max-w-2xl space-y-6">
             {/* Weekly Schedule */}
             <Card>
               <CardHeader>
@@ -1407,6 +1408,20 @@ export default function BookingLinksPage({
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
+                <div className="space-y-2 rounded-lg border border-border bg-muted/20 p-3">
+                  <Label htmlFor="booking-links-availability-timezone">
+                    Timezone
+                  </Label>
+                  <TimezoneCombobox
+                    id="booking-links-availability-timezone"
+                    value={timezone}
+                    onChange={setTimezone}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Weekly hours like 9 AM-5 PM are interpreted in this timezone
+                    before visitors see them in their own browser timezone.
+                  </p>
+                </div>
                 {DAYS.map(({ key, label, short }) => {
                   const day = schedule[key];
                   const slot = day.slots[0] ?? { start: "09:00", end: "17:00" };

--- a/templates/calendar/app/pages/Settings.tsx
+++ b/templates/calendar/app/pages/Settings.tsx
@@ -1,7 +1,5 @@
 import { useState, useEffect } from "react";
 import {
-  IconCheck,
-  IconChevronDown,
   IconExternalLink,
   IconUnlink,
   IconCircleCheck,
@@ -12,19 +10,6 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import {
   Card,
   CardContent,
   CardDescription,
@@ -33,133 +18,14 @@ import {
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { GoogleSetupWizard } from "@/components/calendar/GoogleSetupWizard";
+import { TimezoneCombobox } from "@/components/TimezoneCombobox";
 import { useSettings, useUpdateSettings } from "@/hooks/use-settings";
-import { cn } from "@/lib/utils";
 import {
   useGoogleAuthStatus,
   useGoogleAuthUrl,
   useDisconnectGoogle,
 } from "@/hooks/use-google-auth";
 import { toast } from "sonner";
-
-const FALLBACK_TIMEZONES = [
-  "UTC",
-  "America/New_York",
-  "America/Chicago",
-  "America/Denver",
-  "America/Los_Angeles",
-  "America/Sao_Paulo",
-  "Europe/London",
-  "Europe/Paris",
-  "Europe/Berlin",
-  "Europe/Moscow",
-  "Africa/Cairo",
-  "Asia/Jerusalem",
-  "Asia/Dubai",
-  "Asia/Kolkata",
-  "Asia/Singapore",
-  "Asia/Tokyo",
-  "Asia/Shanghai",
-  "Australia/Sydney",
-  "Pacific/Auckland",
-];
-
-function getSupportedTimezones(currentTimezone: string) {
-  const supported =
-    typeof Intl !== "undefined" && (Intl as any).supportedValuesOf
-      ? ((Intl as any).supportedValuesOf("timeZone") as string[])
-      : FALLBACK_TIMEZONES;
-  return Array.from(new Set([currentTimezone, ...supported].filter(Boolean)));
-}
-
-function getTimezoneCity(timezone: string) {
-  const city = timezone.split("/").pop() || timezone;
-  return city.replace(/_/g, " ");
-}
-
-function getTimezoneRegion(timezone: string) {
-  const region = timezone.split("/")[0] || "";
-  return region.replace(/_/g, " ");
-}
-
-function TimezoneCombobox({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (timezone: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const options = getSupportedTimezones(value).map((timezone) => {
-    const city = getTimezoneCity(timezone);
-    const region = getTimezoneRegion(timezone);
-    return {
-      timezone,
-      city,
-      region,
-      searchValue: `${city} ${region} ${timezone}`.trim(),
-    };
-  });
-  const selected = options.find((option) => option.timezone === value);
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          id="timezone"
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className="h-10 w-full justify-between px-3 font-normal"
-        >
-          <span className="min-w-0 truncate text-left">
-            {selected
-              ? `${selected.city} (${selected.timezone})`
-              : "Select timezone"}
-          </span>
-          <IconChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className="w-[--radix-popover-trigger-width] p-0"
-      >
-        <Command>
-          <CommandInput placeholder="Search timezone or city..." />
-          <CommandList className="max-h-[320px]">
-            <CommandEmpty>No timezone found.</CommandEmpty>
-            <CommandGroup>
-              {options.map((option) => (
-                <CommandItem
-                  key={option.timezone}
-                  value={option.searchValue}
-                  onSelect={() => {
-                    onChange(option.timezone);
-                    setOpen(false);
-                  }}
-                >
-                  <IconCheck
-                    className={cn(
-                      "mr-2 h-4 w-4",
-                      value === option.timezone ? "opacity-100" : "opacity-0",
-                    )}
-                  />
-                  <div className="min-w-0">
-                    <p className="truncate font-medium">{option.city}</p>
-                    <p className="truncate text-xs text-muted-foreground">
-                      {option.timezone}
-                    </p>
-                  </div>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
-}
 
 export default function Settings() {
   const { data: settings } = useSettings();

--- a/templates/calendar/netlify.toml
+++ b/templates/calendar/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs calendar"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && DATABASE_URL=${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL} NITRO_PRESET=netlify pnpm --filter calendar build"
   publish = "templates/calendar/dist"
   functions = "templates/calendar/.netlify/functions-internal"

--- a/templates/calendar/server/handlers/availability.ts
+++ b/templates/calendar/server/handlers/availability.ts
@@ -7,26 +7,32 @@ import {
 import { eq } from "drizzle-orm";
 import type { AvailabilityConfig } from "../../shared/api.js";
 import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
-import { readBody, getSession } from "@agent-native/core/server";
+import {
+  readBody,
+  getRequestTimezone,
+  getSession,
+} from "@agent-native/core/server";
 import { getDb, schema } from "../db/index.js";
 
-const DEFAULT_AVAILABILITY: AvailabilityConfig = {
-  timezone: "America/New_York",
-  weeklySchedule: {
-    monday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
-    tuesday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
-    wednesday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
-    thursday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
-    friday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
-    saturday: { enabled: false, slots: [] },
-    sunday: { enabled: false, slots: [] },
-  },
-  bufferMinutes: 15,
-  minNoticeHours: 24,
-  maxAdvanceDays: 60,
-  slotDurationMinutes: 30,
-  bookingPageSlug: "book",
-};
+function createDefaultAvailability(timezone: string): AvailabilityConfig {
+  return {
+    timezone,
+    weeklySchedule: {
+      monday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      tuesday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      wednesday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      thursday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      friday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      saturday: { enabled: false, slots: [] },
+      sunday: { enabled: false, slots: [] },
+    },
+    bufferMinutes: 15,
+    minNoticeHours: 24,
+    maxAdvanceDays: 60,
+    slotDurationMinutes: 30,
+    bookingPageSlug: "book",
+  };
+}
 
 async function uEmail(event: H3Event): Promise<string> {
   const session = await getSession(event);
@@ -40,9 +46,14 @@ async function uEmail(event: H3Event): Promise<string> {
 export const getAvailability = defineEventHandler(async (event: H3Event) => {
   try {
     const email = await uEmail(event);
+    const settings = (await getUserSetting(email, "calendar-settings")) as {
+      timezone?: string;
+    } | null;
+    const fallbackTimezone =
+      settings?.timezone || getRequestTimezone() || "America/New_York";
     const config =
       (await getUserSetting(email, "calendar-availability")) ||
-      DEFAULT_AVAILABILITY;
+      createDefaultAvailability(fallbackTimezone);
     return config;
   } catch (error: any) {
     setResponseStatus(event, 500);
@@ -66,6 +77,13 @@ export const getPublicAvailability = defineEventHandler(
           "calendar-availability",
         )) as unknown as AvailabilityConfig | null;
         if (ownerConfig) return ownerConfig;
+        const ownerSettings = (await getUserSetting(
+          link.ownerEmail,
+          "calendar-settings",
+        )) as { timezone?: string } | null;
+        return createDefaultAvailability(
+          ownerSettings?.timezone || "America/New_York",
+        );
       }
     }
 
@@ -73,7 +91,7 @@ export const getPublicAvailability = defineEventHandler(
     // setting. That key was historically dual-written by every user's update
     // (see the matching fix in updateAvailability), which meant a brand-new
     // user's public booking link advertised whoever last saved their hours.
-    return DEFAULT_AVAILABILITY;
+    return createDefaultAvailability("America/New_York");
   },
 );
 

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -145,6 +145,107 @@ type AvailabilityContext = {
 
 type ConflictItem = { start: string; end: string };
 
+type LocalDateTimeParts = {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+};
+
+function getLocalDateTimeParts(
+  date: Date,
+  timezone: string,
+): LocalDateTimeParts {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const parts = Object.fromEntries(
+    formatter
+      .formatToParts(date)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, Number(part.value)]),
+  );
+  return {
+    year: parts.year,
+    month: parts.month,
+    day: parts.day,
+    hour: parts.hour === 24 ? 0 : parts.hour,
+    minute: parts.minute,
+    second: parts.second,
+  };
+}
+
+function getTimezoneOffsetMs(date: Date, timezone: string): number {
+  const parts = getLocalDateTimeParts(date, timezone);
+  const utcForLocalParts = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+  );
+  return utcForLocalParts - date.getTime();
+}
+
+function zonedTimeToUtc(
+  localDate: string,
+  localTime: string,
+  timezone: string,
+): Date {
+  const [year, month, day] = localDate.split("-").map(Number);
+  const [hour, minute] = localTime.split(":").map(Number);
+  const utcGuess = Date.UTC(year, month - 1, day, hour, minute, 0);
+  let result = new Date(
+    utcGuess - getTimezoneOffsetMs(new Date(utcGuess), timezone),
+  );
+  result = new Date(utcGuess - getTimezoneOffsetMs(result, timezone));
+  return result;
+}
+
+function formatLocalDateInTimezone(date: Date, timezone: string): string {
+  const parts = getLocalDateTimeParts(date, timezone);
+  return [
+    String(parts.year).padStart(4, "0"),
+    String(parts.month).padStart(2, "0"),
+    String(parts.day).padStart(2, "0"),
+  ].join("-");
+}
+
+function getDayOfWeekInTimezone(date: Date, timezone: string): number {
+  const parts = getLocalDateTimeParts(date, timezone);
+  return new Date(Date.UTC(parts.year, parts.month - 1, parts.day)).getUTCDay();
+}
+
+function createDefaultAvailability(timezone: string): AvailabilityConfig {
+  return {
+    timezone,
+    weeklySchedule: {
+      monday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      tuesday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      wednesday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      thursday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      friday: { enabled: true, slots: [{ start: "09:00", end: "17:00" }] },
+      saturday: { enabled: false, slots: [] },
+      sunday: { enabled: false, slots: [] },
+    },
+    bufferMinutes: 15,
+    minNoticeHours: 24,
+    maxAdvanceDays: 60,
+    slotDurationMinutes: 30,
+    bookingPageSlug: "book",
+  };
+}
+
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
 const MAX_AVAILABILITY_RANGE_DAYS = 93;
 
@@ -168,6 +269,12 @@ function addLocalDays(date: Date, days: number): Date {
   return next;
 }
 
+function addDateString(date: string, days: number): string {
+  const next = new Date(`${date}T00:00:00Z`);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next.toISOString().slice(0, 10);
+}
+
 function countDaysInclusive(start: Date, end: Date): number {
   let count = 0;
   for (
@@ -181,12 +288,16 @@ function countDaysInclusive(start: Date, end: Date): number {
   return count;
 }
 
-function dateStartIso(date: string): string {
-  return new Date(`${date}T00:00:00`).toISOString();
+function dateStartIso(date: string, timezone: string): string {
+  return zonedTimeToUtc(date, "00:00", timezone).toISOString();
 }
 
-function dateEndIso(date: string): string {
-  return new Date(`${date}T23:59:59.999`).toISOString();
+function dateEndIso(date: string, timezone: string): string {
+  return zonedTimeToUtc(
+    addDateString(date, 1),
+    "00:00",
+    timezone,
+  ).toISOString();
 }
 
 async function resolveAvailabilityContext(
@@ -209,6 +320,11 @@ async function resolveAvailabilityContext(
         "calendar-availability",
       )) as unknown as AvailabilityConfig | null)
     : null;
+  const ownerSettings = ownerEmail
+    ? ((await getUserSetting(ownerEmail, "calendar-settings")) as {
+        timezone?: string;
+      } | null)
+    : null;
   const conflictSlugs = ownerEmail
     ? await getBookingLinkSlugsForOwner(ownerEmail)
     : slug
@@ -216,7 +332,13 @@ async function resolveAvailabilityContext(
       : [];
 
   return {
-    effectiveConfig: ownerConfig || config,
+    effectiveConfig:
+      ownerConfig ||
+      (ownerEmail
+        ? createDefaultAvailability(
+            ownerSettings?.timezone || "America/New_York",
+          )
+        : config),
     ownerEmail,
     slug,
     conflictSlugs,
@@ -289,7 +411,7 @@ function generateAvailableSlotsForDate({
   config: AvailabilityConfig;
   conflictItems: ConflictItem[];
 }): TimeSlot[] {
-  const targetDate = new Date(`${date}T00:00:00`);
+  const timezone = config.timezone || "UTC";
   const dayNames = [
     "sunday",
     "monday",
@@ -299,7 +421,8 @@ function generateAvailableSlotsForDate({
     "friday",
     "saturday",
   ] as const;
-  const dayName = dayNames[targetDate.getDay()];
+  const targetNoon = zonedTimeToUtc(date, "12:00", timezone);
+  const dayName = dayNames[getDayOfWeekInTimezone(targetNoon, timezone)];
   const daySchedule =
     config.weeklySchedule[dayName as keyof typeof config.weeklySchedule];
 
@@ -321,9 +444,15 @@ function generateAvailableSlotsForDate({
   const bufferMs = Math.max(0, bufferMinutes) * 60 * 1000;
   const earliestStart =
     Date.now() + Math.max(0, minNoticeHours) * 60 * 60 * 1000;
-  const latestDate = new Date();
-  latestDate.setHours(23, 59, 59, 999);
-  latestDate.setDate(latestDate.getDate() + Math.max(0, maxAdvanceDays));
+  const todayInScheduleTimezone = formatLocalDateInTimezone(
+    new Date(),
+    timezone,
+  );
+  const latestDate = zonedTimeToUtc(
+    addDateString(todayInScheduleTimezone, Math.max(0, maxAdvanceDays) + 1),
+    "00:00",
+    timezone,
+  );
 
   for (const scheduleSlot of daySchedule.slots) {
     const [startHour, startMin] = scheduleSlot.start.split(":").map(Number);
@@ -337,11 +466,9 @@ function generateAvailableSlotsForDate({
       continue;
     }
 
-    const slotStart = new Date(`${date}T00:00:00`);
-    slotStart.setHours(startHour, startMin, 0, 0);
-
-    const slotEnd = new Date(`${date}T00:00:00`);
-    slotEnd.setHours(endHour, endMin, 0, 0);
+    const slotStart = zonedTimeToUtc(date, scheduleSlot.start, timezone);
+    const slotEnd = zonedTimeToUtc(date, scheduleSlot.end, timezone);
+    if (slotEnd <= slotStart) continue;
 
     let current = new Date(slotStart);
 
@@ -794,11 +921,12 @@ export const getAvailableSlots = defineEventHandler(async (event: H3Event) => {
     if (hasRangeQuery) {
       const rangeStart = formatDateOnly(from!);
       const rangeEnd = formatDateOnly(to!);
+      const timezone = context.effectiveConfig.timezone || "UTC";
       const conflictItems = await getConflictItems({
         ownerEmail: context.ownerEmail,
         conflictSlugs: context.conflictSlugs,
-        rangeStartIso: dateStartIso(rangeStart),
-        rangeEndIso: dateEndIso(rangeEnd),
+        rangeStartIso: dateStartIso(rangeStart, timezone),
+        rangeEndIso: dateEndIso(rangeEnd, timezone),
       });
       const dates: string[] = [];
       for (
@@ -820,11 +948,12 @@ export const getAvailableSlots = defineEventHandler(async (event: H3Event) => {
       return { dates };
     }
 
+    const timezone = context.effectiveConfig.timezone || "UTC";
     const conflictItems = await getConflictItems({
       ownerEmail: context.ownerEmail,
       conflictSlugs: context.conflictSlugs,
-      rangeStartIso: dateStartIso(date),
-      rangeEndIso: dateEndIso(date),
+      rangeStartIso: dateStartIso(date, timezone),
+      rangeEndIso: dateEndIso(date, timezone),
     });
     const availableSlots = generateAvailableSlotsForDate({
       date,

--- a/templates/calls/netlify.toml
+++ b/templates/calls/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs calls"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter calls build"
   publish = "templates/calls/dist"
   functions = "templates/calls/.netlify/functions-internal"

--- a/templates/clips/netlify.toml
+++ b/templates/clips/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs clips"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter clips build"
   publish = "templates/clips/dist"
   functions = "templates/clips/.netlify/functions-internal"

--- a/templates/content/netlify.toml
+++ b/templates/content/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs content"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter content build"
   publish = "templates/content/dist"
   functions = "templates/content/.netlify/functions-internal"

--- a/templates/design/netlify.toml
+++ b/templates/design/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs design"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter design build"
   publish = "templates/design/dist"
   functions = "templates/design/.netlify/functions-internal"

--- a/templates/dispatch/netlify.toml
+++ b/templates/dispatch/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs dispatch"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter dispatch build"
   publish = "templates/dispatch/dist"
   functions = "templates/dispatch/.netlify/functions-internal"

--- a/templates/forms/netlify.toml
+++ b/templates/forms/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs forms"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter forms build"
   publish = "templates/forms/dist"
   functions = "templates/forms/.netlify/functions-internal"

--- a/templates/issues/netlify.toml
+++ b/templates/issues/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs issues"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && DATABASE_URL=${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL} NITRO_PRESET=netlify pnpm --filter issues build"
   publish = "templates/issues/dist"
   functions = "templates/issues/.netlify/functions-internal"

--- a/templates/macros/netlify.toml
+++ b/templates/macros/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs macros"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && DATABASE_URL=${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL} NITRO_PRESET=netlify pnpm --filter macros build"
   publish = "templates/macros/dist"
   functions = "templates/macros/.netlify/functions-internal"

--- a/templates/mail/netlify.toml
+++ b/templates/mail/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs mail"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && DATABASE_URL=${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL} NITRO_PRESET=netlify pnpm --filter mail build"
   publish = "templates/mail/dist"
   functions = "templates/mail/.netlify/functions-internal"

--- a/templates/meeting-notes/netlify.toml
+++ b/templates/meeting-notes/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs meeting-notes"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter meeting-notes build"
   publish = "templates/meeting-notes/dist"
   functions = "templates/meeting-notes/.netlify/functions-internal"

--- a/templates/recruiting/netlify.toml
+++ b/templates/recruiting/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs recruiting"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && DATABASE_URL=${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL} NITRO_PRESET=netlify pnpm --filter recruiting build"
   publish = "templates/recruiting/dist"
   functions = "templates/recruiting/.netlify/functions-internal"

--- a/templates/scheduling/netlify.toml
+++ b/templates/scheduling/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs scheduling"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && DATABASE_URL=${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL} NITRO_PRESET=netlify pnpm --filter scheduling build"
   publish = "templates/scheduling/dist"
   functions = "templates/scheduling/.netlify/functions-internal"

--- a/templates/slides/netlify.toml
+++ b/templates/slides/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs slides"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter slides build"
   publish = "templates/slides/dist"
   functions = "templates/slides/.netlify/functions-internal"

--- a/templates/starter/netlify.toml
+++ b/templates/starter/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs starter"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter starter build"
   publish = "templates/starter/dist"
   functions = "templates/starter/.netlify/functions-internal"

--- a/templates/videos/netlify.toml
+++ b/templates/videos/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs videos"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter videos build"
   publish = "templates/videos/dist"
   functions = "templates/videos/.netlify/functions-internal"

--- a/templates/voice/netlify.toml
+++ b/templates/voice/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  ignore = "node ./scripts/netlify-ignore-build.mjs voice"
   command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && NITRO_PRESET=netlify pnpm --filter voice build"
   publish = "templates/voice/dist"
   functions = "templates/voice/.netlify/functions-internal"


### PR DESCRIPTION
## Summary
- Add a reusable Calendar timezone combobox and expose availability timezone controls in settings and booking links
- Generate booking slots and conflict windows in the owner availability timezone instead of server-local time
- Add Netlify ignore-build wiring for template deploys and avoid a duplicate AgentPanel divider border

## Verification
- npx prettier --write packages/core/src/client/AgentPanel.tsx scripts/netlify-ignore-build.mjs templates/calendar/actions/get-availability.ts templates/calendar/app/components/layout/Sidebar.tsx templates/calendar/app/pages/AvailabilitySettings.tsx templates/calendar/app/pages/BookingLinksPage.tsx templates/calendar/app/pages/Settings.tsx templates/calendar/server/handlers/availability.ts templates/calendar/server/handlers/bookings.ts templates/calendar/app/components/TimezoneCombobox.tsx
- pnpm --dir templates/calendar typecheck
- pnpm --dir packages/core typecheck
- git diff --check
- CACHED_COMMIT_REF=origin/main COMMIT_REF=HEAD node scripts/netlify-ignore-build.mjs calendar
- CACHED_COMMIT_REF=HEAD COMMIT_REF=HEAD node scripts/netlify-ignore-build.mjs analytics