### PR TITLE
Fix A2A continuation delivery

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.28",
+  "version": "0.7.29",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -341,6 +341,7 @@ describe("Netlify scaffold rewrite", () => {
     expectRedirect("/apps", "/dispatch/apps", 302);
     expectRedirect("/new-app", "/dispatch/new-app", 302);
     expectRedirect("/dispatch/*", "/.netlify/functions/server", 200);
+    expect(netlify).not.toContain("force = true");
   });
 
   it("keeps unpooled database build overrides for templates that need them", () => {
@@ -410,6 +411,12 @@ describe("Netlify scaffold rewrite", () => {
         '  to = "/dispatch/"',
         "  status = 302",
         "",
+        "[[redirects]]",
+        '  from = "/dispatch/*"',
+        '  to = "/.netlify/functions/server"',
+        "  status = 200",
+        "  force = true",
+        "",
       ].join("\n"),
     );
 
@@ -419,6 +426,8 @@ describe("Netlify scaffold rewrite", () => {
     expect(netlify).toContain('  from = "/"');
     expect(netlify).toContain('  to = "/dispatch/overview"');
     expect(netlify).not.toContain('  to = "/dispatch/"');
+    expect(netlify).toContain('  from = "/dispatch/*"');
+    expect(netlify).not.toContain("force = true");
   });
 });
 

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1031,7 +1031,7 @@ function ensureRedirect(
 ): string {
   const escapedFrom = from.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const redirectPattern = new RegExp(
-    `\\n?\\[\\[redirects\\]\\]\\s+from\\s*=\\s*"${escapedFrom}"\\s+to\\s*=\\s*"[^"]*"\\s+status\\s*=\\s*\\d+`,
+    `\\n?\\[\\[redirects\\]\\]\\s+from\\s*=\\s*"${escapedFrom}"\\s+to\\s*=\\s*"[^"]*"\\s+status\\s*=\\s*\\d+(?:\\s+force\\s*=\\s*(?:true|false))?`,
     "m",
   );
   const block = [

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -5,6 +5,7 @@ import type { PlatformAdapter } from "./types.js";
 const claimA2AContinuationMock = vi.hoisted(() => vi.fn());
 const completeA2AContinuationMock = vi.hoisted(() => vi.fn());
 const failA2AContinuationMock = vi.hoisted(() => vi.fn());
+const getA2AContinuationMock = vi.hoisted(() => vi.fn());
 const rescheduleA2AContinuationMock = vi.hoisted(() => vi.fn());
 const getTaskMock = vi.hoisted(() => vi.fn());
 
@@ -13,6 +14,7 @@ vi.mock("./a2a-continuations-store.js", () => ({
   claimDueA2AContinuations: vi.fn(async () => []),
   completeA2AContinuation: completeA2AContinuationMock,
   failA2AContinuation: failA2AContinuationMock,
+  getA2AContinuation: getA2AContinuationMock,
   rescheduleA2AContinuation: rescheduleA2AContinuationMock,
 }));
 
@@ -30,6 +32,7 @@ vi.mock("./internal-token.js", () => ({
 function continuation(
   overrides: Partial<A2AContinuation> = {},
 ): A2AContinuation {
+  const now = Date.now();
   return {
     id: "cont-1",
     integrationTaskId: "task-1",
@@ -52,8 +55,8 @@ function continuation(
     attempts: 1,
     nextCheckAt: 1,
     errorMessage: null,
-    createdAt: 1,
-    updatedAt: 1,
+    createdAt: now,
+    updatedAt: now,
     completedAt: null,
     ...overrides,
   };
@@ -83,6 +86,9 @@ describe("A2A continuation processor", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.APP_URL = "https://dispatch.agent-native.test";
+    getA2AContinuationMock.mockImplementation(async (id: string) =>
+      continuation({ id, status: "pending" }),
+    );
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response("ok", { status: 200 })),
@@ -130,7 +136,7 @@ describe("A2A continuation processor", () => {
       undefined,
     );
 
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(2_000);
     await dispatch;
   });
 
@@ -252,11 +258,78 @@ describe("A2A continuation processor", () => {
     );
   });
 
-  it("notifies the platform when a remote task exhausts polling attempts", async () => {
+  it("keeps polling a still-working remote task even after many continuation claims", async () => {
     vi.useFakeTimers();
     const sendResponse = vi.fn(async () => undefined);
     claimA2AContinuationMock.mockResolvedValueOnce(
-      continuation({ attempts: 6 }),
+      continuation({ attempts: 12 }),
+    );
+    getTaskMock.mockResolvedValue({
+      id: "a2a-task-1",
+      status: {
+        state: "working",
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    const processing = processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+    await vi.advanceTimersByTimeAsync(20_000);
+    await processing;
+
+    expect(sendResponse).not.toHaveBeenCalled();
+    expect(failA2AContinuationMock).not.toHaveBeenCalled();
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith("cont-1", 5_000);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ continuationId: "cont-1" }),
+      }),
+    );
+  });
+
+  it("waits until a redispatched continuation is due before claiming it", async () => {
+    vi.useFakeTimers();
+    const dueAt = Date.now() + 5_000;
+    const sendResponse = vi.fn(async () => undefined);
+    getA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ status: "pending", nextCheckAt: dueAt }),
+    );
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ status: "pending", nextCheckAt: dueAt }),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    const processing = processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(claimA2AContinuationMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await processing;
+
+    expect(claimA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "https://slides.agent-native.test/deck/deck-qa",
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+  });
+
+  it("notifies the platform when a remote task exceeds the continuation age limit", async () => {
+    vi.useFakeTimers();
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ attempts: 20, createdAt: Date.now() - 10 * 60_000 - 1 }),
     );
     getTaskMock.mockResolvedValue({
       id: "a2a-task-1",
@@ -277,7 +350,7 @@ describe("A2A continuation processor", () => {
     expect(sendResponse).toHaveBeenCalledWith(
       expect.objectContaining({
         text: expect.stringContaining(
-          "The Slides agent could not finish this request: Remote A2A task a2a-task-1 did not complete after 6 attempts",
+          "The Slides agent could not finish this request: Remote A2A task a2a-task-1 did not complete within 10 minutes",
         ),
       }),
       expect.any(Object),
@@ -285,7 +358,7 @@ describe("A2A continuation processor", () => {
     );
     expect(failA2AContinuationMock).toHaveBeenCalledWith(
       "cont-1",
-      "Remote A2A task a2a-task-1 did not complete after 6 attempts",
+      "Remote A2A task a2a-task-1 did not complete within 10 minutes",
     );
   });
 
@@ -301,10 +374,7 @@ describe("A2A continuation processor", () => {
       adapters: new Map([["slack", adapter(sendResponse)]]),
     });
 
-    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith(
-      "cont-1",
-      30_000,
-    );
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith("cont-1", 5_000);
     expect(fetch).toHaveBeenCalledWith(
       "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
       expect.objectContaining({

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -325,6 +325,32 @@ describe("A2A continuation processor", () => {
     );
   });
 
+  it("caps the pre-claim wait for stale future wakeups", async () => {
+    vi.useFakeTimers();
+    const sendResponse = vi.fn(async () => undefined);
+    getA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ status: "pending", nextCheckAt: Date.now() + 30_000 }),
+    );
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ status: "pending", nextCheckAt: Date.now() + 30_000 }),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    const processing = processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    await vi.advanceTimersByTimeAsync(9_999);
+    expect(claimA2AContinuationMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await processing;
+
+    expect(claimA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+    expect(sendResponse).toHaveBeenCalled();
+  });
+
   it("notifies the platform when a remote task exceeds the continuation age limit", async () => {
     vi.useFakeTimers();
     const sendResponse = vi.fn(async () => undefined);

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -9,6 +9,7 @@ import {
   claimDueA2AContinuations,
   completeA2AContinuation,
   failA2AContinuation,
+  getA2AContinuation,
   rescheduleA2AContinuation,
   type A2AContinuation,
 } from "./a2a-continuations-store.js";
@@ -16,9 +17,12 @@ import {
 const PROCESSOR_PATH = `${FRAMEWORK_ROUTE_PREFIX}/integrations/process-a2a-continuation`;
 const TERMINAL_STATES = new Set(["completed", "failed", "canceled"]);
 const MAX_ATTEMPTS = 6;
+const MAX_REMOTE_WORK_MS = 10 * 60_000;
+const RESCHEDULE_DELAY_MS = 5_000;
+const MAX_PRE_CLAIM_WAIT_MS = RESCHEDULE_DELAY_MS + 5_000;
 const POLL_INTERVAL_MS = 2_000;
 const PROCESSOR_WAIT_MS = 20_000;
-const DISPATCH_SETTLE_WAIT_MS = 250;
+const DISPATCH_SETTLE_WAIT_MS = 2_000;
 
 export async function dispatchA2AContinuation(
   continuationId: string,
@@ -99,6 +103,8 @@ export async function processA2AContinuationById(
   continuationId: string,
   options: { adapters: Map<string, PlatformAdapter> },
 ): Promise<void> {
+  const shouldClaim = await waitForContinuationDue(continuationId);
+  if (!shouldClaim) return;
   const continuation = await claimA2AContinuation(continuationId);
   if (!continuation) return;
   await processClaimedContinuation(continuation, options);
@@ -155,21 +161,23 @@ async function processClaimedContinuation(
       );
       return;
     }
-    await rescheduleA2AContinuation(continuation.id, 30_000);
+    await rescheduleA2AContinuation(continuation.id, RESCHEDULE_DELAY_MS);
     await redispatchContinuation(continuation.id);
     return;
   }
 
   if (!task || !TERMINAL_STATES.has(task.status.state)) {
-    if (continuation.attempts >= MAX_ATTEMPTS) {
+    if (isRemoteWorkExpired(continuation)) {
       await notifyAndFailA2AContinuation(
         continuation,
         adapter,
-        `Remote A2A task ${continuation.a2aTaskId} did not complete after ${MAX_ATTEMPTS} attempts`,
+        `Remote A2A task ${continuation.a2aTaskId} did not complete within ${Math.round(
+          MAX_REMOTE_WORK_MS / 60_000,
+        )} minutes`,
       );
       return;
     }
-    await rescheduleA2AContinuation(continuation.id, 30_000);
+    await rescheduleA2AContinuation(continuation.id, RESCHEDULE_DELAY_MS);
     await redispatchContinuation(continuation.id);
     return;
   }
@@ -207,9 +215,27 @@ async function processClaimedContinuation(
       );
       return;
     }
-    await rescheduleA2AContinuation(continuation.id, 30_000);
+    await rescheduleA2AContinuation(continuation.id, RESCHEDULE_DELAY_MS);
     await redispatchContinuation(continuation.id);
   }
+}
+
+async function waitForContinuationDue(
+  continuationId: string,
+): Promise<boolean> {
+  const continuation = await getA2AContinuation(continuationId);
+  if (!continuation) return false;
+  if (continuation.status === "completed" || continuation.status === "failed") {
+    return false;
+  }
+  if (continuation.status !== "pending") return true;
+
+  const waitMs = continuation.nextCheckAt - Date.now();
+  if (waitMs <= 0) return true;
+  if (waitMs > MAX_PRE_CLAIM_WAIT_MS) return false;
+
+  await sleep(waitMs);
+  return true;
 }
 
 async function notifyAndFailA2AContinuation(
@@ -259,6 +285,14 @@ function isLlmCredentialError(reason: string): boolean {
       reason,
     )
   );
+}
+
+function isRemoteWorkExpired(continuation: A2AContinuation): boolean {
+  return Date.now() - continuation.createdAt >= MAX_REMOTE_WORK_MS;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function sanitizeFailureReason(reason: string): string {

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -232,9 +232,8 @@ async function waitForContinuationDue(
 
   const waitMs = continuation.nextCheckAt - Date.now();
   if (waitMs <= 0) return true;
-  if (waitMs > MAX_PRE_CLAIM_WAIT_MS) return false;
 
-  await sleep(waitMs);
+  await sleep(Math.min(waitMs, MAX_PRE_CLAIM_WAIT_MS));
   return true;
 }
 

--- a/scripts/qa-cli-smoke.ts
+++ b/scripts/qa-cli-smoke.ts
@@ -58,11 +58,13 @@ function readJson(file: string): any {
 }
 
 function resolveExpectedCoreDependencyVersion(): string {
-  const localCorePackage = path.join(repoRoot, "packages/core");
-  if (fs.existsSync(path.join(localCorePackage, "package.json"))) {
-    return pathToFileURL(localCorePackage).href;
+  if (process.env.AGENT_NATIVE_CREATE_USE_LOCAL_CORE === "1") {
+    const localCorePackage = path.join(repoRoot, "packages/core");
+    if (fs.existsSync(path.join(localCorePackage, "package.json"))) {
+      return pathToFileURL(localCorePackage).href;
+    }
   }
-  return `^${readJson(path.join(repoRoot, "packages/core/package.json")).version}`;
+  return "latest";
 }
 
 function assertNoUnresolvedPlaceholders(dir: string): void {

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -63,6 +63,7 @@ import { OrgSwitcher } from "@agent-native/core/client/org";
 import {
   FeedbackButton,
   appApiPath,
+  appPath,
   useActionMutation,
 } from "@agent-native/core/client";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
@@ -1001,13 +1002,13 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       <div className="flex h-12 shrink-0 items-center border-b border-border px-4 lg:px-6">
         <Link to="/" className="flex items-center gap-2 font-semibold">
           <img
-            src="/agent-native-icon-light.svg"
+            src={appPath("/agent-native-icon-light.svg")}
             alt=""
             aria-hidden="true"
             className="block h-5 w-auto shrink-0 dark:hidden"
           />
           <img
-            src="/agent-native-icon-dark.svg"
+            src={appPath("/agent-native-icon-dark.svg")}
             alt=""
             aria-hidden="true"
             className="hidden h-5 w-auto shrink-0 dark:block"

--- a/templates/analytics/app/root.tsx
+++ b/templates/analytics/app/root.tsx
@@ -7,6 +7,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import {
   ClientOnly,
   DefaultSpinner,
+  appPath,
   useDbSync,
 } from "@agent-native/core/client";
 import { ThemeProvider } from "next-themes";
@@ -36,7 +37,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#F59E0B" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta
@@ -44,8 +45,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
           content="black-translucent"
         />
         <meta name="apple-mobile-web-app-title" content="Analytics" />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link rel="apple-touch-icon" href="/icon-180.svg" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
+        <link rel="apple-touch-icon" href={appPath("/icon-180.svg")} />
         <Meta />
         <Links />
       </head>

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
 import { Link, useLocation } from "react-router";
-import { agentNativePath } from "@agent-native/core/client";
 import {
   IconCalendar,
   IconSettings,
@@ -44,6 +43,8 @@ import {
   useGoogleAddAccountUrl,
 } from "@/hooks/use-google-auth";
 import {
+  agentNativePath,
+  appPath,
   useSession,
   FeedbackButton,
   DEV_MODE_USER_EMAIL,
@@ -499,13 +500,13 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         <div className="flex h-12 shrink-0 items-center justify-between gap-2.5 border-b border-border px-4">
           <div className="flex items-center gap-2">
             <img
-              src="/agent-native-icon-light.svg"
+              src={appPath("/agent-native-icon-light.svg")}
               alt=""
               aria-hidden="true"
               className="block h-4 w-auto shrink-0 dark:hidden"
             />
             <img
-              src="/agent-native-icon-dark.svg"
+              src={appPath("/agent-native-icon-dark.svg")}
               alt=""
               aria-hidden="true"
               className="hidden h-4 w-auto shrink-0 dark:block"

--- a/templates/calendar/app/root.tsx
+++ b/templates/calendar/app/root.tsx
@@ -11,6 +11,7 @@ import { useDbSync } from "@agent-native/core/client";
 import {
   ClientOnly,
   DefaultSpinner,
+  appPath,
   CommandMenu,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
@@ -40,8 +41,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
+        <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#8B5CF6" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta
@@ -49,7 +50,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           content="black-translucent"
         />
         <meta name="apple-mobile-web-app-title" content="Calendar" />
-        <link rel="apple-touch-icon" href="/icon-180.svg" />
+        <link rel="apple-touch-icon" href={appPath("/icon-180.svg")} />
         <Meta />
         <Links />
       </head>

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -15,7 +15,7 @@ import { toast } from "sonner";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { OrgSwitcher } from "@agent-native/core/client/org";
-import { FeedbackButton } from "@agent-native/core/client";
+import { FeedbackButton, appPath } from "@agent-native/core/client";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
 import { NotionButton } from "./NotionButton";
 import { DocumentTreeItem } from "./DocumentTreeItem";
@@ -227,13 +227,13 @@ export function DocumentSidebar({
       <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-3">
         <div className="flex items-center gap-2 min-w-0">
           <img
-            src="/agent-native-icon-light.svg"
+            src={appPath("/agent-native-icon-light.svg")}
             alt=""
             aria-hidden="true"
             className="block h-4 w-auto shrink-0 dark:hidden"
           />
           <img
-            src="/agent-native-icon-dark.svg"
+            src={appPath("/agent-native-icon-dark.svg")}
             alt=""
             aria-hidden="true"
             className="hidden h-4 w-auto shrink-0 dark:block"

--- a/templates/content/app/root.tsx
+++ b/templates/content/app/root.tsx
@@ -17,6 +17,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import {
   ClientOnly,
   DefaultSpinner,
+  appPath,
   CommandMenu,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
@@ -45,7 +46,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#10B981" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta
@@ -53,8 +54,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
           content="black-translucent"
         />
         <meta name="apple-mobile-web-app-title" content="Content" />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link rel="apple-touch-icon" href="/icon-180.svg" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
+        <link rel="apple-touch-icon" href={appPath("/icon-180.svg")} />
         <Meta />
         <Links />
       </head>

--- a/templates/design/app/components/layout/Sidebar.tsx
+++ b/templates/design/app/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
-import { FeedbackButton } from "@agent-native/core/client";
+import { FeedbackButton, appPath } from "@agent-native/core/client";
 import {
   Tooltip,
   TooltipContent,
@@ -62,13 +62,13 @@ export function Sidebar() {
         {!collapsed && (
           <div className="flex items-center gap-2">
             <img
-              src="/agent-native-icon-light.svg"
+              src={appPath("/agent-native-icon-light.svg")}
               alt=""
               aria-hidden="true"
               className="block h-4 w-auto dark:hidden"
             />
             <img
-              src="/agent-native-icon-dark.svg"
+              src={appPath("/agent-native-icon-dark.svg")}
               alt=""
               aria-hidden="true"
               className="hidden h-4 w-auto dark:block"

--- a/templates/design/app/root.tsx
+++ b/templates/design/app/root.tsx
@@ -11,6 +11,7 @@ import {
   ClientOnly,
   CommandMenu,
   DefaultSpinner,
+  appPath,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
 import { Toaster } from "@/components/ui/sonner";
@@ -41,7 +42,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#71717A" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta
@@ -49,8 +50,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
           content="black-translucent"
         />
         <meta name="apple-mobile-web-app-title" content="Design" />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link rel="apple-touch-icon" href="/icon-180.svg" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
+        <link rel="apple-touch-icon" href={appPath("/icon-180.svg")} />
         <Meta />
         <Links />
       </head>

--- a/templates/dispatch/actions/view-screen.ts
+++ b/templates/dispatch/actions/view-screen.ts
@@ -43,7 +43,11 @@ export default defineAction({
     if (navigation?.view === "destinations") {
       screen.recentDestinations = overview.recentDestinations;
     }
-    if (navigation?.view === "apps" || navigation?.view === "new-app") {
+    if (
+      navigation?.view === "overview" ||
+      navigation?.view === "apps" ||
+      navigation?.view === "new-app"
+    ) {
       screen.workspaceApps = await listWorkspaceApps();
     }
     if (navigation?.view === "vault" || navigation?.view === "new-app") {

--- a/templates/dispatch/app/components/layout/Header.tsx
+++ b/templates/dispatch/app/components/layout/Header.tsx
@@ -27,7 +27,13 @@ function resolveTitle(pathname: string): string {
   return "Dispatch";
 }
 
-export function Header({ onOpenMobile }: { onOpenMobile?: () => void }) {
+export function Header({
+  onOpenMobile,
+  showAgentToggle = true,
+}: {
+  onOpenMobile?: () => void;
+  showAgentToggle?: boolean;
+}) {
   const location = useLocation();
   const title = useHeaderTitle();
   const actions = useHeaderActions();
@@ -54,7 +60,9 @@ export function Header({ onOpenMobile }: { onOpenMobile?: () => void }) {
       </div>
       <div className="flex items-center gap-2 shrink-0">
         {actions}
-        <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
+        {showAgentToggle ? (
+          <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
+        ) : null}
       </div>
     </header>
   );

--- a/templates/dispatch/app/components/layout/Layout.tsx
+++ b/templates/dispatch/app/components/layout/Layout.tsx
@@ -1,6 +1,10 @@
 import { useState, type ReactNode } from "react";
 import { NavLink, useLocation } from "react-router";
-import { AgentSidebar, FeedbackButton } from "@agent-native/core/client";
+import {
+  AgentSidebar,
+  FeedbackButton,
+  appPath,
+} from "@agent-native/core/client";
 import { InvitationBanner } from "@agent-native/core/client/org";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
 import {
@@ -95,13 +99,13 @@ function NavContent({ onNavigate }: { onNavigate?: () => void }) {
         <div className="flex items-center gap-3">
           <div className="flex h-9 w-9 items-center justify-center rounded-xl border bg-card text-foreground">
             <img
-              src="/agent-native-icon-light.svg"
+              src={appPath("/agent-native-icon-light.svg")}
               alt=""
               aria-hidden="true"
               className="block h-4 w-auto shrink-0 dark:hidden"
             />
             <img
-              src="/agent-native-icon-dark.svg"
+              src={appPath("/agent-native-icon-dark.svg")}
               alt=""
               aria-hidden="true"
               className="hidden h-4 w-auto shrink-0 dark:block"
@@ -145,10 +149,27 @@ function NavContent({ onNavigate }: { onNavigate?: () => void }) {
 export function Layout({ children }: { children: ReactNode }) {
   const location = useLocation();
   const [mobileOpen, setMobileOpen] = useState(false);
+  const hasEmbeddedAgentChat =
+    location.pathname === "/" || location.pathname === "/overview";
 
   if (CHROMELESS_PATHS.some((path) => location.pathname === path)) {
     return <>{children}</>;
   }
+
+  const appContent = (
+    <div className="flex h-full flex-1 flex-col overflow-hidden">
+      <Header
+        onOpenMobile={() => setMobileOpen(true)}
+        showAgentToggle={!hasEmbeddedAgentChat}
+      />
+      <InvitationBanner />
+      <main className="flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-7xl space-y-5 px-4 py-6 sm:px-6">
+          {children}
+        </div>
+      </main>
+    </div>
+  );
 
   return (
     <HeaderActionsProvider>
@@ -172,22 +193,18 @@ export function Layout({ children }: { children: ReactNode }) {
           </SheetContent>
         </Sheet>
 
-        <AgentSidebar
-          position="right"
-          defaultOpen={false}
-          emptyStateText="Create apps, grant keys, and route work across the workspace."
-          suggestions={SIDEBAR_SUGGESTIONS}
-        >
-          <div className="flex h-full flex-1 flex-col overflow-hidden">
-            <Header onOpenMobile={() => setMobileOpen(true)} />
-            <InvitationBanner />
-            <main className="flex-1 overflow-y-auto">
-              <div className="mx-auto max-w-7xl space-y-5 px-4 py-6 sm:px-6">
-                {children}
-              </div>
-            </main>
-          </div>
-        </AgentSidebar>
+        {hasEmbeddedAgentChat ? (
+          appContent
+        ) : (
+          <AgentSidebar
+            position="right"
+            defaultOpen={false}
+            emptyStateText="Create apps, grant keys, and route work across the workspace."
+            suggestions={SIDEBAR_SUGGESTIONS}
+          >
+            {appContent}
+          </AgentSidebar>
+        )}
       </div>
     </HeaderActionsProvider>
   );

--- a/templates/dispatch/app/root.tsx
+++ b/templates/dispatch/app/root.tsx
@@ -1,7 +1,11 @@
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigationState } from "@/hooks/use-navigation-state";
-import { focusAgentChat, agentNativePath } from "@agent-native/core/client";
+import {
+  focusAgentChat,
+  agentNativePath,
+  appPath,
+} from "@agent-native/core/client";
 import {
   QueryClient,
   QueryClientProvider,
@@ -43,7 +47,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#0f172a" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta
@@ -51,8 +55,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
           content="black-translucent"
         />
         <meta name="apple-mobile-web-app-title" content="Dispatch" />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link rel="apple-touch-icon" href="/icon-180.svg" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
+        <link rel="apple-touch-icon" href={appPath("/icon-180.svg")} />
         <Meta />
         <Links />
       </head>
@@ -86,6 +90,7 @@ function DbSyncSetup() {
       "list-vault-audit",
       "list-workspace-resources",
       "list-workspace-resource-grants",
+      "list-workspace-apps",
       "list-integrations-catalog",
     ],
     ignoreSource: TAB_ID,

--- a/templates/dispatch/app/routes/overview.tsx
+++ b/templates/dispatch/app/routes/overview.tsx
@@ -1,8 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router";
-import { useActionQuery, agentNativePath } from "@agent-native/core/client";
+import {
+  MultiTabAssistantChat,
+  useActionQuery,
+  agentNativePath,
+} from "@agent-native/core/client";
 import {
   IconAlertTriangle,
+  IconApps,
   IconArrowUpRight,
   IconCheck,
   IconClockHour4,
@@ -16,7 +21,9 @@ import {
 } from "@tabler/icons-react";
 import { DispatchShell } from "@/components/dispatch-shell";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
   TooltipContent,
@@ -54,6 +61,127 @@ const ZERO_TASK_QUEUE_STATS: TaskQueueStats = {
   oldest_pending_age_seconds: 0,
   recent_failures: [],
 };
+
+interface WorkspaceAppSummary {
+  id: string;
+  name: string;
+  description?: string;
+  path: string;
+  url?: string | null;
+  isDispatch: boolean;
+}
+
+const HOME_CHAT_SUGGESTIONS = [
+  "Create a lightweight customer onboarding app",
+  "Ask Slides to draft a board update from our latest metrics",
+  "Schedule a Monday morning analytics digest",
+];
+
+function HomeChatPanel() {
+  return (
+    <section className="overflow-hidden rounded-xl border bg-card shadow-sm">
+      <div className="h-[620px] min-h-[460px] max-h-[calc(100vh-7rem)]">
+        <MultiTabAssistantChat
+          emptyStateText="What should your apps do next?"
+          suggestions={HOME_CHAT_SUGGESTIONS}
+        />
+      </div>
+    </section>
+  );
+}
+
+function AppCardSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 space-y-3">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-24" />
+          <div className="space-y-2 pt-1">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-2/3" />
+          </div>
+        </div>
+        <Skeleton className="h-5 w-5 rounded-md" />
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceAppsSection({
+  apps,
+  isLoading,
+}: {
+  apps: WorkspaceAppSummary[];
+  isLoading: boolean;
+}) {
+  const visibleApps = apps.slice(0, 6);
+  const showSkeletons = isLoading && visibleApps.length === 0;
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <IconApps size={16} className="text-muted-foreground" />
+          <h2 className="text-sm font-semibold text-foreground">
+            Workspace apps
+          </h2>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/apps">
+            View all
+            <IconArrowUpRight size={15} className="ml-1.5" />
+          </Link>
+        </Button>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {showSkeletons
+          ? Array.from({ length: 6 }).map((_, index) => (
+              <AppCardSkeleton key={index} />
+            ))
+          : visibleApps.map((app) => (
+              <a
+                key={app.id}
+                href={app.url || app.path}
+                className="group min-h-32 rounded-lg border bg-card p-4 transition hover:border-foreground/30"
+              >
+                <div className="flex h-full items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <h3 className="truncate text-sm font-semibold text-foreground">
+                        {app.name}
+                      </h3>
+                      {app.isDispatch ? (
+                        <Badge variant="secondary">Control plane</Badge>
+                      ) : null}
+                    </div>
+                    <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
+                      {app.path}
+                    </p>
+                    {app.description ? (
+                      <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                        {app.description}
+                      </p>
+                    ) : null}
+                  </div>
+                  <IconArrowUpRight
+                    size={16}
+                    className="shrink-0 text-muted-foreground transition group-hover:text-foreground"
+                  />
+                </div>
+              </a>
+            ))}
+
+        {!showSkeletons && visibleApps.length === 0 ? (
+          <div className="flex min-h-32 items-center justify-center rounded-lg border border-dashed bg-card p-4 text-sm text-muted-foreground sm:col-span-2 xl:col-span-3">
+            No workspace apps found.
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
 
 function formatAgeSeconds(seconds: number): string {
   if (!seconds || seconds < 0) return "0s";
@@ -283,6 +411,13 @@ export function meta() {
 export default function OverviewRoute() {
   const { data, isLoading } = useActionQuery("list-dispatch-overview", {});
   const { data: connectedAgents } = useActionQuery("list-connected-agents", {});
+  const { data: workspaceApps = [], isLoading: appsLoading } = useActionQuery(
+    "list-workspace-apps",
+    {},
+    {
+      refetchInterval: 2_000,
+    },
+  );
   const [integrationStatuses, setIntegrationStatuses] = useState<
     IntegrationStatus[]
   >([]);
@@ -359,6 +494,7 @@ export default function OverviewRoute() {
   ).length;
   const connectedAgentCount = connectedAgents?.length || 0;
   const vaultSecretCount = data?.vault?.secretCount || 0;
+  const typedWorkspaceApps = workspaceApps as WorkspaceAppSummary[];
 
   const messagingDone = connectedMessagingCount > 0;
   const agentsDone = connectedAgentCount > 0;
@@ -408,6 +544,10 @@ export default function OverviewRoute() {
       title="Overview"
       description="Create apps, manage shared keys, and route work across your workspace."
     >
+      <HomeChatPanel />
+
+      <WorkspaceAppsSection apps={typedWorkspaceApps} isLoading={appsLoading} />
+
       {hasIncompleteSteps && (
         <section className="space-y-3">
           <div className="flex items-center gap-2">

--- a/templates/forms/app/components/layout/Sidebar.tsx
+++ b/templates/forms/app/components/layout/Sidebar.tsx
@@ -18,7 +18,11 @@ import {
   PopoverContent,
 } from "@/components/ui/popover";
 import { useForms, useCreateForm } from "@/hooks/use-forms";
-import { useSendToAgentChat, FeedbackButton } from "@agent-native/core/client";
+import {
+  useSendToAgentChat,
+  FeedbackButton,
+  appPath,
+} from "@agent-native/core/client";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
 import { Textarea } from "@/components/ui/textarea";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -148,13 +152,13 @@ export function Sidebar() {
           onClick={() => isMobile && setMobileOpen(false)}
         >
           <img
-            src="/agent-native-icon-light.svg"
+            src={appPath("/agent-native-icon-light.svg")}
             alt=""
             aria-hidden="true"
             className="block h-4 w-auto shrink-0 dark:hidden"
           />
           <img
-            src="/agent-native-icon-dark.svg"
+            src={appPath("/agent-native-icon-dark.svg")}
             alt=""
             aria-hidden="true"
             className="hidden h-4 w-auto shrink-0 dark:block"

--- a/templates/forms/app/root.tsx
+++ b/templates/forms/app/root.tsx
@@ -14,6 +14,7 @@ import {
   ClientOnly,
   CommandMenu,
   DefaultSpinner,
+  appPath,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
 import { Toaster } from "@/components/ui/sonner";
@@ -41,8 +42,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
+        <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#06B6D4" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta
@@ -50,7 +51,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           content="black-translucent"
         />
         <meta name="apple-mobile-web-app-title" content="Forms" />
-        <link rel="apple-touch-icon" href="/icon-180.svg" />
+        <link rel="apple-touch-icon" href={appPath("/icon-180.svg")} />
         <Meta />
         <Links />
       </head>

--- a/templates/issues/app/components/layout/AppLayout.tsx
+++ b/templates/issues/app/components/layout/AppLayout.tsx
@@ -11,7 +11,11 @@ import {
   IconLayoutSidebar,
   IconUsers,
 } from "@tabler/icons-react";
-import { AgentSidebar, FeedbackButton } from "@agent-native/core/client";
+import {
+  AgentSidebar,
+  FeedbackButton,
+  appPath,
+} from "@agent-native/core/client";
 import { InvitationBanner, OrgSwitcher } from "@agent-native/core/client/org";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
 import { cn } from "@/lib/utils";
@@ -90,13 +94,13 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             {!sidebarCollapsed && (
               <div className="flex items-center gap-2">
                 <img
-                  src="/agent-native-icon-light.svg"
+                  src={appPath("/agent-native-icon-light.svg")}
                   alt=""
                   aria-hidden="true"
                   className="block h-4 w-auto shrink-0 dark:hidden"
                 />
                 <img
-                  src="/agent-native-icon-dark.svg"
+                  src={appPath("/agent-native-icon-dark.svg")}
                   alt=""
                   aria-hidden="true"
                   className="hidden h-4 w-auto shrink-0 dark:block"

--- a/templates/issues/app/root.tsx
+++ b/templates/issues/app/root.tsx
@@ -14,6 +14,7 @@ import { useDbSync } from "@agent-native/core";
 import {
   ClientOnly,
   DefaultSpinner,
+  appPath,
   CommandMenu,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
@@ -42,7 +43,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <meta name="theme-color" content="#2563EB" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta

--- a/templates/macros/app/components/layout/AppLayout.tsx
+++ b/templates/macros/app/components/layout/AppLayout.tsx
@@ -6,10 +6,13 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { AgentSidebar } from "@agent-native/core/client";
+import {
+  AgentSidebar,
+  FeedbackButton,
+  agentNativePath,
+  appPath,
+} from "@agent-native/core/client";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
-import { FeedbackButton } from "@agent-native/core/client";
-import { agentNativePath } from "@agent-native/core/client";
 import { apiFetch } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import {
@@ -183,13 +186,13 @@ function SidebarContent({
         {!collapsed && (
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <img
-              src="/agent-native-icon-light.svg"
+              src={appPath("/agent-native-icon-light.svg")}
               alt=""
               aria-hidden="true"
               className="block h-4 w-auto shrink-0 dark:hidden"
             />
             <img
-              src="/agent-native-icon-dark.svg"
+              src={appPath("/agent-native-icon-dark.svg")}
               alt=""
               aria-hidden="true"
               className="hidden h-4 w-auto shrink-0 dark:block"

--- a/templates/macros/app/root.tsx
+++ b/templates/macros/app/root.tsx
@@ -13,6 +13,7 @@ import { useDbSync } from "@agent-native/core";
 import {
   ClientOnly,
   DefaultSpinner,
+  appPath,
   CommandMenu,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
@@ -42,7 +43,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <meta name="theme-color" content="#0a0a0a" />
         <Meta />
         <Links />

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -10,7 +10,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { useDbSync } from "@agent-native/core";
-import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
+import { ClientOnly, DefaultSpinner, appPath } from "@agent-native/core/client";
 import { appApiPath } from "@/lib/api-path";
 import { TAB_ID } from "@/lib/tab-id";
 import type { LinksFunction } from "react-router";
@@ -36,8 +36,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
+        <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#3B82F6" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta
@@ -45,7 +45,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           content="black-translucent"
         />
         <meta name="apple-mobile-web-app-title" content="Mail" />
-        <link rel="apple-touch-icon" href="/icon-180.svg" />
+        <link rel="apple-touch-icon" href={appPath("/icon-180.svg")} />
         <Meta />
         <Links />
       </head>

--- a/templates/meeting-notes/app/components/layout/Header.tsx
+++ b/templates/meeting-notes/app/components/layout/Header.tsx
@@ -10,7 +10,7 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
-import { AgentToggleButton } from "@agent-native/core/client";
+import { AgentToggleButton, appPath } from "@agent-native/core/client";
 import { useHeaderTitle, useHeaderActions } from "./HeaderActions";
 
 const pageTitles: Record<string, string> = {
@@ -74,13 +74,13 @@ export function Header() {
             <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
               <div className="flex items-center gap-2">
                 <img
-                  src="/agent-native-icon-light.svg"
+                  src={appPath("/agent-native-icon-light.svg")}
                   alt=""
                   aria-hidden="true"
                   className="block h-4 w-auto shrink-0 dark:hidden"
                 />
                 <img
-                  src="/agent-native-icon-dark.svg"
+                  src={appPath("/agent-native-icon-dark.svg")}
                   alt=""
                   aria-hidden="true"
                   className="hidden h-4 w-auto shrink-0 dark:block"

--- a/templates/recruiting/app/components/layout/AppLayout.tsx
+++ b/templates/recruiting/app/components/layout/AppLayout.tsx
@@ -6,7 +6,11 @@ import { OnboardingScreen } from "@/components/recruiting/OnboardingScreen";
 import { CommandPalette } from "./CommandPalette";
 import { useGreenhouseStatus } from "@/hooks/use-greenhouse";
 import { OrgSwitcher, InvitationBanner } from "@agent-native/core/client/org";
-import { AgentSidebar, FeedbackButton } from "@agent-native/core/client";
+import {
+  AgentSidebar,
+  FeedbackButton,
+  appPath,
+} from "@agent-native/core/client";
 import {
   IconLayoutDashboard,
   IconBriefcase,
@@ -172,13 +176,13 @@ export function AppLayout({ children }: AppLayoutProps) {
           >
             <div className="flex h-12 shrink-0 items-center gap-2 px-4 border-b border-border">
               <img
-                src="/agent-native-icon-light.svg"
+                src={appPath("/agent-native-icon-light.svg")}
                 alt=""
                 aria-hidden="true"
                 className="block h-4 w-auto shrink-0 dark:hidden"
               />
               <img
-                src="/agent-native-icon-dark.svg"
+                src={appPath("/agent-native-icon-dark.svg")}
                 alt=""
                 aria-hidden="true"
                 className="hidden h-4 w-auto shrink-0 dark:block"

--- a/templates/recruiting/app/root.tsx
+++ b/templates/recruiting/app/root.tsx
@@ -14,6 +14,7 @@ import { useDbSync } from "@agent-native/core";
 import {
   ClientOnly,
   DefaultSpinner,
+  appPath,
   CommandMenu,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
@@ -58,8 +59,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
+        <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#16A34A" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta

--- a/templates/scheduling/app/components/layout/Layout.tsx
+++ b/templates/scheduling/app/components/layout/Layout.tsx
@@ -14,7 +14,7 @@ import {
 } from "@tabler/icons-react";
 import { OrgSwitcher } from "@agent-native/core/client/org";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
-import { AgentSidebar } from "@agent-native/core/client";
+import { AgentSidebar, appPath } from "@agent-native/core/client";
 import { ThemeToggle } from "./ThemeToggle";
 import { Header } from "./Header";
 import { HeaderActionsProvider } from "./HeaderActions";
@@ -61,13 +61,13 @@ export function Layout({ children }: { children: React.ReactNode }) {
           >
             <span className="flex h-6 w-6 items-center justify-center rounded-md bg-foreground text-background">
               <img
-                src="/agent-native-icon-light.svg"
+                src={appPath("/agent-native-icon-light.svg")}
                 alt=""
                 aria-hidden="true"
                 className="block h-3.5 w-auto shrink-0 dark:hidden"
               />
               <img
-                src="/agent-native-icon-dark.svg"
+                src={appPath("/agent-native-icon-dark.svg")}
                 alt=""
                 aria-hidden="true"
                 className="hidden h-3.5 w-auto shrink-0 dark:block"

--- a/templates/scheduling/app/root.tsx
+++ b/templates/scheduling/app/root.tsx
@@ -11,6 +11,7 @@ import {
   useDbSync,
   ClientOnly,
   CommandMenu,
+  appPath,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
 import { IconSun, IconMoon } from "@tabler/icons-react";
@@ -39,7 +40,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <meta
           name="theme-color"
           content="#ffffff"

--- a/templates/slides/app/components/layout/Sidebar.tsx
+++ b/templates/slides/app/components/layout/Sidebar.tsx
@@ -8,7 +8,7 @@ import {
 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
-import { FeedbackButton } from "@agent-native/core/client";
+import { FeedbackButton, appPath } from "@agent-native/core/client";
 
 const navItems = [
   { icon: IconStack2, label: "Decks", href: "/" },
@@ -75,13 +75,13 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
       <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
         <div className="flex items-center gap-2">
           <img
-            src="/agent-native-icon-light.svg"
+            src={appPath("/agent-native-icon-light.svg")}
             alt=""
             aria-hidden="true"
             className="block h-4 w-auto dark:hidden"
           />
           <img
-            src="/agent-native-icon-dark.svg"
+            src={appPath("/agent-native-icon-dark.svg")}
             alt=""
             aria-hidden="true"
             className="hidden h-4 w-auto dark:block"

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -9,7 +9,7 @@ import {
   ReactNode,
 } from "react";
 import { nanoid } from "nanoid";
-import { appBasePath } from "@agent-native/core/client";
+import { appBasePath, appPath } from "@agent-native/core/client";
 import type { AspectRatio } from "@/lib/aspect-ratios";
 
 export type SlideLayout =
@@ -223,10 +223,12 @@ async function createDeckOnAPI(deck: Deck): Promise<void> {
   }
 }
 
+const builderLogoSrc = appPath("/assets/builder-logo-white.svg");
+
 const defaultSlideContent: Record<SlideLayout, string> = {
   title: `<div class="fmd-slide" style="padding: 80px 110px; justify-content: space-between;">
   <div>
-    <img src="/assets/builder-logo-white.svg" alt="Builder.io" style="height: 28px; width: auto;" />
+    <img src="${builderLogoSrc}" alt="Builder.io" style="height: 28px; width: auto;" />
   </div>
   <div>
     <div style="font-size: 54px; font-weight: 900; color: #fff; line-height: 1.1; letter-spacing: -1px; font-family: 'Poppins', sans-serif;">Presentation Title</div>

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -16,6 +16,7 @@ import {
   ClientOnly,
   CommandMenu,
   DefaultSpinner,
+  appPath,
   enterStyleEditing as coreEnterStyleEditing,
   enterTextEditing as coreEnterTextEditing,
   exitSelectionMode as coreExitSelectionMode,
@@ -97,8 +98,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
+        <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#EC4899" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta
@@ -106,7 +107,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           content="black-translucent"
         />
         <meta name="apple-mobile-web-app-title" content="Slides" />
-        <link rel="apple-touch-icon" href="/icon-180.svg" />
+        <link rel="apple-touch-icon" href={appPath("/icon-180.svg")} />
         <Meta />
         <Links />
       </head>

--- a/templates/starter/app/components/layout/Sidebar.tsx
+++ b/templates/starter/app/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@ import { Link, useLocation } from "react-router";
 import { IconActivity, IconHome, IconPlus } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
-import { FeedbackButton } from "@agent-native/core/client";
+import { FeedbackButton, appPath } from "@agent-native/core/client";
 
 const navItems = [
   { icon: IconHome, label: "Home", href: "/" },
@@ -17,13 +17,13 @@ export function Sidebar() {
     <aside className="flex h-full w-56 shrink-0 flex-col border-r border-border bg-sidebar text-sidebar-foreground">
       <div className="flex h-12 shrink-0 items-center gap-2 px-4 border-b border-border">
         <img
-          src="/agent-native-icon-light.svg"
+          src={appPath("/agent-native-icon-light.svg")}
           alt=""
           aria-hidden="true"
           className="block h-4 w-auto dark:hidden"
         />
         <img
-          src="/agent-native-icon-dark.svg"
+          src={appPath("/agent-native-icon-dark.svg")}
           alt=""
           aria-hidden="true"
           className="hidden h-4 w-auto dark:block"

--- a/templates/starter/app/root.tsx
+++ b/templates/starter/app/root.tsx
@@ -12,6 +12,7 @@ import {
   ClientOnly,
   CommandMenu,
   DefaultSpinner,
+  appPath,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
 import { IconSun, IconMoon } from "@tabler/icons-react";
@@ -42,7 +43,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="manifest" href="/manifest.json" />
+        <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#71717A" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta
@@ -50,8 +51,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
           content="black-translucent"
         />
         <meta name="apple-mobile-web-app-title" content="Starter" />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link rel="apple-touch-icon" href="/icon-180.svg" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
+        <link rel="apple-touch-icon" href={appPath("/icon-180.svg")} />
         <Meta />
         <Links />
       </head>

--- a/templates/videos/app/components/layout/NavSidebar.tsx
+++ b/templates/videos/app/components/layout/NavSidebar.tsx
@@ -7,7 +7,7 @@ import {
 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
-import { FeedbackButton } from "@agent-native/core/client";
+import { FeedbackButton, appPath } from "@agent-native/core/client";
 
 const navItems = [
   { icon: IconVideo, label: "Animations", href: "/" },
@@ -23,13 +23,13 @@ export function NavSidebar() {
     <aside className="flex h-full w-56 shrink-0 flex-col border-r border-border bg-sidebar text-sidebar-foreground">
       <div className="flex h-12 shrink-0 items-center gap-2 px-4 border-b border-border">
         <img
-          src="/agent-native-icon-light.svg"
+          src={appPath("/agent-native-icon-light.svg")}
           alt=""
           aria-hidden="true"
           className="block h-4 w-auto shrink-0 dark:hidden"
         />
         <img
-          src="/agent-native-icon-dark.svg"
+          src={appPath("/agent-native-icon-dark.svg")}
           alt=""
           aria-hidden="true"
           className="hidden h-4 w-auto shrink-0 dark:block"

--- a/templates/voice/app/components/layout/Sidebar.tsx
+++ b/templates/voice/app/components/layout/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { appPath } from "@agent-native/core/client";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
 
 export function Sidebar() {
@@ -6,13 +7,13 @@ export function Sidebar() {
       <div className="border-b px-4 py-3">
         <div className="flex items-center gap-2">
           <img
-            src="/agent-native-icon-light.svg"
+            src={appPath("/agent-native-icon-light.svg")}
             alt=""
             aria-hidden="true"
             className="block h-4 w-auto dark:hidden"
           />
           <img
-            src="/agent-native-icon-dark.svg"
+            src={appPath("/agent-native-icon-dark.svg")}
             alt=""
             aria-hidden="true"
             className="hidden h-4 w-auto dark:block"

--- a/templates/voice/app/root.tsx
+++ b/templates/voice/app/root.tsx
@@ -7,6 +7,7 @@ import {
   ClientOnly,
   DefaultSpinner,
   CommandMenu,
+  appPath,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
 import { Toaster } from "sonner";
@@ -45,8 +46,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-        <link rel="apple-touch-icon" href="/icon-180.svg" />
+        <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
+        <link rel="apple-touch-icon" href={appPath("/icon-180.svg")} />
         <Meta />
         <Links />
       </head>


### PR DESCRIPTION
## Summary
- keep integration A2A continuations polling beyond the old attempt cap while the remote task is still working
- wait briefly for redispatched continuations to become due before claiming, without holding serverless functions for long pre-claim sleeps
- fail long-running remote work by wall-clock age instead of a small claim count
- bump @agent-native/core to 0.7.29

## Verification
- pnpm --filter @agent-native/core exec vitest --run src/integrations/a2a-continuation-processor.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- git diff --check