### PR TITLE
Fix workspace auth routing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.37",
+  "version": "0.7.38",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -366,8 +366,8 @@ describe("Netlify scaffold rewrite", () => {
     expect(netlify).toContain('  VITE_APP_BASE_PATH = "/dispatch"');
     expectRedirect("/", "/dispatch/overview", 302);
     expectRedirect("/dispatch", "/dispatch/overview", 302);
-    expectRedirect("/apps", "/dispatch/apps", 302);
-    expectRedirect("/new-app", "/dispatch/new-app", 302);
+    expect(netlify).not.toContain('  from = "/apps"');
+    expect(netlify).not.toContain('  from = "/new-app"');
     expect(netlify).not.toContain('from = "/dispatch/*"');
     expect(netlify).not.toContain('to = "/.netlify/functions/server"');
     expect(netlify).not.toContain("force = true");

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -974,8 +974,6 @@ function rewriteCoreDependencyVersions(projectDir: string): void {
 
 const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
   ["overview", "overview"],
-  ["apps", "apps"],
-  ["new-app", "new-app"],
   ["vault", "vault"],
   ["integrations", "integrations"],
   ["agents", "agents"],

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -332,7 +332,8 @@ describe("workspace deploy", () => {
     expect(redirects).toContain("/dispatch /dispatch/overview 302");
     expect(redirects).toContain("/login /dispatch/login 302");
     expect(redirects).toContain("/signup /dispatch/signup 302");
-    expect(redirects).toContain("/apps /dispatch/apps 302");
+    expect(redirects).not.toContain("/apps /dispatch/apps 302");
+    expect(redirects).not.toContain("/new-app /dispatch/new-app 302");
     expect(redirects).not.toMatch(/^\/dispatch\/\* .* 200$/m);
     expect(redirects).not.toMatch(/^\/starter .* 200$/m);
     expect(redirects).not.toMatch(/^\/starter\/\* .* 200$/m);

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -310,8 +310,6 @@ const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
   ["overview", "overview"],
   ["login", "login"],
   ["signup", "signup"],
-  ["apps", "apps"],
-  ["new-app", "new-app"],
   ["vault", "vault"],
   ["integrations", "integrations"],
   ["agents", "agents"],

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -986,6 +986,20 @@ describe("server/auth", () => {
       expect(html).not.toContain("window.open(data.url");
       expect(html).not.toContain("Waiting for sign-in");
     });
+
+    it("renders marketing assets under APP_BASE_PATH", async () => {
+      vi.stubEnv("APP_BASE_PATH", "/dispatch");
+      const { getOnboardingHtml } = await import("./onboarding-html.js");
+      const html = getOnboardingHtml({
+        marketing: {
+          appName: "Dispatch",
+          tagline: "Coordinate the workspace",
+        },
+      });
+
+      expect(html).toContain('src="/dispatch/agent-native-icon-dark.svg"');
+      expect(html).not.toContain('src="/agent-native-icon-dark.svg"');
+    });
   });
 
   describe("onboarding signup verification flow", () => {
@@ -1063,6 +1077,113 @@ describe("server/auth", () => {
       expect(getAppUrl(event, "/_agent-native/google/callback")).toBe(
         "https://app.example.test/docs/_agent-native/google/callback",
       );
+    });
+  });
+
+  describe("resolveOAuthRedirectUri", () => {
+    it("defaults root workspace framework-route requests to the root callback", async () => {
+      vi.stubEnv("APP_BASE_PATH", "/dispatch");
+      const { resolveOAuthRedirectUri } = await import("./google-oauth.js");
+      const event = createMockEvent({
+        path: "/_agent-native/google/auth-url",
+        headers: {
+          host: "agent-workspace.builder.io",
+          "x-forwarded-proto": "https",
+        },
+      });
+
+      expect(resolveOAuthRedirectUri(event)).toBe(
+        "https://agent-workspace.builder.io/_agent-native/google/callback",
+      );
+    });
+
+    it("defaults app-base framework-route requests to the app-base callback", async () => {
+      vi.stubEnv("APP_BASE_PATH", "/dispatch");
+      const { resolveOAuthRedirectUri } = await import("./google-oauth.js");
+      const event = createMockEvent({
+        path: "/dispatch/_agent-native/google/auth-url",
+        headers: {
+          host: "agent-workspace.builder.io",
+          "x-forwarded-proto": "https",
+        },
+      });
+
+      expect(resolveOAuthRedirectUri(event)).toBe(
+        "https://agent-workspace.builder.io/dispatch/_agent-native/google/callback",
+      );
+    });
+
+    it("allows same-origin root and app-base framework redirect overrides", async () => {
+      vi.stubEnv("APP_BASE_PATH", "/dispatch");
+      const { resolveOAuthRedirectUri } = await import("./google-oauth.js");
+      const headers = {
+        host: "agent-workspace.builder.io",
+        "x-forwarded-proto": "https",
+      };
+
+      expect(
+        resolveOAuthRedirectUri(
+          createMockEvent({
+            path: "/_agent-native/google/auth-url",
+            headers,
+            query: {
+              redirect_uri:
+                "https://agent-workspace.builder.io/_agent-native/google/callback",
+            },
+          }),
+        ),
+      ).toBe(
+        "https://agent-workspace.builder.io/_agent-native/google/callback",
+      );
+      expect(
+        resolveOAuthRedirectUri(
+          createMockEvent({
+            path: "/dispatch/_agent-native/google/auth-url",
+            headers,
+            query: {
+              redirect_uri:
+                "https://agent-workspace.builder.io/dispatch/_agent-native/google/callback",
+            },
+          }),
+        ),
+      ).toBe(
+        "https://agent-workspace.builder.io/dispatch/_agent-native/google/callback",
+      );
+    });
+
+    it("rejects cross-origin redirect overrides", async () => {
+      vi.stubEnv("APP_BASE_PATH", "/dispatch");
+      const { resolveOAuthRedirectUri } = await import("./google-oauth.js");
+      const event = createMockEvent({
+        path: "/_agent-native/google/auth-url",
+        headers: {
+          host: "agent-workspace.builder.io",
+          "x-forwarded-proto": "https",
+        },
+        query: {
+          redirect_uri: "https://evil.example/_agent-native/google/callback",
+        },
+      });
+
+      expect(resolveOAuthRedirectUri(event)).toBeNull();
+    });
+
+    it("rejects root redirect overrides from app-base framework-route requests", async () => {
+      vi.stubEnv("APP_BASE_PATH", "/dispatch");
+      const { resolveOAuthRedirectUri } = await import("./google-oauth.js");
+      const event = createMockEvent({
+        path: "/dispatch/_agent-native/google/auth-url",
+        headers: {
+          host: "agent-workspace.builder.io",
+          "x-forwarded-proto": "https",
+        },
+        query: {
+          redirect_uri:
+            "https://agent-workspace.builder.io/_agent-native/google/callback",
+        },
+      });
+
+      expect(resolveOAuthRedirectUri(event)).toBeNull();
     });
   });
 });

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -137,6 +137,46 @@ export function getAppUrl(event: H3Event, path = "/"): string {
   return `${getOrigin(event)}${getAppBasePath()}${cleanPath}`;
 }
 
+function getOriginalRequestPath(event: H3Event): string {
+  const mountedPathname = (event as any).context?._mountedPathname;
+  if (typeof mountedPathname === "string" && mountedPathname) {
+    return mountedPathname;
+  }
+
+  const urlPathname = (event as any).url?.pathname;
+  if (typeof urlPathname === "string" && urlPathname) return urlPathname;
+
+  const nodeUrl = event.node?.req?.url;
+  if (typeof nodeUrl === "string" && nodeUrl) {
+    const queryStart = nodeUrl.indexOf("?");
+    return queryStart >= 0 ? nodeUrl.slice(0, queryStart) : nodeUrl;
+  }
+
+  const eventPath = (event as any).path;
+  if (typeof eventPath === "string" && eventPath) {
+    const queryStart = eventPath.indexOf("?");
+    return queryStart >= 0 ? eventPath.slice(0, queryStart) : eventPath;
+  }
+
+  return "/";
+}
+
+function isRequestUnderAppBasePath(event: H3Event): boolean {
+  const basePath = getAppBasePath();
+  if (!basePath) return false;
+  const requestPath = getOriginalRequestPath(event);
+  return (
+    requestPath === `${basePath}/_agent-native` ||
+    requestPath.startsWith(`${basePath}/_agent-native/`)
+  );
+}
+
+function getDefaultOAuthRedirectUrl(event: H3Event, path: string): string {
+  const cleanPath = path.startsWith("/") ? path : `/${path}`;
+  const basePath = isRequestUnderAppBasePath(event) ? getAppBasePath() : "";
+  return `${getOrigin(event)}${basePath}${cleanPath}`;
+}
+
 // ─── redirect_uri Allowlist ──────────────────────────────────────────────────
 
 /**
@@ -184,10 +224,18 @@ export function isAllowedOAuthRedirectUri(
   }
   if (url.protocol !== expectedUrl.protocol) return false;
   if (url.host !== expectedUrl.host) return false;
-  // Must live under the framework's namespace.
+  // Must live under the framework's namespace. Workspace deploys can route
+  // root /_agent-native/* to Dispatch even when Dispatch itself is mounted at
+  // /dispatch, but app-prefixed requests should not be able to swap their
+  // callback to that root namespace.
   const basePath = getAppBasePath();
-  const required = `${basePath}/_agent-native/`;
-  if (!url.pathname.startsWith(required)) return false;
+  const allowedPrefixes =
+    basePath && isRequestUnderAppBasePath(event)
+      ? [`${basePath}/_agent-native/`]
+      : ["/_agent-native/"];
+  if (!allowedPrefixes.some((prefix) => url.pathname.startsWith(prefix))) {
+    return false;
+  }
   return true;
 }
 
@@ -213,7 +261,7 @@ export function resolveOAuthRedirectUri(
   if (typeof supplied === "string" && supplied.length > 0) {
     return isAllowedOAuthRedirectUri(supplied, event) ? supplied : null;
   }
-  return getAppUrl(event, defaultPath);
+  return getDefaultOAuthRedirectUrl(event, defaultPath);
 }
 
 // ─── OAuth State ─────────────────────────────────────────────────────────────

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -24,6 +24,21 @@ function getConnectionLabel(): string {
   return "SQL database";
 }
 
+function normalizeAppBasePath(value: string | undefined): string {
+  if (!value || value === "/") return "";
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "/") return "";
+  return `/${trimmed.replace(/^\/+/, "").replace(/\/+$/, "")}`;
+}
+
+function withAppBasePath(path: string): string {
+  const cleanPath = path.startsWith("/") ? path : `/${path}`;
+  const basePath = normalizeAppBasePath(
+    process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH,
+  );
+  return `${basePath}${cleanPath}`;
+}
+
 export interface OnboardingHtmlOptions {
   /**
    * Hide email/password forms and show ONLY the Google sign-in button.
@@ -50,6 +65,7 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
 
   const marketing = opts.marketing;
   const hasMarketing = !!marketing;
+  const brandMarkSrc = withAppBasePath("/agent-native-icon-dark.svg");
   const esc = (s: string) =>
     s
       .replace(/&/g, "&amp;")
@@ -178,7 +194,7 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
   <div class="marketing-panel">
     <div class="marketing-content">
       <h2 class="app-name">
-        <img class="brand-mark" src="/agent-native-icon-dark.svg" alt="" aria-hidden="true" />
+        <img class="brand-mark" src="${esc(brandMarkSrc)}" alt="" aria-hidden="true" />
         <span>${esc(marketing!.appName)}</span>
       </h2>
       <p class="app-tagline">${esc(marketing!.tagline)}</p>


### PR DESCRIPTION
## Summary
- default root workspace Google OAuth to root /_agent-native callback while keeping app-mounted callbacks for app-prefixed requests
- make onboarding marketing icon paths respect APP_BASE_PATH/VITE_APP_BASE_PATH
- stop generating root /apps and /new-app Dispatch aliases that can collide with future workspace app paths
- bump @agent-native/core to 0.7.38

## Verification
- pnpm exec prettier --write packages/core/src/server/google-oauth.ts packages/core/src/server/onboarding-html.ts packages/core/src/server/auth.spec.ts packages/core/src/deploy/workspace-deploy.ts packages/core/src/deploy/workspace-deploy.spec.ts packages/core/src/cli/create.ts packages/core/src/cli/create-e2e.spec.ts
- pnpm --filter @agent-native/core exec vitest run src/server/auth.spec.ts --testNamePattern "onboarding auth|resolveOAuthRedirectUri|getAppUrl"
- pnpm --filter @agent-native/core exec vitest run src/deploy/workspace-deploy.spec.ts src/cli/create-e2e.spec.ts --testNamePattern "Netlify|workspace"
- pnpm --filter @agent-native/core exec tsc --noEmit --pretty false

## Production QA note
- Slack app manifest QA now returns Dispatch and Starter on https://agent-workspace.builder.io after builder-workspace PR #15.