### PR TITLE
Use workspace app manifest in production

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.36",
+  "version": "0.7.37",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -12,6 +12,7 @@ let previousDatabaseUrl: string | undefined;
 let previousUnpooledDatabaseUrl: string | undefined;
 let previousNitroPreset: string | undefined;
 let previousViteAppBasePath: string | undefined;
+let previousWorkspaceAppsJson: string | undefined;
 let execFile: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
@@ -27,11 +28,13 @@ beforeEach(() => {
   previousUnpooledDatabaseUrl = process.env.NETLIFY_DATABASE_URL_UNPOOLED;
   previousNitroPreset = process.env.NITRO_PRESET;
   previousViteAppBasePath = process.env.VITE_APP_BASE_PATH;
+  previousWorkspaceAppsJson = process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
   delete process.env.APP_BASE_PATH;
   delete process.env.DATABASE_URL;
   delete process.env.NETLIFY_DATABASE_URL_UNPOOLED;
   delete process.env.NITRO_PRESET;
   delete process.env.VITE_APP_BASE_PATH;
+  delete process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
 });
 
 afterEach(() => {
@@ -40,6 +43,7 @@ afterEach(() => {
   restoreEnv("NETLIFY_DATABASE_URL_UNPOOLED", previousUnpooledDatabaseUrl);
   restoreEnv("NITRO_PRESET", previousNitroPreset);
   restoreEnv("VITE_APP_BASE_PATH", previousViteAppBasePath);
+  restoreEnv("AGENT_NATIVE_WORKSPACE_APPS_JSON", previousWorkspaceAppsJson);
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -63,6 +67,24 @@ describe("workspace deploy", () => {
       APP_BASE_PATH: "/dispatch",
       VITE_APP_BASE_PATH: "/dispatch",
     });
+    expect(
+      JSON.parse(dispatchCall?.env?.AGENT_NATIVE_WORKSPACE_APPS_JSON ?? "[]"),
+    ).toEqual([
+      {
+        id: "dispatch",
+        name: "Dispatch",
+        description: "",
+        path: "/dispatch",
+        isDispatch: true,
+      },
+      {
+        id: "starter",
+        name: "Starter",
+        description: "",
+        path: "/starter",
+        isDispatch: false,
+      },
+    ]);
 
     const starterCall = buildCallForApp("starter");
     expect(starterCall?.env).toMatchObject({
@@ -171,6 +193,39 @@ describe("workspace deploy", () => {
       ),
     ).toBe(false);
 
+    const dispatchManifest = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          tmpDir,
+          ".netlify",
+          "functions-internal",
+          "dispatch-server",
+          ".agent-native",
+          "workspace-apps.json",
+        ),
+        "utf-8",
+      ),
+    );
+    expect(dispatchManifest).toEqual({
+      version: 1,
+      apps: [
+        {
+          id: "dispatch",
+          name: "Dispatch",
+          description: "",
+          path: "/dispatch",
+          isDispatch: true,
+        },
+        {
+          id: "starter",
+          name: "Starter",
+          description: "",
+          path: "/starter",
+          isDispatch: false,
+        },
+      ],
+    });
+
     const dispatchServer = fs.readFileSync(
       path.join(
         tmpDir,
@@ -184,6 +239,8 @@ describe("workspace deploy", () => {
     expect(dispatchServer).toContain('const basePath = "/dispatch";');
     expect(dispatchServer).toContain("Object.assign(processRef.env");
     expect(dispatchServer).toContain("APP_BASE_PATH: basePath");
+    expect(dispatchServer).toContain("AGENT_NATIVE_WORKSPACE_APPS_JSON");
+    expect(dispatchServer).toContain('\\"path\\":\\"/starter\\"');
     expect(dispatchServer).toContain('await import("./main.mjs")');
     expect(dispatchServer).toContain(
       'path: ["/_agent-native/*","/dispatch/*"]',
@@ -228,6 +285,14 @@ describe("workspace deploy", () => {
     await dispatchModule.default();
     expect(process.env.APP_BASE_PATH).toBe("/dispatch");
     expect(process.env.VITE_APP_BASE_PATH).toBe("/dispatch");
+    expect(
+      JSON.parse(process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON ?? "[]").map(
+        (app: { id: string; path: string }) => [app.id, app.path],
+      ),
+    ).toEqual([
+      ["dispatch", "/dispatch"],
+      ["starter", "/starter"],
+    ]);
 
     const starterModule = await import(
       `${

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -32,6 +32,17 @@ const NETLIFY_PUBLIC_ASSET_EXTENSIONS = [
   "jpeg",
   "webp",
 ];
+const WORKSPACE_APPS_ENV_KEY = "AGENT_NATIVE_WORKSPACE_APPS_JSON";
+const WORKSPACE_APPS_MANIFEST_DIR = ".agent-native";
+const WORKSPACE_APPS_MANIFEST_FILE = "workspace-apps.json";
+
+interface WorkspaceAppManifestEntry {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  isDispatch: boolean;
+}
 
 export interface WorkspaceDeployOptions {
   args?: string[];
@@ -72,6 +83,7 @@ export async function runWorkspaceDeploy(
       `Workspace has no apps. Run \`agent-native add-app\` to add one.`,
     );
   }
+  const workspaceApps = readWorkspaceAppManifest(workspaceRoot, apps);
 
   const preset = resolvePreset(opts.preset, rawArgs);
   const distDir = path.join(workspaceRoot, "dist");
@@ -90,9 +102,16 @@ export async function runWorkspaceDeploy(
 
   const execFile = opts.execFile ?? execFileSync;
   for (const app of apps) {
-    buildOneApp(workspaceRoot, app, preset, execFile);
-    moveAppBuildIntoDist(workspaceRoot, app, distDir, preset);
+    buildOneApp(workspaceRoot, app, preset, execFile, workspaceApps);
+    moveAppBuildIntoDist(workspaceRoot, app, distDir, preset, workspaceApps);
   }
+  writeWorkspaceAppManifests(
+    workspaceRoot,
+    distDir,
+    apps,
+    workspaceApps,
+    preset,
+  );
 
   if (preset === "netlify") {
     writeNetlifyRedirects(distDir, apps);
@@ -126,6 +145,7 @@ function buildOneApp(
   app: string,
   preset: WorkspaceDeployPreset,
   execFile: typeof execFileSync,
+  workspaceApps: WorkspaceAppManifestEntry[],
 ): void {
   const appDir = path.join(workspaceRoot, "apps", app);
   const env: NodeJS.ProcessEnv = {
@@ -133,6 +153,7 @@ function buildOneApp(
     NITRO_PRESET: preset,
     APP_BASE_PATH: `/${app}`,
     VITE_APP_BASE_PATH: `/${app}`,
+    [WORKSPACE_APPS_ENV_KEY]: JSON.stringify(workspaceApps),
   };
 
   if (preset === "netlify" && appUsesNetlifyUnpooledDatabaseUrl(appDir)) {
@@ -160,6 +181,7 @@ function moveAppBuildIntoDist(
   app: string,
   distDir: string,
   preset: WorkspaceDeployPreset,
+  workspaceApps: WorkspaceAppManifestEntry[],
 ): void {
   const appDir = path.join(workspaceRoot, "apps", app);
   // Resolve the per-app build output: prefer dist/ (standard), fall back to
@@ -184,7 +206,7 @@ function moveAppBuildIntoDist(
     // dist/<app>/<app>/...; the workspace root already supplies the outer
     // mount path, so keeping it would publish duplicate /<app>/<app> URLs.
     fs.rmSync(path.join(target, app), { recursive: true, force: true });
-    copyNetlifyFunctionIntoWorkspace(workspaceRoot, app);
+    copyNetlifyFunctionIntoWorkspace(workspaceRoot, app, workspaceApps);
   } else {
     const target = path.join(distDir, app);
     fs.mkdirSync(target, { recursive: true });
@@ -305,6 +327,7 @@ const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
 function copyNetlifyFunctionIntoWorkspace(
   workspaceRoot: string,
   app: string,
+  workspaceApps: WorkspaceAppManifestEntry[],
 ): void {
   const appDir = path.join(workspaceRoot, "apps", app);
   const src = path.join(appDir, ".netlify", "functions-internal", "server");
@@ -317,10 +340,14 @@ function copyNetlifyFunctionIntoWorkspace(
   const dest = path.join(netlifyFunctionsDir(workspaceRoot), `${app}-server`);
   fs.rmSync(dest, { recursive: true, force: true });
   copyDir(src, dest);
-  patchNetlifyFunctionEntry(dest, app);
+  patchNetlifyFunctionEntry(dest, app, workspaceApps);
 }
 
-function patchNetlifyFunctionEntry(functionDir: string, app: string): void {
+function patchNetlifyFunctionEntry(
+  functionDir: string,
+  app: string,
+  workspaceApps: WorkspaceAppManifestEntry[],
+): void {
   const serverPath = path.join(functionDir, "server.mjs");
   if (!fs.existsSync(serverPath)) return;
 
@@ -356,6 +383,7 @@ function setBasePathEnv() {
   Object.assign(processRef.env, {
     APP_BASE_PATH: basePath,
     VITE_APP_BASE_PATH: basePath,
+    ${JSON.stringify(WORKSPACE_APPS_ENV_KEY)}: ${JSON.stringify(JSON.stringify(workspaceApps))},
   });
 }
 
@@ -418,6 +446,86 @@ function appUsesNetlifyUnpooledDatabaseUrl(appDir: string): boolean {
   } catch {
     return false;
   }
+}
+
+function writeWorkspaceAppManifests(
+  workspaceRoot: string,
+  distDir: string,
+  apps: string[],
+  workspaceApps: WorkspaceAppManifestEntry[],
+  preset: WorkspaceDeployPreset,
+): void {
+  const manifest = JSON.stringify(
+    {
+      version: 1,
+      apps: workspaceApps,
+    },
+    null,
+    2,
+  );
+
+  const targets =
+    preset === "netlify"
+      ? apps.map((app) =>
+          path.join(
+            netlifyFunctionsDir(workspaceRoot),
+            `${app}-server`,
+            WORKSPACE_APPS_MANIFEST_DIR,
+            WORKSPACE_APPS_MANIFEST_FILE,
+          ),
+        )
+      : apps.map((app) =>
+          path.join(
+            distDir,
+            app,
+            WORKSPACE_APPS_MANIFEST_DIR,
+            WORKSPACE_APPS_MANIFEST_FILE,
+          ),
+        );
+
+  for (const target of targets) {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, `${manifest}\n`);
+  }
+}
+
+function readWorkspaceAppManifest(
+  workspaceRoot: string,
+  apps: string[],
+): WorkspaceAppManifestEntry[] {
+  return apps
+    .map((app) => {
+      const appDir = path.join(workspaceRoot, "apps", app);
+      const pkg = readPackageJson(path.join(appDir, "package.json"));
+      return {
+        id: app,
+        name: pkg?.displayName || titleCase(app),
+        description: pkg?.description || "",
+        path: `/${app}`,
+        isDispatch: app === "dispatch",
+      };
+    })
+    .sort((a, b) => {
+      if (a.id === "dispatch") return -1;
+      if (b.id === "dispatch") return 1;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+function readPackageJson(file: string): Record<string, any> | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }
 
 function parsePresetArg(args: string[]): WorkspaceDeployPreset | null {

--- a/templates/dispatch/server/lib/app-creation-store.ts
+++ b/templates/dispatch/server/lib/app-creation-store.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { getSetting, putSetting } from "@agent-native/core/settings";
 import {
   getBuilderBranchProjectId,
@@ -14,6 +15,8 @@ import {
 import { grantSecretsToApp, listSecrets } from "./vault-store.js";
 
 const SETTINGS_KEY = "dispatch-app-creation-settings";
+const WORKSPACE_APPS_ENV_KEY = "AGENT_NATIVE_WORKSPACE_APPS_JSON";
+const WORKSPACE_APPS_MANIFEST_FILE = "workspace-apps.json";
 
 export interface WorkspaceAppSummary {
   id: string;
@@ -83,6 +86,88 @@ function workspaceAppUrl(appPath: string): string | null {
   }
 }
 
+function parseWorkspaceAppsManifest(parsed: any): WorkspaceAppSummary[] | null {
+  const rawApps = Array.isArray(parsed?.apps)
+    ? parsed.apps
+    : Array.isArray(parsed)
+      ? parsed
+      : null;
+  if (!rawApps) return null;
+
+  const apps = rawApps
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return null;
+      const id = typeof entry.id === "string" ? entry.id.trim() : "";
+      const pathValue = typeof entry.path === "string" ? entry.path.trim() : "";
+      if (!id || !pathValue.startsWith("/")) return null;
+      return {
+        id,
+        name:
+          typeof entry.name === "string" && entry.name.trim()
+            ? entry.name.trim()
+            : titleCase(id),
+        description:
+          typeof entry.description === "string" ? entry.description : "",
+        path: pathValue,
+        url: workspaceAppUrl(pathValue),
+        isDispatch:
+          typeof entry.isDispatch === "boolean"
+            ? entry.isDispatch
+            : id === "dispatch",
+      } satisfies WorkspaceAppSummary;
+    })
+    .filter((app): app is WorkspaceAppSummary => !!app)
+    .sort((a, b) => {
+      if (a.id === "dispatch") return -1;
+      if (b.id === "dispatch") return 1;
+      return a.name.localeCompare(b.name);
+    });
+
+  return apps.length ? apps : null;
+}
+
+function readWorkspaceAppsFromEnv(): WorkspaceAppSummary[] | null {
+  const raw = process.env[WORKSPACE_APPS_ENV_KEY];
+  if (!raw) return null;
+  try {
+    return parseWorkspaceAppsManifest(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+function workspaceAppsManifestCandidates(): string[] {
+  const candidates: string[] = [];
+  try {
+    candidates.push(
+      path.join(process.cwd(), ".agent-native", WORKSPACE_APPS_MANIFEST_FILE),
+      path.join(process.cwd(), WORKSPACE_APPS_MANIFEST_FILE),
+    );
+  } catch {
+    // Some edge runtimes do not expose process.cwd().
+  }
+  try {
+    const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+    candidates.push(
+      path.join(moduleDir, ".agent-native", WORKSPACE_APPS_MANIFEST_FILE),
+      path.join(moduleDir, WORKSPACE_APPS_MANIFEST_FILE),
+    );
+  } catch {
+    // Some edge runtimes expose non-file module URLs. The env manifest still
+    // works there, so skip file-relative candidates.
+  }
+  return candidates;
+}
+
+function readWorkspaceAppsFromManifestFile(): WorkspaceAppSummary[] | null {
+  for (const file of workspaceAppsManifestCandidates()) {
+    if (!fs.existsSync(file)) continue;
+    const apps = parseWorkspaceAppsManifest(readJson(file));
+    if (apps) return apps;
+  }
+  return null;
+}
+
 export function getEnvBuilderProjectId(): string | null {
   return (
     process.env.DISPATCH_BUILDER_PROJECT_ID ||
@@ -93,6 +178,10 @@ export function getEnvBuilderProjectId(): string | null {
 }
 
 export async function listWorkspaceApps(): Promise<WorkspaceAppSummary[]> {
+  const manifestApps =
+    readWorkspaceAppsFromEnv() ?? readWorkspaceAppsFromManifestFile();
+  if (manifestApps) return manifestApps;
+
   const workspaceRoot = findWorkspaceRoot();
   if (!workspaceRoot) {
     return [


### PR DESCRIPTION
## Summary\n- generate a workspace app manifest during workspace deploy\n- inject the manifest into per-app server functions so production Dispatch can list all mounted apps\n- have Dispatch prefer the manifest before source filesystem scanning\n- bump @agent-native/core to 0.7.37\n\n## Validation\n- pnpm --filter @agent-native/core exec vitest run src/deploy/workspace-deploy.spec.ts\n- pnpm --filter @agent-native/core typecheck