### PR TITLE
Inject runtime date context into agent prompts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.63",
+  "version": "0.7.64",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/agent/runtime-context.spec.ts
+++ b/packages/core/src/agent/runtime-context.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRuntimeContextPrompt } from "./runtime-context.js";
+
+describe("buildRuntimeContextPrompt", () => {
+  it("includes authoritative UTC and local dates for relative date resolution", () => {
+    const prompt = buildRuntimeContextPrompt({
+      now: new Date("2026-05-03T18:30:00Z"),
+      timezone: "America/New_York",
+    });
+
+    expect(prompt).toContain("<runtime-context>");
+    expect(prompt).toContain("currentUtc: 2026-05-03T18:30:00.000Z");
+    expect(prompt).toContain("currentDateUtc: 2026-05-03");
+    expect(prompt).toContain("currentTimezone: America/New_York");
+    expect(prompt).toContain("currentDateInTimezone: 2026-05-03");
+    expect(prompt).toContain("relative dates");
+  });
+
+  it("falls back to UTC when the timezone is invalid", () => {
+    const prompt = buildRuntimeContextPrompt({
+      now: new Date("2026-05-03T18:30:00Z"),
+      timezone: "not/a-zone",
+    });
+
+    expect(prompt).toContain("currentTimezone: UTC");
+    expect(prompt).toContain("currentDateInTimezone: 2026-05-03");
+  });
+});

--- a/packages/core/src/agent/runtime-context.ts
+++ b/packages/core/src/agent/runtime-context.ts
@@ -1,0 +1,61 @@
+export interface RuntimeContextOptions {
+  now?: Date;
+  timezone?: string | null;
+}
+
+function isValidTimezone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function formatDateTime(date: Date, timezone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  }).format(date);
+}
+
+function formatDate(date: Date, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const year = parts.find((part) => part.type === "year")?.value ?? "1970";
+  const month = parts.find((part) => part.type === "month")?.value ?? "01";
+  const day = parts.find((part) => part.type === "day")?.value ?? "01";
+  return `${year}-${month}-${day}`;
+}
+
+export function buildRuntimeContextPrompt(
+  options: RuntimeContextOptions = {},
+): string {
+  const now = options.now ?? new Date();
+  const timezone =
+    typeof options.timezone === "string" && isValidTimezone(options.timezone)
+      ? options.timezone
+      : "UTC";
+
+  return `
+
+<runtime-context>
+currentUtc: ${now.toISOString()}
+currentDateUtc: ${formatDate(now, "UTC")}
+currentTimezone: ${timezone}
+currentDateInTimezone: ${formatDate(now, timezone)}
+currentTimeInTimezone: ${formatDateTime(now, timezone)}
+Use this runtime context as authoritative for relative dates such as today, yesterday, tomorrow, this week, and last month. Resolve relative dates to explicit calendar dates before querying data or creating artifacts, and include the exact date or date range in factual answers.
+</runtime-context>`;
+}

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -231,6 +231,7 @@ describe("integration webhook handler engine resolution", () => {
       expect.objectContaining({
         engine: expect.objectContaining({ name: "builder" }),
         model: "claude-sonnet-4-6",
+        systemPrompt: expect.stringContaining("<runtime-context>"),
       }),
     );
     expect(sendResponse).toHaveBeenCalledWith(

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -45,6 +45,7 @@ import {
   appendA2AArtifactLinks,
   type A2AToolResultSummary,
 } from "../a2a/artifact-response.js";
+import { buildRuntimeContextPrompt } from "../agent/runtime-context.js";
 
 const PROCESSOR_DISPATCH_SETTLE_WAIT_MS = 1_500;
 
@@ -424,6 +425,7 @@ async function processIncomingMessage(
     ownerEmail,
     engine: engineOption,
   } = options;
+  const effectiveSystemPrompt = systemPrompt + buildRuntimeContextPrompt();
 
   // Resolve or create internal thread
   let mapping = await getThreadMapping(
@@ -556,7 +558,7 @@ async function processIncomingMessage(
             return runAgentLoop({
               engine,
               model: resolvedModel,
-              systemPrompt,
+              systemPrompt: effectiveSystemPrompt,
               tools,
               messages,
               actions,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -94,6 +94,7 @@ import {
 } from "../a2a/artifact-response.js";
 import { updateTaskStatusMessage } from "../a2a/task-store.js";
 import { collectFinalResponseTextFromAgentEvents } from "../a2a/response-text.js";
+import { buildRuntimeContextPrompt } from "../agent/runtime-context.js";
 
 // Lazy fs — loaded via dynamic import() on first use.
 // This avoids require() which bundlers convert to createRequire(import.meta.url)
@@ -1372,6 +1373,7 @@ const FRAMEWORK_CORE_COMPACT = `
 9. **Never fabricate factual claims** — Do NOT invent numbers, metrics, records, query results, URLs, citations, source attributions, customer names, dates, or success rates. This applies inside generated artifacts too: decks, documents, reports, dashboards, Slack/email replies, and charts must not contain unsupported factual specifics. Only state factual numbers/claims when the user provided them or you retrieved them with an action/tool. If a data source is unavailable (missing credentials, connection error, tool failure), say so clearly and work with what you have. If a specific metric would be useful but is not known, use qualitative wording, placeholders like \`[metric TBD]\`, or clearly labeled draft assumptions instead of plausible-looking facts. Presenting made-up data as real is a critical failure — it is worse than admitting the limitation.
 10. **Never fabricate success from tool errors** — When any tool call returns an error (marked \`isError: true\`, contains "Command failed", "Error:", or non-zero exit output), the operation FAILED. Do NOT synthesize a success narrative or describe what the action "would have" produced. Report the failure verbatim from the tool output. This applies especially to \`shell(command="pnpm action ...")\` calls: if the action threw, it did NOT succeed.
 11. **Find tools when unsure** — Use \`tool-search\` to find the exact action/tool for a capability. It searches the live registry, including connected MCP server tools.
+12. **Relative dates use runtime context** — The \`<runtime-context>\` block gives the authoritative current date/time. Resolve "today", "yesterday", "last week", and similar phrases to explicit calendar dates before querying data or creating artifacts.
 
 ### Resources
 
@@ -1550,6 +1552,7 @@ const FRAMEWORK_CORE = `
 9. **Never fabricate factual claims** — Do NOT invent numbers, metrics, records, query results, URLs, citations, source attributions, customer names, dates, or success rates. This applies inside generated artifacts too: decks, documents, reports, dashboards, Slack/email replies, and charts must not contain unsupported factual specifics. Only state factual numbers/claims when the user provided them or you retrieved them with an action/tool. If a data source is unavailable (missing credentials, connection error, tool failure), say so clearly and work with what you have. If a specific metric would be useful but is not known, use qualitative wording, placeholders like \`[metric TBD]\`, or clearly labeled draft assumptions instead of plausible-looking facts. Presenting made-up data as real is a critical failure — it is worse than admitting the limitation.
 10. **Never fabricate success from tool errors** — When any tool call returns an error (marked \`isError: true\`, contains "Command failed", "Error:", or non-zero exit output), the operation FAILED. Do NOT synthesize a success narrative, format a result table, or describe what the action "would have" produced. Report the failure verbatim from the tool output. This applies especially to \`shell(command="pnpm action ...")\` calls: if the underlying action threw (visible in the error text), the action did NOT succeed — report the error, do not describe a successful outcome.
 11. **Find tools when unsure** — Use \`tool-search\` to find the exact action/tool for a capability. It searches the live registry, including connected MCP server tools added through config, settings, or the MCP hub.
+12. **Relative dates use runtime context** — The \`<runtime-context>\` block gives the authoritative current date/time. Resolve "today", "yesterday", "last week", and similar phrases to explicit calendar dates before querying data or creating artifacts. When answering factual questions, include the exact date or date range you used.
 
 ### Resources
 
@@ -2733,9 +2736,10 @@ export function createAgentChatPlugin(
             ? ""
             : await buildSchemaBlock(owner, devActive);
           const extra = await resolveExtraContext(context.event, owner);
+          const runtimeContext = runtimeContextForEvent(context.event);
           const systemPrompt = devActive
-            ? devPrompt + resources + schemaBlock + extra
-            : basePrompt + resources + schemaBlock + extra;
+            ? devPrompt + runtimeContext + resources + schemaBlock + extra
+            : basePrompt + runtimeContext + resources + schemaBlock + extra;
 
           const model = options?.model ?? DEFAULT_MODEL;
 
@@ -2965,8 +2969,14 @@ export function createAgentChatPlugin(
                 ? DEV_FRAMEWORK_PROMPT_COMPACT
                 : DEV_FRAMEWORK_PROMPT) + devActionsPrompt;
           const systemPrompt = devActiveMcp
-            ? mcpDevPrompt + resources + schemaBlock
-            : basePrompt + resources + schemaBlock;
+            ? mcpDevPrompt +
+              buildRuntimeContextPrompt() +
+              resources +
+              schemaBlock
+            : basePrompt +
+              buildRuntimeContextPrompt() +
+              resources +
+              schemaBlock;
 
           let accumulatedText = "";
           const controller = new AbortController();
@@ -3373,12 +3383,26 @@ export function createAgentChatPlugin(
         return prompt;
       };
 
+      const runtimeContextForEvent = (event: any): string => {
+        const tzRaw = getHeader(event, "x-user-timezone");
+        const timezone =
+          typeof tzRaw === "string" &&
+          tzRaw.trim().length > 0 &&
+          tzRaw.trim().length < 64
+            ? tzRaw.trim()
+            : undefined;
+        return buildRuntimeContextPrompt({ timezone });
+      };
+
       const prodHandler = createProductionAgentHandler({
         actions: leanPrompt ? leanActions : prodActions,
         systemPrompt: async (event: any) => {
           const { owner, extra } = await prepareRun(event);
+          const runtimeContext = runtimeContextForEvent(event);
           if (leanPrompt) {
-            return setSystemPromptOnContext(leanBasePrompt + extra);
+            return setSystemPromptOnContext(
+              leanBasePrompt + runtimeContext + extra,
+            );
           }
           const resources = await loadResourcesForPrompt(owner, lazyContext);
           // In lazy context mode, skip embedding the full schema — the agent
@@ -3387,7 +3411,7 @@ export function createAgentChatPlugin(
             ? ""
             : await buildSchemaBlock(owner, false);
           return setSystemPromptOnContext(
-            basePrompt + resources + schemaBlock + extra,
+            basePrompt + runtimeContext + resources + schemaBlock + extra,
           );
         },
         model: options?.model ?? DEFAULT_MODEL,
@@ -3467,15 +3491,18 @@ export function createAgentChatPlugin(
           actions: devActions,
           systemPrompt: async (event: any) => {
             const { owner, extra } = await prepareRun(event);
+            const runtimeContext = runtimeContextForEvent(event);
             if (leanPrompt) {
-              return setSystemPromptOnContext(leanBasePrompt + extra);
+              return setSystemPromptOnContext(
+                leanBasePrompt + runtimeContext + extra,
+              );
             }
             const resources = await loadResourcesForPrompt(owner, lazyContext);
             const schemaBlock = lazyContext
               ? ""
               : await buildSchemaBlock(owner, true);
             return setSystemPromptOnContext(
-              devPrompt + resources + schemaBlock + extra,
+              devPrompt + runtimeContext + resources + schemaBlock + extra,
             );
           },
           model: options?.model,


### PR DESCRIPTION
## Summary\n- add a per-request runtime context block with current UTC/local date and timezone\n- include runtime context in chat, dev/prod, A2A, MCP, and Slack/integration agent loops\n- instruct agents to resolve relative dates before querying factual data\n- bump @agent-native/core to 0.7.64\n\n## Why\nSlack analytics QA proved the agent could query real data for a stale inferred "yesterday" date. This makes the current date explicit and authoritative.\n\n## Verification\n- pnpm --filter @agent-native/core exec vitest --run src/agent/runtime-context.spec.ts src/integrations/webhook-handler-engine.spec.ts src/integrations/a2a-continuation-processor.spec.ts\n- pnpm --filter @agent-native/core typecheck\n- pnpm --filter @agent-native/core test\n- pnpm --filter @agent-native/core build\n- pnpm guards\n- git diff --check