### PR TITLE
Fix A2A continuation delivery for Slack

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.27",
+  "version": "0.7.28",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { A2AContinuation } from "./a2a-continuations-store.js";
 import type { PlatformAdapter } from "./types.js";
 
@@ -100,6 +100,69 @@ describe("A2A continuation processor", () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches without aborting a long-running processor request", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    const { dispatchA2AContinuation } =
+      await import("./a2a-continuation-processor.js");
+
+    const dispatch = dispatchA2AContinuation(
+      "cont-long",
+      "https://dispatch.agent-native.test",
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ continuationId: "cont-long" }),
+      }),
+    );
+    expect((vi.mocked(fetch).mock.calls[0]?.[1] as RequestInit).signal).toBe(
+      undefined,
+    );
+
+    await vi.advanceTimersByTimeAsync(250);
+    await dispatch;
+  });
+
+  it("logs when the continuation processor route rejects dispatch", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("bad continuation token", {
+            status: 401,
+            statusText: "Unauthorized",
+          }),
+      ),
+    );
+    const { dispatchA2AContinuation } =
+      await import("./a2a-continuation-processor.js");
+
+    await dispatchA2AContinuation(
+      "cont-rejected",
+      "https://dispatch.agent-native.test",
+    );
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "A2A continuation cont-rejected processor dispatch returned HTTP 401 Unauthorized: bad continuation token",
+      ),
+    );
+  });
+
   it("posts completed remote task text and marks the continuation completed", async () => {
     const sendResponse = vi.fn(async () => undefined);
     claimA2AContinuationMock.mockResolvedValueOnce(continuation());
@@ -119,6 +182,111 @@ describe("A2A continuation processor", () => {
     );
     expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("notifies the platform when the remote task fails", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    getTaskMock.mockResolvedValueOnce({
+      id: "a2a-task-1",
+      status: {
+        state: "failed",
+        message: {
+          role: "agent",
+          parts: [{ type: "text", text: "The deck export failed" }],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining(
+          "The Slides agent could not finish this request: The deck export failed",
+        ),
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(failA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      "The deck export failed",
+    );
+    expect(completeA2AContinuationMock).not.toHaveBeenCalled();
+  });
+
+  it("describes downstream LLM credential failures without naming a raw env var", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    getTaskMock.mockResolvedValueOnce({
+      id: "a2a-task-1",
+      status: {
+        state: "failed",
+        message: {
+          role: "agent",
+          parts: [{ type: "text", text: "ANTHROPIC_API_KEY is not set" }],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    const sentText = vi.mocked(sendResponse).mock.calls[0]?.[0].text ?? "";
+    expect(sentText).toContain("needs an LLM connection");
+    expect(sentText).toContain("Connect Builder.io");
+    expect(sentText).not.toContain("ANTHROPIC_API_KEY");
+    expect(failA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      "ANTHROPIC_API_KEY is not set",
+    );
+  });
+
+  it("notifies the platform when a remote task exhausts polling attempts", async () => {
+    vi.useFakeTimers();
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ attempts: 6 }),
+    );
+    getTaskMock.mockResolvedValue({
+      id: "a2a-task-1",
+      status: {
+        state: "working",
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    const processing = processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+    await vi.advanceTimersByTimeAsync(20_000);
+    await processing;
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining(
+          "The Slides agent could not finish this request: Remote A2A task a2a-task-1 did not complete after 6 attempts",
+        ),
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(failA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      "Remote A2A task a2a-task-1 did not complete after 6 attempts",
+    );
   });
 
   it("reschedules and redispatches when the platform send fails", async () => {

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -18,6 +18,7 @@ const TERMINAL_STATES = new Set(["completed", "failed", "canceled"]);
 const MAX_ATTEMPTS = 6;
 const POLL_INTERVAL_MS = 2_000;
 const PROCESSOR_WAIT_MS = 20_000;
+const DISPATCH_SETTLE_WAIT_MS = 250;
 
 export async function dispatchA2AContinuation(
   continuationId: string,
@@ -52,18 +53,46 @@ export async function dispatchA2AContinuation(
     }
   }
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5_000);
-  try {
-    await fetch(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ continuationId }),
-      signal: controller.signal,
+  const dispatchPromise = fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ continuationId }),
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        await logFailedDispatchResponse(continuationId, response);
+      }
+    })
+    .catch((err) => {
+      console.error(
+        `[integrations] Failed to dispatch A2A continuation ${continuationId}:`,
+        err,
+      );
     });
-  } finally {
-    clearTimeout(timer);
-  }
+
+  await Promise.race([
+    dispatchPromise,
+    new Promise<void>((resolve) =>
+      setTimeout(resolve, DISPATCH_SETTLE_WAIT_MS),
+    ),
+  ]);
+}
+
+async function logFailedDispatchResponse(
+  continuationId: string,
+  response: Response,
+): Promise<void> {
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {}
+
+  const trimmedBody = body.trim();
+  console.error(
+    `[integrations] A2A continuation ${continuationId} processor dispatch returned HTTP ` +
+      `${response.status}${response.statusText ? ` ${response.statusText}` : ""}` +
+      `${trimmedBody ? `: ${trimmedBody.slice(0, 500)}` : ""}`,
+  );
 }
 
 export async function processA2AContinuationById(
@@ -119,8 +148,9 @@ async function processClaimedContinuation(
     }
   } catch (err) {
     if (continuation.attempts >= MAX_ATTEMPTS) {
-      await failA2AContinuation(
-        continuation.id,
+      await notifyAndFailA2AContinuation(
+        continuation,
+        adapter,
         err instanceof Error ? err.message : String(err),
       );
       return;
@@ -132,8 +162,9 @@ async function processClaimedContinuation(
 
   if (!task || !TERMINAL_STATES.has(task.status.state)) {
     if (continuation.attempts >= MAX_ATTEMPTS) {
-      await failA2AContinuation(
-        continuation.id,
+      await notifyAndFailA2AContinuation(
+        continuation,
+        adapter,
         `Remote A2A task ${continuation.a2aTaskId} did not complete after ${MAX_ATTEMPTS} attempts`,
       );
       return;
@@ -144,17 +175,18 @@ async function processClaimedContinuation(
   }
 
   if (task.status.state !== "completed") {
-    await failA2AContinuation(
-      continuation.id,
-      `Remote A2A task ${continuation.a2aTaskId} ended with state ${task.status.state}`,
-    );
+    const reason =
+      extractTaskText(task) ||
+      `Remote A2A task ${continuation.a2aTaskId} ended with state ${task.status.state}`;
+    await notifyAndFailA2AContinuation(continuation, adapter, reason);
     return;
   }
 
   const text = expandRelativeUrls(extractTaskText(task), continuation.agentUrl);
   if (!text.trim()) {
-    await failA2AContinuation(
-      continuation.id,
+    await notifyAndFailA2AContinuation(
+      continuation,
+      adapter,
       `Remote A2A task ${continuation.a2aTaskId} completed without text`,
     );
     return;
@@ -178,6 +210,67 @@ async function processClaimedContinuation(
     await rescheduleA2AContinuation(continuation.id, 30_000);
     await redispatchContinuation(continuation.id);
   }
+}
+
+async function notifyAndFailA2AContinuation(
+  continuation: A2AContinuation,
+  adapter: PlatformAdapter,
+  reason: string,
+): Promise<void> {
+  const message = formatContinuationFailureMessage(continuation, reason);
+  try {
+    await adapter.sendResponse(
+      adapter.formatAgentResponse(message),
+      continuation.incoming,
+      { placeholderRef: continuation.placeholderRef ?? undefined },
+    );
+  } catch (err) {
+    console.error(
+      `[integrations] Failed to notify ${continuation.platform} about failed A2A continuation ${continuation.id}:`,
+      err,
+    );
+  }
+
+  await failA2AContinuation(continuation.id, reason);
+}
+
+function formatContinuationFailureMessage(
+  continuation: A2AContinuation,
+  reason: string,
+): string {
+  if (isLlmCredentialError(reason)) {
+    return `The ${continuation.agentName} agent could not finish this request because that app needs an LLM connection. Connect Builder.io or another LLM provider for the ${continuation.agentName} app, then try again.`;
+  }
+
+  return `The ${continuation.agentName} agent could not finish this request: ${sanitizeFailureReason(
+    reason,
+  )}`;
+}
+
+function isLlmCredentialError(reason: string): boolean {
+  return (
+    /(?:ANTHROPIC|OPENAI|GOOGLE|GEMINI|MISTRAL|GROQ|TOGETHER|XAI|PERPLEXITY|FIREWORKS|DEEPSEEK)_[A-Z0-9_]*API_KEY/i.test(
+      reason,
+    ) ||
+    /(?:api key|llm|model provider).*(?:missing|not set|not configured|required)/i.test(
+      reason,
+    ) ||
+    /(?:missing|not set|not configured|required).*(?:api key|llm|model provider)/i.test(
+      reason,
+    )
+  );
+}
+
+function sanitizeFailureReason(reason: string): string {
+  const oneLine = reason.replace(/\s+/g, " ").trim();
+  const withoutEnvNames = oneLine.replace(
+    /\b[A-Z][A-Z0-9_]*(?:API_KEY|PRIVATE_KEY|SECRET|TOKEN)\b/g,
+    "a required credential",
+  );
+  return (
+    withoutEnvNames.slice(0, 500) ||
+    "the downstream agent returned an empty error"
+  );
 }
 
 async function redispatchContinuation(continuationId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- keep A2A continuation self-dispatch requests from aborting while the processor polls downstream agents
- log rejected continuation processor dispatches
- notify the originating integration thread when downstream A2A tasks fail, return no text, or exhaust retries
- phrase LLM credential failures as a missing LLM connection instead of raw env var instructions
- bump @agent-native/core to 0.7.28

## Testing
- pnpm --filter @agent-native/core exec vitest --run src/integrations/a2a-continuation-processor.spec.ts
- pnpm --filter @agent-native/core typecheck
- git diff --check