### PR TITLE
Fix hidden remote-agent discovery

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.24",
+  "version": "0.7.25",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/server/agent-discovery.spec.ts
+++ b/packages/core/src/server/agent-discovery.spec.ts
@@ -1,11 +1,34 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BUILTIN_AGENTS_FOR_SEEDING,
+  discoverAgents,
   getBuiltinAgents,
 } from "./agent-discovery.js";
 import { visibleTemplates } from "../cli/templates-meta.js";
 
+const resourceListMock = vi.hoisted(() => vi.fn());
+const resourceListAccessibleMock = vi.hoisted(() => vi.fn());
+const resourceGetMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../resources/store.js", () => ({
+  resourceGet: resourceGetMock,
+  resourceList: resourceListMock,
+  resourceListAccessible: resourceListAccessibleMock,
+  SHARED_OWNER: "__shared__",
+}));
+
+vi.mock("./auth.js", () => ({
+  DEV_MODE_USER_EMAIL: "dev@example.test",
+}));
+
 describe("agent discovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resourceListMock.mockResolvedValue([]);
+    resourceListAccessibleMock.mockResolvedValue([]);
+    resourceGetMock.mockResolvedValue(null);
+  });
+
   it("derives built-in connected agents from visible production templates", () => {
     const expected = visibleTemplates()
       .filter((template) => template.prodUrl && template.name !== "dispatch")
@@ -35,5 +58,39 @@ describe("agent discovery", () => {
       expect(agent.url).not.toContain("localhost");
       expect(agent.url).not.toContain("127.0.0.1");
     }
+  });
+
+  it("ignores stale hidden first-party remote-agent resources", async () => {
+    resourceListAccessibleMock.mockResolvedValue([
+      { id: "issues-resource", path: "remote-agents/issues.json" },
+      { id: "recruiting-resource", path: "remote-agents/recruiting.json" },
+      { id: "custom-resource", path: "remote-agents/custom-qa.json" },
+    ]);
+    resourceGetMock.mockImplementation(async (id: string) => {
+      const contentById: Record<string, string> = {
+        "issues-resource": JSON.stringify({
+          id: "issues",
+          name: "Issues",
+          url: "https://issues.agent-native.com",
+        }),
+        "recruiting-resource": JSON.stringify({
+          id: "recruiting",
+          name: "Recruiting",
+          url: "https://recruiting.agent-native.com",
+        }),
+        "custom-resource": JSON.stringify({
+          id: "custom-qa",
+          name: "Custom QA",
+          url: "https://custom.example.com",
+        }),
+      };
+      return { id, content: contentById[id] ?? "{}" };
+    });
+
+    const ids = (await discoverAgents("dispatch")).map((agent) => agent.id);
+
+    expect(ids).not.toContain("issues");
+    expect(ids).not.toContain("recruiting");
+    expect(ids).toContain("custom-qa");
   });
 });

--- a/packages/core/src/server/agent-discovery.ts
+++ b/packages/core/src/server/agent-discovery.ts
@@ -1,4 +1,4 @@
-import { visibleTemplates } from "../cli/templates-meta.js";
+import { TEMPLATES, visibleTemplates } from "../cli/templates-meta.js";
 
 export interface DiscoveredAgent {
   id: string;
@@ -34,6 +34,12 @@ const BUILTIN_AGENTS: AgentEntry[] = visibleTemplates()
     devPort: template.devPort,
     color: template.color,
   }));
+
+const HIDDEN_FIRST_PARTY_AGENT_IDS = new Set(
+  TEMPLATES.filter((template) => template.hidden && template.prodUrl).map(
+    (template) => template.name,
+  ),
+);
 
 /**
  * Get built-in agents (static, no DB). Used as fallback and for seeding.
@@ -87,6 +93,7 @@ export async function discoverAgents(
         if (!full) continue;
         const manifest = parseRemoteAgentManifest(full.content, r.path);
         if (!manifest || manifest.id === selfAppId) continue;
+        if (HIDDEN_FIRST_PARTY_AGENT_IDS.has(manifest.id)) continue;
 
         // If the resource override carries a localhost URL but we're running
         // in production (e.g. a stale dev-time seed got promoted to the prod

--- a/templates/dispatch/actions/list-connected-agents.ts
+++ b/templates/dispatch/actions/list-connected-agents.ts
@@ -24,7 +24,10 @@ export default defineAction({
     );
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");
-    const resources = await resourceListAccessible(ownerEmail, "agents/");
+    const resources = await resourceListAccessible(
+      ownerEmail,
+      "remote-agents/",
+    );
     const customById = new Map<
       string,
       { resourceId: string; path: string; scope: "shared" | "personal" }


### PR DESCRIPTION
## Summary
- Ignore stale hidden first-party remote-agent resources such as issues/recruiting during agent discovery
- Read Dispatch custom connected-agent metadata from remote-agents/ to match the discovery store
- Bump @agent-native/core to 0.7.25

## Tests
- pnpm --filter @agent-native/core test -- --run src/server/agent-discovery.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter dispatch typecheck
