### PR TITLE
Harden Slack artifact delivery

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.58",
+  "version": "0.7.59",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/artifact-response.spec.ts
+++ b/packages/core/src/a2a/artifact-response.spec.ts
@@ -212,6 +212,61 @@ describe("appendA2AArtifactLinks", () => {
     );
   });
 
+  it("blocks unverified production Design URLs even when the caller is another app", () => {
+    const text = appendA2AArtifactLinks(
+      "The Design agent returned https://design.agent-native.com/design/us1sfMEZNWUQZHDldxoFA",
+      [],
+      { baseUrl: "https://dispatch.agent-native.com" },
+    );
+
+    expect(text).toContain("could not verify the design URL");
+    expect(text).toContain("saved app data");
+    expect(text).not.toContain("us1sfMEZNWUQZHDldxoFA");
+    expect(text).not.toContain("https://design.agent-native.com/design/");
+  });
+
+  it("allows verified production Slides URLs when a successful deck action returned the same artifact", () => {
+    const text = appendA2AArtifactLinks(
+      "Deck ready: https://slides.agent-native.com/deck/deck_123",
+      [
+        {
+          tool: "create-deck",
+          result: JSON.stringify({
+            id: "deck_123",
+            slideCount: 1,
+            url: "https://slides.agent-native.com/deck/deck_123",
+          }),
+        },
+      ],
+      { baseUrl: "https://dispatch.agent-native.com" },
+    );
+
+    expect(text).toBe(
+      "Deck ready: https://slides.agent-native.com/deck/deck_123",
+    );
+  });
+
+  it("allows verified production Content URLs when a successful document action returned the same artifact", () => {
+    const text = appendA2AArtifactLinks(
+      "Document ready: https://content.agent-native.com/page/doc_123",
+      [
+        {
+          tool: "create-document",
+          result: JSON.stringify({
+            id: "doc_123",
+            title: "Launch Brief",
+            url: "https://content.agent-native.com/page/doc_123",
+          }),
+        },
+      ],
+      { baseUrl: "https://dispatch.agent-native.com" },
+    );
+
+    expect(text).toBe(
+      "Document ready: https://content.agent-native.com/page/doc_123",
+    );
+  });
+
   it("blocks generic shell-only design success even when the model omitted the id", () => {
     const text = appendA2AArtifactLinks(
       "Done.",

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -336,12 +336,11 @@ function collectReferencedArtifacts(
 
   for (const match of text.matchAll(artifactUrlPattern)) {
     const origin = safeOrigin(match[1]);
-    if (origin && baseOrigin && origin !== baseOrigin) continue;
-
     const route = match[2];
     const id = match[3];
     const kind: ReferencedArtifactKind =
       route === "deck" ? "deck" : route === "design" ? "design" : "document";
+    if (!shouldValidateArtifactReference(origin, baseOrigin, kind)) continue;
     refs.set(`${kind}:${id}`, { kind, id });
   }
 
@@ -355,6 +354,37 @@ function safeOrigin(url: string | undefined): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+const KNOWN_AGENT_NATIVE_ARTIFACT_HOSTS: Record<
+  ReferencedArtifactKind,
+  ReadonlySet<string>
+> = {
+  deck: new Set(["slides.agent-native.com"]),
+  design: new Set(["design.agent-native.com"]),
+  document: new Set(["content.agent-native.com"]),
+};
+
+function safeHostnameFromOrigin(
+  origin: string | undefined,
+): string | undefined {
+  if (!origin) return undefined;
+  try {
+    return new URL(origin).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+function shouldValidateArtifactReference(
+  origin: string | undefined,
+  baseOrigin: string | undefined,
+  kind: ReferencedArtifactKind,
+): boolean {
+  if (!origin || !baseOrigin || origin === baseOrigin) return true;
+
+  const hostname = safeHostnameFromOrigin(origin);
+  return !!hostname && KNOWN_AGENT_NATIVE_ARTIFACT_HOSTS[kind].has(hostname);
 }
 
 function findUnverifiedArtifactReferences(
@@ -393,7 +423,7 @@ function formatUnverifiedArtifactMessage(
         ? "deck URL"
         : "artifact URL";
   const plural = refs.length === 1 ? label : `${label}s`;
-  const message = `I could not verify the ${plural} in the final answer against a successful artifact action, so I cannot return it.`;
+  const message = `I could not verify the ${plural} in the final answer against a successful artifact action that saved app data, so I cannot return it.`;
   const verifiedLines = [
     ...documents.map((document) => formatDocumentLine(document, baseUrl)),
     ...decks.map((deck) => formatDeckLine(deck, baseUrl)),

--- a/packages/core/src/a2a/client.spec.ts
+++ b/packages/core/src/a2a/client.spec.ts
@@ -15,6 +15,7 @@ describe("A2AClient", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     process.env = originalEnv;
   });
@@ -136,6 +137,80 @@ describe("A2AClient", () => {
     ).rejects.toBeInstanceOf(A2ATaskTimeoutError);
   });
 
+  it("returns receiver-verified recoverable artifact text when callAgent times out", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        if (!init) return new Response("not found", { status: 404 });
+        const body = JSON.parse(String(init.body));
+        if (body.method === "message/send") {
+          return workingResponse(body, "task-deck");
+        }
+        return workingResponse(body, "task-deck", {
+          message: {
+            role: "agent",
+            metadata: { agentNativeRecoverableArtifacts: true },
+            parts: [
+              {
+                type: "text",
+                text: "Artifacts:\n- Deck: https://slides.agent.test/deck/deck-real (ID: deck-real)",
+              },
+            ],
+          },
+        });
+      }),
+    );
+
+    const result = callAgent("https://slides.agent.test", "make a deck", {
+      timeoutMs: 1,
+    });
+    const assertion = expect(result).resolves.toContain(
+      "https://slides.agent.test/deck/deck-real",
+    );
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await assertion;
+  });
+
+  it("does not treat unmarked timeout text as a recoverable artifact", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        if (!init) return new Response("not found", { status: 404 });
+        const body = JSON.parse(String(init.body));
+        if (body.method === "message/send") {
+          return workingResponse(body, "task-fake");
+        }
+        return workingResponse(body, "task-fake", {
+          message: {
+            role: "agent",
+            parts: [
+              {
+                type: "text",
+                text: "Maybe try https://slides.agent.test/deck/deck-guessed",
+              },
+            ],
+          },
+        });
+      }),
+    );
+
+    const result = callAgent("https://slides.agent.test", "make a deck", {
+      timeoutMs: 1,
+    });
+    const assertion = expect(result).rejects.toMatchObject({
+      name: "A2ATaskTimeoutError",
+      taskId: "task-fake",
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await assertion;
+  });
+
   it("can prefer the shared global A2A secret before an org secret", async () => {
     process.env.A2A_SECRET = "global-a2a-secret";
 
@@ -173,6 +248,30 @@ function completedResponse(body: any, text: string): Response {
             role: "agent",
             parts: [{ type: "text", text }],
           },
+        },
+        history: [],
+        artifacts: [],
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+function workingResponse(
+  body: any,
+  taskId: string,
+  status: Record<string, unknown> = {},
+): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: body.id,
+      result: {
+        id: taskId,
+        status: {
+          state: "working",
+          timestamp: new Date().toISOString(),
+          ...status,
         },
         history: [],
         artifacts: [],

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -494,11 +494,19 @@ export async function callAgent(
 
   let task: Task;
   if (useAsync) {
-    task = await client.sendAndWait(message, {
-      contextId: opts?.contextId,
-      metadata,
-      timeoutMs: opts?.timeoutMs,
-    });
+    try {
+      task = await client.sendAndWait(message, {
+        contextId: opts?.contextId,
+        metadata,
+        timeoutMs: opts?.timeoutMs,
+      });
+    } catch (err) {
+      if (err instanceof A2ATaskTimeoutError) {
+        const recoverableText = extractRecoverableArtifactText(err.lastTask);
+        if (recoverableText) return recoverableText;
+      }
+      throw err;
+    }
   } else {
     task = await client.send(message, {
       contextId: opts?.contextId,
@@ -516,4 +524,18 @@ export async function callAgent(
   }
 
   return "";
+}
+
+function extractRecoverableArtifactText(task: Task): string {
+  if (!task.status.message?.metadata?.agentNativeRecoverableArtifacts) {
+    return "";
+  }
+  return extractMessageText(task.status.message);
+}
+
+function extractMessageText(message: Message): string {
+  return message.parts
+    .filter((p): p is { type: "text"; text: string } => p.type === "text")
+    .map((p) => p.text)
+    .join("\n");
 }

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -661,6 +661,80 @@ describe("integration webhook handler engine resolution", () => {
     );
   });
 
+  it("sends verified recoverable A2A artifact tool results when no final text is emitted", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const sendResponse = vi.fn();
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({
+        type: "tool_start",
+        tool: "call-agent",
+        input: { agent: "slides", message: "make a launch deck" },
+      });
+      send({
+        type: "tool_done",
+        tool: "call-agent",
+        result:
+          "The agent is still working on the full response, but these verified artifacts already exist:\n\n" +
+          "Artifacts:\n" +
+          "- Deck: https://slides.agent.test/deck/deck-real (ID: deck-real)",
+      });
+    });
+
+    await processIntegrationTask(pendingTask({ id: "task-recoverable-a2a" }), {
+      adapter: createAdapter(sendResponse),
+      systemPrompt: "system",
+      actions: {},
+      model: "claude-sonnet-4-6",
+      apiKey: "",
+      ownerEmail: "dispatch+qa@integration.local",
+    });
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining(
+          "https://slides.agent.test/deck/deck-real",
+        ),
+      }),
+      expect.any(Object),
+      expect.objectContaining({ placeholderRef: undefined }),
+    );
+  });
+
+  it("does not fall back to unmarked A2A tool URLs when no final text is emitted", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const sendResponse = vi.fn();
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({
+        type: "tool_start",
+        tool: "call-agent",
+        input: { agent: "slides", message: "make a launch deck" },
+      });
+      send({
+        type: "tool_done",
+        tool: "call-agent",
+        result: "Maybe try https://slides.agent.test/deck/deck-guessed",
+      });
+    });
+
+    await processIntegrationTask(pendingTask({ id: "task-unmarked-a2a" }), {
+      adapter: createAdapter(sendResponse),
+      systemPrompt: "system",
+      actions: {},
+      model: "claude-sonnet-4-6",
+      apiKey: "",
+      ownerEmail: "dispatch+qa@integration.local",
+    });
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "(No response)",
+      }),
+      expect.any(Object),
+      expect.objectContaining({ placeholderRef: undefined }),
+    );
+    expect(sendResponse.mock.calls[0][0].text).not.toContain("deck-guessed");
+  });
+
   it("does not send hallucinated local design URLs to Slack-style integrations", async () => {
     const { processIntegrationTask } = await import("./webhook-handler.js");
     const previousAppUrl = process.env.APP_URL;
@@ -699,6 +773,54 @@ describe("integration webhook handler engine resolution", () => {
     );
     expect(sendResponse.mock.calls[0][0].text).not.toContain(
       "DSyLeIdyBc9p_drm40Tfp",
+    );
+  });
+
+  it("does not relay unverified production Design URLs from Dispatch Slack replies", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const previousAppUrl = process.env.APP_URL;
+    process.env.APP_URL = "https://dispatch.agent-native.com";
+    const sendResponse = vi.fn();
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({
+        type: "text",
+        text: "The Design agent returned https://design.agent-native.com/design/us1sfMEZNWUQZHDldxoFA",
+      });
+    });
+
+    try {
+      await processIntegrationTask(
+        pendingTask({ id: "task-cross-app-false-design" }),
+        {
+          adapter: createAdapter(sendResponse),
+          systemPrompt: "system",
+          actions: {},
+          model: "claude-sonnet-4-6",
+          apiKey: "",
+          ownerEmail: "dispatch+qa@integration.local",
+        },
+      );
+    } finally {
+      if (previousAppUrl === undefined) {
+        delete process.env.APP_URL;
+      } else {
+        process.env.APP_URL = previousAppUrl;
+      }
+    }
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("could not verify the design URL"),
+      }),
+      expect.any(Object),
+      expect.objectContaining({ placeholderRef: undefined }),
+    );
+    expect(sendResponse.mock.calls[0][0].text).toContain("saved app data");
+    expect(sendResponse.mock.calls[0][0].text).not.toContain(
+      "us1sfMEZNWUQZHDldxoFA",
+    );
+    expect(sendResponse.mock.calls[0][0].text).not.toContain(
+      "https://design.agent-native.com/design/",
     );
   });
 

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -569,10 +569,19 @@ async function processIncomingMessage(
       async (completedRun: ActiveRun) => {
         try {
           const queuedA2AContinuation = hasQueuedA2AContinuation(completedRun);
+          let usedRecoverableA2AArtifactToolResult = false;
           let responseText = collectFinalResponseTextFromAgentEvents(
             completedRun.events.map((runEvent) => runEvent.event),
             { fallbackToPreToolText: !queuedA2AContinuation },
           );
+          if (!queuedA2AContinuation && !responseText.trim()) {
+            const recoverableA2AArtifactText =
+              extractRecoverableA2AArtifactToolResult(completedRun);
+            if (recoverableA2AArtifactText) {
+              responseText = recoverableA2AArtifactText;
+              usedRecoverableA2AArtifactToolResult = true;
+            }
+          }
 
           const suppressPlatformReply =
             queuedA2AContinuation &&
@@ -616,7 +625,7 @@ async function processIncomingMessage(
           // preview card.
           const baseUrl = process.env.APP_URL || process.env.URL || "";
           const appBaseUrl = baseUrl ? withConfiguredAppBasePath(baseUrl) : "";
-          if (!suppressPlatformReply) {
+          if (!suppressPlatformReply && !usedRecoverableA2AArtifactToolResult) {
             responseText = appendA2AArtifactLinks(
               responseText,
               collectToolResultSummaries(completedRun),
@@ -675,6 +684,24 @@ function hasQueuedA2AContinuation(completedRun: ActiveRun): boolean {
       String(event.result ?? "").includes(A2A_CONTINUATION_QUEUED_MARKER)
     );
   });
+}
+
+function extractRecoverableA2AArtifactToolResult(
+  completedRun: ActiveRun,
+): string | null {
+  for (let i = completedRun.events.length - 1; i >= 0; i--) {
+    const event = completedRun.events[i].event;
+    if (event.type !== "tool_done" || event.tool !== "call-agent") continue;
+
+    const result = String(event.result ?? "").trim();
+    if (
+      result.includes("verified artifacts already exist") &&
+      result.includes("\nArtifacts:\n")
+    ) {
+      return result;
+    }
+  }
+  return null;
 }
 
 function isQueuedA2AContinuationDeferral(text: string): boolean {

--- a/templates/dispatch/actions/list-connected-agents.ts
+++ b/templates/dispatch/actions/list-connected-agents.ts
@@ -70,7 +70,7 @@ export default defineAction({
       const isBuiltin = builtinIds.has(agent.id);
       return {
         ...agent,
-        source: isBuiltin ? "builtin" : custom ? "custom" : "builtin",
+        source: isBuiltin ? "builtin" : custom ? "custom" : "workspace",
         resourceId: custom?.resourceId,
         path: custom?.path,
         scope: custom?.scope,

--- a/templates/dispatch/app/components/agents-panel.tsx
+++ b/templates/dispatch/app/components/agents-panel.tsx
@@ -21,7 +21,7 @@ export interface ConnectedAgent {
   description: string;
   url: string;
   color: string;
-  source: "builtin" | "custom";
+  source: "builtin" | "custom" | "workspace";
   resourceId?: string;
   path?: string;
   scope?: "shared" | "personal";
@@ -41,6 +41,9 @@ export function AgentsPanel({
   const nameRef = useRef<HTMLInputElement>(null);
 
   const customAgents = agents.filter((agent) => agent.source === "custom");
+  const workspaceAgents = agents.filter(
+    (agent) => agent.source === "workspace",
+  );
   const builtinAgents = agents.filter((agent) => agent.source === "builtin");
 
   const handleAdd = async () => {
@@ -129,6 +132,34 @@ export function AgentsPanel({
               Added in this workspace
             </div>
             <div className="mt-2 space-y-2">
+              {workspaceAgents.map((agent) => (
+                <div
+                  key={agent.id}
+                  className="flex items-start justify-between gap-3 rounded-xl border bg-muted/30 px-4 py-3"
+                >
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-foreground">
+                      {agent.name}
+                    </div>
+                    {agent.description ? (
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        {agent.description}
+                      </div>
+                    ) : null}
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      <a
+                        href={agent.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1 hover:text-foreground"
+                      >
+                        {agent.url}
+                        <IconExternalLink className="h-3 w-3" />
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              ))}
               {customAgents.map((agent) => (
                 <div
                   key={agent.id}
@@ -183,7 +214,7 @@ export function AgentsPanel({
                   </AlertDialog>
                 </div>
               ))}
-              {customAgents.length === 0 && (
+              {workspaceAgents.length === 0 && customAgents.length === 0 && (
                 <div className="rounded-xl border border-dashed px-4 py-6 text-sm text-muted-foreground">
                   No extra agents added yet.
                 </div>

--- a/templates/dispatch/server/lib/app-creation-store.ts
+++ b/templates/dispatch/server/lib/app-creation-store.ts
@@ -100,6 +100,7 @@ async function readSettingsRecord(): Promise<Record<string, any>> {
 
 function workspaceAppUrl(appPath: string): string | null {
   const base =
+    process.env.WORKSPACE_GATEWAY_URL ||
     process.env.APP_URL ||
     process.env.URL ||
     process.env.DEPLOY_URL ||
@@ -517,8 +518,10 @@ function buildWorkspaceAppPrompt(input: {
         : "Do not grant or request any Dispatch vault keys unless the user asks later.",
       "",
       "Branch readiness requirements before handing off:",
-      `- Update the workspace app registry metadata for "${appId}" (workspace-apps.json or .agent-native/workspace-apps.json, whichever this workspace uses) so Dispatch lists the app at /${appId} after merge/deploy.`,
-      "- Update the app manifest/package/deploy metadata needed by the existing workspace deployment model; do not leave the branch relying only on local discovery.",
+      `- Create apps/${appId} with package.json displayName/description/scripts/dependencies matching the workspace conventions.`,
+      "- Do not add or update workspace-apps.json or .agent-native/workspace-apps.json unless the app needs an explicit external URL override; the root deploy generates the workspace app registry from apps/* and deploy metadata.",
+      "- Update pnpm-lock.yaml when adding or changing dependencies so Netlify can install the branch reliably.",
+      "- Update the app manifest/package/deploy metadata needed by the existing workspace deployment model; do not leave the branch relying only on uncommitted local state.",
       "- Verify the app's agent card/A2A metadata is ready so Dispatch can discover and delegate to the app after deployment.",
       "- Include a final verification note covering the registry entry, manifest/deploy metadata, and agent-card readiness.",
       `When it is ready, start or update the workspace dev server and navigate the user to /${appId}.`,


### PR DESCRIPTION
## Summary
- recover receiver-verified A2A artifact URLs when call-agent times out during Slack/integration processing
- block unverified cross-app production artifact URLs, especially shell-only design links
- clarify workspace app creation prompts and label workspace apps separately from default/custom agents
- bump @agent-native/core to 0.7.59

## Verification
- pnpm test
- pnpm typecheck
- pnpm guards
- pnpm --filter @agent-native/core build
- pnpm --filter dispatch test
- pnpm --filter dispatch typecheck
- builder-workspace: pnpm --filter dispatch typecheck
- builder-workspace: pnpm --filter dispatch build
- builder-workspace: pnpm fmt:check
- git diff --check