### PR TITLE
Discover workspace apps as agents

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -124,7 +124,7 @@ Create and edit visual designs by prompt or by hand, with the agent as your co-d
 
 **Mission control for agent-native apps**
 
-Centralized messaging and management for every agent in your stack. Talk to your agents from Slack, Telegram, or the web; route jobs, hold memory, approve actions, and delegate across apps.
+Message, manage, and delegate to agents from Slack, Telegram, or the web, with routing, memory, and approvals built in.
 
 </td>
 </tr>
@@ -166,7 +166,7 @@ npx @agent-native/core create my-app --standalone --template mail
 
 ## Workspaces (Monorepo)
 
-A workspace is the default shape of an agent-native project. Every app sits under `apps/`, and a shared `packages/core-module/` layers auth, agent-chat config, skills, and branding across every app — so cross-cutting concerns get wired up once, not per app.
+A workspace is the default shape of an agent-native project. Every app sits under `apps/`, and `packages/shared/` is available for the small amount of code, instructions, skills, or branding that should truly apply to every app.
 
 ```
 my-platform/
@@ -174,7 +174,7 @@ my-platform/
 ├── pnpm-workspace.yaml
 ├── .env                           # shared secrets: ANTHROPIC_API_KEY, BUILDER_PRIVATE_KEY, A2A_SECRET, ...
 ├── packages/
-│   └── core-module/               # shared auth, agent-chat plugin, skills, Tailwind v4 design tokens
+│   └── shared/                    # optional shared custom code
 └── apps/
     ├── mail/
     ├── calendar/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.39",
+  "version": "0.7.40",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -283,6 +283,7 @@ async function scaffoldOneAppIntoWorkspace(
   templateName: string,
   clack: typeof import("@clack/prompts"),
 ): Promise<void> {
+  validateWorkspaceAppName(appName, clack);
   const appsDir = path.join(workspace.workspaceRoot, "apps");
   fs.mkdirSync(appsDir, { recursive: true });
   const appDir = path.join(appsDir, appName);
@@ -974,6 +975,8 @@ function rewriteCoreDependencyVersions(projectDir: string): void {
 
 const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
   ["overview", "overview"],
+  ["login", "login"],
+  ["signup", "signup"],
   ["vault", "vault"],
   ["integrations", "integrations"],
   ["agents", "agents"],
@@ -985,6 +988,31 @@ const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
   ["audit", "audit"],
   ["team", "team"],
 ];
+
+const RESERVED_WORKSPACE_APP_NAMES = new Set([
+  "_agent-native",
+  "_workspace_static",
+  "netlify",
+  ...DISPATCH_WORKSPACE_ROOT_REDIRECTS.map(([from]) => from),
+]);
+
+function validateWorkspaceAppName(
+  appName: string,
+  clack: typeof import("@clack/prompts"),
+): void {
+  if (!/^[a-z][a-z0-9-]*$/.test(appName)) {
+    clack.cancel(
+      `Invalid app name "${appName}". Use lowercase letters, numbers, and hyphens.`,
+    );
+    process.exit(1);
+  }
+  if (RESERVED_WORKSPACE_APP_NAMES.has(appName)) {
+    clack.cancel(
+      `App name "${appName}" conflicts with a reserved workspace route. Choose a different name.`,
+    );
+    process.exit(1);
+  }
+}
 
 function upsertTomlBuildEnvironment(
   content: string,

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -370,6 +370,20 @@ describe("workspace deploy", () => {
     });
   });
 
+  it("rejects app ids that conflict with reserved workspace routes", async () => {
+    makeWorkspaceApp(tmpDir, "dispatch");
+    makeWorkspaceApp(tmpDir, "login");
+
+    await expect(
+      runWorkspaceDeploy({
+        workspaceRoot: tmpDir,
+        args: ["--preset=netlify", "--build-only"],
+        execFile: execFile as typeof execFileSync,
+      }),
+    ).rejects.toThrow(/reserved workspace routes/);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
   it("routes root framework requests to Dispatch for Cloudflare workspaces", async () => {
     makeWorkspaceApp(tmpDir, "dispatch");
     makeWorkspaceApp(tmpDir, "starter");

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -83,6 +83,7 @@ export async function runWorkspaceDeploy(
       `Workspace has no apps. Run \`agent-native add-app\` to add one.`,
     );
   }
+  assertNoReservedWorkspaceAppIds(apps);
   const workspaceApps = readWorkspaceAppManifest(workspaceRoot, apps);
 
   const preset = resolvePreset(opts.preset, rawArgs);
@@ -321,6 +322,23 @@ const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
   ["audit", "audit"],
   ["team", "team"],
 ];
+
+const RESERVED_WORKSPACE_APP_IDS = new Set([
+  "_agent-native",
+  "_workspace_static",
+  "netlify",
+  ...DISPATCH_WORKSPACE_ROOT_REDIRECTS.map(([from]) => from),
+]);
+
+function assertNoReservedWorkspaceAppIds(apps: string[]): void {
+  const conflicts = apps.filter(
+    (app) => app !== "dispatch" && RESERVED_WORKSPACE_APP_IDS.has(app),
+  );
+  if (conflicts.length === 0) return;
+  throw new Error(
+    `Workspace app id ${conflicts.map((id) => `"${id}"`).join(", ")} conflicts with reserved workspace routes. Choose a different app id.`,
+  );
+}
 
 function copyNetlifyFunctionIntoWorkspace(
   workspaceRoot: string,

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -410,4 +410,29 @@ describe("A2A continuation processor", () => {
     );
     expect(completeA2AContinuationMock).not.toHaveBeenCalled();
   });
+
+  it("reschedules and redispatches when the platform send hangs", async () => {
+    vi.useFakeTimers();
+    const sendResponse = vi.fn(() => new Promise<void>(() => {}));
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    const processing = processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    await vi.advanceTimersByTimeAsync(12_000);
+    await processing;
+
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith("cont-1", 5_000);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ continuationId: "cont-1" }),
+      }),
+    );
+    expect(completeA2AContinuationMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -26,6 +26,7 @@ const RESCHEDULE_DELAY_MS = 5_000;
 const MAX_PRE_CLAIM_WAIT_MS = RESCHEDULE_DELAY_MS + 5_000;
 const POLL_INTERVAL_MS = 2_000;
 const PROCESSOR_WAIT_MS = 20_000;
+const PLATFORM_SEND_TIMEOUT_MS = 12_000;
 const DISPATCH_SETTLE_WAIT_MS = 2_000;
 
 export async function dispatchA2AContinuation(
@@ -205,10 +206,14 @@ async function processClaimedContinuation(
   }
 
   try {
-    await adapter.sendResponse(
-      adapter.formatAgentResponse(text),
-      continuation.incoming,
-      { placeholderRef: continuation.placeholderRef ?? undefined },
+    await withTimeout(
+      adapter.sendResponse(
+        adapter.formatAgentResponse(text),
+        continuation.incoming,
+        { placeholderRef: continuation.placeholderRef ?? undefined },
+      ),
+      PLATFORM_SEND_TIMEOUT_MS,
+      `${continuation.platform} response delivery timed out`,
     );
     await completeA2AContinuation(continuation.id);
   } catch (err) {
@@ -248,10 +253,14 @@ async function notifyAndFailA2AContinuation(
 ): Promise<void> {
   const message = formatContinuationFailureMessage(continuation, reason);
   try {
-    await adapter.sendResponse(
-      adapter.formatAgentResponse(message),
-      continuation.incoming,
-      { placeholderRef: continuation.placeholderRef ?? undefined },
+    await withTimeout(
+      adapter.sendResponse(
+        adapter.formatAgentResponse(message),
+        continuation.incoming,
+        { placeholderRef: continuation.placeholderRef ?? undefined },
+      ),
+      PLATFORM_SEND_TIMEOUT_MS,
+      `${continuation.platform} failure notification timed out`,
     );
   } catch (err) {
     console.error(
@@ -284,6 +293,24 @@ function isRemoteWorkExpired(continuation: A2AContinuation): boolean {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 function sanitizeFailureReason(reason: string): string {

--- a/packages/core/src/integrations/adapters/slack.spec.ts
+++ b/packages/core/src/integrations/adapters/slack.spec.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { slackAdapter } from "./slack.js";
 
 describe("slackAdapter", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete process.env.SLACK_BOT_TOKEN;
+  });
+
   it("answers Slack URL verification with the raw challenge string", async () => {
     const adapter = slackAdapter();
     const event = {
@@ -27,5 +33,41 @@ describe("slackAdapter", () => {
     expect(formatted.text).toBe(
       "<https://slides.agent-native.com/deck/deck-qa>",
     );
+  });
+
+  it("aborts hung Slack delivery requests", async () => {
+    vi.useFakeTimers();
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    let deliverySignal: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (String(url).includes("assistant.threads.setStatus")) {
+          return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+        }
+        deliverySignal = init?.signal ?? undefined;
+        return new Promise<Response>((resolve) => {
+          init?.signal?.addEventListener("abort", () => {
+            resolve(new Response(JSON.stringify({ ok: true })));
+          });
+        });
+      }),
+    );
+
+    const delivery = slackAdapter().sendResponse(
+      { text: "done", platformContext: {} },
+      {
+        platform: "slack",
+        externalThreadId: "C123:123.456",
+        text: "make a deck",
+        timestamp: 1,
+        platformContext: { channelId: "C123", threadTs: "123.456" },
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await delivery;
+
+    expect(deliverySignal?.aborted).toBe(true);
   });
 });

--- a/packages/core/src/integrations/adapters/slack.ts
+++ b/packages/core/src/integrations/adapters/slack.ts
@@ -12,6 +12,7 @@ import { getIntegrationConfig } from "../config-store.js";
 
 /** Slack's max message length */
 const SLACK_MAX_LENGTH = 4000;
+const SLACK_API_TIMEOUT_MS = 10_000;
 
 /**
  * Create a Slack platform adapter.
@@ -241,7 +242,7 @@ export function slackAdapter(): PlatformAdapter {
       try {
         if (placeholderRef) {
           // Replace the "thinking…" placeholder in place.
-          const res = await fetch("https://slack.com/api/chat.update", {
+          const res = await slackApiFetch("https://slack.com/api/chat.update", {
             method: "POST",
             headers: {
               Authorization: `Bearer ${token}`,
@@ -303,14 +304,17 @@ export function slackAdapter(): PlatformAdapter {
         if (target.threadRef) body.thread_ts = target.threadRef;
 
         try {
-          const res = await fetch("https://slack.com/api/chat.postMessage", {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${token}`,
-              "Content-Type": "application/json",
+          const res = await slackApiFetch(
+            "https://slack.com/api/chat.postMessage",
+            {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify(body),
             },
-            body: JSON.stringify(body),
-          });
+          );
           const data = (await res.json()) as { ok: boolean; error?: string };
           if (!data.ok) {
             throw new Error(data.error || "chat.postMessage failed");
@@ -537,7 +541,7 @@ function setSlackAssistantStatus(
   threadTs: string,
   status: string,
 ): void {
-  fetch("https://slack.com/api/assistant.threads.setStatus", {
+  slackApiFetch("https://slack.com/api/assistant.threads.setStatus", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -598,7 +602,7 @@ async function postFresh(
     channel: channelId,
   };
   if (threadTs && !payload.thread_ts) payload.thread_ts = threadTs;
-  const res = await fetch("https://slack.com/api/chat.postMessage", {
+  const res = await slackApiFetch("https://slack.com/api/chat.postMessage", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -610,5 +614,24 @@ async function postFresh(
   if (!data.ok) {
     console.error("[slack] chat.postMessage error:", data.error);
     throw new Error(data.error || "chat.postMessage failed");
+  }
+}
+
+async function slackApiFetch(
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  const controller =
+    typeof AbortController !== "undefined" ? new AbortController() : undefined;
+  const timer = controller
+    ? setTimeout(() => controller.abort(), SLACK_API_TIMEOUT_MS)
+    : undefined;
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller?.signal ?? init.signal,
+    });
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }

--- a/packages/core/src/server/agent-discovery.spec.ts
+++ b/packages/core/src/server/agent-discovery.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BUILTIN_AGENTS_FOR_SEEDING,
   discoverAgents,
@@ -9,6 +9,8 @@ import { visibleTemplates } from "../cli/templates-meta.js";
 const resourceListMock = vi.hoisted(() => vi.fn());
 const resourceListAccessibleMock = vi.hoisted(() => vi.fn());
 const resourceGetMock = vi.hoisted(() => vi.fn());
+let previousWorkspaceAppsJson: string | undefined;
+let previousAppUrl: string | undefined;
 
 vi.mock("../resources/store.js", () => ({
   resourceGet: resourceGetMock,
@@ -27,6 +29,15 @@ describe("agent discovery", () => {
     resourceListMock.mockResolvedValue([]);
     resourceListAccessibleMock.mockResolvedValue([]);
     resourceGetMock.mockResolvedValue(null);
+    previousWorkspaceAppsJson = process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
+    previousAppUrl = process.env.APP_URL;
+    delete process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
+    delete process.env.APP_URL;
+  });
+
+  afterEach(() => {
+    restoreEnv("AGENT_NATIVE_WORKSPACE_APPS_JSON", previousWorkspaceAppsJson);
+    restoreEnv("APP_URL", previousAppUrl);
   });
 
   it("derives built-in connected agents from visible production templates", () => {
@@ -93,4 +104,59 @@ describe("agent discovery", () => {
     expect(ids).not.toContain("recruiting");
     expect(ids).toContain("custom-qa");
   });
+
+  it("discovers sibling workspace apps from the workspace manifest", async () => {
+    process.env.APP_URL = "https://workspace.example.test";
+    process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({
+      version: 1,
+      apps: [
+        {
+          id: "dispatch",
+          name: "Dispatch",
+          path: "/dispatch",
+          isDispatch: true,
+        },
+        {
+          id: "starter",
+          name: "Starter",
+          description: "Workspace starter",
+          path: "/starter",
+          isDispatch: false,
+        },
+        {
+          id: "mail",
+          name: "Workspace Mail",
+          description: "Workspace-specific mail app",
+          path: "/mail",
+          isDispatch: false,
+        },
+      ],
+    });
+
+    const agents = await discoverAgents("dispatch");
+    const starter = agents.find((agent) => agent.id === "starter");
+    const mail = agents.find((agent) => agent.id === "mail");
+
+    expect(agents.map((agent) => agent.id)).not.toContain("dispatch");
+    expect(starter).toMatchObject({
+      id: "starter",
+      name: "Starter",
+      description: "Workspace starter",
+      url: "https://workspace.example.test/starter",
+    });
+    expect(mail).toMatchObject({
+      id: "mail",
+      name: "Workspace Mail",
+      description: "Workspace-specific mail app",
+      url: "https://workspace.example.test/mail",
+    });
+  });
 });
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}

--- a/packages/core/src/server/agent-discovery.ts
+++ b/packages/core/src/server/agent-discovery.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { TEMPLATES, visibleTemplates } from "../cli/templates-meta.js";
 
 export interface DiscoveredAgent {
@@ -40,6 +43,18 @@ const HIDDEN_FIRST_PARTY_AGENT_IDS = new Set(
     (template) => template.name,
   ),
 );
+
+const WORKSPACE_APPS_ENV_KEY = "AGENT_NATIVE_WORKSPACE_APPS_JSON";
+const WORKSPACE_APPS_MANIFEST_FILE = "workspace-apps.json";
+
+interface WorkspaceAppManifestEntry {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+  url?: string | null;
+  isDispatch?: boolean;
+}
 
 /**
  * Get built-in agents (static, no DB). Used as fallback and for seeding.
@@ -127,6 +142,12 @@ export async function discoverAgents(
     // Resources not available — use built-ins only
   }
 
+  // Overlay sibling workspace apps last so same-origin workspaces prefer the
+  // app mounted in this workspace over the public template with the same id.
+  for (const agent of discoverWorkspaceAgents(selfAppId)) {
+    agentsById.set(agent.id, agent);
+  }
+
   return Array.from(agentsById.values());
 }
 
@@ -153,6 +174,205 @@ function resolveAgentUrl(app: AgentEntry): string {
     return app.devUrl || `http://localhost:${app.devPort}`;
   }
   return app.url;
+}
+
+function readJson(file: string): any {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function findWorkspaceRoot(startDir = process.cwd()): string | null {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i < 20; i++) {
+    const pkg = readJson(path.join(dir, "package.json"));
+    if (typeof pkg?.["agent-native"]?.workspaceCore === "string") {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function titleCase(value: string): string {
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function parseWorkspaceAppsManifest(
+  parsed: any,
+): WorkspaceAppManifestEntry[] | null {
+  const rawApps = Array.isArray(parsed?.apps)
+    ? parsed.apps
+    : Array.isArray(parsed)
+      ? parsed
+      : null;
+  if (!rawApps) return null;
+
+  const apps = rawApps
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return null;
+      const id = typeof entry.id === "string" ? entry.id.trim() : "";
+      const pathValue = typeof entry.path === "string" ? entry.path.trim() : "";
+      if (!id || !pathValue.startsWith("/")) return null;
+      return {
+        id,
+        name:
+          typeof entry.name === "string" && entry.name.trim()
+            ? entry.name.trim()
+            : titleCase(id),
+        description:
+          typeof entry.description === "string" ? entry.description : "",
+        path: pathValue,
+        url:
+          typeof entry.url === "string" && entry.url.trim()
+            ? entry.url.trim()
+            : null,
+        isDispatch:
+          typeof entry.isDispatch === "boolean"
+            ? entry.isDispatch
+            : id === "dispatch",
+      } satisfies WorkspaceAppManifestEntry;
+    })
+    .filter((app): app is WorkspaceAppManifestEntry => !!app)
+    .sort((a, b) => {
+      if (a.id === "dispatch") return -1;
+      if (b.id === "dispatch") return 1;
+      return a.name.localeCompare(b.name);
+    });
+
+  return apps.length ? apps : null;
+}
+
+function readWorkspaceAppsFromEnv(): WorkspaceAppManifestEntry[] | null {
+  const raw = process.env[WORKSPACE_APPS_ENV_KEY];
+  if (!raw) return null;
+  try {
+    return parseWorkspaceAppsManifest(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+function workspaceAppsManifestCandidates(): string[] {
+  const candidates: string[] = [];
+  try {
+    candidates.push(
+      path.join(process.cwd(), ".agent-native", WORKSPACE_APPS_MANIFEST_FILE),
+      path.join(process.cwd(), WORKSPACE_APPS_MANIFEST_FILE),
+    );
+  } catch {
+    // Some edge runtimes do not expose process.cwd().
+  }
+  try {
+    const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+    candidates.push(
+      path.join(moduleDir, ".agent-native", WORKSPACE_APPS_MANIFEST_FILE),
+      path.join(moduleDir, WORKSPACE_APPS_MANIFEST_FILE),
+    );
+  } catch {
+    // Some edge runtimes expose non-file module URLs. The env manifest still
+    // works there, so skip file-relative candidates.
+  }
+  return candidates;
+}
+
+function readWorkspaceAppsFromManifestFile():
+  | WorkspaceAppManifestEntry[]
+  | null {
+  for (const file of workspaceAppsManifestCandidates()) {
+    if (!fs.existsSync(file)) continue;
+    const apps = parseWorkspaceAppsManifest(readJson(file));
+    if (apps) return apps;
+  }
+  return null;
+}
+
+function readWorkspaceAppsFromFilesystem(): WorkspaceAppManifestEntry[] | null {
+  const workspaceRoot = findWorkspaceRoot();
+  if (!workspaceRoot) return null;
+  const appsDir = path.join(workspaceRoot, "apps");
+  if (!fs.existsSync(appsDir)) return null;
+
+  const apps = fs
+    .readdirSync(appsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry): WorkspaceAppManifestEntry | null => {
+      const appDir = path.join(appsDir, entry.name);
+      const pkg = readJson(path.join(appDir, "package.json"));
+      if (!pkg) return null;
+      return {
+        id: entry.name,
+        name: pkg.displayName || titleCase(entry.name),
+        description: pkg.description || "",
+        path: `/${entry.name}`,
+        isDispatch: entry.name === "dispatch",
+      } satisfies WorkspaceAppManifestEntry;
+    })
+    .filter((app): app is WorkspaceAppManifestEntry => !!app)
+    .sort((a, b) => {
+      if (a.id === "dispatch") return -1;
+      if (b.id === "dispatch") return 1;
+      return a.name.localeCompare(b.name);
+    });
+
+  return apps.length ? apps : null;
+}
+
+function workspaceBaseUrl(): string | null {
+  return (
+    process.env.WORKSPACE_GATEWAY_URL ||
+    process.env.APP_URL ||
+    process.env.URL ||
+    process.env.DEPLOY_URL ||
+    process.env.BETTER_AUTH_URL ||
+    null
+  );
+}
+
+function workspaceAppUrl(app: WorkspaceAppManifestEntry): string | null {
+  if (app.url) return app.url;
+  const base = workspaceBaseUrl();
+  if (!base) return null;
+  try {
+    return new URL(app.path, `${base.replace(/\/$/, "")}/`).toString();
+  } catch {
+    return null;
+  }
+}
+
+function discoverWorkspaceAgents(selfAppId?: string): DiscoveredAgent[] {
+  const workspaceApps =
+    readWorkspaceAppsFromEnv() ??
+    readWorkspaceAppsFromManifestFile() ??
+    readWorkspaceAppsFromFilesystem();
+  if (!workspaceApps) return [];
+
+  return workspaceApps
+    .filter((app) => app.id !== selfAppId)
+    .map((app) => {
+      const url = workspaceAppUrl(app);
+      if (!url) return null;
+      const builtin = BUILTIN_AGENTS.find((agent) => agent.id === app.id);
+      return {
+        id: app.id,
+        name: app.name,
+        description:
+          app.description ||
+          builtin?.description ||
+          `Workspace app mounted at ${app.path}`,
+        url,
+        color: builtin?.color || "#6B7280",
+      } satisfies DiscoveredAgent;
+    })
+    .filter((agent): agent is DiscoveredAgent => !!agent);
 }
 
 /**


### PR DESCRIPTION
## Summary\n- Discover sibling workspace apps from the generated workspace manifest/env/file system and expose them as agents\n- Overlay workspace apps over public template agents so same-origin apps win when ids match\n- Reserve workspace root route names in CLI/deploy so apps cannot collide with Dispatch root aliases\n- Bump @agent-native/core to 0.7.40\n\n## Verification\n- pnpm exec prettier --write packages/core/src/cli/create.ts packages/core/src/deploy/workspace-deploy.ts packages/core/src/deploy/workspace-deploy.spec.ts packages/core/src/server/agent-discovery.ts packages/core/src/server/agent-discovery.spec.ts\n- pnpm --filter @agent-native/core exec vitest run src/server/agent-discovery.spec.ts src/deploy/workspace-deploy.spec.ts --testNamePattern "workspace manifest|reserved workspace routes|sibling workspace apps"\n- pnpm --filter @agent-native/core exec tsc --noEmit --pretty false