### PR TITLE
Fix Google-only auth onboarding copy

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1074,6 +1074,16 @@ describe("server/auth", () => {
       expect(html).not.toContain("Waiting for sign-in");
     });
 
+    it("uses sign-in copy when only Google auth is enabled", async () => {
+      const { getOnboardingHtml } = await import("./onboarding-html.js");
+      const html = getOnboardingHtml({ googleOnly: true });
+
+      expect(html).toContain('<h1 id="heading">Sign in</h1>');
+      expect(html).toContain("Use your workspace Google account to continue");
+      expect(html).not.toContain("Create an account to get started");
+      expect(html).not.toContain('data-tab="signup"');
+    });
+
     it("renders marketing assets under APP_BASE_PATH", async () => {
       vi.stubEnv("APP_BASE_PATH", "/dispatch");
       const { getOnboardingHtml } = await import("./onboarding-html.js");

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -593,8 +593,8 @@ ${marketingStyles}
 <body${hasMarketing ? ' class="has-marketing"' : ""}>
 ${marketingPanelHtml}
 <div class="card">
-  <h1 id="heading">Welcome</h1>
-  <p class="subtitle" id="subtitle">Create an account to get started</p>
+  <h1 id="heading">${googleOnly ? "Sign in" : "Welcome"}</h1>
+  <p class="subtitle" id="subtitle">${googleOnly ? "Use your workspace Google account to continue" : "Create an account to get started"}</p>
   <p
     class="upgrade-note"
     id="upgrade-note"


### PR DESCRIPTION
## Summary\n- use sign-in copy when googleOnly auth is enabled\n- add a regression test so workspace apps do not show account-creation language when email/password auth is hidden\n- bump @agent-native/core to 0.7.67\n\n## Verification\n- pnpm --filter @agent-native/core test -- src/server/auth.spec.ts\n- pnpm --filter @agent-native/core typecheck\n- pnpm --filter @agent-native/core build\n- pnpm guards