### PR TITLE
Fix Slack A2A continuation recovery

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -65,10 +65,16 @@ export class A2AClient {
   private baseUrl: string;
   private apiKey?: string;
   private a2aPath = "/_agent-native/a2a";
+  private requestTimeoutMs?: number;
 
-  constructor(baseUrl: string, apiKey?: string) {
+  constructor(
+    baseUrl: string,
+    apiKey?: string,
+    options?: { requestTimeoutMs?: number },
+  ) {
     this.baseUrl = baseUrl.replace(/\/$/, "");
     this.apiKey = apiKey;
+    this.requestTimeoutMs = options?.requestTimeoutMs;
   }
 
   /**
@@ -107,11 +113,24 @@ export class A2AClient {
     const url = `${this.baseUrl}${this.a2aPath}`;
     console.log(`[A2A Client] POST ${url} method=${method}`);
     const startTime = Date.now();
-    const res = await fetch(url, {
-      method: "POST",
-      headers: this.headers(),
-      body: JSON.stringify(body),
-    });
+    const controller = this.requestTimeoutMs
+      ? new AbortController()
+      : undefined;
+    const timer =
+      controller && this.requestTimeoutMs
+        ? setTimeout(() => controller.abort(), this.requestTimeoutMs)
+        : undefined;
+    let res!: Response;
+    try {
+      res = await fetch(url, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify(body),
+        signal: controller?.signal,
+      });
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
     console.log(
       `[A2A Client] Response: ${res.status} in ${Date.now() - startTime}ms`,
     );

--- a/packages/core/src/a2a/handlers.spec.ts
+++ b/packages/core/src/a2a/handlers.spec.ts
@@ -80,6 +80,22 @@ vi.mock("./task-store.js", () => {
       };
       return task;
     },
+    async getA2ATaskDispatchState(id: string) {
+      const task = tasks[id];
+      if (!task) return null;
+      return {
+        id,
+        statusState: task.status.state,
+        metadata: task.metadata,
+        updatedAt: Date.now(),
+      };
+    },
+    async touchQueuedA2ATaskDispatch() {
+      return true;
+    },
+    async resetStuckA2ATaskForRetry() {
+      return true;
+    },
   };
 });
 

--- a/packages/core/src/a2a/handlers.ts
+++ b/packages/core/src/a2a/handlers.ts
@@ -15,6 +15,9 @@ import {
   getTaskOwner,
   updateTask,
   claimA2ATaskForProcessing,
+  getA2ATaskDispatchState,
+  resetStuckA2ATaskForRetry,
+  touchQueuedA2ATaskDispatch,
 } from "./task-store.js";
 import { agentChat } from "../shared/agent-chat.js";
 import { signInternalToken } from "../integrations/internal-token.js";
@@ -24,6 +27,8 @@ import { withConfiguredAppBasePath } from "../server/app-base-path.js";
 // transitive deps) into the a2a/handlers test boundary. Must stay in sync
 // with FRAMEWORK_ROUTE_PREFIX in `server/core-routes-plugin.ts`.
 const A2A_PROCESS_TASK_PATH = "/_agent-native/a2a/_process-task";
+const A2A_QUEUED_DISPATCH_STUCK_AFTER_MS = 10_000;
+const A2A_PROCESSING_STUCK_AFTER_MS = 5 * 60 * 1000;
 
 /**
  * Resolve the base URL we should fire the A2A processor request to. Mirrors
@@ -731,7 +736,41 @@ async function handleGet(
   if (!task) {
     return jsonRpcError(0, -32001, "Task not found");
   }
+  await refireStuckAsyncTaskIfNeeded(id, event).catch((err) => {
+    console.error("[a2a] Failed to refire stuck async task:", err);
+  });
   return jsonRpcResult(0, sanitizeTaskForResponse(task));
+}
+
+async function refireStuckAsyncTaskIfNeeded(
+  taskId: string,
+  event: any,
+): Promise<void> {
+  const state = await getA2ATaskDispatchState(taskId);
+  if (!state) return;
+  if (!state.metadata?.__a2a_processor) return;
+
+  const now = Date.now();
+  if (
+    (state.statusState === "submitted" || state.statusState === "working") &&
+    state.updatedAt <= now - A2A_QUEUED_DISPATCH_STUCK_AFTER_MS
+  ) {
+    if (await touchQueuedA2ATaskDispatch(taskId)) {
+      await fireProcessTaskDispatch(event, taskId);
+    }
+    return;
+  }
+
+  if (
+    state.statusState === "processing" &&
+    state.updatedAt <= now - A2A_PROCESSING_STUCK_AFTER_MS
+  ) {
+    const reset = await resetStuckA2ATaskForRetry(
+      taskId,
+      now - A2A_PROCESSING_STUCK_AFTER_MS,
+    );
+    if (reset) await fireProcessTaskDispatch(event, taskId);
+  }
 }
 
 async function handleCancel(

--- a/packages/core/src/a2a/task-store.ts
+++ b/packages/core/src/a2a/task-store.ts
@@ -155,6 +155,65 @@ export async function claimA2ATaskForProcessing(
   return taskFromRow(rows[0]);
 }
 
+export async function getA2ATaskDispatchState(id: string): Promise<{
+  id: string;
+  statusState: string;
+  metadata: Record<string, unknown> | undefined;
+  updatedAt: number;
+} | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT id, status_state, metadata, updated_at FROM a2a_tasks WHERE id = ?`,
+    args: [id],
+  });
+  const row = rows[0] as any;
+  if (!row) return null;
+  return {
+    id: row.id as string,
+    statusState: row.status_state as string,
+    metadata: row.metadata ? JSON.parse(row.metadata as string) : undefined,
+    updatedAt: Number(row.updated_at ?? 0),
+  };
+}
+
+export async function touchQueuedA2ATaskDispatch(id: string): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const result = await client.execute({
+    sql: `UPDATE a2a_tasks
+            SET updated_at = ?
+          WHERE id = ?
+            AND status_state IN ('submitted', 'working')`,
+    args: [now, id],
+  });
+  const affected = (result as any)?.rowsAffected ?? (result as any)?.rowCount;
+  return affected !== 0;
+}
+
+export async function resetStuckA2ATaskForRetry(
+  id: string,
+  processingCutoff: number,
+): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const timestamp = new Date().toISOString();
+  const result = await client.execute({
+    sql: `UPDATE a2a_tasks
+            SET status_state = 'working',
+                status_timestamp = ?,
+                updated_at = ?
+          WHERE id = ?
+            AND status_state = 'processing'
+            AND updated_at <= ?`,
+    args: [timestamp, now, id, processingCutoff],
+  });
+  const affected = (result as any)?.rowsAffected ?? (result as any)?.rowCount;
+  return affected !== 0;
+}
+
 export async function getTask(id: string): Promise<Task | null> {
   await ensureTable();
   const client = getDbExec();

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { A2AContinuation } from "./a2a-continuations-store.js";
+import type { PlatformAdapter } from "./types.js";
+
+const claimA2AContinuationMock = vi.hoisted(() => vi.fn());
+const completeA2AContinuationMock = vi.hoisted(() => vi.fn());
+const failA2AContinuationMock = vi.hoisted(() => vi.fn());
+const rescheduleA2AContinuationMock = vi.hoisted(() => vi.fn());
+const getTaskMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./a2a-continuations-store.js", () => ({
+  claimA2AContinuation: claimA2AContinuationMock,
+  claimDueA2AContinuations: vi.fn(async () => []),
+  completeA2AContinuation: completeA2AContinuationMock,
+  failA2AContinuation: failA2AContinuationMock,
+  rescheduleA2AContinuation: rescheduleA2AContinuationMock,
+}));
+
+vi.mock("../a2a/client.js", () => ({
+  A2AClient: vi.fn().mockImplementation(function A2AClient() {
+    return { getTask: getTaskMock };
+  }),
+  signA2AToken: vi.fn(async () => "signed-a2a-token"),
+}));
+
+vi.mock("./internal-token.js", () => ({
+  signInternalToken: vi.fn(() => "signed-internal-token"),
+}));
+
+function continuation(
+  overrides: Partial<A2AContinuation> = {},
+): A2AContinuation {
+  return {
+    id: "cont-1",
+    integrationTaskId: "task-1",
+    platform: "slack",
+    externalThreadId: "C123:123.456",
+    incoming: {
+      platform: "slack",
+      externalThreadId: "C123:123.456",
+      text: "make a deck",
+      timestamp: 1,
+      platformContext: { channelId: "C123", threadTs: "123.456" },
+    },
+    placeholderRef: null,
+    ownerEmail: "alice+qa@agent-native.test",
+    orgId: null,
+    agentName: "Slides",
+    agentUrl: "https://slides.agent-native.test",
+    a2aTaskId: "a2a-task-1",
+    status: "processing",
+    attempts: 1,
+    nextCheckAt: 1,
+    errorMessage: null,
+    createdAt: 1,
+    updatedAt: 1,
+    completedAt: null,
+    ...overrides,
+  };
+}
+
+function adapter(sendResponse = vi.fn(async () => undefined)): PlatformAdapter {
+  return {
+    platform: "slack",
+    label: "Slack",
+    getRequiredEnvKeys: () => [],
+    handleVerification: async () => ({ handled: false }),
+    verifyWebhook: async () => true,
+    parseIncomingMessage: async () => null,
+    sendResponse,
+    sendMessageToTarget: async () => undefined,
+    formatAgentResponse: (text) => ({ text, platformContext: {} }),
+    getStatus: async () => ({
+      platform: "slack",
+      label: "Slack",
+      enabled: true,
+      configured: true,
+    }),
+  };
+}
+
+describe("A2A continuation processor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.APP_URL = "https://dispatch.agent-native.test";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("ok", { status: 200 })),
+    );
+    getTaskMock.mockResolvedValue({
+      id: "a2a-task-1",
+      status: {
+        state: "completed",
+        message: {
+          role: "agent",
+          parts: [{ type: "text", text: "/deck/deck-qa" }],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    });
+  });
+
+  it("posts completed remote task text and marks the continuation completed", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "https://slides.agent-native.test/deck/deck-qa",
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("reschedules and redispatches when the platform send fails", async () => {
+    const sendResponse = vi.fn(async () => {
+      throw new Error("slack unavailable");
+    });
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      30_000,
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ continuationId: "cont-1" }),
+      }),
+    );
+    expect(completeA2AContinuationMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -106,6 +106,7 @@ async function processClaimedContinuation(
   const client = new A2AClient(
     continuation.agentUrl,
     await signContinuationToken(continuation),
+    { requestTimeoutMs: 10_000 },
   );
   const deadline = Date.now() + PROCESSOR_WAIT_MS;
   let task: Task | null = null;
@@ -125,6 +126,7 @@ async function processClaimedContinuation(
       return;
     }
     await rescheduleA2AContinuation(continuation.id, 30_000);
+    await redispatchContinuation(continuation.id);
     return;
   }
 
@@ -137,6 +139,7 @@ async function processClaimedContinuation(
       return;
     }
     await rescheduleA2AContinuation(continuation.id, 30_000);
+    await redispatchContinuation(continuation.id);
     return;
   }
 
@@ -173,7 +176,17 @@ async function processClaimedContinuation(
       return;
     }
     await rescheduleA2AContinuation(continuation.id, 30_000);
+    await redispatchContinuation(continuation.id);
   }
+}
+
+async function redispatchContinuation(continuationId: string): Promise<void> {
+  await dispatchA2AContinuation(continuationId).catch((err) => {
+    console.error(
+      `[integrations] Failed to redispatch A2A continuation ${continuationId}:`,
+      err,
+    );
+  });
 }
 
 async function signContinuationToken(

--- a/packages/core/src/integrations/a2a-continuations-store.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.ts
@@ -2,6 +2,7 @@ import { getDbExec, isPostgres, intType } from "../db/client.js";
 import type { IncomingMessage } from "./types.js";
 
 let _initPromise: Promise<void> | undefined;
+const PROCESSING_STUCK_AFTER_MS = 5 * 60 * 1000;
 
 async function ensureTable(): Promise<void> {
   if (!_initPromise) {
@@ -194,22 +195,28 @@ export async function claimA2AContinuation(
   await ensureTable();
   const client = getDbExec();
   const now = Date.now();
-  const { rows } = await client.execute({
+  const processingCutoff = now - PROCESSING_STUCK_AFTER_MS;
+  const result = await client.execute({
     sql: isPostgres()
       ? `UPDATE integration_a2a_continuations
            SET status = ?, attempts = attempts + 1, updated_at = ?
-         WHERE id = ? AND status = 'pending'
+         WHERE id = ?
+           AND (status = 'pending' OR (status = 'processing' AND updated_at <= ?))
          RETURNING *`
       : `UPDATE integration_a2a_continuations
            SET status = ?, attempts = attempts + 1, updated_at = ?
-         WHERE id = ? AND status = 'pending'`,
-    args: ["processing", now, id],
+         WHERE id = ?
+           AND (status = 'pending' OR (status = 'processing' AND updated_at <= ?))`,
+    args: ["processing", now, id, processingCutoff],
   });
+  const rows = result.rows ?? [];
   if (isPostgres()) {
     return rows[0]
       ? rowToContinuation(rows[0] as Record<string, unknown>)
       : null;
   }
+  const affected = (result as any)?.rowsAffected ?? (result as any)?.rowCount;
+  if (affected === 0) return null;
   const fetched = await getA2AContinuation(id);
   if (!fetched || fetched.status !== "processing") return null;
   return fetched;

--- a/packages/core/src/integrations/adapters/slack.spec.ts
+++ b/packages/core/src/integrations/adapters/slack.spec.ts
@@ -18,4 +18,14 @@ describe("slackAdapter", () => {
       response: "qa-challenge",
     });
   });
+
+  it("does not bold-wrap bare URLs", () => {
+    const formatted = slackAdapter().formatAgentResponse(
+      "**https://slides.agent-native.com/deck/deck-qa**",
+    );
+
+    expect(formatted.text).toBe(
+      "<https://slides.agent-native.com/deck/deck-qa>",
+    );
+  });
 });

--- a/packages/core/src/integrations/adapters/slack.ts
+++ b/packages/core/src/integrations/adapters/slack.ts
@@ -280,6 +280,7 @@ export function slackAdapter(): PlatformAdapter {
         }
       } catch (err) {
         console.error("[slack] Failed to send message:", err);
+        throw err;
       }
     },
 
@@ -512,6 +513,9 @@ function markdownToSlackMrkdwn(text: string): string {
   return (
     bounded
       .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>")
+      // Do not wrap bare URLs in Slack bold markers. Slack's autolinker can
+      // treat the trailing `*` as part of the URL, producing a broken link.
+      .replace(/\*\*<?(https?:\/\/[^\s>*]+)>?\*\*/g, "<$1>")
       // Bounded character class instead of `.+?` with the `s` flag — caps
       // each bold span at 5000 chars so an attacker can't construct a
       // pathological "**" sequence that exhibits super-linear backtracking.
@@ -605,5 +609,6 @@ async function postFresh(
   const data = (await res.json()) as { ok: boolean; error?: string };
   if (!data.ok) {
     console.error("[slack] chat.postMessage error:", data.error);
+    throw new Error(data.error || "chat.postMessage failed");
   }
 }

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -47,6 +47,11 @@ function startA2AContinuationRetryJob(
   adapters: Map<string, PlatformAdapter>,
 ): void {
   if (a2aContinuationRetryInterval) return;
+  setTimeout(() => {
+    processDueA2AContinuations({ adapters }).catch((err) => {
+      console.error("[integrations] A2A continuation retry job failed:", err);
+    });
+  }, 10_000);
   a2aContinuationRetryInterval = setInterval(() => {
     processDueA2AContinuations({ adapters }).catch((err) => {
       console.error("[integrations] A2A continuation retry job failed:", err);
@@ -386,6 +391,15 @@ export function createIntegrationsPlugin(
             ownerEmail: task.ownerEmail,
           });
           await markTaskCompleted(taskId);
+          await processDueA2AContinuations({
+            adapters: adapterMap,
+            limit: 2,
+          }).catch((err) => {
+            console.error(
+              "[integrations] A2A continuation opportunistic sweep failed:",
+              err,
+            );
+          });
           return { ok: true, taskId };
         } catch (err: any) {
           await markTaskFailed(

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -16,6 +16,7 @@ use crate::state::{
 };
 use crate::util::{
     build_overlay_url, mark_popover_shown, primary_monitor_physical_size, set_capture_excluded,
+    set_dictation_active,
 };
 
 /// Native overlay windows for the recording experience. These render the same
@@ -521,8 +522,8 @@ pub async fn show_flow_bar(app: AppHandle) -> Result<(), String> {
     // Wider + taller than the pill alone so the live transcript chip
     // can stack above it. Height accommodates: bottom-anchored 32px pill
     // + 6px gap + ~28px transcript chip + drop-shadow margin.
-    let w: u32 = 800;
-    let h: u32 = 180;
+    let w: u32 = 420;
+    let h: u32 = 120;
     let x: i32 = ((mw as i32 - w as i32) / 2).max(0);
     // Bottom margin: ~14 logical px ≈ 28 physical px, matching Wispr Flow.
     let y: i32 = (mh as i32 - h as i32 - 28).max(0);
@@ -534,6 +535,7 @@ pub async fn show_flow_bar(app: AppHandle) -> Result<(), String> {
         // JS side emitting voice:state-change.
         let _ = existing.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));
         let _ = existing.set_position(PhysicalPosition::new(x, y));
+        let _ = existing.set_ignore_cursor_events(false);
         crate::util::show_without_activation(&existing);
         return Ok(());
     }
@@ -555,7 +557,10 @@ pub async fn show_flow_bar(app: AppHandle) -> Result<(), String> {
         })?;
     let _ = win.set_size(tauri::Size::Physical(PhysicalSize::new(w, h)));
     let _ = win.set_position(PhysicalPosition::new(x, y));
-    let _ = win.set_ignore_cursor_events(true);
+    // The flow bar contains a visible cancel button, so it must be a real
+    // click target. Keep the OS window compact instead of making a wide
+    // click-through rectangle that strands the X button.
+    let _ = win.set_ignore_cursor_events(false);
     set_capture_excluded(&win);
     crate::util::show_without_activation(&win);
     let app_for_timeout = app.clone();
@@ -584,6 +589,7 @@ pub async fn show_flow_bar(app: AppHandle) -> Result<(), String> {
 
 #[tauri::command]
 pub async fn hide_flow_bar(app: AppHandle) -> Result<(), String> {
+    set_dictation_active(&app, false);
     // Hide (don't close) so the next show_flow_bar can reuse the window
     // and avoid the ~200ms WebKit cold-start that creates the stutter
     // on second/third Fn presses.

--- a/templates/clips/desktop/src-tauri/src/shortcuts.rs
+++ b/templates/clips/desktop/src-tauri/src/shortcuts.rs
@@ -6,7 +6,7 @@ use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut}
 use crate::clips::toggle_popover;
 use crate::dlog;
 use crate::state::{DictationActive, VoiceWakePopover};
-use crate::util::{is_recording_active, show_without_activation};
+use crate::util::{is_recording_active, set_dictation_active, show_without_activation};
 
 fn escape_shortcut() -> Shortcut {
     Shortcut::new(None, Code::Escape)
@@ -234,6 +234,13 @@ fn install_fn_event_tap(app: tauri::AppHandle) {
     let needs_reenable = Arc::new(AtomicBool::new(false));
     let event_count = Arc::new(AtomicU64::new(0));
 
+    let app_for_cancel = app.clone();
+    let prev_for_cancel = prev_down.clone();
+    app.listen("voice:cancel", move |_event| {
+        prev_for_cancel.store(false, Ordering::SeqCst);
+        set_dictation_active(&app_for_cancel, false);
+    });
+
     dlog!("[clips-tray][fn-tap] install_fn_event_tap called — spawning listener thread");
 
     thread::Builder::new()
@@ -325,6 +332,7 @@ fn install_fn_event_tap(app: tauri::AppHandle) {
                                 serde_json::json!({ "source": "fn" }),
                             );
                         });
+                        install_fn_release_watchdog(app_for_cb.clone(), prev_for_cb.clone());
                     } else {
                         dlog!("[clips-tray] Fn up — stopping voice dictation");
                         let _ = app_for_cb.emit(
@@ -399,10 +407,46 @@ fn install_fn_event_tap(app: tauri::AppHandle) {
 }
 
 #[cfg(target_os = "macos")]
-fn set_dictation_active(app: &tauri::AppHandle, active: bool) {
-    if let Some(state) = app.try_state::<DictationActive>() {
-        if let Ok(mut g) = state.0.lock() {
-            *g = active;
+fn install_fn_release_watchdog(
+    app: tauri::AppHandle,
+    prev_down: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    use std::sync::atomic::Ordering;
+    use std::thread;
+    use std::time::Duration;
+
+    thread::spawn(move || {
+        // The CGEventTap occasionally misses the Fn up-edge after sleep,
+        // Mission Control, or tap re-enable churn. Poll the current HID
+        // modifier flags while we believe Fn is down; if the physical state
+        // says it is up, synthesize the missing stop event.
+        thread::sleep(Duration::from_millis(120));
+        while prev_down.load(Ordering::SeqCst) {
+            if !current_fn_flag_down() {
+                if prev_down.swap(false, Ordering::SeqCst) {
+                    dlog!("[clips-tray] Fn up missed — synthesizing voice stop");
+                    set_dictation_active(&app, false);
+                    let _ = app.emit(
+                        "voice:shortcut-stop",
+                        serde_json::json!({ "source": "fn", "synthetic": true }),
+                    );
+                }
+                break;
+            }
+            thread::sleep(Duration::from_millis(120));
         }
+    });
+}
+
+#[cfg(target_os = "macos")]
+fn current_fn_flag_down() -> bool {
+    use core_graphics::event::CGEventFlags;
+    use core_graphics::event_source::CGEventSourceStateID;
+
+    extern "C" {
+        fn CGEventSourceFlagsState(state_id: CGEventSourceStateID) -> CGEventFlags;
     }
+
+    let flags = unsafe { CGEventSourceFlagsState(CGEventSourceStateID::HIDSystemState) };
+    flags.contains(CGEventFlags::CGEventFlagSecondaryFn)
 }

--- a/templates/clips/desktop/src-tauri/src/util.rs
+++ b/templates/clips/desktop/src-tauri/src/util.rs
@@ -1,7 +1,7 @@
 use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindow};
 
 use crate::dlog;
-use crate::state::{PopoverShownAt, RecordingActive};
+use crate::state::{DictationActive, PopoverShownAt, RecordingActive};
 
 // ---------------------------------------------------------------------------
 // Exclude-from-capture helper (macOS only)
@@ -170,4 +170,12 @@ pub fn is_recording_active(app: &AppHandle) -> bool {
     app.try_state::<RecordingActive>()
         .and_then(|s| s.0.lock().ok().map(|g| *g))
         .unwrap_or(false)
+}
+
+pub fn set_dictation_active(app: &AppHandle, active: bool) {
+    if let Some(state) = app.try_state::<DictationActive>() {
+        if let Ok(mut g) = state.0.lock() {
+            *g = active;
+        }
+    }
 }

--- a/templates/clips/desktop/src/overlays/flow-bar.tsx
+++ b/templates/clips/desktop/src/overlays/flow-bar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 import { IconX } from "@tabler/icons-react";
 
@@ -155,6 +156,9 @@ export function FlowBar() {
     // it will abort any in-flight transcribe, stop recording, and hide
     // the bar without pasting text.
     emit("voice:cancel").catch(() => {});
+    window.setTimeout(() => {
+      invoke("hide_flow_bar").catch(() => {});
+    }, 250);
   };
 
   // The transcript chip is independent of the pill — it can linger on

--- a/templates/dispatch/AGENTS.md
+++ b/templates/dispatch/AGENTS.md
@@ -64,7 +64,7 @@ The agent can navigate with:
 
 ### Vault (workspace-wide secrets)
 
-- `list-workspace-apps`: list apps installed in the workspace and their mounted paths
+- `list-workspace-apps`: list apps installed in the workspace and their mounted paths; when `url` is present, use it for links in Slack/email replies instead of returning only the relative path
 - `get-app-creation-settings`: see whether production app creation can use a Builder project
 - `set-app-creation-settings`: set the default Builder project ID in Dispatch settings without writing env vars or files
 - `start-workspace-app-creation`: start a new app request; in local dev, use the returned prompt with the local code agent, and in production it creates a Builder branch when a Builder project is configured

--- a/templates/dispatch/actions/list-workspace-apps.ts
+++ b/templates/dispatch/actions/list-workspace-apps.ts
@@ -4,7 +4,7 @@ import { listWorkspaceApps } from "../server/lib/app-creation-store.js";
 
 export default defineAction({
   description:
-    "List apps installed in this workspace, including their mounted paths.",
+    "List apps installed in this workspace, including their mounted paths and absolute URLs when the public app URL is configured.",
   schema: z.object({}),
   http: { method: "GET" },
   run: async () => listWorkspaceApps(),

--- a/templates/dispatch/app/routes/apps.tsx
+++ b/templates/dispatch/app/routes/apps.tsx
@@ -10,6 +10,7 @@ interface WorkspaceAppSummary {
   name: string;
   description?: string;
   path: string;
+  url?: string | null;
   isDispatch: boolean;
 }
 
@@ -53,7 +54,7 @@ export default function AppsRoute() {
             {typedApps.map((app) => (
               <a
                 key={app.id}
-                href={app.path}
+                href={app.url || app.path}
                 className="group rounded-lg border bg-card p-4 transition hover:border-foreground/30"
               >
                 <div className="flex items-start justify-between gap-3">

--- a/templates/dispatch/server/lib/app-creation-store.ts
+++ b/templates/dispatch/server/lib/app-creation-store.ts
@@ -20,6 +20,7 @@ export interface WorkspaceAppSummary {
   name: string;
   description: string;
   path: string;
+  url: string | null;
   isDispatch: boolean;
 }
 
@@ -67,6 +68,21 @@ function scopedSettingsKey(): string {
   return `${SETTINGS_KEY}:user:${currentOwnerEmail()}`;
 }
 
+function workspaceAppUrl(appPath: string): string | null {
+  const base =
+    process.env.APP_URL ||
+    process.env.URL ||
+    process.env.DEPLOY_URL ||
+    process.env.BETTER_AUTH_URL ||
+    null;
+  if (!base) return null;
+  try {
+    return new URL(appPath, `${base.replace(/\/$/, "")}/`).toString();
+  } catch {
+    return null;
+  }
+}
+
 export function getEnvBuilderProjectId(): string | null {
   return (
     process.env.DISPATCH_BUILDER_PROJECT_ID ||
@@ -85,6 +101,7 @@ export async function listWorkspaceApps(): Promise<WorkspaceAppSummary[]> {
         name: "Dispatch",
         description: "Workspace control plane",
         path: "/dispatch",
+        url: workspaceAppUrl("/dispatch"),
         isDispatch: true,
       },
     ];
@@ -105,6 +122,7 @@ export async function listWorkspaceApps(): Promise<WorkspaceAppSummary[]> {
         name: pkg.displayName || titleCase(entry.name),
         description: pkg.description || "",
         path: `/${entry.name}`,
+        url: workspaceAppUrl(`/${entry.name}`),
         isDispatch: entry.name === "dispatch",
       } satisfies WorkspaceAppSummary;
     })


### PR DESCRIPTION
## Summary
- make A2A continuations recover stale processing rows and redispatch themselves after retryable poll/send failures
- refire stuck async A2A tasks from tasks/get polling and add bounded A2A request timeouts for continuation polling
- make Slack send failures throw, avoid malformed bold bare URLs, and include absolute workspace app URLs in Dispatch app listings
- improve Clips desktop voice cancellation / flow-bar handling from the concurrent local fix
- bump @agent-native/core to 0.7.26

## Testing
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core test -- src/integrations/a2a-continuation-processor.spec.ts src/integrations/adapters/slack.spec.ts src/integrations/pending-tasks-retry-job.spec.ts src/a2a/handlers.spec.ts src/a2a/task-store.spec.ts src/server/agent-discovery.spec.ts
- pnpm --filter dispatch typecheck
- pnpm guards
- builder-workspace: pnpm typecheck
- builder-workspace: pnpm build
- clips desktop: cargo fmt
- clips desktop: cargo check
- clips: pnpm --filter clips typecheck
- clips desktop: pnpm --dir templates/clips/desktop build
