### PR TITLE
Fix Workspace docs link and upgrade tooltips to shadcn

### DIFF
--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -34,6 +34,12 @@ import React, {
 } from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./components/ui/tooltip.js";
+import {
   IconMessage,
   IconTerminal2,
   IconSettings,
@@ -435,65 +441,88 @@ export function AgentPanel({
 
   const renderModeButtons = useCallback(
     (activeMode: PanelMode) => (
-      <div className="flex shrink-0 items-center gap-1">
-        <button
-          onClick={() => switchMode("chat")}
-          className={cn(
-            "flex items-center gap-1 rounded-md px-2 py-1 text-[12px] leading-none",
-            activeMode === "chat"
-              ? "bg-accent text-foreground"
-              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+      <TooltipProvider delayDuration={200}>
+        <div className="flex shrink-0 items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => switchMode("chat")}
+                aria-label="Chat mode"
+                className={cn(
+                  "flex items-center gap-1 rounded-md px-2 py-1 text-[12px] leading-none",
+                  activeMode === "chat"
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                )}
+                style={AGENT_PANEL_CONTROL_STYLE}
+              >
+                <IconMessage size={14} />
+                Chat
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Chat mode</TooltipContent>
+          </Tooltip>
+          {isDevMode && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => switchMode("cli")}
+                  aria-label="CLI terminal mode"
+                  className={cn(
+                    "flex items-center gap-1 rounded-md px-2 py-1 text-[12px] leading-none",
+                    activeMode === "cli"
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                  )}
+                  style={AGENT_PANEL_CONTROL_STYLE}
+                >
+                  <IconTerminal2 size={14} />
+                  CLI
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>CLI terminal mode</TooltipContent>
+            </Tooltip>
           )}
-          title="Chat mode"
-          style={AGENT_PANEL_CONTROL_STYLE}
-        >
-          <IconMessage size={14} />
-          Chat
-        </button>
-        {isDevMode && (
-          <button
-            onClick={() => switchMode("cli")}
-            className={cn(
-              "flex items-center gap-1 rounded-md px-2 py-1 text-[12px] leading-none",
-              activeMode === "cli"
-                ? "bg-accent text-foreground"
-                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-            )}
-            title="CLI terminal mode"
-            style={AGENT_PANEL_CONTROL_STYLE}
-          >
-            <IconTerminal2 size={14} />
-            CLI
-          </button>
-        )}
-        <button
-          onClick={() => switchMode("resources")}
-          className={cn(
-            "flex items-center gap-1 rounded-md px-2 py-1 text-[12px] leading-none",
-            activeMode === "resources"
-              ? "bg-accent text-foreground"
-              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-          )}
-          title="Workspace files, agents, skills, and tasks"
-          style={AGENT_PANEL_CONTROL_STYLE}
-        >
-          <IconLayoutGrid size={14} />
-          Workspace
-        </button>
-        <button
-          onClick={() => switchMode("settings")}
-          aria-label="Setup and configuration"
-          className={cn(
-            "flex items-center justify-center rounded-md px-1.5 py-1",
-            activeMode === "settings"
-              ? "bg-accent text-foreground"
-              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-          )}
-          title="Setup and configuration"
-        >
-          <IconSettings size={14} />
-        </button>
-      </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => switchMode("resources")}
+                aria-label="Workspace files, agents, skills, and tasks"
+                className={cn(
+                  "flex items-center gap-1 rounded-md px-2 py-1 text-[12px] leading-none",
+                  activeMode === "resources"
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                )}
+                style={AGENT_PANEL_CONTROL_STYLE}
+              >
+                <IconLayoutGrid size={14} />
+                Workspace
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Workspace files, agents, skills, and tasks
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => switchMode("settings")}
+                aria-label="Setup and configuration"
+                className={cn(
+                  "flex items-center justify-center rounded-md px-1.5 py-1",
+                  activeMode === "settings"
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                )}
+              >
+                <IconSettings size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Setup and configuration</TooltipContent>
+          </Tooltip>
+        </div>
+      </TooltipProvider>
     ),
     [isDevMode],
   );

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -36,6 +36,12 @@ import { cn } from "./utils.js";
 import { AgentTaskCard } from "./AgentTaskCard.js";
 import { ConnectBuilderCard } from "./ConnectBuilderCard.js";
 import { useBuilderConnectFlow } from "./settings/useBuilderStatus.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./components/ui/tooltip.js";
 import { IframeEmbed, parseEmbedBody } from "./IframeEmbed.js";
 import { useDevMode } from "./use-dev-mode.js";
 import { agentNativePath } from "./api-path.js";
@@ -2806,14 +2812,21 @@ const AssistantChatInner = forwardRef<
                 </span>
                 <div className="flex items-center gap-1">
                   {onSwitchToCli && (
-                    <button
-                      onClick={onSwitchToCli}
-                      className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground px-2 py-1 rounded-md hover:bg-accent"
-                      title="Switch to CLI"
-                    >
-                      <IconTerminal className="h-3.5 w-3.5" />
-                      CLI
-                    </button>
+                    <TooltipProvider delayDuration={200}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            onClick={onSwitchToCli}
+                            aria-label="Switch to CLI"
+                            className="flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground px-2 py-1 rounded-md hover:bg-accent"
+                          >
+                            <IconTerminal className="h-3.5 w-3.5" />
+                            CLI
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>Switch to CLI</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                   )}
                 </div>
               </div>

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -7,6 +7,12 @@ import {
 } from "./AssistantChat.js";
 import { isTrustedFrameMessage } from "./frame.js";
 import { cn } from "./utils.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./components/ui/tooltip.js";
 import { useChatThreads, type ChatThreadSummary } from "./use-chat-threads.js";
 import { agentNativePath } from "./api-path.js";
 import { DEFAULT_MODEL } from "../agent/default-model.js";
@@ -1229,27 +1235,37 @@ export function MultiTabAssistantChat({
                         );
                       })}
                     </div>
-                    <div className="flex items-center gap-px shrink-0 ml-auto">
-                      <button
-                        onClick={addTab}
-                        className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground hover:bg-accent/50"
-                        title="New chat"
-                        aria-label="New chat"
-                      >
-                        <IconPlus size={12} />
-                      </button>
-                      <button
-                        onClick={() => setShowHistory(!showHistory)}
-                        aria-label="Chat history"
-                        className={cn(
-                          "flex h-6 w-6 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground hover:bg-accent/50",
-                          showHistory && "bg-accent text-foreground",
-                        )}
-                        title="Chat history"
-                      >
-                        <IconHistory size={12} />
-                      </button>
-                    </div>
+                    <TooltipProvider delayDuration={200}>
+                      <div className="flex items-center gap-px shrink-0 ml-auto">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={addTab}
+                              aria-label="New chat"
+                              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground hover:bg-accent/50"
+                            >
+                              <IconPlus size={12} />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>New chat</TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={() => setShowHistory(!showHistory)}
+                              aria-label="Chat history"
+                              className={cn(
+                                "flex h-6 w-6 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground hover:bg-accent/50",
+                                showHistory && "bg-accent text-foreground",
+                              )}
+                            >
+                              <IconHistory size={12} />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>Chat history</TooltipContent>
+                        </Tooltip>
+                      </div>
+                    </TooltipProvider>
                   </div>
                   {hasSubTabs && (
                     <div className="flex items-center px-1 py-0.5 border-b border-border shrink-0 gap-0.5 bg-muted/30">

--- a/packages/core/src/client/components/ui/tooltip.tsx
+++ b/packages/core/src/client/components/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "../../utils.js";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-[230] overflow-hidden rounded-md border border-border bg-popover px-2 py-1 text-[11px] text-foreground shadow-md animate-in fade-in-0 zoom-in-95",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/packages/core/src/client/resources/ResourceTree.tsx
+++ b/packages/core/src/client/resources/ResourceTree.tsx
@@ -18,6 +18,34 @@ import {
 import { cn } from "../utils.js";
 import type { TreeNode, ResourceMeta, JobMetadata } from "./use-resources.js";
 import type { McpServer } from "./use-mcp-servers.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
+
+function StatusDot({
+  className,
+  tooltip,
+}: {
+  className: string;
+  tooltip: string;
+}) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            aria-label={tooltip}
+            className={cn("ml-1 inline-block h-1.5 w-1.5 shrink-0", className)}
+          />
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -87,24 +115,24 @@ interface CreatingState {
 function McpStatusDot({ server }: { server: McpServer }) {
   if (server.status.state === "connected") {
     return (
-      <span
-        className="ml-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-green-500"
-        title={`Connected — ${server.status.toolCount} tool${server.status.toolCount === 1 ? "" : "s"}`}
+      <StatusDot
+        className="rounded-full bg-green-500"
+        tooltip={`Connected — ${server.status.toolCount} tool${server.status.toolCount === 1 ? "" : "s"}`}
       />
     );
   }
   if (server.status.state === "error") {
     return (
-      <span
-        className="ml-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-red-500"
-        title={`Error: ${server.status.error}`}
+      <StatusDot
+        className="rounded-full bg-red-500"
+        tooltip={`Error: ${server.status.error}`}
       />
     );
   }
   return (
-    <span
-      className="ml-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40"
-      title="Connecting…"
+    <StatusDot
+      className="rounded-full bg-muted-foreground/40"
+      tooltip="Connecting…"
     />
   );
 }
@@ -112,40 +140,40 @@ function McpStatusDot({ server }: { server: McpServer }) {
 function JobStatusDot({ meta }: { meta: JobMetadata }) {
   if (!meta.enabled) {
     return (
-      <span
-        className="ml-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40"
-        title="Disabled"
+      <StatusDot
+        className="rounded-full bg-muted-foreground/40"
+        tooltip="Disabled"
       />
     );
   }
   if (meta.lastStatus === "running") {
     return (
-      <span
-        className="ml-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500 animate-pulse"
-        title="Running"
+      <StatusDot
+        className="rounded-full bg-blue-500 animate-pulse"
+        tooltip="Running"
       />
     );
   }
   if (meta.lastStatus === "error") {
     return (
-      <span
-        className="ml-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-red-500"
-        title="Last run failed"
+      <StatusDot
+        className="rounded-full bg-red-500"
+        tooltip="Last run failed"
       />
     );
   }
   if (meta.lastStatus === "success") {
     return (
-      <span
-        className="ml-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-green-500"
-        title="Last run succeeded"
+      <StatusDot
+        className="rounded-full bg-green-500"
+        tooltip="Last run succeeded"
       />
     );
   }
   return (
-    <span
-      className="ml-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
-      title="Scheduled (not yet run)"
+    <StatusDot
+      className="rounded-full bg-amber-500"
+      tooltip="Scheduled (not yet run)"
     />
   );
 }
@@ -221,38 +249,55 @@ function TreeNodeRow({
         {node.mcpServerMeta && <McpStatusDot server={node.mcpServerMeta} />}
         {!readOnly && (
           <div className="ml-auto flex shrink-0 items-center gap-0.5 opacity-0 group-hover/row:opacity-100">
-            {isFolder && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onStartCreate(node.path, "file");
-                }}
-                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                title="New file"
-              >
-                <IconPlus className="h-3 w-3" />
-              </button>
-            )}
-            {node.resource &&
-              (isDeleting ? (
-                <span
-                  className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground"
-                  title="Deleting..."
-                >
-                  <IconLoader2 className="h-3 w-3 animate-spin" />
-                </span>
-              ) : (
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDelete(node.resource!.id);
-                  }}
-                  className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-destructive hover:bg-accent/50"
-                  title="Delete"
-                >
-                  <IconTrash className="h-3 w-3" />
-                </button>
-              ))}
+            <TooltipProvider delayDuration={200}>
+              {isFolder && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onStartCreate(node.path, "file");
+                      }}
+                      aria-label="New file"
+                      className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                    >
+                      <IconPlus className="h-3 w-3" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>New file</TooltipContent>
+                </Tooltip>
+              )}
+              {node.resource &&
+                (isDeleting ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span
+                        aria-label="Deleting…"
+                        className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground"
+                      >
+                        <IconLoader2 className="h-3 w-3 animate-spin" />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>Deleting…</TooltipContent>
+                  </Tooltip>
+                ) : (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDelete(node.resource!.id);
+                        }}
+                        aria-label="Delete"
+                        className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-destructive hover:bg-accent/50"
+                      >
+                        <IconTrash className="h-3 w-3" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Delete</TooltipContent>
+                  </Tooltip>
+                ))}
+            </TooltipProvider>
           </div>
         )}
       </div>
@@ -428,26 +473,46 @@ export function ResourceTree({
     >
       {/* Section heading */}
       <div className="group/root flex items-center justify-between px-1.5 py-1">
-        <span
-          className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60"
-          title={titleTooltip}
-        >
-          {title}
-          {headingHint && (
-            <span className="text-[10px] font-normal normal-case tracking-normal text-muted-foreground/50">
-              {headingHint}
+        <TooltipProvider delayDuration={200}>
+          {titleTooltip ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
+                  {title}
+                  {headingHint && (
+                    <span className="text-[10px] font-normal normal-case tracking-normal text-muted-foreground/50">
+                      {headingHint}
+                    </span>
+                  )}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>{titleTooltip}</TooltipContent>
+            </Tooltip>
+          ) : (
+            <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/60">
+              {title}
+              {headingHint && (
+                <span className="text-[10px] font-normal normal-case tracking-normal text-muted-foreground/50">
+                  {headingHint}
+                </span>
+              )}
             </span>
           )}
-        </span>
-        {!readOnly && (
-          <button
-            onClick={() => handleStartCreate("", "file")}
-            className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/50 opacity-0 group-hover/root:opacity-100 hover:text-foreground hover:bg-accent/50"
-            title="New file"
-          >
-            <IconPlus className="h-3 w-3" />
-          </button>
-        )}
+          {!readOnly && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => handleStartCreate("", "file")}
+                  aria-label="New file"
+                  className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/50 opacity-0 group-hover/root:opacity-100 hover:text-foreground hover:bg-accent/50"
+                >
+                  <IconPlus className="h-3 w-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>New file</TooltipContent>
+            </Tooltip>
+          )}
+        </TooltipProvider>
       </div>
 
       {tree.map((node) => (

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -47,6 +47,14 @@ import {
 } from "./use-mcp-servers.js";
 import { McpServerDetail } from "./McpServerDetail.js";
 import { useOrg } from "../org/hooks.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
+
+const WORKSPACE_DOCS_URL = "https://agent-native.com/docs/workspace";
 
 // ─── Create Menu (unified + button) ────────────────────────────────────────
 
@@ -1260,13 +1268,20 @@ export function ResourcesPanel() {
       {isEditing ? (
         <div className="flex shrink-0 items-center justify-between border-b border-border px-2 py-1.5">
           <div className="flex items-center gap-1.5 min-w-0">
-            <button
-              onClick={handleBack}
-              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
-              title="Back to workspace"
-            >
-              <IconArrowLeft className="h-3.5 w-3.5" />
-            </button>
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={handleBack}
+                    aria-label="Back to workspace"
+                    className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                  >
+                    <IconArrowLeft className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Back to workspace</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             {selectedMcpServer ? (
               <PathBreadcrumb
                 path={`mcp-servers/${selectedMcpServer.name}.json`}
@@ -1281,30 +1296,42 @@ export function ResourcesPanel() {
               (resourceQuery.data.mimeType === "text/markdown" ||
                 resourceQuery.data.path.endsWith(".md")) && (
                 <div className="flex items-center gap-0.5 mr-1">
-                  <button
-                    onClick={() => setEditorView("visual")}
-                    className={cn(
-                      "flex h-6 w-6 items-center justify-center rounded-md",
-                      editorView === "visual"
-                        ? "bg-accent text-foreground"
-                        : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
-                    )}
-                    title="Visual editor"
-                  >
-                    <IconEye className="h-3.5 w-3.5" />
-                  </button>
-                  <button
-                    onClick={() => setEditorView("code")}
-                    className={cn(
-                      "flex h-6 w-6 items-center justify-center rounded-md",
-                      editorView === "code"
-                        ? "bg-accent text-foreground"
-                        : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
-                    )}
-                    title="Code editor"
-                  >
-                    <IconCode className="h-3.5 w-3.5" />
-                  </button>
+                  <TooltipProvider delayDuration={200}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={() => setEditorView("visual")}
+                          aria-label="Visual editor"
+                          className={cn(
+                            "flex h-6 w-6 items-center justify-center rounded-md",
+                            editorView === "visual"
+                              ? "bg-accent text-foreground"
+                              : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
+                          )}
+                        >
+                          <IconEye className="h-3.5 w-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>Visual editor</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={() => setEditorView("code")}
+                          aria-label="Code editor"
+                          className={cn(
+                            "flex h-6 w-6 items-center justify-center rounded-md",
+                            editorView === "code"
+                              ? "bg-accent text-foreground"
+                              : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
+                          )}
+                        >
+                          <IconCode className="h-3.5 w-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>Code editor</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
               )}
             <span className="text-[11px] text-muted-foreground/60 mr-1">
@@ -1314,15 +1341,22 @@ export function ResourcesPanel() {
                   ? "Saved"
                   : ""}
             </span>
-            <button
-              onClick={() => {
-                if (selectedResourceId) handleDelete(selectedResourceId);
-              }}
-              className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-destructive hover:bg-accent/50"
-              title="Delete resource"
-            >
-              <IconTrash className="h-3.5 w-3.5" />
-            </button>
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => {
+                      if (selectedResourceId) handleDelete(selectedResourceId);
+                    }}
+                    aria-label="Delete resource"
+                    className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-destructive hover:bg-accent/50"
+                  >
+                    <IconTrash className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Delete resource</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         </div>
       ) : (
@@ -1336,22 +1370,38 @@ export function ResourcesPanel() {
             canCreateOrgMcp={canCreateOrgMcp}
             hasOrg={hasOrgForMcp}
           />
-          <button
-            onClick={() => fileInputRef.current?.click()}
-            className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
-            title="Upload file"
-          >
-            <IconUpload className="h-3.5 w-3.5" />
-          </button>
-          <a
-            href="https://www.builder.io/c/docs/agent-native-resources"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
-            title="What is the Workspace? — open docs"
-          >
-            <IconHelp className="h-3.5 w-3.5" />
-          </a>
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => fileInputRef.current?.click()}
+                  aria-label="Upload file"
+                  className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                >
+                  <IconUpload className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Upload file</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <a
+                  href={WORKSPACE_DOCS_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="What is the Workspace? — open docs"
+                  className="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                >
+                  <IconHelp className="h-3.5 w-3.5" />
+                </a>
+              </TooltipTrigger>
+              <TooltipContent>
+                What is the Workspace? — open docs
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           <input
             ref={fileInputRef}
             type="file"
@@ -1417,7 +1467,7 @@ export function ResourcesPanel() {
                     {org?.orgId ? " — only admins can edit." : "."}
                   </p>
                   <a
-                    href="https://www.builder.io/c/docs/agent-native-resources"
+                    href={WORKSPACE_DOCS_URL}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-1 text-foreground hover:underline"


### PR DESCRIPTION
### Summary
Fixes the dead Workspace help/docs link in the agent-native UI and replaces all browser-native `title` attribute tooltips across the chat sidebar and Workspace panel with proper shadcn `Tooltip` components.

### Problem
The help (question-mark) icon in the Workspace area linked to `builder.io/c/docs/agent-native-resources`, which was a dead/incorrect destination. Additionally, multiple buttons across `AgentPanel`, `AssistantChat`, `MultiTabAssistantChat`, and `ResourcesPanel` used browser-native `title` attributes for tooltips, resulting in inconsistent, unstyled tooltip behavior that didn't match the app's design system.

### Solution
- Updated the Workspace docs URL to point to `https://agent-native.com/docs/workspace` and extracted it into a named constant (`WORKSPACE_DOCS_URL`) for easy maintenance.
- Audited all `title`-based tooltips in the affected files and replaced them with shadcn `<Tooltip>` / `<TooltipTrigger>` / `<TooltipContent>` / `<TooltipProvider>` components.
- Replaced `title` props with `aria-label` on buttons for accessibility.

### Key Changes
- **`ResourcesPanel.tsx`**: Added `WORKSPACE_DOCS_URL = "https://agent-native.com/docs/workspace"` constant; updated both the help icon link and the inline docs anchor to use it; converted all icon-button `title` tooltips (back, visual editor, code editor, delete, upload, help) to shadcn tooltips.
- **`AgentPanel.tsx`**: Wrapped all mode-switcher buttons (Chat, CLI, Workspace, Settings) in a shared `<TooltipProvider>` with shadcn `<Tooltip>` components, replacing `title` attributes.
- **`AssistantChat.tsx`**: Converted the "Switch to CLI" button tooltip from `title` to a shadcn `<Tooltip>`.
- **`MultiTabAssistantChat.tsx`**: Converted tab-bar action buttons (new chat, history) to use shadcn tooltips.
- All converted buttons now use `aria-label` instead of `title` for improved accessibility.

---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/high-street-sdb6zx7o"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-high-street-sdb6zx7o_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 413`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>high-street-sdb6zx7o</branchName>-->