### PR TITLE
Polish workspace Netlify defaults and LLM setup errors

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.35",
+  "version": "0.7.36",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/agent/engine/anthropic-engine.spec.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.spec.ts
@@ -107,6 +107,8 @@ describe("createAnthropicEngine", () => {
     const events = await collectEvents(engine.stream(opts));
     const stopEvent = events.find((e) => e.type === "stop");
     expect(stopEvent?.reason).toBe("error");
-    expect(stopEvent?.error).toContain("ANTHROPIC_API_KEY");
+    expect(stopEvent?.error).toContain("Connect an LLM provider or Builder");
+    expect(stopEvent?.error).not.toContain("ANTHROPIC_API_KEY");
+    expect(stopEvent?.errorCode).toBe("missing_credentials");
   });
 });

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -22,6 +22,10 @@ import {
 } from "./translate-anthropic.js";
 import { readDeployCredentialEnv } from "../../server/credential-provider.js";
 import { normalizeReasoningEffortForModel } from "../../shared/reasoning-effort.js";
+import {
+  LLM_MISSING_CREDENTIALS_ERROR_CODE,
+  LLM_MISSING_CREDENTIALS_MESSAGE,
+} from "./credential-errors.js";
 
 export const ANTHROPIC_CAPABILITIES: EngineCapabilities = {
   thinking: true,
@@ -205,7 +209,8 @@ export function createAnthropicEngine(
         yield {
           type: "stop" as const,
           reason: "error" as const,
-          error: "ANTHROPIC_API_KEY is not set",
+          error: LLM_MISSING_CREDENTIALS_MESSAGE,
+          errorCode: LLM_MISSING_CREDENTIALS_ERROR_CODE,
         };
       },
     };

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -99,7 +99,8 @@ describe("createBuilderEngine", () => {
     const stop = events.find((e) => e.type === "stop");
     expect(stop?.reason).toBe("error");
     expect(stop?.errorCode).toBe("missing_credentials");
-    expect(stop?.error).toContain("BUILDER_PRIVATE_KEY");
+    expect(stop?.error).toContain("Connect an LLM provider or Builder");
+    expect(stop?.error).not.toContain("BUILDER_PRIVATE_KEY");
   });
 
   it("short-circuits with missing-credentials when resolveBuilderAuthHeader returns null", async () => {

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -32,6 +32,10 @@ import {
   normalizeReasoningEffortForModel,
   type ReasoningEffort,
 } from "../../shared/reasoning-effort.js";
+import {
+  LLM_MISSING_CREDENTIALS_ERROR_CODE,
+  LLM_MISSING_CREDENTIALS_MESSAGE,
+} from "./credential-errors.js";
 
 export const BUILDER_CAPABILITIES: EngineCapabilities = {
   thinking: true,
@@ -125,8 +129,8 @@ class BuilderEngine implements AgentEngine {
       yield {
         type: "stop",
         reason: "error",
-        error: "BUILDER_PRIVATE_KEY is not set",
-        errorCode: "missing_credentials",
+        error: LLM_MISSING_CREDENTIALS_MESSAGE,
+        errorCode: LLM_MISSING_CREDENTIALS_ERROR_CODE,
       };
       return;
     }

--- a/packages/core/src/agent/engine/credential-errors.spec.ts
+++ b/packages/core/src/agent/engine/credential-errors.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatLlmCredentialErrorMessage,
+  isLlmCredentialError,
+  LLM_MISSING_CREDENTIALS_MESSAGE,
+  userFacingLlmCredentialError,
+} from "./credential-errors.js";
+
+describe("LLM credential error helpers", () => {
+  it("detects raw LLM provider env var failures", () => {
+    expect(isLlmCredentialError("ANTHROPIC_API_KEY is not set")).toBe(true);
+    expect(
+      userFacingLlmCredentialError(new Error("OPENAI_API_KEY is required")),
+    ).toBe(LLM_MISSING_CREDENTIALS_MESSAGE);
+  });
+
+  it("detects structured missing-credential errors", () => {
+    expect(
+      isLlmCredentialError(new Error("anything"), "missing_credentials"),
+    ).toBe(true);
+  });
+
+  it("does not treat generic authentication failures as LLM setup failures", () => {
+    expect(isLlmCredentialError("Authentication required")).toBe(false);
+    expect(
+      isLlmCredentialError("Slack outbound messaging is not configured"),
+    ).toBe(false);
+    expect(isLlmCredentialError("Credentials are not configured")).toBe(false);
+  });
+
+  it("formats agent-specific copy without provider env vars", () => {
+    const message = formatLlmCredentialErrorMessage({ agentName: "Slides" });
+    expect(message).toContain("Slides agent");
+    expect(message).toContain("Connect an LLM provider or Builder");
+    expect(message).not.toContain("ANTHROPIC_API_KEY");
+  });
+});

--- a/packages/core/src/agent/engine/credential-errors.ts
+++ b/packages/core/src/agent/engine/credential-errors.ts
@@ -1,0 +1,69 @@
+import { PROVIDER_ENV_VARS } from "./provider-env-vars.js";
+
+export const LLM_MISSING_CREDENTIALS_ERROR_CODE = "missing_credentials";
+
+export const LLM_MISSING_CREDENTIALS_MESSAGE =
+  "No LLM provider is connected. Connect an LLM provider or Builder, then try again.";
+
+const LLM_CREDENTIAL_KEYS = new Set([
+  ...PROVIDER_ENV_VARS,
+  "BUILDER_PRIVATE_KEY",
+  "BUILDER_PUBLIC_KEY",
+]);
+
+const MISSING_CREDENTIAL_PATTERNS = [
+  /\b(?:llm|model provider|ai engine)\b.*\b(?:missing|not set|not configured|required|connected)\b/i,
+  /\b(?:missing|not set|not configured|required|connected)\b.*\b(?:llm|model provider|ai engine)\b/i,
+  /\b(?:llm|model provider|ai engine)\b.*\b(?:api\s*key|credential|credentials|provider key)\b/i,
+  /\b(?:api\s*key|credential|credentials|provider key)\b.*\b(?:llm|model provider|ai engine)\b/i,
+];
+
+export function isLlmCredentialError(
+  error: unknown,
+  errorCode?: string | null,
+): boolean {
+  const code =
+    errorCode ??
+    (typeof error === "object" && error && "errorCode" in error
+      ? String((error as { errorCode?: unknown }).errorCode ?? "")
+      : "");
+  if (code === LLM_MISSING_CREDENTIALS_ERROR_CODE) return true;
+
+  const message = getErrorMessage(error);
+  if (!message) return false;
+
+  const mentionsKnownLlmCredential = [...LLM_CREDENTIAL_KEYS].some((key) =>
+    message.includes(key),
+  );
+  if (mentionsKnownLlmCredential) return true;
+
+  return MISSING_CREDENTIAL_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+export function formatLlmCredentialErrorMessage(options?: {
+  agentName?: string;
+}): string {
+  const agentName = options?.agentName?.trim();
+  if (agentName) {
+    return `The ${agentName} agent could not finish this request because that app needs an LLM connection. Connect an LLM provider or Builder for the ${agentName} app, then try again.`;
+  }
+  return LLM_MISSING_CREDENTIALS_MESSAGE;
+}
+
+export function userFacingLlmCredentialError(
+  error: unknown,
+  options?: { agentName?: string },
+): string | null {
+  return isLlmCredentialError(error)
+    ? formatLlmCredentialErrorMessage(options)
+    : null;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error && "message" in error) {
+    return String((error as { message?: unknown }).message ?? "");
+  }
+  return "";
+}

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -27,6 +27,7 @@ import {
   registerBuiltinEngines,
   getStoredModelForEngine,
 } from "./engine/index.js";
+import { userFacingLlmCredentialError } from "./engine/credential-errors.js";
 import { PROVIDER_TO_ENV } from "./engine/provider-env-vars.js";
 import { readAppState } from "../application-state/script-helpers.js";
 import {
@@ -1610,7 +1611,11 @@ export function createProductionAgentHandler(
                   agent: ref.name,
                   status: "error",
                 });
-                return `<agent-response name="${ref.name}" id="${ref.refId}" type="custom-agent" error="true">\nFailed to run ${ref.name}: ${err?.message}\n</agent-response>`;
+                const message =
+                  userFacingLlmCredentialError(err, {
+                    agentName: ref.name,
+                  }) ?? `Failed to run ${ref.name}: ${err?.message}`;
+                return `<agent-response name="${ref.name}" id="${ref.refId}" type="custom-agent" error="true">\n${message}\n</agent-response>`;
               }
             }),
           );
@@ -1728,7 +1733,11 @@ export function createProductionAgentHandler(
                   agent: ref.name,
                   status: "error",
                 });
-                return `<agent-response name="${ref.name}" id="${ref.refId}" error="true">\nFailed to reach ${ref.name}: ${err?.message}\n</agent-response>`;
+                const message =
+                  userFacingLlmCredentialError(err, {
+                    agentName: ref.name,
+                  }) ?? `Failed to reach ${ref.name}: ${err?.message}`;
+                return `<agent-response name="${ref.name}" id="${ref.refId}" error="true">\n${message}\n</agent-response>`;
               }
             }),
           );

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -290,11 +290,13 @@ describe("workspace scaffold defaults", () => {
 
     const netlify = fs.readFileSync(path.join(wsDir, "netlify.toml"), "utf-8");
     expect(netlify).toContain(
-      "pnpm exec agent-native deploy --preset netlify --build-only",
+      'export DATABASE_URL=\\"${NETLIFY_DATABASE_URL:-$DATABASE_URL}\\" && pnpm install && pnpm exec agent-native deploy --preset netlify --build-only',
     );
     expect(netlify).toContain('publish = "dist"');
     expect(netlify).toContain('functions = ".netlify/functions-internal"');
     expect(netlify).toContain('NITRO_PRESET = "netlify"');
+    expect(netlify).toContain('[functions."*"]');
+    expect(netlify).toContain("  timeout = 60");
 
     const gitignore = fs.readFileSync(path.join(wsDir, ".gitignore"), "utf-8");
     expect(gitignore).toContain(".netlify/");
@@ -353,7 +355,7 @@ describe("Netlify scaffold rewrite", () => {
     };
 
     expect(netlify).toContain(
-      'command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && APP_BASE_PATH=/dispatch VITE_APP_BASE_PATH=/dispatch NITRO_PRESET=netlify pnpm --filter dispatch build"',
+      'command = "export DATABASE_URL=\\"${NETLIFY_DATABASE_URL:-$DATABASE_URL}\\" && APP_BASE_PATH=/dispatch VITE_APP_BASE_PATH=/dispatch NITRO_PRESET=netlify pnpm --filter dispatch build"',
     );
     expect(netlify).not.toContain("pnpm install");
     expect(netlify).toContain('publish = "apps/dispatch/dist"');
@@ -389,7 +391,7 @@ describe("Netlify scaffold rewrite", () => {
 
     const netlify = fs.readFileSync(path.join(appDir, "netlify.toml"), "utf-8");
     expect(netlify).toContain(
-      'command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && DATABASE_URL=${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL} NITRO_PRESET=netlify pnpm build"',
+      'command = "export DATABASE_URL=\\"${NETLIFY_DATABASE_URL:-$DATABASE_URL}\\" && DATABASE_URL=\\"${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL}\\" NITRO_PRESET=netlify pnpm build"',
     );
     expect(netlify).not.toContain("pnpm install");
     expect(netlify).toContain('publish = "dist"');
@@ -414,7 +416,7 @@ describe("Netlify scaffold rewrite", () => {
 
     const netlify = fs.readFileSync(path.join(appDir, "netlify.toml"), "utf-8");
     expect(netlify).toContain(
-      'command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && APP_BASE_PATH=/starter VITE_APP_BASE_PATH=/starter NITRO_PRESET=netlify pnpm --filter starter build"',
+      'command = "export DATABASE_URL=\\"${NETLIFY_DATABASE_URL:-$DATABASE_URL}\\" && APP_BASE_PATH=/starter VITE_APP_BASE_PATH=/starter NITRO_PRESET=netlify pnpm --filter starter build"',
     );
     expect(netlify).toContain('  APP_BASE_PATH = "/starter"');
     expect(netlify).toContain('  VITE_APP_BASE_PATH = "/starter"');

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -1102,9 +1102,9 @@ function rewriteNetlifyToml(
         ? `APP_BASE_PATH=/${appName} VITE_APP_BASE_PATH=/${appName} NITRO_PRESET=netlify pnpm --filter ${appName} build`
         : "NITRO_PRESET=netlify pnpm build";
     const databaseSetup =
-      "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL}";
+      'export DATABASE_URL=\\"${NETLIFY_DATABASE_URL:-$DATABASE_URL}\\"';
     const buildDatabasePrefix = usesUnpooledDatabase
-      ? "DATABASE_URL=${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL} "
+      ? 'DATABASE_URL=\\"${NETLIFY_DATABASE_URL_UNPOOLED:-$DATABASE_URL}\\" '
       : "";
     const command = `${databaseSetup} && ${buildDatabasePrefix}${buildCommand}`;
     const publishPath = mode === "workspace" ? `apps/${appName}/dist` : "dist";

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -250,7 +250,7 @@ describe("A2A continuation processor", () => {
 
     const sentText = vi.mocked(sendResponse).mock.calls[0]?.[0].text ?? "";
     expect(sentText).toContain("needs an LLM connection");
-    expect(sentText).toContain("Connect Builder.io");
+    expect(sentText).toContain("Connect an LLM provider or Builder");
     expect(sentText).not.toContain("ANTHROPIC_API_KEY");
     expect(failA2AContinuationMock).toHaveBeenCalledWith(
       "cont-1",

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -5,6 +5,10 @@ import { FRAMEWORK_ROUTE_PREFIX } from "../server/core-routes-plugin.js";
 import { signInternalToken } from "./internal-token.js";
 import type { PlatformAdapter } from "./types.js";
 import {
+  formatLlmCredentialErrorMessage,
+  isLlmCredentialError,
+} from "../agent/engine/credential-errors.js";
+import {
   claimA2AContinuation,
   claimDueA2AContinuations,
   completeA2AContinuation,
@@ -264,26 +268,14 @@ function formatContinuationFailureMessage(
   reason: string,
 ): string {
   if (isLlmCredentialError(reason)) {
-    return `The ${continuation.agentName} agent could not finish this request because that app needs an LLM connection. Connect Builder.io or another LLM provider for the ${continuation.agentName} app, then try again.`;
+    return formatLlmCredentialErrorMessage({
+      agentName: continuation.agentName,
+    });
   }
 
   return `The ${continuation.agentName} agent could not finish this request: ${sanitizeFailureReason(
     reason,
   )}`;
-}
-
-function isLlmCredentialError(reason: string): boolean {
-  return (
-    /(?:ANTHROPIC|OPENAI|GOOGLE|GEMINI|MISTRAL|GROQ|TOGETHER|XAI|PERPLEXITY|FIREWORKS|DEEPSEEK)_[A-Z0-9_]*API_KEY/i.test(
-      reason,
-    ) ||
-    /(?:api key|llm|model provider).*(?:missing|not set|not configured|required)/i.test(
-      reason,
-    ) ||
-    /(?:missing|not set|not configured|required).*(?:api key|llm|model provider)/i.test(
-      reason,
-    )
-  );
 }
 
 function isRemoteWorkExpired(continuation: A2AContinuation): boolean {

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -257,6 +257,51 @@ describe("integration webhook handler engine resolution", () => {
     });
   });
 
+  it("sanitizes missing LLM credential text before sending platform replies", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const sendResponse = vi.fn();
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({ type: "text", text: "ANTHROPIC_API_KEY is not set" });
+    });
+    const task: PendingTask = {
+      id: "task-missing-llm",
+      platform: "fake",
+      externalEventKey: "fake:thread-missing-llm:1007",
+      externalThreadId: "thread-missing-llm",
+      payload: JSON.stringify({
+        incoming: {
+          platform: "fake",
+          externalThreadId: "thread-missing-llm",
+          text: "hello from slack",
+          senderName: "QA User",
+          platformContext: { channel: "C123" },
+          timestamp: 1007,
+        },
+      }),
+      ownerEmail: "dispatch+qa@integration.local",
+      orgId: "org-qa",
+      status: "processing",
+      attempts: 1,
+      errorMessage: null,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      completedAt: null,
+    };
+
+    await processIntegrationTask(task, {
+      adapter: createAdapter(sendResponse),
+      systemPrompt: "system",
+      actions: {},
+      model: "claude-sonnet-4-6",
+      apiKey: "",
+      ownerEmail: task.ownerEmail,
+    });
+
+    const sentText = vi.mocked(sendResponse).mock.calls[0]?.[0].text ?? "";
+    expect(sentText).toContain("Connect an LLM provider or Builder");
+    expect(sentText).not.toContain("ANTHROPIC_API_KEY");
+  });
+
   it("uses the explicit provider env key when no owner key exists in single-tenant mode", async () => {
     const { processIntegrationTask } = await import("./webhook-handler.js");
     const sendResponse = vi.fn();

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -17,6 +17,10 @@ import {
   getStoredModelForEngine,
   resolveEngine,
 } from "../agent/engine/index.js";
+import {
+  formatLlmCredentialErrorMessage,
+  isLlmCredentialError,
+} from "../agent/engine/credential-errors.js";
 import type { AgentEngine } from "../agent/engine/types.js";
 import type { EngineMessage } from "../agent/engine/types.js";
 import { startRun, type ActiveRun } from "../agent/run-manager.js";
@@ -586,7 +590,18 @@ async function processIncomingMessage(
           // Common case: an A2A delegation timed out and the agent loop bailed
           // before generating any user-facing text.
           const runErrored = completedRun.status === "errored";
-          if (!responseText.trim() || runErrored) {
+          const runErrorText = completedRun.events
+            .map((runEvent) =>
+              runEvent.event.type === "error" ? runEvent.event.error : "",
+            )
+            .filter(Boolean)
+            .join("\n");
+          if (
+            isLlmCredentialError(responseText) ||
+            isLlmCredentialError(runErrorText)
+          ) {
+            responseText = formatLlmCredentialErrorMessage();
+          } else if (!responseText.trim() || runErrored) {
             if (runErrored) {
               responseText =
                 (responseText.trim() ? responseText + "\n\n" : "") +

--- a/packages/core/src/templates/workspace-root/netlify.toml
+++ b/packages/core/src/templates/workspace-root/netlify.toml
@@ -1,8 +1,11 @@
 [build]
-  command = "export DATABASE_URL=${NETLIFY_DATABASE_URL:-$DATABASE_URL} && pnpm install && pnpm exec agent-native deploy --preset netlify --build-only"
+  command = "export DATABASE_URL=\"${NETLIFY_DATABASE_URL:-$DATABASE_URL}\" && pnpm install && pnpm exec agent-native deploy --preset netlify --build-only"
   publish = "dist"
   functions = ".netlify/functions-internal"
 
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+
+[functions."*"]
+  timeout = 60


### PR DESCRIPTION
## Summary\n- add generic LLM credential error helpers so integrations/A2A/custom agents avoid leaking raw provider env var names\n- update Anthropic and Builder engine missing-credential stop events to use generic connection copy\n- quote generated Netlify database env exports and default workspace functions to 60s\n- bump @agent-native/core to 0.7.36\n\n## Validation\n- pnpm --filter @agent-native/core exec vitest run src/agent/engine/credential-errors.spec.ts src/agent/engine/anthropic-engine.spec.ts src/agent/engine/builder-engine.spec.ts src/integrations/a2a-continuation-processor.spec.ts src/integrations/webhook-handler.spec.ts\n- pnpm --filter @agent-native/core exec vitest run src/integrations/webhook-handler-engine.spec.ts\n- pnpm --filter @agent-native/core exec vitest run src/cli/create-e2e.spec.ts --testNamePattern "workspace scaffold defaults|Netlify scaffold rewrite"\n- pnpm --filter @agent-native/core exec vitest run src/deploy/workspace-deploy.spec.ts\n- pnpm --filter @agent-native/core typecheck