### PR TITLE
Fix onboarding copy and Dispatch workspace webhooks

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.32",
+  "version": "0.7.33",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -185,7 +185,9 @@ describe("workspace deploy", () => {
     expect(dispatchServer).toContain("Object.assign(processRef.env");
     expect(dispatchServer).toContain("APP_BASE_PATH: basePath");
     expect(dispatchServer).toContain('await import("./main.mjs")');
-    expect(dispatchServer).toContain('path: "/dispatch/*"');
+    expect(dispatchServer).toContain(
+      'path: ["/_agent-native/*","/dispatch/*"]',
+    );
     expect(dispatchServer).toContain('"/dispatch/assets/*"');
     expect(dispatchServer).toContain('"/dispatch/*.svg"');
     expect(dispatchServer).toContain('"/.netlify/*"');

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -312,7 +312,9 @@ function patchNetlifyFunctionEntry(functionDir: string, app: string): void {
 
   const basePath = `/${app}`;
   const pathConfig =
-    app === "dispatch" ? `${basePath}/*` : [basePath, `${basePath}/*`];
+    app === "dispatch"
+      ? ["/_agent-native/*", `${basePath}/*`]
+      : [basePath, `${basePath}/*`];
   const normalizeBasePathHelper =
     app === "dispatch"
       ? ""

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getOnboardingHtml } from "./onboarding-html.js";
+
+describe("getOnboardingHtml", () => {
+  it("does not include local upgrade copy in SSR HTML by default", () => {
+    const html = getOnboardingHtml();
+
+    expect(html).not.toContain("local@localhost");
+    expect(html).not.toContain("You started this flow");
+    expect(html).toContain('id="upgrade-note"');
+  });
+
+  it("reveals the upgrade note only from explicit upgrade markers", () => {
+    const html = getOnboardingHtml();
+
+    expect(html).toContain("upgrade-from-local");
+    expect(html).toContain("an_migrate_from_local");
+    expect(html).toContain(
+      "Continue signing in to attach this app to your account and migrate local data.",
+    );
+  });
+});

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -576,9 +576,11 @@ ${marketingPanelHtml}
 <div class="card">
   <h1 id="heading">Welcome</h1>
   <p class="subtitle" id="subtitle">Create an account to get started</p>
-  <p class="upgrade-note" id="upgrade-note">
-    You started this flow from <code>local@localhost</code>. Continue signing in to upgrade this workspace to a real account and migrate your local data. If you want to cancel that and keep using local mode, use the secondary button below.
-  </p>
+  <p
+    class="upgrade-note"
+    id="upgrade-note"
+    data-upgrade-copy="Continue signing in to attach this app to your account and migrate local data."
+  ></p>
 
 ${
   showGoogle
@@ -685,6 +687,21 @@ ${
       var n = document.getElementById('local-note');
       if (n) n.classList.add('show');
     }
+  })();
+  (function revealUpgradeNote() {
+    var shouldShow = false;
+    try {
+      var params = new URLSearchParams(location.search);
+      shouldShow = params.get('signin') === '1' || params.get('upgrade-from-local') === '1';
+    } catch(e) {}
+    if (!shouldShow) {
+      try { shouldShow = localStorage.getItem('an_migrate_from_local') === '1'; } catch(e) {}
+    }
+    if (!shouldShow) return;
+    var n = document.getElementById('upgrade-note');
+    if (!n) return;
+    n.textContent = n.getAttribute('data-upgrade-copy') || 'Continue signing in to migrate local data.';
+    n.classList.add('show');
   })();
 ${
   googleOnly


### PR DESCRIPTION
## Summary\n- hide local-upgrade onboarding copy from initial SSR HTML\n- route root /_agent-native/* to Dispatch in Netlify workspace deploys so existing Slack webhooks keep working\n- bump @agent-native/core to 0.7.33\n\n## Tests\n- pnpm --filter @agent-native/core exec vitest --run src/deploy/workspace-deploy.spec.ts