### PR TITLE
Fix A2A continuations and agent discovery

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.50",
+  "version": "0.7.51",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/agent-card.spec.ts
+++ b/packages/core/src/a2a/agent-card.spec.ts
@@ -1,8 +1,22 @@
-import { afterEach, describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { generateAgentCard } from "./agent-card.js";
 import type { A2AConfig } from "./types.js";
 
 describe("generateAgentCard", () => {
+  beforeEach(() => {
+    vi.stubEnv("A2A_SECRET", "");
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("NETLIFY", "");
+    vi.stubEnv("NETLIFY_LOCAL", "");
+    vi.stubEnv("AWS_LAMBDA_FUNCTION_NAME", "");
+    vi.stubEnv("CF_PAGES", "");
+    vi.stubEnv("VERCEL", "");
+    vi.stubEnv("VERCEL_ENV", "");
+    vi.stubEnv("RENDER", "");
+    vi.stubEnv("FLY_APP_NAME", "");
+    vi.stubEnv("K_SERVICE", "");
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
   });
@@ -81,6 +95,32 @@ describe("generateAgentCard", () => {
     expect(card.security).toBeUndefined();
   });
 
+  it("advertises JWT bearer auth when A2A_SECRET is configured", () => {
+    vi.stubEnv("A2A_SECRET", "shared-secret");
+    const card = generateAgentCard(baseConfig, "https://example.com");
+    expect(card.securitySchemes).toEqual({
+      jwtBearer: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+    });
+    expect(card.security).toEqual([{ jwtBearer: [] }]);
+  });
+
+  it("advertises JWT bearer auth on hosted runtimes", () => {
+    vi.stubEnv("NETLIFY", "true");
+    const card = generateAgentCard(baseConfig, "https://example.com");
+    expect(card.securitySchemes).toEqual({
+      jwtBearer: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+    });
+    expect(card.security).toEqual([{ jwtBearer: [] }]);
+  });
+
   it("includes security schemes when apiKeyEnv is set", () => {
     const card = generateAgentCard(
       { ...baseConfig, apiKeyEnv: "MY_API_KEY" },
@@ -90,5 +130,22 @@ describe("generateAgentCard", () => {
       apiKey: { type: "http", scheme: "bearer" },
     });
     expect(card.security).toEqual([{ apiKey: [] }]);
+  });
+
+  it("advertises JWT and legacy API key auth as alternatives when both are configured", () => {
+    vi.stubEnv("A2A_SECRET", "shared-secret");
+    const card = generateAgentCard(
+      { ...baseConfig, apiKeyEnv: "MY_API_KEY" },
+      "https://example.com",
+    );
+    expect(card.securitySchemes).toEqual({
+      jwtBearer: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+      apiKey: { type: "http", scheme: "bearer" },
+    });
+    expect(card.security).toEqual([{ jwtBearer: [] }, { apiKey: [] }]);
   });
 });

--- a/packages/core/src/a2a/agent-card.ts
+++ b/packages/core/src/a2a/agent-card.ts
@@ -1,5 +1,6 @@
 import type { A2AConfig, AgentCard } from "./types.js";
 import { withConfiguredAppBasePath } from "../server/app-base-path.js";
+import { shouldAdvertiseJwtA2AAuth } from "./auth-policy.js";
 
 export function generateAgentCard(
   config: A2AConfig,
@@ -20,24 +21,32 @@ export function generateAgentCard(
     skills: config.skills,
   };
 
-  // Advertise JWT-based A2A identity when A2A_SECRET is configured
-  if (process.env.A2A_SECRET) {
-    card.securitySchemes = {
-      jwtBearer: {
-        type: "http",
-        scheme: "bearer",
-        bearerFormat: "JWT",
-      },
+  const securitySchemes: NonNullable<AgentCard["securitySchemes"]> = {};
+  const security: NonNullable<AgentCard["security"]> = [];
+
+  // Hosted production deployments require JWT-capable A2A even before card
+  // generation can prove whether auth will use the shared A2A_SECRET or an
+  // org-scoped secret from SQL.
+  if (shouldAdvertiseJwtA2AAuth()) {
+    securitySchemes.jwtBearer = {
+      type: "http",
+      scheme: "bearer",
+      bearerFormat: "JWT",
     };
-    card.security = [{ jwtBearer: [] }];
-  } else if (config.apiKeyEnv) {
-    card.securitySchemes = {
-      apiKey: {
-        type: "http",
-        scheme: "bearer",
-      },
+    security.push({ jwtBearer: [] });
+  }
+
+  if (config.apiKeyEnv) {
+    securitySchemes.apiKey = {
+      type: "http",
+      scheme: "bearer",
     };
-    card.security = [{ apiKey: [] }];
+    security.push({ apiKey: [] });
+  }
+
+  if (security.length > 0) {
+    card.securitySchemes = securitySchemes;
+    card.security = security;
   }
 
   return card;

--- a/packages/core/src/a2a/auth-policy.ts
+++ b/packages/core/src/a2a/auth-policy.ts
@@ -1,0 +1,33 @@
+/**
+ * A2A auth policy helpers shared by discovery, the JSON-RPC gate, and task
+ * handlers. Serverless providers do not always expose `NODE_ENV=production`
+ * consistently at runtime, so production-like A2A checks also look at the
+ * provider flags those platforms set in deployed functions.
+ */
+export function isA2AProductionRuntime(): boolean {
+  if (process.env.NODE_ENV === "production") return true;
+  if (process.env.NETLIFY === "true" && process.env.NETLIFY_LOCAL !== "true") {
+    return true;
+  }
+  if (
+    process.env.AWS_LAMBDA_FUNCTION_NAME &&
+    process.env.NETLIFY_LOCAL !== "true"
+  ) {
+    return true;
+  }
+  if (process.env.CF_PAGES === "1") return true;
+  if ("__cf_env" in globalThis) return true;
+  if (process.env.VERCEL || process.env.VERCEL_ENV) return true;
+  if (process.env.RENDER || process.env.FLY_APP_NAME || process.env.K_SERVICE) {
+    return true;
+  }
+  return false;
+}
+
+export function hasConfiguredA2ASecret(): boolean {
+  return !!process.env.A2A_SECRET?.trim();
+}
+
+export function shouldAdvertiseJwtA2AAuth(): boolean {
+  return hasConfiguredA2ASecret() || isA2AProductionRuntime();
+}

--- a/packages/core/src/a2a/handlers.spec.ts
+++ b/packages/core/src/a2a/handlers.spec.ts
@@ -463,6 +463,52 @@ describe("handleJsonRpc", () => {
     );
   });
 
+  it("refuses async message/send on hosted runtimes without A2A auth config", async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    const previousNetlify = process.env.NETLIFY;
+    const previousNetlifyLocal = process.env.NETLIFY_LOCAL;
+    const previousA2ASecret = process.env.A2A_SECRET;
+    try {
+      process.env.NODE_ENV = "development";
+      process.env.NETLIFY = "true";
+      delete process.env.NETLIFY_LOCAL;
+      delete process.env.A2A_SECRET;
+
+      const event = mockEvent();
+      const result = await handleJsonRpc(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "message/send",
+          params: {
+            async: true,
+            message: {
+              role: "user",
+              parts: [{ type: "text", text: "go" }],
+            },
+          },
+        },
+        event,
+        customHandler,
+      );
+
+      expect(result.error).toMatchObject({
+        code: -32001,
+        message:
+          "A2A async mode is not available — A2A_SECRET or apiKeyEnv must be configured.",
+      });
+    } finally {
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
+      if (previousNetlify === undefined) delete process.env.NETLIFY;
+      else process.env.NETLIFY = previousNetlify;
+      if (previousNetlifyLocal === undefined) delete process.env.NETLIFY_LOCAL;
+      else process.env.NETLIFY_LOCAL = previousNetlifyLocal;
+      if (previousA2ASecret === undefined) delete process.env.A2A_SECRET;
+      else process.env.A2A_SECRET = previousA2ASecret;
+    }
+  });
+
   it("passes the processor H3 event through async handler context", async () => {
     let processorEvent: any;
     const eventAwareConfig: A2AConfig = {

--- a/packages/core/src/a2a/handlers.ts
+++ b/packages/core/src/a2a/handlers.ts
@@ -22,6 +22,10 @@ import {
 import { agentChat } from "../shared/agent-chat.js";
 import { signInternalToken } from "../integrations/internal-token.js";
 import { withConfiguredAppBasePath } from "../server/app-base-path.js";
+import {
+  hasConfiguredA2ASecret,
+  isA2AProductionRuntime,
+} from "./auth-policy.js";
 
 // Inlined to avoid pulling the entire core-routes-plugin (and its h3
 // transitive deps) into the a2a/handlers test boundary. Must stay in sync
@@ -458,9 +462,9 @@ async function handleSend(
     // with the lack of caller identity here would let any unauthenticated
     // attacker queue and trigger handler runs. In production, require some
     // form of auth so the verifiedEmail is bound to the task.
-    const hasA2ASecret = !!process.env.A2A_SECRET;
+    const hasA2ASecret = hasConfiguredA2ASecret();
     const hasApiKey = !!(config.apiKeyEnv && process.env[config.apiKeyEnv]);
-    if (process.env.NODE_ENV === "production" && !hasA2ASecret && !hasApiKey) {
+    if (isA2AProductionRuntime() && !hasA2ASecret && !hasApiKey) {
       return {
         ...jsonRpcError(
           0,
@@ -704,9 +708,9 @@ function authorizeTaskAccess(
 ): JsonRpcResponse | null {
   const verifiedEmail =
     (event?.context?.__a2aVerifiedEmail as string | undefined) ?? null;
-  const hasA2ASecret = !!process.env.A2A_SECRET;
+  const hasA2ASecret = hasConfiguredA2ASecret();
   const hasApiKey = !!(config.apiKeyEnv && process.env[config.apiKeyEnv]);
-  const inProduction = process.env.NODE_ENV === "production";
+  const inProduction = isA2AProductionRuntime();
 
   if (inProduction && !hasA2ASecret && !hasApiKey) {
     // No way to authenticate the caller in production — refuse access.

--- a/packages/core/src/a2a/index.ts
+++ b/packages/core/src/a2a/index.ts
@@ -1,5 +1,6 @@
 // Server (H3/Nitro)
 export { mountA2A } from "./server.js";
+export { generateAgentCard } from "./agent-card.js";
 
 // Client
 export { A2AClient, callAgent, signA2AToken } from "./client.js";

--- a/packages/core/src/a2a/server.spec.ts
+++ b/packages/core/src/a2a/server.spec.ts
@@ -126,6 +126,70 @@ describe("mountA2A auth", () => {
     expect(event._status).toBeUndefined();
     expect(handleJsonRpcH3Mock).toHaveBeenCalledOnce();
   });
+
+  it("rejects invalid bearer tokens before tasks/get can report a lookup miss", async () => {
+    delete process.env.A2A_SECRET;
+    process.env.NODE_ENV = "development";
+    const handler = await mountedA2AHandler(config);
+
+    const event = postEvent({ authorization: "Bearer not-a-valid-token" });
+    const response = await handler(event);
+
+    expect(event._status).toBe(401);
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32001,
+        message: "Invalid or expired A2A token",
+      },
+    });
+    expect(handleJsonRpcH3Mock).not.toHaveBeenCalled();
+  });
+
+  it("treats hosted Netlify runtime as production for missing A2A auth", async () => {
+    delete process.env.A2A_SECRET;
+    process.env.NODE_ENV = "development";
+    process.env.NETLIFY = "true";
+    const handler = await mountedA2AHandler(config);
+
+    const event = postEvent({});
+    const response = await handler(event);
+
+    expect(event._status).toBe(503);
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32001,
+        message:
+          "A2A authentication not configured. Set A2A_SECRET (preferred) or configure apiKeyEnv to accept inbound A2A traffic.",
+      },
+    });
+    expect(handleJsonRpcH3Mock).not.toHaveBeenCalled();
+  });
+
+  it("treats hosted Netlify runtime as production for unsigned async processors", async () => {
+    delete process.env.A2A_SECRET;
+    process.env.NODE_ENV = "development";
+    process.env.NETLIFY = "true";
+    const handler = await mountedA2AProcessorHandler(config);
+
+    const event = {
+      method: "POST",
+      headers: {},
+      path: "/",
+      context: {},
+      body: { taskId: "task-1" },
+    };
+    const response = await handler(event);
+
+    expect(event._status).toBe(503);
+    expect(response).toEqual({
+      error:
+        "A2A processor not configured — set A2A_SECRET on this deployment to enable async A2A.",
+    });
+  });
 });
 
 async function mountedA2AHandler(
@@ -136,6 +200,19 @@ async function mountedA2AHandler(
   mountA2A(app, config);
   const route = app.routes.find((entry) => entry.path === "/_agent-native/a2a");
   if (!route) throw new Error("A2A route was not mounted");
+  return route.handler;
+}
+
+async function mountedA2AProcessorHandler(
+  config: A2AConfig,
+): Promise<(event: any) => any> {
+  const { mountA2A } = await import("./server.js");
+  const app = { routes: [] as Array<{ path: string; handler: any }> };
+  mountA2A(app, config);
+  const route = app.routes.find(
+    (entry) => entry.path === "/_agent-native/a2a/_process-task",
+  );
+  if (!route) throw new Error("A2A processor route was not mounted");
   return route.handler;
 }
 

--- a/packages/core/src/a2a/server.ts
+++ b/packages/core/src/a2a/server.ts
@@ -15,6 +15,10 @@ import {
   extractBearerToken,
   verifyInternalToken,
 } from "../integrations/internal-token.js";
+import {
+  hasConfiguredA2ASecret,
+  isA2AProductionRuntime,
+} from "./auth-policy.js";
 
 /**
  * One-time warning when A2A is running unauthenticated in development. We
@@ -77,11 +81,9 @@ function expectedJwtAudience(event: any | undefined): string | undefined {
 }
 
 async function verifyA2AToken(
-  authHeader: string,
+  token: string,
   event: any | undefined,
 ): Promise<A2ATokenPayload> {
-  const token = authHeader.replace("Bearer ", "");
-
   // Step 1: Peek at JWT claims WITHOUT verification to get org_domain.
   // This is safe because we only use org_domain to look up the secret,
   // then verify the full JWT with that secret. If someone forges a JWT
@@ -248,14 +250,14 @@ export function mountA2A(
       // of logs / a share link could otherwise force-replay it). In
       // development, a missing secret is permitted so local templates work
       // out of the box, but we log a one-time warning so operators notice.
-      if (process.env.A2A_SECRET) {
+      if (hasConfiguredA2ASecret()) {
         const auth = getRequestHeader(event, "authorization");
         const tok = extractBearerToken(auth);
         if (!verifyInternalToken(taskId, tok)) {
           setResponseStatus(event, 401);
           return { error: "Invalid or expired processor token" };
         }
-      } else if (process.env.NODE_ENV === "production") {
+      } else if (isA2AProductionRuntime()) {
         setResponseStatus(event, 503);
         return {
           error:
@@ -294,6 +296,7 @@ export function mountA2A(
       if (sub.startsWith("_process-task")) return;
 
       const authHeader = getRequestHeader(event, "authorization");
+      const bearerToken = extractBearerToken(authHeader);
       let verifiedCallerEmail: string | null = null;
       let verifiedOrgDomain: string | null = null;
       let legacyApiKeyAuthenticated = false;
@@ -304,12 +307,12 @@ export function mountA2A(
       // in production — return 503 with a clear message instead of running
       // the agent loop unauthenticated. In development, log a one-time
       // warning but allow so local templates work out of the box.
-      const hasA2ASecret = !!process.env.A2A_SECRET;
+      const hasA2ASecret = hasConfiguredA2ASecret();
       const hasApiKey = !!(config.apiKeyEnv && process.env[config.apiKeyEnv]);
 
       // Try JWT verification first (org-level or global A2A_SECRET-based identity)
-      if (authHeader?.startsWith("Bearer ")) {
-        const tokenPayload = await verifyA2AToken(authHeader, event);
+      if (bearerToken) {
+        const tokenPayload = await verifyA2AToken(bearerToken, event);
         verifiedCallerEmail = tokenPayload.email;
         verifiedOrgDomain = tokenPayload.orgDomain;
         bearerTokenRejectedByJwt = !verifiedCallerEmail;
@@ -319,7 +322,7 @@ export function mountA2A(
       if (!verifiedCallerEmail && config.apiKeyEnv) {
         const expectedKey = process.env[config.apiKeyEnv];
         if (expectedKey) {
-          if (!authHeader || !authHeader.startsWith("Bearer ")) {
+          if (!bearerToken) {
             setResponseStatus(event, 401);
             return {
               jsonrpc: "2.0",
@@ -327,8 +330,7 @@ export function mountA2A(
               error: { code: -32001, message: "Authentication required" },
             };
           }
-          const token = authHeader.slice(7);
-          if (token !== expectedKey) {
+          if (bearerToken !== expectedKey) {
             setResponseStatus(event, 401);
             return {
               jsonrpc: "2.0",
@@ -341,9 +343,11 @@ export function mountA2A(
       }
 
       if (!verifiedCallerEmail && !legacyApiKeyAuthenticated) {
-        // If a global secret exists and JWT verification failed, reject after
-        // giving the legacy exact-match apiKeyEnv path a chance to succeed.
-        if (bearerTokenRejectedByJwt && process.env.A2A_SECRET) {
+        // Any supplied bearer token that failed JWT verification is an auth
+        // failure after the legacy exact-match apiKeyEnv path has had a
+        // chance to succeed. Do not let bad tokens fall through to tasks/get
+        // and get reported as lookup misses.
+        if (bearerTokenRejectedByJwt) {
           setResponseStatus(event, 401);
           return {
             jsonrpc: "2.0",
@@ -356,7 +360,7 @@ export function mountA2A(
         }
 
         if (!hasA2ASecret && !hasApiKey) {
-          if (process.env.NODE_ENV === "production") {
+          if (isA2AProductionRuntime()) {
             setResponseStatus(event, 503);
             return {
               jsonrpc: "2.0",

--- a/packages/core/src/client/resources/ResourceEditor.tsx
+++ b/packages/core/src/client/resources/ResourceEditor.tsx
@@ -15,6 +15,7 @@ import { agentNativePath } from "../api-path.js";
 import type { Resource } from "./use-resources.js";
 import {
   type ParsedFrontmatter,
+  getRemoteAgentIdFromPath,
   getFrontmatterValue,
   isCustomAgentPath,
   isRemoteAgentPath,
@@ -960,9 +961,7 @@ function parseRemoteAgentContent(
   content: string,
   path: string,
 ): RemoteAgentFormValue {
-  const fallbackId = path
-    .replace(/^remote-agents\//, "")
-    .replace(/\.json$/, "");
+  const fallbackId = getRemoteAgentIdFromPath(path);
   try {
     const data = JSON.parse(content || "{}");
     return {

--- a/packages/core/src/client/settings/AgentsSection.tsx
+++ b/packages/core/src/client/settings/AgentsSection.tsx
@@ -1,4 +1,9 @@
 import { agentNativePath } from "../api-path.js";
+import {
+  getRemoteAgentIdFromPath,
+  isRemoteAgentPath,
+  remoteAgentResourcePath,
+} from "../../resources/metadata.js";
 import { useState, useEffect, useRef, useCallback } from "react";
 import {
   IconPlus,
@@ -227,8 +232,7 @@ export function AgentsSection() {
       if (!res.ok) return;
       const data = await res.json();
       const agentResources = (data.resources ?? []).filter(
-        (r: { path: string }) =>
-          r.path.startsWith("remote-agents/") && r.path.endsWith(".json"),
+        (r: { path: string }) => isRemoteAgentPath(r.path),
       );
       const parsed = await Promise.all(
         agentResources.map(async (r: { id: string; path: string }) => {
@@ -280,7 +284,7 @@ export function AgentsSection() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          path: `remote-agents/${id}.json`,
+          path: remoteAgentResourcePath(id),
           content: agentJson,
           shared: true,
         }),
@@ -295,10 +299,7 @@ export function AgentsSection() {
   const handleSave = async (agent: AgentInfo) => {
     const agentJson = JSON.stringify(
       {
-        id: agent.path
-          .replace("remote-agents/", "")
-          .replace("agents/", "")
-          .replace(".json", ""),
+        id: getRemoteAgentIdFromPath(agent.path),
         name: agent.name,
         description: agent.description || undefined,
         url: agent.url,

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -32,6 +32,7 @@ import {
   getWorkspaceCoreExports,
   type WorkspaceCoreExports,
 } from "./workspace-core.js";
+import { generateActionRegistryForProject } from "../vite/action-types-plugin.js";
 
 const cwd = process.cwd();
 const preset = process.env.NITRO_PRESET || "node";
@@ -418,6 +419,8 @@ export default {
  *     assets/           (static client assets)
  */
 async function buildCloudflarePages() {
+  generateActionRegistryForProject(cwd);
+
   const buildDir = path.join(cwd, "build");
   const clientDir = path.join(buildDir, "client");
   const serverDir = path.join(buildDir, "server");
@@ -1057,6 +1060,13 @@ function createDanglingOptionalDepStubs() {
 async function buildWithNitro() {
   console.log(`[deploy] Building for preset "${preset}" via Nitro...`);
   const appBasePath = normalizeConfiguredAppBasePath();
+
+  // Nitro runs its own server build after the React Router/Vite build. The
+  // template's agent-chat plugin imports .generated/actions-registry.ts so the
+  // serverless bundle has static imports for every domain action. Regenerate
+  // here as well so deploy builds are not coupled to a previous Vite run or to
+  // ignored local .generated files being present.
+  generateActionRegistryForProject(cwd);
 
   // Work around pnpm + nitro:externals (nf3) bug where dangling symlinks for
   // platform-specific optional deps cause realpath ENOENT during file tracing.

--- a/packages/core/src/deploy/route-discovery.ts
+++ b/packages/core/src/deploy/route-discovery.ts
@@ -123,12 +123,19 @@ export async function discoverPlugins(cwd: string): Promise<string[]> {
     if (!fs.existsSync(pluginsDir)) return [];
     return fs
       .readdirSync(pluginsDir)
-      .filter((f) => f.endsWith(".ts") || f.endsWith(".js"))
+      .filter(isRuntimeSourceFile)
       .sort()
       .map((f) => path.join(pluginsDir, f));
   } catch {
     return []; // Edge runtime — no filesystem
   }
+}
+
+function isRuntimeSourceFile(filename: string): boolean {
+  if (!/\.(ts|js)$/.test(filename)) return false;
+  if (/\.d\.ts$/.test(filename)) return false;
+  if (/\.(test|spec)\.(ts|js)$/.test(filename)) return false;
+  return true;
 }
 
 /**
@@ -255,7 +262,7 @@ export async function getMissingDefaultPlugins(cwd: string): Promise<string[]> {
       fs.existsSync(pluginsDir)
         ? fs
             .readdirSync(pluginsDir)
-            .filter((f) => f.endsWith(".ts") || f.endsWith(".js"))
+            .filter(isRuntimeSourceFile)
             .map((f) => path.basename(f, path.extname(f)))
         : [],
     );

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -3,6 +3,7 @@ import type { A2AContinuation } from "./a2a-continuations-store.js";
 import type { PlatformAdapter } from "./types.js";
 
 const claimA2AContinuationMock = vi.hoisted(() => vi.fn());
+const claimA2AContinuationDeliveryMock = vi.hoisted(() => vi.fn());
 const completeA2AContinuationMock = vi.hoisted(() => vi.fn());
 const failA2AContinuationMock = vi.hoisted(() => vi.fn());
 const getA2AContinuationMock = vi.hoisted(() => vi.fn());
@@ -19,6 +20,7 @@ const A2AClientMock = vi.hoisted(() =>
 
 vi.mock("./a2a-continuations-store.js", () => ({
   claimA2AContinuation: claimA2AContinuationMock,
+  claimA2AContinuationDelivery: claimA2AContinuationDeliveryMock,
   claimDueA2AContinuations: vi.fn(async () => []),
   completeA2AContinuation: completeA2AContinuationMock,
   failA2AContinuation: failA2AContinuationMock,
@@ -100,6 +102,9 @@ describe("A2A continuation processor", () => {
     };
     getA2AContinuationMock.mockImplementation(async (id: string) =>
       continuation({ id, status: "pending" }),
+    );
+    claimA2AContinuationDeliveryMock.mockImplementation(async (id: string) =>
+      continuation({ id, status: "delivering" }),
     );
     vi.stubGlobal(
       "fetch",
@@ -201,6 +206,24 @@ describe("A2A continuation processor", () => {
     );
     expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not post completed text when another processor already claimed delivery", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    claimA2AContinuationDeliveryMock.mockResolvedValueOnce(null);
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(claimA2AContinuationDeliveryMock).toHaveBeenCalledWith("cont-1");
+    expect(sendResponse).not.toHaveBeenCalled();
+    expect(completeA2AContinuationMock).not.toHaveBeenCalled();
+    expect(rescheduleA2AContinuationMock).not.toHaveBeenCalled();
+    expect(failA2AContinuationMock).not.toHaveBeenCalled();
   });
 
   it("reuses opaque bearer tokens stored on the continuation", async () => {

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -10,6 +10,7 @@ import {
 } from "../agent/engine/credential-errors.js";
 import {
   claimA2AContinuation,
+  claimA2AContinuationDelivery,
   claimDueA2AContinuations,
   completeA2AContinuation,
   failA2AContinuation,
@@ -219,27 +220,35 @@ async function processClaimedContinuation(
     return;
   }
 
+  const deliveryContinuation = await claimA2AContinuationDelivery(
+    continuation.id,
+  );
+  if (!deliveryContinuation) return;
+
   try {
     await withTimeout(
       adapter.sendResponse(
         adapter.formatAgentResponse(text),
-        continuation.incoming,
-        { placeholderRef: continuation.placeholderRef ?? undefined },
+        deliveryContinuation.incoming,
+        { placeholderRef: deliveryContinuation.placeholderRef ?? undefined },
       ),
       PLATFORM_SEND_TIMEOUT_MS,
-      `${continuation.platform} response delivery timed out`,
+      `${deliveryContinuation.platform} response delivery timed out`,
     );
-    await completeA2AContinuation(continuation.id);
+    await completeA2AContinuation(deliveryContinuation.id);
   } catch (err) {
-    if (continuation.attempts >= MAX_ATTEMPTS) {
+    if (deliveryContinuation.attempts >= MAX_ATTEMPTS) {
       await failA2AContinuation(
-        continuation.id,
+        deliveryContinuation.id,
         err instanceof Error ? err.message : String(err),
       );
       return;
     }
-    await rescheduleA2AContinuation(continuation.id, RESCHEDULE_DELAY_MS);
-    await redispatchContinuation(continuation.id);
+    await rescheduleA2AContinuation(
+      deliveryContinuation.id,
+      RESCHEDULE_DELAY_MS,
+    );
+    await redispatchContinuation(deliveryContinuation.id);
   }
 }
 
@@ -265,25 +274,33 @@ async function notifyAndFailA2AContinuation(
   adapter: PlatformAdapter,
   reason: string,
 ): Promise<void> {
-  const message = formatContinuationFailureMessage(continuation, reason);
+  const deliveryContinuation = await claimA2AContinuationDelivery(
+    continuation.id,
+  );
+  if (!deliveryContinuation) return;
+
+  const message = formatContinuationFailureMessage(
+    deliveryContinuation,
+    reason,
+  );
   try {
     await withTimeout(
       adapter.sendResponse(
         adapter.formatAgentResponse(message),
-        continuation.incoming,
-        { placeholderRef: continuation.placeholderRef ?? undefined },
+        deliveryContinuation.incoming,
+        { placeholderRef: deliveryContinuation.placeholderRef ?? undefined },
       ),
       PLATFORM_SEND_TIMEOUT_MS,
-      `${continuation.platform} failure notification timed out`,
+      `${deliveryContinuation.platform} failure notification timed out`,
     );
   } catch (err) {
     console.error(
-      `[integrations] Failed to notify ${continuation.platform} about failed A2A continuation ${continuation.id}:`,
+      `[integrations] Failed to notify ${deliveryContinuation.platform} about failed A2A continuation ${deliveryContinuation.id}:`,
       err,
     );
   }
 
-  await failA2AContinuation(continuation.id, reason);
+  await failA2AContinuation(deliveryContinuation.id, reason);
 }
 
 function formatContinuationFailureMessage(

--- a/packages/core/src/integrations/a2a-continuations-store.spec.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.spec.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const executeMock = vi.hoisted(() => vi.fn());
+const isPostgresMock = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({ execute: executeMock }),
+  isPostgres: isPostgresMock,
+  intType: () => "INTEGER",
+}));
+
+async function loadStore() {
+  vi.resetModules();
+  return import("./a2a-continuations-store.js");
+}
+
+function querySql(query: string | { sql: string }): string {
+  return typeof query === "string" ? query : query.sql;
+}
+
+function queryArgs(query: string | { args?: unknown[] }): unknown[] {
+  return typeof query === "string" ? [] : (query.args ?? []);
+}
+
+function continuationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "cont-1",
+    integration_task_id: "task-1",
+    platform: "slack",
+    external_thread_id: "C123:123.456",
+    incoming_payload: JSON.stringify({
+      platform: "slack",
+      externalThreadId: "C123:123.456",
+      text: "make a deck",
+      timestamp: 1,
+    }),
+    placeholder_ref: null,
+    owner_email: "alice+qa@agent-native.test",
+    org_id: null,
+    agent_name: "Slides",
+    agent_url: "https://slides.agent-native.test",
+    a2a_task_id: "a2a-task-1",
+    a2a_auth_token: null,
+    status: "processing",
+    attempts: 1,
+    next_check_at: 1,
+    error_message: null,
+    created_at: 1,
+    updated_at: 2,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+describe("A2A continuations store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isPostgresMock.mockReturnValue(false);
+  });
+
+  it("atomically marks a processing continuation as delivering before platform send", async () => {
+    const { claimA2AContinuationDelivery } = await loadStore();
+    executeMock.mockImplementation(
+      async (query: string | { sql: string; args?: unknown[] }) => {
+        const sql = querySql(query);
+        const args = queryArgs(query);
+        if (sql.includes("UPDATE integration_a2a_continuations")) {
+          return { rows: [], rowsAffected: 1 };
+        }
+        if (
+          sql.includes(
+            "SELECT * FROM integration_a2a_continuations WHERE id = ?",
+          )
+        ) {
+          return {
+            rows: [continuationRow({ id: args[0], status: "delivering" })],
+            rowsAffected: 0,
+          };
+        }
+        return { rows: [], rowsAffected: 0 };
+      },
+    );
+
+    const claimed = await claimA2AContinuationDelivery("cont-1");
+
+    expect(claimed?.status).toBe("delivering");
+    const updateCall = executeMock.mock.calls.find(([query]) => {
+      const sql = querySql(query);
+      return (
+        sql.includes("UPDATE integration_a2a_continuations") &&
+        sql.includes("WHERE id = ? AND status = 'processing'")
+      );
+    });
+    expect(updateCall?.[0]).toEqual(
+      expect.objectContaining({
+        sql: expect.stringContaining("WHERE id = ? AND status = 'processing'"),
+        args: ["delivering", expect.any(Number), "cont-1"],
+      }),
+    );
+  });
+
+  it("does not claim delivery once another processor has moved the continuation on", async () => {
+    const { claimA2AContinuationDelivery } = await loadStore();
+    executeMock.mockImplementation(
+      async (query: string | { sql: string; args?: unknown[] }) => {
+        const sql = querySql(query);
+        if (sql.includes("UPDATE integration_a2a_continuations")) {
+          return { rows: [], rowsAffected: 0 };
+        }
+        if (
+          sql.includes(
+            "SELECT * FROM integration_a2a_continuations WHERE id = ?",
+          )
+        ) {
+          throw new Error("delivery claim should not fetch after no-op update");
+        }
+        return { rows: [], rowsAffected: 0 };
+      },
+    );
+
+    await expect(claimA2AContinuationDelivery("cont-1")).resolves.toBeNull();
+  });
+
+  it("allows stale delivering continuations to be reclaimed for retry", async () => {
+    const { claimA2AContinuation } = await loadStore();
+    executeMock.mockImplementation(
+      async (query: string | { sql: string; args?: unknown[] }) => {
+        const sql = querySql(query);
+        const args = queryArgs(query);
+        if (sql.includes("UPDATE integration_a2a_continuations")) {
+          return { rows: [], rowsAffected: 1 };
+        }
+        if (
+          sql.includes(
+            "SELECT * FROM integration_a2a_continuations WHERE id = ?",
+          )
+        ) {
+          return {
+            rows: [
+              continuationRow({
+                id: args[0],
+                status: "processing",
+                attempts: 2,
+              }),
+            ],
+            rowsAffected: 0,
+          };
+        }
+        return { rows: [], rowsAffected: 0 };
+      },
+    );
+
+    const claimed = await claimA2AContinuation("cont-1");
+
+    expect(claimed?.status).toBe("processing");
+    const updateCall = executeMock.mock.calls.find(([query]) =>
+      querySql(query).includes(
+        "SET status = ?, attempts = attempts + 1, updated_at = ?",
+      ),
+    );
+    expect(updateCall).toBeDefined();
+    expect(querySql(updateCall![0])).toContain(
+      "status IN ('processing', 'delivering')",
+    );
+  });
+});

--- a/packages/core/src/integrations/a2a-continuations-store.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.ts
@@ -52,6 +52,7 @@ async function ensureTable(): Promise<void> {
 export type A2AContinuationStatus =
   | "pending"
   | "processing"
+  | "delivering"
   | "completed"
   | "failed";
 
@@ -213,12 +214,12 @@ export async function claimA2AContinuation(
       ? `UPDATE integration_a2a_continuations
            SET status = ?, attempts = attempts + 1, updated_at = ?
          WHERE id = ?
-           AND (status = 'pending' OR (status = 'processing' AND updated_at <= ?))
+           AND (status = 'pending' OR (status IN ('processing', 'delivering') AND updated_at <= ?))
          RETURNING *`
       : `UPDATE integration_a2a_continuations
            SET status = ?, attempts = attempts + 1, updated_at = ?
          WHERE id = ?
-           AND (status = 'pending' OR (status = 'processing' AND updated_at <= ?))`,
+           AND (status = 'pending' OR (status IN ('processing', 'delivering') AND updated_at <= ?))`,
     args: ["processing", now, id, processingCutoff],
   });
   const rows = result.rows ?? [];
@@ -243,7 +244,7 @@ export async function claimDueA2AContinuations(
   await client.execute({
     sql: `UPDATE integration_a2a_continuations
           SET status = ?, next_check_at = ?, updated_at = ?
-          WHERE status = 'processing' AND updated_at <= ?`,
+          WHERE status IN ('processing', 'delivering') AND updated_at <= ?`,
     args: ["pending", now, now, now - 5 * 60 * 1000],
   });
   const { rows } = await client.execute({
@@ -261,6 +262,36 @@ export async function claimDueA2AContinuations(
   return claimed;
 }
 
+export async function claimA2AContinuationDelivery(
+  id: string,
+): Promise<A2AContinuation | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const result = await client.execute({
+    sql: isPostgres()
+      ? `UPDATE integration_a2a_continuations
+           SET status = ?, updated_at = ?
+         WHERE id = ? AND status = 'processing'
+         RETURNING *`
+      : `UPDATE integration_a2a_continuations
+           SET status = ?, updated_at = ?
+         WHERE id = ? AND status = 'processing'`,
+    args: ["delivering", now, id],
+  });
+  const rows = result.rows ?? [];
+  if (isPostgres()) {
+    return rows[0]
+      ? rowToContinuation(rows[0] as Record<string, unknown>)
+      : null;
+  }
+  const affected = (result as any)?.rowsAffected ?? (result as any)?.rowCount;
+  if (affected === 0) return null;
+  const fetched = await getA2AContinuation(id);
+  if (!fetched || fetched.status !== "delivering") return null;
+  return fetched;
+}
+
 export async function rescheduleA2AContinuation(
   id: string,
   delayMs: number,
@@ -271,7 +302,7 @@ export async function rescheduleA2AContinuation(
   await client.execute({
     sql: `UPDATE integration_a2a_continuations
           SET status = ?, next_check_at = ?, updated_at = ?
-          WHERE id = ? AND status = 'processing'`,
+          WHERE id = ? AND status IN ('processing', 'delivering')`,
     args: ["pending", now + delayMs, now, id],
   });
 }

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -581,6 +581,8 @@ describe("integration webhook handler engine resolution", () => {
       A2A_CONTINUATION_QUEUED_MARKER,
       "The Analytics answer will show up here shortly.",
       "I will relay from the Analytics agent when the result is ready.",
+      "The Slides agent is working on your *Launch Readiness Snapshot* deck (title, risks, next steps). The result will be posted here in this thread as soon as it's ready - hang tight!",
+      "The Design agent is working on your *Launch Readiness Status Card* - it'll post the artifact URL directly here in this thread as soon as it's ready. Hang tight! :art:",
     ];
 
     for (const [index, text] of deferrals.entries()) {

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -659,7 +659,7 @@ function isQueuedA2AContinuationDeferral(text: string): boolean {
   const normalized = text.replace(/\s+/g, " ").trim();
   if (!normalized) return true;
   if (normalized.includes(A2A_CONTINUATION_QUEUED_MARKER)) return true;
-  return /\b(?:still (?:working|processing)|taking longer than expected|will (?:post|update|surface|show up)|final result when it finishes|while you wait|as soon as (?:it|the result) (?:comes back|is ready)|relay from the .* agent)\b/i.test(
+  return /\b(?:still (?:working|processing)|is working on|taking longer than expected|will (?:post|update|surface|show up)|(?:it'?ll|it will|the result will|the final result will) (?:post|be posted|update|be updated|surface|show up)|will be (?:posted|updated|sent|shared)|final result when it finishes|while you wait|as soon as (?:it|it'?s|it is|the result|the artifact) (?:comes back|is ready|ready)|hang tight|relay from the .* agent)\b/i.test(
     normalized,
   );
 }

--- a/packages/core/src/resources/handlers.ts
+++ b/packages/core/src/resources/handlers.ts
@@ -23,6 +23,7 @@ import {
 } from "./store.js";
 import {
   getResourceKind,
+  isRemoteAgentPath,
   parseCustomAgentProfile,
   parseRemoteAgentManifest,
   parseSkillMetadata,
@@ -271,10 +272,7 @@ async function enrichTreeNodes(nodes: TreeNode[]): Promise<void> {
             undefined;
         }
 
-        if (
-          node.resource.path.startsWith("remote-agents/") &&
-          node.resource.path.endsWith(".json")
-        ) {
+        if (isRemoteAgentPath(node.resource.path)) {
           node.remoteAgentMeta =
             parseRemoteAgentManifest(full.content, node.resource.path) ??
             undefined;

--- a/packages/core/src/resources/metadata.spec.ts
+++ b/packages/core/src/resources/metadata.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  getRemoteAgentIdFromPath,
+  getResourceKind,
+  isRemoteAgentPath,
+  parseRemoteAgentManifest,
+  remoteAgentResourcePath,
+} from "./metadata.js";
+
+describe("resource metadata", () => {
+  it("treats remote-agents/*.json as the canonical remote-agent path", () => {
+    expect(remoteAgentResourcePath("qa-agent")).toBe(
+      "remote-agents/qa-agent.json",
+    );
+    expect(isRemoteAgentPath("remote-agents/qa-agent.json")).toBe(true);
+    expect(getResourceKind("remote-agents/qa-agent.json")).toBe("remote-agent");
+  });
+
+  it("continues to recognize legacy agents/*.json remote-agent manifests", () => {
+    const manifest = parseRemoteAgentManifest(
+      JSON.stringify({
+        name: "Legacy QA",
+        url: "https://qa.example.com",
+      }),
+      "agents/legacy-qa.json",
+    );
+
+    expect(isRemoteAgentPath("agents/legacy-qa.json")).toBe(true);
+    expect(getResourceKind("agents/legacy-qa.json")).toBe("remote-agent");
+    expect(getRemoteAgentIdFromPath("agents/legacy-qa.json")).toBe("legacy-qa");
+    expect(manifest).toMatchObject({
+      id: "legacy-qa",
+      path: "agents/legacy-qa.json",
+      name: "Legacy QA",
+      url: "https://qa.example.com",
+    });
+  });
+
+  it("keeps markdown agents classified as local custom agents", () => {
+    expect(isRemoteAgentPath("agents/researcher.md")).toBe(false);
+    expect(getResourceKind("agents/researcher.md")).toBe("agent");
+  });
+});

--- a/packages/core/src/resources/metadata.ts
+++ b/packages/core/src/resources/metadata.ts
@@ -32,6 +32,13 @@ export interface RemoteAgentManifest {
   color?: string;
 }
 
+export const REMOTE_AGENT_RESOURCE_PREFIX = "remote-agents/";
+export const LEGACY_REMOTE_AGENT_RESOURCE_PREFIX = "agents/";
+export const REMOTE_AGENT_RESOURCE_PREFIXES = [
+  REMOTE_AGENT_RESOURCE_PREFIX,
+  LEGACY_REMOTE_AGENT_RESOURCE_PREFIX,
+] as const;
+
 function normalizeFrontmatterValue(value: string): string {
   const trimmed = value.trim();
   if (
@@ -141,7 +148,22 @@ export function isCustomAgentPath(path: string): boolean {
 }
 
 export function isRemoteAgentPath(path: string): boolean {
-  return path.startsWith("remote-agents/") && path.endsWith(".json");
+  return (
+    path.endsWith(".json") &&
+    REMOTE_AGENT_RESOURCE_PREFIXES.some((prefix) => path.startsWith(prefix))
+  );
+}
+
+export function getRemoteAgentIdFromPath(path: string): string {
+  const prefix = REMOTE_AGENT_RESOURCE_PREFIXES.find((candidate) =>
+    path.startsWith(candidate),
+  );
+  const withoutPrefix = prefix ? path.slice(prefix.length) : path;
+  return withoutPrefix.replace(/\.json$/, "");
+}
+
+export function remoteAgentResourcePath(id: string): string {
+  return `${REMOTE_AGENT_RESOURCE_PREFIX}${id}.json`;
 }
 
 export function getResourceKind(path: string): ResourceKind {
@@ -196,8 +218,7 @@ export function parseRemoteAgentManifest(
   if (!isRemoteAgentPath(path)) return null;
   try {
     const data = JSON.parse(content);
-    const id =
-      data.id || path.replace(/^remote-agents\//, "").replace(/\.json$/, "");
+    const id = data.id || getRemoteAgentIdFromPath(path);
     if (!data.url) return null;
     return {
       id,

--- a/packages/core/src/resources/store.ts
+++ b/packages/core/src/resources/store.ts
@@ -330,7 +330,8 @@ async function _doEnsureTable(): Promise<void> {
         });
       } catch {
         // Skip if destination path already exists (unique constraint) —
-        // we'll leave the old row in place; it'll be ignored by readers.
+        // we'll leave the old row in place; readers accept both paths and
+        // canonical remote-agents/ entries win when both exist.
       }
     }
   } catch {

--- a/packages/core/src/server/agent-discovery.spec.ts
+++ b/packages/core/src/server/agent-discovery.spec.ts
@@ -105,6 +105,40 @@ describe("agent discovery", () => {
     expect(ids).toContain("custom-qa");
   });
 
+  it("discovers legacy agents/*.json remote-agent resources", async () => {
+    resourceListAccessibleMock.mockImplementation(
+      async (_owner: string, prefix: string) => {
+        if (prefix === "agents/") {
+          return [{ id: "legacy-resource", path: "agents/external-qa.json" }];
+        }
+        return [];
+      },
+    );
+    resourceGetMock.mockResolvedValue({
+      id: "legacy-resource",
+      content: JSON.stringify({
+        name: "External QA",
+        url: "https://qa.example.com",
+      }),
+    });
+
+    const agents = await discoverAgents("dispatch");
+
+    expect(resourceListAccessibleMock).toHaveBeenCalledWith(
+      "dev@example.test",
+      "remote-agents/",
+    );
+    expect(resourceListAccessibleMock).toHaveBeenCalledWith(
+      "dev@example.test",
+      "agents/",
+    );
+    expect(agents.find((agent) => agent.id === "external-qa")).toMatchObject({
+      id: "external-qa",
+      name: "External QA",
+      url: "https://qa.example.com",
+    });
+  });
+
   it("discovers sibling workspace apps from the workspace manifest", async () => {
     process.env.APP_URL = "https://workspace.example.test";
     process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({

--- a/packages/core/src/server/agent-discovery.ts
+++ b/packages/core/src/server/agent-discovery.ts
@@ -95,11 +95,17 @@ export async function discoverAgents(
     const isDevMode =
       typeof process !== "undefined" && process.env?.NODE_ENV !== "production";
 
-    const resources = isDevMode
-      ? await resourceListAccessible(DEV_MODE_USER_EMAIL, "remote-agents/")
-      : await resourceList(SHARED_OWNER, "remote-agents/");
-    const { parseRemoteAgentManifest } =
+    const { parseRemoteAgentManifest, REMOTE_AGENT_RESOURCE_PREFIXES } =
       await import("../resources/metadata.js");
+
+    const resources: Array<{ id: string; path: string }> = [];
+    for (const prefix of [...REMOTE_AGENT_RESOURCE_PREFIXES].reverse()) {
+      resources.push(
+        ...(isDevMode
+          ? await resourceListAccessible(DEV_MODE_USER_EMAIL, prefix)
+          : await resourceList(SHARED_OWNER, prefix)),
+      );
+    }
 
     for (const r of resources) {
       if (!r.path.endsWith(".json")) continue;

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -318,6 +318,35 @@ describe("server/auth", () => {
       expect(result).toBeUndefined();
     });
 
+    it("lets signed integration processor routes bypass the global auth guard", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      vi.stubEnv("APP_BASE_PATH", "/dispatch");
+      delete process.env.AUTH_MODE;
+      const { autoMountAuth } = await import("./auth.js");
+
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const app = createMockApp();
+      await autoMountAuth(app);
+      logSpy.mockRestore();
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      for (const path of [
+        "/dispatch/_agent-native/integrations/process-task",
+        "/dispatch/_agent-native/integrations/process-a2a-continuation",
+      ]) {
+        const event = createMockEvent({ path });
+        event.req.method = "POST";
+        event.node.req.method = "POST";
+
+        await expect(guard(event)).resolves.toBeUndefined();
+      }
+    });
+
     it("serves mounted login and signup pages from the framework guard", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("APP_BASE_PATH", "/dispatch");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -828,6 +828,13 @@ function createAuthGuardFn(): (
       return;
     }
 
+    // Internal processor endpoint for deferred A2A continuations created by
+    // integration tasks. It uses the same HMAC internal-token scheme as the
+    // primary integration processor, so it must bypass cookie/session auth.
+    if (p === "/_agent-native/integrations/process-a2a-continuation") {
+      return;
+    }
+
     // A2A endpoint verifies authenticity via JWT signed with the org's A2A
     // secret (or the global A2A_SECRET fallback), not via session cookies.
     if (p === "/_agent-native/a2a") {

--- a/packages/core/src/vite/index.ts
+++ b/packages/core/src/vite/index.ts
@@ -3,5 +3,8 @@ export {
   type ClientConfigOptions,
   type NitroOptions,
 } from "./client.js";
-export { actionTypesPlugin } from "./action-types-plugin.js";
+export {
+  actionTypesPlugin,
+  generateActionRegistryForProject,
+} from "./action-types-plugin.js";
 export { agentsBundlePlugin } from "./agents-bundle-plugin.js";

--- a/templates/dispatch/AGENTS.md
+++ b/templates/dispatch/AGENTS.md
@@ -31,12 +31,13 @@ Read both personal and shared copies of these when they exist:
 2. `LEARNINGS.md`
 3. `jobs/`
 4. `agents/`
+5. `remote-agents/`
 
 Use resources for:
 
 - Long-term memory and operating instructions
 - Specialized local sub-agent profiles in `agents/*.md`
-- Remote agent definitions in `agents/*.json`
+- Remote agent definitions in `remote-agents/*.json` (legacy `agents/*.json` is still readable)
 - Recurring automations in `jobs/*.md`
 
 ## Navigation State

--- a/templates/dispatch/actions/create-workspace-resource.ts
+++ b/templates/dispatch/actions/create-workspace-resource.ts
@@ -14,13 +14,11 @@ export default defineAction({
     path: z
       .string()
       .describe(
-        'Resource path, e.g. "skills/designer.md" or "agents/researcher.md"',
+        'Resource path, e.g. "skills/designer.md", "agents/researcher.md", or "remote-agents/researcher.json"',
       ),
     content: z
       .string()
-      .describe(
-        "Full resource content (markdown with optional YAML frontmatter)",
-      ),
+      .describe("Full resource content (markdown or remote-agent JSON)"),
     scope: z
       .enum(["all", "selected"])
       .describe(

--- a/templates/dispatch/actions/list-connected-agents.ts
+++ b/templates/dispatch/actions/list-connected-agents.ts
@@ -10,7 +10,10 @@ import {
   resourceListAccessible,
   SHARED_OWNER,
 } from "@agent-native/core/resources/store";
-import { parseRemoteAgentManifest } from "@agent-native/core/resources/metadata";
+import {
+  REMOTE_AGENT_RESOURCE_PREFIXES,
+  parseRemoteAgentManifest,
+} from "@agent-native/core/resources/metadata";
 
 export default defineAction({
   description:
@@ -24,13 +27,21 @@ export default defineAction({
     );
     const ownerEmail = getRequestUserEmail();
     if (!ownerEmail) throw new Error("no authenticated user");
-    const resources = await resourceListAccessible(
-      ownerEmail,
-      "remote-agents/",
-    );
+    const resources: Array<{ id: string; path: string; owner: string }> = [];
+    for (const prefix of [...REMOTE_AGENT_RESOURCE_PREFIXES].reverse()) {
+      resources.push(...(await resourceListAccessible(ownerEmail, prefix)));
+    }
     const customById = new Map<
       string,
-      { resourceId: string; path: string; scope: "shared" | "personal" }
+      {
+        resourceId: string;
+        path: string;
+        scope: "shared" | "personal";
+        name: string;
+        description: string;
+        url: string;
+        color: string;
+      }
     >();
 
     // Only treat a resource as a "custom" agent if its id is not a builtin.
@@ -47,10 +58,14 @@ export default defineAction({
         resourceId: resource.id,
         path: resource.path,
         scope: resource.owner === SHARED_OWNER ? "shared" : "personal",
+        name: manifest.name,
+        description: manifest.description || "",
+        url: manifest.url,
+        color: manifest.color || "#6B7280",
       });
     }
 
-    return discovered.map((agent) => {
+    const connected = discovered.map((agent) => {
       const custom = customById.get(agent.id);
       const isBuiltin = builtinIds.has(agent.id);
       return {
@@ -61,5 +76,23 @@ export default defineAction({
         scope: custom?.scope,
       };
     });
+
+    const discoveredIds = new Set(connected.map((agent) => agent.id));
+    for (const [id, custom] of customById) {
+      if (discoveredIds.has(id)) continue;
+      connected.push({
+        id,
+        name: custom.name,
+        description: custom.description,
+        url: custom.url,
+        color: custom.color,
+        source: "custom",
+        resourceId: custom.resourceId,
+        path: custom.path,
+        scope: custom.scope,
+      });
+    }
+
+    return connected;
   },
 });

--- a/templates/dispatch/app/components/agents-panel.tsx
+++ b/templates/dispatch/app/components/agents-panel.tsx
@@ -67,7 +67,7 @@ export function AgentsPanel({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          path: `agents/${id}.json`,
+          path: `remote-agents/${id}.json`,
           content: agentJson,
           shared: true,
         }),

--- a/templates/dispatch/server/plugins/agent-chat.ts
+++ b/templates/dispatch/server/plugins/agent-chat.ts
@@ -24,9 +24,9 @@ Default posture:
 - Prefer replying in the current external thread unless the user explicitly asks you to send to a saved destination.
 
 Use the standard workspace primitives:
-- Read and update resources like AGENTS.md, LEARNINGS.md, jobs/*.md, and agents/* when appropriate.
+- Read and update resources like AGENTS.md, LEARNINGS.md, jobs/*.md, agents/*.md, and remote-agents/*.json when appropriate.
 - Use recurring jobs for scheduled behavior.
-- Use custom agent profiles in agents/*.md for local spawned work and agents/*.json for remote A2A apps.
+- Use custom agent profiles in agents/*.md for local spawned work and remote-agents/*.json for remote A2A apps.
 
 When a user asks for something like a digest, reminder, routing rule, or saved behavior:
 - First decide whether it should be a resource, a recurring job, a destination, or a delegated task.

--- a/templates/slides/server/agent-card.test.ts
+++ b/templates/slides/server/agent-card.test.ts
@@ -1,0 +1,51 @@
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { generateAgentCard } from "@agent-native/core/a2a";
+import { loadActionsFromStaticRegistry } from "@agent-native/core/server";
+import { generateActionRegistryForProject } from "@agent-native/core/vite";
+import { describe, expect, it } from "vitest";
+
+const projectRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const REQUIRED_SLIDES_ACTIONS = [
+  "create-deck",
+  "add-slide",
+  "get-deck",
+  "list-decks",
+  "update-slide",
+  "navigate",
+];
+
+describe("slides agent card", () => {
+  it("advertises slides domain actions from the generated static registry", async () => {
+    generateActionRegistryForProject(projectRoot);
+
+    const registryUrl =
+      pathToFileURL(path.join(projectRoot, ".generated/actions-registry.ts"))
+        .href + `?cacheBust=${Date.now()}`;
+    const { default: modules } = await import(registryUrl);
+    const actions = loadActionsFromStaticRegistry(modules);
+    const card = generateAgentCard(
+      {
+        name: "Slides",
+        description: "Agent-native slides agent",
+        skills: Object.entries(actions).map(([name, entry]) => ({
+          id: name,
+          name,
+          description: entry.tool.description,
+        })),
+        streaming: true,
+      },
+      "https://slides.agent-native.com",
+    );
+
+    expect(card.name).toBe("Slides");
+    expect(card.description).toBe("Agent-native slides agent");
+    expect(card.skills.map((skill) => skill.id)).toEqual(
+      expect.arrayContaining(REQUIRED_SLIDES_ACTIONS),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- harden hosted A2A auth policy and JWT advertisement, including invalid bearer rejection before task lookups
- make deferred Slack/A2A continuation processing auth-safe, idempotent, and less noisy for interim replies
- regenerate action registries during deploy builds so production agent cards include template domain actions
- canonicalize remote agent resources under remote-agents/ while continuing to read legacy agents/*.json
- bump @agent-native/core to 0.7.51

## Verification
- pnpm lint
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- pnpm --filter @agent-native/core exec vitest --run src/a2a src/resources/metadata.spec.ts src/server/agent-discovery.spec.ts src/deploy/route-discovery.spec.ts src/deploy/build.spec.ts src/integrations/a2a-continuation-processor.spec.ts src/integrations/a2a-continuations-store.spec.ts src/integrations/webhook-handler-engine.spec.ts src/integrations/webhook-handler.spec.ts src/server/auth.spec.ts
- pnpm --filter slides exec vitest --run server/agent-card.test.ts
- pnpm --filter dispatch typecheck
