### PR TITLE
[codex] Validate workspace app routes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.47",
+  "version": "0.7.48",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -5,6 +5,10 @@ import { execFileSync } from "child_process";
 import { setupAgentSymlinks } from "./setup-agents.js";
 import { workspacifyApp, parseWorkspaceScope } from "./workspacify.js";
 import {
+  DISPATCH_WORKSPACE_ROOT_REDIRECTS,
+  getWorkspaceAppIdValidationError,
+} from "../shared/workspace-app-id.js";
+import {
   coreTemplates,
   getTemplate,
   allTemplateNames,
@@ -980,46 +984,13 @@ function rewriteCoreDependencyVersions(projectDir: string): void {
   } catch {}
 }
 
-const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
-  ["overview", "overview"],
-  ["login", "login"],
-  ["signup", "signup"],
-  ["apps", "apps"],
-  ["apps/new-app", "new-app"],
-  ["new-app", "new-app"],
-  ["vault", "vault"],
-  ["integrations", "integrations"],
-  ["agents", "agents"],
-  ["workspace", "workspace"],
-  ["messaging", "messaging"],
-  ["destinations", "destinations"],
-  ["identities", "identities"],
-  ["approvals", "approvals"],
-  ["audit", "audit"],
-  ["team", "team"],
-];
-
-const RESERVED_WORKSPACE_APP_NAMES = new Set([
-  "_agent-native",
-  "_workspace_static",
-  "netlify",
-  ...DISPATCH_WORKSPACE_ROOT_REDIRECTS.map(([from]) => from),
-]);
-
 function validateWorkspaceAppName(
   appName: string,
   clack: typeof import("@clack/prompts"),
 ): void {
-  if (!/^[a-z][a-z0-9-]*$/.test(appName)) {
-    clack.cancel(
-      `Invalid app name "${appName}". Use lowercase letters, numbers, and hyphens.`,
-    );
-    process.exit(1);
-  }
-  if (RESERVED_WORKSPACE_APP_NAMES.has(appName)) {
-    clack.cancel(
-      `App name "${appName}" conflicts with a reserved workspace route. Choose a different name.`,
-    );
+  const error = getWorkspaceAppIdValidationError(appName);
+  if (error) {
+    clack.cancel(error);
     process.exit(1);
   }
 }

--- a/packages/core/src/client/NewWorkspaceAppFlow.tsx
+++ b/packages/core/src/client/NewWorkspaceAppFlow.tsx
@@ -12,6 +12,7 @@ import { agentNativePath, appBasePath } from "./api-path.js";
 import { sendToAgentChat } from "./agent-chat.js";
 import { isInBuilderFrame } from "./builder-frame.js";
 import { useDevMode } from "./use-dev-mode.js";
+import { getWorkspaceAppIdValidationError } from "../shared/workspace-app-id.js";
 
 export interface VaultSecretOption {
   id: string;
@@ -140,8 +141,15 @@ export function NewWorkspaceAppFlow({
     selectedSecretIds.length === 0
       ? "No keys selected"
       : `${selectedSecretIds.length} key${selectedSecretIds.length === 1 ? "" : "s"} selected`;
+  const hasAppNameCandidate =
+    appName.trim().length > 0 || prompt.trim().length > 0;
+  const safeAppName = slugify(appName) || titleFromPrompt(prompt);
+  const appNameError = hasAppNameCandidate
+    ? getWorkspaceAppIdValidationError(safeAppName)
+    : null;
 
-  const canSubmit = prompt.trim().length > 0 && slugify(appName).length > 0;
+  const canSubmit =
+    prompt.trim().length > 0 && safeAppName.length > 0 && !appNameError;
   const submitShortcut =
     typeof navigator !== "undefined" &&
     /Mac|iPhone|iPad/.test(navigator.userAgent)
@@ -149,7 +157,6 @@ export function NewWorkspaceAppFlow({
       : "Ctrl";
 
   function buildMessage(): string {
-    const safeAppName = slugify(appName) || titleFromPrompt(prompt);
     const keyList = selectedSecrets.map((s) => s.credentialKey).join(", ");
     return [
       `Create a new agent-native app in this workspace.`,
@@ -192,7 +199,11 @@ export function NewWorkspaceAppFlow({
 
   async function submit() {
     if (!canSubmit || isSubmitting) return;
-    const safeAppName = slugify(appName) || titleFromPrompt(prompt);
+    const validationError = getWorkspaceAppIdValidationError(safeAppName);
+    if (validationError) {
+      setStatusMessage(validationError);
+      return;
+    }
     const message = buildMessage();
     setIsSubmitting(true);
     setStatusMessage(null);
@@ -288,8 +299,15 @@ export function NewWorkspaceAppFlow({
                   value={appName}
                   onChange={(e) => setAppName(slugify(e.target.value))}
                   placeholder="customer-health"
-                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:border-ring"
+                  className={`h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:border-ring ${
+                    appNameError ? "border-destructive" : "border-input"
+                  }`}
                 />
+                {appNameError ? (
+                  <span className="block text-xs text-destructive">
+                    {appNameError}
+                  </span>
+                ) : null}
               </label>
               <label className="block space-y-2">
                 <span className="text-xs font-medium text-muted-foreground">

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -505,6 +505,9 @@ describe("workspace deploy", () => {
       "utf-8",
     );
     expect(worker).toContain(
+      'return Response.redirect(new URL("/dispatch/overview", request.url).toString(), 302);',
+    );
+    expect(worker).toContain(
       'if (pathname === "/_agent-native" || pathname.startsWith("/_agent-native/")) return app_dispatch.fetch(request, env, ctx);',
     );
     expect(worker).toContain(

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -88,7 +88,8 @@ export async function runWorkspaceDeploy(
     .readdirSync(appsDir, { withFileTypes: true })
     .filter((e) => e.isDirectory())
     .map((e) => e.name)
-    .filter((n) => fs.existsSync(path.join(appsDir, n, "package.json")));
+    .filter((n) => fs.existsSync(path.join(appsDir, n, "package.json")))
+    .sort(compareWorkspaceAppIds);
 
   if (apps.length === 0) {
     throw new Error(
@@ -272,13 +273,17 @@ export default {
     const { pathname } = new URL(request.url);
 ${dispatchRootFrameworkRoutes}${dispatch}
     if (pathname === "/") {
-      return Response.redirect(new URL("/${apps[0]}/", request.url).toString(), 302);
+      return Response.redirect(new URL("${cloudflareRootRedirectPath(apps)}", request.url).toString(), 302);
     }
     return new Response("Not found", { status: 404 });
   },
 };
 `;
   fs.writeFileSync(path.join(distDir, "_worker.js"), worker);
+}
+
+function cloudflareRootRedirectPath(apps: string[]): string {
+  return apps.includes("dispatch") ? "/dispatch/overview" : `/${apps[0]}/`;
 }
 
 function writeNetlifyRedirects(distDir: string, apps: string[]): void {
@@ -726,6 +731,12 @@ function normalizePreset(
 
 function moduleIdent(app: string): string {
   return "app_" + app.replace(/[^a-zA-Z0-9_]/g, "_");
+}
+
+function compareWorkspaceAppIds(a: string, b: string): number {
+  if (a === "dispatch") return -1;
+  if (b === "dispatch") return 1;
+  return a.localeCompare(b);
 }
 
 function copyDir(src: string, dest: string): void {

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -6,3 +6,10 @@ export {
 } from "./agent-chat.js";
 export { agentEnv, type EnvVar } from "./agent-env.js";
 export { truncate } from "./truncate.js";
+export {
+  DISPATCH_WORKSPACE_ROOT_REDIRECTS,
+  RESERVED_WORKSPACE_APP_IDS,
+  assertValidWorkspaceAppId,
+  getWorkspaceAppIdValidationError,
+  isValidWorkspaceAppIdFormat,
+} from "./workspace-app-id.js";

--- a/packages/core/src/shared/workspace-app-id.spec.ts
+++ b/packages/core/src/shared/workspace-app-id.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  getWorkspaceAppIdValidationError,
+  isValidWorkspaceAppIdFormat,
+} from "./workspace-app-id.js";
+
+describe("workspace app id validation", () => {
+  it("accepts lowercase workspace app ids", () => {
+    expect(isValidWorkspaceAppIdFormat("customer-portal2")).toBe(true);
+    expect(getWorkspaceAppIdValidationError("customer-portal2")).toBeNull();
+  });
+
+  it("rejects ids that cannot be mounted as workspace app paths", () => {
+    expect(getWorkspaceAppIdValidationError("Customer Portal")).toContain(
+      "Use lowercase letters",
+    );
+  });
+
+  it("rejects reserved workspace routes", () => {
+    for (const appId of [
+      "dispatch",
+      "apps",
+      "login",
+      "_agent-native",
+      "api",
+      "auth",
+    ]) {
+      expect(getWorkspaceAppIdValidationError(appId)).toContain(
+        "reserved workspace route",
+      );
+    }
+  });
+});

--- a/packages/core/src/shared/workspace-app-id.ts
+++ b/packages/core/src/shared/workspace-app-id.ts
@@ -1,0 +1,47 @@
+export const DISPATCH_WORKSPACE_ROOT_REDIRECTS = [
+  ["overview", "overview"],
+  ["login", "login"],
+  ["signup", "signup"],
+  ["apps", "apps"],
+  ["apps/new-app", "new-app"],
+  ["new-app", "new-app"],
+  ["vault", "vault"],
+  ["integrations", "integrations"],
+  ["agents", "agents"],
+  ["workspace", "workspace"],
+  ["messaging", "messaging"],
+  ["destinations", "destinations"],
+  ["identities", "identities"],
+  ["approvals", "approvals"],
+  ["audit", "audit"],
+  ["team", "team"],
+] as const;
+
+export const RESERVED_WORKSPACE_APP_IDS = new Set([
+  "_agent-native",
+  "_workspace_static",
+  "api",
+  "auth",
+  "dispatch",
+  "netlify",
+  ...DISPATCH_WORKSPACE_ROOT_REDIRECTS.map(([from]) => from),
+]);
+
+export function isValidWorkspaceAppIdFormat(appId: string): boolean {
+  return /^[a-z][a-z0-9-]*$/.test(appId);
+}
+
+export function getWorkspaceAppIdValidationError(appId: string): string | null {
+  if (RESERVED_WORKSPACE_APP_IDS.has(appId)) {
+    return `App name "${appId}" conflicts with a reserved workspace route. Choose a different name.`;
+  }
+  if (!isValidWorkspaceAppIdFormat(appId)) {
+    return `Invalid app name "${appId}". Use lowercase letters, numbers, and hyphens.`;
+  }
+  return null;
+}
+
+export function assertValidWorkspaceAppId(appId: string): void {
+  const error = getWorkspaceAppIdValidationError(appId);
+  if (error) throw new Error(error);
+}

--- a/templates/dispatch/actions/start-workspace-app-creation.ts
+++ b/templates/dispatch/actions/start-workspace-app-creation.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core";
+import { getWorkspaceAppIdValidationError } from "@agent-native/core/shared";
 import { z } from "zod";
 import { startWorkspaceAppCreation } from "../server/lib/app-creation-store.js";
 
@@ -9,7 +10,11 @@ export default defineAction({
     prompt: z.string().min(1).describe("The user's app creation request"),
     appId: z
       .string()
-      .regex(/^[a-z][a-z0-9-]{0,63}$/)
+      .max(64)
+      .refine((appId) => !getWorkspaceAppIdValidationError(appId), {
+        message:
+          "Use a non-reserved app id with lowercase letters, numbers, and hyphens.",
+      })
       .optional()
       .nullable()
       .describe("Desired workspace app id/path"),

--- a/templates/dispatch/server/lib/app-creation-store.spec.ts
+++ b/templates/dispatch/server/lib/app-creation-store.spec.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSettingMock = vi.hoisted(() => vi.fn());
+const runBuilderAgentMock = vi.hoisted(() => vi.fn());
+const grantSecretsToAppMock = vi.hoisted(() => vi.fn());
+const listSecretsMock = vi.hoisted(() => vi.fn());
+const originalNodeEnv = process.env.NODE_ENV;
+
+vi.mock("@agent-native/core/settings", () => ({
+  getSetting: getSettingMock,
+  putSetting: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/server", () => ({
+  getBuilderBranchProjectId: vi.fn(() => null),
+  resolveBuilderCredentials: vi.fn(async () => null),
+  runBuilderAgent: runBuilderAgentMock,
+}));
+
+vi.mock("./dispatch-store.js", () => ({
+  currentOrgId: vi.fn(() => null),
+  currentOwnerEmail: vi.fn(() => "dispatch-test@example.com"),
+  recordAudit: vi.fn(),
+}));
+
+vi.mock("./vault-store.js", () => ({
+  grantSecretsToApp: grantSecretsToAppMock,
+  listSecrets: listSecretsMock,
+}));
+
+describe("startWorkspaceAppCreation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    getSettingMock.mockReset();
+    runBuilderAgentMock.mockReset();
+    grantSecretsToAppMock.mockReset();
+    listSecretsMock.mockReset();
+    getSettingMock.mockResolvedValue({ builderProjectId: "builder-project" });
+    runBuilderAgentMock.mockResolvedValue({
+      branchName: "branch",
+      url: "https://builder.io/branch",
+      status: "started",
+    });
+    process.env.NODE_ENV = "production";
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("rejects reserved workspace app ids before Builder branch creation", async () => {
+    const { startWorkspaceAppCreation } =
+      await import("./app-creation-store.js");
+
+    await expect(
+      startWorkspaceAppCreation({
+        prompt: "make a dispatch app",
+        appId: "dispatch",
+      }),
+    ).rejects.toThrow("reserved workspace route");
+
+    expect(getSettingMock).not.toHaveBeenCalled();
+    expect(runBuilderAgentMock).not.toHaveBeenCalled();
+    expect(grantSecretsToAppMock).not.toHaveBeenCalled();
+  });
+});

--- a/templates/dispatch/server/lib/app-creation-store.ts
+++ b/templates/dispatch/server/lib/app-creation-store.ts
@@ -7,6 +7,7 @@ import {
   resolveBuilderCredentials,
   runBuilderAgent,
 } from "@agent-native/core/server";
+import { assertValidWorkspaceAppId } from "@agent-native/core/shared";
 import {
   currentOrgId,
   currentOwnerEmail,
@@ -348,12 +349,13 @@ export async function startWorkspaceAppCreation(input: {
   secretIds?: string[];
   preparedPrompt?: string | null;
 }) {
-  const settings = await getAppCreationSettings();
   const initial = buildWorkspaceAppPrompt({
     prompt: input.prompt,
     appId: input.appId,
     template: input.template,
   });
+  assertValidWorkspaceAppId(initial.appId);
+  const settings = await getAppCreationSettings();
   const selectedKeys = input.secretIds?.length
     ? (await listSecrets())
         .filter((secret) => input.secretIds?.includes(secret.id))


### PR DESCRIPTION
## Summary
- share workspace app-id validation between the CLI, Dispatch UI, and Dispatch app-creation action/store
- reject reserved workspace routes like dispatch, apps, login, api, auth, and _agent-native before Builder branch creation
- make Cloudflare workspace root redirects prefer /dispatch/overview when Dispatch exists
- bump @agent-native/core to 0.7.48

## Tests
- pnpm --filter @agent-native/core exec vitest --run src/shared/workspace-app-id.spec.ts src/cli/create.spec.ts src/deploy/workspace-deploy.spec.ts
- pnpm --dir templates/dispatch exec vitest --run server/lib/app-creation-store.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --dir templates/dispatch typecheck
- pnpm --filter @agent-native/core build
- git diff --check