### PR TITLE
Handle nested workspace app creation redirect

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.44",
+  "version": "0.7.45",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -367,6 +367,7 @@ describe("Netlify scaffold rewrite", () => {
     expectRedirect("/", "/dispatch/overview", 302);
     expectRedirect("/dispatch", "/dispatch/overview", 302);
     expectRedirect("/apps", "/dispatch/apps", 302);
+    expectRedirect("/apps/new-app", "/dispatch/new-app", 302);
     expectRedirect("/new-app", "/dispatch/new-app", 302);
     expect(netlify).not.toContain('from = "/dispatch/*"');
     expect(netlify).not.toContain('to = "/.netlify/functions/server"');

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -978,6 +978,7 @@ const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
   ["login", "login"],
   ["signup", "signup"],
   ["apps", "apps"],
+  ["apps/new-app", "new-app"],
   ["new-app", "new-app"],
   ["vault", "vault"],
   ["integrations", "integrations"],

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -362,6 +362,7 @@ describe("workspace deploy", () => {
     expect(redirects).toContain("/login /dispatch/login 302");
     expect(redirects).toContain("/signup /dispatch/signup 302");
     expect(redirects).toContain("/apps /dispatch/apps 302");
+    expect(redirects).toContain("/apps/new-app /dispatch/new-app 302");
     expect(redirects).toContain("/new-app /dispatch/new-app 302");
     expect(redirects).not.toMatch(/^\/dispatch\/\* .* 200$/m);
     expect(redirects).not.toMatch(/^\/starter .* 200$/m);

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -328,6 +328,7 @@ const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
   ["login", "login"],
   ["signup", "signup"],
   ["apps", "apps"],
+  ["apps/new-app", "new-app"],
   ["new-app", "new-app"],
   ["vault", "vault"],
   ["integrations", "integrations"],


### PR DESCRIPTION
## Summary
- redirect `/apps/new-app` to `/dispatch/new-app` in generated workspace Netlify config
- add the same redirect to CLI-generated dispatch app config
- bump @agent-native/core to 0.7.45 for publishing

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/deploy/workspace-deploy.spec.ts src/cli/create-e2e.spec.ts
- pnpm --filter @agent-native/core typecheck
- git diff --check