### PR TITLE
Tune integration processor dispatch wait

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.34",
+  "version": "0.7.35",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -36,7 +36,7 @@ import { signInternalToken } from "./internal-token.js";
 import { FRAMEWORK_ROUTE_PREFIX } from "../server/core-routes-plugin.js";
 import { withConfiguredAppBasePath } from "../server/app-base-path.js";
 
-const PROCESSOR_DISPATCH_SETTLE_WAIT_MS = 2_000;
+const PROCESSOR_DISPATCH_SETTLE_WAIT_MS = 1_500;
 
 /**
  * Build a stable per-event dedup key from the incoming message. The same


### PR DESCRIPTION
## Summary\n- reduce the integration processor self-dispatch settle wait from 2.0s to 1.5s\n- keeps Netlify enough time to flush the processor request while staying farther under Slack's 3s webhook acknowledgement window\n- bump @agent-native/core to 0.7.35\n\n## Validation\n- pnpm exec prettier --write packages/core/package.json packages/core/src/integrations/webhook-handler.ts\n- pnpm --filter @agent-native/core exec vitest --run src/integrations/webhook-handler.spec.ts