### PR TITLE
[codex] Fix generated workspace metadata and slides URLs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.45",
+  "version": "0.7.46",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -62,6 +62,18 @@ function allDeps(pkg: Record<string, any>): Record<string, string> {
  * ───────────────────────────────────────────────────────────────────────── */
 
 describe("standalone scaffold — starter template", { timeout: 60000 }, () => {
+  it("rewrites the copied starter tracking app id to the generated app id", async () => {
+    await createApp("test-app", { template: "starter" });
+    const root = fs.readFileSync(
+      path.join(tmpDir, "test-app", "app", "root.tsx"),
+      "utf-8",
+    );
+
+    expect(root).toContain('app: "test-app"');
+    expect(root).toContain('template: "starter"');
+    expect(root).not.toContain('app: "agent-native-starter"');
+  });
+
   it("resolves all workspace:* deps for standalone install", async () => {
     await createApp("test-app", { template: "starter" });
     const pkg = readPkg(path.join(tmpDir, "test-app"));
@@ -236,6 +248,31 @@ describe("workspace scaffold — required packages", { timeout: 60000 }, () => {
     expect(rootPkg.dependencies["@agent-native/core"]).toBe(
       _getCoreDependencyVersion(),
     );
+  });
+});
+
+describe("workspace add-app scaffold", { timeout: 60000 }, () => {
+  it("rewrites starter tracking identity for a renamed workspace app", async () => {
+    await createApp("my-ws", { template: "starter,dispatch" });
+
+    const starterRoot = fs.readFileSync(
+      path.join(tmpDir, "my-ws", "apps", "starter", "app", "root.tsx"),
+      "utf-8",
+    );
+    expect(starterRoot).toContain('app: "starter"');
+    expect(starterRoot).not.toContain('app: "agent-native-starter"');
+
+    process.chdir(path.join(tmpDir, "my-ws"));
+    await createApp("crm", { template: "starter" });
+
+    const root = fs.readFileSync(
+      path.join(tmpDir, "my-ws", "apps", "crm", "app", "root.tsx"),
+      "utf-8",
+    );
+
+    expect(root).toContain('app: "crm"');
+    expect(root).toContain('template: "starter"');
+    expect(root).not.toContain('app: "agent-native-starter"');
   });
 });
 

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -144,6 +144,7 @@ async function createWorkspaceInteractive(
       const appDir = path.join(targetDir, "apps", t);
       await scaffoldAppTemplate(appDir, t);
       replacePlaceholders(appDir, t, titleCase(t), name);
+      rewriteTrackingAppId(appDir, t, t);
       workspacifyApp({
         appDir,
         appName: t,
@@ -304,6 +305,7 @@ async function scaffoldOneAppIntoWorkspace(
       titleCase(appName),
       path.basename(workspace.workspaceRoot),
     );
+    rewriteTrackingAppId(appDir, appName, templateName);
     workspacifyApp({
       appDir,
       appName,
@@ -385,7 +387,7 @@ async function createStandaloneApp(
   s.start("Scaffolding your app...");
   try {
     await scaffoldAppTemplate(targetDir, template);
-    postProcessStandalone(name, targetDir);
+    postProcessStandalone(name, targetDir, template);
     s.stop("App created!");
   } catch (err: any) {
     s.stop("Failed to create app.");
@@ -577,9 +579,14 @@ async function scaffoldRequiredPackages(
  * Post-process a standalone scaffold: replace placeholders, strip
  * workspace:* deps, set up agent symlinks, etc.
  */
-function postProcessStandalone(name: string, targetDir: string): void {
+function postProcessStandalone(
+  name: string,
+  targetDir: string,
+  templateName?: string,
+): void {
   const appTitle = titleCase(name);
   replacePlaceholders(targetDir, name, appTitle);
+  rewriteTrackingAppId(targetDir, name, templateName);
   fixPackageJsonName(targetDir, name);
   rewriteNetlifyToml(targetDir, name, "standalone");
 
@@ -1159,6 +1166,48 @@ function rewriteNetlifyToml(
 
     fs.writeFileSync(netlifyPath, content);
   } catch {}
+}
+
+function rewriteTrackingAppId(
+  appDir: string,
+  appName: string,
+  templateName?: string,
+): void {
+  const rootPath = path.join(appDir, "app", "root.tsx");
+  if (!fs.existsSync(rootPath)) return;
+
+  try {
+    const content = fs.readFileSync(rootPath, "utf-8");
+    const pattern =
+      /(^\s*app:\s*)(["'])(?:agent-native-[^"']+|\{\{APP_NAME\}\})\2(\s*,?)/m;
+    if (!pattern.test(content)) return;
+
+    let next = content.replace(
+      pattern,
+      (_match, prefix: string, quote: string, suffix: string) =>
+        `${prefix}${quote}${appName}${quote}${suffix}`,
+    );
+
+    if (
+      templateName &&
+      templateName !== appName &&
+      !hasTrackingTemplate(next)
+    ) {
+      next = next.replace(
+        /(^\s*app:\s*["'][^"']+["'],?\s*$)/m,
+        (line) => `${line}\n    template: ${JSON.stringify(templateName)},`,
+      );
+    }
+
+    if (next !== content) {
+      fs.writeFileSync(rootPath, next);
+    }
+  } catch {}
+}
+
+function hasTrackingTemplate(content: string): boolean {
+  const match = content.match(/configureTracking\(\{[\s\S]*?\}\);/);
+  return !!match && /^\s*template\s*:/m.test(match[0]);
 }
 
 function tryGitInit(dir: string): boolean {

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -316,13 +316,13 @@ Read (`get-deck`, `list-decks`, `view-screen`) admits rows the current user owns
 
 When this agent is called via A2A (e.g. dispatch asking "make a deck about X"), the caller is in a different app and **cannot see your local UI state, navigation, or deck list**. They only see the text you put in your reply.
 
-**After creating or modifying a deck, always include the canonical deck URL in your reply text — fully-qualified, never a relative path:**
+**After creating or modifying a deck, always include the canonical deck URL in your reply text — fully-qualified, never a relative path. Prefer the `url` returned by the deck action.**
 
 ```
-${process.env.APP_URL}/deck/<deckId>
+<configured app URL>/deck/<deckId>
 ```
 
-The URL pattern is `/deck/<id>` (singular `deck`). If `process.env.APP_URL` isn't set, fall back to `https://slides.agent-native.com/deck/<id>` for the prod app.
+The URL pattern is `/deck/<id>` (singular `deck`). If constructing a URL manually, use the configured app URL for this running app, including any workspace mount path such as `APP_BASE_PATH=/slides`. Do not drop the base path when the Slides app is hosted inside a workspace.
 
 **Examples — good vs bad replies for "Create a 3-slide deck about Acme Analytics. Reply with just the URL.":**
 
@@ -330,7 +330,7 @@ The URL pattern is `/deck/<id>` (singular `deck`). If `process.env.APP_URL` isn'
 | --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ❌  | "I'll create a 3-slide deck about Acme Analytics! Slide 1 — What is Acme Analytics? Slide 2 — Key features. Slide 3 — Get started." (no URL — caller has nothing to point to) |
 | ❌  | "Created at `/deck/deck-123`" (relative path — caller's host won't resolve it)                                                                                                |
-| ✅  | "https://slides.agent-native.com/deck/deck-1777482594025-d7x2x" (verbatim, fully-qualified, just the URL the user asked for)                                                  |
+| ✅  | "https://workspace.example.com/slides/deck/deck-1777482594025-d7x2x" (verbatim, fully-qualified, just the URL the user asked for)                                             |
 
 Same rule for `/deck/<id>/present` (presentation mode), `/share/<token>` (share link), and any other URL the caller might need.
 

--- a/templates/slides/actions/_app-url.test.ts
+++ b/templates/slides/actions/_app-url.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getDeckUrl, getExportUrl, getSlidesAppUrl } from "./_app-url.js";
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("slides app URLs", () => {
+  it("preserves workspace gateway URLs and APP_BASE_PATH", () => {
+    vi.stubEnv("WORKSPACE_GATEWAY_URL", "https://workspace.example.test");
+    vi.stubEnv("APP_BASE_PATH", "/slides");
+
+    expect(getSlidesAppUrl()).toBe("https://workspace.example.test/slides");
+    expect(getDeckUrl("deck-1")).toBe(
+      "https://workspace.example.test/slides/deck/deck-1",
+    );
+  });
+
+  it("does not duplicate APP_BASE_PATH when APP_URL is already scoped", () => {
+    vi.stubEnv("APP_URL", "https://workspace.example.test/slides/");
+    vi.stubEnv("APP_BASE_PATH", "/slides");
+
+    expect(getDeckUrl("deck-2")).toBe(
+      "https://workspace.example.test/slides/deck/deck-2",
+    );
+  });
+
+  it("uses hosting URL env vars for generated workspace deploys", () => {
+    vi.stubEnv("URL", "https://generated-workspace.netlify.app");
+    vi.stubEnv("APP_BASE_PATH", "/slides");
+
+    expect(getExportUrl("deck.pptx")).toBe(
+      "https://generated-workspace.netlify.app/slides/api/exports/deck.pptx",
+    );
+  });
+
+  it("falls back to the first-party Slides host when no app URL is configured", () => {
+    expect(getDeckUrl("deck-3")).toBe(
+      "https://slides.agent-native.com/deck/deck-3",
+    );
+  });
+});

--- a/templates/slides/actions/_app-url.ts
+++ b/templates/slides/actions/_app-url.ts
@@ -1,0 +1,43 @@
+import { withConfiguredAppBasePath } from "@agent-native/core/server";
+
+const FALLBACK_SLIDES_APP_URL = "https://slides.agent-native.com";
+
+function normalizeUrl(raw: string): string {
+  const trimmed = raw.trim().replace(/\/+$/, "");
+  if (!trimmed) return "";
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+}
+
+function configuredBaseUrl(): string | undefined {
+  const candidates = [
+    process.env.APP_URL,
+    process.env.WORKSPACE_GATEWAY_URL,
+    process.env.URL,
+    process.env.DEPLOY_URL,
+    process.env.BETTER_AUTH_URL,
+    process.env.VERCEL_PROJECT_PRODUCTION_URL,
+    process.env.VERCEL_URL,
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate?.trim()) continue;
+    return normalizeUrl(candidate);
+  }
+
+  return undefined;
+}
+
+export function getSlidesAppUrl(): string {
+  const baseUrl = configuredBaseUrl();
+  if (!baseUrl) return FALLBACK_SLIDES_APP_URL;
+  return withConfiguredAppBasePath(baseUrl);
+}
+
+export function getDeckUrl(deckId: string): string {
+  return `${getSlidesAppUrl()}/deck/${deckId}`;
+}
+
+export function getExportUrl(filename: string): string {
+  return `${getSlidesAppUrl()}/api/exports/${filename}`;
+}

--- a/templates/slides/actions/create-deck.test.ts
+++ b/templates/slides/actions/create-deck.test.ts
@@ -66,6 +66,7 @@ import action from "./create-deck";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.unstubAllEnvs();
   existingDeckRow = undefined;
   insertedRow = undefined;
   updatedFields = undefined;
@@ -85,6 +86,17 @@ describe("create-deck — aspectRatio", () => {
     await action.run({ title: "T", slides: [], aspectRatio: "9:16" });
     const data = JSON.parse(insertedRow!.data as string);
     expect(data.aspectRatio).toBe("9:16");
+  });
+
+  it("returns a workspace-scoped deck URL when the app is mounted under a base path", async () => {
+    vi.stubEnv("WORKSPACE_GATEWAY_URL", "https://workspace.example.test");
+    vi.stubEnv("APP_BASE_PATH", "/slides");
+
+    const result = await action.run({ title: "T", slides: [] });
+
+    expect(result.url).toMatch(
+      /^https:\/\/workspace\.example\.test\/slides\/deck\/deck-/,
+    );
   });
 
   it("preserves the existing aspectRatio when bulk-replacing slides without specifying it", async () => {

--- a/templates/slides/actions/create-deck.ts
+++ b/templates/slides/actions/create-deck.ts
@@ -10,6 +10,7 @@ import {
 } from "@agent-native/core/server/request-context";
 import { notifyClients } from "../server/handlers/decks.js";
 import { ASPECT_RATIO_VALUES } from "../shared/aspect-ratios.js";
+import { getDeckUrl } from "./_app-url.js";
 
 const SlideSchema = z.object({
   id: z.string().describe("Unique slide ID, e.g. 'slide-1'"),
@@ -63,7 +64,6 @@ export default defineAction({
   run: async ({ title, slides, deckId, aspectRatio }) => {
     const db = getDb();
     const now = new Date().toISOString();
-    const appUrl = process.env.APP_URL || "https://slides.agent-native.com";
 
     if (deckId) {
       // Update existing deck — requires editor access.
@@ -92,7 +92,7 @@ export default defineAction({
         id: deckId,
         title,
         slideCount: slides.length,
-        url: `${appUrl}/deck/${deckId}`,
+        url: getDeckUrl(deckId),
       };
     }
 
@@ -124,7 +124,7 @@ export default defineAction({
       id,
       title,
       slideCount: slides.length,
-      url: `${appUrl}/deck/${id}`,
+      url: getDeckUrl(id),
     };
   },
 });

--- a/templates/slides/actions/duplicate-deck.ts
+++ b/templates/slides/actions/duplicate-deck.ts
@@ -7,6 +7,7 @@ import {
   getRequestOrgId,
 } from "@agent-native/core/server/request-context";
 import { nanoid } from "nanoid";
+import { getDeckUrl } from "./_app-url.js";
 
 export default defineAction({
   description:
@@ -60,12 +61,11 @@ export default defineAction({
       orgId: getRequestOrgId() || null,
     });
 
-    const appUrl = process.env.APP_URL || "https://slides.agent-native.com";
     return {
       id: newId,
       title: newTitle,
       slideCount: (deckData.slides || []).length,
-      url: `${appUrl}/deck/${newId}`,
+      url: getDeckUrl(newId),
     };
   },
 });

--- a/templates/slides/actions/export-google-slides.ts
+++ b/templates/slides/actions/export-google-slides.ts
@@ -1,6 +1,7 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
 import exportPptxAction from "./export-pptx.js";
+import { getExportUrl, getSlidesAppUrl } from "./_app-url.js";
 
 /**
  * Google Slides has no first-party "import this URL" REST API — there is no
@@ -32,8 +33,8 @@ export default defineAction({
     const result = await exportPptxAction.run({ deckId, includeNotes });
     const { filename, slideCount } = result;
 
-    const appUrl = process.env.APP_URL || "https://slides.agent-native.com";
-    const downloadUrl = `${appUrl}/api/exports/${filename}`;
+    const appUrl = getSlidesAppUrl();
+    const downloadUrl = getExportUrl(filename);
 
     // The /api/exports/:filename route requires a logged-in session, so
     // Google's importer cannot fetch it directly even when APP_URL is

--- a/templates/slides/actions/import-pptx.ts
+++ b/templates/slides/actions/import-pptx.ts
@@ -13,6 +13,7 @@ import { parsePptx } from "../server/handlers/import/pptx-parser.js";
 import { convertToSlideHtml } from "../server/handlers/import/html-converter.js";
 import fs from "fs";
 import { resolveUserUploadedFile } from "./_uploaded-files.js";
+import { getDeckUrl } from "./_app-url.js";
 
 export default defineAction({
   description:
@@ -85,14 +86,13 @@ export default defineAction({
         source: "import-pptx",
       });
 
-      const appUrl = process.env.APP_URL || "https://slides.agent-native.com";
       return {
         id: deckId,
         title: deckTitle,
         slideCount: slides.length,
         theme: presentation.theme,
         imported: true,
-        url: `${appUrl}/deck/${deckId}`,
+        url: getDeckUrl(deckId),
       };
     }
 
@@ -116,14 +116,13 @@ export default defineAction({
     notifyClients(id);
     await writeAppState("refresh-signal", { ts: now, source: "import-pptx" });
 
-    const appUrl = process.env.APP_URL || "https://slides.agent-native.com";
     return {
       id,
       title: deckTitle,
       slideCount: slides.length,
       theme: presentation.theme,
       imported: true,
-      url: `${appUrl}/deck/${id}`,
+      url: getDeckUrl(id),
     };
   },
 });


### PR DESCRIPTION
## Summary

- Rewrite copied template tracking `app` ids during `agent-native create` and `agent-native add-app` post-processing so generated apps report their generated app id instead of the source template id.
- Preserve the source template in tracking defaults when an app is generated from a differently named template, such as `crm` from `starter`.
- Add CLI e2e coverage for standalone starter scaffolds, workspace starter scaffolds, and renamed workspace apps cloned from starter.

## Validation

- `pnpm --filter @agent-native/core exec vitest run src/cli/create-e2e.spec.ts`
- `pnpm --filter @agent-native/core typecheck`
- `pnpm --filter @agent-native/core exec vitest run src/cli/create.spec.ts`
- `git diff --check`