### PR TITLE
Fix app-scoped agent cards during startup

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.41",
+  "version": "0.7.42",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/client.spec.ts
+++ b/packages/core/src/a2a/client.spec.ts
@@ -1,15 +1,75 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { A2AClient, A2ATaskTimeoutError } from "./client.js";
+import { A2AClient, A2ATaskTimeoutError, callAgent } from "./client.js";
 
 describe("A2AClient", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
+  it("uses the A2A endpoint advertised by the agent card", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init) {
+        expect(url).toBe("https://agent.test/.well-known/agent-card.json");
+        return new Response(
+          JSON.stringify({
+            name: "Standard Agent",
+            description: "Uses the conventional A2A endpoint",
+            url: "https://agent.test/a2a",
+            version: "1.0.0",
+            protocolVersion: "0.3",
+            capabilities: {},
+            skills: [],
+          }),
+          { status: 200 },
+        );
+      }
+
+      expect(url).toBe("https://agent.test/a2a");
+      const body = JSON.parse(String(init.body));
+      return completedResponse(body, "hello from standard a2a");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      callAgent("https://agent.test", "hello", { async: false }),
+    ).resolves.toBe("hello from standard a2a");
+
+    const postUrls = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === "POST")
+      .map(([url]) => url);
+    expect(postUrls).toEqual(["https://agent.test/a2a"]);
+  });
+
+  it("falls back to /a2a when the agent-native endpoint is absent", async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (!init) return new Response("not found", { status: 404 });
+      if (url === "https://agent.test/_agent-native/a2a") {
+        return new Response("not found", { status: 404 });
+      }
+      expect(url).toBe("https://agent.test/a2a");
+      const body = JSON.parse(String(init.body));
+      return completedResponse(body, "fallback ok");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      callAgent("https://agent.test", "hello", { async: false }),
+    ).resolves.toBe("fallback ok");
+
+    const postUrls = fetchMock.mock.calls
+      .filter(([, init]) => init?.method === "POST")
+      .map(([url]) => url);
+    expect(postUrls).toEqual([
+      "https://agent.test/_agent-native/a2a",
+      "https://agent.test/a2a",
+    ]);
+  });
+
   it("throws structured timeout errors with the remote task id", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (_url: string, init: RequestInit) => {
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        if (!init) return new Response("not found", { status: 404 });
         const body = JSON.parse(String(init.body));
         if (body.method === "message/send") {
           return new Response(
@@ -63,3 +123,25 @@ describe("A2AClient", () => {
     ).rejects.toBeInstanceOf(A2ATaskTimeoutError);
   });
 });
+
+function completedResponse(body: any, text: string): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: body.id,
+      result: {
+        id: "task-ok",
+        status: {
+          state: "completed",
+          message: {
+            role: "agent",
+            parts: [{ type: "text", text }],
+          },
+        },
+        history: [],
+        artifacts: [],
+      },
+    }),
+    { status: 200 },
+  );
+}

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -64,7 +64,8 @@ export async function signA2AToken(
 export class A2AClient {
   private baseUrl: string;
   private apiKey?: string;
-  private a2aPath = "/_agent-native/a2a";
+  private endpointCandidates: string[] = [];
+  private endpointResolved = false;
   private requestTimeoutMs?: number;
 
   constructor(
@@ -72,7 +73,13 @@ export class A2AClient {
     apiKey?: string,
     options?: { requestTimeoutMs?: number },
   ) {
-    this.baseUrl = baseUrl.replace(/\/$/, "");
+    const normalized = baseUrl.replace(/\/$/, "");
+    const explicitEndpoint = splitExplicitA2AEndpoint(normalized);
+    this.baseUrl = explicitEndpoint?.baseUrl ?? normalized;
+    if (explicitEndpoint) {
+      this.endpointCandidates = [explicitEndpoint.endpointUrl];
+      this.endpointResolved = true;
+    }
     this.apiKey = apiKey;
     this.requestTimeoutMs = options?.requestTimeoutMs;
   }
@@ -82,13 +89,24 @@ export class A2AClient {
    * Agent-native apps use /_agent-native/a2a, external agents may use /a2a.
    */
   async resolveEndpoint(): Promise<void> {
-    try {
-      const res = await fetch(`${this.baseUrl}/_agent-native/a2a`, {
-        method: "OPTIONS",
-      });
-      if (res.status !== 404) return; // /_agent-native/a2a exists
-    } catch {}
-    this.a2aPath = "/a2a"; // Fallback for external A2A servers
+    await this.ensureEndpointCandidates();
+    if (this.endpointCandidates.length <= 1) return;
+
+    for (const endpoint of this.endpointCandidates) {
+      try {
+        const res = await fetch(endpoint, { method: "OPTIONS" });
+        if (res.status !== 404 && res.status !== 405) {
+          this.endpointCandidates = [endpoint];
+          return;
+        }
+        if (res.status === 405) {
+          this.endpointCandidates = [endpoint];
+          return;
+        }
+      } catch {
+        // Try the next candidate.
+      }
+    }
   }
 
   private headers(): Record<string, string> {
@@ -110,37 +128,30 @@ export class A2AClient {
       params,
     };
 
-    const url = `${this.baseUrl}${this.a2aPath}`;
-    console.log(`[A2A Client] POST ${url} method=${method}`);
-    const startTime = Date.now();
-    const controller = this.requestTimeoutMs
-      ? new AbortController()
-      : undefined;
-    const timer =
-      controller && this.requestTimeoutMs
-        ? setTimeout(() => controller.abort(), this.requestTimeoutMs)
-        : undefined;
-    let res!: Response;
-    try {
-      res = await fetch(url, {
-        method: "POST",
-        headers: this.headers(),
-        body: JSON.stringify(body),
-        signal: controller?.signal,
-      });
-    } finally {
-      if (timer) clearTimeout(timer);
-    }
-    console.log(
-      `[A2A Client] Response: ${res.status} in ${Date.now() - startTime}ms`,
-    );
+    await this.ensureEndpointCandidates();
+    let lastError: Error | null = null;
 
-    if (!res.ok) {
+    for (const url of this.endpointCandidates) {
+      console.log(`[A2A Client] POST ${url} method=${method}`);
+      const startTime = Date.now();
+      const res = await this.postJson(url, body);
+      console.log(
+        `[A2A Client] Response: ${res.status} in ${Date.now() - startTime}ms`,
+      );
+
+      if (res.ok) {
+        this.endpointCandidates = [url];
+        return res.json() as Promise<JsonRpcResponse>;
+      }
+
       const text = await res.text();
-      throw new Error(`A2A request failed (${res.status}): ${text}`);
+      lastError = new Error(`A2A request failed (${res.status}): ${text}`);
+      if (!shouldTryNextEndpoint(res.status)) {
+        throw lastError;
+      }
     }
 
-    return res.json() as Promise<JsonRpcResponse>;
+    throw lastError ?? new Error("No A2A endpoint candidates available");
   }
 
   async getAgentCard(): Promise<AgentCard> {
@@ -261,15 +272,21 @@ export class A2AClient {
       },
     };
 
-    const res = await fetch(`${this.baseUrl}${this.a2aPath}`, {
-      method: "POST",
-      headers: this.headers(),
-      body: JSON.stringify(body),
-    });
-
-    if (!res.ok) {
+    await this.ensureEndpointCandidates();
+    let res: Response | null = null;
+    let lastError: Error | null = null;
+    for (const candidate of this.endpointCandidates) {
+      res = await this.postJson(candidate, body);
+      if (res.ok) {
+        this.endpointCandidates = [candidate];
+        break;
+      }
       const text = await res.text();
-      throw new Error(`A2A stream failed (${res.status}): ${text}`);
+      lastError = new Error(`A2A stream failed (${res.status}): ${text}`);
+      if (!shouldTryNextEndpoint(res.status)) throw lastError;
+    }
+    if (!res?.ok) {
+      throw lastError ?? new Error("No A2A endpoint candidates available");
     }
 
     const reader = res.body?.getReader();
@@ -303,6 +320,108 @@ export class A2AClient {
       }
     }
   }
+
+  private async ensureEndpointCandidates(): Promise<void> {
+    if (this.endpointResolved) return;
+    this.endpointResolved = true;
+
+    const candidates: string[] = [];
+    addDefaultEndpointCandidates(candidates, this.baseUrl);
+
+    try {
+      const card = await this.getAgentCard();
+      const cardUrl = normalizeUrl(card.url, this.baseUrl);
+      if (cardUrl) {
+        const explicitEndpoint = splitExplicitA2AEndpoint(cardUrl);
+        if (explicitEndpoint) {
+          candidates.unshift(explicitEndpoint.endpointUrl);
+        } else {
+          addDefaultEndpointCandidates(candidates, cardUrl);
+        }
+      }
+    } catch {
+      // Agent cards are discovery hints. Fall back to conventional endpoints.
+    }
+
+    this.endpointCandidates = unique(candidates);
+  }
+
+  private async postJson(url: string, body: JsonRpcRequest): Promise<Response> {
+    const controller = this.requestTimeoutMs
+      ? new AbortController()
+      : undefined;
+    const timer =
+      controller && this.requestTimeoutMs
+        ? setTimeout(() => controller.abort(), this.requestTimeoutMs)
+        : undefined;
+    try {
+      return await fetch(url, {
+        method: "POST",
+        headers: this.headers(),
+        body: JSON.stringify(body),
+        signal: controller?.signal,
+      });
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}
+
+function splitExplicitA2AEndpoint(
+  url: string,
+): { baseUrl: string; endpointUrl: string } | null {
+  try {
+    const parsed = new URL(url);
+    const pathname = parsed.pathname.replace(/\/$/, "");
+    if (pathname.endsWith("/_agent-native/a2a")) {
+      parsed.pathname = pathname.slice(0, -"/_agent-native/a2a".length) || "/";
+      parsed.search = "";
+      parsed.hash = "";
+      return {
+        baseUrl: parsed.toString().replace(/\/$/, ""),
+        endpointUrl: url,
+      };
+    }
+    if (pathname.endsWith("/a2a")) {
+      parsed.pathname = pathname.slice(0, -"/a2a".length) || "/";
+      parsed.search = "";
+      parsed.hash = "";
+      return {
+        baseUrl: parsed.toString().replace(/\/$/, ""),
+        endpointUrl: url,
+      };
+    }
+  } catch {
+    // Relative or invalid URLs are handled by the caller's normal fetch path.
+  }
+  return null;
+}
+
+function addDefaultEndpointCandidates(candidates: string[], baseUrl: string) {
+  const base = baseUrl.replace(/\/$/, "");
+  candidates.push(`${base}/_agent-native/a2a`, `${base}/a2a`);
+}
+
+function normalizeUrl(
+  value: string | undefined,
+  baseUrl: string,
+): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value, `${baseUrl.replace(/\/$/, "")}/`)
+      .toString()
+      .replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
+function shouldTryNextEndpoint(status: number): boolean {
+  return status === 404 || status === 405;
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values));
 }
 
 /**

--- a/packages/core/src/client/NewWorkspaceAppFlow.tsx
+++ b/packages/core/src/client/NewWorkspaceAppFlow.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   IconArrowUpRight,
   IconCheck,
+  IconChevronDown,
   IconCode,
   IconKey,
   IconLoader2,
@@ -135,6 +136,10 @@ export function NewWorkspaceAppFlow({
     () => secrets.filter((secret) => selectedSecretIds.includes(secret.id)),
     [secrets, selectedSecretIds],
   );
+  const selectedSecretLabel =
+    selectedSecretIds.length === 0
+      ? "No keys selected"
+      : `${selectedSecretIds.length} key${selectedSecretIds.length === 1 ? "" : "s"} selected`;
 
   const canSubmit = prompt.trim().length > 0 && slugify(appName).length > 0;
   const submitShortcut =
@@ -345,9 +350,14 @@ export function NewWorkspaceAppFlow({
 
         <aside className="rounded-lg border border-border bg-card">
           <div className="border-b border-border px-4 py-3">
-            <div className="flex items-center gap-2 text-sm font-medium">
-              <IconKey className="h-4 w-4" />
-              Dispatch keys
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <IconKey className="h-4 w-4" />
+                Dispatch keys
+              </div>
+              <span className="shrink-0 rounded border border-border bg-background/40 px-2 py-0.5 text-[11px] text-muted-foreground">
+                {selectedSecretLabel}
+              </span>
             </div>
           </div>
           <div className="max-h-[440px] space-y-2 overflow-y-auto p-3">
@@ -363,35 +373,53 @@ export function NewWorkspaceAppFlow({
               secrets.map((secret) => {
                 const selected = selectedSecretIds.includes(secret.id);
                 return (
-                  <button
+                  <div
                     key={secret.id}
-                    type="button"
-                    aria-pressed={selected}
-                    onClick={() => toggleSecret(secret.id)}
-                    className={`group flex w-full items-start gap-3 rounded-md border px-3 py-2 text-left text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 ${
+                    className={`group rounded-md border text-sm transition ${
                       selected
-                        ? "border-ring/60 bg-muted/70 text-foreground"
-                        : "border-border bg-background/30 text-foreground hover:border-muted-foreground/40 hover:bg-accent/45"
+                        ? "border-primary/45 bg-primary/5 text-foreground shadow-[inset_0_0_0_1px_hsl(var(--primary)/0.08)]"
+                        : "border-border bg-background/25 text-foreground hover:border-muted-foreground/40 hover:bg-accent/35"
                     }`}
                   >
-                    <span
-                      className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border transition ${
-                        selected
-                          ? "border-ring bg-background text-foreground"
-                          : "border-muted-foreground/35 text-transparent group-hover:border-muted-foreground/60"
-                      }`}
+                    <button
+                      type="button"
+                      aria-pressed={selected}
+                      onClick={() => toggleSecret(secret.id)}
+                      className="flex w-full items-start gap-3 rounded-md px-3 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
                     >
-                      {selected ? <IconCheck className="h-3 w-3" /> : null}
-                    </span>
-                    <span className="min-w-0">
-                      <span className="block truncate font-medium">
-                        {secret.credentialKey}
+                      <span
+                        className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border transition ${
+                          selected
+                            ? "border-primary/60 bg-primary/10 text-primary"
+                            : "border-muted-foreground/35 text-transparent group-hover:border-muted-foreground/60"
+                        }`}
+                      >
+                        {selected ? <IconCheck className="h-3 w-3" /> : null}
                       </span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {secret.provider || secret.name}
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate font-medium">
+                          {secret.credentialKey}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground/70">
+                          {selected
+                            ? "Will be granted to this app"
+                            : "Click to grant"}
+                        </span>
                       </span>
-                    </span>
-                  </button>
+                    </button>
+                    <details className="group/details border-t border-border/60 px-3 py-1.5 text-xs text-muted-foreground/75 open:bg-background/10">
+                      <summary className="flex cursor-pointer list-none items-center gap-1.5 text-[11px] hover:text-muted-foreground [&::-webkit-details-marker]:hidden">
+                        <IconChevronDown className="h-3 w-3 transition-transform group-open/details:rotate-180" />
+                        Details
+                      </summary>
+                      <div className="mt-1.5 space-y-1 pb-0.5 pl-4">
+                        <div className="truncate">
+                          Provider: {secret.provider || "Not specified"}
+                        </div>
+                        <div className="truncate">Name: {secret.name}</div>
+                      </div>
+                    </details>
+                  </div>
                 );
               })
             )}

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -399,6 +399,74 @@ describe("workspace deploy", () => {
     });
   });
 
+  it("writes workspace app URLs and preserves explicit manifest URLs", async () => {
+    process.env.APP_URL = "https://workspace.example.test/dispatch";
+    process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({
+      version: 1,
+      apps: [
+        {
+          id: "mail",
+          path: "/mail",
+          url: "https://mail.custom.example.test/",
+        },
+      ],
+    });
+    makeWorkspaceApp(tmpDir, "dispatch");
+    makeWorkspaceApp(tmpDir, "mail");
+
+    await runWorkspaceDeploy({
+      workspaceRoot: tmpDir,
+      preset: "netlify",
+      buildOnly: true,
+      execFile: execFile as typeof execFileSync,
+    });
+
+    const dispatchCall = buildCallForApp("dispatch");
+    expect(
+      JSON.parse(dispatchCall?.env?.AGENT_NATIVE_WORKSPACE_APPS_JSON ?? "[]"),
+    ).toEqual([
+      {
+        id: "dispatch",
+        name: "Dispatch",
+        description: "",
+        path: "/dispatch",
+        url: "https://workspace.example.test/dispatch",
+        isDispatch: true,
+      },
+      {
+        id: "mail",
+        name: "Mail",
+        description: "",
+        path: "/mail",
+        url: "https://mail.custom.example.test",
+        isDispatch: false,
+      },
+    ]);
+
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          tmpDir,
+          ".netlify",
+          "functions-internal",
+          "mail-server",
+          ".agent-native",
+          "workspace-apps.json",
+        ),
+        "utf-8",
+      ),
+    );
+    expect(
+      manifest.apps.map((app: { id: string; url: string }) => [
+        app.id,
+        app.url,
+      ]),
+    ).toEqual([
+      ["dispatch", "https://workspace.example.test/dispatch"],
+      ["mail", "https://mail.custom.example.test"],
+    ]);
+  });
+
   it("rejects app ids that conflict with reserved workspace routes", async () => {
     makeWorkspaceApp(tmpDir, "dispatch");
     makeWorkspaceApp(tmpDir, "login");

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -52,6 +52,7 @@ interface WorkspaceAppManifestEntry {
   name: string;
   description: string;
   path: string;
+  url?: string;
   isDispatch: boolean;
 }
 
@@ -547,15 +548,22 @@ function readWorkspaceAppManifest(
   workspaceRoot: string,
   apps: string[],
 ): WorkspaceAppManifestEntry[] {
+  const explicitApps = readExistingWorkspaceAppManifest(workspaceRoot);
+
   return apps
     .map((app) => {
       const appDir = path.join(workspaceRoot, "apps", app);
       const pkg = readPackageJson(path.join(appDir, "package.json"));
+      const appPath = `/${app}`;
+      const explicit = explicitApps.get(app);
+      const url =
+        normalizeWorkspaceAppUrl(explicit?.url) ?? workspaceAppUrl(appPath);
       return {
         id: app,
         name: pkg?.displayName || titleCase(app),
         description: pkg?.description || "",
-        path: `/${app}`,
+        path: appPath,
+        ...(url ? { url } : {}),
         isDispatch: app === "dispatch",
       };
     })
@@ -564,6 +572,99 @@ function readWorkspaceAppManifest(
       if (b.id === "dispatch") return 1;
       return a.name.localeCompare(b.name);
     });
+}
+
+function readExistingWorkspaceAppManifest(
+  workspaceRoot: string,
+): Map<string, { url?: string }> {
+  const fromEnv = parseWorkspaceAppsJson(process.env[WORKSPACE_APPS_ENV_KEY]);
+  const fromFile =
+    readWorkspaceAppsFromFile(
+      path.join(
+        workspaceRoot,
+        WORKSPACE_APPS_MANIFEST_DIR,
+        WORKSPACE_APPS_MANIFEST_FILE,
+      ),
+    ) ??
+    readWorkspaceAppsFromFile(
+      path.join(workspaceRoot, WORKSPACE_APPS_MANIFEST_FILE),
+    );
+  const apps = fromEnv ?? fromFile ?? [];
+  return new Map(apps.map((app) => [app.id, app]));
+}
+
+function parseWorkspaceAppsJson(
+  raw: string | undefined,
+): Array<{ id: string; url?: string }> | null {
+  if (!raw) return null;
+  try {
+    return parseWorkspaceAppsManifest(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+function readWorkspaceAppsFromFile(
+  file: string,
+): Array<{ id: string; url?: string }> | null {
+  if (!fs.existsSync(file)) return null;
+  return parseWorkspaceAppsManifest(readPackageJson(file));
+}
+
+function parseWorkspaceAppsManifest(
+  parsed: any,
+): Array<{ id: string; url?: string }> | null {
+  const rawApps = Array.isArray(parsed?.apps)
+    ? parsed.apps
+    : Array.isArray(parsed)
+      ? parsed
+      : null;
+  if (!rawApps) return null;
+
+  const apps = rawApps
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return null;
+      const id = typeof entry.id === "string" ? entry.id.trim() : "";
+      if (!id) return null;
+      const url = normalizeWorkspaceAppUrl(entry.url);
+      return {
+        id,
+        ...(url ? { url } : {}),
+      };
+    })
+    .filter((app): app is { id: string; url?: string } => !!app);
+
+  return apps.length ? apps : null;
+}
+
+function workspaceBaseUrl(): string | null {
+  return (
+    process.env.WORKSPACE_GATEWAY_URL ||
+    process.env.APP_URL ||
+    process.env.URL ||
+    process.env.DEPLOY_URL ||
+    process.env.BETTER_AUTH_URL ||
+    null
+  );
+}
+
+function workspaceAppUrl(appPath: string): string | undefined {
+  const base = workspaceBaseUrl();
+  if (!base) return undefined;
+  try {
+    return new URL(appPath, `${base.replace(/\/$/, "")}/`).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeWorkspaceAppUrl(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  try {
+    return new URL(value.trim()).toString().replace(/\/$/, "");
+  } catch {
+    return undefined;
+  }
 }
 
 function readPackageJson(file: string): Record<string, any> | null {

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -292,6 +292,61 @@ describe("A2A continuation processor", () => {
     );
   });
 
+  it("treats aborted task polling as transient until the remote work deadline", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ attempts: 99 }),
+    );
+    getTaskMock.mockRejectedValueOnce(
+      new DOMException("This operation was aborted", "AbortError"),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(sendResponse).not.toHaveBeenCalled();
+    expect(failA2AContinuationMock).not.toHaveBeenCalled();
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith("cont-1", 5_000);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ continuationId: "cont-1" }),
+      }),
+    );
+  });
+
+  it("reports a friendly timeout when task polling aborts after the remote work deadline", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ attempts: 99, createdAt: Date.now() - 10 * 60_000 - 1 }),
+    );
+    getTaskMock.mockRejectedValueOnce(
+      new DOMException("This operation was aborted", "AbortError"),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    const sentText = vi.mocked(sendResponse).mock.calls[0]?.[0].text ?? "";
+    expect(sentText).toContain(
+      "The Slides agent could not finish this request: Timed out polling the Slides A2A task a2a-task-1 after 10 minutes",
+    );
+    expect(sentText).not.toContain("This operation was aborted");
+    expect(failA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      expect.stringContaining(
+        "Timed out polling the Slides A2A task a2a-task-1 after 10 minutes",
+      ),
+    );
+  });
+
   it("waits until a redispatched continuation is due before claiming it", async () => {
     vi.useFakeTimers();
     const dueAt = Date.now() + 5_000;

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -26,6 +26,7 @@ const RESCHEDULE_DELAY_MS = 5_000;
 const MAX_PRE_CLAIM_WAIT_MS = RESCHEDULE_DELAY_MS + 5_000;
 const POLL_INTERVAL_MS = 2_000;
 const PROCESSOR_WAIT_MS = 20_000;
+const POLL_REQUEST_TIMEOUT_MS = 25_000;
 const PLATFORM_SEND_TIMEOUT_MS = 12_000;
 const DISPATCH_SETTLE_WAIT_MS = 2_000;
 
@@ -146,7 +147,7 @@ async function processClaimedContinuation(
   const client = new A2AClient(
     continuation.agentUrl,
     await signContinuationToken(continuation),
-    { requestTimeoutMs: 10_000 },
+    { requestTimeoutMs: POLL_REQUEST_TIMEOUT_MS },
   );
   const deadline = Date.now() + PROCESSOR_WAIT_MS;
   let task: Task | null = null;
@@ -158,6 +159,19 @@ async function processClaimedContinuation(
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
   } catch (err) {
+    if (isTransientA2APollError(err)) {
+      if (isRemoteWorkExpired(continuation)) {
+        await notifyAndFailA2AContinuation(
+          continuation,
+          adapter,
+          remotePollTimeoutReason(continuation),
+        );
+        return;
+      }
+      await rescheduleA2AContinuation(continuation.id, RESCHEDULE_DELAY_MS);
+      await redispatchContinuation(continuation.id);
+      return;
+    }
     if (continuation.attempts >= MAX_ATTEMPTS) {
       await notifyAndFailA2AContinuation(
         continuation,
@@ -289,6 +303,18 @@ function formatContinuationFailureMessage(
 
 function isRemoteWorkExpired(continuation: A2AContinuation): boolean {
   return Date.now() - continuation.createdAt >= MAX_REMOTE_WORK_MS;
+}
+
+function isTransientA2APollError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.name === "AbortError") return true;
+  return /operation was aborted|aborted|timed out|timeout/i.test(err.message);
+}
+
+function remotePollTimeoutReason(continuation: A2AContinuation): string {
+  return `Timed out polling the ${continuation.agentName} A2A task ${continuation.a2aTaskId} after ${Math.round(
+    MAX_REMOTE_WORK_MS / 60_000,
+  )} minutes. The downstream agent did not return a final result.`;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/core/src/server/agent-discovery.spec.ts
+++ b/packages/core/src/server/agent-discovery.spec.ts
@@ -151,6 +151,29 @@ describe("agent discovery", () => {
       url: "https://workspace.example.test/mail",
     });
   });
+
+  it("uses explicit workspace manifest URLs without falling back to built-ins", async () => {
+    process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({
+      version: 1,
+      apps: [
+        {
+          id: "mail",
+          name: "Workspace Mail",
+          description: "Custom workspace mail app",
+          path: "/mail",
+          url: "https://mail.workspace.example.test/",
+        },
+      ],
+    });
+
+    const agents = await discoverAgents("dispatch");
+    expect(agents.find((agent) => agent.id === "mail")).toMatchObject({
+      id: "mail",
+      name: "Workspace Mail",
+      description: "Custom workspace mail app",
+      url: "https://mail.workspace.example.test/",
+    });
+  });
 });
 
 function restoreEnv(name: string, value: string | undefined): void {

--- a/packages/core/src/server/framework-request-handler.spec.ts
+++ b/packages/core/src/server/framework-request-handler.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getH3App } from "./framework-request-handler.js";
+import { getMissingDefaultPlugins } from "../deploy/route-discovery.js";
 
 vi.mock("../deploy/route-discovery.js", () => ({
   getMissingDefaultPlugins: vi.fn(async () => []),
@@ -118,6 +119,30 @@ describe("framework request handler", () => {
       pathname: "/",
       path: "/",
     });
+  });
+
+  it("waits for default plugin bootstrap before app-scoped well-known routes fall through", async () => {
+    process.env.APP_BASE_PATH = "/starter";
+    let release!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const nitroApp = createNitroApp();
+    vi.mocked(getMissingDefaultPlugins).mockImplementationOnce(async () => {
+      await ready;
+      getH3App(nitroApp).use("/.well-known/agent-card.json", () => ({
+        ok: true,
+      }));
+      return [];
+    });
+
+    getH3App(nitroApp);
+    const pending = dispatch(nitroApp, "/starter/.well-known/agent-card.json");
+    await Promise.resolve();
+
+    release();
+
+    await expect(pending).resolves.toEqual({ ok: true });
   });
 
   it("does not treat similar non-prefixed paths as framework routes", async () => {

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -117,13 +117,15 @@ export function getH3App(nitroApp: any): H3AppShim {
 
     // Readiness gate: Nitro v3 doesn't await async plugins, so routes
     // registered inside an async plugin may not exist when the first
-    // request arrives. This middleware holds /_agent-native requests
-    // until all tracked plugin inits complete.
-    registerMiddleware(nitroApp, FRAMEWORK_PREFIX, (async (event: H3Event) => {
-      await awaitPluginsReady(nitroApp);
+    // request arrives. These middleware entries hold framework routes
+    // until default-plugin bootstrap and tracked plugin inits complete.
+    const readinessGate = (async (event: H3Event) => {
+      await awaitFrameworkRoutesReady(nitroApp);
       // Fall through — the actual route handler runs next.
       return undefined;
-    }) as EventHandler);
+    }) as EventHandler;
+    registerMiddleware(nitroApp, FRAMEWORK_PREFIX, readinessGate);
+    registerMiddleware(nitroApp, WELL_KNOWN_PREFIX, readinessGate);
   }
 
   return shim;
@@ -147,6 +149,20 @@ export async function awaitBootstrap(nitroApp: any): Promise<void> {
   getH3App(nitroApp);
   const promise = nitroApp[BOOTSTRAP_PROMISE_KEY];
   if (promise) await promise;
+}
+
+/**
+ * Wait until framework routes are safe to dispatch.
+ *
+ * Request-time gates must wait for both phases:
+ *   1. default-plugin bootstrap, which discovers and starts missing plugins
+ *   2. async plugin init promises, which register routes such as A2A cards
+ */
+async function awaitFrameworkRoutesReady(nitroApp: any): Promise<void> {
+  if (!nitroApp) return;
+  const bootstrapPromise = nitroApp[BOOTSTRAP_PROMISE_KEY];
+  if (bootstrapPromise) await bootstrapPromise;
+  await awaitPluginsReady(nitroApp);
 }
 
 /**

--- a/packages/core/src/templates/workspace-root/.env.example
+++ b/packages/core/src/templates/workspace-root/.env.example
@@ -10,6 +10,13 @@ DATABASE_URL=
 #   openssl rand -hex 32
 BETTER_AUTH_SECRET=
 
+# Canonical public workspace URL. Use the root origin, not /dispatch.
+# WEBHOOK_BASE_URL overrides self-callback URLs for Slack/email/etc. if your
+# deploy provider exposes a preview URL but webhooks should use a custom domain.
+APP_URL=
+BETTER_AUTH_URL=
+WEBHOOK_BASE_URL=
+
 # Anthropic API key for the agent chat.
 ANTHROPIC_API_KEY=
 
@@ -21,6 +28,7 @@ OPENAI_API_KEY=
 # callback handler to this workspace-level .env).
 BUILDER_PRIVATE_KEY=
 BUILDER_PUBLIC_KEY=
+BUILDER_USER_ID=
 
 # Builder app creation / branching. In local dev these can live in .env.
 # In production, configure deploy env vars instead; production app creation
@@ -28,11 +36,24 @@ BUILDER_PUBLIC_KEY=
 ENABLE_BUILDER=
 DISPATCH_BUILDER_PROJECT_ID=
 BUILDER_BRANCH_PROJECT_ID=
+BUILDER_PROJECT_ID=
 
-# A2A shared secret — required for cross-app JWT verification. Every app
-# in the workspace should use the same value. Generate with:
+# A2A shared secret — required in production for cross-app JWT verification
+# and integration webhook processing. Every app in the workspace should use
+# the same value. Generate with:
 #   openssl rand -hex 32
 A2A_SECRET=
+
+# Slack integration. Required for @agent-native Slack mentions and replies.
+SLACK_BOT_TOKEN=
+SLACK_SIGNING_SECRET=
+SLACK_ALLOWED_TEAM_IDS=
+SLACK_ALLOWED_API_APP_IDS=
+
+# Optional production default for unlinked Slack users. This makes all
+# unlinked Slack requests run as this owner, so only set it for trusted,
+# single-workspace deployments.
+DISPATCH_DEFAULT_OWNER_EMAIL=
 
 # Google sign-in — optional. Leave blank to use email/password only.
 # Both values come from Google Cloud Console → APIs & Services → Credentials.


### PR DESCRIPTION
## Summary
- wait for default-plugin bootstrap before dispatching app-scoped .well-known routes
- keep the existing readiness gate for /_agent-native and extend it to /.well-known
- bump @agent-native/core to 0.7.42

## Tests
- pnpm --filter @agent-native/core exec vitest run src/server/framework-request-handler.spec.ts src/deploy/workspace-deploy.spec.ts src/server/auth.spec.ts src/server/onboarding-html.spec.ts
- pnpm --filter @agent-native/core exec tsc --noEmit --pretty false