### PR TITLE
Align slides Netlify function timeout with agent run soft timeout

### DIFF
--- a/templates/slides/netlify.toml
+++ b/templates/slides/netlify.toml
@@ -9,6 +9,9 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Use Netlify's current standard synchronous function budget.
+# Aligned with the agent-run soft timeout in
+# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# so the framework's friendly "run_timeout" event fires before Netlify kills
+# the function.
 [functions."*"]
-  timeout = 60
+  timeout = 75


### PR DESCRIPTION
## Summary
- Bump `[functions."*"] timeout` in `templates/slides/netlify.toml` from `60` → `75` so it matches `DEFAULT_RUN_SOFT_TIMEOUT_MS` (75_000) in `packages/core/src/agent/run-manager.ts:32`.
- Previously the Netlify function was killed 15s before the framework's `run_timeout` event could fire, depriving users of the friendly "run exceeded 75 seconds, partial output preserved" UX the soft timeout is designed to deliver.
- Comment updated to point future readers at the source-of-truth constant instead of the prior "current standard synchronous function budget" rationale.

The deeper fix (splitting heavy slides ops like `generate-slides-ai` and batch image generation into background jobs) is being discussed separately with the engineering team — this PR just removes the platform-level cap that made the situation worse.

## Test plan
- [ ] Inspect `templates/slides/netlify.toml` diff: single value bump (`60` → `75`) and refreshed comment, no other edits.
- [ ] CI / `pnpm prep` green (no template-list, drizzle-push, or unscoped-query guards touch this file).
- [ ] After deploy, an agent run that previously got cut around 60s now reaches 75s and surfaces the framework's `run_timeout` warning panel instead of being silently killed by the platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)