### PR TITLE
Fix duplicate A2A retries and workspace agent-card reporting

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.64",
+  "version": "0.7.65",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/handlers.spec.ts
+++ b/packages/core/src/a2a/handlers.spec.ts
@@ -39,6 +39,7 @@ vi.mock("./task-store.js", () => {
         artifacts: [],
         metadata,
         ownerEmail: ownerEmail ?? null,
+        updatedAt: Date.now(),
       };
       tasks[id] = task;
       return task;
@@ -60,6 +61,7 @@ vi.mock("./task-store.js", () => {
           message: update.message ?? task.status.message,
           timestamp: new Date().toISOString(),
         };
+        task.updatedAt = Date.now();
       }
       if (update.message && task.history) {
         task.history.push(update.message);
@@ -78,6 +80,7 @@ vi.mock("./task-store.js", () => {
         message: task.status.message,
         timestamp: new Date().toISOString(),
       };
+      task.updatedAt = Date.now();
       return task;
     },
     async getA2ATaskDispatchState(id: string) {
@@ -87,13 +90,30 @@ vi.mock("./task-store.js", () => {
         id,
         statusState: task.status.state,
         metadata: task.metadata,
-        updatedAt: Date.now(),
+        updatedAt:
+          typeof task.metadata?.testUpdatedAt === "number"
+            ? task.metadata.testUpdatedAt
+            : task.updatedAt,
       };
     },
     async touchQueuedA2ATaskDispatch() {
       return true;
     },
     async resetStuckA2ATaskForRetry() {
+      return true;
+    },
+    async failStuckA2ATask(id: string, _cutoff: number, reason: string) {
+      const task = tasks[id];
+      if (!task || task.status.state !== "processing") return false;
+      task.status = {
+        state: "failed",
+        message: {
+          role: "agent",
+          parts: [{ type: "text", text: reason }],
+        },
+        timestamp: new Date().toISOString(),
+      };
+      task.updatedAt = Date.now();
       return true;
     },
   };
@@ -461,6 +481,65 @@ describe("handleJsonRpc", () => {
     expect(followup.result.status.message.parts[0].text).toBe(
       "done eventually",
     );
+  });
+
+  it("fails stale processing async tasks instead of rerunning side effects from tasks/get", async () => {
+    let started: (value: unknown) => void = () => {};
+    const startedPromise = new Promise((resolve) => {
+      started = resolve;
+    });
+    const handler = vi.fn(async () => {
+      started(undefined);
+      return new Promise<never>(() => {});
+    });
+    const sideEffectConfig: A2AConfig = {
+      ...customHandler,
+      handler,
+    };
+    const event = mockEvent();
+    const result = await handleJsonRpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "message/send",
+        params: {
+          async: true,
+          metadata: {
+            testUpdatedAt: Date.now() - 5 * 60 * 1000 - 1,
+          },
+          message: {
+            role: "user",
+            parts: [{ type: "text", text: "create something" }],
+          },
+        },
+      },
+      event,
+      sideEffectConfig,
+    );
+    expect(result.error).toBeUndefined();
+    const taskId = result.result.id;
+
+    const { processA2ATaskFromQueue } = await import("./handlers.js");
+    void processA2ATaskFromQueue(taskId, sideEffectConfig);
+    await startedPromise;
+
+    const status = await handleJsonRpc(
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tasks/get",
+        params: { id: taskId },
+      },
+      event,
+      sideEffectConfig,
+    );
+
+    expect(status.error).toBeUndefined();
+    expect(status.result.status.state).toBe("failed");
+    expect(status.result.status.message.parts[0].text).toContain(
+      "async A2A processor timed out",
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 
   it("refuses async message/send on hosted runtimes without A2A auth config", async () => {

--- a/packages/core/src/a2a/handlers.ts
+++ b/packages/core/src/a2a/handlers.ts
@@ -16,7 +16,7 @@ import {
   updateTask,
   claimA2ATaskForProcessing,
   getA2ATaskDispatchState,
-  resetStuckA2ATaskForRetry,
+  failStuckA2ATask,
   touchQueuedA2ATaskDispatch,
 } from "./task-store.js";
 import { agentChat } from "../shared/agent-chat.js";
@@ -747,19 +747,26 @@ async function handleGet(
   if (!task) {
     return jsonRpcError(0, -32001, "Task not found");
   }
-  await refireStuckAsyncTaskIfNeeded(id, event).catch((err) => {
-    console.error("[a2a] Failed to refire stuck async task:", err);
-  });
+  const taskChanged = await refireStuckAsyncTaskIfNeeded(id, event).catch(
+    (err) => {
+      console.error("[a2a] Failed to refire stuck async task:", err);
+      return false;
+    },
+  );
+  if (taskChanged) {
+    const updated = await getTask(id);
+    if (updated) return jsonRpcResult(0, sanitizeTaskForResponse(updated));
+  }
   return jsonRpcResult(0, sanitizeTaskForResponse(task));
 }
 
 async function refireStuckAsyncTaskIfNeeded(
   taskId: string,
   event: any,
-): Promise<void> {
+): Promise<boolean> {
   const state = await getA2ATaskDispatchState(taskId);
-  if (!state) return;
-  if (!state.metadata?.__a2a_processor) return;
+  if (!state) return false;
+  if (!state.metadata?.__a2a_processor) return false;
 
   const now = Date.now();
   if (
@@ -768,20 +775,27 @@ async function refireStuckAsyncTaskIfNeeded(
   ) {
     if (await touchQueuedA2ATaskDispatch(taskId)) {
       await fireProcessTaskDispatch(event, taskId);
+      return true;
     }
-    return;
+    return false;
   }
 
   if (
     state.statusState === "processing" &&
     state.updatedAt <= now - A2A_PROCESSING_STUCK_AFTER_MS
   ) {
-    const reset = await resetStuckA2ATaskForRetry(
+    // A processor that died mid-handler may have already performed
+    // side-effectful work. Retrying from the top can duplicate artifacts, so
+    // fail deterministically and let the caller issue an intentional retry.
+    const failed = await failStuckA2ATask(
       taskId,
       now - A2A_PROCESSING_STUCK_AFTER_MS,
+      "The async A2A processor timed out before completing. Please retry the request.",
     );
-    if (reset) await fireProcessTaskDispatch(event, taskId);
+    return failed;
   }
+
+  return false;
 }
 
 async function handleCancel(

--- a/packages/core/src/a2a/task-store.ts
+++ b/packages/core/src/a2a/task-store.ts
@@ -214,6 +214,34 @@ export async function resetStuckA2ATaskForRetry(
   return affected !== 0;
 }
 
+export async function failStuckA2ATask(
+  id: string,
+  processingCutoff: number,
+  reason: string,
+): Promise<boolean> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  const timestamp = new Date().toISOString();
+  const message: Message = {
+    role: "agent",
+    parts: [{ type: "text", text: reason }],
+  };
+  const result = await client.execute({
+    sql: `UPDATE a2a_tasks
+            SET status_state = 'failed',
+                status_message = ?,
+                status_timestamp = ?,
+                updated_at = ?
+          WHERE id = ?
+            AND status_state = 'processing'
+            AND updated_at <= ?`,
+    args: [JSON.stringify(message), timestamp, now, id, processingCutoff],
+  });
+  const affected = (result as any)?.rowsAffected ?? (result as any)?.rowCount;
+  return affected !== 0;
+}
+
 export async function getTask(id: string): Promise<Task | null> {
   await ensureTable();
   const client = getDbExec();

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -76,6 +76,7 @@ describe("createBuilderEngine", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
@@ -397,6 +398,81 @@ describe("createBuilderEngine", () => {
     expect(stop?.errorCode).toBe("too_many_concurrent_requests");
     // Must contain "too many requests" so production-agent's isRetryableError triggers.
     expect(stop?.error?.toLowerCase()).toContain("too many requests");
+  });
+
+  it("aborts hung gateway requests before the host function timeout", async () => {
+    vi.stubEnv("AGENT_NATIVE_BUILDER_GATEWAY_TIMEOUT_MS", "1");
+    const fetchSpy = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason ?? new Error("aborted"));
+          });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const engine = createBuilderEngine();
+    const events = await collectEvents(engine.stream(BASE_OPTS));
+
+    const stop = events.find((e) => e.type === "stop");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(stop?.reason).toBe("error");
+    expect(stop?.errorCode).toBe("builder_gateway_timeout");
+    expect(stop?.error).toContain("Builder gateway timed out");
+  });
+
+  it("keeps the hard timeout active while reading the gateway stream", async () => {
+    vi.stubEnv("AGENT_NATIVE_BUILDER_GATEWAY_TIMEOUT_MS", "1");
+    const fetchSpy = vi.fn((_url: string, init?: RequestInit) => {
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          init?.signal?.addEventListener("abort", () => {
+            controller.error(init.signal?.reason ?? new Error("aborted"));
+          });
+        },
+      });
+      return Promise.resolve(
+        new Response(stream, {
+          status: 200,
+          headers: { "Content-Type": "application/jsonl" },
+        }),
+      );
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const engine = createBuilderEngine();
+    const events = await collectEvents(engine.stream(BASE_OPTS));
+
+    const stop = events.find((e) => e.type === "stop");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(stop?.reason).toBe("error");
+    expect(stop?.errorCode).toBe("builder_gateway_timeout");
+    expect(stop?.error).toContain("Builder gateway timed out");
+  });
+
+  it("caps configured gateway timeouts below the 60s serverless function limit", async () => {
+    vi.stubEnv("AGENT_NATIVE_BUILDER_GATEWAY_TIMEOUT_MS", "60000");
+    vi.useFakeTimers();
+    const fetchSpy = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason ?? new Error("aborted"));
+          });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const engine = createBuilderEngine();
+    const eventsPromise = collectEvents(engine.stream(BASE_OPTS));
+    await vi.advanceTimersByTimeAsync(55_000);
+    const events = await eventsPromise;
+
+    const stop = events.find((e) => e.type === "stop");
+    expect(stop?.reason).toBe("error");
+    expect(stop?.errorCode).toBe("builder_gateway_timeout");
+    expect(stop?.error).toContain("55s");
   });
 
   it("maps mid-stream rate_limited into a retryable error stop", async () => {

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -67,6 +67,9 @@ export const BUILDER_SUPPORTED_MODELS = [
   "z-ai-glm-5-1",
 ] as const;
 
+const DEFAULT_BUILDER_GATEWAY_TIMEOUT_MS = 45_000;
+const MAX_BUILDER_GATEWAY_TIMEOUT_MS = 55_000;
+
 // Inherits from agent/default-model.ts — single source of truth so a
 // new model release is a one-line bump.
 import { DEFAULT_MODEL } from "../default-model.js";
@@ -168,58 +171,77 @@ class BuilderEngine implements AgentEngine {
       `[builder-engine] → POST ${gatewayBaseUrl}/messages model=${opts.model} tools=${tools.length} org=${orgLabel}`,
     );
 
-    let response: Response;
-    try {
-      response = await fetch(`${gatewayBaseUrl}/messages`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: authHeader,
-        },
-        body: JSON.stringify(body),
-        signal: opts.abortSignal,
-      });
-    } catch (err) {
-      yield {
-        type: "stop",
-        reason: "error",
-        error: err instanceof Error ? err.message : String(err),
-      };
-      return;
-    }
-
-    console.log(
-      `[builder-engine] ← ${response.status} ${response.statusText} in ${Date.now() - tStart}ms`,
+    const gatewayTimeoutMs = getBuilderGatewayTimeoutMs();
+    const gatewayAbort = createGatewayAbortSignal(
+      opts.abortSignal,
+      gatewayTimeoutMs,
     );
+    try {
+      let response: Response;
+      try {
+        response = await fetch(`${gatewayBaseUrl}/messages`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: authHeader,
+          },
+          body: JSON.stringify(body),
+          signal: gatewayAbort.signal,
+        });
+      } catch (err) {
+        if (gatewayAbort.didTimeout()) {
+          console.warn(
+            `[builder-engine] gateway timed out after ${Date.now() - tStart}ms`,
+          );
+        }
+        yield createBuilderGatewayTimeoutStop(
+          err,
+          gatewayAbort.didTimeout(),
+          gatewayTimeoutMs,
+        );
+        return;
+      }
 
-    if (!response.ok) {
-      yield* emitHttpError(response);
-      return;
+      console.log(
+        `[builder-engine] ← ${response.status} ${response.statusText} in ${Date.now() - tStart}ms`,
+      );
+
+      if (!response.ok) {
+        yield* emitHttpError(response);
+        return;
+      }
+
+      const contentType = response.headers.get("content-type") ?? "";
+      if (contentType.includes("text/html")) {
+        const rawText = await response.text().catch(() => "");
+        yield {
+          type: "stop",
+          reason: "error",
+          error: normalizeGatewayErrorText(rawText, response.status || 502),
+          errorCode: `http_${response.status || 502}`,
+        };
+        return;
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        yield {
+          type: "stop",
+          reason: "error",
+          error: "Builder gateway response has no body",
+        };
+        return;
+      }
+
+      yield* parseJsonlStream(
+        reader,
+        opts.model,
+        gatewayAbort.didTimeout,
+        gatewayTimeoutMs,
+      );
+    } finally {
+      gatewayAbort.cleanup();
     }
-
-    const contentType = response.headers.get("content-type") ?? "";
-    if (contentType.includes("text/html")) {
-      const rawText = await response.text().catch(() => "");
-      yield {
-        type: "stop",
-        reason: "error",
-        error: normalizeGatewayErrorText(rawText, response.status || 502),
-        errorCode: `http_${response.status || 502}`,
-      };
-      return;
-    }
-
-    const reader = response.body?.getReader();
-    if (!reader) {
-      yield {
-        type: "stop",
-        reason: "error",
-        error: "Builder gateway response has no body",
-      };
-      return;
-    }
-
-    yield* parseJsonlStream(reader, opts.model);
   }
 }
 
@@ -329,6 +351,8 @@ async function* readJsonlLines(
 async function* parseJsonlStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   model: string,
+  didGatewayTimeout?: () => boolean,
+  gatewayTimeoutMs = DEFAULT_BUILDER_GATEWAY_TIMEOUT_MS,
 ): AsyncIterable<EngineEvent> {
   const parts: EngineContentPart[] = [];
   let pendingText = "";
@@ -495,11 +519,11 @@ async function* parseJsonlStream(
       error: "Builder gateway stream ended without a stop event",
     };
   } catch (err) {
-    yield {
-      type: "stop",
-      reason: "error",
-      error: err instanceof Error ? err.message : String(err),
-    };
+    yield createBuilderGatewayTimeoutStop(
+      err,
+      didGatewayTimeout?.() ?? false,
+      gatewayTimeoutMs,
+    );
   } finally {
     // Release the reader on every exit path — early returns (invalid JSONL,
     // stop event) and generator abandonment both leave the underlying
@@ -548,4 +572,82 @@ export function createBuilderEngine(
   _config: Record<string, unknown> = {},
 ): AgentEngine {
   return new BuilderEngine();
+}
+
+function getBuilderGatewayTimeoutMs(): number {
+  const raw = process.env.AGENT_NATIVE_BUILDER_GATEWAY_TIMEOUT_MS;
+  if (!raw) return DEFAULT_BUILDER_GATEWAY_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_BUILDER_GATEWAY_TIMEOUT_MS;
+  }
+  return Math.min(parsed, MAX_BUILDER_GATEWAY_TIMEOUT_MS);
+}
+
+function createGatewayAbortSignal(
+  parentSignal: AbortSignal,
+  timeoutMs: number,
+): {
+  signal: AbortSignal;
+  didTimeout: () => boolean;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  let timedOut = false;
+
+  const abortFromParent = () => {
+    if (!controller.signal.aborted) {
+      controller.abort(parentSignal.reason);
+    }
+  };
+
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    if (!controller.signal.aborted) {
+      controller.abort(new Error("Builder gateway request timed out"));
+    }
+  }, timeoutMs);
+
+  if (parentSignal.aborted) abortFromParent();
+  parentSignal.addEventListener("abort", abortFromParent, { once: true });
+
+  return {
+    signal: controller.signal,
+    didTimeout: () => timedOut,
+    cleanup: () => {
+      clearTimeout(timeout);
+      parentSignal.removeEventListener("abort", abortFromParent);
+    },
+  };
+}
+
+function normalizeBuilderGatewayFetchError(
+  err: unknown,
+  timedOut: boolean,
+  timeoutMs: number,
+): string {
+  if (timedOut) {
+    return `Builder gateway timed out after ${formatTimeoutMs(
+      timeoutMs,
+    )} before the hosting function limit. Please retry; if this keeps happening, reduce the prompt size or try again when the gateway is less busy.`;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+function createBuilderGatewayTimeoutStop(
+  err: unknown,
+  timedOut: boolean,
+  timeoutMs: number,
+): EngineEvent {
+  return {
+    type: "stop",
+    reason: "error",
+    error: normalizeBuilderGatewayFetchError(err, timedOut, timeoutMs),
+    ...(timedOut ? { errorCode: "builder_gateway_timeout" } : {}),
+  };
+}
+
+function formatTimeoutMs(timeoutMs: number): string {
+  if (timeoutMs < 1000) return `${timeoutMs}ms`;
+  return `${Math.round(timeoutMs / 1000)}s`;
 }

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -411,4 +411,45 @@ describe("runAgentLoop", () => {
       ],
     });
   });
+
+  it("does not retry Builder gateway timeouts inside one serverless run", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        yield {
+          type: "stop",
+          reason: "error",
+          error: "Builder gateway timed out after 45s",
+          errorCode: "builder_gateway_timeout",
+        };
+      },
+    };
+
+    await expect(
+      runAgentLoop({
+        engine,
+        model: "test-model",
+        systemPrompt: "system",
+        tools: [],
+        messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+        actions: {},
+        send: () => {},
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow("Builder gateway timed out after 45s");
+
+    expect(streamCalls).toBe(1);
+  });
 });

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -486,6 +486,7 @@ function isRetryableError(err: unknown): boolean {
   const msg = err.message.toLowerCase();
   const code =
     err instanceof EngineError ? (err.errorCode ?? "").toLowerCase() : "";
+  if (code === "builder_gateway_timeout") return false;
   return (
     code === "http_502" ||
     code === "http_503" ||

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -501,7 +501,7 @@ describe("A2A continuation processor", () => {
     );
   });
 
-  it("keeps polling a still-working remote task even after many continuation claims", async () => {
+  it("backs off a still-working remote task without chaining self-dispatches", async () => {
     vi.useFakeTimers();
     const sendResponse = vi.fn(async () => undefined);
     claimA2AContinuationMock.mockResolvedValueOnce(
@@ -525,14 +525,11 @@ describe("A2A continuation processor", () => {
 
     expect(sendResponse).not.toHaveBeenCalled();
     expect(failA2AContinuationMock).not.toHaveBeenCalled();
-    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith("cont-1", 5_000);
-    expect(fetch).toHaveBeenCalledWith(
-      "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ continuationId: "cont-1" }),
-      }),
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      60_000,
     );
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("delivers a verified recoverable artifact from a still-working remote task", async () => {
@@ -596,14 +593,11 @@ describe("A2A continuation processor", () => {
 
     expect(sendResponse).not.toHaveBeenCalled();
     expect(failA2AContinuationMock).not.toHaveBeenCalled();
-    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith("cont-1", 5_000);
-    expect(fetch).toHaveBeenCalledWith(
-      "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ continuationId: "cont-1" }),
-      }),
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      60_000,
     );
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("treats A2A token rejection during polling as transient until the remote work deadline", async () => {
@@ -623,14 +617,35 @@ describe("A2A continuation processor", () => {
 
     expect(sendResponse).not.toHaveBeenCalled();
     expect(failA2AContinuationMock).not.toHaveBeenCalled();
-    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith("cont-1", 5_000);
-    expect(fetch).toHaveBeenCalledWith(
-      "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ continuationId: "cont-1" }),
-      }),
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      60_000,
     );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("treats Netlify loop-protection 508s as transient until the remote work deadline", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ attempts: 99 }),
+    );
+    getTaskMock.mockRejectedValueOnce(
+      new Error("A2A request failed (508): loop detected"),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(sendResponse).not.toHaveBeenCalled();
+    expect(failA2AContinuationMock).not.toHaveBeenCalled();
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      60_000,
+    );
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("reports a friendly timeout when task polling aborts after the remote work deadline", async () => {
@@ -694,13 +709,10 @@ describe("A2A continuation processor", () => {
     );
   });
 
-  it("caps the pre-claim wait for stale future wakeups", async () => {
+  it("does not claim continuations that are scheduled far in the future", async () => {
     vi.useFakeTimers();
     const sendResponse = vi.fn(async () => undefined);
     getA2AContinuationMock.mockResolvedValueOnce(
-      continuation({ status: "pending", nextCheckAt: Date.now() + 30_000 }),
-    );
-    claimA2AContinuationMock.mockResolvedValueOnce(
       continuation({ status: "pending", nextCheckAt: Date.now() + 30_000 }),
     );
     const { processA2AContinuationById } =
@@ -716,8 +728,8 @@ describe("A2A continuation processor", () => {
     await vi.advanceTimersByTimeAsync(1);
     await processing;
 
-    expect(claimA2AContinuationMock).toHaveBeenCalledWith("cont-1");
-    expect(sendResponse).toHaveBeenCalled();
+    expect(claimA2AContinuationMock).not.toHaveBeenCalled();
+    expect(sendResponse).not.toHaveBeenCalled();
   });
 
   it("notifies the platform when a remote task exceeds the continuation age limit", async () => {
@@ -757,7 +769,7 @@ describe("A2A continuation processor", () => {
     );
   });
 
-  it("reschedules and redispatches when the platform send fails", async () => {
+  it("reschedules through the retry job when the platform send fails", async () => {
     const sendResponse = vi.fn(async () => {
       throw new Error("slack unavailable");
     });
@@ -769,18 +781,15 @@ describe("A2A continuation processor", () => {
       adapters: new Map([["slack", adapter(sendResponse)]]),
     });
 
-    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith("cont-1", 5_000);
-    expect(fetch).toHaveBeenCalledWith(
-      "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ continuationId: "cont-1" }),
-      }),
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      60_000,
     );
+    expect(fetch).not.toHaveBeenCalled();
     expect(completeA2AContinuationMock).not.toHaveBeenCalled();
   });
 
-  it("reschedules and redispatches when the platform send hangs", async () => {
+  it("reschedules through the retry job when the platform send hangs", async () => {
     vi.useFakeTimers();
     const sendResponse = vi.fn(() => new Promise<void>(() => {}));
     claimA2AContinuationMock.mockResolvedValueOnce(continuation());
@@ -794,14 +803,11 @@ describe("A2A continuation processor", () => {
     await vi.advanceTimersByTimeAsync(12_000);
     await processing;
 
-    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith("cont-1", 5_000);
-    expect(fetch).toHaveBeenCalledWith(
-      "https://dispatch.agent-native.test/_agent-native/integrations/process-a2a-continuation",
-      expect.objectContaining({
-        method: "POST",
-        body: JSON.stringify({ continuationId: "cont-1" }),
-      }),
+    expect(rescheduleA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      60_000,
     );
+    expect(fetch).not.toHaveBeenCalled();
     expect(completeA2AContinuationMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -24,8 +24,11 @@ const PROCESSOR_PATH = `${FRAMEWORK_ROUTE_PREFIX}/integrations/process-a2a-conti
 const TERMINAL_STATES = new Set(["completed", "failed", "canceled"]);
 const MAX_ATTEMPTS = 6;
 const MAX_REMOTE_WORK_MS = 10 * 60_000;
-const RESCHEDULE_DELAY_MS = 5_000;
-const MAX_PRE_CLAIM_WAIT_MS = RESCHEDULE_DELAY_MS + 5_000;
+// Do not chain immediate self-dispatches for long-running remote A2A tasks.
+// Netlify and similar hosts can reject repeated same-site self-invocations
+// with loop-protection responses. The integration retry job sweeps due rows.
+const RESCHEDULE_DELAY_MS = 60_000;
+const MAX_PRE_CLAIM_WAIT_MS = 10_000;
 const POLL_INTERVAL_MS = 2_000;
 const PROCESSOR_WAIT_MS = 20_000;
 const POLL_REQUEST_TIMEOUT_MS = 25_000;
@@ -172,7 +175,6 @@ async function processClaimedContinuation(
         return;
       }
       await rescheduleA2AContinuation(continuation.id, RESCHEDULE_DELAY_MS);
-      await redispatchContinuation(continuation.id);
       return;
     }
     if (continuation.attempts >= MAX_ATTEMPTS) {
@@ -184,7 +186,6 @@ async function processClaimedContinuation(
       return;
     }
     await rescheduleA2AContinuation(continuation.id, RESCHEDULE_DELAY_MS);
-    await redispatchContinuation(continuation.id);
     return;
   }
 
@@ -213,7 +214,6 @@ async function processClaimedContinuation(
       return;
     }
     await rescheduleA2AContinuation(continuation.id, RESCHEDULE_DELAY_MS);
-    await redispatchContinuation(continuation.id);
     return;
   }
 
@@ -254,7 +254,9 @@ async function waitForContinuationDue(
   const waitMs = continuation.nextCheckAt - Date.now();
   if (waitMs <= 0) return true;
 
-  await sleep(Math.min(waitMs, MAX_PRE_CLAIM_WAIT_MS));
+  if (waitMs > MAX_PRE_CLAIM_WAIT_MS) return false;
+
+  await sleep(waitMs);
   return true;
 }
 
@@ -324,7 +326,6 @@ async function deliverAndCompleteA2AContinuation(
       deliveryContinuation.id,
       RESCHEDULE_DELAY_MS,
     );
-    await redispatchContinuation(deliveryContinuation.id);
     return;
   }
 
@@ -373,7 +374,7 @@ function isRemoteWorkExpired(continuation: A2AContinuation): boolean {
 function isTransientA2APollError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   if (err.name === "AbortError") return true;
-  return /operation was aborted|aborted|timed out|timeout|Invalid or expired A2A token|A2A request failed \(401\)/i.test(
+  return /operation was aborted|aborted|timed out|timeout|Invalid or expired A2A token|A2A request failed \((?:401|508)\)/i.test(
     err.message,
   );
 }
@@ -416,15 +417,6 @@ function sanitizeFailureReason(reason: string): string {
     withoutEnvNames.slice(0, 500) ||
     "the downstream agent returned an empty error"
   );
-}
-
-async function redispatchContinuation(continuationId: string): Promise<void> {
-  await dispatchA2AContinuation(continuationId).catch((err) => {
-    console.error(
-      `[integrations] Failed to redispatch A2A continuation ${continuationId}:`,
-      err,
-    );
-  });
 }
 
 async function signContinuationToken(

--- a/packages/core/src/integrations/a2a-continuations-store.spec.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.spec.ts
@@ -58,6 +58,100 @@ describe("A2A continuations store", () => {
     isPostgresMock.mockReturnValue(false);
   });
 
+  it("finds an existing continuation for an integration task", async () => {
+    const { getA2AContinuationForIntegrationTask } = await loadStore();
+    executeMock.mockImplementation(
+      async (query: string | { sql: string; args?: unknown[] }) => {
+        const sql = querySql(query);
+        const args = queryArgs(query);
+        if (
+          sql.includes("WHERE integration_task_id = ?") &&
+          sql.includes("ORDER BY created_at ASC")
+        ) {
+          return {
+            rows: [
+              continuationRow({
+                id: "cont-existing",
+                integration_task_id: args[0],
+                created_at: 10,
+              }),
+            ],
+            rowsAffected: 0,
+          };
+        }
+        return { rows: [], rowsAffected: 0 };
+      },
+    );
+
+    const continuation =
+      await getA2AContinuationForIntegrationTask("task-existing");
+
+    expect(continuation?.id).toBe("cont-existing");
+    expect(continuation?.integrationTaskId).toBe("task-existing");
+  });
+
+  it("allows multiple downstream continuations for one integration task", async () => {
+    const { insertA2AContinuation } = await loadStore();
+    executeMock.mockImplementation(
+      async (query: string | { sql: string; args?: unknown[] }) => {
+        const sql = querySql(query);
+        const args = queryArgs(query);
+        if (
+          sql.trim().startsWith("INSERT INTO integration_a2a_continuations")
+        ) {
+          return { rows: [], rowsAffected: 1 };
+        }
+        if (
+          sql.includes(
+            "SELECT * FROM integration_a2a_continuations WHERE id = ?",
+          )
+        ) {
+          return {
+            rows: [
+              continuationRow({
+                id: args[0],
+                integration_task_id: "task-existing",
+                agent_name: "Analytics",
+                agent_url: "https://analytics.agent-native.test",
+                a2a_task_id: "a2a-task-new",
+              }),
+            ],
+            rowsAffected: 0,
+          };
+        }
+        return { rows: [], rowsAffected: 0 };
+      },
+    );
+
+    const continuation = await insertA2AContinuation({
+      integrationTaskId: "task-existing",
+      platform: "slack",
+      externalThreadId: "C123:123.456",
+      incoming: {
+        platform: "slack",
+        externalThreadId: "C123:123.456",
+        text: "make a deck",
+        platformContext: {},
+        timestamp: 1,
+      },
+      ownerEmail: "alice+qa@agent-native.test",
+      agentName: "Analytics",
+      agentUrl: "https://analytics.agent-native.test",
+      a2aTaskId: "a2a-task-new",
+    });
+
+    expect(continuation.integrationTaskId).toBe("task-existing");
+    expect(continuation.agentName).toBe("Analytics");
+    expect(continuation.a2aTaskId).toBe("a2a-task-new");
+    expect(
+      executeMock.mock.calls.some(([query]) =>
+        querySql(query)
+          .trim()
+          .startsWith("INSERT INTO integration_a2a_continuations"),
+      ),
+    ).toBe(true);
+  });
+
   it("atomically marks a processing continuation as delivering before platform send", async () => {
     const { claimA2AContinuationDelivery } = await loadStore();
     executeMock.mockImplementation(

--- a/packages/core/src/integrations/a2a-continuations-store.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.ts
@@ -35,6 +35,9 @@ async function ensureTable(): Promise<void> {
         `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_status_next ON integration_a2a_continuations(status, next_check_at)`,
       );
       await client.execute(
+        `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_integration_task ON integration_a2a_continuations(integration_task_id)`,
+      );
+      await client.execute(
         `CREATE UNIQUE INDEX IF NOT EXISTS idx_a2a_continuations_remote_task ON integration_a2a_continuations(integration_task_id, agent_url, a2a_task_id)`,
       );
       try {
@@ -160,6 +163,21 @@ export async function insertA2AContinuation(input: {
     if (existing) return existing;
     throw err;
   }
+}
+
+export async function getA2AContinuationForIntegrationTask(
+  integrationTaskId: string,
+): Promise<A2AContinuation | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT * FROM integration_a2a_continuations
+          WHERE integration_task_id = ?
+          ORDER BY created_at ASC
+          LIMIT 1`,
+    args: [integrationTaskId],
+  });
+  return rows[0] ? rowToContinuation(rows[0] as Record<string, unknown>) : null;
 }
 
 function isDuplicateContinuationError(err: unknown): boolean {

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -16,6 +16,7 @@ const resolveEngineMock = vi.hoisted(() => vi.fn());
 const getStoredModelForEngineMock = vi.hoisted(() => vi.fn());
 const isLocalDatabaseMock = vi.hoisted(() => vi.fn());
 const readDeployCredentialEnvMock = vi.hoisted(() => vi.fn());
+const getA2AContinuationForIntegrationTaskMock = vi.hoisted(() => vi.fn());
 const originalNodeEnv = process.env.NODE_ENV;
 
 vi.mock("./thread-mapping-store.js", () => ({
@@ -60,6 +61,11 @@ vi.mock("../db/client.js", async () => {
 
 vi.mock("../server/credential-provider.js", () => ({
   readDeployCredentialEnv: readDeployCredentialEnvMock,
+}));
+
+vi.mock("./a2a-continuations-store.js", () => ({
+  getA2AContinuationForIntegrationTask:
+    getA2AContinuationForIntegrationTaskMock,
 }));
 
 vi.mock("../agent/run-manager.js", () => ({
@@ -161,6 +167,7 @@ describe("integration webhook handler engine resolution", () => {
     getOwnerApiKeyMock.mockResolvedValue(undefined);
     isLocalDatabaseMock.mockReturnValue(true);
     readDeployCredentialEnvMock.mockReturnValue(undefined);
+    getA2AContinuationForIntegrationTaskMock.mockResolvedValue(null);
     actionsToEngineToolsMock.mockReturnValue([]);
     getStoredModelForEngineMock.mockResolvedValue(undefined);
     resolveEngineMock.mockResolvedValue({
@@ -535,6 +542,55 @@ describe("integration webhook handler engine resolution", () => {
         }),
       }),
     );
+  });
+
+  it("does not rerun the agent loop when retrying a task that already queued an A2A continuation", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const { A2A_CONTINUATION_QUEUED_MARKER } =
+      await import("./a2a-continuation-marker.js");
+    const sendResponse = vi.fn();
+    const task = pendingTask({ id: "task-retry-existing-continuation" });
+    getA2AContinuationForIntegrationTaskMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "cont-existing",
+        integrationTaskId: task.id,
+      });
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({
+        type: "tool_start",
+        tool: "call-agent",
+        input: { agent: "starter", message: "finish the setup" },
+      });
+      send({
+        type: "tool_done",
+        tool: "call-agent",
+        result: `${A2A_CONTINUATION_QUEUED_MARKER}\nThe Starter agent is still working.`,
+      });
+    });
+
+    await processIntegrationTask(task, {
+      adapter: createAdapter(sendResponse),
+      systemPrompt: "system",
+      actions: {},
+      model: "claude-sonnet-4-6",
+      apiKey: "",
+      ownerEmail: "dispatch+qa@integration.local",
+    });
+    await processIntegrationTask(task, {
+      adapter: createAdapter(sendResponse),
+      systemPrompt: "system",
+      actions: {},
+      model: "claude-sonnet-4-6",
+      apiKey: "",
+      ownerEmail: "dispatch+qa@integration.local",
+    });
+
+    expect(getA2AContinuationForIntegrationTaskMock).toHaveBeenCalledWith(
+      task.id,
+    );
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
+    expect(sendResponse).not.toHaveBeenCalled();
   });
 
   it("suppresses stale A2A continuation deferral replies", async () => {

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -40,6 +40,7 @@ import { signInternalToken } from "./internal-token.js";
 import { FRAMEWORK_ROUTE_PREFIX } from "../server/core-routes-plugin.js";
 import { withConfiguredAppBasePath } from "../server/app-base-path.js";
 import { A2A_CONTINUATION_QUEUED_MARKER } from "./a2a-continuation-marker.js";
+import { getA2AContinuationForIntegrationTask } from "./a2a-continuations-store.js";
 import { collectFinalResponseTextFromAgentEvents } from "../a2a/response-text.js";
 import {
   appendA2AArtifactLinks,
@@ -401,6 +402,16 @@ export async function processIntegrationTask(
     incoming: IncomingMessage;
     placeholderRef?: string;
   };
+  const existingContinuation = await getA2AContinuationForIntegrationTask(
+    task.id,
+  );
+  if (existingContinuation) {
+    console.log(
+      `[integrations] Skipping integration task ${task.id}; A2A continuation ${existingContinuation.id} already exists`,
+    );
+    return;
+  }
+
   await processIncomingMessage(parsed.incoming, options, {
     taskId: task.id,
     placeholderRef: parsed.placeholderRef,

--- a/templates/dispatch/AGENTS.md
+++ b/templates/dispatch/AGENTS.md
@@ -66,7 +66,7 @@ The agent can navigate with:
 
 ### Vault (workspace-wide secrets)
 
-- `list-workspace-apps`: list apps installed in the workspace and their mounted paths; when `url` is present, use it for links in Slack/email replies instead of returning only the relative path
+- `list-workspace-apps`: list apps installed in the workspace and their mounted paths; when `url` is present, use it for links in Slack/email replies instead of returning only the relative path. When the user asks whether workspace apps have agent cards or A2A endpoints, call this with `includeAgentCards: true`; without that probe, missing `agentCard*`/`a2aEndpointUrl` fields mean "not checked", not "none".
 - `get-app-creation-settings`: see whether production app creation can use a Builder project
 - `set-app-creation-settings`: set the default Builder project ID in Dispatch settings without writing env vars or files
 - `start-workspace-app-creation`: start a new app request; in local dev, use the returned prompt with the local code agent, and in production it creates a Builder branch when a Builder project is configured

--- a/templates/dispatch/actions/list-workspace-apps.ts
+++ b/templates/dispatch/actions/list-workspace-apps.ts
@@ -4,8 +4,15 @@ import { listWorkspaceApps } from "../server/lib/app-creation-store.js";
 
 export default defineAction({
   description:
-    "List apps installed in this workspace, including their mounted paths and absolute URLs when the public app URL is configured.",
-  schema: z.object({}),
+    "List apps installed in this workspace, including mounted paths and absolute URLs. Pass includeAgentCards=true when answering whether workspace apps expose agent cards or A2A endpoints; agent-card probing is optional and off by default.",
+  schema: z.object({
+    includeAgentCards: z
+      .boolean()
+      .optional()
+      .describe(
+        "Fetch each ready app's /.well-known/agent-card.json with a short non-throwing timeout and include agentCardUrl, agentCardReachable, a2aEndpointUrl, agentName, and agentSkillsCount. Defaults to false; pending Builder apps are not probed.",
+      ),
+  }),
   http: { method: "GET" },
-  run: async () => listWorkspaceApps(),
+  run: async (input) => listWorkspaceApps(input),
 });

--- a/templates/dispatch/app/routes/apps.$appId.tsx
+++ b/templates/dispatch/app/routes/apps.$appId.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useMemo } from "react";
+import { Link, useParams } from "react-router";
+import { useActionQuery } from "@agent-native/core/client";
+import {
+  IconArrowLeft,
+  IconArrowUpRight,
+  IconClockHour4,
+} from "@tabler/icons-react";
+import { DispatchShell } from "@/components/dispatch-shell";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface WorkspaceAppSummary {
+  id: string;
+  name: string;
+  description?: string;
+  path: string;
+  url?: string | null;
+  status?: "ready" | "pending";
+  statusLabel?: string;
+  builderUrl?: string | null;
+  branchName?: string | null;
+}
+
+function workspaceAppHref(app: WorkspaceAppSummary): string | null {
+  if (app.status === "pending") return app.builderUrl || null;
+  return app.url || app.path || null;
+}
+
+export function meta() {
+  return [{ title: "Workspace app - Dispatch" }];
+}
+
+export default function WorkspaceAppRoute() {
+  const { appId } = useParams();
+  const { data: apps = [], isLoading } = useActionQuery(
+    "list-workspace-apps",
+    {},
+    {
+      refetchInterval: 2_000,
+    },
+  );
+  const app = useMemo(
+    () =>
+      (apps as WorkspaceAppSummary[]).find((item) => item.id === appId) ?? null,
+    [appId, apps],
+  );
+  const href = app ? workspaceAppHref(app) : null;
+
+  useEffect(() => {
+    if (!app || app.status === "pending" || !href) return;
+    window.location.assign(href);
+  }, [app, href]);
+
+  return (
+    <DispatchShell
+      title={app?.name || "Workspace App"}
+      description="Open a deployed app or check the status of an app being created."
+    >
+      <div className="max-w-2xl rounded-lg border bg-card p-5">
+        <Button asChild size="sm" variant="ghost" className="-ml-2 mb-4">
+          <Link to="/apps">
+            <IconArrowLeft size={15} className="mr-1.5" />
+            Apps
+          </Link>
+        </Button>
+
+        {isLoading && !app ? (
+          <p className="text-sm text-muted-foreground">Loading app status...</p>
+        ) : !app ? (
+          <div className="space-y-3">
+            <h2 className="text-base font-semibold text-foreground">
+              App not found
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              This route is not in the workspace app list yet.
+            </p>
+          </div>
+        ) : app.status === "pending" ? (
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-base font-semibold text-foreground">
+                {app.name}
+              </h2>
+              <Badge
+                variant="outline"
+                className="gap-1 border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+              >
+                <IconClockHour4 size={12} />
+                Building
+              </Badge>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              This app is being created. It will be available at{" "}
+              <span className="font-mono text-foreground">{app.path}</span>{" "}
+              after its branch is merged and the workspace deploy finishes.
+            </p>
+            {app.branchName ? (
+              <p className="text-xs text-muted-foreground">
+                Branch: {app.branchName}
+              </p>
+            ) : null}
+            {app.builderUrl ? (
+              <Button asChild>
+                <a href={app.builderUrl} target="_blank" rel="noreferrer">
+                  Open Builder branch
+                  <IconArrowUpRight size={15} className="ml-1.5" />
+                </a>
+              </Button>
+            ) : null}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <h2 className="text-base font-semibold text-foreground">
+              Opening {app.name}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Redirecting to{" "}
+              <span className="font-mono text-foreground">{app.path}</span>.
+            </p>
+            {href ? (
+              <Button asChild>
+                <a href={href}>
+                  Open app
+                  <IconArrowUpRight size={15} className="ml-1.5" />
+                </a>
+              </Button>
+            ) : null}
+          </div>
+        )}
+      </div>
+    </DispatchShell>
+  );
+}

--- a/templates/dispatch/app/routes/apps.tsx
+++ b/templates/dispatch/app/routes/apps.tsx
@@ -24,6 +24,23 @@ interface WorkspaceAppSummary {
   branchName?: string | null;
 }
 
+function workspaceAppHref(app: WorkspaceAppSummary): string | null {
+  if (app.status === "pending") return app.builderUrl || null;
+  return app.url || app.path || null;
+}
+
+function isExternalHref(href: string): boolean {
+  if (!/^https?:\/\//i.test(href)) return false;
+  if (typeof window === "undefined") return true;
+  try {
+    return (
+      new URL(href, window.location.href).origin !== window.location.origin
+    );
+  } catch {
+    return true;
+  }
+}
+
 export function meta() {
   return [{ title: "Apps — Dispatch" }];
 }
@@ -63,49 +80,56 @@ export default function AppsRoute() {
           </div>
 
           <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {typedApps.map((app) => (
-              <a
-                key={app.id}
-                href={app.url || app.path}
-                className="group rounded-lg border bg-card p-4 transition hover:border-foreground/30"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <h3 className="truncate text-sm font-semibold text-foreground">
-                        {app.name}
-                      </h3>
-                      {app.status === "pending" ? (
-                        <Badge
-                          variant="outline"
-                          className="shrink-0 gap-1 border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-                        >
-                          <IconClockHour4 size={12} />
-                          Building
-                        </Badge>
+            {typedApps.map((app) => {
+              const href = workspaceAppHref(app);
+              const external = href ? isExternalHref(href) : false;
+              return (
+                <a
+                  key={app.id}
+                  href={href ?? undefined}
+                  target={external ? "_blank" : undefined}
+                  rel={external ? "noreferrer" : undefined}
+                  aria-disabled={!href}
+                  className="group rounded-lg border bg-card p-4 transition hover:border-foreground/30 aria-disabled:pointer-events-none aria-disabled:opacity-60"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <h3 className="truncate text-sm font-semibold text-foreground">
+                          {app.name}
+                        </h3>
+                        {app.status === "pending" ? (
+                          <Badge
+                            variant="outline"
+                            className="shrink-0 gap-1 border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+                          >
+                            <IconClockHour4 size={12} />
+                            Building
+                          </Badge>
+                        ) : null}
+                      </div>
+                      <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
+                        {app.path}
+                      </p>
+                      {app.status === "pending" && app.branchName ? (
+                        <p className="mt-1 truncate text-xs text-muted-foreground">
+                          Branch: {app.branchName}
+                        </p>
+                      ) : null}
+                      {app.description ? (
+                        <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                          {app.description}
+                        </p>
                       ) : null}
                     </div>
-                    <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
-                      {app.path}
-                    </p>
-                    {app.status === "pending" && app.branchName ? (
-                      <p className="mt-1 truncate text-xs text-muted-foreground">
-                        Branch: {app.branchName}
-                      </p>
-                    ) : null}
-                    {app.description ? (
-                      <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-                        {app.description}
-                      </p>
-                    ) : null}
+                    <IconArrowUpRight
+                      size={16}
+                      className="shrink-0 text-muted-foreground transition group-hover:text-foreground"
+                    />
                   </div>
-                  <IconArrowUpRight
-                    size={16}
-                    className="shrink-0 text-muted-foreground transition group-hover:text-foreground"
-                  />
-                </div>
-              </a>
-            ))}
+                </a>
+              );
+            })}
 
             <CreateAppPopover />
           </div>

--- a/templates/dispatch/app/routes/overview.tsx
+++ b/templates/dispatch/app/routes/overview.tsx
@@ -78,6 +78,23 @@ interface WorkspaceAppSummary {
   branchName?: string | null;
 }
 
+function workspaceAppHref(app: WorkspaceAppSummary): string | null {
+  if (app.status === "pending") return app.builderUrl || null;
+  return app.url || app.path || null;
+}
+
+function isExternalHref(href: string): boolean {
+  if (!/^https?:\/\//i.test(href)) return false;
+  if (typeof window === "undefined") return true;
+  try {
+    return (
+      new URL(href, window.location.href).origin !== window.location.origin
+    );
+  } catch {
+    return true;
+  }
+}
+
 const HOME_CHAT_SUGGESTIONS = [
   "Create a lightweight customer onboarding app",
   "Ask Slides to draft a board update from our latest metrics",
@@ -195,49 +212,56 @@ function WorkspaceAppsSection({
           ? Array.from({ length: 6 }).map((_, index) => (
               <AppCardSkeleton key={index} />
             ))
-          : visibleApps.map((app) => (
-              <a
-                key={app.id}
-                href={app.url || app.path}
-                className="group min-h-32 rounded-lg border bg-card p-4 transition hover:border-foreground/30"
-              >
-                <div className="flex h-full items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <h3 className="truncate text-sm font-semibold text-foreground">
-                        {app.name}
-                      </h3>
-                      {app.status === "pending" ? (
-                        <Badge
-                          variant="outline"
-                          className="shrink-0 gap-1 border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-                        >
-                          <IconClockHour4 size={12} />
-                          Building
-                        </Badge>
+          : visibleApps.map((app) => {
+              const href = workspaceAppHref(app);
+              const external = href ? isExternalHref(href) : false;
+              return (
+                <a
+                  key={app.id}
+                  href={href ?? undefined}
+                  target={external ? "_blank" : undefined}
+                  rel={external ? "noreferrer" : undefined}
+                  aria-disabled={!href}
+                  className="group min-h-32 rounded-lg border bg-card p-4 transition hover:border-foreground/30 aria-disabled:pointer-events-none aria-disabled:opacity-60"
+                >
+                  <div className="flex h-full items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <h3 className="truncate text-sm font-semibold text-foreground">
+                          {app.name}
+                        </h3>
+                        {app.status === "pending" ? (
+                          <Badge
+                            variant="outline"
+                            className="shrink-0 gap-1 border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+                          >
+                            <IconClockHour4 size={12} />
+                            Building
+                          </Badge>
+                        ) : null}
+                      </div>
+                      <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
+                        {app.path}
+                      </p>
+                      {app.status === "pending" && app.branchName ? (
+                        <p className="mt-1 truncate text-xs text-muted-foreground">
+                          Branch: {app.branchName}
+                        </p>
+                      ) : null}
+                      {app.description ? (
+                        <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                          {app.description}
+                        </p>
                       ) : null}
                     </div>
-                    <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
-                      {app.path}
-                    </p>
-                    {app.status === "pending" && app.branchName ? (
-                      <p className="mt-1 truncate text-xs text-muted-foreground">
-                        Branch: {app.branchName}
-                      </p>
-                    ) : null}
-                    {app.description ? (
-                      <p className="mt-2 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-                        {app.description}
-                      </p>
-                    ) : null}
+                    <IconArrowUpRight
+                      size={16}
+                      className="shrink-0 text-muted-foreground transition group-hover:text-foreground"
+                    />
                   </div>
-                  <IconArrowUpRight
-                    size={16}
-                    className="shrink-0 text-muted-foreground transition group-hover:text-foreground"
-                  />
-                </div>
-              </a>
-            ))}
+                </a>
+              );
+            })}
 
         {!showSkeletons ? <CreateAppPopover /> : null}
       </div>

--- a/templates/dispatch/server/lib/app-creation-store.spec.ts
+++ b/templates/dispatch/server/lib/app-creation-store.spec.ts
@@ -11,6 +11,7 @@ const currentOwnerEmailMock = vi.hoisted(() => vi.fn());
 const originalNodeEnv = process.env.NODE_ENV;
 const originalWorkspaceAppsJson = process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
 const originalAppUrl = process.env.APP_URL;
+const originalFetch = globalThis.fetch;
 
 vi.mock("@agent-native/core/settings", () => ({
   getSetting: getSettingMock,
@@ -72,6 +73,10 @@ describe("startWorkspaceAppCreation", () => {
       delete process.env.APP_URL;
     } else {
       process.env.APP_URL = originalAppUrl;
+    }
+    vi.unstubAllGlobals();
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
     }
   });
 
@@ -350,5 +355,130 @@ describe("startWorkspaceAppCreation", () => {
       url: "https://builder.io/pending",
       branchName: "pending-branch",
     });
+  });
+
+  it("does not probe agent cards unless requested", async () => {
+    process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({
+      apps: [
+        {
+          id: "dispatch",
+          name: "Dispatch",
+          path: "/dispatch",
+          isDispatch: true,
+        },
+      ],
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { listWorkspaceApps } = await import("./app-creation-store.js");
+    const apps = await listWorkspaceApps();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(apps[0]).not.toHaveProperty("agentCardUrl");
+    expect(apps[0]).not.toHaveProperty("a2aEndpointUrl");
+  });
+
+  it("optionally probes ready app agent cards and returns A2A metadata", async () => {
+    process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({
+      apps: [
+        {
+          id: "dispatch",
+          name: "Dispatch",
+          path: "/dispatch",
+          isDispatch: true,
+        },
+        {
+          id: "starter",
+          name: "Starter",
+          path: "/starter",
+        },
+      ],
+    });
+    const fetchMock = vi.fn(async (url: string) => ({
+      ok: true,
+      json: async () => ({
+        name: url.includes("/starter/") ? "Starter Agent" : "Dispatch Agent",
+        url: url.includes("/starter/")
+          ? "https://workspace.example.test/starter/_agent-native/a2a"
+          : "https://workspace.example.test/dispatch/_agent-native/a2a",
+        skills: url.includes("/starter/") ? [{ id: "draft" }] : [],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { listWorkspaceApps } = await import("./app-creation-store.js");
+    const apps = await listWorkspaceApps({ includeAgentCards: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://workspace.example.test/dispatch/.well-known/agent-card.json",
+      expect.objectContaining({
+        headers: { accept: "application/json" },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(apps.find((app) => app.id === "starter")).toMatchObject({
+      agentCardUrl:
+        "https://workspace.example.test/starter/.well-known/agent-card.json",
+      agentCardReachable: true,
+      a2aEndpointUrl:
+        "https://workspace.example.test/starter/_agent-native/a2a",
+      agentName: "Starter Agent",
+      agentSkillsCount: 1,
+    });
+  });
+
+  it("reports unreachable agent cards without throwing and skips pending Builder apps", async () => {
+    process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({
+      apps: [
+        {
+          id: "dispatch",
+          name: "Dispatch",
+          path: "/dispatch",
+          isDispatch: true,
+        },
+      ],
+    });
+    getSettingMock.mockResolvedValue({
+      pendingApps: [
+        {
+          id: "pending-app",
+          path: "/pending-app",
+          builderUrl: "https://builder.io/pending",
+          branchName: "pending-branch",
+          createdAt: "2026-05-03T00:00:00.000Z",
+          updatedAt: "2026-05-03T00:00:00.000Z",
+        },
+      ],
+    });
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network unavailable");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { listWorkspaceApps } = await import("./app-creation-store.js");
+    const apps = await listWorkspaceApps({ includeAgentCards: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://workspace.example.test/dispatch/.well-known/agent-card.json",
+      expect.any(Object),
+    );
+    expect(apps.find((app) => app.id === "dispatch")).toMatchObject({
+      agentCardUrl:
+        "https://workspace.example.test/dispatch/.well-known/agent-card.json",
+      agentCardReachable: false,
+      a2aEndpointUrl: null,
+      agentName: null,
+      agentSkillsCount: null,
+    });
+    expect(apps.find((app) => app.id === "pending-app")).toMatchObject({
+      status: "pending",
+      url: "https://builder.io/pending",
+    });
+    expect(apps.find((app) => app.id === "pending-app")).not.toHaveProperty(
+      "agentCardUrl",
+    );
   });
 });

--- a/templates/dispatch/server/lib/app-creation-store.ts
+++ b/templates/dispatch/server/lib/app-creation-store.ts
@@ -20,6 +20,8 @@ const SETTINGS_KEY = "dispatch-app-creation-settings";
 const WORKSPACE_APPS_ENV_KEY = "AGENT_NATIVE_WORKSPACE_APPS_JSON";
 const WORKSPACE_APPS_MANIFEST_FILE = "workspace-apps.json";
 const MAX_PENDING_APPS = 50;
+const AGENT_CARD_PATH = "/.well-known/agent-card.json";
+const AGENT_CARD_FETCH_TIMEOUT_MS = 1_500;
 
 export interface WorkspaceAppSummary {
   id: string;
@@ -33,6 +35,15 @@ export interface WorkspaceAppSummary {
   builderUrl?: string | null;
   branchName?: string | null;
   createdAt?: string | null;
+  agentCardUrl?: string | null;
+  agentCardReachable?: boolean;
+  a2aEndpointUrl?: string | null;
+  agentName?: string | null;
+  agentSkillsCount?: number | null;
+}
+
+export interface ListWorkspaceAppsOptions {
+  includeAgentCards?: boolean;
 }
 
 export interface AppCreationSettings {
@@ -252,6 +263,123 @@ async function appendPendingWorkspaceApps(
   return [...apps, ...pendingApps].sort(sortWorkspaceApps);
 }
 
+function agentCardUrlForApp(appUrl: string | null): string | null {
+  if (!appUrl) return null;
+  const trimmed = appUrl.replace(/\/+$/, "");
+  if (!trimmed) return null;
+  try {
+    return new URL(`${trimmed}${AGENT_CARD_PATH}`).toString();
+  } catch {
+    return `${trimmed}${AGENT_CARD_PATH}`;
+  }
+}
+
+function stringField(
+  record: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function numberOfSkills(card: Record<string, unknown>): number | null {
+  return Array.isArray(card.skills) ? card.skills.length : null;
+}
+
+async function fetchAgentCardMetadata(
+  app: WorkspaceAppSummary,
+): Promise<
+  Pick<
+    WorkspaceAppSummary,
+    | "agentCardUrl"
+    | "agentCardReachable"
+    | "a2aEndpointUrl"
+    | "agentName"
+    | "agentSkillsCount"
+  >
+> {
+  const agentCardUrl = agentCardUrlForApp(app.url);
+  if (!agentCardUrl) {
+    return {
+      agentCardUrl: null,
+      agentCardReachable: false,
+      a2aEndpointUrl: null,
+      agentName: null,
+      agentSkillsCount: null,
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    AGENT_CARD_FETCH_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(agentCardUrl, {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return {
+        agentCardUrl,
+        agentCardReachable: false,
+        a2aEndpointUrl: null,
+        agentName: null,
+        agentSkillsCount: null,
+      };
+    }
+
+    const parsed = await response.json().catch(() => null);
+    const card =
+      parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    if (!card) {
+      return {
+        agentCardUrl,
+        agentCardReachable: false,
+        a2aEndpointUrl: null,
+        agentName: null,
+        agentSkillsCount: null,
+      };
+    }
+
+    return {
+      agentCardUrl,
+      agentCardReachable: true,
+      a2aEndpointUrl:
+        stringField(card, "url") ?? stringField(card, "endpointUrl"),
+      agentName: stringField(card, "name"),
+      agentSkillsCount: numberOfSkills(card),
+    };
+  } catch {
+    return {
+      agentCardUrl,
+      agentCardReachable: false,
+      a2aEndpointUrl: null,
+      agentName: null,
+      agentSkillsCount: null,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function maybeIncludeAgentCards(
+  apps: WorkspaceAppSummary[],
+  options: ListWorkspaceAppsOptions,
+): Promise<WorkspaceAppSummary[]> {
+  if (!options.includeAgentCards) return apps;
+  return Promise.all(
+    apps.map(async (app) => {
+      if (app.status === "pending") return app;
+      const metadata = await fetchAgentCardMetadata(app);
+      return { ...app, ...metadata };
+    }),
+  );
+}
+
 async function recordPendingWorkspaceApp(input: {
   appId: string;
   projectId: string | null;
@@ -347,28 +475,43 @@ export function getEnvBuilderProjectId(): string | null {
   );
 }
 
-export async function listWorkspaceApps(): Promise<WorkspaceAppSummary[]> {
+export async function listWorkspaceApps(
+  options: ListWorkspaceAppsOptions = {},
+): Promise<WorkspaceAppSummary[]> {
   const manifestApps =
     readWorkspaceAppsFromEnv() ?? readWorkspaceAppsFromManifestFile();
-  if (manifestApps) return appendPendingWorkspaceApps(manifestApps);
+  if (manifestApps) {
+    return maybeIncludeAgentCards(
+      await appendPendingWorkspaceApps(manifestApps),
+      options,
+    );
+  }
 
   const workspaceRoot = findWorkspaceRoot();
   if (!workspaceRoot) {
-    return appendPendingWorkspaceApps([
-      {
-        id: "dispatch",
-        name: "Dispatch",
-        description: "Workspace control plane",
-        path: "/dispatch",
-        url: workspaceAppUrl("/dispatch"),
-        isDispatch: true,
-        status: "ready",
-      },
-    ]);
+    return maybeIncludeAgentCards(
+      await appendPendingWorkspaceApps([
+        {
+          id: "dispatch",
+          name: "Dispatch",
+          description: "Workspace control plane",
+          path: "/dispatch",
+          url: workspaceAppUrl("/dispatch"),
+          isDispatch: true,
+          status: "ready",
+        },
+      ]),
+      options,
+    );
   }
 
   const appsDir = path.join(workspaceRoot, "apps");
-  if (!fs.existsSync(appsDir)) return appendPendingWorkspaceApps([]);
+  if (!fs.existsSync(appsDir)) {
+    return maybeIncludeAgentCards(
+      await appendPendingWorkspaceApps([]),
+      options,
+    );
+  }
 
   const apps = fs
     .readdirSync(appsDir, { withFileTypes: true })
@@ -389,7 +532,10 @@ export async function listWorkspaceApps(): Promise<WorkspaceAppSummary[]> {
     })
     .filter((app): app is WorkspaceAppSummary => !!app)
     .sort(sortWorkspaceApps);
-  return appendPendingWorkspaceApps(apps);
+  return maybeIncludeAgentCards(
+    await appendPendingWorkspaceApps(apps),
+    options,
+  );
 }
 
 export async function getAppCreationSettings(): Promise<AppCreationSettings> {

--- a/templates/dispatch/server/plugins/agent-chat.ts
+++ b/templates/dispatch/server/plugins/agent-chat.ts
@@ -27,6 +27,7 @@ Use the standard workspace primitives:
 - Read and update resources like AGENTS.md, LEARNINGS.md, jobs/*.md, agents/*.md, and remote-agents/*.json when appropriate.
 - Use recurring jobs for scheduled behavior.
 - Use custom agent profiles in agents/*.md for local spawned work and remote-agents/*.json for remote A2A apps.
+- When answering whether workspace apps expose agent cards or A2A endpoints, call list-workspace-apps with includeAgentCards=true. If you have not requested that probe, absence of agent-card fields means unchecked, not unavailable.
 
 When a user asks for something like a digest, reminder, routing rule, or saved behavior:
 - First decide whether it should be a resource, a recurring job, a destination, or a delegated task.

--- a/templates/dispatch/server/plugins/integrations.ts
+++ b/templates/dispatch/server/plugins/integrations.ts
@@ -14,6 +14,7 @@ Default posture:
 - Treat Slack, Telegram, and email as shared entrypoints into the workspace.
 - Heavily delegate domain work to specialized agents through A2A (call-agent) when another app owns the job. Apps you can delegate to include slides (decks/presentations), analytics (data/dashboards), content (docs/articles), videos (Remotion compositions), forms (form builder), clips (screen recordings), and design (visual designs).
 - Use list-connected-agents to see what agents are available before assuming a request must be handled locally.
+- When asked whether workspace apps expose agent cards or A2A endpoints, call list-workspace-apps with includeAgentCards=true. Without that probe, missing agent-card fields mean unchecked, not unavailable.
 - Keep durable memory and operating instructions in resources rather than ephemeral chat.
 - Reply in the originating thread unless the user explicitly asks you to send to a saved destination.
 


### PR DESCRIPTION
## Summary
- skip rerunning integration pending tasks that already handed off to an A2A continuation, preventing duplicate Slack replies after retry sweeps
- add an indexed lookup for A2A continuations by integration task while preserving multiple downstream continuations during a single original run
- let Dispatch optionally probe ready workspace apps for agent-card/A2A endpoint metadata and teach both chat + Slack prompts when to use it
- bump @agent-native/core to 0.7.65

## Tests
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core exec vitest --run src/integrations/a2a-continuations-store.spec.ts src/integrations/webhook-handler-engine.spec.ts
- pnpm --filter @agent-native/core test
- pnpm --filter @agent-native/core build
- pnpm --filter dispatch exec vitest run --root ../.. --exclude '.claude/**' templates/dispatch/server/lib/app-creation-store.spec.ts
- pnpm --filter dispatch typecheck
- pnpm guards