### PR TITLE
[codex] Harden A2A continuation polling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.46",
+  "version": "0.7.47",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -36,6 +36,7 @@ export async function signA2AToken(
   email: string,
   orgDomain?: string,
   orgSecret?: string,
+  options?: { expiresIn?: string | number },
 ): Promise<string> {
   const secret = orgSecret || process.env.A2A_SECRET;
   if (!secret) {
@@ -57,7 +58,7 @@ export async function signA2AToken(
     .setProtectedHeader({ alg: "HS256" })
     .setIssuer(appUrl)
     .setIssuedAt()
-    .setExpirationTime("15m")
+    .setExpirationTime(options?.expiresIn ?? "15m")
     .sign(new TextEncoder().encode(secret));
 }
 

--- a/packages/core/src/a2a/server.spec.ts
+++ b/packages/core/src/a2a/server.spec.ts
@@ -1,0 +1,126 @@
+import * as jose from "jose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { A2AConfig } from "./types.js";
+
+const handleJsonRpcH3Mock = vi.hoisted(() =>
+  vi.fn(async () => ({ jsonrpc: "2.0", id: 1, result: { ok: true } })),
+);
+const getA2ASecretByDomainMock = vi.hoisted(() => vi.fn());
+const setResponseStatusMock = vi.hoisted(() =>
+  vi.fn((event: any, code: number) => {
+    event._status = code;
+  }),
+);
+
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: any) => handler,
+  getMethod: (event: any) => event.method ?? "POST",
+  getRequestHeader: (event: any, name: string) =>
+    event.headers?.[name.toLowerCase()] ?? event.headers?.[name],
+  setResponseHeader: vi.fn(),
+  setResponseStatus: setResponseStatusMock,
+}));
+
+vi.mock("../server/framework-request-handler.js", () => ({
+  getH3App: (app: any) => ({
+    use: (path: string, handler: any) => {
+      app.routes.push({ path, handler });
+    },
+  }),
+}));
+
+vi.mock("./handlers.js", () => ({
+  handleJsonRpcH3: handleJsonRpcH3Mock,
+  processA2ATaskFromQueue: vi.fn(async () => undefined),
+}));
+
+vi.mock("../server/h3-helpers.js", () => ({
+  readBody: vi.fn(async (event: any) => event.body ?? {}),
+}));
+
+vi.mock("../org/context.js", () => ({
+  getA2ASecretByDomain: getA2ASecretByDomainMock,
+}));
+
+const config: A2AConfig = {
+  name: "QA Agent",
+  description: "Test agent",
+  skills: [],
+};
+
+describe("mountA2A auth", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    handleJsonRpcH3Mock.mockClear();
+    getA2ASecretByDomainMock.mockReset();
+    setResponseStatusMock.mockClear();
+    process.env = { ...originalEnv, NODE_ENV: "production" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("allows legacy apiKeyEnv bearer auth even when A2A_SECRET is configured", async () => {
+    process.env.A2A_SECRET = "jwt-secret";
+    process.env.LEGACY_A2A_KEY = "legacy-key";
+    const handler = await mountedA2AHandler({
+      ...config,
+      apiKeyEnv: "LEGACY_A2A_KEY",
+    });
+
+    const event = postEvent({ authorization: "Bearer legacy-key" });
+    const response = await handler(event);
+
+    expect(response).toEqual({ jsonrpc: "2.0", id: 1, result: { ok: true } });
+    expect(event._status).toBeUndefined();
+    expect(handleJsonRpcH3Mock).toHaveBeenCalledOnce();
+  });
+
+  it("verifies org-secret JWTs before deciding production auth is unconfigured", async () => {
+    delete process.env.A2A_SECRET;
+    getA2ASecretByDomainMock.mockResolvedValueOnce("org-a2a-secret");
+    const token = await new jose.SignJWT({
+      sub: "alice+qa@builder.io",
+      org_domain: "builder.io",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuer("https://dispatch.agent-native.test")
+      .setIssuedAt()
+      .setExpirationTime("15m")
+      .sign(new TextEncoder().encode("org-a2a-secret"));
+    const handler = await mountedA2AHandler(config);
+
+    const event = postEvent({ authorization: `Bearer ${token}` });
+    const response = await handler(event);
+
+    expect(response).toEqual({ jsonrpc: "2.0", id: 1, result: { ok: true } });
+    expect(event.context.__a2aVerifiedEmail).toBe("alice+qa@builder.io");
+    expect(event.context.__a2aOrgDomain).toBe("builder.io");
+    expect(event._status).toBeUndefined();
+    expect(handleJsonRpcH3Mock).toHaveBeenCalledOnce();
+  });
+});
+
+async function mountedA2AHandler(
+  config: A2AConfig,
+): Promise<(event: any) => any> {
+  const { mountA2A } = await import("./server.js");
+  const app = { routes: [] as Array<{ path: string; handler: any }> };
+  mountA2A(app, config);
+  const route = app.routes.find((entry) => entry.path === "/_agent-native/a2a");
+  if (!route) throw new Error("A2A route was not mounted");
+  return route.handler;
+}
+
+function postEvent(headers: Record<string, string>): any {
+  return {
+    method: "POST",
+    headers,
+    path: "/",
+    context: {},
+    body: { jsonrpc: "2.0", id: 1, method: "tasks/get", params: {} },
+  };
+}

--- a/packages/core/src/a2a/server.ts
+++ b/packages/core/src/a2a/server.ts
@@ -280,6 +280,8 @@ export function mountA2A(
       const authHeader = getRequestHeader(event, "authorization");
       let verifiedCallerEmail: string | null = null;
       let verifiedOrgDomain: string | null = null;
+      let legacyApiKeyAuthenticated = false;
+      let bearerTokenRejectedByJwt = false;
 
       // SECURITY: when neither A2A_SECRET nor an apiKeyEnv is configured,
       // there's no way to authenticate the caller. Default to "auth required"
@@ -288,39 +290,13 @@ export function mountA2A(
       // warning but allow so local templates work out of the box.
       const hasA2ASecret = !!process.env.A2A_SECRET;
       const hasApiKey = !!(config.apiKeyEnv && process.env[config.apiKeyEnv]);
-      if (!hasA2ASecret && !hasApiKey) {
-        if (process.env.NODE_ENV === "production") {
-          setResponseStatus(event, 503);
-          return {
-            jsonrpc: "2.0",
-            id: null,
-            error: {
-              code: -32001,
-              message:
-                "A2A authentication not configured. Set A2A_SECRET (preferred) or configure apiKeyEnv to accept inbound A2A traffic.",
-            },
-          };
-        }
-        warnA2AUnauthOnce();
-      }
 
       // Try JWT verification first (org-level or global A2A_SECRET-based identity)
       if (authHeader?.startsWith("Bearer ")) {
         const tokenPayload = await verifyA2AToken(authHeader, event);
         verifiedCallerEmail = tokenPayload.email;
         verifiedOrgDomain = tokenPayload.orgDomain;
-        // If a secret exists (org-level or global) and token fails verification, reject
-        if (!verifiedCallerEmail && process.env.A2A_SECRET) {
-          setResponseStatus(event, 401);
-          return {
-            jsonrpc: "2.0",
-            id: null,
-            error: {
-              code: -32001,
-              message: "Invalid or expired A2A token",
-            },
-          };
-        }
+        bearerTokenRejectedByJwt = !verifiedCallerEmail;
       }
 
       // Fall back to legacy API key check (exact string match)
@@ -344,6 +320,39 @@ export function mountA2A(
               error: { code: -32001, message: "Invalid API key" },
             };
           }
+          legacyApiKeyAuthenticated = true;
+        }
+      }
+
+      if (!verifiedCallerEmail && !legacyApiKeyAuthenticated) {
+        // If a global secret exists and JWT verification failed, reject after
+        // giving the legacy exact-match apiKeyEnv path a chance to succeed.
+        if (bearerTokenRejectedByJwt && process.env.A2A_SECRET) {
+          setResponseStatus(event, 401);
+          return {
+            jsonrpc: "2.0",
+            id: null,
+            error: {
+              code: -32001,
+              message: "Invalid or expired A2A token",
+            },
+          };
+        }
+
+        if (!hasA2ASecret && !hasApiKey) {
+          if (process.env.NODE_ENV === "production") {
+            setResponseStatus(event, 503);
+            return {
+              jsonrpc: "2.0",
+              id: null,
+              error: {
+                code: -32001,
+                message:
+                  "A2A authentication not configured. Set A2A_SECRET (preferred) or configure apiKeyEnv to accept inbound A2A traffic.",
+              },
+            };
+          }
+          warnA2AUnauthOnce();
         }
       }
 

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -8,6 +8,14 @@ const failA2AContinuationMock = vi.hoisted(() => vi.fn());
 const getA2AContinuationMock = vi.hoisted(() => vi.fn());
 const rescheduleA2AContinuationMock = vi.hoisted(() => vi.fn());
 const getTaskMock = vi.hoisted(() => vi.fn());
+const signA2ATokenMock = vi.hoisted(() =>
+  vi.fn(async () => "signed-a2a-token"),
+);
+const A2AClientMock = vi.hoisted(() =>
+  vi.fn().mockImplementation(function A2AClient() {
+    return { getTask: getTaskMock };
+  }),
+);
 
 vi.mock("./a2a-continuations-store.js", () => ({
   claimA2AContinuation: claimA2AContinuationMock,
@@ -19,10 +27,8 @@ vi.mock("./a2a-continuations-store.js", () => ({
 }));
 
 vi.mock("../a2a/client.js", () => ({
-  A2AClient: vi.fn().mockImplementation(function A2AClient() {
-    return { getTask: getTaskMock };
-  }),
-  signA2AToken: vi.fn(async () => "signed-a2a-token"),
+  A2AClient: A2AClientMock,
+  signA2AToken: signA2ATokenMock,
 }));
 
 vi.mock("./internal-token.js", () => ({
@@ -51,6 +57,7 @@ function continuation(
     agentName: "Slides",
     agentUrl: "https://slides.agent-native.test",
     a2aTaskId: "a2a-task-1",
+    a2aAuthToken: null,
     status: "processing",
     attempts: 1,
     nextCheckAt: 1,
@@ -190,6 +197,48 @@ describe("A2A continuation processor", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("reuses the original A2A bearer token stored on the continuation", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ a2aAuthToken: "original-a2a-token" }),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(A2AClientMock).toHaveBeenCalledWith(
+      "https://slides.agent-native.test",
+      "original-a2a-token",
+      { requestTimeoutMs: 25_000 },
+    );
+    expect(signA2ATokenMock).not.toHaveBeenCalled();
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+  });
+
+  it("preserves an originally unsigned A2A call when polling a continuation", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ a2aAuthToken: "" }),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(A2AClientMock).toHaveBeenCalledWith(
+      "https://slides.agent-native.test",
+      undefined,
+      { requestTimeoutMs: 25_000 },
+    );
+    expect(signA2ATokenMock).not.toHaveBeenCalled();
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+  });
+
   it("notifies the platform when the remote task fails", async () => {
     const sendResponse = vi.fn(async () => undefined);
     claimA2AContinuationMock.mockResolvedValueOnce(continuation());
@@ -299,6 +348,33 @@ describe("A2A continuation processor", () => {
     );
     getTaskMock.mockRejectedValueOnce(
       new DOMException("This operation was aborted", "AbortError"),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(sendResponse).not.toHaveBeenCalled();
+    expect(failA2AContinuationMock).not.toHaveBeenCalled();
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith("cont-1", 5_000);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ continuationId: "cont-1" }),
+      }),
+    );
+  });
+
+  it("treats A2A token rejection during polling as transient until the remote work deadline", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    getTaskMock.mockRejectedValueOnce(
+      new Error(
+        'A2A request failed (401): {"error":{"message":"Invalid or expired A2A token"}}',
+      ),
     );
     const { processA2AContinuationById } =
       await import("./a2a-continuation-processor.js");

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -308,7 +308,9 @@ function isRemoteWorkExpired(continuation: A2AContinuation): boolean {
 function isTransientA2APollError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   if (err.name === "AbortError") return true;
-  return /operation was aborted|aborted|timed out|timeout/i.test(err.message);
+  return /operation was aborted|aborted|timed out|timeout|Invalid or expired A2A token|A2A request failed \(401\)/i.test(
+    err.message,
+  );
 }
 
 function remotePollTimeoutReason(continuation: A2AContinuation): string {
@@ -363,6 +365,10 @@ async function redispatchContinuation(continuationId: string): Promise<void> {
 async function signContinuationToken(
   continuation: A2AContinuation,
 ): Promise<string | undefined> {
+  if (continuation.a2aAuthToken !== null) {
+    return continuation.a2aAuthToken || undefined;
+  }
+
   let orgDomain: string | undefined;
   let orgSecret: string | undefined;
   if (continuation.orgId) {
@@ -379,7 +385,9 @@ async function signContinuationToken(
   }
 
   try {
-    return await signA2AToken(continuation.ownerEmail, orgDomain, orgSecret);
+    return await signA2AToken(continuation.ownerEmail, orgDomain, orgSecret, {
+      expiresIn: "30m",
+    });
   } catch {
     return undefined;
   }

--- a/packages/core/src/integrations/a2a-continuations-store.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.ts
@@ -21,6 +21,7 @@ async function ensureTable(): Promise<void> {
           agent_name TEXT NOT NULL,
           agent_url TEXT NOT NULL,
           a2a_task_id TEXT NOT NULL,
+          a2a_auth_token TEXT,
           status TEXT NOT NULL,
           attempts ${intType()} NOT NULL DEFAULT 0,
           next_check_at ${intType()} NOT NULL,
@@ -36,6 +37,13 @@ async function ensureTable(): Promise<void> {
       await client.execute(
         `CREATE UNIQUE INDEX IF NOT EXISTS idx_a2a_continuations_remote_task ON integration_a2a_continuations(integration_task_id, agent_url, a2a_task_id)`,
       );
+      try {
+        await client.execute(
+          `ALTER TABLE integration_a2a_continuations ADD COLUMN a2a_auth_token TEXT`,
+        );
+      } catch {
+        // Column already exists.
+      }
     })();
   }
   return _initPromise;
@@ -59,6 +67,7 @@ export interface A2AContinuation {
   agentName: string;
   agentUrl: string;
   a2aTaskId: string;
+  a2aAuthToken: string | null;
   status: A2AContinuationStatus;
   attempts: number;
   nextCheckAt: number;
@@ -81,6 +90,7 @@ function rowToContinuation(row: Record<string, unknown>): A2AContinuation {
     agentName: row.agent_name as string,
     agentUrl: row.agent_url as string,
     a2aTaskId: row.a2a_task_id as string,
+    a2aAuthToken: (row.a2a_auth_token as string | null) ?? null,
     status: row.status as A2AContinuationStatus,
     attempts: Number(row.attempts ?? 0),
     nextCheckAt: Number(row.next_check_at ?? 0),
@@ -103,6 +113,7 @@ export async function insertA2AContinuation(input: {
   agentName: string;
   agentUrl: string;
   a2aTaskId: string;
+  a2aAuthToken?: string | null;
 }): Promise<A2AContinuation> {
   await ensureTable();
   const client = getDbExec();
@@ -114,9 +125,9 @@ export async function insertA2AContinuation(input: {
     await client.execute({
       sql: `INSERT INTO integration_a2a_continuations
         (id, integration_task_id, platform, external_thread_id, incoming_payload,
-         placeholder_ref, owner_email, org_id, agent_name, agent_url, a2a_task_id,
+         placeholder_ref, owner_email, org_id, agent_name, agent_url, a2a_task_id, a2a_auth_token,
          status, attempts, next_check_at, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       args: [
         id,
         input.integrationTaskId,
@@ -129,6 +140,7 @@ export async function insertA2AContinuation(input: {
         input.agentName,
         input.agentUrl,
         input.a2aTaskId,
+        input.a2aAuthToken ?? null,
         "pending",
         0,
         now,

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -17,6 +17,7 @@ import { getOrgDomain, getOrgA2ASecret } from "../org/context.js";
 
 const DEFAULT_SERVERLESS_INTEGRATION_A2A_TIMEOUT_MS = 18_000;
 const NETLIFY_INTEGRATION_A2A_TIMEOUT_MS = 50_000;
+const INTEGRATION_A2A_TOKEN_TTL = "30m";
 
 function parseTimeoutMs(value: string | undefined): number | undefined {
   if (!value) return undefined;
@@ -144,6 +145,7 @@ export async function run(
             callerEmail,
             callerOrgDomain,
             callerOrgSecret,
+            { expiresIn: INTEGRATION_A2A_TOKEN_TTL },
           );
         } catch {}
       }
@@ -205,6 +207,7 @@ export async function run(
         // still need to finish before their current function execution dies.
         const callTimeoutMs = getIntegrationCallTimeoutMs();
         responseText = await callAgent(agent.url, messageWithHint, {
+          apiKey,
           userEmail: callerEmail,
           orgDomain: callerOrgDomain,
           orgSecret: callerOrgSecret,
@@ -223,6 +226,7 @@ export async function run(
             pollErr,
             agent,
             callerEmail,
+            apiKey,
           );
           if (queued) {
             responseText = `The ${agent.name} agent is still working. I will update this thread with the final result when it finishes.`;
@@ -281,6 +285,7 @@ async function enqueueIntegrationContinuationIfPossible(
   error: A2ATaskTimeoutError,
   agent: { name: string; url: string },
   ownerEmail: string | undefined,
+  a2aAuthToken: string | undefined,
 ): Promise<boolean> {
   const integration = getIntegrationRequestContext();
   if (!integration || !ownerEmail) return false;
@@ -302,6 +307,7 @@ async function enqueueIntegrationContinuationIfPossible(
       agentName: agent.name,
       agentUrl: agent.url,
       a2aTaskId: error.taskId,
+      a2aAuthToken: a2aAuthToken ?? "",
     });
     await dispatchA2AContinuation(continuation.id).catch((err) => {
       console.error(


### PR DESCRIPTION
## Summary
- persist the original A2A bearer state for integration continuations so retry polling preserves the same auth mode as the initial cross-app task
- extend integration A2A token TTL to cover serverless continuation windows and treat transient polling auth/timeouts as retryable until the remote-work deadline
- let legacy apiKeyEnv auth fall back cleanly after JWT verification fails, and cover org-secret route verification

## Tests
- pnpm --filter @agent-native/core exec vitest --run src/a2a/server.spec.ts src/integrations/a2a-continuation-processor.spec.ts src/cli/create-e2e.spec.ts src/cli/create.spec.ts
- pnpm --filter @agent-native/core exec vitest --run src/a2a/handlers.spec.ts src/a2a/server.spec.ts src/a2a/client.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- git diff --check