### PR TITLE
Verify listed slide deck URLs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.68",
+  "version": "0.7.69",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/artifact-response.spec.ts
+++ b/packages/core/src/a2a/artifact-response.spec.ts
@@ -157,6 +157,67 @@ describe("appendA2AArtifactLinks", () => {
     );
   });
 
+  it("treats list-decks results as verified read-only deck artifacts", () => {
+    const text = appendA2AArtifactLinks(
+      "Existing deck: https://slides.agent-native.com/deck/deck_123",
+      [
+        {
+          tool: "list-decks",
+          result: JSON.stringify({
+            count: 1,
+            decks: [
+              {
+                id: "deck_123",
+                title: "Builder Workspace Slack QA Deck",
+                url: "https://slides.agent-native.com/deck/deck_123",
+                slideCount: 7,
+              },
+            ],
+          }),
+        },
+      ],
+      {
+        baseUrl: "https://slides.agent-native.com",
+        includeReferencedArtifacts: true,
+      },
+    );
+
+    expect(text).toContain(
+      "Existing deck: https://slides.agent-native.com/deck/deck_123",
+    );
+    expect(text).toContain(
+      "Artifacts:\n- Deck: https://slides.agent-native.com/deck/deck_123 (ID: deck_123)",
+    );
+    expect(text).not.toContain("could not verify");
+  });
+
+  it("does not let list-decks verify deck URLs for IDs that were not listed", () => {
+    const text = appendA2AArtifactLinks(
+      "Existing deck: https://slides.agent-native.com/deck/deck_fake",
+      [
+        {
+          tool: "list-decks",
+          result: JSON.stringify({
+            count: 1,
+            decks: [
+              {
+                id: "deck_real",
+                title: "Real Deck",
+                url: "https://slides.agent-native.com/deck/deck_real",
+                slideCount: 7,
+              },
+            ],
+          }),
+        },
+      ],
+      { baseUrl: "https://slides.agent-native.com" },
+    );
+
+    expect(text).toContain("could not verify the deck URL");
+    expect(text).not.toContain("deck_fake");
+    expect(text).toContain("https://slides.agent-native.com/deck/deck_real");
+  });
+
   it("blocks hallucinated deck URLs with no successful deck action", () => {
     const text = appendA2AArtifactLinks(
       "Done: https://slides.agent.test/deck/deck_404",

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -147,6 +147,33 @@ function isReadyDeckArtifact(parsed: Record<string, unknown>): boolean {
   return true;
 }
 
+function addDeckArtifact(
+  decks: Map<string, CreatedDeckArtifact>,
+  parsed: Record<string, unknown>,
+  options: { requireReady: boolean },
+): void {
+  const id = deckIdValue(parsed);
+  if (!id) return;
+  if (options.requireReady && !isReadyDeckArtifact(parsed)) return;
+  decks.set(id, {
+    id,
+    url: stringValue(parsed.url) ?? stringValue(parsed.urlPath),
+  });
+}
+
+function addListedDeckArtifacts(
+  decks: Map<string, CreatedDeckArtifact>,
+  parsed: Record<string, unknown>,
+): void {
+  const items = parsed.decks;
+  if (!Array.isArray(items)) return;
+  for (const item of items) {
+    const deck = asRecord(item);
+    if (!deck) continue;
+    addDeckArtifact(decks, deck, { requireReady: false });
+  }
+}
+
 function collectArtifacts(results: A2AToolResultSummary[]): {
   documents: CreatedDocumentArtifact[];
   decks: CreatedDeckArtifact[];
@@ -204,16 +231,19 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
 
     if (
       toolResult.tool === "create-deck" ||
-      toolResult.tool === "get-deck" ||
       toolResult.tool === "duplicate-deck"
     ) {
-      const id = deckIdValue(parsed);
-      if (id && isReadyDeckArtifact(parsed)) {
-        decks.set(id, {
-          id,
-          url: stringValue(parsed.url) ?? stringValue(parsed.urlPath),
-        });
-      }
+      addDeckArtifact(decks, parsed, { requireReady: true });
+      continue;
+    }
+
+    if (toolResult.tool === "get-deck") {
+      addDeckArtifact(decks, parsed, { requireReady: false });
+      continue;
+    }
+
+    if (toolResult.tool === "list-decks") {
+      addListedDeckArtifacts(decks, parsed);
       continue;
     }
 

--- a/templates/slides/actions/list-decks.test.ts
+++ b/templates/slides/actions/list-decks.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const deckRows = [
+  {
+    id: "deck_123",
+    title: "Roadmap",
+    data: JSON.stringify({ slides: [{ id: "slide-1" }] }),
+    visibility: "private",
+    designSystemId: null,
+    createdAt: "2026-05-03T00:00:00.000Z",
+    updatedAt: "2026-05-03T00:00:00.000Z",
+  },
+];
+
+const orderByFn = vi.fn(async () => deckRows);
+const whereFn = vi.fn(() => ({ orderBy: orderByFn }));
+const fromFn = vi.fn(() => ({ where: whereFn }));
+const selectFn = vi.fn(() => ({ from: fromFn }));
+const mockDb = { select: selectFn };
+
+vi.mock("../server/db/index.js", () => ({
+  getDb: () => mockDb,
+  schema: {
+    decks: { updatedAt: "updated_at_col" },
+    deckShares: {},
+  },
+}));
+
+vi.mock("@agent-native/core/sharing", () => ({
+  accessFilter: () => ({ allowed: true }),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  desc: (value: unknown) => ({ desc: value }),
+}));
+
+import action from "./list-decks";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("APP_URL", "https://slides.agent.test");
+});
+
+describe("list-decks", () => {
+  it("returns canonical deck URLs for A2A artifact verification", async () => {
+    const result = await action.run({});
+
+    expect(result.decks[0]).toMatchObject({
+      id: "deck_123",
+      title: "Roadmap",
+      url: "https://slides.agent.test/deck/deck_123",
+      slideCount: 1,
+    });
+  });
+
+  it("includes URLs in compact output too", async () => {
+    const result = await action.run({ compact: "true" });
+
+    expect(result.decks[0]).toMatchObject({
+      id: "deck_123",
+      url: "https://slides.agent.test/deck/deck_123",
+    });
+  });
+});

--- a/templates/slides/actions/list-decks.ts
+++ b/templates/slides/actions/list-decks.ts
@@ -3,6 +3,7 @@ import { desc } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import { accessFilter } from "@agent-native/core/sharing";
 import { z } from "zod";
+import { getDeckUrl } from "./_app-url.js";
 
 export default defineAction({
   description: "List all decks from the database with metadata.",
@@ -32,6 +33,7 @@ export default defineAction({
         return {
           id: row.id,
           title: row.title,
+          url: getDeckUrl(row.id),
           slideCount: slides?.length ?? 0,
           visibility: row.visibility,
           designSystemId: row.designSystemId ?? null,
@@ -40,6 +42,7 @@ export default defineAction({
       return {
         id: row.id,
         title: row.title,
+        url: getDeckUrl(row.id),
         slideCount: slides?.length ?? 0,
         visibility: row.visibility,
         designSystemId: row.designSystemId ?? null,


### PR DESCRIPTION
## Summary
- include canonical deck URLs in the Slides list-decks action
- treat list-decks/get-deck results as trusted deck artifacts only for action-backed IDs
- keep hallucinated or mismatched deck URLs blocked
- bump @agent-native/core to 0.7.69

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/a2a/artifact-response.spec.ts
- pnpm --filter slides exec vitest --run actions/list-decks.test.ts
- pnpm --filter @agent-native/core build
- pnpm --filter @agent-native/core typecheck
- pnpm --filter slides typecheck
- pnpm guards
