### PR TITLE
feat(mail): add queued draft review links

### DIFF
--- a/packages/core/src/integrations/adapters/email.spec.ts
+++ b/packages/core/src/integrations/adapters/email.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { emailAdapter } from "./email.js";
+
+describe("emailAdapter formatting", () => {
+  it("renders bare URLs as labelled links instead of visible raw URLs", () => {
+    const outgoing = emailAdapter().formatAgentResponse(
+      "Join here: https://builder-io.zoom.us/j/123?pwd=secret.",
+    );
+
+    expect(outgoing.text).toContain(
+      'href="https://builder-io.zoom.us/j/123?pwd=secret"',
+    );
+    expect(outgoing.text).toContain(">Open builder-io.zoom.us</a>.");
+    expect(outgoing.text).not.toContain(
+      ">https://builder-io.zoom.us/j/123?pwd=secret</a>",
+    );
+  });
+
+  it("keeps markdown link labels but collapses URL labels", () => {
+    const outgoing = emailAdapter().formatAgentResponse(
+      "[Manage booking](https://app.test/booking/manage/abc)\n\n[https://app.test/long/path](https://app.test/long/path)",
+    );
+
+    expect(outgoing.text).toContain(">Manage booking</a>");
+    expect(outgoing.text).toContain(">Open app.test</a>");
+    expect(outgoing.text).not.toContain(">https://app.test/long/path</a>");
+  });
+});

--- a/packages/core/src/integrations/adapters/email.ts
+++ b/packages/core/src/integrations/adapters/email.ts
@@ -809,15 +809,99 @@ function stripHtmlForPlainText(html: string): string {
     .trim();
 }
 
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function decodeBasicHtmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function splitTrailingUrlPunctuation(raw: string): {
+  url: string;
+  trailing: string;
+} {
+  let url = raw;
+  let trailing = "";
+  const trailingEntities = ["&quot;", "&#39;"];
+
+  for (;;) {
+    const entity = trailingEntities.find((candidate) =>
+      url.endsWith(candidate),
+    );
+    if (!entity) break;
+    url = url.slice(0, -entity.length);
+    trailing = entity + trailing;
+  }
+
+  while (/[.,!?;:]$/.test(url)) {
+    trailing = url.slice(-1) + trailing;
+    url = url.slice(0, -1);
+  }
+
+  while (url.endsWith(")") && !url.includes("(")) {
+    trailing = ")" + trailing;
+    url = url.slice(0, -1);
+  }
+
+  return { url, trailing };
+}
+
+function labelForUrl(rawUrl: string): string {
+  try {
+    const parsed = new URL(decodeBasicHtmlEntities(rawUrl));
+    const host = parsed.hostname.replace(/^www\./, "");
+    return host ? `Open ${host}` : "Open link";
+  } catch {
+    return "Open link";
+  }
+}
+
+function linkifyTextSegment(segment: string): string {
+  return segment.replace(/\bhttps?:\/\/[^\s<>"']+/gi, (raw) => {
+    const { url, trailing } = splitTrailingUrlPunctuation(raw);
+    const href = decodeBasicHtmlEntities(url);
+    return `<a href="${escapeHtml(href)}" style="color:#2563eb;text-decoration:underline;">${escapeHtml(
+      labelForUrl(url),
+    )}</a>${trailing}`;
+  });
+}
+
+function linkifyBareUrlsInHtml(html: string): string {
+  const parts = html.split(/(<\/?[^>]+>)/g);
+  let skipDepth = 0;
+
+  return parts
+    .map((part) => {
+      if (part.startsWith("<") && part.endsWith(">")) {
+        if (/^<\/\s*(a|code)\b/i.test(part)) {
+          skipDepth = Math.max(0, skipDepth - 1);
+        } else if (/^<\s*(a|code)\b/i.test(part)) {
+          skipDepth += 1;
+        }
+        return part;
+      }
+      return skipDepth > 0 ? part : linkifyTextSegment(part);
+    })
+    .join("");
+}
+
 /** Convert basic markdown to HTML for email rendering */
 function markdownToHtml(md: string): string {
   let html = md;
 
   // Escape HTML entities in the source (but not our generated tags)
-  html = html
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+  html = escapeHtml(html);
 
   // Bold: **text** or __text__
   html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
@@ -828,16 +912,23 @@ function markdownToHtml(md: string): string {
   html = html.replace(/(?<!\w)_([^_]+?)_(?!\w)/g, "<em>$1</em>");
 
   // Links: [text](url)
-  html = html.replace(
-    /\[([^\]]+)\]\(([^)]+)\)/g,
-    '<a href="$2" style="color:#2563eb;text-decoration:underline;">$1</a>',
-  );
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, url) => {
+    const visibleLabel = /^https?:\/\//i.test(decodeBasicHtmlEntities(label))
+      ? escapeHtml(labelForUrl(label))
+      : label;
+    return `<a href="${escapeHtml(
+      decodeBasicHtmlEntities(url),
+    )}" style="color:#2563eb;text-decoration:underline;">${visibleLabel}</a>`;
+  });
 
   // Inline code: `code`
   html = html.replace(
     /`([^`]+)`/g,
     '<code style="background:#f1f5f9;padding:1px 4px;border-radius:3px;font-size:0.9em;">$1</code>',
   );
+
+  // Bare URLs: keep the destination in href but avoid spelling long URLs out.
+  html = linkifyBareUrlsInHtml(html);
 
   // Unordered lists: lines starting with "- " or "* "
   html = html.replace(/^([*-]) (.+)$/gm, "<li>$2</li>");

--- a/packages/core/src/integrations/types.ts
+++ b/packages/core/src/integrations/types.ts
@@ -13,6 +13,8 @@ export interface IncomingMessage {
   text: string;
   /** Display name of the sender */
   senderName?: string;
+  /** Verified sender email, when the platform can provide one */
+  senderEmail?: string;
   /** Platform-specific sender ID */
   senderId?: string;
   /** Raw platform-specific context needed for routing responses */

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -397,10 +397,22 @@ async function processIncomingMessage(
     } catch {}
   }
 
-  // Add the new user message
+  // Add the new user message. Include verified platform identity as lightweight
+  // context so app-specific agents can attribute requests without guessing.
+  const identityLines = [
+    `Platform: ${incoming.platform}`,
+    incoming.senderName ? `Sender name: ${incoming.senderName}` : null,
+    incoming.senderEmail ? `Sender email: ${incoming.senderEmail}` : null,
+    incoming.senderId ? `Sender ID: ${incoming.senderId}` : null,
+  ].filter(Boolean);
+  const userText =
+    identityLines.length > 1
+      ? `<integration-context>\n${identityLines.join("\n")}\n</integration-context>\n\n${incoming.text}`
+      : incoming.text;
+
   const messages: EngineMessage[] = [
     ...existingMessages,
-    { role: "user", content: [{ type: "text", text: incoming.text }] },
+    { role: "user", content: [{ type: "text", text: userText }] },
   ];
 
   // Run agent loop via startRun, wrapped in a request context so that

--- a/packages/core/src/server/email-template.spec.ts
+++ b/packages/core/src/server/email-template.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { emailLink, renderEmail } from "./email-template.js";
+
+describe("renderEmail", () => {
+  it("renders CTA buttons without visible fallback URLs", () => {
+    const { html } = renderEmail({
+      heading: "Your meeting is booked",
+      paragraphs: [
+        `Meeting link: ${emailLink(
+          "Join meeting",
+          "https://builder-io.zoom.us/j/123?pwd=secret",
+        )}.`,
+      ],
+      cta: {
+        label: "Manage booking",
+        url: "http://localhost:8082/booking/manage/token",
+      },
+    });
+
+    expect(html).toContain(">Join meeting</a>");
+    expect(html).toMatch(/>\s*Manage booking\s*<\/a>/);
+    expect(html).not.toContain("Or paste this link into your browser");
+    expect(html).not.toMatch(/>https?:\/\//);
+  });
+});

--- a/packages/core/src/server/email-template.ts
+++ b/packages/core/src/server/email-template.ts
@@ -97,10 +97,6 @@ export function renderEmail(args: RenderEmailArgs): RenderedEmail {
           </td>
         </tr>
       </table>
-      <p style="margin:20px 0 0 0; font-size:13px; line-height:1.5; color:#71717a; word-break:break-all;">
-        Or paste this link into your browser:<br/>
-        <a href="${escapeAttr(args.cta.url)}" style="color:${linkColor}; text-decoration:none;">${escapeHtml(args.cta.url)}</a>
-      </p>
     `
     : "";
 
@@ -185,4 +181,12 @@ function stripTags(s: string): string {
  */
 export function emailStrong(text: string): string {
   return `<strong style="color:#fafafa; font-weight:600;">${escapeHtml(text)}</strong>`;
+}
+
+/**
+ * Build a labelled inline link for paragraph strings passed to `renderEmail`.
+ * Use this instead of rendering raw URLs in the visible email body.
+ */
+export function emailLink(label: string, url: string): string {
+  return `<a href="${escapeAttr(url)}" style="color:#a1a1aa; text-decoration:underline;">${escapeHtml(label)}</a>`;
 }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -219,6 +219,11 @@ export {
 } from "./email-template.js";
 export { getAppProductionUrl, getFirstPartyProdUrl } from "./app-url.js";
 export {
+  getConfiguredAppBasePath,
+  normalizeAppBasePath,
+  withConfiguredAppBasePath,
+} from "./app-base-path.js";
+export {
   signShortLivedToken,
   verifyShortLivedToken,
   type ShortLivedTokenClaims,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -213,6 +213,7 @@ export {
 export {
   renderEmail,
   emailStrong,
+  emailLink,
   type RenderEmailArgs,
   type RenderedEmail,
   type EmailCta,

--- a/templates/calendar/app/components/booking/DatePicker.tsx
+++ b/templates/calendar/app/components/booking/DatePicker.tsx
@@ -18,6 +18,7 @@ import {
 import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
 import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import type { AvailabilityConfig } from "@shared/api";
 
@@ -112,9 +113,21 @@ export function DatePicker({
       </div>
 
       {/* Days */}
-      <div className="grid grid-cols-7 gap-1">
+      <div className="grid grid-cols-7 gap-1" aria-busy={availabilityLoading}>
         {days.map((day) => {
           const inMonth = isSameMonth(day, viewMonth);
+
+          if (availabilityLoading) {
+            return inMonth ? (
+              <Skeleton
+                key={day.toISOString()}
+                className="h-10 w-full rounded-md"
+              />
+            ) : (
+              <div key={day.toISOString()} className="h-10 opacity-0" />
+            );
+          }
+
           const disabled = !inMonth || isDayDisabled(day);
           const selected = selectedDate && isSameDay(day, selectedDate);
           const todayMark = isToday(day);
@@ -139,11 +152,6 @@ export function DatePicker({
           );
         })}
       </div>
-      {availabilityLoading && (
-        <p className="mt-3 text-center text-xs text-muted-foreground">
-          Checking availability…
-        </p>
-      )}
     </div>
   );
 }

--- a/templates/calendar/server/lib/booking-emails.ts
+++ b/templates/calendar/server/lib/booking-emails.ts
@@ -1,4 +1,5 @@
 import {
+  emailLink,
   emailStrong,
   isEmailConfigured,
   renderEmail,
@@ -70,7 +71,7 @@ export async function sendBookingConfirmationEmails({
   ];
   if (booking.meetingLink) {
     attendeeParagraphs.push(
-      `Meeting link: ${emailStrong(booking.meetingLink)}.`,
+      `Meeting link: ${emailLink("Join meeting", booking.meetingLink)}.`,
     );
   }
 
@@ -99,7 +100,7 @@ export async function sendBookingConfirmationEmails({
       `Time: ${emailStrong(when)}.`,
       `Guest: ${emailStrong(attendee)}.`,
       ...(booking.meetingLink
-        ? [`Meeting link: ${emailStrong(booking.meetingLink)}.`]
+        ? [`Meeting link: ${emailLink("Join meeting", booking.meetingLink)}.`]
         : []),
     ],
     cta: { label: "View booking", url: manageUrl },

--- a/templates/mail/.agents/skills/draft-queue/SKILL.md
+++ b/templates/mail/.agents/skills/draft-queue/SKILL.md
@@ -12,26 +12,28 @@ The draft queue is for teammate-requested emails that need the owner to review b
 - Use `queue-email-draft` when a teammate asks the agent to prepare an email for an organization member.
 - The requester and reviewer must both be members of the active organization.
 - Slack requests should queue drafts, not send raw emails.
+- `queue-email-draft` returns `reviewUrl`; include that URL when replying to Slack so the owner can open the exact draft.
+- Slack intake verifies the sender email via Slack `users.info` when the app has `users:read.email`, and passes verified sender name/email into the agent context.
 - Use `send-queued-drafts` only when the queued draft owner explicitly asks to send.
 - Use `open-queued-draft` when the user wants to manually tweak a queued draft in the compose panel.
 
 ## Actions
 
-| Action | Purpose |
-| --- | --- |
-| `list-org-members` | Resolve valid organization members for `ownerEmail` |
-| `queue-email-draft` | Create a queued draft for a member to review |
-| `list-queued-drafts` | List active, sent, dismissed, review, or requested drafts |
-| `update-queued-draft` | Edit queued draft fields or set status |
-| `open-queued-draft` | Open a queued draft as `compose-{id}` |
-| `send-queued-drafts` | Send one queued draft or all active drafts assigned to the current user |
-| `navigate --view=draft-queue` | Open the queue UI |
+| Action                        | Purpose                                                                 |
+| ----------------------------- | ----------------------------------------------------------------------- |
+| `list-org-members`            | Resolve valid organization members for `ownerEmail`                     |
+| `queue-email-draft`           | Create a queued draft for a member to review                            |
+| `list-queued-drafts`          | List active, sent, dismissed, review, or requested drafts               |
+| `update-queued-draft`         | Edit queued draft fields or set status                                  |
+| `open-queued-draft`           | Open a queued draft as `compose-{id}`                                   |
+| `send-queued-drafts`          | Send one queued draft or all active drafts assigned to the current user |
+| `navigate --view=draft-queue` | Open the queue UI                                                       |
 
 ## Typical Flow
 
 1. Resolve the target reviewer with `list-org-members` if the user gave a name.
 2. Call `queue-email-draft` with `ownerEmail`, recipients, subject, body, and context.
-3. Tell the requester it was queued.
+3. Tell the requester it was queued and include the returned `reviewUrl`.
 
 For review:
 

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -159,6 +159,7 @@ When the user asks you to **draft**, **compose**, or **write** an email, use `wr
 Queued drafts are durable SQL rows in `queued_email_drafts`. Use them when someone else asks the agent to prepare an email for an organization member to review and send, especially from Slack.
 
 - Use `queue-email-draft` to queue a draft for an org member. The requester and owner must both be in the active organization.
+- `queue-email-draft` returns `reviewUrl`; include it in Slack replies so the owner can open `/draft-queue/<id>` directly in the deployed mail app.
 - Use `list-queued-drafts --scope=review --status=active` to see drafts assigned to the current user.
 - Use `update-queued-draft` to revise queued drafts before sending.
 - Use `open-queued-draft` to open a queued draft in the compose panel for manual edits.
@@ -385,7 +386,7 @@ Scripts use `readAppState()` / `writeAppState()` from `@agent-native/core/applic
 | Action                | Args                                                                                      | Purpose                                  |
 | --------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------- |
 | `manage-draft`        | `--action=create\|update\|delete\|delete-all [--id] [--to] [--subject] [--body] [--mode]` | Create, update, or delete compose drafts |
-| `queue-email-draft`   | `--ownerEmail <member> --to <emails> --subject <s> --body <b> [--context]`                | Queue a draft for an org member          |
+| `queue-email-draft`   | `--ownerEmail <member> --to <emails> --subject <s> --body <b> [--context]`                | Queue a draft and return `reviewUrl`     |
 | `list-queued-drafts`  | `[--scope=review\|requested\|all] [--status=active\|queued\|in_review\|sent\|dismissed]`  | List queued drafts                       |
 | `update-queued-draft` | `--id <id> [--to] [--subject] [--body] [--context] [--status]`                            | Edit or dismiss a queued draft           |
 | `open-queued-draft`   | `--id <id>`                                                                               | Open queued draft in compose             |

--- a/templates/mail/actions/queue-email-draft.ts
+++ b/templates/mail/actions/queue-email-draft.ts
@@ -4,7 +4,7 @@ import { createQueuedDraft } from "../server/lib/queued-drafts.js";
 
 export default defineAction({
   description:
-    "Queue an email draft for an organization member to review, edit, and send. Use this for Slack or teammate requests instead of sending directly.",
+    "Queue an email draft for an organization member to review, edit, and send. Returns reviewUrl for a direct link to the queued draft. Use this for Slack or teammate requests instead of sending directly.",
   schema: z.object({
     ownerEmail: z
       .string()

--- a/templates/mail/app/hooks/use-draft-queue.ts
+++ b/templates/mail/app/hooks/use-draft-queue.ts
@@ -23,6 +23,7 @@ export type QueuedEmailDraft = {
   createdAt: number;
   updatedAt: number;
   sentAt: number | null;
+  reviewUrl?: string;
 };
 
 export type DraftQueueMember = {

--- a/templates/mail/app/pages/DraftQueuePage.tsx
+++ b/templates/mail/app/pages/DraftQueuePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router";
+import { useNavigate, useParams, useSearchParams } from "react-router";
 import {
   IconCheck,
   IconClock,
@@ -593,11 +593,13 @@ function DraftDetail({
 }
 
 export function DraftQueuePage() {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const params = useParams();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const routeDraftId = params.id;
   const [scope, setScope] = useState<QueueScope>("review");
   const [selectedId, setSelectedId] = useState<string | null>(
-    searchParams.get("id"),
+    routeDraftId || searchParams.get("id"),
   );
   const [dialogOpen, setDialogOpen] = useState(false);
   const [form, setForm] = useState<DraftFormState>(EMPTY_FORM);
@@ -611,9 +613,9 @@ export function DraftQueuePage() {
   );
 
   useEffect(() => {
-    const id = searchParams.get("id");
+    const id = routeDraftId || searchParams.get("id");
     if (id && id !== selectedId) setSelectedId(id);
-  }, [searchParams, selectedId]);
+  }, [routeDraftId, searchParams, selectedId]);
 
   useEffect(() => {
     if (queue.drafts.length === 0) {
@@ -641,7 +643,7 @@ export function DraftQueuePage() {
   useEffect(() => {
     if (!navCommand || navCommand.view !== "draft-queue") return;
     const target = navCommand.queuedDraftId
-      ? `/draft-queue?id=${encodeURIComponent(navCommand.queuedDraftId)}`
+      ? `/draft-queue/${encodeURIComponent(navCommand.queuedDraftId)}`
       : "/draft-queue";
     if (navCommand.queuedDraftId) {
       setSelectedId(navCommand.queuedDraftId);
@@ -722,7 +724,7 @@ export function DraftQueuePage() {
               selectedId={selectedId}
               onSelect={(id) => {
                 setSelectedId(id);
-                setSearchParams({ id });
+                navigate(`/draft-queue/${encodeURIComponent(id)}`);
               }}
               isLoading={queue.isLoading}
             />

--- a/templates/mail/app/routes/draft-queue.$id.tsx
+++ b/templates/mail/app/routes/draft-queue.$id.tsx
@@ -1,0 +1,18 @@
+import { DraftQueuePage } from "@/pages/DraftQueuePage";
+import { Spinner } from "@/components/ui/spinner";
+
+export function meta() {
+  return [{ title: "Draft Queue — Mail" }];
+}
+
+export function HydrateFallback() {
+  return (
+    <div className="flex h-screen w-full items-center justify-center">
+      <Spinner className="size-8" />
+    </div>
+  );
+}
+
+export default function DraftQueueDetailRoute() {
+  return <DraftQueuePage />;
+}

--- a/templates/mail/server/lib/mail-integrations.ts
+++ b/templates/mail/server/lib/mail-integrations.ts
@@ -5,9 +5,14 @@ import type {
 } from "@agent-native/core/server";
 import { resolveOrgIdForEmail } from "@agent-native/core/org";
 
-const slackEmailCache = new Map<
+type SlackSenderProfile = {
+  email: string | null;
+  name: string | null;
+};
+
+const slackProfileCache = new Map<
   string,
-  { email: string | null; expiresAt: number }
+  { profile: SlackSenderProfile; expiresAt: number }
 >();
 const SLACK_EMAIL_CACHE_TTL = 10 * 60 * 1000;
 
@@ -31,18 +36,18 @@ function fallbackOwnerForIncoming(incoming: IncomingMessage): string {
   return `mail+${hash}@integration.local`;
 }
 
-async function resolveSlackSenderEmail(
+async function resolveSlackSenderProfile(
   incoming: IncomingMessage,
-): Promise<string | null> {
-  if (incoming.platform !== "slack") return null;
+): Promise<SlackSenderProfile> {
+  if (incoming.platform !== "slack") return { email: null, name: null };
   const token = process.env.SLACK_BOT_TOKEN;
   const userId = contextString(incoming.senderId);
   const teamId = contextString(incoming.platformContext.teamId);
-  if (!token || !userId) return null;
+  if (!token || !userId) return { email: null, name: null };
 
   const cacheKey = `${teamId ?? "default"}:${userId}`;
-  const cached = slackEmailCache.get(cacheKey);
-  if (cached && cached.expiresAt > Date.now()) return cached.email;
+  const cached = slackProfileCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.profile;
 
   try {
     const params = new URLSearchParams({ user: userId });
@@ -51,18 +56,34 @@ async function resolveSlackSenderEmail(
     });
     const data = (await res.json()) as {
       ok?: boolean;
-      user?: { profile?: { email?: string } };
+      user?: {
+        real_name?: string;
+        name?: string;
+        profile?: {
+          email?: string;
+          real_name?: string;
+          display_name?: string;
+        };
+      };
     };
-    const email = data.ok
-      ? data.user?.profile?.email?.trim().toLowerCase() || null
-      : null;
-    slackEmailCache.set(cacheKey, {
-      email,
+    const profile = data.ok
+      ? {
+          email: data.user?.profile?.email?.trim().toLowerCase() || null,
+          name:
+            data.user?.profile?.real_name?.trim() ||
+            data.user?.profile?.display_name?.trim() ||
+            data.user?.real_name?.trim() ||
+            data.user?.name?.trim() ||
+            null,
+        }
+      : { email: null, name: null };
+    slackProfileCache.set(cacheKey, {
+      profile,
       expiresAt: Date.now() + SLACK_EMAIL_CACHE_TTL,
     });
-    return email;
+    return profile;
   } catch {
-    return null;
+    return { email: null, name: null };
   }
 }
 
@@ -70,7 +91,7 @@ async function resolveIncomingEmail(
   incoming: IncomingMessage,
 ): Promise<string | null> {
   if (incoming.platform === "slack") {
-    return resolveSlackSenderEmail(incoming);
+    return (await resolveSlackSenderProfile(incoming)).email;
   }
   if (incoming.senderId?.includes("@")) {
     return incoming.senderId.trim().toLowerCase();
@@ -90,7 +111,11 @@ export async function beforeMailIntegrationProcess(
   incoming: IncomingMessage,
   _adapter: PlatformAdapter,
 ): Promise<{ handled: true; responseText?: string } | { handled: false }> {
-  const email = await resolveIncomingEmail(incoming);
+  const profile =
+    incoming.platform === "slack"
+      ? await resolveSlackSenderProfile(incoming)
+      : { email: await resolveIncomingEmail(incoming), name: null };
+  const email = profile.email;
   if (!email) {
     return {
       handled: true,
@@ -107,6 +132,11 @@ export async function beforeMailIntegrationProcess(
         "I can only queue email drafts for Agent-Native organization members. Ask an organization owner to invite you first.",
     };
   }
+
+  incoming.senderEmail = email;
+  incoming.senderName = profile.name || incoming.senderName;
+  incoming.platformContext.senderEmail = email;
+  if (profile.name) incoming.platformContext.senderName = profile.name;
 
   return { handled: false };
 }

--- a/templates/mail/server/lib/queued-drafts.ts
+++ b/templates/mail/server/lib/queued-drafts.ts
@@ -3,8 +3,10 @@ import { nanoid } from "nanoid";
 import { writeAppState } from "@agent-native/core/application-state";
 import { getDbExec } from "@agent-native/core/db";
 import {
+  getAppProductionUrl,
   getRequestOrgId,
   getRequestUserEmail,
+  withConfiguredAppBasePath,
 } from "@agent-native/core/server";
 import { getDb, schema } from "../db/index.js";
 
@@ -46,6 +48,7 @@ export type QueuedEmailDraft = {
   createdAt: number;
   updatedAt: number;
   sentAt: number | null;
+  reviewUrl?: string;
 };
 
 function normalizeEmail(value: string): string {
@@ -57,7 +60,7 @@ function isAdminRole(role: string | undefined): boolean {
 }
 
 export function serializeQueuedDraft(row: any): QueuedEmailDraft {
-  return {
+  const draft = {
     id: row.id,
     orgId: row.orgId,
     ownerEmail: row.ownerEmail,
@@ -79,6 +82,12 @@ export function serializeQueuedDraft(row: any): QueuedEmailDraft {
     updatedAt: Number(row.updatedAt),
     sentAt: row.sentAt == null ? null : Number(row.sentAt),
   };
+  return { ...draft, reviewUrl: buildQueuedDraftUrl(draft.id) };
+}
+
+export function buildQueuedDraftUrl(id: string): string {
+  const baseUrl = withConfiguredAppBasePath(getAppProductionUrl());
+  return `${baseUrl}/draft-queue/${encodeURIComponent(id)}`;
 }
 
 async function getMembership(

--- a/templates/mail/server/plugins/integrations.ts
+++ b/templates/mail/server/plugins/integrations.ts
@@ -19,6 +19,8 @@ Your main Slack job is email draft intake for an organization:
 - If they do not say who should review/send it, ask which organization member should own the draft.
 - Use list-org-members when you need the exact owner email.
 - Keep the queued draft useful: include recipients, subject, body, and any review context from the Slack request.
+- After queue-email-draft succeeds, reply with the returned reviewUrl so the owner can open the draft directly in this deployment.
+- The Slack sender context includes verified sender email/name when Slack grants users:read.email. Use that as requester identity; do not guess.
 - The owner will review queued drafts in the web UI, tweak them manually or with the agent, and send them.
 
 If the owner asks from Slack to send their queued drafts, use send-queued-drafts. If they ask to tune queued drafts first, list-queued-drafts, update-queued-draft, then send-queued-drafts.


### PR DESCRIPTION
## Summary
- Add direct draft queue detail routes and return reviewUrl for queued email drafts
- Pass verified Slack sender name/email into integration context for draft intake
- Update Mail draft-queue instructions so Slack replies include the review link

## Verification
- npx prettier --write on touched core and mail files
- pnpm --dir packages/core typecheck
- pnpm --dir templates/mail typecheck
- git diff --check