### PR TITLE
Harden downstream artifact proof delivery

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.60",
+  "version": "0.7.61",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/artifact-response.spec.ts
+++ b/packages/core/src/a2a/artifact-response.spec.ts
@@ -106,6 +106,57 @@ describe("appendA2AArtifactLinks", () => {
     expect(text).not.toContain("Artifacts:");
   });
 
+  it("can include an artifact proof block for already-mentioned verified URLs", () => {
+    const text = appendA2AArtifactLinks(
+      "Deck ready: https://slides.agent-native.com/deck/deck_123",
+      [
+        {
+          tool: "create-deck",
+          result: JSON.stringify({
+            id: "deck_123",
+            slideCount: 1,
+            url: "https://slides.agent-native.com/deck/deck_123",
+          }),
+        },
+      ],
+      {
+        baseUrl: "https://slides.agent-native.com",
+        includeReferencedArtifacts: true,
+      },
+    );
+
+    expect(text).toContain(
+      "Deck ready: https://slides.agent-native.com/deck/deck_123",
+    );
+    expect(text).toContain(
+      "Artifacts:\n- Deck: https://slides.agent-native.com/deck/deck_123 (ID: deck_123)",
+    );
+  });
+
+  it("can include a read-only get-deck proof block when the response already mentions the URL", () => {
+    const text = appendA2AArtifactLinks(
+      "Deck exists: https://slides.agent-native.com/deck/deck_123",
+      [
+        {
+          tool: "get-deck",
+          result: JSON.stringify({
+            id: "deck_123",
+            title: "Builder Workspace Slack QA Deck",
+            slideCount: 7,
+          }),
+        },
+      ],
+      {
+        baseUrl: "https://slides.agent-native.com",
+        includeReferencedArtifacts: true,
+      },
+    );
+
+    expect(text).toContain(
+      "Artifacts:\n- Deck: https://slides.agent-native.com/deck/deck_123 (ID: deck_123)",
+    );
+  });
+
   it("blocks hallucinated deck URLs with no successful deck action", () => {
     const text = appendA2AArtifactLinks(
       "Done: https://slides.agent.test/deck/deck_404",
@@ -296,6 +347,44 @@ describe("appendA2AArtifactLinks", () => {
       "https://design.agent-native.com/design/design_real",
     );
     expect(text).not.toContain("could not verify");
+  });
+
+  it("allows titled downstream deck artifact proof lines", () => {
+    const text = appendA2AArtifactLinks(
+      "Slides: https://slides.agent-native.com/deck/deck_real",
+      [
+        {
+          tool: "call-agent",
+          result: [
+            "Artifacts:",
+            '- Deck "Builder Workspace Slack QA Deck" (7 slides): https://slides.agent-native.com/deck/deck_real (ID: deck_real)',
+          ].join("\n"),
+        },
+      ],
+      { baseUrl: "https://dispatch.agent-native.com" },
+    );
+
+    expect(text).toBe("Slides: https://slides.agent-native.com/deck/deck_real");
+  });
+
+  it("allows downstream deck presentation URLs as proof for the deck", () => {
+    const text = appendA2AArtifactLinks(
+      "Slides: https://slides.agent-native.com/deck/deck_real/present",
+      [
+        {
+          tool: "call-agent",
+          result: [
+            "Artifacts:",
+            "- Deck: https://slides.agent-native.com/deck/deck_real/present (ID: deck_real)",
+          ].join("\n"),
+        },
+      ],
+      { baseUrl: "https://dispatch.agent-native.com" },
+    );
+
+    expect(text).toBe(
+      "Slides: https://slides.agent-native.com/deck/deck_real/present",
+    );
   });
 
   it("does not treat unstructured call-agent URLs as artifact proof", () => {

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -5,6 +5,7 @@ export interface A2AToolResultSummary {
 
 export interface A2AArtifactResponseOptions {
   baseUrl?: string;
+  includeReferencedArtifacts?: boolean;
 }
 
 interface CreatedDocumentArtifact {
@@ -324,7 +325,9 @@ type DownstreamArtifact =
 function parseDownstreamArtifactBlock(result: string): DownstreamArtifact[] {
   const artifacts: DownstreamArtifact[] = [];
   for (const line of downstreamArtifactLines(result)) {
-    const deck = line.match(/^- Deck:\s+(\S+)\s+\(ID:\s*([A-Za-z0-9_-]+)\)$/);
+    const deck = line.match(
+      /^- Deck(?:\s+"[^"]+")?(?:\s+\([^)]*\))?:\s+(\S+)\s+\(ID:\s*([A-Za-z0-9_-]+)\)$/,
+    );
     if (deck) {
       const id = deck[2];
       if (!artifactUrlReferencesId(deck[1], "deck", id)) continue;
@@ -410,18 +413,17 @@ function parseArtifactReferenceUrl(rawUrl: string): ReferencedArtifact | null {
 
   if (url.protocol !== "http:" && url.protocol !== "https:") return null;
 
-  const match = url.pathname.match(
-    /(?:^|\/)(deck|design|page)\/([A-Za-z0-9_-]+)\/?$/,
-  );
-  if (!match) return null;
+  const path = url.pathname.replace(/\/+$/, "");
+  const deck = path.match(/(?:^|\/)deck\/([A-Za-z0-9_-]+)(?:\/present)?$/);
+  if (deck) return { kind: "deck", id: deck[1] };
 
-  const kind: ReferencedArtifactKind =
-    match[1] === "deck"
-      ? "deck"
-      : match[1] === "design"
-        ? "design"
-        : "document";
-  return { kind, id: match[2] };
+  const design = path.match(/(?:^|\/)design\/([A-Za-z0-9_-]+)$/);
+  if (design) return { kind: "design", id: design[1] };
+
+  const document = path.match(/(?:^|\/)page\/([A-Za-z0-9_-]+)$/);
+  if (document) return { kind: "document", id: document[1] };
+
+  return null;
 }
 
 function formatDocumentLine(
@@ -573,6 +575,8 @@ export function appendA2AArtifactLinks(
   options: A2AArtifactResponseOptions = {},
 ): string {
   const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const includeReferencedArtifacts =
+    options.includeReferencedArtifacts ?? false;
   const { documents, decks, designShells, generatedDesigns } =
     collectArtifacts(toolResults);
   const generatedDesignIds = new Set(
@@ -616,19 +620,28 @@ export function appendA2AArtifactLinks(
   const missingLines: string[] = [];
   for (const document of documents) {
     const path = `/page/${document.id}`;
-    if (!responseAlreadyMentionsPath(text, path)) {
+    if (
+      includeReferencedArtifacts ||
+      !responseAlreadyMentionsPath(text, path)
+    ) {
       missingLines.push(formatDocumentLine(document, baseUrl));
     }
   }
   for (const deck of decks) {
     const path = `/deck/${deck.id}`;
-    if (!responseAlreadyMentionsPath(text, path)) {
+    if (
+      includeReferencedArtifacts ||
+      !responseAlreadyMentionsPath(text, path)
+    ) {
       missingLines.push(formatDeckLine(deck, baseUrl));
     }
   }
   for (const design of generatedDesigns) {
     const path = `/design/${design.id}`;
-    if (!responseAlreadyMentionsPath(text, path)) {
+    if (
+      includeReferencedArtifacts ||
+      !responseAlreadyMentionsPath(text, path)
+    ) {
       missingLines.push(formatDesignLine(design, baseUrl));
     }
   }

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -211,6 +211,89 @@ describe("A2A continuation processor", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("blocks unverified completed production artifact URLs before posting continuations", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    getTaskMock.mockResolvedValueOnce({
+      id: "a2a-task-1",
+      status: {
+        state: "completed",
+        message: {
+          role: "agent",
+          parts: [
+            {
+              type: "text",
+              text: "The Design agent returned https://design.agent-native.com/design/design_fake",
+            },
+          ],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("could not verify the design URL"),
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(sendResponse.mock.calls[0][0].text).not.toContain("design_fake");
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+  });
+
+  it("allows completed continuation artifact URLs with downstream proof blocks", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
+    getTaskMock.mockResolvedValueOnce({
+      id: "a2a-task-1",
+      status: {
+        state: "completed",
+        message: {
+          role: "agent",
+          parts: [
+            {
+              type: "text",
+              text: [
+                "Design ready: https://design.agent-native.com/design/design_real",
+                "",
+                "Artifacts:",
+                "- Design: https://design.agent-native.com/design/design_real (ID: design_real, 1 file)",
+              ].join("\n"),
+            },
+          ],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining(
+          "https://design.agent-native.com/design/design_real",
+        ),
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(sendResponse.mock.calls[0][0].text).not.toContain(
+      "could not verify",
+    );
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+  });
+
   it("leaves completion failures in delivery for stale retry recovery", async () => {
     const consoleError = vi
       .spyOn(console, "error")

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -1,4 +1,5 @@
 import { A2AClient, signA2AToken } from "../a2a/client.js";
+import { appendA2AArtifactLinks } from "../a2a/artifact-response.js";
 import type { Task } from "../a2a/types.js";
 import { withConfiguredAppBasePath } from "../server/app-base-path.js";
 import { FRAMEWORK_ROUTE_PREFIX } from "../server/core-routes-plugin.js";
@@ -193,7 +194,10 @@ async function processClaimedContinuation(
       await deliverAndCompleteA2AContinuation(
         continuation,
         adapter,
-        expandRelativeUrls(recoverableArtifactText, continuation.agentUrl),
+        formatContinuationArtifactText(
+          recoverableArtifactText,
+          continuation.agentUrl,
+        ),
       );
       return;
     }
@@ -221,7 +225,10 @@ async function processClaimedContinuation(
     return;
   }
 
-  const text = expandRelativeUrls(extractTaskText(task), continuation.agentUrl);
+  const text = formatContinuationArtifactText(
+    extractTaskText(task),
+    continuation.agentUrl,
+  );
   if (!text.trim()) {
     await notifyAndFailA2AContinuation(
       continuation,
@@ -488,6 +495,24 @@ function extractRecoverableArtifactText(task: Task | null): string {
     return "";
   }
   return extractTaskText(task);
+}
+
+function formatContinuationArtifactText(
+  text: string,
+  agentUrl: string,
+): string {
+  const expandedText = expandRelativeUrls(text, agentUrl);
+  return appendA2AArtifactLinks(
+    expandedText,
+    [{ tool: "call-agent", result: expandedText }],
+    { baseUrl: resolveArtifactBaseUrl() },
+  );
+}
+
+function resolveArtifactBaseUrl(): string | undefined {
+  const baseUrl =
+    process.env.APP_URL || process.env.URL || process.env.DEPLOY_URL;
+  return baseUrl ? withConfiguredAppBasePath(baseUrl) : undefined;
 }
 
 function expandRelativeUrls(text: string, agentUrl: string): string {

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -700,6 +700,57 @@ describe("integration webhook handler engine resolution", () => {
     );
   });
 
+  it("guards recoverable A2A artifact fallbacks before sending Slack-style replies", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const previousAppUrl = process.env.APP_URL;
+    process.env.APP_URL = "https://dispatch.agent-native.com";
+    const sendResponse = vi.fn();
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({
+        type: "tool_start",
+        tool: "call-agent",
+        input: { agent: "design", message: "make a launch card" },
+      });
+      send({
+        type: "tool_done",
+        tool: "call-agent",
+        result:
+          "The agent is still working on the full response, but these verified artifacts already exist:\n\n" +
+          "Artifacts:\n" +
+          "- Design: https://design.agent-native.com/design/design-empty (ID: design-empty, 0 files)",
+      });
+    });
+
+    try {
+      await processIntegrationTask(
+        pendingTask({ id: "task-recoverable-a2a-empty-design" }),
+        {
+          adapter: createAdapter(sendResponse),
+          systemPrompt: "system",
+          actions: {},
+          model: "claude-sonnet-4-6",
+          apiKey: "",
+          ownerEmail: "dispatch+qa@integration.local",
+        },
+      );
+    } finally {
+      if (previousAppUrl === undefined) {
+        delete process.env.APP_URL;
+      } else {
+        process.env.APP_URL = previousAppUrl;
+      }
+    }
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("could not verify the design URL"),
+      }),
+      expect.any(Object),
+      expect.objectContaining({ placeholderRef: undefined }),
+    );
+    expect(sendResponse.mock.calls[0][0].text).not.toContain("design-empty");
+  });
+
   it("does not fall back to unmarked A2A tool URLs when no final text is emitted", async () => {
     const { processIntegrationTask } = await import("./webhook-handler.js");
     const sendResponse = vi.fn();

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -569,7 +569,6 @@ async function processIncomingMessage(
       async (completedRun: ActiveRun) => {
         try {
           const queuedA2AContinuation = hasQueuedA2AContinuation(completedRun);
-          let usedRecoverableA2AArtifactToolResult = false;
           let responseText = collectFinalResponseTextFromAgentEvents(
             completedRun.events.map((runEvent) => runEvent.event),
             { fallbackToPreToolText: !queuedA2AContinuation },
@@ -579,7 +578,6 @@ async function processIncomingMessage(
               extractRecoverableA2AArtifactToolResult(completedRun);
             if (recoverableA2AArtifactText) {
               responseText = recoverableA2AArtifactText;
-              usedRecoverableA2AArtifactToolResult = true;
             }
           }
 
@@ -625,7 +623,7 @@ async function processIncomingMessage(
           // preview card.
           const baseUrl = process.env.APP_URL || process.env.URL || "";
           const appBaseUrl = baseUrl ? withConfiguredAppBasePath(baseUrl) : "";
-          if (!suppressPlatformReply && !usedRecoverableA2AArtifactToolResult) {
+          if (!suppressPlatformReply) {
             responseText = appendA2AArtifactLinks(
               responseText,
               collectToolResultSummaries(completedRun),

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -160,6 +160,7 @@ export function assembleA2AFinalResponse(
   const responseText = collectFinalResponseTextFromAgentEvents(events);
   const finalText = appendA2AArtifactLinks(responseText, [...toolResults], {
     baseUrl: options.baseUrl ?? resolveArtifactBaseUrl(options.event),
+    includeReferencedArtifacts: true,
   });
   return { responseText, finalText };
 }

--- a/templates/dispatch/public/manifest.json
+++ b/templates/dispatch/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Agent Native",
+  "name": "Agent-Native Dispatch",
   "short_name": "Dispatch",
-  "description": "Blank starter template",
+  "description": "Workspace control plane for secrets, integrations, agents, and app creation.",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#111111",


### PR DESCRIPTION
## Summary
- make A2A final responses include receiver-verified artifact proof blocks even when the model already mentioned the URL
- re-verify continuation and recoverable A2A artifact replies before posting them back to Slack-style integrations
- accept general downstream deck proof variants, including titled/read-only deck proofs and deck presentation URLs
- update Dispatch template PWA manifest copy
- bump @agent-native/core to 0.7.61

## Verification
- pnpm --filter @agent-native/core exec vitest --run src/a2a/artifact-response.spec.ts src/a2a/client.spec.ts src/integrations/webhook-handler-engine.spec.ts src/integrations/a2a-continuation-processor.spec.ts
- pnpm --filter @agent-native/core test
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- pnpm guards
- pnpm guard:no-generated-artifacts
- git diff --check