### PR TITLE
Fix workspace redirects and remove template hardcoding

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.42",
+  "version": "0.7.43",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -366,8 +366,8 @@ describe("Netlify scaffold rewrite", () => {
     expect(netlify).toContain('  VITE_APP_BASE_PATH = "/dispatch"');
     expectRedirect("/", "/dispatch/overview", 302);
     expectRedirect("/dispatch", "/dispatch/overview", 302);
-    expect(netlify).not.toContain('  from = "/apps"');
-    expect(netlify).not.toContain('  from = "/new-app"');
+    expectRedirect("/apps", "/dispatch/apps", 302);
+    expectRedirect("/new-app", "/dispatch/new-app", 302);
     expect(netlify).not.toContain('from = "/dispatch/*"');
     expect(netlify).not.toContain('to = "/.netlify/functions/server"');
     expect(netlify).not.toContain("force = true");
@@ -421,6 +421,7 @@ describe("Netlify scaffold rewrite", () => {
     expect(netlify).toContain('  APP_BASE_PATH = "/starter"');
     expect(netlify).toContain('  VITE_APP_BASE_PATH = "/starter"');
     expect(netlify).not.toContain('  to = "/dispatch/apps"');
+    expect(netlify).not.toContain('  to = "/dispatch/new-app"');
     expect(netlify).not.toContain('  from = "/dispatch/*"');
   });
 

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -977,6 +977,8 @@ const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
   ["overview", "overview"],
   ["login", "login"],
   ["signup", "signup"],
+  ["apps", "apps"],
+  ["new-app", "new-app"],
   ["vault", "vault"],
   ["integrations", "integrations"],
   ["agents", "agents"],

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -361,8 +361,8 @@ describe("workspace deploy", () => {
     expect(redirects).toContain("/dispatch /dispatch/overview 302");
     expect(redirects).toContain("/login /dispatch/login 302");
     expect(redirects).toContain("/signup /dispatch/signup 302");
-    expect(redirects).not.toContain("/apps /dispatch/apps 302");
-    expect(redirects).not.toContain("/new-app /dispatch/new-app 302");
+    expect(redirects).toContain("/apps /dispatch/apps 302");
+    expect(redirects).toContain("/new-app /dispatch/new-app 302");
     expect(redirects).not.toMatch(/^\/dispatch\/\* .* 200$/m);
     expect(redirects).not.toMatch(/^\/starter .* 200$/m);
     expect(redirects).not.toMatch(/^\/starter\/\* .* 200$/m);

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -327,6 +327,8 @@ const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
   ["overview", "overview"],
   ["login", "login"],
   ["signup", "signup"],
+  ["apps", "apps"],
+  ["new-app", "new-app"],
   ["vault", "vault"],
   ["integrations", "integrations"],
   ["agents", "agents"],

--- a/templates/analytics/actions/create-analytics-public-key.ts
+++ b/templates/analytics/actions/create-analytics-public-key.ts
@@ -14,7 +14,7 @@ function resolveScope() {
 
 export default defineAction({
   description:
-    "Generate a public write key for first-party analytics ingestion. Use this when the user wants hosted apps to send events to analytics.agent-native.com/track. The returned publicKey is shown once and should be put in AGENT_NATIVE_ANALYTICS_PUBLIC_KEY / VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY on the emitting app.",
+    "Generate a public write key for first-party analytics ingestion. Use this when the user wants hosted apps to send events to the configured analytics endpoint. The returned publicKey is shown once and should be put in AGENT_NATIVE_ANALYTICS_PUBLIC_KEY / VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY on the emitting app.",
   schema: z.object({
     name: z
       .string()

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -58,6 +58,11 @@ interface AnalyticsPublicKeyRow {
   orgId: string | null;
 }
 
+const firstPartyAnalyticsEndpoint =
+  (import.meta.env as Record<string, string | undefined>)
+    .VITE_AGENT_NATIVE_ANALYTICS_ENDPOINT ||
+  "https://analytics.agent-native.com/track";
+
 async function fetchEnvStatus(): Promise<EnvKeyStatus[]> {
   const token = await getIdToken();
   const res = await fetch(appApiPath("/api/credential-status"), {
@@ -855,7 +860,7 @@ function FirstPartyAnalyticsCard() {
                 First-party Analytics
               </CardTitle>
               <CardDescription className="text-xs mt-0.5">
-                Receive product events at analytics.agent-native.com and query
+                Receive product events at your first-party endpoint and query
                 them as a dashboard data source.
               </CardDescription>
             </div>
@@ -880,7 +885,7 @@ function FirstPartyAnalyticsCard() {
           <div className="flex items-center justify-between gap-3">
             <span className="text-muted-foreground">Endpoint</span>
             <code className="truncate font-mono">
-              https://analytics.agent-native.com/track
+              {firstPartyAnalyticsEndpoint}
             </code>
           </div>
           <div className="flex items-center justify-between gap-3">

--- a/templates/dispatch/server/lib/app-creation-store.ts
+++ b/templates/dispatch/server/lib/app-creation-store.ts
@@ -86,6 +86,20 @@ function workspaceAppUrl(appPath: string): string | null {
   }
 }
 
+function workspaceAppLink(
+  appPath: string,
+  explicitUrl?: unknown,
+): string | null {
+  const urlValue = typeof explicitUrl === "string" ? explicitUrl.trim() : "";
+  if (!urlValue) return workspaceAppUrl(appPath);
+  if (urlValue.startsWith("/")) return workspaceAppUrl(urlValue) ?? urlValue;
+  try {
+    return new URL(urlValue).toString();
+  } catch {
+    return urlValue;
+  }
+}
+
 function parseWorkspaceAppsManifest(parsed: any): WorkspaceAppSummary[] | null {
   const rawApps = Array.isArray(parsed?.apps)
     ? parsed.apps
@@ -109,7 +123,7 @@ function parseWorkspaceAppsManifest(parsed: any): WorkspaceAppSummary[] | null {
         description:
           typeof entry.description === "string" ? entry.description : "",
         path: pathValue,
-        url: workspaceAppUrl(pathValue),
+        url: workspaceAppLink(pathValue, entry.url),
         isDispatch:
           typeof entry.isDispatch === "boolean"
             ? entry.isDispatch

--- a/templates/dispatch/server/middleware/auth.ts
+++ b/templates/dispatch/server/middleware/auth.ts
@@ -17,6 +17,24 @@ function normalizeBasePath(value?: string): string {
   return `/${trimmed.replace(/^\/+/, "").replace(/\/+$/, "")}`;
 }
 
+const DISPATCH_PAGE_PATHS = new Set([
+  "/overview",
+  "/login",
+  "/signup",
+  "/apps",
+  "/new-app",
+  "/vault",
+  "/integrations",
+  "/agents",
+  "/workspace",
+  "/messaging",
+  "/destinations",
+  "/identities",
+  "/approvals",
+  "/audit",
+  "/team",
+]);
+
 function rootDispatchRedirect(
   pathname: string,
   search: string,
@@ -33,14 +51,14 @@ function rootDispatchRedirect(
   if (pathname === "/") {
     return new Response(null, {
       status: 302,
-      headers: { Location: `${basePath}/${search}` },
+      headers: { Location: `${basePath}/overview${search}` },
     });
   }
 
   if (pathname === basePath) {
     return new Response(null, {
-      status: 301,
-      headers: { Location: `${basePath}/${search}` },
+      status: 302,
+      headers: { Location: `${basePath}/overview${search}` },
     });
   }
 
@@ -53,6 +71,13 @@ function rootDispatchRedirect(
 
   if (pathname.startsWith(`${basePath}/`)) {
     return null;
+  }
+
+  if (DISPATCH_PAGE_PATHS.has(pathname)) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `${basePath}${pathname}${search}` },
+    });
   }
 
   return new Response("Reserved for workspace app routes", {

--- a/templates/mail/actions/request-code-change.ts
+++ b/templates/mail/actions/request-code-change.ts
@@ -1,22 +1,15 @@
 import { defineAction } from "@agent-native/core";
+import {
+  getBuilderBranchProjectId,
+  resolveBuilderCredentials,
+  runBuilderAgent,
+} from "@agent-native/core/server";
+import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { z } from "zod";
-
-/** Generate a deterministic-looking but unique project branch ID */
-function generateBranchId(description: string): string {
-  const seed = description.length + Date.now();
-  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-  let id = "";
-  let n = seed;
-  for (let i = 0; i < 8; i++) {
-    n = (n * 1664525 + 1013904223) & 0xffffffff;
-    id += chars[Math.abs(n) % chars.length];
-  }
-  return id;
-}
 
 export default defineAction({
   description:
-    "Request a code change via the Builder.io background agent. Use this in production whenever the user asks to modify the UI, add features, change styles, or update any source code.",
+    "Request a production code change through configured Builder branch creation. Use this in production when the user asks to modify UI, add features, change styles, fix bugs, or update source code.",
   schema: z.object({
     description: z
       .string()
@@ -40,23 +33,70 @@ export default defineAction({
     const isProduction = process.env.NODE_ENV === "production";
     if (!isProduction) {
       return [
-        "⚠️  request-code-change is only active in production.",
+        "request-code-change is only active in production.",
         "In development, you can edit files directly via the dev agent tools.",
         `Requested change: "${description}"`,
       ].join("\n");
     }
 
-    const branchId = generateBranchId(description);
-    const projectId = `proj_${branchId}`;
-    const url = `https://builder.io/app/projects/${projectId}`;
+    const projectId = getBuilderBranchProjectId();
+    if (!projectId) {
+      return {
+        status: "not_configured",
+        description,
+        ...(files ? { files: files.split(",").map((f) => f.trim()) } : {}),
+        message:
+          "Production code changes need Builder branch creation to be configured. Set ENABLE_BUILDER=true with BUILDER_BRANCH_PROJECT_ID or BUILDER_PROJECT_ID, then connect Builder credentials for this user or deployment.",
+      };
+    }
+
+    const credentials = await resolveBuilderCredentials().catch(() => null);
+    if (!credentials?.privateKey || !credentials.publicKey) {
+      return {
+        status: "not_configured",
+        projectId,
+        description,
+        ...(files ? { files: files.split(",").map((f) => f.trim()) } : {}),
+        message:
+          "Builder branch creation is enabled, but Builder credentials are not connected. Connect Builder for this user or configure deployment-managed Builder credentials.",
+      };
+    }
+
+    const userEmail = getRequestUserEmail() || undefined;
+    const userId = credentials.userId || undefined;
+    if (!userEmail && !userId) {
+      return {
+        status: "not_authenticated",
+        projectId,
+        description,
+        ...(files ? { files: files.split(",").map((f) => f.trim()) } : {}),
+        message:
+          "A signed-in user or Builder user ID is required to start a production code branch.",
+      };
+    }
+
+    const prompt = [
+      "Make this production code change in the app:",
+      description,
+      files?.trim() ? `Likely files: ${files}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+
+    const result = await runBuilderAgent({
+      prompt,
+      projectId,
+      ...(userId ? { userId } : { userEmail }),
+    });
 
     return {
       status: "queued",
-      projectId,
-      url,
+      projectId: result.projectId || projectId,
+      branchName: result.branchName,
+      url: result.url,
       description,
       ...(files ? { files: files.split(",").map((f) => f.trim()) } : {}),
-      message: `Builder.io background agent queued. Track the change at: ${url}`,
+      message: `Builder branch creation is running. Track the change at: ${result.url}`,
     };
   },
 });

--- a/templates/mail/server/plugins/agent-chat.ts
+++ b/templates/mail/server/plugins/agent-chat.ts
@@ -124,9 +124,9 @@ When running in production and the user asks to change, add, or modify anything 
 
 Do NOT attempt to edit files directly in production. Instead:
 1. Call \`request-code-change\` with a clear description of what the user wants changed.
-2. Share the Builder.io link returned by the tool so the user can track and accept the change.
-3. Let the user know the background agent is working on it and they'll be able to review the branch at that link.
+2. If it returns a URL, share that link so the user can track and accept the change.
+3. If it says Builder is not configured, explain that production code changes need a connected Builder branch target before they can run.
 
 Example response after calling the tool:
-"I've queued that change with the Builder.io agent. You can track and accept it here: https://builder.io/app/projects/..."`,
+"I've queued that change with Builder branch creation. You can track and accept it here: <url>"`,
 });

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -223,12 +223,10 @@ async function createDeckOnAPI(deck: Deck): Promise<void> {
   }
 }
 
-const builderLogoSrc = appPath("/assets/builder-logo-white.svg");
-
 const defaultSlideContent: Record<SlideLayout, string> = {
   title: `<div class="fmd-slide" style="padding: 80px 110px; justify-content: space-between;">
   <div>
-    <img src="${builderLogoSrc}" alt="Builder.io" style="height: 28px; width: auto;" />
+    <div style="font-size: 16px; font-weight: 800; color: #fff; letter-spacing: 0; font-family: 'Poppins', sans-serif;">Deck</div>
   </div>
   <div>
     <div style="font-size: 54px; font-weight: 900; color: #fff; line-height: 1.1; letter-spacing: -1px; font-family: 'Poppins', sans-serif;">Presentation Title</div>

--- a/templates/slides/server/handlers/image-gen.ts
+++ b/templates/slides/server/handlers/image-gen.ts
@@ -63,7 +63,7 @@ export async function generateWithGemini(
 
   if (referenceImages.length > 0) {
     contents.push({
-      text: `You are a world-class visual designer creating assets for Builder.io's brand. Study the ${selectedRefs.length} reference images above — they ARE the brand. Your output must be indistinguishable from these references in style.
+      text: `You are a world-class visual designer creating assets in a specific visual system. Study the ${selectedRefs.length} reference images above; they define the target style. Your output must feel indistinguishable from these references.
 
 CRITICAL STYLE RULES (extract these from the references):
 - **Exact same color palette**: Match the precise dark backgrounds, accent colors, gradients, and glow effects from the references. Do NOT use different blues, purples, or color schemes.

--- a/templates/slides/server/handlers/image-providers/gemini.ts
+++ b/templates/slides/server/handlers/image-providers/gemini.ts
@@ -155,7 +155,7 @@ function buildStylePrompt(
   refCount: number,
   context?: { slideContent?: string; deckText?: string },
 ): string {
-  return `You are a world-class visual designer creating assets for Builder.io's brand. Study the ${refCount} reference images above — they ARE the brand. Your output must be indistinguishable from these references in style.
+  return `You are a world-class visual designer creating assets in a specific visual system. Study the ${refCount} reference images above; they define the target style. Your output must feel indistinguishable from these references.
 
 CRITICAL STYLE RULES (extract these from the references):
 - **Exact same color palette**: Match the precise dark backgrounds, accent colors, gradients, and glow effects from the references. Do NOT use different blues, purples, or color schemes.

--- a/templates/slides/shared/api.ts
+++ b/templates/slides/shared/api.ts
@@ -8,18 +8,7 @@ export interface DemoResponse {
 
 // --- Default Style References ---
 
-export const DEFAULT_STYLE_REFERENCE_URLS = [
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F316cb1fd488249069477dc234092f9d2?format=webp&width=800&height=1200",
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fd273e90ea8414158ba30bb9800956244?format=webp&width=800&height=1200",
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F177545e5bf10405aa2d36e94cbdcec14?format=webp&width=800&height=1200",
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fb9b6ebd71c0b4854a925b659eafc17c6?format=webp&width=800&height=1200",
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F280ea3201b234cdf9408038f95c82145?format=webp&width=800&height=1200",
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fa5294bbcb5b848029db6294600a7f14f?format=webp&width=800&height=1200",
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F7cd5efb949424ae2a83c68aaf159e848?format=webp&width=800&height=1200",
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F5b0a40f909b749fa90c36b323c535f81?format=webp&width=800&height=1200",
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Faadcd3f216e444249769e0853994a2ef?format=webp&width=800&height=1200",
-  "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F3fc375a2cdbd4788a23efef060008821?format=webp&width=800&height=1200",
-];
+export const DEFAULT_STYLE_REFERENCE_URLS: string[] = [];
 
 // --- Image Generation ---
 


### PR DESCRIPTION
## Summary
- add Dispatch /apps and /new-app workspace redirects to generated Netlify deploys and CLI configs
- preserve explicit workspace app URLs in the Dispatch template app list
- remove hardcoded Builder-specific template defaults from Mail/Slides/Analytics surfaces
- bump @agent-native/core to 0.7.43

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/deploy/workspace-deploy.spec.ts src/cli/create-e2e.spec.ts src/integrations/a2a-continuation-processor.spec.ts
- pnpm --filter @agent-native/core exec tsc --noEmit --pretty false
- pnpm --filter mail typecheck
- pnpm --filter slides typecheck
- pnpm --filter analytics typecheck
- pnpm --filter dispatch typecheck
