### PR TITLE
[codex] Add unified Netlify workspace deploy

### DIFF
--- a/packages/core/docs/content/deployment.md
+++ b/packages/core/docs/content/deployment.md
@@ -18,7 +18,7 @@ agent-native deploy
 # https://your-agents.com/forms/*      → apps/forms
 ```
 
-Each app is built with `APP_BASE_PATH=/<name>`, packaged into `dist/<name>/`, and fronted by a generated dispatcher worker at `dist/_worker.js`. A `_routes.json` manifest tells Cloudflare Pages which paths are dynamic.
+Each app is built with `APP_BASE_PATH=/<name>` and `VITE_APP_BASE_PATH=/<name>`, then packaged into `dist/<name>/`. Cloudflare Pages is the default preset and uses a generated dispatcher worker at `dist/_worker.js`; Netlify uses one function per app in `.netlify/functions-internal/<app>-server` plus generated redirects.
 
 Same-origin deploy gives you two big wins for free:
 
@@ -31,7 +31,13 @@ Publish the output with:
 wrangler pages deploy dist
 ```
 
-Only need to deploy to Cloudflare Pages? That's the out-of-the-box target. Other targets stay per-app (see below) — or file an issue if you want another unified preset.
+For Netlify unified deploys, use the Netlify preset:
+
+```bash
+agent-native deploy --preset netlify
+```
+
+Generated workspaces include a root `netlify.toml` that runs `agent-native deploy --preset netlify --build-only`, publishes `dist`, and points Netlify at `.netlify/functions-internal`.
 
 Per-app independent deploy is still supported — just `cd apps/<name> && agent-native build` like a standalone scaffold.
 
@@ -126,6 +132,14 @@ export default defineConfig({
 ```
 
 …or set `NITRO_PRESET=netlify` at build time.
+
+For a workspace, deploy every app from one Netlify site by running:
+
+```bash
+agent-native deploy --preset netlify
+```
+
+The workspace build writes static assets to `dist/<app>/` and routes each app to its own Netlify function without forced redirects, so files like `/mail/assets/...` are served statically before the server function handles app routes.
 
 ## Cloudflare Pages {#cloudflare-pages}
 

--- a/packages/core/docs/content/multi-app-workspace.md
+++ b/packages/core/docs/content/multi-app-workspace.md
@@ -201,7 +201,7 @@ agent-native deploy
 # https://your-agents.com/forms/*      → apps/forms
 ```
 
-Each app is built with `APP_BASE_PATH=/<name>` and emitted into `dist/<name>/`. A dispatcher worker at `dist/_worker.js` routes each path to the matching app, and a `_routes.json` manifest tells Cloudflare Pages which paths to treat as dynamic.
+Each app is built with `APP_BASE_PATH=/<name>` and `VITE_APP_BASE_PATH=/<name>` and emitted into `dist/<name>/`. Cloudflare Pages is the default preset and uses a dispatcher worker at `dist/_worker.js` plus `_routes.json`. Netlify is also supported with `agent-native deploy --preset netlify`; it emits app functions under `.netlify/functions-internal/<app>-server` and generated redirects that leave static assets unforced so the CDN serves files first.
 
 Being on the **same origin** is where the real payoff lives:
 
@@ -213,6 +213,12 @@ Publish the `dist/` output:
 
 ```bash
 wrangler pages deploy dist
+```
+
+For Netlify, generated workspaces already include a root `netlify.toml`. Existing workspaces can use:
+
+```bash
+agent-native deploy --preset netlify --build-only
 ```
 
 ### Per-app independent deploy

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.29",
+  "version": "0.7.30",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -274,6 +274,22 @@ describe("workspace scaffold defaults", () => {
     ).toBe(false);
   });
 
+  it("scaffolds root Netlify config for unified workspace deploys", async () => {
+    const wsDir = path.join(tmpDir, "my-ws");
+    await _scaffoldWorkspaceRoot(wsDir, "my-ws");
+
+    const netlify = fs.readFileSync(path.join(wsDir, "netlify.toml"), "utf-8");
+    expect(netlify).toContain(
+      "pnpm exec agent-native deploy --preset netlify --build-only",
+    );
+    expect(netlify).toContain('publish = "dist"');
+    expect(netlify).toContain('functions = ".netlify/functions-internal"');
+    expect(netlify).toContain('NITRO_PRESET = "netlify"');
+
+    const gitignore = fs.readFileSync(path.join(wsDir, ".gitignore"), "utf-8");
+    expect(gitignore).toContain(".netlify/");
+  });
+
   it("does not copy generated Vercel output or legacy Claude settings", async () => {
     const wsDir = await (async () => {
       const targetDir = path.join(tmpDir, "my-ws");

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -440,6 +440,9 @@ Options:
                                 (mail,calendar,analytics,...) — or
                                 github:user/repo for community templates
   --standalone                  Scaffold a single standalone app (no workspace)
+  --preset <name>               Workspace deploy preset:
+                                cloudflare_pages (default) or netlify
+  --build-only                  Build workspace deploy artifacts without publishing
 
 Feedback:  ${FEEDBACK_URL}
 Bugs:      ${BUGS_URL}`);

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -1,0 +1,280 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { pathToFileURL } from "url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runWorkspaceDeploy } from "./workspace-deploy.js";
+
+let tmpDir: string;
+let previousAppBasePath: string | undefined;
+let previousDatabaseUrl: string | undefined;
+let previousUnpooledDatabaseUrl: string | undefined;
+let previousNitroPreset: string | undefined;
+let previousViteAppBasePath: string | undefined;
+let execFile: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "an-workspace-deploy-"));
+  execFile = vi.fn(((_cmd, args) => {
+    if (Array.isArray(args) && args[0] === "--filter") {
+      writeAppBuildOutput(tmpDir, String(args[1]));
+    }
+    return Buffer.from("");
+  }) as typeof execFileSync);
+  previousAppBasePath = process.env.APP_BASE_PATH;
+  previousDatabaseUrl = process.env.DATABASE_URL;
+  previousUnpooledDatabaseUrl = process.env.NETLIFY_DATABASE_URL_UNPOOLED;
+  previousNitroPreset = process.env.NITRO_PRESET;
+  previousViteAppBasePath = process.env.VITE_APP_BASE_PATH;
+  delete process.env.APP_BASE_PATH;
+  delete process.env.DATABASE_URL;
+  delete process.env.NETLIFY_DATABASE_URL_UNPOOLED;
+  delete process.env.NITRO_PRESET;
+  delete process.env.VITE_APP_BASE_PATH;
+});
+
+afterEach(() => {
+  restoreEnv("APP_BASE_PATH", previousAppBasePath);
+  restoreEnv("DATABASE_URL", previousDatabaseUrl);
+  restoreEnv("NETLIFY_DATABASE_URL_UNPOOLED", previousUnpooledDatabaseUrl);
+  restoreEnv("NITRO_PRESET", previousNitroPreset);
+  restoreEnv("VITE_APP_BASE_PATH", previousViteAppBasePath);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("workspace deploy", () => {
+  it("collects Netlify static assets, functions, and redirects for a workspace", async () => {
+    makeWorkspaceApp(tmpDir, "dispatch");
+    makeWorkspaceApp(tmpDir, "starter");
+
+    await runWorkspaceDeploy({
+      workspaceRoot: tmpDir,
+      args: ["--preset=netlify", "--build-only"],
+      execFile: execFile as typeof execFileSync,
+    });
+
+    const calls = execFile.mock.calls;
+    expect(calls).toHaveLength(2);
+
+    const dispatchCall = buildCallForApp("dispatch");
+    expect(dispatchCall?.env).toMatchObject({
+      NITRO_PRESET: "netlify",
+      APP_BASE_PATH: "/dispatch",
+      VITE_APP_BASE_PATH: "/dispatch",
+    });
+
+    const starterCall = buildCallForApp("starter");
+    expect(starterCall?.env).toMatchObject({
+      NITRO_PRESET: "netlify",
+      APP_BASE_PATH: "/starter",
+      VITE_APP_BASE_PATH: "/starter",
+    });
+
+    expect(
+      fs.existsSync(path.join(tmpDir, "dist", "dispatch", "assets", "app.js")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(tmpDir, "dist", "starter", "assets", "app.js")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(tmpDir, "dist", "dispatch", "dispatch", "assets", "app.js"),
+      ),
+    ).toBe(false);
+    expect(
+      fs.existsSync(
+        path.join(
+          tmpDir,
+          ".netlify",
+          "functions-internal",
+          "dispatch-server",
+          "dispatch-server.mjs",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          tmpDir,
+          ".netlify",
+          "functions-internal",
+          "starter-server",
+          "starter-server.mjs",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          tmpDir,
+          ".netlify",
+          "functions-internal",
+          "dispatch-server",
+          "main.mjs",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          tmpDir,
+          ".netlify",
+          "functions-internal",
+          "dispatch-server",
+          "server.mjs",
+        ),
+      ),
+    ).toBe(false);
+
+    const dispatchServer = fs.readFileSync(
+      path.join(
+        tmpDir,
+        ".netlify",
+        "functions-internal",
+        "dispatch-server",
+        "dispatch-server.mjs",
+      ),
+      "utf-8",
+    );
+    expect(dispatchServer).toContain('const basePath = "/dispatch";');
+    expect(dispatchServer).toContain("Object.assign(processRef.env");
+    expect(dispatchServer).toContain("APP_BASE_PATH: basePath");
+    expect(dispatchServer).toContain('await import("./main.mjs")');
+    expect(dispatchServer).toContain('path: "/dispatch/*"');
+
+    const dispatchModule = await import(
+      `${
+        pathToFileURL(
+          path.join(
+            tmpDir,
+            ".netlify",
+            "functions-internal",
+            "dispatch-server",
+            "dispatch-server.mjs",
+          ),
+        ).href
+      }?t=${Date.now()}`
+    );
+    process.env.APP_BASE_PATH = "/wrong";
+    process.env.VITE_APP_BASE_PATH = "/wrong";
+    await dispatchModule.default();
+    expect(process.env.APP_BASE_PATH).toBe("/dispatch");
+    expect(process.env.VITE_APP_BASE_PATH).toBe("/dispatch");
+
+    const redirects = fs.readFileSync(
+      path.join(tmpDir, "dist", "_redirects"),
+      "utf-8",
+    );
+    expect(redirects).toContain("/ /dispatch/overview 302");
+    expect(redirects).toContain("/dispatch /dispatch/overview 302");
+    expect(redirects).toContain("/apps /dispatch/apps 302");
+    expect(redirects).toContain(
+      "/dispatch/* /.netlify/functions/dispatch-server 200",
+    );
+    expect(redirects).toContain(
+      "/starter /.netlify/functions/starter-server 200",
+    );
+    expect(redirects).toContain(
+      "/starter/* /.netlify/functions/starter-server 200",
+    );
+    expect(redirects).not.toContain("!");
+    expect(redirects).not.toMatch(
+      /^\/\* \/.netlify\/functions\/dispatch-server 200$/m,
+    );
+    expect(redirects).not.toContain(
+      "/unknown /.netlify/functions/dispatch-server",
+    );
+    expect(fs.existsSync(path.join(tmpDir, "dist", "_routes.json"))).toBe(
+      false,
+    );
+    expect(fs.existsSync(path.join(tmpDir, "dist", "_worker.js"))).toBe(false);
+  });
+
+  it("uses Netlify unpooled database URLs for apps that request them", async () => {
+    process.env.DATABASE_URL = "postgres://pooled";
+    process.env.NETLIFY_DATABASE_URL_UNPOOLED = "postgres://unpooled";
+    makeWorkspaceApp(tmpDir, "mail", { usesUnpooledDatabaseUrl: true });
+
+    await runWorkspaceDeploy({
+      workspaceRoot: tmpDir,
+      preset: "netlify",
+      buildOnly: true,
+      execFile: execFile as typeof execFileSync,
+    });
+
+    expect(buildCallForApp("mail")?.env).toMatchObject({
+      DATABASE_URL: "postgres://unpooled",
+      NITRO_PRESET: "netlify",
+      APP_BASE_PATH: "/mail",
+      VITE_APP_BASE_PATH: "/mail",
+    });
+  });
+});
+
+function makeWorkspaceApp(
+  workspaceRoot: string,
+  app: string,
+  opts: { usesUnpooledDatabaseUrl?: boolean } = {},
+): void {
+  const appDir = path.join(workspaceRoot, "apps", app);
+  fs.mkdirSync(appDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(appDir, "package.json"),
+    JSON.stringify({ name: app, scripts: { build: "agent-native build" } }),
+  );
+
+  if (opts.usesUnpooledDatabaseUrl) {
+    fs.writeFileSync(
+      path.join(appDir, "netlify.toml"),
+      [
+        "[build]",
+        '  command = "DATABASE_URL=${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL} NITRO_PRESET=netlify pnpm build"',
+        "",
+      ].join("\n"),
+    );
+  }
+}
+
+function writeAppBuildOutput(workspaceRoot: string, app: string): void {
+  const appDir = path.join(workspaceRoot, "apps", app);
+  fs.mkdirSync(path.join(appDir, "dist", app, "assets"), { recursive: true });
+  fs.mkdirSync(path.join(appDir, ".netlify", "functions-internal", "server"), {
+    recursive: true,
+  });
+  fs.writeFileSync(
+    path.join(appDir, "dist", app, "assets", "app.js"),
+    "export {};",
+  );
+  fs.writeFileSync(
+    path.join(appDir, ".netlify", "functions-internal", "server", "main.mjs"),
+    "export default async function handler() { return new Response('ok'); }\n",
+  );
+  fs.writeFileSync(
+    path.join(appDir, ".netlify", "functions-internal", "server", "server.mjs"),
+    [
+      'export { default } from "./main.mjs";',
+      "export const config = {",
+      '  name: "server handler",',
+      '  path: "/*",',
+      "  preferStatic: true,",
+      "};",
+      "",
+    ].join("\n"),
+  );
+}
+
+function buildCallForApp(app: string): { env?: NodeJS.ProcessEnv } | undefined {
+  const call = vi
+    .mocked(execFile)
+    .mock.calls.find(([, args]) => Array.isArray(args) && args[1] === app);
+  return call?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -83,6 +83,9 @@ describe("workspace deploy", () => {
       ),
     ).toBe(false);
     expect(
+      fs.existsSync(path.join(tmpDir, "dist", "dispatch", "dispatch")),
+    ).toBe(false);
+    expect(
       fs.existsSync(
         path.join(
           tmpDir,
@@ -244,6 +247,13 @@ function writeAppBuildOutput(workspaceRoot: string, app: string): void {
   });
   fs.writeFileSync(
     path.join(appDir, "dist", app, "assets", "app.js"),
+    "export {};",
+  );
+  fs.mkdirSync(path.join(appDir, "dist", app, app, "assets"), {
+    recursive: true,
+  });
+  fs.writeFileSync(
+    path.join(appDir, "dist", app, app, "assets", "duplicate.js"),
     "export {};",
   );
   fs.writeFileSync(

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -19,6 +19,8 @@ import fs from "fs";
 import path from "path";
 import { findWorkspaceRoot } from "../scripts/utils.js";
 
+export type WorkspaceDeployPreset = "cloudflare_pages" | "netlify";
+
 export interface WorkspaceDeployOptions {
   args?: string[];
   /** Override the workspace root (defaults to walking up from cwd). */
@@ -26,7 +28,9 @@ export interface WorkspaceDeployOptions {
   /** Only build — don't invoke the deploy platform CLI. */
   buildOnly?: boolean;
   /** Target preset. Defaults to `cloudflare_pages`. */
-  preset?: "cloudflare_pages";
+  preset?: WorkspaceDeployPreset;
+  /** @internal Override process execution in tests. */
+  execFile?: typeof execFileSync;
 }
 
 export async function runWorkspaceDeploy(
@@ -41,7 +45,8 @@ export async function runWorkspaceDeploy(
     );
   }
 
-  const args = new Set(opts.args ?? []);
+  const rawArgs = opts.args ?? [];
+  const args = new Set(rawArgs);
   const buildOnly = opts.buildOnly ?? args.has("--build-only");
 
   const apps = fs
@@ -56,21 +61,32 @@ export async function runWorkspaceDeploy(
     );
   }
 
-  const preset = opts.preset ?? "cloudflare_pages";
+  const preset = resolvePreset(opts.preset, rawArgs);
   const distDir = path.join(workspaceRoot, "dist");
   fs.rmSync(distDir, { recursive: true, force: true });
   fs.mkdirSync(distDir, { recursive: true });
+
+  if (preset === "netlify") {
+    const functionsDir = netlifyFunctionsDir(workspaceRoot);
+    fs.rmSync(functionsDir, { recursive: true, force: true });
+    fs.mkdirSync(functionsDir, { recursive: true });
+  }
 
   console.log(
     `[workspace-deploy] Building ${apps.length} app(s) for preset=${preset}`,
   );
 
+  const execFile = opts.execFile ?? execFileSync;
   for (const app of apps) {
-    buildOneApp(workspaceRoot, app, preset);
-    moveAppBuildIntoDist(workspaceRoot, app, distDir);
+    buildOneApp(workspaceRoot, app, preset, execFile);
+    moveAppBuildIntoDist(workspaceRoot, app, distDir, preset);
   }
 
-  writeWorkspaceRoutingManifest(distDir, apps);
+  if (preset === "netlify") {
+    writeNetlifyRedirects(distDir, apps);
+  } else {
+    writeCloudflareRoutingManifest(distDir, apps);
+  }
 
   if (buildOnly) {
     console.log(
@@ -81,25 +97,46 @@ export async function runWorkspaceDeploy(
 
   console.log(`\n[workspace-deploy] Build complete. Publish with:\n`);
   console.log(`  cd ${path.relative(process.cwd(), workspaceRoot) || "."}`);
-  console.log(`  wrangler pages deploy dist\n`);
+  if (preset === "netlify") {
+    console.log(
+      `  netlify deploy --prod --dir=dist --functions=.netlify/functions-internal\n`,
+    );
+  } else {
+    console.log(`  wrangler pages deploy dist\n`);
+  }
   console.log(
     `All apps live at https://<origin>/<app-name>/*. Log in once on any app\nand the session is shared across the workspace.`,
   );
 }
 
-function buildOneApp(workspaceRoot: string, app: string, preset: string): void {
-  const env = {
+function buildOneApp(
+  workspaceRoot: string,
+  app: string,
+  preset: WorkspaceDeployPreset,
+  execFile: typeof execFileSync,
+): void {
+  const appDir = path.join(workspaceRoot, "apps", app);
+  const env: NodeJS.ProcessEnv = {
     ...process.env,
     NITRO_PRESET: preset,
     APP_BASE_PATH: `/${app}`,
     VITE_APP_BASE_PATH: `/${app}`,
   };
 
+  if (preset === "netlify" && appUsesNetlifyUnpooledDatabaseUrl(appDir)) {
+    env.DATABASE_URL =
+      process.env.NETLIFY_DATABASE_URL_UNPOOLED ??
+      process.env.DATABASE_URL ??
+      env.DATABASE_URL;
+  }
+
   console.log(
     `[workspace-deploy] Building ${app} (base=/${app}, preset=${preset})`,
   );
 
-  execFileSync("pnpm", ["--filter", app, "build"], {
+  cleanAppBuildOutputs(appDir);
+
+  execFile("pnpm", ["--filter", app, "build"], {
     cwd: workspaceRoot,
     env,
     stdio: "inherit",
@@ -110,6 +147,7 @@ function moveAppBuildIntoDist(
   workspaceRoot: string,
   app: string,
   distDir: string,
+  preset: WorkspaceDeployPreset,
 ): void {
   const appDir = path.join(workspaceRoot, "apps", app);
   // Resolve the per-app build output: prefer dist/ (standard), fall back to
@@ -124,16 +162,25 @@ function moveAppBuildIntoDist(
       `Expected ${candidates.join(" or ")} under ${appDir} but none existed. Check the app's build script.`,
     );
   }
-  const target = path.join(distDir, app);
-  fs.mkdirSync(target, { recursive: true });
-  copyDir(src, target);
+  if (preset === "netlify") {
+    const mountedSrc = path.join(src, app);
+    const staticSrc = fs.existsSync(mountedSrc) ? mountedSrc : src;
+    const target = path.join(distDir, app);
+    fs.mkdirSync(target, { recursive: true });
+    copyDir(staticSrc, target);
+    copyNetlifyFunctionIntoWorkspace(workspaceRoot, app);
+  } else {
+    const target = path.join(distDir, app);
+    fs.mkdirSync(target, { recursive: true });
+    copyDir(src, target);
+  }
 }
 
 /**
  * Write the Cloudflare Pages `_routes.json` and a dispatcher `_worker.js` at
  * the workspace dist root so each app is reachable under /<app>/*.
  */
-function writeWorkspaceRoutingManifest(distDir: string, apps: string[]): void {
+function writeCloudflareRoutingManifest(distDir: string, apps: string[]): void {
   // _routes.json tells Cloudflare which paths are dynamic (Functions) vs
   // static. Mark /<app>/* as include so every app's worker handles its
   // subtree.
@@ -173,6 +220,171 @@ ${dispatch}
 };
 `;
   fs.writeFileSync(path.join(distDir, "_worker.js"), worker);
+}
+
+function writeNetlifyRedirects(distDir: string, apps: string[]): void {
+  const lines: string[] = [
+    "# Generated by agent-native deploy --preset netlify",
+    "# No forced rewrites: Netlify should serve static files from dist/ first.",
+  ];
+
+  if (apps.includes("dispatch")) {
+    lines.push("/ /dispatch/overview 302");
+    lines.push("/dispatch /dispatch/overview 302");
+    for (const [from, to] of DISPATCH_WORKSPACE_ROOT_REDIRECTS) {
+      lines.push(`/${from} /dispatch/${to} 302`);
+    }
+  } else {
+    lines.push(`/ /${apps[0]}/ 302`);
+  }
+
+  for (const app of apps) {
+    const functionPath = `/.netlify/functions/${app}-server`;
+    if (app !== "dispatch") {
+      lines.push(`/${app} ${functionPath} 200`);
+    }
+    lines.push(`/${app}/* ${functionPath} 200`);
+  }
+
+  fs.writeFileSync(path.join(distDir, "_redirects"), lines.join("\n") + "\n");
+}
+
+const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
+  ["overview", "overview"],
+  ["apps", "apps"],
+  ["new-app", "new-app"],
+  ["vault", "vault"],
+  ["integrations", "integrations"],
+  ["agents", "agents"],
+  ["workspace", "workspace"],
+  ["messaging", "messaging"],
+  ["destinations", "destinations"],
+  ["identities", "identities"],
+  ["approvals", "approvals"],
+  ["audit", "audit"],
+  ["team", "team"],
+];
+
+function copyNetlifyFunctionIntoWorkspace(
+  workspaceRoot: string,
+  app: string,
+): void {
+  const appDir = path.join(workspaceRoot, "apps", app);
+  const src = path.join(appDir, ".netlify", "functions-internal", "server");
+  if (!fs.existsSync(src)) {
+    throw new Error(
+      `Expected Netlify function at ${src} after building ${app}. Check the app's build script and NITRO_PRESET.`,
+    );
+  }
+
+  const dest = path.join(netlifyFunctionsDir(workspaceRoot), `${app}-server`);
+  fs.rmSync(dest, { recursive: true, force: true });
+  copyDir(src, dest);
+  patchNetlifyFunctionEntry(dest, app);
+}
+
+function patchNetlifyFunctionEntry(functionDir: string, app: string): void {
+  const serverPath = path.join(functionDir, "server.mjs");
+  if (!fs.existsSync(serverPath)) return;
+
+  const basePath = `/${app}`;
+  const server = `const basePath = ${JSON.stringify(basePath)};
+
+function setBasePathEnv() {
+  const processRef = globalThis.process ??= { env: {} };
+  processRef.env ??= {};
+  Object.assign(processRef.env, {
+    APP_BASE_PATH: basePath,
+    VITE_APP_BASE_PATH: basePath,
+  });
+}
+
+setBasePathEnv();
+
+let cachedHandler;
+
+export default async function handler(...args) {
+  setBasePathEnv();
+  cachedHandler ??= (await import("./main.mjs")).default;
+  return cachedHandler(...args);
+}
+
+export const config = {
+  name: ${JSON.stringify(`${app} server handler`)},
+  generator: "agent-native workspace deploy",
+  path: ${JSON.stringify(`${basePath}/*`)},
+  nodeBundler: "none",
+  includedFiles: ["**"],
+  excludedPath: ["/.netlify/*"],
+  preferStatic: true,
+};
+`;
+  fs.rmSync(serverPath, { force: true });
+  fs.writeFileSync(path.join(functionDir, `${app}-server.mjs`), server);
+}
+
+function netlifyFunctionsDir(workspaceRoot: string): string {
+  return path.join(workspaceRoot, ".netlify", "functions-internal");
+}
+
+function cleanAppBuildOutputs(appDir: string): void {
+  for (const name of ["dist", ".output", "build"]) {
+    fs.rmSync(path.join(appDir, name), { recursive: true, force: true });
+  }
+  fs.rmSync(path.join(appDir, ".netlify", "functions-internal"), {
+    recursive: true,
+    force: true,
+  });
+}
+
+function appUsesNetlifyUnpooledDatabaseUrl(appDir: string): boolean {
+  const netlifyPath = path.join(appDir, "netlify.toml");
+  if (!fs.existsSync(netlifyPath)) return false;
+  try {
+    return fs
+      .readFileSync(netlifyPath, "utf-8")
+      .includes("NETLIFY_DATABASE_URL_UNPOOLED");
+  } catch {
+    return false;
+  }
+}
+
+function parsePresetArg(args: string[]): WorkspaceDeployPreset | null {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--preset" && args[i + 1]) {
+      return normalizePreset(args[i + 1]);
+    }
+    if (arg.startsWith("--preset=")) {
+      return normalizePreset(arg.slice("--preset=".length));
+    }
+  }
+  return null;
+}
+
+function resolvePreset(
+  optionPreset: WorkspaceDeployPreset | undefined,
+  args: string[],
+): WorkspaceDeployPreset {
+  return (
+    optionPreset ??
+    parsePresetArg(args) ??
+    normalizePreset(process.env.NITRO_PRESET) ??
+    "cloudflare_pages"
+  );
+}
+
+function normalizePreset(
+  value: string | undefined,
+): WorkspaceDeployPreset | null {
+  if (!value) return null;
+  if (value === "cloudflare_pages" || value === "cloudflare-pages") {
+    return "cloudflare_pages";
+  }
+  if (value === "netlify") return "netlify";
+  throw new Error(
+    `Unsupported workspace deploy preset "${value}". Supported presets: cloudflare_pages, netlify.`,
+  );
 }
 
 function moduleIdent(app: string): string {

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -168,6 +168,10 @@ function moveAppBuildIntoDist(
     const target = path.join(distDir, app);
     fs.mkdirSync(target, { recursive: true });
     copyDir(staticSrc, target);
+    // Nitro/Vite mounted builds can contain a nested copy of public assets at
+    // dist/<app>/<app>/...; the workspace root already supplies the outer
+    // mount path, so keeping it would publish duplicate /<app>/<app> URLs.
+    fs.rmSync(path.join(target, app), { recursive: true, force: true });
     copyNetlifyFunctionIntoWorkspace(workspaceRoot, app);
   } else {
     const target = path.join(distDir, app);

--- a/packages/core/src/templates/workspace-root/_gitignore
+++ b/packages/core/src/templates/workspace-root/_gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.netlify/
 dist/
 build/
 apps/*/dist/

--- a/packages/core/src/templates/workspace-root/netlify.toml
+++ b/packages/core/src/templates/workspace-root/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && pnpm exec agent-native deploy --preset netlify --build-only"
+  publish = "dist"
+  functions = ".netlify/functions-internal"
+
+[build.environment]
+  NITRO_PRESET = "netlify"
+  NPM_CONFIG_PRODUCTION = "false"


### PR DESCRIPTION
## Summary

Adds first-class Netlify support to unified workspace deploys in `@agent-native/core`.

- Adds `agent-native deploy --preset netlify` support alongside the existing Cloudflare Pages default.
- Builds each workspace app with `APP_BASE_PATH` / `VITE_APP_BASE_PATH` set to `/<app>` and `NITRO_PRESET=netlify`.
- Collects mounted static assets into root `dist/<app>/`, collects each app function into `.netlify/functions-internal/<app>-server`, and generates unforced Netlify redirects so static assets win.
- Adds root workspace `netlify.toml` scaffolding so newly generated workspaces deploy all apps from one Netlify site.
- Documents unified Netlify workspace deploys and bumps `@agent-native/core` to `0.7.30`.

## Validation

- `pnpm --filter @agent-native/core exec vitest --run src/deploy/workspace-deploy.spec.ts src/cli/create-e2e.spec.ts`
- `pnpm --filter @agent-native/core typecheck`
- `pnpm --filter @agent-native/core test`
- `pnpm guards`
- `pnpm fmt:check`