### PR TITLE
[codex] Harden hosted workspace A2A integrations

### DIFF
--- a/packages/core/docs/content/deployment.md
+++ b/packages/core/docs/content/deployment.md
@@ -39,6 +39,10 @@ agent-native deploy --preset netlify
 
 Generated workspaces include a root `netlify.toml` that runs `agent-native deploy --preset netlify --build-only`, publishes `dist`, and points Netlify at `.netlify/functions-internal`.
 
+Hosted workspace builds require `A2A_SECRET` in the deploy provider environment.
+This makes Slack, inbound webhooks, and cross-app A2A resume work through signed
+background processors. Local `--build-only` artifact checks still run without it.
+
 Per-app independent deploy is still supported — just `cd apps/<name> && agent-native build` like a standalone scaffold.
 
 ## How It Works {#how-it-works}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.48",
+  "version": "0.7.49",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/response-text.spec.ts
+++ b/packages/core/src/a2a/response-text.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { collectFinalResponseTextFromAgentEvents } from "./response-text.js";
+import type { AgentChatEvent } from "../agent/types.js";
+
+describe("collectFinalResponseTextFromAgentEvents", () => {
+  it("returns all text when no tools ran", () => {
+    expect(
+      collectFinalResponseTextFromAgentEvents([
+        { type: "text", text: "Hello " },
+        { type: "text", text: "there" },
+        { type: "done" },
+      ]),
+    ).toBe("Hello there");
+  });
+
+  it("drops pre-tool narration and keeps the final answer after the last tool", () => {
+    const events: AgentChatEvent[] = [
+      { type: "text", text: "I will check analytics." },
+      { type: "tool_start", tool: "call-agent", input: {} },
+      { type: "tool_done", tool: "call-agent", result: "371" },
+      { type: "text", text: "371 pageview events yesterday." },
+      { type: "done" },
+    ];
+
+    expect(collectFinalResponseTextFromAgentEvents(events)).toBe(
+      "371 pageview events yesterday.",
+    );
+  });
+
+  it("uses text after the last tool when several tools ran", () => {
+    const events: AgentChatEvent[] = [
+      { type: "text", text: "Let me route that." },
+      { type: "tool_start", tool: "call-agent", input: {} },
+      { type: "tool_done", tool: "call-agent", result: "queued" },
+      { type: "text", text: "I have the first result." },
+      { type: "tool_start", tool: "create-document", input: {} },
+      { type: "tool_done", tool: "create-document", result: "{}" },
+      { type: "text", text: "Here is the finished deck URL." },
+    ];
+
+    expect(collectFinalResponseTextFromAgentEvents(events)).toBe(
+      "Here is the finished deck URL.",
+    );
+  });
+
+  it("falls back to all text when the post-tool window is empty", () => {
+    const events: AgentChatEvent[] = [
+      { type: "text", text: "Created it." },
+      { type: "tool_start", tool: "create-document", input: {} },
+      { type: "tool_done", tool: "create-document", result: "{}" },
+      { type: "done" },
+    ];
+
+    expect(collectFinalResponseTextFromAgentEvents(events)).toBe("Created it.");
+  });
+});

--- a/packages/core/src/a2a/response-text.ts
+++ b/packages/core/src/a2a/response-text.ts
@@ -1,0 +1,38 @@
+import type { AgentChatEvent } from "../agent/types.js";
+
+export function collectFinalResponseTextFromAgentEvents(
+  events: readonly AgentChatEvent[],
+): string {
+  let lastToolIdx = -1;
+  for (let i = events.length - 1; i >= 0; i--) {
+    const type = events[i].type;
+    if (type === "tool_start" || type === "tool_done") {
+      lastToolIdx = i;
+      break;
+    }
+  }
+
+  const startIdx = lastToolIdx >= 0 ? lastToolIdx + 1 : 0;
+  let responseText = collectTextEvents(events, startIdx);
+
+  // Some agents let the final tool output speak for itself. Fall back to all
+  // text so callers do not get an empty reply just because no post-tool text
+  // was emitted.
+  if (!responseText.trim() && lastToolIdx >= 0) {
+    responseText = collectTextEvents(events, 0);
+  }
+
+  return responseText;
+}
+
+function collectTextEvents(
+  events: readonly AgentChatEvent[],
+  startIdx: number,
+): string {
+  let text = "";
+  for (let i = startIdx; i < events.length; i++) {
+    const event = events[i];
+    if (event.type === "text") text += event.text;
+  }
+  return text;
+}

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -8,8 +8,12 @@ import { runWorkspaceDeploy } from "./workspace-deploy.js";
 
 let tmpDir: string;
 let previousAppBasePath: string | undefined;
+let previousA2ASecret: string | undefined;
+let previousCfPages: string | undefined;
 let previousDatabaseUrl: string | undefined;
 let previousUnpooledDatabaseUrl: string | undefined;
+let previousNetlify: string | undefined;
+let previousNetlifyLocal: string | undefined;
 let previousNitroPreset: string | undefined;
 let previousViteAppBasePath: string | undefined;
 let previousWorkspaceAppsJson: string | undefined;
@@ -24,14 +28,22 @@ beforeEach(() => {
     return Buffer.from("");
   }) as typeof execFileSync);
   previousAppBasePath = process.env.APP_BASE_PATH;
+  previousA2ASecret = process.env.A2A_SECRET;
+  previousCfPages = process.env.CF_PAGES;
   previousDatabaseUrl = process.env.DATABASE_URL;
   previousUnpooledDatabaseUrl = process.env.NETLIFY_DATABASE_URL_UNPOOLED;
+  previousNetlify = process.env.NETLIFY;
+  previousNetlifyLocal = process.env.NETLIFY_LOCAL;
   previousNitroPreset = process.env.NITRO_PRESET;
   previousViteAppBasePath = process.env.VITE_APP_BASE_PATH;
   previousWorkspaceAppsJson = process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
   delete process.env.APP_BASE_PATH;
+  delete process.env.A2A_SECRET;
+  delete process.env.CF_PAGES;
   delete process.env.DATABASE_URL;
   delete process.env.NETLIFY_DATABASE_URL_UNPOOLED;
+  delete process.env.NETLIFY;
+  delete process.env.NETLIFY_LOCAL;
   delete process.env.NITRO_PRESET;
   delete process.env.VITE_APP_BASE_PATH;
   delete process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
@@ -39,8 +51,12 @@ beforeEach(() => {
 
 afterEach(() => {
   restoreEnv("APP_BASE_PATH", previousAppBasePath);
+  restoreEnv("A2A_SECRET", previousA2ASecret);
+  restoreEnv("CF_PAGES", previousCfPages);
   restoreEnv("DATABASE_URL", previousDatabaseUrl);
   restoreEnv("NETLIFY_DATABASE_URL_UNPOOLED", previousUnpooledDatabaseUrl);
+  restoreEnv("NETLIFY", previousNetlify);
+  restoreEnv("NETLIFY_LOCAL", previousNetlifyLocal);
   restoreEnv("NITRO_PRESET", previousNitroPreset);
   restoreEnv("VITE_APP_BASE_PATH", previousViteAppBasePath);
   restoreEnv("AGENT_NATIVE_WORKSPACE_APPS_JSON", previousWorkspaceAppsJson);
@@ -398,6 +414,78 @@ describe("workspace deploy", () => {
       APP_BASE_PATH: "/mail",
       VITE_APP_BASE_PATH: "/mail",
     });
+  });
+
+  it("allows local build-only deploy checks without A2A_SECRET", async () => {
+    makeWorkspaceApp(tmpDir, "dispatch");
+
+    await runWorkspaceDeploy({
+      workspaceRoot: tmpDir,
+      preset: "netlify",
+      buildOnly: true,
+      execFile: execFile as typeof execFileSync,
+    });
+
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("requires A2A_SECRET for hosted Netlify workspace deploy builds", async () => {
+    process.env.NETLIFY = "true";
+    makeWorkspaceApp(tmpDir, "dispatch");
+
+    await expect(
+      runWorkspaceDeploy({
+        workspaceRoot: tmpDir,
+        preset: "netlify",
+        buildOnly: true,
+        execFile: execFile as typeof execFileSync,
+      }),
+    ).rejects.toThrow(/A2A_SECRET is required/);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("requires A2A_SECRET for hosted Cloudflare workspace deploy builds", async () => {
+    process.env.CF_PAGES = "1";
+    makeWorkspaceApp(tmpDir, "dispatch");
+
+    await expect(
+      runWorkspaceDeploy({
+        workspaceRoot: tmpDir,
+        preset: "cloudflare_pages",
+        buildOnly: true,
+        execFile: execFile as typeof execFileSync,
+      }),
+    ).rejects.toThrow(/A2A_SECRET is required/);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("requires A2A_SECRET for publish-oriented workspace deploys", async () => {
+    makeWorkspaceApp(tmpDir, "dispatch");
+
+    await expect(
+      runWorkspaceDeploy({
+        workspaceRoot: tmpDir,
+        preset: "netlify",
+        buildOnly: false,
+        execFile: execFile as typeof execFileSync,
+      }),
+    ).rejects.toThrow(/A2A_SECRET is required/);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("continues production workspace deploys when A2A_SECRET is configured", async () => {
+    process.env.NETLIFY = "true";
+    process.env.A2A_SECRET = "secret";
+    makeWorkspaceApp(tmpDir, "dispatch");
+
+    await runWorkspaceDeploy({
+      workspaceRoot: tmpDir,
+      preset: "netlify",
+      buildOnly: true,
+      execFile: execFile as typeof execFileSync,
+    });
+
+    expect(execFile).toHaveBeenCalledTimes(1);
   });
 
   it("writes workspace app URLs and preserves explicit manifest URLs", async () => {

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -100,6 +100,7 @@ export async function runWorkspaceDeploy(
   const workspaceApps = readWorkspaceAppManifest(workspaceRoot, apps);
 
   const preset = resolvePreset(opts.preset, rawArgs);
+  assertWorkspaceDeployProductionEnv({ buildOnly, preset });
   const distDir = path.join(workspaceRoot, "dist");
   fs.rmSync(distDir, { recursive: true, force: true });
   fs.mkdirSync(distDir, { recursive: true });
@@ -714,6 +715,40 @@ function resolvePreset(
     normalizePreset(process.env.NITRO_PRESET) ??
     "cloudflare_pages"
   );
+}
+
+function assertWorkspaceDeployProductionEnv(opts: {
+  buildOnly: boolean;
+  preset: WorkspaceDeployPreset;
+}): void {
+  if (!isProductionWorkspaceDeploy(opts)) return;
+  if (process.env.A2A_SECRET?.trim()) return;
+  throw new Error(
+    [
+      "A2A_SECRET is required for production workspace deploys.",
+      "Workspace Slack, webhook, and cross-app A2A work resumes through signed background processors; without A2A_SECRET those production routes return 503.",
+      'Set A2A_SECRET in your deploy provider (for example: netlify env:set A2A_SECRET "$(openssl rand -hex 32)") and redeploy.',
+      "For local artifact checks, run agent-native deploy --build-only outside the deploy provider environment.",
+    ].join(" "),
+  );
+}
+
+function isProductionWorkspaceDeploy(opts: {
+  buildOnly: boolean;
+  preset: WorkspaceDeployPreset;
+}): boolean {
+  if (!opts.buildOnly) return true;
+  if (
+    opts.preset === "netlify" &&
+    process.env.NETLIFY === "true" &&
+    process.env.NETLIFY_LOCAL !== "true"
+  ) {
+    return true;
+  }
+  if (opts.preset === "cloudflare_pages" && process.env.CF_PAGES === "1") {
+    return true;
+  }
+  return false;
 }
 
 function normalizePreset(

--- a/packages/core/src/integrations/a2a-continuation-marker.ts
+++ b/packages/core/src/integrations/a2a-continuation-marker.ts
@@ -1,0 +1,2 @@
+export const A2A_CONTINUATION_QUEUED_MARKER =
+  "[agent-native:a2a-continuation-queued]";

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -115,6 +115,39 @@ function createAdapter(sendResponse = vi.fn()): PlatformAdapter {
   };
 }
 
+function pendingTask(
+  overrides: Partial<PendingTask> & { payload?: PendingTask["payload"] } = {},
+): PendingTask {
+  const id = overrides.id ?? "task-qa";
+  return {
+    id,
+    platform: "fake",
+    externalEventKey: `fake:${id}:1001`,
+    externalThreadId: "thread-qa",
+    payload:
+      overrides.payload ??
+      JSON.stringify({
+        incoming: {
+          platform: "fake",
+          externalThreadId: "thread-qa",
+          text: "hello from slack",
+          senderName: "QA User",
+          platformContext: { channel: "C123" },
+          timestamp: 1001,
+        },
+      }),
+    ownerEmail: "dispatch+qa@integration.local",
+    orgId: "org-qa",
+    status: "processing",
+    attempts: 1,
+    errorMessage: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    completedAt: null,
+    ...overrides,
+  };
+}
+
 describe("integration webhook handler engine resolution", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -500,6 +533,129 @@ describe("integration webhook handler engine resolution", () => {
           externalThreadId: "thread-4",
         }),
       }),
+    );
+  });
+
+  it("suppresses stale A2A continuation deferral replies", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const { A2A_CONTINUATION_QUEUED_MARKER } =
+      await import("./a2a-continuation-marker.js");
+    const sendResponse = vi.fn();
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({
+        type: "tool_start",
+        tool: "call-agent",
+        input: { agent: "analytics", message: "count pageviews" },
+      });
+      send({
+        type: "tool_done",
+        tool: "call-agent",
+        result: `${A2A_CONTINUATION_QUEUED_MARKER}\nThe Analytics agent is still working.`,
+      });
+      send({
+        type: "text",
+        text: "Here is the relay from the Analytics agent. It is still processing and will post the result back to this thread when complete.",
+      });
+    });
+
+    await processIntegrationTask(pendingTask({ id: "task-continuation" }), {
+      adapter: createAdapter(sendResponse),
+      systemPrompt: "system",
+      actions: {},
+      model: "claude-sonnet-4-6",
+      apiKey: "",
+      ownerEmail: "dispatch+qa@integration.local",
+    });
+
+    expect(sendResponse).not.toHaveBeenCalled();
+    expect(updateThreadDataMock).toHaveBeenCalled();
+  });
+
+  it("suppresses alternate A2A continuation deferral wording", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const { A2A_CONTINUATION_QUEUED_MARKER } =
+      await import("./a2a-continuation-marker.js");
+    const sendResponse = vi.fn();
+    const deferrals = [
+      "",
+      A2A_CONTINUATION_QUEUED_MARKER,
+      "The Analytics answer will show up here shortly.",
+      "I will relay from the Analytics agent when the result is ready.",
+    ];
+
+    for (const [index, text] of deferrals.entries()) {
+      runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+        send({
+          type: "tool_start",
+          tool: "call-agent",
+          input: { agent: "analytics", message: "count pageviews" },
+        });
+        send({
+          type: "tool_done",
+          tool: "call-agent",
+          result: `${A2A_CONTINUATION_QUEUED_MARKER}\nThe Analytics agent is still working.`,
+        });
+        if (text) {
+          send({
+            type: "text",
+            text,
+          });
+        }
+      });
+
+      await processIntegrationTask(
+        pendingTask({ id: `task-continuation-wording-${index}` }),
+        {
+          adapter: createAdapter(sendResponse),
+          systemPrompt: "system",
+          actions: {},
+          model: "claude-sonnet-4-6",
+          apiKey: "",
+          ownerEmail: "dispatch+qa@integration.local",
+        },
+      );
+    }
+
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  it("still sends real final text after an A2A continuation marker", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const { A2A_CONTINUATION_QUEUED_MARKER } =
+      await import("./a2a-continuation-marker.js");
+    const sendResponse = vi.fn();
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({
+        type: "tool_start",
+        tool: "call-agent",
+        input: { agent: "analytics", message: "count pageviews" },
+      });
+      send({
+        type: "tool_done",
+        tool: "call-agent",
+        result: `${A2A_CONTINUATION_QUEUED_MARKER}\nThe Analytics agent is still working.`,
+      });
+      send({
+        type: "text",
+        text: "371 pageview events were recorded in the requested window.",
+      });
+    });
+
+    await processIntegrationTask(pendingTask({ id: "task-final" }), {
+      adapter: createAdapter(sendResponse),
+      systemPrompt: "system",
+      actions: {},
+      model: "claude-sonnet-4-6",
+      apiKey: "",
+      ownerEmail: "dispatch+qa@integration.local",
+    });
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "371 pageview events were recorded in the requested window.",
+      }),
+      expect.any(Object),
+      expect.objectContaining({ placeholderRef: undefined }),
     );
   });
 });

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -39,6 +39,8 @@ import {
 import { signInternalToken } from "./internal-token.js";
 import { FRAMEWORK_ROUTE_PREFIX } from "../server/core-routes-plugin.js";
 import { withConfiguredAppBasePath } from "../server/app-base-path.js";
+import { A2A_CONTINUATION_QUEUED_MARKER } from "./a2a-continuation-marker.js";
+import { collectFinalResponseTextFromAgentEvents } from "../a2a/response-text.js";
 
 const PROCESSOR_DISPATCH_SETTLE_WAIT_MS = 1_500;
 
@@ -551,39 +553,13 @@ async function processIncomingMessage(
       },
       async (completedRun: ActiveRun) => {
         try {
-          // Collect text events from the run, but drop any pre-tool-call
-          // preamble so the user sees just the final answer instead of
-          // "I need to delegate this..." run-on into the raw tool result.
-          //
-          // Heuristic: when the agent fired any tool, only keep text events
-          // that come AFTER the last tool. The preamble ("Let me check…")
-          // and the final answer ("630") are emitted as two separate text
-          // events, and concatenating them with no separator was producing
-          // "...signup data.630" in Slack.
-          let lastToolIdx = -1;
-          for (let i = completedRun.events.length - 1; i >= 0; i--) {
-            const t = completedRun.events[i].event.type;
-            if (t === "tool_start" || t === "tool_done") {
-              lastToolIdx = i;
-              break;
-            }
-          }
-          const startIdx = lastToolIdx >= 0 ? lastToolIdx + 1 : 0;
-          let responseText = "";
-          for (let i = startIdx; i < completedRun.events.length; i++) {
-            const ev = completedRun.events[i].event;
-            if (ev.type === "text") responseText += ev.text;
-          }
-          // If the post-tool window had no text (tool spoke for itself),
-          // fall back to all text events so we never leave the user with
-          // an empty reply.
-          if (!responseText.trim() && lastToolIdx >= 0) {
-            for (const runEvent of completedRun.events) {
-              if (runEvent.event.type === "text") {
-                responseText += runEvent.event.text;
-              }
-            }
-          }
+          let responseText = collectFinalResponseTextFromAgentEvents(
+            completedRun.events.map((runEvent) => runEvent.event),
+          );
+
+          const suppressPlatformReply =
+            hasQueuedA2AContinuation(completedRun) &&
+            isQueuedA2AContinuationDeferral(responseText);
 
           // If the run errored OR produced no text, post a graceful fallback so
           // the user isn't left wondering whether the bot saw their message.
@@ -601,7 +577,10 @@ async function processIncomingMessage(
             isLlmCredentialError(runErrorText)
           ) {
             responseText = formatLlmCredentialErrorMessage();
-          } else if (!responseText.trim() || runErrored) {
+          } else if (
+            !suppressPlatformReply &&
+            (!responseText.trim() || runErrored)
+          ) {
             if (runErrored) {
               responseText =
                 (responseText.trim() ? responseText + "\n\n" : "") +
@@ -627,12 +606,14 @@ async function processIncomingMessage(
 
           // Format and send back to platform — update the "thinking…"
           // placeholder in place if the adapter supplied one.
-          const outgoing = adapter.formatAgentResponse(responseText, {
-            threadDeepLinkUrl,
-          });
-          await adapter.sendResponse(outgoing, incoming, {
-            placeholderRef: opts.placeholderRef,
-          });
+          if (!suppressPlatformReply) {
+            const outgoing = adapter.formatAgentResponse(responseText, {
+              threadDeepLinkUrl,
+            });
+            await adapter.sendResponse(outgoing, incoming, {
+              placeholderRef: opts.placeholderRef,
+            });
+          }
 
           // Persist thread data
           await persistThreadData(
@@ -659,6 +640,26 @@ async function processIncomingMessage(
       },
     );
   });
+}
+
+function hasQueuedA2AContinuation(completedRun: ActiveRun): boolean {
+  return completedRun.events.some((runEvent) => {
+    const event = runEvent.event;
+    return (
+      event.type === "tool_done" &&
+      event.tool === "call-agent" &&
+      String(event.result ?? "").includes(A2A_CONTINUATION_QUEUED_MARKER)
+    );
+  });
+}
+
+function isQueuedA2AContinuationDeferral(text: string): boolean {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) return true;
+  if (normalized.includes(A2A_CONTINUATION_QUEUED_MARKER)) return true;
+  return /\b(?:still (?:working|processing)|taking longer than expected|will (?:post|update|surface|show up)|final result when it finishes|while you wait|as soon as (?:it|the result) (?:comes back|is ready)|relay from the .* agent)\b/i.test(
+    normalized,
+  );
 }
 
 /**

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -7,6 +7,7 @@ import {
   callAgent,
   signA2AToken,
 } from "../a2a/client.js";
+import { A2A_CONTINUATION_QUEUED_MARKER } from "../integrations/a2a-continuation-marker.js";
 import {
   getRequestUserEmail,
   getRequestOrgId,
@@ -229,8 +230,7 @@ export async function run(
             apiKey,
           );
           if (queued) {
-            responseText = `The ${agent.name} agent is still working. I will update this thread with the final result when it finishes.`;
-            emitNewText(responseText);
+            responseText = `${A2A_CONTINUATION_QUEUED_MARKER}\nThe ${agent.name} agent is still working. Do not send an interim reply to the user; the final result will be posted to the originating integration thread automatically.`;
           } else {
             const reason = pollErr?.message ?? "unknown error";
             responseText = `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -22,6 +22,7 @@ import type { AgentEngine, EngineMessage } from "../agent/engine/types.js";
 import { resolveEngine, createAnthropicEngine } from "../agent/engine/index.js";
 import { DEFAULT_MODEL } from "../agent/default-model.js";
 import type {
+  AgentChatEvent,
   ActionTool,
   MentionProvider,
   MentionProviderItem,
@@ -81,7 +82,12 @@ import { readBody } from "./h3-helpers.js";
 import { getBuilderBrowserConnectUrl } from "./builder-browser.js";
 import { captureCliOutput } from "./cli-capture.js";
 import { withConfiguredAppBasePath } from "./app-base-path.js";
-import { appendA2AArtifactLinks } from "../a2a/artifact-response.js";
+import {
+  appendA2AArtifactLinks,
+  type A2AArtifactResponseOptions,
+  type A2AToolResultSummary,
+} from "../a2a/artifact-response.js";
+import { collectFinalResponseTextFromAgentEvents } from "../a2a/response-text.js";
 
 // Lazy fs — loaded via dynamic import() on first use.
 // This avoids require() which bundlers convert to createRequire(import.meta.url)
@@ -138,6 +144,18 @@ function resolveArtifactBaseUrl(event: any | undefined): string | undefined {
   } catch {}
 
   return undefined;
+}
+
+export function assembleA2AFinalResponse(
+  events: readonly AgentChatEvent[],
+  toolResults: readonly A2AToolResultSummary[],
+  options: A2AArtifactResponseOptions & { event?: any } = {},
+): { responseText: string; finalText: string } {
+  const responseText = collectFinalResponseTextFromAgentEvents(events);
+  const finalText = appendA2AArtifactLinks(responseText, [...toolResults], {
+    baseUrl: options.baseUrl ?? resolveArtifactBaseUrl(options.event),
+  });
+  return { responseText, finalText };
 }
 
 /**
@@ -2749,8 +2767,9 @@ export function createAgentChatPlugin(
             { role: "user", content: [{ type: "text", text }] },
           ];
 
-          // Run the SAME agent loop, collect text events, yield as A2A messages
-          let accumulatedText = "";
+          // Run the SAME agent loop, then extract the final answer from the
+          // event stream so pre-tool narration never leaks as the A2A result.
+          const a2aEvents: AgentChatEvent[] = [];
           const a2aToolResults: Array<{ tool: string; result: string }> = [];
           const controller = new AbortController();
 
@@ -2766,9 +2785,8 @@ export function createAgentChatPlugin(
             messages: a2aMessages,
             actions: a2aActions,
             send: (event) => {
-              if (event.type === "text") {
-                accumulatedText += event.text;
-              } else if (event.type === "tool_start") {
+              a2aEvents.push(event);
+              if (event.type === "tool_start") {
                 console.log(`[A2A] Tool call: ${event.tool}`);
               } else if (event.type === "tool_done") {
                 a2aToolResults.push({
@@ -2778,22 +2796,20 @@ export function createAgentChatPlugin(
               } else if (event.type === "error") {
                 console.error(`[A2A] Error: ${event.error}`);
               } else if (event.type === "done") {
-                console.log(
-                  `[A2A] Done. Response: ${accumulatedText.length} chars`,
-                );
+                console.log(`[A2A] Done. Events: ${a2aEvents.length}`);
               }
             },
             signal: controller.signal,
           });
 
-          console.log(
-            `[A2A] Loop complete. Text: ${accumulatedText.slice(0, 100)}...`,
+          const { responseText, finalText } = assembleA2AFinalResponse(
+            a2aEvents,
+            a2aToolResults,
+            { event: context.event },
           );
 
-          const finalText = appendA2AArtifactLinks(
-            accumulatedText,
-            a2aToolResults,
-            { baseUrl: resolveArtifactBaseUrl(context.event) },
+          console.log(
+            `[A2A] Loop complete. Text: ${responseText.slice(0, 100)}...`,
           );
 
           // Yield the final accumulated text

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -40,8 +40,7 @@ import {
   putUserSetting,
   deleteUserSetting,
 } from "../settings/user-settings.js";
-import { getSession, isDevEnvironment, DEV_MODE_USER_EMAIL } from "./auth.js";
-import { isLocalDatabase } from "../db/client.js";
+import { getSession, DEV_MODE_USER_EMAIL } from "./auth.js";
 import { getOrigin } from "./google-oauth.js";
 import { findWorkspaceRoot } from "../scripts/utils.js";
 import { listOnboardingSteps } from "../onboarding/registry.js";
@@ -82,6 +81,7 @@ import {
   isStoredEngineUsable,
 } from "../agent/engine/registry.js";
 import { getOrgContext } from "../org/context.js";
+import { isEnvVarWriteAllowed } from "./env-var-writes.js";
 
 /**
  * The base path prefix for all framework-level routes.
@@ -89,26 +89,6 @@ import { getOrgContext } from "../org/context.js";
  * collisions with template-specific `/api/*` routes.
  */
 export const FRAMEWORK_ROUTE_PREFIX = "/_agent-native";
-
-/**
- * Whether deployment-wide `process.env` writes (and rehydration from the
- * unscoped `persisted-env-vars` settings row) are safe on this deployment.
- *
- * Allowed only when:
- *   - we're running against a local SQLite-only database in a development
- *     environment (no shared-tenant exposure), OR
- *   - the operator has explicitly opted in via
- *     `AGENT_NATIVE_ALLOW_ENV_VAR_WRITES=1` (single-tenant self-hosted).
- *
- * On any hosted multi-tenant deploy this returns false: env vars are
- * deployment-wide globals and one tenant could otherwise overwrite Stripe /
- * OpenAI / Sentry keys for every other tenant. Per-org credentials must use
- * the per-user/org `app_secrets` store via `saveCredential()` instead.
- */
-function isEnvVarWriteAllowed(): boolean {
-  if (process.env.AGENT_NATIVE_ALLOW_ENV_VAR_WRITES === "1") return true;
-  return isDevEnvironment() && isLocalDatabase();
-}
 
 function trackBuilderLifecycle(
   name: string,

--- a/packages/core/src/server/create-server.ts
+++ b/packages/core/src/server/create-server.ts
@@ -11,19 +11,7 @@ import {
 import path from "path";
 import { agentEnv } from "../shared/agent-env.js";
 import { readBody } from "../server/h3-helpers.js";
-import { isDevEnvironment } from "./auth.js";
-import { isLocalDatabase } from "../db/client.js";
-
-/**
- * Mirror of `isEnvVarWriteAllowed` in core-routes-plugin.ts. See the comment
- * there — env vars are deployment-wide globals and writes from authenticated
- * users would let one tenant overwrite shared Stripe / OpenAI / Sentry keys
- * for every other tenant on shared-DB hosted templates.
- */
-function isEnvVarWriteAllowed(): boolean {
-  if (process.env.AGENT_NATIVE_ALLOW_ENV_VAR_WRITES === "1") return true;
-  return isDevEnvironment() && isLocalDatabase();
-}
+import { isEnvVarWriteAllowed } from "./env-var-writes.js";
 
 export interface EnvKeyConfig {
   /** Environment variable name (e.g. "HUBSPOT_ACCESS_TOKEN") */

--- a/packages/core/src/server/env-var-writes.spec.ts
+++ b/packages/core/src/server/env-var-writes.spec.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isEnvVarWriteAllowed } from "./env-var-writes.js";
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_ALLOW = process.env.AGENT_NATIVE_ALLOW_ENV_VAR_WRITES;
+
+describe("isEnvVarWriteAllowed", () => {
+  afterEach(() => {
+    restoreEnv("NODE_ENV", ORIGINAL_NODE_ENV);
+    restoreEnv("AGENT_NATIVE_ALLOW_ENV_VAR_WRITES", ORIGINAL_ALLOW);
+    vi.unstubAllEnvs();
+  });
+
+  it("refuses request-time env writes in production even with the opt-in flag", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("AGENT_NATIVE_ALLOW_ENV_VAR_WRITES", "1");
+
+    expect(isEnvVarWriteAllowed()).toBe(false);
+  });
+
+  it("allows explicit non-production single-tenant opt-in", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("AGENT_NATIVE_ALLOW_ENV_VAR_WRITES", "1");
+
+    expect(isEnvVarWriteAllowed()).toBe(true);
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/packages/core/src/server/env-var-writes.ts
+++ b/packages/core/src/server/env-var-writes.ts
@@ -1,0 +1,16 @@
+import { isLocalDatabase } from "../db/client.js";
+import { isDevEnvironment } from "./auth.js";
+
+/**
+ * Whether deployment-wide `process.env` writes (and .env file writes) are safe.
+ *
+ * Production never allows request-time env writes, even with the escape hatch.
+ * Env vars are deployment-wide globals and one tenant could otherwise
+ * overwrite shared keys for every other tenant. Per-user/org credentials
+ * should use `app_secrets` instead.
+ */
+export function isEnvVarWriteAllowed(): boolean {
+  if (process.env.NODE_ENV === "production") return false;
+  if (process.env.AGENT_NATIVE_ALLOW_ENV_VAR_WRITES === "1") return true;
+  return isDevEnvironment() && isLocalDatabase();
+}

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -267,6 +267,7 @@ You do NOT get auto-injected screen state. You MUST call `view-screen` yourself 
 ### Running actions
 
 **Always use `pnpm action <name>` for operations** — never curl or raw HTTP.
+For design artifacts, projects, files, and design systems, use the design actions (`create-design`, `generate-design`, `create-file`, `update-file`, etc.). Do **not** create or modify design rows with `db-exec` or raw SQL; raw SQL bypasses action validation, sharing/ownership, file bookkeeping, and the UI refresh contract.
 
 Your shell cwd is this template's root (e.g., `templates/design/`). Run actions directly:
 
@@ -383,8 +384,8 @@ This is the core workflow. The agent generates complete HTML designs and saves t
 When a request arrives from Slack, Dispatch, or any other app via A2A, the caller cannot see Design's local editor overlays, question flow, or `design-variants` picker. For those requests:
 
 1. Do **not** use `application-state/show-questions` or `application-state/design-variants`.
-2. Create the design shell with `create-design`.
-3. Immediately persist at least one complete, self-contained HTML/JSX file with `generate-design`.
+2. Create the design shell with `create-design` — never by inserting rows with `db-exec` or raw SQL.
+3. Immediately persist at least one complete, self-contained HTML/JSX file with `generate-design` — never by writing directly to design tables.
 4. Verify the saved result with `get-design` or the `generate-design` return value. A design is ready only when `files.length > 0` and an `index.html` or other renderable HTML/JSX file exists.
 5. Only then reply with the design ID and the full URL/path for `/design/<id>`. Never report a `create-design` ID or URL as success before `generate-design` succeeds; that is only an empty shell.
 


### PR DESCRIPTION
## Summary
- require hosted workspace deploys to configure A2A_SECRET before production-style deploys
- suppress stale Slack/integration deferral replies when A2A continuations have been queued
- share final-response extraction between webhook replies and A2A server responses so pre-tool narration does not leak into final answers
- block production env-var writes even if an opt-in flag is present, keeping request-time secret writes local-only
- clarify design A2A instructions to use actions instead of direct SQL for artifacts

## Verification
- pnpm --filter @agent-native/core exec vitest --run src/a2a/response-text.spec.ts src/integrations/webhook-handler-engine.spec.ts src/integrations/a2a-continuation-processor.spec.ts src/deploy/workspace-deploy.spec.ts src/server/env-var-writes.spec.ts src/server/create-server.spec.ts
- pnpm --filter @agent-native/core test
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- pnpm lint