### PR TITLE
Harden Slack queue claims and Builder branch URLs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.70",
+  "version": "0.7.71",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -211,6 +211,43 @@ describe("A2A continuation processor", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it("expands relative URLs against the agent public base, not the A2A endpoint", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({
+        agentName: "Analytics",
+        agentUrl:
+          "https://agent-workspace.builder.io/analytics/_agent-native/a2a",
+      }),
+    );
+    getTaskMock.mockResolvedValueOnce({
+      id: "a2a-task-1",
+      status: {
+        state: "completed",
+        message: {
+          role: "agent",
+          parts: [{ type: "text", text: "Report: /analyses/qa-report" }],
+        },
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Report: https://agent-workspace.builder.io/analytics/analyses/qa-report",
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+  });
+
   it("blocks unverified completed production artifact URLs before posting continuations", async () => {
     const sendResponse = vi.fn(async () => undefined);
     claimA2AContinuationMock.mockResolvedValueOnce(continuation());
@@ -379,7 +416,7 @@ describe("A2A continuation processor", () => {
     expect(A2AClientMock).toHaveBeenCalledWith(
       "https://slides.agent-native.test",
       "original-opaque-a2a-token",
-      { requestTimeoutMs: 25_000 },
+      { requestTimeoutMs: 8_000 },
     );
     expect(signA2ATokenMock).not.toHaveBeenCalled();
     expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
@@ -407,7 +444,7 @@ describe("A2A continuation processor", () => {
     expect(A2AClientMock).toHaveBeenCalledWith(
       "https://slides.agent-native.test",
       "signed-a2a-token",
-      { requestTimeoutMs: 25_000 },
+      { requestTimeoutMs: 8_000 },
     );
     expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
   });
@@ -427,7 +464,7 @@ describe("A2A continuation processor", () => {
     expect(A2AClientMock).toHaveBeenCalledWith(
       "https://slides.agent-native.test",
       undefined,
-      { requestTimeoutMs: 25_000 },
+      { requestTimeoutMs: 8_000 },
     );
     expect(signA2ATokenMock).not.toHaveBeenCalled();
     expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
@@ -504,9 +541,7 @@ describe("A2A continuation processor", () => {
   it("backs off a still-working remote task without chaining self-dispatches", async () => {
     vi.useFakeTimers();
     const sendResponse = vi.fn(async () => undefined);
-    claimA2AContinuationMock.mockResolvedValueOnce(
-      continuation({ attempts: 12 }),
-    );
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
     getTaskMock.mockResolvedValue({
       id: "a2a-task-1",
       status: {
@@ -529,6 +564,47 @@ describe("A2A continuation processor", () => {
       "cont-1",
       60_000,
     );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("notifies the platform when a still-working remote task exhausts polling attempts", async () => {
+    vi.useFakeTimers();
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ attempts: 6 }),
+    );
+    getTaskMock.mockResolvedValue({
+      id: "a2a-task-1",
+      status: {
+        state: "working",
+        timestamp: new Date().toISOString(),
+      },
+    });
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    const processing = processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+    await vi.advanceTimersByTimeAsync(10_000);
+    await processing;
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining(
+          "The Slides agent could not finish this request: Timed out polling the Slides A2A task a2a-task-1 after 6 attempts",
+        ),
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(failA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      expect.stringContaining(
+        "Timed out polling the Slides A2A task a2a-task-1 after 6 attempts",
+      ),
+    );
+    expect(rescheduleA2AContinuationMock).not.toHaveBeenCalled();
     expect(fetch).not.toHaveBeenCalled();
   });
 
@@ -576,11 +652,9 @@ describe("A2A continuation processor", () => {
     expect(failA2AContinuationMock).not.toHaveBeenCalled();
   });
 
-  it("treats aborted task polling as transient until the remote work deadline", async () => {
+  it("treats aborted task polling as transient while attempts remain", async () => {
     const sendResponse = vi.fn(async () => undefined);
-    claimA2AContinuationMock.mockResolvedValueOnce(
-      continuation({ attempts: 99 }),
-    );
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
     getTaskMock.mockRejectedValueOnce(
       new DOMException("This operation was aborted", "AbortError"),
     );
@@ -600,7 +674,41 @@ describe("A2A continuation processor", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("treats A2A token rejection during polling as transient until the remote work deadline", async () => {
+  it("notifies the platform when transient polling errors exhaust attempts", async () => {
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ attempts: 6 }),
+    );
+    getTaskMock.mockRejectedValueOnce(
+      new DOMException("This operation was aborted", "AbortError"),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining(
+          "The Slides agent could not finish this request: Timed out polling the Slides A2A task a2a-task-1 after 6 attempts",
+        ),
+      }),
+      expect.any(Object),
+      { placeholderRef: undefined },
+    );
+    expect(failA2AContinuationMock).toHaveBeenCalledWith(
+      "cont-1",
+      expect.stringContaining(
+        "Timed out polling the Slides A2A task a2a-task-1 after 6 attempts",
+      ),
+    );
+    expect(rescheduleA2AContinuationMock).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("treats A2A token rejection during polling as transient while attempts remain", async () => {
     const sendResponse = vi.fn(async () => undefined);
     claimA2AContinuationMock.mockResolvedValueOnce(continuation());
     getTaskMock.mockRejectedValueOnce(
@@ -624,11 +732,9 @@ describe("A2A continuation processor", () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("treats Netlify loop-protection 508s as transient until the remote work deadline", async () => {
+  it("treats Netlify loop-protection 508s as transient while attempts remain", async () => {
     const sendResponse = vi.fn(async () => undefined);
-    claimA2AContinuationMock.mockResolvedValueOnce(
-      continuation({ attempts: 99 }),
-    );
+    claimA2AContinuationMock.mockResolvedValueOnce(continuation());
     getTaskMock.mockRejectedValueOnce(
       new Error("A2A request failed (508): loop detected"),
     );
@@ -757,7 +863,7 @@ describe("A2A continuation processor", () => {
     expect(sendResponse).toHaveBeenCalledWith(
       expect.objectContaining({
         text: expect.stringContaining(
-          "The Slides agent could not finish this request: Remote A2A task a2a-task-1 did not complete within 10 minutes",
+          "The Slides agent could not finish this request: Timed out polling the Slides A2A task a2a-task-1 after 10 minutes",
         ),
       }),
       expect.any(Object),
@@ -765,7 +871,9 @@ describe("A2A continuation processor", () => {
     );
     expect(failA2AContinuationMock).toHaveBeenCalledWith(
       "cont-1",
-      "Remote A2A task a2a-task-1 did not complete within 10 minutes",
+      expect.stringContaining(
+        "Timed out polling the Slides A2A task a2a-task-1 after 10 minutes",
+      ),
     );
   });
 

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -30,8 +30,8 @@ const MAX_REMOTE_WORK_MS = 10 * 60_000;
 const RESCHEDULE_DELAY_MS = 60_000;
 const MAX_PRE_CLAIM_WAIT_MS = 10_000;
 const POLL_INTERVAL_MS = 2_000;
-const PROCESSOR_WAIT_MS = 20_000;
-const POLL_REQUEST_TIMEOUT_MS = 25_000;
+const PROCESSOR_WAIT_MS = 10_000;
+const POLL_REQUEST_TIMEOUT_MS = 8_000;
 const PLATFORM_SEND_TIMEOUT_MS = 12_000;
 const DISPATCH_SETTLE_WAIT_MS = 2_000;
 const COMPLETE_AFTER_DELIVERY_ATTEMPTS = 3;
@@ -166,11 +166,11 @@ async function processClaimedContinuation(
     }
   } catch (err) {
     if (isTransientA2APollError(err)) {
-      if (isRemoteWorkExpired(continuation)) {
+      if (shouldStopPollingRemoteTask(continuation)) {
         await notifyAndFailA2AContinuation(
           continuation,
           adapter,
-          remotePollTimeoutReason(continuation),
+          remotePollFailureReason(continuation),
         );
         return;
       }
@@ -203,13 +203,11 @@ async function processClaimedContinuation(
       return;
     }
 
-    if (isRemoteWorkExpired(continuation)) {
+    if (shouldStopPollingRemoteTask(continuation)) {
       await notifyAndFailA2AContinuation(
         continuation,
         adapter,
-        `Remote A2A task ${continuation.a2aTaskId} did not complete within ${Math.round(
-          MAX_REMOTE_WORK_MS / 60_000,
-        )} minutes`,
+        remotePollFailureReason(continuation),
       );
       return;
     }
@@ -371,6 +369,12 @@ function isRemoteWorkExpired(continuation: A2AContinuation): boolean {
   return Date.now() - continuation.createdAt >= MAX_REMOTE_WORK_MS;
 }
 
+function shouldStopPollingRemoteTask(continuation: A2AContinuation): boolean {
+  return (
+    continuation.attempts >= MAX_ATTEMPTS || isRemoteWorkExpired(continuation)
+  );
+}
+
 function isTransientA2APollError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   if (err.name === "AbortError") return true;
@@ -379,10 +383,14 @@ function isTransientA2APollError(err: unknown): boolean {
   );
 }
 
-function remotePollTimeoutReason(continuation: A2AContinuation): string {
-  return `Timed out polling the ${continuation.agentName} A2A task ${continuation.a2aTaskId} after ${Math.round(
-    MAX_REMOTE_WORK_MS / 60_000,
-  )} minutes. The downstream agent did not return a final result.`;
+function remotePollFailureReason(continuation: A2AContinuation): string {
+  if (isRemoteWorkExpired(continuation)) {
+    return `Timed out polling the ${continuation.agentName} A2A task ${continuation.a2aTaskId} after ${Math.round(
+      MAX_REMOTE_WORK_MS / 60_000,
+    )} minutes. The downstream agent did not return a final result.`;
+  }
+
+  return `Timed out polling the ${continuation.agentName} A2A task ${continuation.a2aTaskId} after ${MAX_ATTEMPTS} attempts. The downstream agent did not return a final result.`;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -509,9 +517,25 @@ function resolveArtifactBaseUrl(): string | undefined {
 
 function expandRelativeUrls(text: string, agentUrl: string): string {
   if (!text || !agentUrl) return text;
-  const base = agentUrl.replace(/\/$/, "");
+  const base = publicAgentBaseUrl(agentUrl);
   return text.replace(
     /(^|[\s(\[<"'`])(\/[a-z0-9_-][a-z0-9_/?&=%#.,:-]*)/gi,
     (_match, lead, path) => `${lead}${base}${path}`,
   );
+}
+
+function publicAgentBaseUrl(agentUrl: string): string {
+  try {
+    const url = new URL(agentUrl);
+    const routeIndex = url.pathname.indexOf(FRAMEWORK_ROUTE_PREFIX);
+    url.pathname =
+      routeIndex >= 0
+        ? url.pathname.slice(0, routeIndex) || "/"
+        : url.pathname.replace(/\/+$/, "") || "/";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return agentUrl.replace(/\/$/, "");
+  }
 }

--- a/packages/core/src/integrations/pending-tasks-store.spec.ts
+++ b/packages/core/src/integrations/pending-tasks-store.spec.ts
@@ -44,6 +44,9 @@ describe("integration pending task store", () => {
           ],
         };
       }
+      if (sql.includes("UPDATE integration_pending_tasks")) {
+        return { rows: [], rowsAffected: 1 };
+      }
       return { rows: [] };
     });
 
@@ -65,6 +68,9 @@ describe("integration pending task store", () => {
     const { claimPendingTask } = await loadStore();
     executeMock.mockImplementation(async (query: string | { sql: string }) => {
       const sql = typeof query === "string" ? query : query.sql;
+      if (sql.includes("UPDATE integration_pending_tasks")) {
+        return { rows: [], rowsAffected: 0 };
+      }
       if (sql.includes("SELECT id, platform")) {
         return {
           rows: [
@@ -89,6 +95,45 @@ describe("integration pending task store", () => {
     });
 
     await expect(claimPendingTask("task-failed")).resolves.toBeNull();
+  });
+
+  it("returns null when a SQLite claim loses the conditional update race", async () => {
+    const { claimPendingTask } = await loadStore();
+    executeMock.mockImplementation(async (query: string | { sql: string }) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (sql.includes("UPDATE integration_pending_tasks")) {
+        return { rows: [], rowsAffected: 0 };
+      }
+      if (sql.includes("SELECT id, platform")) {
+        return {
+          rows: [
+            {
+              id: "task-raced",
+              platform: "slack",
+              external_thread_id: "thread-1",
+              payload: "{}",
+              owner_email: "alice+qa@agent-native.test",
+              org_id: null,
+              status: "processing",
+              attempts: 1,
+              error_message: null,
+              created_at: 1,
+              updated_at: 2,
+              completed_at: null,
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    await expect(claimPendingTask("task-raced")).resolves.toBeNull();
+
+    const selectCall = executeMock.mock.calls.find(([query]) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      return sql.includes("SELECT id, platform");
+    });
+    expect(selectCall).toBeUndefined();
   });
 
   it("does not claim failed tasks on the Postgres RETURNING path", async () => {

--- a/packages/core/src/integrations/pending-tasks-store.ts
+++ b/packages/core/src/integrations/pending-tasks-store.ts
@@ -206,7 +206,7 @@ export async function claimPendingTask(
 
   // Conditional update: only flip if currently pending. Failed tasks are
   // terminal unless an explicit retry path resets them to pending first.
-  const { rows } = await client.execute({
+  const result = await client.execute({
     sql: isPostgres()
       ? `UPDATE integration_pending_tasks
          SET status = ?, attempts = attempts + 1, updated_at = ?
@@ -217,6 +217,7 @@ export async function claimPendingTask(
          WHERE id = ? AND status = 'pending'`,
     args: ["processing", now, id],
   });
+  const rows = result.rows ?? [];
 
   if (isPostgres()) {
     if (rows.length === 0) return null;
@@ -225,6 +226,10 @@ export async function claimPendingTask(
 
   // SQLite: no RETURNING, so re-read after the update. Confirm we actually
   // moved it into 'processing' (vs. lost the race).
+  const affected =
+    (result as { rowsAffected?: number; rowCount?: number }).rowsAffected ??
+    (result as { rowsAffected?: number; rowCount?: number }).rowCount;
+  if (affected === 0) return null;
   const fetched = await getPendingTask(id);
   if (!fetched || fetched.status !== "processing") return null;
   return fetched;

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -332,5 +332,92 @@ describe("Builder callback CSRF state", () => {
       expect(body.userId).toBe("builder-user-123");
       expect(body.userEmail).toBeUndefined();
     });
+
+    it("rejects a blank branchName from Builder instead of returning an unusable run", async () => {
+      process.env.BUILDER_PRIVATE_KEY = "bpk-test";
+      process.env.BUILDER_PUBLIC_KEY = "pub-test";
+      process.env.BUILDER_USER_ID = "builder-user-123";
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              branchName: " ",
+              projectId: "project-123",
+              url: "https://builder.io/app/projects/project-123/branch/qa",
+              status: "processing",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      );
+
+      await expect(
+        runBuilderAgent({
+          prompt: "Create an app",
+          projectId: "project-123",
+          userEmail: "dispatch+slack@integration.local",
+        }),
+      ).rejects.toThrow("Builder agent run returned a blank branchName");
+    });
+
+    it("rejects a malformed Builder branch URL instead of returning it", async () => {
+      process.env.BUILDER_PRIVATE_KEY = "bpk-test";
+      process.env.BUILDER_PUBLIC_KEY = "pub-test";
+      process.env.BUILDER_USER_ID = "builder-user-123";
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              branchName: "qa-branch",
+              projectId: "project-123",
+              url: "not a url",
+              status: "processing",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      );
+
+      await expect(
+        runBuilderAgent({
+          prompt: "Create an app",
+          projectId: "project-123",
+          userEmail: "dispatch+slack@integration.local",
+        }),
+      ).rejects.toThrow("Builder agent run returned a malformed url");
+    });
+
+    it("rejects a non-Builder branch URL instead of returning it", async () => {
+      process.env.BUILDER_PRIVATE_KEY = "bpk-test";
+      process.env.BUILDER_PUBLIC_KEY = "pub-test";
+      process.env.BUILDER_USER_ID = "builder-user-123";
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              branchName: "qa-branch",
+              projectId: "project-123",
+              url: "https://example.com/branch",
+              status: "processing",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      );
+
+      await expect(
+        runBuilderAgent({
+          prompt: "Create an app",
+          projectId: "project-123",
+          userEmail: "dispatch+slack@integration.local",
+        }),
+      ).rejects.toThrow("Builder agent run returned a non-Builder url");
+    });
   });
 });

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -463,6 +463,37 @@ export interface RunBuilderAgentResult {
   status: string;
 }
 
+function normalizeBuilderApiString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`Builder agent run returned a blank ${fieldName}`);
+  }
+  const trimmed = value.trim();
+  if (/[\u0000-\u001f\u007f]/.test(trimmed)) {
+    throw new Error(`Builder agent run returned a malformed ${fieldName}`);
+  }
+  return trimmed;
+}
+
+function normalizeBuilderBranchUrl(value: unknown): string {
+  const urlString = normalizeBuilderApiString(value, "url");
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    throw new Error("Builder agent run returned a malformed url");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("Builder agent run returned a malformed url");
+  }
+  if (
+    parsed.hostname !== "builder.io" &&
+    !parsed.hostname.endsWith(".builder.io")
+  ) {
+    throw new Error("Builder agent run returned a non-Builder url");
+  }
+  return parsed.toString();
+}
+
 /**
  * POST a prompt to the Builder agents-run API. The Builder agent runs in a
  * cloud sandbox and writes code to a branch; the returned URL opens that
@@ -527,10 +558,16 @@ export async function runBuilderAgent(
   }
 
   return {
-    branchName: String(parsed.branchName ?? ""),
-    projectId: String(parsed.projectId ?? ""),
-    url: String(parsed.url ?? ""),
-    status: String(parsed.status ?? "processing"),
+    branchName: normalizeBuilderApiString(parsed.branchName, "branchName"),
+    projectId:
+      typeof parsed.projectId === "string" && parsed.projectId.trim()
+        ? parsed.projectId.trim()
+        : projectId,
+    url: normalizeBuilderBranchUrl(parsed.url),
+    status:
+      typeof parsed.status === "string" && parsed.status.trim()
+        ? parsed.status.trim()
+        : "processing",
   };
 }
 

--- a/templates/dispatch/server/lib/app-creation-store.spec.ts
+++ b/templates/dispatch/server/lib/app-creation-store.spec.ts
@@ -149,6 +149,81 @@ describe("startWorkspaceAppCreation", () => {
     expect(builderPrompt).toContain("agent card/A2A metadata");
   });
 
+  it("does not record pending apps when Builder returns a blank branchName", async () => {
+    runBuilderAgentMock.mockResolvedValue({
+      branchName: "",
+      url: "https://builder.io/branch",
+      status: "started",
+    });
+    const { startWorkspaceAppCreation } =
+      await import("./app-creation-store.js");
+
+    const result = await startWorkspaceAppCreation({
+      prompt: "make a QA dashboard",
+      appId: "qa-dashboard",
+    });
+
+    expect(result).toMatchObject({
+      mode: "builder-unavailable",
+      appId: "qa-dashboard",
+      message: expect.stringContaining(
+        "Builder app creation returned a blank branchName",
+      ),
+    });
+    expect(putSettingMock).not.toHaveBeenCalled();
+    expect(createRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("does not record pending apps when Builder returns a malformed branch URL", async () => {
+    runBuilderAgentMock.mockResolvedValue({
+      branchName: "branch",
+      url: "not a builder branch url",
+      status: "started",
+    });
+    const { startWorkspaceAppCreation } =
+      await import("./app-creation-store.js");
+
+    const result = await startWorkspaceAppCreation({
+      prompt: "make a QA dashboard",
+      appId: "qa-dashboard",
+    });
+
+    expect(result).toMatchObject({
+      mode: "builder-unavailable",
+      appId: "qa-dashboard",
+      message: expect.stringContaining(
+        "Builder app creation returned a malformed url",
+      ),
+    });
+    expect(putSettingMock).not.toHaveBeenCalled();
+    expect(createRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("does not record pending apps when Builder returns a non-Builder branch URL", async () => {
+    runBuilderAgentMock.mockResolvedValue({
+      branchName: "branch",
+      url: "https://example.com/branch",
+      status: "started",
+    });
+    const { startWorkspaceAppCreation } =
+      await import("./app-creation-store.js");
+
+    const result = await startWorkspaceAppCreation({
+      prompt: "make a QA dashboard",
+      appId: "qa-dashboard",
+    });
+
+    expect(result).toMatchObject({
+      mode: "builder-unavailable",
+      appId: "qa-dashboard",
+      message: expect.stringContaining(
+        "Builder app creation returned a non-Builder url",
+      ),
+    });
+    expect(putSettingMock).not.toHaveBeenCalled();
+    expect(createRequestMock).not.toHaveBeenCalled();
+  });
+
   it("blocks remote Builder starts for synthetic integration owners", async () => {
     currentOwnerEmailMock.mockReturnValue(
       "dispatch+abc123def4567890@integration.local",

--- a/templates/dispatch/server/lib/app-creation-store.ts
+++ b/templates/dispatch/server/lib/app-creation-store.ts
@@ -616,6 +616,56 @@ function isSyntheticIntegrationOwner(ownerEmail: string): boolean {
   );
 }
 
+function normalizeBuilderRunString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`Builder app creation returned a blank ${fieldName}`);
+  }
+  const trimmed = value.trim();
+  if (/[\u0000-\u001f\u007f]/.test(trimmed)) {
+    throw new Error(`Builder app creation returned a malformed ${fieldName}`);
+  }
+  return trimmed;
+}
+
+function normalizeBuilderRunUrl(value: unknown): string {
+  const urlString = normalizeBuilderRunString(value, "url");
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    throw new Error("Builder app creation returned a malformed url");
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("Builder app creation returned a malformed url");
+  }
+  if (
+    parsed.hostname !== "builder.io" &&
+    !parsed.hostname.endsWith(".builder.io")
+  ) {
+    throw new Error("Builder app creation returned a non-Builder url");
+  }
+  return parsed.toString();
+}
+
+function normalizeBuilderRunResult(result: unknown): {
+  branchName: string;
+  url: string;
+  status: string;
+} {
+  const record =
+    result && typeof result === "object" && !Array.isArray(result)
+      ? (result as Record<string, unknown>)
+      : {};
+  return {
+    branchName: normalizeBuilderRunString(record.branchName, "branchName"),
+    url: normalizeBuilderRunUrl(record.url),
+    status:
+      typeof record.status === "string" && record.status.trim()
+        ? record.status.trim()
+        : "processing",
+  };
+}
+
 function remoteAppCreationAuthorization():
   | { ok: true }
   | { ok: false; message: string } {
@@ -756,17 +806,23 @@ export async function startWorkspaceAppCreation(input: {
     };
   }
 
-  let result;
+  let result: {
+    branchName: string;
+    url: string;
+    status: string;
+  };
   try {
     const builderCreds = await resolveBuilderCredentials().catch(() => null);
     const builderUserId = builderCreds?.userId || undefined;
-    result = await runBuilderAgent({
-      prompt,
-      projectId: settings.builderProjectId,
-      ...(builderUserId
-        ? { userId: builderUserId }
-        : { userEmail: currentOwnerEmail() }),
-    });
+    result = normalizeBuilderRunResult(
+      await runBuilderAgent({
+        prompt,
+        projectId: settings.builderProjectId,
+        ...(builderUserId
+          ? { userId: builderUserId }
+          : { userEmail: currentOwnerEmail() }),
+      }),
+    );
   } catch (err) {
     const detail =
       err instanceof Error && err.message


### PR DESCRIPTION
## Summary
- make SQLite integration task claims return null when the conditional claim update loses the race
- validate Builder agent branchName/url outputs before returning or recording branch results
- reject non-Builder branch URLs from app creation instead of storing bogus pending app records
- notify Slack/integrations when A2A continuations exhaust retries or remote work times out instead of silently rescheduling forever
- expand downstream relative URLs against the agent app public base, not the A2A endpoint
- bump @agent-native/core to 0.7.71

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/integrations/pending-tasks-store.spec.ts src/server/builder-browser.spec.ts
- pnpm --filter dispatch exec vitest --run server/lib/app-creation-store.spec.ts
- pnpm --filter @agent-native/core exec vitest --run src/integrations/a2a-continuation-processor.spec.ts src/integrations/a2a-continuations-store.spec.ts src/integrations/webhook-handler-engine.spec.ts src/integrations/adapters/slack.spec.ts src/a2a/client.spec.ts src/a2a/handlers.spec.ts src/a2a/task-store.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter dispatch typecheck
- pnpm --filter @agent-native/core build
- pnpm guards
- git diff --check
