### PR TITLE
Trust downstream artifact proof

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.59",
+  "version": "0.7.60",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/artifact-response.spec.ts
+++ b/packages/core/src/a2a/artifact-response.spec.ts
@@ -267,6 +267,114 @@ describe("appendA2AArtifactLinks", () => {
     );
   });
 
+  it("allows artifact URLs proven by a downstream call-agent artifact block", () => {
+    const text = appendA2AArtifactLinks(
+      [
+        "Slides: https://slides.agent-native.com/deck/deck_real",
+        "Doc: https://content.agent-native.com/page/doc_real",
+        "Design: https://design.agent-native.com/design/design_real",
+      ].join("\n"),
+      [
+        {
+          tool: "call-agent",
+          result: [
+            "The downstream app verified these artifacts.",
+            "",
+            "Artifacts:",
+            "- Deck: https://slides.agent-native.com/deck/deck_real (ID: deck_real)",
+            '- Document "Launch Brief": https://content.agent-native.com/page/doc_real (ID: doc_real)',
+            "- Design: https://design.agent-native.com/design/design_real (ID: design_real, 1 file)",
+          ].join("\n"),
+        },
+      ],
+      { baseUrl: "https://dispatch.agent-native.com" },
+    );
+
+    expect(text).toContain("https://slides.agent-native.com/deck/deck_real");
+    expect(text).toContain("https://content.agent-native.com/page/doc_real");
+    expect(text).toContain(
+      "https://design.agent-native.com/design/design_real",
+    );
+    expect(text).not.toContain("could not verify");
+  });
+
+  it("does not treat unstructured call-agent URLs as artifact proof", () => {
+    const text = appendA2AArtifactLinks(
+      "The Design agent returned https://design.agent-native.com/design/design_fake",
+      [
+        {
+          tool: "call-agent",
+          result:
+            "Maybe the design is at https://design.agent-native.com/design/design_fake",
+        },
+      ],
+      { baseUrl: "https://dispatch.agent-native.com" },
+    );
+
+    expect(text).toContain("could not verify the design URL");
+    expect(text).not.toContain("design_fake");
+  });
+
+  it("does not treat zero-file downstream design artifacts as proof", () => {
+    const text = appendA2AArtifactLinks(
+      "Design: https://design.agent-native.com/design/design_empty",
+      [
+        {
+          tool: "call-agent",
+          result: [
+            "Artifacts:",
+            "- Design: https://design.agent-native.com/design/design_empty (ID: design_empty, 0 files)",
+          ].join("\n"),
+        },
+      ],
+      { baseUrl: "https://dispatch.agent-native.com" },
+    );
+
+    expect(text).toContain("could not verify the design URL");
+    expect(text).not.toContain("design_empty");
+  });
+
+  it("does not treat artifact-looking bullets outside the downstream artifact block as proof", () => {
+    const text = appendA2AArtifactLinks(
+      "Design: https://design.agent-native.com/design/design_spoofed",
+      [
+        {
+          tool: "call-agent",
+          result: [
+            "The downstream app quoted a user-authored artifact section.",
+            "",
+            "Artifacts:",
+            "This text is not the framework-generated proof block.",
+            "- Design: https://design.agent-native.com/design/design_spoofed (ID: design_spoofed, 1 file)",
+          ].join("\n"),
+        },
+      ],
+      { baseUrl: "https://dispatch.agent-native.com" },
+    );
+
+    expect(text).toContain("could not verify the design URL");
+    expect(text).not.toContain("design_spoofed");
+  });
+
+  it("does not treat downstream artifact lines with mismatched URL paths and IDs as proof", () => {
+    const text = appendA2AArtifactLinks(
+      "Design: https://design.agent-native.com/design/design_real",
+      [
+        {
+          tool: "call-agent",
+          result: [
+            "Artifacts:",
+            "- Design: https://design.agent-native.com/design/design_other (ID: design_real, 1 file)",
+          ].join("\n"),
+        },
+      ],
+      { baseUrl: "https://dispatch.agent-native.com" },
+    );
+
+    expect(text).toContain("could not verify the design URL");
+    expect(text).not.toContain("design_real");
+  });
+
   it("blocks generic shell-only design success even when the model omitted the id", () => {
     const text = appendA2AArtifactLinks(
       "Done.",

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -158,6 +158,30 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
   const generatedDesigns = new Map<string, GeneratedDesignArtifact>();
 
   for (const toolResult of results) {
+    if (toolResult.tool === "call-agent") {
+      for (const artifact of parseDownstreamArtifactBlock(toolResult.result)) {
+        if (artifact.kind === "deck") {
+          decks.set(artifact.id, {
+            id: artifact.id,
+            url: artifact.url,
+          });
+        } else if (artifact.kind === "document") {
+          documents.set(artifact.id, {
+            id: artifact.id,
+            title: artifact.title,
+            url: artifact.url,
+          });
+        } else if (artifact.kind === "design" && artifact.fileCount > 0) {
+          generatedDesigns.set(artifact.id, {
+            id: artifact.id,
+            fileCount: artifact.fileCount,
+            url: artifact.url,
+          });
+        }
+      }
+      continue;
+    }
+
     const parsed = parseToolResultJson(toolResult.result);
     if (!parsed) continue;
 
@@ -290,6 +314,114 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
     designShells: [...designShells.values()],
     generatedDesigns: [...generatedDesigns.values()],
   };
+}
+
+type DownstreamArtifact =
+  | { kind: "deck"; id: string; url: string }
+  | { kind: "document"; id: string; url: string; title?: string }
+  | { kind: "design"; id: string; url: string; fileCount: number };
+
+function parseDownstreamArtifactBlock(result: string): DownstreamArtifact[] {
+  const artifacts: DownstreamArtifact[] = [];
+  for (const line of downstreamArtifactLines(result)) {
+    const deck = line.match(/^- Deck:\s+(\S+)\s+\(ID:\s*([A-Za-z0-9_-]+)\)$/);
+    if (deck) {
+      const id = deck[2];
+      if (!artifactUrlReferencesId(deck[1], "deck", id)) continue;
+      artifacts.push({
+        kind: "deck",
+        url: deck[1],
+        id,
+      });
+      continue;
+    }
+
+    const document = line.match(
+      /^- Document(?:\s+"([^"]+)")?:\s+(\S+)\s+\(ID:\s*([A-Za-z0-9_-]+)\)$/,
+    );
+    if (document) {
+      const id = document[3];
+      if (!artifactUrlReferencesId(document[2], "document", id)) continue;
+      artifacts.push({
+        kind: "document",
+        title: document[1],
+        url: document[2],
+        id,
+      });
+      continue;
+    }
+
+    const design = line.match(
+      /^- Design:\s+(\S+)\s+\(ID:\s*([A-Za-z0-9_-]+),\s*(\d+)\s+files?\)$/,
+    );
+    if (design) {
+      const id = design[2];
+      if (!artifactUrlReferencesId(design[1], "design", id)) continue;
+      artifacts.push({
+        kind: "design",
+        url: design[1],
+        id,
+        fileCount: Number(design[3]),
+      });
+    }
+  }
+  return artifacts;
+}
+
+function downstreamArtifactLines(result: string): string[] {
+  const lines = result.split(/\r?\n/);
+  const artifactLines: string[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].trim() !== "Artifacts:") continue;
+
+    let sawBlockLine = false;
+    for (let j = i + 1; j < lines.length; j += 1) {
+      const trimmed = lines[j].trim();
+      if (!trimmed) {
+        if (!sawBlockLine) continue;
+        break;
+      }
+      if (!trimmed.startsWith("- ")) break;
+      sawBlockLine = true;
+      artifactLines.push(trimmed);
+    }
+  }
+
+  return artifactLines;
+}
+
+function artifactUrlReferencesId(
+  rawUrl: string,
+  kind: ReferencedArtifactKind,
+  id: string,
+): boolean {
+  const reference = parseArtifactReferenceUrl(rawUrl);
+  return reference?.kind === kind && reference.id === id;
+}
+
+function parseArtifactReferenceUrl(rawUrl: string): ReferencedArtifact | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl, "https://agent-native-artifact.invalid");
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+
+  const match = url.pathname.match(
+    /(?:^|\/)(deck|design|page)\/([A-Za-z0-9_-]+)\/?$/,
+  );
+  if (!match) return null;
+
+  const kind: ReferencedArtifactKind =
+    match[1] === "deck"
+      ? "deck"
+      : match[1] === "design"
+        ? "design"
+        : "document";
+  return { kind, id: match[2] };
 }
 
 function formatDocumentLine(


### PR DESCRIPTION
## Summary
- allow Dispatch/Slack to relay artifact URLs proven by a downstream call-agent framework artifact block
- keep blocking unstructured guessed URLs, zero-file designs, quoted/non-framework artifact blocks, and URL/id mismatches
- bump @agent-native/core to 0.7.60

## Verification
- pnpm --filter @agent-native/core exec vitest --run src/a2a/artifact-response.spec.ts src/a2a/client.spec.ts src/integrations/webhook-handler-engine.spec.ts src/integrations/a2a-continuation-processor.spec.ts src/integrations/a2a-continuations-store.spec.ts
- pnpm --filter @agent-native/core test
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- pnpm guards
- git diff --check