### PR TITLE
Fix workspace Netlify root asset routing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.40",
+  "version": "0.7.41",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -246,7 +246,10 @@ describe("workspace deploy", () => {
       'path: ["/_agent-native/*","/dispatch/*"]',
     );
     expect(dispatchServer).toContain('"/dispatch/assets/*"');
-    expect(dispatchServer).toContain('"/dispatch/*.svg"');
+    expect(dispatchServer).toContain('"/dispatch/favicon.svg"');
+    expect(dispatchServer).toContain('"/dispatch/site.webmanifest"');
+    expect(dispatchServer).not.toContain('"/dispatch/*.json"');
+    expect(dispatchServer).not.toContain('"/dispatch/*.svg"');
     expect(dispatchServer).toContain('"/.netlify/*"');
     expect(dispatchServer).toContain("preferStatic: false");
     expect(dispatchServer).not.toContain("normalizeBasePathArgs");
@@ -264,7 +267,10 @@ describe("workspace deploy", () => {
     expect(starterServer).toContain('path: ["/starter","/starter/*"]');
     expect(starterServer).toContain("normalizeBasePathArgs");
     expect(starterServer).toContain('"/starter/assets/*"');
-    expect(starterServer).toContain('"/starter/*.webmanifest"');
+    expect(starterServer).toContain('"/starter/favicon.svg"');
+    expect(starterServer).toContain('"/starter/site.webmanifest"');
+    expect(starterServer).not.toContain('"/starter/*.json"');
+    expect(starterServer).not.toContain('"/starter/*.webmanifest"');
     expect(starterServer).toContain("preferStatic: false");
 
     const dispatchModule = await import(
@@ -320,11 +326,15 @@ describe("workspace deploy", () => {
       "/dispatch/assets/* /_workspace_static/dispatch/assets/:splat 200",
     );
     expect(redirects).toContain(
-      "/dispatch/:file.svg /_workspace_static/dispatch/:file.svg 200",
+      "/dispatch/favicon.svg /_workspace_static/dispatch/favicon.svg 200",
     );
     expect(redirects).toContain(
-      "/starter/:file.webmanifest /_workspace_static/starter/:file.webmanifest 200",
+      "/starter/site.webmanifest /_workspace_static/starter/site.webmanifest 200",
     );
+    expect(redirects).not.toContain("/:file.json");
+    expect(redirects).not.toContain("/:file.svg");
+    expect(redirects).not.toContain("/:file.webmanifest");
+    expect(redirects).not.toContain("/.well-known/");
     expect(redirects).toContain(
       "/_agent-native/* /.netlify/functions/dispatch-server 200",
     );

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -247,6 +247,8 @@ describe("workspace deploy", () => {
     );
     expect(dispatchServer).toContain('"/dispatch/assets/*"');
     expect(dispatchServer).toContain('"/dispatch/favicon.svg"');
+    expect(dispatchServer).toContain('"/dispatch/manifest.json"');
+    expect(dispatchServer).toContain('"/dispatch/robots.txt"');
     expect(dispatchServer).toContain('"/dispatch/site.webmanifest"');
     expect(dispatchServer).not.toContain('"/dispatch/*.json"');
     expect(dispatchServer).not.toContain('"/dispatch/*.svg"');
@@ -267,7 +269,9 @@ describe("workspace deploy", () => {
     expect(starterServer).toContain('path: ["/starter","/starter/*"]');
     expect(starterServer).toContain("normalizeBasePathArgs");
     expect(starterServer).toContain('"/starter/assets/*"');
+    expect(starterServer).toContain('"/starter/feed.xml"');
     expect(starterServer).toContain('"/starter/favicon.svg"');
+    expect(starterServer).toContain('"/starter/icon-192.png"');
     expect(starterServer).toContain('"/starter/site.webmanifest"');
     expect(starterServer).not.toContain('"/starter/*.json"');
     expect(starterServer).not.toContain('"/starter/*.webmanifest"');
@@ -327,6 +331,21 @@ describe("workspace deploy", () => {
     );
     expect(redirects).toContain(
       "/dispatch/favicon.svg /_workspace_static/dispatch/favicon.svg 200",
+    );
+    expect(redirects).toContain(
+      "/dispatch/manifest.json /_workspace_static/dispatch/manifest.json 200",
+    );
+    expect(redirects).toContain(
+      "/dispatch/robots.txt /_workspace_static/dispatch/robots.txt 200",
+    );
+    expect(redirects).toContain(
+      "/starter/feed.xml /_workspace_static/starter/feed.xml 200",
+    );
+    expect(redirects).toContain(
+      "/starter/icon-192.png /_workspace_static/starter/icon-192.png 200",
+    );
+    expect(redirects).toContain(
+      "/starter/poster.avif /_workspace_static/starter/poster.avif 200",
     );
     expect(redirects).toContain(
       "/starter/site.webmanifest /_workspace_static/starter/site.webmanifest 200",
@@ -488,6 +507,12 @@ function writeAppBuildOutput(workspaceRoot: string, app: string): void {
     path.join(appDir, "dist", app, "favicon.svg"),
     "<svg></svg>",
   );
+  fs.writeFileSync(path.join(appDir, "dist", app, "favicon.ico"), "");
+  fs.writeFileSync(path.join(appDir, "dist", app, "feed.xml"), "<feed />");
+  fs.writeFileSync(path.join(appDir, "dist", app, "icon-192.png"), "");
+  fs.writeFileSync(path.join(appDir, "dist", app, "manifest.json"), "{}");
+  fs.writeFileSync(path.join(appDir, "dist", app, "poster.avif"), "");
+  fs.writeFileSync(path.join(appDir, "dist", app, "robots.txt"), "");
   fs.writeFileSync(path.join(appDir, "dist", app, "site.webmanifest"), "{}");
   fs.mkdirSync(path.join(appDir, "dist", app, app, "assets"), {
     recursive: true,

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -22,7 +22,7 @@ import { findWorkspaceRoot } from "../scripts/utils.js";
 export type WorkspaceDeployPreset = "cloudflare_pages" | "netlify";
 
 const NETLIFY_WORKSPACE_STATIC_DIR = "_workspace_static";
-const NETLIFY_PUBLIC_ASSET_EXTENSIONS = [
+const NETLIFY_PUBLIC_ASSET_EXTENSIONS = new Set([
   "svg",
   "json",
   "webmanifest",
@@ -31,7 +31,7 @@ const NETLIFY_PUBLIC_ASSET_EXTENSIONS = [
   "jpg",
   "jpeg",
   "webp",
-];
+]);
 const WORKSPACE_APPS_ENV_KEY = "AGENT_NATIVE_WORKSPACE_APPS_JSON";
 const WORKSPACE_APPS_MANIFEST_DIR = ".agent-native";
 const WORKSPACE_APPS_MANIFEST_FILE = "workspace-apps.json";
@@ -207,7 +207,7 @@ function moveAppBuildIntoDist(
     // dist/<app>/<app>/...; the workspace root already supplies the outer
     // mount path, so keeping it would publish duplicate /<app>/<app> URLs.
     fs.rmSync(path.join(target, app), { recursive: true, force: true });
-    copyNetlifyFunctionIntoWorkspace(workspaceRoot, app, workspaceApps);
+    copyNetlifyFunctionIntoWorkspace(workspaceRoot, app, workspaceApps, target);
   } else {
     const target = path.join(distDir, app);
     fs.mkdirSync(target, { recursive: true });
@@ -280,7 +280,7 @@ function writeNetlifyRedirects(distDir: string, apps: string[]): void {
   }
 
   for (const app of apps) {
-    lines.push(...netlifyAssetRedirectsFor(app));
+    lines.push(...netlifyAssetRedirectsFor(app, distDir));
   }
 
   if (apps.includes("dispatch")) {
@@ -296,14 +296,18 @@ function writeNetlifyRedirects(distDir: string, apps: string[]): void {
   fs.writeFileSync(path.join(distDir, "_redirects"), lines.join("\n") + "\n");
 }
 
-function netlifyAssetRedirectsFor(app: string): string[] {
+function netlifyAssetRedirectsFor(app: string, distDir: string): string[] {
   const from = `/${app}`;
   const to = `/${NETLIFY_WORKSPACE_STATIC_DIR}/${app}`;
   return [
     `${from}/assets/* ${to}/assets/:splat 200`,
-    ...NETLIFY_PUBLIC_ASSET_EXTENSIONS.map(
-      (ext) => `${from}/:file.${ext} ${to}/:file.${ext} 200`,
-    ),
+    ...netlifyPublicRootAssetPaths(
+      app,
+      path.join(distDir, NETLIFY_WORKSPACE_STATIC_DIR, app),
+    ).map((assetPath) => {
+      const assetName = assetPath.slice(from.length + 1);
+      return `${assetPath} ${to}/${assetName} 200`;
+    }),
   ];
 }
 
@@ -344,6 +348,7 @@ function copyNetlifyFunctionIntoWorkspace(
   workspaceRoot: string,
   app: string,
   workspaceApps: WorkspaceAppManifestEntry[],
+  staticDir: string,
 ): void {
   const appDir = path.join(workspaceRoot, "apps", app);
   const src = path.join(appDir, ".netlify", "functions-internal", "server");
@@ -356,13 +361,14 @@ function copyNetlifyFunctionIntoWorkspace(
   const dest = path.join(netlifyFunctionsDir(workspaceRoot), `${app}-server`);
   fs.rmSync(dest, { recursive: true, force: true });
   copyDir(src, dest);
-  patchNetlifyFunctionEntry(dest, app, workspaceApps);
+  patchNetlifyFunctionEntry(dest, app, workspaceApps, staticDir);
 }
 
 function patchNetlifyFunctionEntry(
   functionDir: string,
   app: string,
   workspaceApps: WorkspaceAppManifestEntry[],
+  staticDir: string,
 ): void {
   const serverPath = path.join(functionDir, "server.mjs");
   if (!fs.existsSync(serverPath)) return;
@@ -420,7 +426,11 @@ export const config = {
   path: ${JSON.stringify(pathConfig)},
   nodeBundler: "none",
   includedFiles: ["**"],
-  excludedPath: ${JSON.stringify(netlifyFunctionExcludedPaths(app), null, 2)
+  excludedPath: ${JSON.stringify(
+    netlifyFunctionExcludedPaths(app, staticDir),
+    null,
+    2,
+  )
     .split("\n")
     .join("\n  ")},
   preferStatic: false,
@@ -430,12 +440,29 @@ export const config = {
   fs.writeFileSync(path.join(functionDir, `${app}-server.mjs`), server);
 }
 
-function netlifyFunctionExcludedPaths(app: string): string[] {
+function netlifyFunctionExcludedPaths(
+  app: string,
+  staticDir: string,
+): string[] {
   return [
     "/.netlify/*",
     `/${app}/assets/*`,
-    ...NETLIFY_PUBLIC_ASSET_EXTENSIONS.map((ext) => `/${app}/*.${ext}`),
+    ...netlifyPublicRootAssetPaths(app, staticDir),
   ];
+}
+
+function netlifyPublicRootAssetPaths(app: string, staticDir: string): string[] {
+  if (!fs.existsSync(staticDir)) return [];
+  return fs
+    .readdirSync(staticDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => {
+      const ext = path.extname(name).slice(1).toLowerCase();
+      return NETLIFY_PUBLIC_ASSET_EXTENSIONS.has(ext);
+    })
+    .sort()
+    .map((name) => `/${app}/${encodeURI(name)}`);
 }
 
 function netlifyFunctionsDir(workspaceRoot: string): string {

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -23,14 +23,25 @@ export type WorkspaceDeployPreset = "cloudflare_pages" | "netlify";
 
 const NETLIFY_WORKSPACE_STATIC_DIR = "_workspace_static";
 const NETLIFY_PUBLIC_ASSET_EXTENSIONS = new Set([
-  "svg",
-  "json",
-  "webmanifest",
+  "avif",
+  "css",
+  "gif",
   "ico",
-  "png",
-  "jpg",
   "jpeg",
+  "jpg",
+  "js",
+  "json",
+  "map",
+  "mp4",
+  "pdf",
+  "png",
+  "svg",
+  "txt",
+  "wasm",
+  "webm",
+  "webmanifest",
   "webp",
+  "xml",
 ]);
 const WORKSPACE_APPS_ENV_KEY = "AGENT_NATIVE_WORKSPACE_APPS_JSON";
 const WORKSPACE_APPS_MANIFEST_DIR = ".agent-native";

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -318,6 +318,64 @@ describe("server/auth", () => {
       expect(result).toBeUndefined();
     });
 
+    it("serves mounted login and signup pages from the framework guard", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("APP_BASE_PATH", "/dispatch");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      delete process.env.AUTH_DISABLED;
+      delete process.env.AUTH_MODE;
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app, {
+        getSession: async () => null,
+        loginHtml: "<!doctype html><title>QA login</title>",
+      });
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      for (const path of ["/dispatch/login", "/dispatch/signup"]) {
+        const result = await guard(createMockEvent({ path }));
+
+        expect(result).toBeInstanceOf(Response);
+        expect((result as Response).status).toBe(200);
+        expect(await (result as Response).text()).toContain("QA login");
+      }
+    });
+
+    it("redirects mounted login and signup pages when a session already exists", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("APP_BASE_PATH", "/dispatch");
+      delete process.env.ACCESS_TOKEN;
+      delete process.env.ACCESS_TOKENS;
+      delete process.env.AUTH_DISABLED;
+      delete process.env.AUTH_MODE;
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app, {
+        getSession: async () => ({ email: "qa+local@example.com" }),
+        loginHtml: "<!doctype html><title>QA login</title>",
+      });
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      for (const path of ["/dispatch/login", "/dispatch/signup"]) {
+        const result = await guard(createMockEvent({ path }));
+
+        expect(result).toBeInstanceOf(Response);
+        expect((result as Response).status).toBe(302);
+        expect((result as Response).headers.get("location")).toBe("/dispatch");
+      }
+    });
+
     it("allows app-state request-source headers in CORS preflight responses", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("ACCESS_TOKEN", "my-secret");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -885,6 +885,23 @@ function createAuthGuardFn(): (
       });
     }
 
+    // Auth entry pages are framework-owned pages, not app routes. When a user
+    // already has a session (including AUTH_MODE=local), redirect them back to
+    // the mounted app instead of letting React Router try to render /login.
+    if (p === "/login" || p === "/signup") {
+      const session = await getSession(event);
+      if (session) {
+        return new Response("", {
+          status: 302,
+          headers: { Location: getAppBasePath() || "/" },
+        });
+      }
+      return new Response(loginHtml, {
+        status: 200,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    }
+
     // Skip static assets (Vite chunks, fonts, images, etc.)
     if (
       p.startsWith("/assets/") ||

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getOnboardingHtml } from "./onboarding-html.js";
 
 describe("getOnboardingHtml", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("does not include local upgrade copy in SSR HTML by default", () => {
     const html = getOnboardingHtml();
 
@@ -18,5 +22,22 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain(
       "Continue signing in to attach this app to your account and migrate local data.",
     );
+  });
+
+  it("injects APP_BASE_PATH so mounted login pages call app-scoped auth endpoints", () => {
+    vi.stubEnv("APP_BASE_PATH", "/starter/");
+    vi.stubEnv("GOOGLE_CLIENT_ID", "google-client-id");
+    vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-client-secret");
+
+    const html = getOnboardingHtml();
+
+    expect(html).toContain('var configured = "/starter";');
+    expect(html).toContain("__anPath('/_agent-native/auth/session')");
+    expect(html).toContain("__anPath('/_agent-native/auth/register')");
+    expect(html).toContain("__anPath('/_agent-native/auth/login')");
+    expect(html).toContain(
+      "__anPath('/_agent-native/auth/ba/request-password-reset')",
+    );
+    expect(html).toContain("__anPath('/_agent-native/google/auth-url')");
   });
 });

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -62,6 +62,9 @@ export interface OnboardingHtmlOptions {
 export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
   const showGoogle = hasGoogleOAuth();
   const googleOnly = !!opts.googleOnly;
+  const appBasePath = normalizeAppBasePath(
+    process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH,
+  );
 
   const marketing = opts.marketing;
   const hasMarketing = !!marketing;
@@ -683,6 +686,8 @@ ${
 </p>${marketingCloseHtml}
 <script>
   function __anBasePath() {
+    var configured = ${JSON.stringify(appBasePath)};
+    if (configured) return configured;
     var marker = '/_agent-native';
     var idx = window.location.pathname.indexOf(marker);
     return idx > 0 ? window.location.pathname.slice(0, idx) : '';


### PR DESCRIPTION
## Summary\n- make workspace Netlify redirects enumerate actual root assets instead of wildcarding json/svg/webmanifest files\n- keep app server functions from claiming static root assets while avoiding broad /:file.json style rules\n- bump @agent-native/core to 0.7.41\n\n## Tests\n- pnpm --filter @agent-native/core exec vitest run src/deploy/workspace-deploy.spec.ts --testNamePattern "Netlify"\n- pnpm --filter @agent-native/core exec tsc --noEmit --pretty false\n- pnpm exec prettier --write packages/core/src/deploy/workspace-deploy.ts packages/core/src/deploy/workspace-deploy.spec.ts packages/core/package.json\n- git diff --check