### PR TITLE
Improve workspace app discovery for agents

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.65",
+  "version": "0.7.66",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1721,6 +1721,10 @@ export function createProductionAgentHandler(
                     );
                   }
                 }
+                responseText =
+                  userFacingLlmCredentialError(responseText, {
+                    agentName: ref.name,
+                  }) ?? responseText;
 
                 send({
                   type: "agent_call",

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -9,6 +9,10 @@ import {
 } from "../a2a/client.js";
 import { A2A_CONTINUATION_QUEUED_MARKER } from "../integrations/a2a-continuation-marker.js";
 import {
+  formatLlmCredentialErrorMessage,
+  isLlmCredentialError,
+} from "../agent/engine/credential-errors.js";
+import {
   getRequestUserEmail,
   getRequestOrgId,
   isIntegrationCallerRequest,
@@ -52,6 +56,15 @@ function getIntegrationCallTimeoutMs(): number | undefined {
   if (process.env.NETLIFY) return NETLIFY_INTEGRATION_A2A_TIMEOUT_MS;
 
   return DEFAULT_SERVERLESS_INTEGRATION_A2A_TIMEOUT_MS;
+}
+
+function formatDownstreamLlmCredentialFailure(
+  agentName: string,
+  value: unknown,
+): string | null {
+  return isLlmCredentialError(value)
+    ? formatLlmCredentialErrorMessage({ agentName })
+    : null;
 }
 
 export const tool: ActionTool = {
@@ -217,6 +230,9 @@ export async function run(
           orgSecret: callerOrgSecret,
           ...(callTimeoutMs ? { timeoutMs: callTimeoutMs } : {}),
         });
+        responseText =
+          formatDownstreamLlmCredentialFailure(agent.name, responseText) ??
+          responseText;
         // Some agents reply with relative paths (e.g. slides emits
         // "/deck/abc"). Those resolve against the caller's host, not the
         // receiver's, so they're broken for the user. Expand any leading-slash
@@ -239,7 +255,9 @@ export async function run(
           }
         } else {
           const reason = pollErr?.message ?? "unknown error";
-          responseText = `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;
+          responseText =
+            formatDownstreamLlmCredentialFailure(agent.name, pollErr) ??
+            `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;
         }
       }
 
@@ -271,9 +289,16 @@ export async function run(
       orgDomain: domain,
       orgSecret,
     });
-    return expandRelativeUrls(response, agent.url) || "(empty response)";
+    const sanitized =
+      formatDownstreamLlmCredentialFailure(agent.name, response) ?? response;
+    return expandRelativeUrls(sanitized, agent.url) || "(empty response)";
   } catch (err: any) {
     const msg = err?.message ?? String(err);
+    const credentialMessage = formatDownstreamLlmCredentialFailure(
+      agent.name,
+      err,
+    );
+    if (credentialMessage) return credentialMessage;
     // Friendlier message for the common timeout case so the calling agent can
     // decide whether to give up or retry.
     if (/timeout|did not complete|Inactivity|504/i.test(msg)) {

--- a/packages/core/src/templates/workspace-core/src/server/index.ts
+++ b/packages/core/src/templates/workspace-core/src/server/index.ts
@@ -1,3 +1,7 @@
 // Export workspace-wide server plugin overrides here when you need them.
-// Anything not exported falls through to @agent-native/core defaults.
-export {};
+// Starter apps inherit these exports, so provide explicit framework defaults
+// to keep generated workspaces warning-free until a workspace customizes them.
+export {
+  defaultAgentChatPlugin,
+  defaultAuthPlugin,
+} from "@agent-native/core/server";

--- a/templates/dispatch/actions/list-workspace-apps.ts
+++ b/templates/dispatch/actions/list-workspace-apps.ts
@@ -2,15 +2,22 @@ import { defineAction } from "@agent-native/core";
 import { z } from "zod";
 import { listWorkspaceApps } from "../server/lib/app-creation-store.js";
 
+const httpBoolean = z.preprocess((value) => {
+  if (typeof value !== "string") return value;
+  const normalized = value.trim().toLowerCase();
+  if (["true", "1", "yes", "on"].includes(normalized)) return true;
+  if (["false", "0", "no", "off"].includes(normalized)) return false;
+  return value;
+}, z.boolean());
+
 export default defineAction({
   description:
-    "List apps installed in this workspace, including mounted paths and absolute URLs. Pass includeAgentCards=true when answering whether workspace apps expose agent cards or A2A endpoints; agent-card probing is optional and off by default.",
+    "List apps installed in this workspace, including mounted paths, absolute URLs, and agent-card/A2A metadata for ready apps by default. UI polling callers can pass includeAgentCards=false to skip network probes.",
   schema: z.object({
-    includeAgentCards: z
-      .boolean()
-      .optional()
+    includeAgentCards: httpBoolean
+      .default(true)
       .describe(
-        "Fetch each ready app's /.well-known/agent-card.json with a short non-throwing timeout and include agentCardUrl, agentCardReachable, a2aEndpointUrl, agentName, and agentSkillsCount. Defaults to false; pending Builder apps are not probed.",
+        "Fetch each ready app's /.well-known/agent-card.json with a short non-throwing timeout and include agentCardUrl, agentCardReachable, a2aEndpointUrl, agentName, and agentSkillsCount. Defaults to true for agent calls; UI polling should pass false. Pending Builder apps are not probed.",
       ),
   }),
   http: { method: "GET" },

--- a/templates/dispatch/actions/view-screen.ts
+++ b/templates/dispatch/actions/view-screen.ts
@@ -48,7 +48,9 @@ export default defineAction({
       navigation?.view === "apps" ||
       navigation?.view === "new-app"
     ) {
-      screen.workspaceApps = await listWorkspaceApps();
+      screen.workspaceApps = await listWorkspaceApps({
+        includeAgentCards: true,
+      });
     }
     if (navigation?.view === "vault" || navigation?.view === "new-app") {
       const [secrets, grants, requests] = await Promise.all([

--- a/templates/dispatch/app/routes/apps.$appId.tsx
+++ b/templates/dispatch/app/routes/apps.$appId.tsx
@@ -35,7 +35,7 @@ export default function WorkspaceAppRoute() {
   const { appId } = useParams();
   const { data: apps = [], isLoading } = useActionQuery(
     "list-workspace-apps",
-    {},
+    { includeAgentCards: false },
     {
       refetchInterval: 2_000,
     },

--- a/templates/dispatch/app/routes/apps.tsx
+++ b/templates/dispatch/app/routes/apps.tsx
@@ -48,7 +48,7 @@ export function meta() {
 export default function AppsRoute() {
   const { data: apps = [] } = useActionQuery(
     "list-workspace-apps",
-    {},
+    { includeAgentCards: false },
     {
       refetchInterval: 2_000,
     },

--- a/templates/dispatch/app/routes/overview.tsx
+++ b/templates/dispatch/app/routes/overview.tsx
@@ -499,7 +499,7 @@ export default function OverviewRoute() {
   const { data: connectedAgents } = useActionQuery("list-connected-agents", {});
   const { data: workspaceApps = [], isLoading: appsLoading } = useActionQuery(
     "list-workspace-apps",
-    {},
+    { includeAgentCards: false },
     {
       refetchInterval: 2_000,
     },

--- a/templates/dispatch/server/lib/app-creation-store.spec.ts
+++ b/templates/dispatch/server/lib/app-creation-store.spec.ts
@@ -379,6 +379,49 @@ describe("startWorkspaceAppCreation", () => {
     expect(apps[0]).not.toHaveProperty("a2aEndpointUrl");
   });
 
+  it("probes agent cards by default for action calls and lets UI polling opt out", async () => {
+    process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({
+      apps: [
+        {
+          id: "dispatch",
+          name: "Dispatch",
+          path: "/dispatch",
+          isDispatch: true,
+        },
+      ],
+    });
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        name: "Dispatch Agent",
+        url: "https://workspace.example.test/dispatch/_agent-native/a2a",
+        skills: [],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const action = (await import("../../actions/list-workspace-apps.js"))
+      .default;
+
+    const apps = await action.run({});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(apps[0]).toMatchObject({
+      agentCardReachable: true,
+      a2aEndpointUrl:
+        "https://workspace.example.test/dispatch/_agent-native/a2a",
+    });
+
+    fetchMock.mockClear();
+    const appsWithoutCards = await action.run({
+      includeAgentCards: "false",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(appsWithoutCards[0]).not.toHaveProperty("agentCardUrl");
+    expect(appsWithoutCards[0]).not.toHaveProperty("a2aEndpointUrl");
+  });
+
   it("optionally probes ready app agent cards and returns A2A metadata", async () => {
     process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON = JSON.stringify({
       apps: [


### PR DESCRIPTION
## Summary\n- make Dispatch's list-workspace-apps action return agent-card/A2A metadata by default for agent calls while UI polling opts out\n- include agent-card metadata in Dispatch view-screen context\n- export explicit workspace-core default server plugins so generated workspaces avoid inherited-plugin build warnings\n- generalize downstream LLM credential failures in call-agent/production-agent responses\n- bump @agent-native/core to 0.7.66\n\n## Verification\n- pnpm --filter dispatch test\n- pnpm --filter dispatch typecheck\n- pnpm --filter @agent-native/core test\n- pnpm --filter @agent-native/core typecheck\n- pnpm --filter @agent-native/core build\n- pnpm guards