### PR TITLE
Split Slack blocks by byte length

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.61",
+  "version": "0.7.62",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/integrations/adapters/slack.spec.ts
+++ b/packages/core/src/integrations/adapters/slack.spec.ts
@@ -118,6 +118,76 @@ describe("slackAdapter", () => {
 
     expect(deliverySignal?.aborted).toBe(true);
   });
+
+  it("keeps generated Slack section blocks within Block Kit limits", async () => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    const deliveryBodies: any[] = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (String(url).includes("chat.postMessage")) {
+          deliveryBodies.push(JSON.parse(String(init?.body ?? "{}")));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+      }),
+    );
+
+    await slackAdapter().sendResponse(
+      { text: "a".repeat(3605), platformContext: {} },
+      {
+        platform: "slack",
+        externalThreadId: "C123:123.456",
+        text: "ask starter",
+        timestamp: 1,
+        platformContext: { channelId: "C123", threadTs: "123.456" },
+      },
+    );
+
+    const sectionBlocks = deliveryBodies[0].blocks.filter(
+      (block: any) => block.type === "section",
+    );
+    expect(sectionBlocks).toHaveLength(2);
+    expect(
+      sectionBlocks.every((block: any) => block.text.text.length <= 3000),
+    ).toBe(true);
+  });
+
+  it("splits Slack section blocks by UTF-8 bytes, not JS character length", async () => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    const deliveryBodies: any[] = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (String(url).includes("chat.postMessage")) {
+          deliveryBodies.push(JSON.parse(String(init?.body ?? "{}")));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+      }),
+    );
+
+    await slackAdapter().sendResponse(
+      { text: `${"a".repeat(2994)}🗄️`, platformContext: {} },
+      {
+        platform: "slack",
+        externalThreadId: "C123:123.456",
+        text: "ask starter",
+        timestamp: 1,
+        platformContext: { channelId: "C123", threadTs: "123.456" },
+      },
+    );
+
+    const sectionBlocks = deliveryBodies[0].blocks.filter(
+      (block: any) => block.type === "section",
+    );
+    expect(sectionBlocks.length).toBeGreaterThan(1);
+    expect(
+      sectionBlocks.every(
+        (block: any) => Buffer.byteLength(block.text.text, "utf8") <= 3000,
+      ),
+    ).toBe(true);
+  });
 });
 
 function slackEvent(overrides: Record<string, unknown> = {}) {

--- a/packages/core/src/integrations/adapters/slack.ts
+++ b/packages/core/src/integrations/adapters/slack.ts
@@ -12,6 +12,7 @@ import { getIntegrationConfig } from "../config-store.js";
 
 /** Slack's max message length */
 const SLACK_MAX_LENGTH = 4000;
+const SLACK_SECTION_TEXT_MAX_LENGTH = 3000;
 const SLACK_API_TIMEOUT_MS = 10_000;
 
 /**
@@ -472,24 +473,43 @@ async function readRawBodyCached(event: H3Event): Promise<string> {
   return raw;
 }
 
-/** Split a message into chunks that fit within the platform's limit */
+function utf8ByteLength(text: string): number {
+  return new TextEncoder().encode(text).length;
+}
+
+function prefixWithinUtf8ByteLimit(text: string, maxLength: number): string {
+  let bytes = 0;
+  let end = 0;
+  for (const char of text) {
+    const nextBytes = utf8ByteLength(char);
+    if (bytes + nextBytes > maxLength) break;
+    bytes += nextBytes;
+    end += char.length;
+  }
+  return text.slice(0, end || 1);
+}
+
+/** Split a message into chunks that fit within the platform's byte limit. */
 function splitMessage(text: string, maxLength: number): string[] {
-  if (text.length <= maxLength) return [text];
+  if (utf8ByteLength(text) <= maxLength) return [text];
   const chunks: string[] = [];
   let remaining = text;
   while (remaining.length > 0) {
-    if (remaining.length <= maxLength) {
+    if (utf8ByteLength(remaining) <= maxLength) {
       chunks.push(remaining);
       break;
     }
+
+    const prefix = prefixWithinUtf8ByteLimit(remaining, maxLength);
+
     // Try to split at a newline
-    let splitIdx = remaining.lastIndexOf("\n", maxLength);
+    let splitIdx = prefix.lastIndexOf("\n");
     if (splitIdx <= 0) {
       // Try to split at a space
-      splitIdx = remaining.lastIndexOf(" ", maxLength);
+      splitIdx = prefix.lastIndexOf(" ");
     }
     if (splitIdx <= 0) {
-      splitIdx = maxLength;
+      splitIdx = prefix.length;
     }
     chunks.push(remaining.slice(0, splitIdx));
     remaining = remaining.slice(splitIdx).trimStart();
@@ -568,12 +588,14 @@ function buildResponseBlocks(
   text: string,
   opts: { threadDeepLinkUrl?: string },
 ): unknown[] {
-  const blocks: any[] = [
-    {
-      type: "section",
-      text: { type: "mrkdwn", text: text || "_(no response)_" },
-    },
-  ];
+  const sectionChunks = splitMessage(
+    text || "_(no response)_",
+    SLACK_SECTION_TEXT_MAX_LENGTH,
+  );
+  const blocks: any[] = sectionChunks.map((chunk) => ({
+    type: "section",
+    text: { type: "mrkdwn", text: chunk },
+  }));
   if (opts.threadDeepLinkUrl) {
     blocks.push({
       type: "actions",


### PR DESCRIPTION
## Summary
- split Slack message and section chunks by UTF-8 byte length instead of JS character length
- add a regression for emoji-heavy section text that is under 3000 chars but over Slack's byte-sensitive section limit
- bump @agent-native/core to 0.7.62

## Verification
- pnpm --filter @agent-native/core exec vitest --run src/integrations/adapters/slack.spec.ts src/integrations/a2a-continuation-processor.spec.ts src/integrations/webhook-handler-engine.spec.ts
- pnpm --filter @agent-native/core test
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- pnpm guards
- pnpm guard:no-generated-artifacts
- git diff --check