### PR TITLE
Fix mounted Dispatch manifest routing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.62",
+  "version": "0.7.63",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/templates/dispatch/server/lib/pre-auth-routing.spec.ts
+++ b/templates/dispatch/server/lib/pre-auth-routing.spec.ts
@@ -46,6 +46,20 @@ describe("dispatch pre-auth routing", () => {
     expect(rootDispatchRedirect("/dispatch/tools/tool-123/", "")).toBeNull();
   });
 
+  it("allows React Router manifest patch requests through the mounted dispatch path", () => {
+    useDispatchBasePath();
+
+    expect(
+      rootDispatchRedirect(
+        "/dispatch/__manifest",
+        "?paths=%2Fdispatch%2Foverview",
+      ),
+    ).toBeNull();
+    expect(
+      rootDispatchRedirect("/__manifest", "?paths=%2Fdispatch%2Foverview"),
+    ).toBeNull();
+  });
+
   it("still redirects root dispatch aliases to the mounted overview route", () => {
     useDispatchBasePath();
 

--- a/templates/dispatch/server/lib/pre-auth-routing.ts
+++ b/templates/dispatch/server/lib/pre-auth-routing.ts
@@ -47,6 +47,8 @@ function isDispatchPagePath(pathname: string): boolean {
 
 function isDispatchAssetOrFrameworkPath(pathname: string): boolean {
   return (
+    pathname === "/__manifest" ||
+    pathname.startsWith("/__manifest/") ||
     pathname === "/_agent-native" ||
     pathname.startsWith("/_agent-native/") ||
     pathname === "/.well-known" ||
@@ -82,6 +84,8 @@ export function rootDispatchRedirect(
   if (!basePath) return null;
 
   if (
+    normalizedPathname === "/__manifest" ||
+    normalizedPathname.startsWith("/__manifest/") ||
     normalizedPathname === "/_agent-native" ||
     normalizedPathname.startsWith("/_agent-native/")
   ) {


### PR DESCRIPTION
## Summary\n- allow Dispatch pre-auth routing to pass React Router __manifest requests through mounted workspace paths\n- add a regression test for /dispatch/__manifest route-patch loading\n- bump @agent-native/core to 0.7.63\n\n## Verification\n- pnpm --filter dispatch test\n- pnpm --filter @agent-native/core typecheck\n- pnpm --filter @agent-native/core test\n- pnpm --filter @agent-native/core build\n- pnpm --filter dispatch typecheck\n- pnpm --filter dispatch build\n- pnpm guards\n- git diff --check