### PR TITLE
Prevent blank Slack replies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.69",
+  "version": "0.7.70",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/integrations/adapters/slack.spec.ts
+++ b/packages/core/src/integrations/adapters/slack.spec.ts
@@ -153,6 +153,131 @@ describe("slackAdapter", () => {
     ).toBe(true);
   });
 
+  it("does not send whitespace-only Slack replies", async () => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    const deliveryUrls: string[] = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        deliveryUrls.push(String(url));
+        return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+      }),
+    );
+
+    await slackAdapter().sendResponse(
+      { text: " \n\t ", platformContext: {} },
+      {
+        platform: "slack",
+        externalThreadId: "C123:123.456",
+        text: "ask starter",
+        timestamp: 1,
+        platformContext: { channelId: "C123", threadTs: "123.456" },
+      },
+    );
+
+    expect(
+      deliveryUrls.some(
+        (url) =>
+          url.includes("chat.postMessage") || url.includes("chat.update"),
+      ),
+    ).toBe(false);
+  });
+
+  it("drops blank Slack chunks and still sends non-empty content", async () => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    const deliveryBodies: any[] = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (String(url).includes("chat.postMessage")) {
+          deliveryBodies.push(JSON.parse(String(init?.body ?? "{}")));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+      }),
+    );
+
+    await slackAdapter().sendResponse(
+      {
+        text: `${" ".repeat(4001)}Deck: https://example.com/decks/qa`,
+        platformContext: {},
+      },
+      {
+        platform: "slack",
+        externalThreadId: "C123:123.456",
+        text: "ask slides",
+        timestamp: 1,
+        platformContext: { channelId: "C123", threadTs: "123.456" },
+      },
+    );
+
+    expect(deliveryBodies).toHaveLength(1);
+    expect(deliveryBodies[0].text).toBe("Deck: https://example.com/decks/qa");
+  });
+
+  it("does not send whitespace-only proactive Slack messages", async () => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    const deliveryUrls: string[] = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        deliveryUrls.push(String(url));
+        return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+      }),
+    );
+
+    await slackAdapter().sendMessageToTarget?.(
+      { text: "\n\n ", platformContext: {} },
+      { platform: "slack", destination: "C123" },
+    );
+
+    expect(deliveryUrls.some((url) => url.includes("chat.postMessage"))).toBe(
+      false,
+    );
+  });
+
+  it("keeps block-rich Slack replies when fallback text is blank", async () => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    const deliveryBodies: any[] = [];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (String(url).includes("chat.postMessage")) {
+          deliveryBodies.push(JSON.parse(String(init?.body ?? "{}")));
+        }
+        return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+      }),
+    );
+
+    const blocks = [
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "Deck is ready." },
+      },
+    ];
+
+    await slackAdapter().sendResponse(
+      {
+        text: " ",
+        platformContext: { blocks },
+      },
+      {
+        platform: "slack",
+        externalThreadId: "C123:123.456",
+        text: "ask slides",
+        timestamp: 1,
+        platformContext: { channelId: "C123", threadTs: "123.456" },
+      },
+    );
+
+    expect(deliveryBodies).toHaveLength(1);
+    expect(deliveryBodies[0].text).toBe("Response");
+    expect(deliveryBodies[0].blocks).toEqual(blocks);
+  });
+
   it("splits Slack section blocks by UTF-8 bytes, not JS character length", async () => {
     process.env.SLACK_BOT_TOKEN = "xoxb-test";
     const deliveryBodies: any[] = [];

--- a/packages/core/src/integrations/adapters/slack.ts
+++ b/packages/core/src/integrations/adapters/slack.ts
@@ -220,8 +220,15 @@ export function slackAdapter(): PlatformAdapter {
       // Block-rich path: split text into chunks but render the FIRST chunk as
       // blocks (so we keep the in-place edit + button) and any overflow as
       // plain follow-up posts. The vast majority of replies fit in one block.
-      const chunks = splitMessage(message.text, SLACK_MAX_LENGTH);
-      const firstChunk = chunks[0] ?? "";
+      const chunks = splitNonEmptyMessage(message.text, SLACK_MAX_LENGTH);
+      const hasProvidedBlocks = Array.isArray(blocks) && blocks.length > 0;
+      const firstChunk = chunks[0] ?? (hasProvidedBlocks ? "Response" : "");
+      if (!firstChunk) {
+        if (threadTs) {
+          setSlackAssistantStatus(token, channelId, threadTs, "");
+        }
+        return;
+      }
       const restChunks = chunks.slice(1);
 
       const finalBlocks =
@@ -296,7 +303,8 @@ export function slackAdapter(): PlatformAdapter {
         return;
       }
 
-      const chunks = splitMessage(message.text, SLACK_MAX_LENGTH);
+      const chunks = splitNonEmptyMessage(message.text, SLACK_MAX_LENGTH);
+      if (chunks.length === 0) return;
       for (const chunk of chunks) {
         const body: Record<string, unknown> = {
           channel: target.destination,
@@ -517,6 +525,13 @@ function splitMessage(text: string, maxLength: number): string[] {
   return chunks;
 }
 
+/** Split a message and drop chunks Slack would render as blank messages. */
+function splitNonEmptyMessage(text: string, maxLength: number): string[] {
+  return splitMessage(text, maxLength).filter(
+    (chunk) => chunk.trim().length > 0,
+  );
+}
+
 /** Hard cap on input length we feed to the regex-based mrkdwn converter.
  *  L2 in the webhook audit: `\*\*(.+?)\*\*` with the `s` flag on a long
  *  string of asterisks can exhibit super-linear backtracking. Slack
@@ -622,6 +637,16 @@ async function postFresh(
   threadTs: string | undefined,
   body: Record<string, unknown>,
 ): Promise<void> {
+  const hasBlocks =
+    Array.isArray(body.blocks) && (body.blocks as unknown[]).length > 0;
+  if (
+    typeof body.text === "string" &&
+    body.text.trim().length === 0 &&
+    !hasBlocks
+  ) {
+    return;
+  }
+
   const payload: Record<string, unknown> = {
     ...body,
     channel: channelId,


### PR DESCRIPTION
## Summary
- drop whitespace-only Slack response chunks before posting
- skip empty proactive Slack sends
- keep block-rich responses deliverable even when fallback text is blank
- bump @agent-native/core to 0.7.70

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/integrations/adapters/slack.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- pnpm guards
- git diff --check
