### PR TITLE
Fix hosted A2A auth and Slack continuations

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.49",
+  "version": "0.7.50",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/client.spec.ts
+++ b/packages/core/src/a2a/client.spec.ts
@@ -1,9 +1,22 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { A2AClient, A2ATaskTimeoutError, callAgent } from "./client.js";
+import * as jose from "jose";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  A2AClient,
+  A2ATaskTimeoutError,
+  callAgent,
+  signA2AToken,
+} from "./client.js";
 
 describe("A2AClient", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
+    process.env = originalEnv;
   });
 
   it("uses the A2A endpoint advertised by the agent card", async () => {
@@ -121,6 +134,29 @@ describe("A2AClient", () => {
         { timeoutMs: 1, pollIntervalMs: 1 },
       ),
     ).rejects.toBeInstanceOf(A2ATaskTimeoutError);
+  });
+
+  it("can prefer the shared global A2A secret before an org secret", async () => {
+    process.env.A2A_SECRET = "global-a2a-secret";
+
+    const token = await signA2AToken(
+      "alice+qa@agent-native.test",
+      "builder.io",
+      "org-a2a-secret",
+      { preferGlobalSecret: true },
+    );
+
+    await expect(
+      jose.jwtVerify(token, new TextEncoder().encode("global-a2a-secret")),
+    ).resolves.toMatchObject({
+      payload: {
+        sub: "alice+qa@agent-native.test",
+        org_domain: "builder.io",
+      },
+    });
+    await expect(
+      jose.jwtVerify(token, new TextEncoder().encode("org-a2a-secret")),
+    ).rejects.toThrow();
   });
 });
 

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -29,16 +29,21 @@ export class A2ATaskTimeoutError extends Error {
 /**
  * Sign a JWT for A2A cross-app identity verification.
  *
- * Uses A2A_SECRET as an HMAC key. The token contains the caller's email
- * as `sub`, so the receiving app can verify who's calling.
+ * Uses an org-level secret by default for direct org-secret workflows. Callers
+ * that are doing ordinary hosted cross-app delegation can set
+ * `preferGlobalSecret` so deployments with a shared A2A_SECRET don't depend on
+ * every app database having an identical org row. The token contains the
+ * caller's email as `sub`, so the receiving app can verify who's calling.
  */
 export async function signA2AToken(
   email: string,
   orgDomain?: string,
   orgSecret?: string,
-  options?: { expiresIn?: string | number },
+  options?: { expiresIn?: string | number; preferGlobalSecret?: boolean },
 ): Promise<string> {
-  const secret = orgSecret || process.env.A2A_SECRET;
+  const secret = options?.preferGlobalSecret
+    ? process.env.A2A_SECRET || orgSecret
+    : orgSecret || process.env.A2A_SECRET;
   if (!secret) {
     throw new Error(
       "No A2A secret available. Set an org-level A2A secret in Team settings, " +
@@ -464,6 +469,7 @@ export async function callAgent(
         opts.userEmail,
         opts.orgDomain,
         opts.orgSecret,
+        { preferGlobalSecret: true },
       );
     } catch {
       // Fall back to unsigned call

--- a/packages/core/src/a2a/response-text.spec.ts
+++ b/packages/core/src/a2a/response-text.spec.ts
@@ -53,4 +53,24 @@ describe("collectFinalResponseTextFromAgentEvents", () => {
 
     expect(collectFinalResponseTextFromAgentEvents(events)).toBe("Created it.");
   });
+
+  it("can leave the response empty instead of falling back to pre-tool narration", () => {
+    const events: AgentChatEvent[] = [
+      { type: "text", text: "I will ask Analytics to check that." },
+      { type: "tool_start", tool: "call-agent", input: {} },
+      {
+        type: "tool_done",
+        tool: "call-agent",
+        result:
+          "[agent-native:a2a-continuation-queued]\nThe Analytics agent is still working.",
+      },
+      { type: "done" },
+    ];
+
+    expect(
+      collectFinalResponseTextFromAgentEvents(events, {
+        fallbackToPreToolText: false,
+      }),
+    ).toBe("");
+  });
 });

--- a/packages/core/src/a2a/response-text.ts
+++ b/packages/core/src/a2a/response-text.ts
@@ -1,8 +1,14 @@
 import type { AgentChatEvent } from "../agent/types.js";
 
+export interface CollectFinalResponseTextOptions {
+  fallbackToPreToolText?: boolean;
+}
+
 export function collectFinalResponseTextFromAgentEvents(
   events: readonly AgentChatEvent[],
+  options: CollectFinalResponseTextOptions = {},
 ): string {
+  const fallbackToPreToolText = options.fallbackToPreToolText ?? true;
   let lastToolIdx = -1;
   for (let i = events.length - 1; i >= 0; i--) {
     const type = events[i].type;
@@ -18,7 +24,7 @@ export function collectFinalResponseTextFromAgentEvents(
   // Some agents let the final tool output speak for itself. Fall back to all
   // text so callers do not get an empty reply just because no post-tool text
   // was emitted.
-  if (!responseText.trim() && lastToolIdx >= 0) {
+  if (!responseText.trim() && lastToolIdx >= 0 && fallbackToPreToolText) {
     responseText = collectTextEvents(events, 0);
   }
 

--- a/packages/core/src/a2a/server.spec.ts
+++ b/packages/core/src/a2a/server.spec.ts
@@ -102,6 +102,30 @@ describe("mountA2A auth", () => {
     expect(event._status).toBeUndefined();
     expect(handleJsonRpcH3Mock).toHaveBeenCalledOnce();
   });
+
+  it("falls back to the shared A2A_SECRET when the receiver org secret differs", async () => {
+    process.env.A2A_SECRET = "shared-global-secret";
+    getA2ASecretByDomainMock.mockResolvedValueOnce("receiver-local-org-secret");
+    const token = await new jose.SignJWT({
+      sub: "alice+qa@builder.io",
+      org_domain: "builder.io",
+    })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuer("https://dispatch.agent-native.test")
+      .setIssuedAt()
+      .setExpirationTime("15m")
+      .sign(new TextEncoder().encode("shared-global-secret"));
+    const handler = await mountedA2AHandler(config);
+
+    const event = postEvent({ authorization: `Bearer ${token}` });
+    const response = await handler(event);
+
+    expect(response).toEqual({ jsonrpc: "2.0", id: 1, result: { ok: true } });
+    expect(event.context.__a2aVerifiedEmail).toBe("alice+qa@builder.io");
+    expect(event.context.__a2aOrgDomain).toBe("builder.io");
+    expect(event._status).toBeUndefined();
+    expect(handleJsonRpcH3Mock).toHaveBeenCalledOnce();
+  });
 });
 
 async function mountedA2AHandler(

--- a/packages/core/src/a2a/server.ts
+++ b/packages/core/src/a2a/server.ts
@@ -42,6 +42,15 @@ interface A2ATokenPayload {
   orgDomain: string | null;
 }
 
+function addSecretCandidate(
+  candidates: string[],
+  secret: string | undefined,
+): void {
+  const trimmed = secret?.trim();
+  if (!trimmed || candidates.includes(trimmed)) return;
+  candidates.push(trimmed);
+}
+
 /**
  * Resolve the audience (`aud`) value to expect in an inbound JWT. We use the
  * receiver's app URL — it's the natural identifier of "who this token was
@@ -87,23 +96,23 @@ async function verifyA2AToken(
     // Malformed token — fall through to global secret attempt
   }
 
-  // Step 2: Look up the org's A2A secret by domain
-  let secret: string | undefined;
+  // Step 2: Build a small, ordered set of candidate secrets. Tokens minted by
+  // current callers prefer the shared A2A_SECRET; older callers may still use
+  // an org-level secret. Try both without logging or reflecting secret details.
+  const candidateSecrets: string[] = [];
+  addSecretCandidate(candidateSecrets, process.env.A2A_SECRET);
   if (orgDomainHint) {
     try {
       const { getA2ASecretByDomain } = await import("../org/context.js");
       const orgSecret = await getA2ASecretByDomain(orgDomainHint);
-      if (orgSecret) secret = orgSecret;
+      addSecretCandidate(candidateSecrets, orgSecret);
     } catch {
       // DB not ready or column doesn't exist yet — fall through
     }
   }
+  if (candidateSecrets.length === 0) return { email: null, orgDomain: null };
 
-  // Step 3: Fall back to global A2A_SECRET
-  if (!secret) secret = process.env.A2A_SECRET;
-  if (!secret) return { email: null, orgDomain: null };
-
-  // Step 4: Verify JWT with the resolved secret.
+  // Step 3: Verify JWT with the candidate secrets.
   //
   // - `audience`: passed only when the token carries an `aud` claim
   //   (backward-compat: tokens minted by older `signA2AToken` versions
@@ -131,18 +140,25 @@ async function verifyA2AToken(
     ) {
       verifyOptions.issuer = unverifiedPayload.iss;
     }
-    const { payload } = await jose.jwtVerify(
-      token,
-      new TextEncoder().encode(secret),
-      verifyOptions,
-    );
-    return {
-      email: (payload.sub as string) ?? null,
-      orgDomain: (payload.org_domain as string) ?? null,
-    };
+    for (const secret of candidateSecrets) {
+      try {
+        const { payload } = await jose.jwtVerify(
+          token,
+          new TextEncoder().encode(secret),
+          verifyOptions,
+        );
+        return {
+          email: (payload.sub as string) ?? null,
+          orgDomain: (payload.org_domain as string) ?? null,
+        };
+      } catch {
+        // Try the next candidate without leaking which secret failed.
+      }
+    }
   } catch {
-    return { email: null, orgDomain: null };
+    // Keep malformed option construction indistinguishable from auth failure.
   }
+  return { email: null, orgDomain: null };
 }
 
 /**

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -90,9 +90,14 @@ function adapter(sendResponse = vi.fn(async () => undefined)): PlatformAdapter {
 }
 
 describe("A2A continuation processor", () => {
+  const originalEnv = { ...process.env };
+
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.APP_URL = "https://dispatch.agent-native.test";
+    process.env = {
+      ...originalEnv,
+      APP_URL: "https://dispatch.agent-native.test",
+    };
     getA2AContinuationMock.mockImplementation(async (id: string) =>
       continuation({ id, status: "pending" }),
     );
@@ -116,6 +121,7 @@ describe("A2A continuation processor", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    process.env = originalEnv;
   });
 
   it("dispatches without aborting a long-running processor request", async () => {
@@ -197,10 +203,10 @@ describe("A2A continuation processor", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("reuses the original A2A bearer token stored on the continuation", async () => {
+  it("reuses opaque bearer tokens stored on the continuation", async () => {
     const sendResponse = vi.fn(async () => undefined);
     claimA2AContinuationMock.mockResolvedValueOnce(
-      continuation({ a2aAuthToken: "original-a2a-token" }),
+      continuation({ a2aAuthToken: "original-opaque-a2a-token" }),
     );
     const { processA2AContinuationById } =
       await import("./a2a-continuation-processor.js");
@@ -211,10 +217,37 @@ describe("A2A continuation processor", () => {
 
     expect(A2AClientMock).toHaveBeenCalledWith(
       "https://slides.agent-native.test",
-      "original-a2a-token",
+      "original-opaque-a2a-token",
       { requestTimeoutMs: 25_000 },
     );
     expect(signA2ATokenMock).not.toHaveBeenCalled();
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+  });
+
+  it("re-signs instead of replaying a stored A2A JWT", async () => {
+    process.env.A2A_SECRET = "shared-a2a-secret";
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ a2aAuthToken: "old.jwt.token" }),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(signA2ATokenMock).toHaveBeenCalledWith(
+      "alice+qa@agent-native.test",
+      undefined,
+      undefined,
+      { expiresIn: "30m", preferGlobalSecret: true },
+    );
+    expect(A2AClientMock).toHaveBeenCalledWith(
+      "https://slides.agent-native.test",
+      "signed-a2a-token",
+      { requestTimeoutMs: 25_000 },
+    );
     expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
   });
 

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -365,10 +365,27 @@ async function redispatchContinuation(continuationId: string): Promise<void> {
 async function signContinuationToken(
   continuation: A2AContinuation,
 ): Promise<string | undefined> {
-  if (continuation.a2aAuthToken !== null) {
-    return continuation.a2aAuthToken || undefined;
+  if (continuation.a2aAuthToken === "") {
+    return undefined;
   }
 
+  const storedToken = continuation.a2aAuthToken;
+  if (storedToken && !isLikelyJwt(storedToken)) return storedToken;
+
+  const freshToken = await signFreshContinuationToken(continuation);
+  if (freshToken) return freshToken;
+  if (!storedToken) return undefined;
+
+  // Older continuations may have persisted the initial short-lived JWT. Avoid
+  // replaying it forever after expiry; opaque legacy bearer keys can still be
+  // reused because we cannot re-mint those.
+  if (isLikelyJwt(storedToken)) return undefined;
+  return storedToken;
+}
+
+async function signFreshContinuationToken(
+  continuation: A2AContinuation,
+): Promise<string | undefined> {
   let orgDomain: string | undefined;
   let orgSecret: string | undefined;
   if (continuation.orgId) {
@@ -387,10 +404,15 @@ async function signContinuationToken(
   try {
     return await signA2AToken(continuation.ownerEmail, orgDomain, orgSecret, {
       expiresIn: "30m",
+      preferGlobalSecret: true,
     });
   } catch {
     return undefined;
   }
+}
+
+function isLikelyJwt(token: string): boolean {
+  return token.split(".").length === 3;
 }
 
 function extractTaskText(task: Task): string {

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -553,12 +553,14 @@ async function processIncomingMessage(
       },
       async (completedRun: ActiveRun) => {
         try {
+          const queuedA2AContinuation = hasQueuedA2AContinuation(completedRun);
           let responseText = collectFinalResponseTextFromAgentEvents(
             completedRun.events.map((runEvent) => runEvent.event),
+            { fallbackToPreToolText: !queuedA2AContinuation },
           );
 
           const suppressPlatformReply =
-            hasQueuedA2AContinuation(completedRun) &&
+            queuedA2AContinuation &&
             isQueuedA2AContinuationDeferral(responseText);
 
           // If the run errored OR produced no text, post a graceful fallback so

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -146,7 +146,10 @@ export async function run(
             callerEmail,
             callerOrgDomain,
             callerOrgSecret,
-            { expiresIn: INTEGRATION_A2A_TOKEN_TTL },
+            {
+              expiresIn: INTEGRATION_A2A_TOKEN_TTL,
+              preferGlobalSecret: true,
+            },
           );
         } catch {}
       }
@@ -227,7 +230,6 @@ export async function run(
             pollErr,
             agent,
             callerEmail,
-            apiKey,
           );
           if (queued) {
             responseText = `${A2A_CONTINUATION_QUEUED_MARKER}\nThe ${agent.name} agent is still working. Do not send an interim reply to the user; the final result will be posted to the originating integration thread automatically.`;
@@ -285,7 +287,6 @@ async function enqueueIntegrationContinuationIfPossible(
   error: A2ATaskTimeoutError,
   agent: { name: string; url: string },
   ownerEmail: string | undefined,
-  a2aAuthToken: string | undefined,
 ): Promise<boolean> {
   const integration = getIntegrationRequestContext();
   if (!integration || !ownerEmail) return false;
@@ -307,7 +308,9 @@ async function enqueueIntegrationContinuationIfPossible(
       agentName: agent.name,
       agentUrl: agent.url,
       a2aTaskId: error.taskId,
-      a2aAuthToken: a2aAuthToken ?? "",
+      // Do not persist the short-lived JWT used for the initial send. The
+      // continuation processor can mint a fresh token for each poll.
+      a2aAuthToken: null,
     });
     await dispatchA2AContinuation(continuation.id).catch((err) => {
       console.error(

--- a/scripts/ensure-builder-orgs.ts
+++ b/scripts/ensure-builder-orgs.ts
@@ -48,6 +48,7 @@ interface EnsureResult {
   orgCreated: boolean;
   orgNameUpdated: boolean;
   a2aSecretCreated: boolean;
+  a2aSecretSynced: boolean;
   memberCreated: boolean;
   memberPromoted: boolean;
   betterAuthOrgCreated: boolean;
@@ -56,6 +57,12 @@ interface EnsureResult {
   betterAuthUserMissing: boolean;
   clipsSettingsCreated: boolean;
   activeOrgSet: boolean;
+}
+
+interface A2ASecretSource {
+  secret: string;
+  source: "env" | "generated";
+  envName?: string;
 }
 
 const argv = process.argv.slice(2);
@@ -71,11 +78,29 @@ if (argv.includes("--help")) {
   process.exit(0);
 }
 
+const orgA2ASecretEnvNames = orgA2ASecretEnvCandidates();
+let orgA2ASecret: A2ASecretSource;
+try {
+  orgA2ASecret = resolveOrgA2ASecret(orgA2ASecretEnvNames);
+} catch (error) {
+  console.error(`failed - ${formatError(error)}`);
+  process.exit(1);
+}
+
 console.log(
   write
     ? "Applying Builder.io org seed to production template databases..."
     : "Dry run. Pass --write to apply Builder.io org seed.",
 );
+if (orgA2ASecret.source === "env") {
+  console.log(`Using shared org A2A secret from ${orgA2ASecret.envName}.`);
+} else if (write) {
+  console.warn(
+    `No shared org A2A secret env set (${orgA2ASecretEnvNames.join(
+      ", ",
+    )}); generated one secret for orgs created or filled during this run. Existing non-empty secrets will not be rotated.`,
+  );
+}
 
 const failures: Array<{ app: string; error: unknown }> = [];
 
@@ -89,7 +114,7 @@ for (const app of apps) {
       await ensureBetterAuthOrgTables(db);
       if (app === "clips") await ensureClipsOrgSettingsTable(db);
     }
-    const result = await ensureBuilderOrg(db, app, write);
+    const result = await ensureBuilderOrg(db, app, write, orgA2ASecret);
     printResult(result, write);
   } catch (error) {
     failures.push({ app, error });
@@ -105,7 +130,7 @@ if (failures.length > 0) {
 }
 
 function printHelp(): void {
-  console.log(`Usage: pnpm exec tsx scripts/ensure-builder-orgs.ts [--write] [--apps mail,slides]
+  console.log(`Usage: pnpm exec tsx scripts/ensure-builder-orgs.ts [--write] [--apps mail,slides] [--org-a2a-secret-env AGENT_NATIVE_ORG_A2A_SECRET]
 
 Creates or verifies the standard Builder.io organization in core app production
 databases from each app's templates/<app>/.env:
@@ -115,7 +140,14 @@ databases from each app's templates/<app>/.env:
   - org_members includes steve@builder.io as owner
   - settings u:steve@builder.io:active-org-id points at that org
 
-Without --write, the script only reports what it would do.`);
+Set AGENT_NATIVE_ORG_A2A_SECRET (or pass --org-a2a-secret-env NAME) to sync the
+same org A2A secret across every app, including existing app org rows whose
+secret differs. Without a shared secret env, --write uses one generated secret
+for orgs created or filled during that run and leaves existing non-empty secrets
+untouched.
+
+Without --write, the script only reports what it would do. Secret values are
+never printed.`);
 }
 
 function flagValue(name: string): string | null {
@@ -188,6 +220,29 @@ function parseEnv(contents: string): Record<string, string> {
     result[key] = value;
   }
   return result;
+}
+
+function orgA2ASecretEnvCandidates(): string[] {
+  const explicit = flagValue("--org-a2a-secret-env")?.trim();
+  if (explicit) return [explicit];
+  return ["AGENT_NATIVE_ORG_A2A_SECRET", "ORG_A2A_SECRET"];
+}
+
+function resolveOrgA2ASecret(envNames: string[]): A2ASecretSource {
+  for (const envName of envNames) {
+    const secret = process.env[envName]?.trim();
+    if (!secret) continue;
+    validateA2ASecret(secret, envName);
+    return { secret, source: "env", envName };
+  }
+
+  return { secret: randomSecret(), source: "generated" };
+}
+
+function validateA2ASecret(secret: string, source: string): void {
+  if (secret.length < 32) {
+    throw new Error(`${source} must be at least 32 characters.`);
+  }
 }
 
 async function importWorkspacePackage<T>(specifier: string): Promise<T> {
@@ -415,6 +470,7 @@ async function ensureBuilderOrg(
   db: Db,
   app: string,
   shouldWrite: boolean,
+  a2aSecretSource: A2ASecretSource,
 ): Promise<EnsureResult> {
   const existing = await db.execute(
     `SELECT id, name, a2a_secret
@@ -430,24 +486,40 @@ async function ensureBuilderOrg(
   let orgCreated = false;
   let orgNameUpdated = false;
   let a2aSecretCreated = false;
+  let a2aSecretSynced = false;
 
   if (existing.rows[0]) {
     const row = existing.rows[0];
     orgId = String(row.id);
+    const existingA2ASecret = String(row.a2a_secret ?? "").trim();
     orgNameUpdated = String(row.name) !== ORG_NAME;
-    a2aSecretCreated = !String(row.a2a_secret ?? "");
+    a2aSecretCreated = !existingA2ASecret;
+    a2aSecretSynced =
+      a2aSecretSource.source === "env" &&
+      !!existingA2ASecret &&
+      existingA2ASecret !== a2aSecretSource.secret;
 
-    if (shouldWrite && (orgNameUpdated || a2aSecretCreated)) {
+    if (
+      shouldWrite &&
+      (orgNameUpdated || a2aSecretCreated || a2aSecretSynced)
+    ) {
       await db.execute(
         `UPDATE organizations
          SET name = ?,
-             a2a_secret = COALESCE(NULLIF(a2a_secret, ''), ?)
+             a2a_secret = ?
          WHERE id = ?`,
-        [ORG_NAME, randomSecret(), orgId],
+        [
+          ORG_NAME,
+          a2aSecretCreated || a2aSecretSynced
+            ? a2aSecretSource.secret
+            : existingA2ASecret,
+          orgId,
+        ],
       );
     }
   } else {
     orgCreated = true;
+    a2aSecretCreated = true;
     orgId = shouldWrite
       ? ((await findBetterAuthBuilderOrgId(db)) ?? (await availableOrgId(db)))
       : ORG_ID_BASE;
@@ -457,9 +529,8 @@ async function ensureBuilderOrg(
         `INSERT INTO organizations
            (id, name, created_by, created_at, allowed_domain, a2a_secret)
          VALUES (?, ?, ?, ?, ?, ?)`,
-        [orgId, ORG_NAME, OWNER_EMAIL, now, ORG_DOMAIN, randomSecret()],
+        [orgId, ORG_NAME, OWNER_EMAIL, now, ORG_DOMAIN, a2aSecretSource.secret],
       );
-      a2aSecretCreated = true;
     }
   }
 
@@ -506,6 +577,7 @@ async function ensureBuilderOrg(
     orgCreated,
     orgNameUpdated,
     a2aSecretCreated,
+    a2aSecretSynced,
     memberCreated,
     memberPromoted,
     betterAuthOrgCreated: betterAuth.orgCreated,
@@ -748,6 +820,7 @@ function printResult(result: EnsureResult, didWrite: boolean): void {
         ? "org renamed"
         : "org present",
     result.a2aSecretCreated ? "a2a secret set" : null,
+    result.a2aSecretSynced ? "a2a secret synced" : null,
     result.memberCreated
       ? `${OWNER_EMAIL} added as owner`
       : result.memberPromoted


### PR DESCRIPTION
## Summary\n- prefer shared A2A_SECRET for hosted cross-app delegation while preserving explicit org-secret workflows\n- verify inbound A2A JWTs against safe candidate secrets so mismatched org rows do not break hosted apps\n- re-sign continuation polling tokens and suppress stale Slack replies when A2A continuation handoff is queued\n- let the Builder org seeding script sync a shared org A2A secret without printing secret values\n- bump @agent-native/core to 0.7.50\n\n## Verification\n- pnpm --filter @agent-native/core exec vitest --run src/a2a/client.spec.ts src/a2a/server.spec.ts src/a2a/response-text.spec.ts src/integrations/a2a-continuation-processor.spec.ts src/integrations/webhook-handler-engine.spec.ts\n- pnpm --filter @agent-native/core typecheck\n- pnpm --filter @agent-native/core build\n- pnpm lint\n- pnpm --filter @agent-native/core test\n- pnpm exec tsx scripts/ensure-builder-orgs.ts --help\n- AGENT_NATIVE_ORG_A2A_SECRET=short pnpm exec tsx scripts/ensure-builder-orgs.ts --apps none (expected validation failure, secret not printed)