### PR TITLE
Improve Dispatch app creation and prompt flows

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/artifact-response.spec.ts
+++ b/packages/core/src/a2a/artifact-response.spec.ts
@@ -70,6 +70,46 @@ describe("appendA2AArtifactLinks", () => {
     );
   });
 
+  it("treats update-dashboard as a recoverable dashboard artifact", () => {
+    const text = buildA2ARecoverableArtifactMessage(
+      [
+        {
+          tool: "update-dashboard",
+          result: JSON.stringify({
+            id: "growth-funnel",
+            name: "Growth Funnel",
+            urlPath: "/adhoc/growth-funnel",
+          }),
+        },
+      ],
+      { baseUrl: "https://analytics.agent.test/" },
+    );
+
+    expect(text).toContain(
+      '- Dashboard "Growth Funnel": https://analytics.agent.test/adhoc/growth-funnel (ID: growth-funnel)',
+    );
+  });
+
+  it("treats save-analysis as a recoverable report artifact", () => {
+    const text = buildA2ARecoverableArtifactMessage(
+      [
+        {
+          tool: "save-analysis",
+          result: JSON.stringify({
+            id: "q2-pipeline-report",
+            name: "Q2 Pipeline Report",
+            urlPath: "/analyses/q2-pipeline-report",
+          }),
+        },
+      ],
+      { baseUrl: "https://analytics.agent.test/" },
+    );
+
+    expect(text).toContain(
+      '- Report "Q2 Pipeline Report": https://analytics.agent.test/analyses/q2-pipeline-report (ID: q2-pipeline-report)',
+    );
+  });
+
   it("prefers canonical URLs returned by successful artifact actions", () => {
     const text = appendA2AArtifactLinks(
       "Created the deck.",
@@ -606,5 +646,37 @@ describe("appendA2AArtifactLinks", () => {
     );
 
     expect(text).toContain("https://content.agent.test/page/doc_123");
+  });
+
+  it("blocks unverified analytics artifact URLs on known production hosts", () => {
+    const text = appendA2AArtifactLinks(
+      "Dashboard ready: https://analytics.agent-native.com/adhoc/fake-dashboard",
+      [],
+      { baseUrl: "https://dispatch.agent-native.com" },
+    );
+
+    expect(text).toContain("could not verify the dashboard URL");
+  });
+
+  it("parses downstream dashboard and report artifact proof blocks", () => {
+    const text = appendA2AArtifactLinks(
+      "Created both.",
+      [
+        {
+          tool: "call-agent",
+          result: [
+            "Artifacts:",
+            "- Dashboard: https://analytics.agent.test/adhoc/growth-funnel (ID: growth-funnel)",
+            "- Report: https://analytics.agent.test/analyses/q2-pipeline-report (ID: q2-pipeline-report)",
+          ].join("\n"),
+        },
+      ],
+      { baseUrl: "https://dispatch.agent.test" },
+    );
+
+    expect(text).toContain("https://analytics.agent.test/adhoc/growth-funnel");
+    expect(text).toContain(
+      "https://analytics.agent.test/analyses/q2-pipeline-report",
+    );
   });
 });

--- a/packages/core/src/a2a/artifact-response.ts
+++ b/packages/core/src/a2a/artifact-response.ts
@@ -30,7 +30,24 @@ interface CreatedDeckArtifact {
   url?: string;
 }
 
-type ReferencedArtifactKind = "deck" | "design" | "document";
+interface CreatedDashboardArtifact {
+  id: string;
+  title?: string;
+  url?: string;
+}
+
+interface CreatedAnalysisArtifact {
+  id: string;
+  title?: string;
+  url?: string;
+}
+
+type ReferencedArtifactKind =
+  | "deck"
+  | "design"
+  | "document"
+  | "dashboard"
+  | "analysis";
 
 interface ReferencedArtifact {
   kind: ReferencedArtifactKind;
@@ -140,6 +157,14 @@ function deckIdValue(parsed: Record<string, unknown>): string | undefined {
   return stringValue(parsed.id) ?? stringValue(parsed.deckId);
 }
 
+function dashboardIdValue(parsed: Record<string, unknown>): string | undefined {
+  return stringValue(parsed.id) ?? stringValue(parsed.dashboardId);
+}
+
+function analysisIdValue(parsed: Record<string, unknown>): string | undefined {
+  return stringValue(parsed.id) ?? stringValue(parsed.analysisId);
+}
+
 function isReadyDeckArtifact(parsed: Record<string, unknown>): boolean {
   const slideCount = numberValue(parsed.slideCount);
   if (slideCount !== undefined) return slideCount > 0;
@@ -177,11 +202,15 @@ function addListedDeckArtifacts(
 function collectArtifacts(results: A2AToolResultSummary[]): {
   documents: CreatedDocumentArtifact[];
   decks: CreatedDeckArtifact[];
+  dashboards: CreatedDashboardArtifact[];
+  analyses: CreatedAnalysisArtifact[];
   designShells: CreatedDesignShell[];
   generatedDesigns: GeneratedDesignArtifact[];
 } {
   const documents = new Map<string, CreatedDocumentArtifact>();
   const decks = new Map<string, CreatedDeckArtifact>();
+  const dashboards = new Map<string, CreatedDashboardArtifact>();
+  const analyses = new Map<string, CreatedAnalysisArtifact>();
   const designShells = new Map<string, CreatedDesignShell>();
   const generatedDesigns = new Map<string, GeneratedDesignArtifact>();
 
@@ -195,6 +224,18 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
           });
         } else if (artifact.kind === "document") {
           documents.set(artifact.id, {
+            id: artifact.id,
+            title: artifact.title,
+            url: artifact.url,
+          });
+        } else if (artifact.kind === "dashboard") {
+          dashboards.set(artifact.id, {
+            id: artifact.id,
+            title: artifact.title,
+            url: artifact.url,
+          });
+        } else if (artifact.kind === "analysis") {
+          analyses.set(artifact.id, {
             id: artifact.id,
             title: artifact.title,
             url: artifact.url,
@@ -253,6 +294,37 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
       if (id && slideCount !== undefined && slideCount > 0) {
         decks.set(id, {
           id,
+          url: stringValue(parsed.url) ?? stringValue(parsed.urlPath),
+        });
+      }
+      continue;
+    }
+
+    if (
+      toolResult.tool === "update-dashboard" ||
+      toolResult.tool === "rename-dashboard" ||
+      toolResult.tool === "get-dashboard"
+    ) {
+      const id = dashboardIdValue(parsed);
+      if (id) {
+        dashboards.set(id, {
+          id,
+          title: stringValue(parsed.name) ?? stringValue(parsed.title),
+          url: stringValue(parsed.url) ?? stringValue(parsed.urlPath),
+        });
+      }
+      continue;
+    }
+
+    if (
+      toolResult.tool === "save-analysis" ||
+      toolResult.tool === "get-analysis"
+    ) {
+      const id = analysisIdValue(parsed);
+      if (id) {
+        analyses.set(id, {
+          id,
+          title: stringValue(parsed.name) ?? stringValue(parsed.title),
           url: stringValue(parsed.url) ?? stringValue(parsed.urlPath),
         });
       }
@@ -342,6 +414,8 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
   return {
     documents: [...documents.values()],
     decks: [...decks.values()],
+    dashboards: [...dashboards.values()],
+    analyses: [...analyses.values()],
     designShells: [...designShells.values()],
     generatedDesigns: [...generatedDesigns.values()],
   };
@@ -350,6 +424,8 @@ function collectArtifacts(results: A2AToolResultSummary[]): {
 type DownstreamArtifact =
   | { kind: "deck"; id: string; url: string }
   | { kind: "document"; id: string; url: string; title?: string }
+  | { kind: "dashboard"; id: string; url: string; title?: string }
+  | { kind: "analysis"; id: string; url: string; title?: string }
   | { kind: "design"; id: string; url: string; fileCount: number };
 
 function parseDownstreamArtifactBlock(result: string): DownstreamArtifact[] {
@@ -379,6 +455,36 @@ function parseDownstreamArtifactBlock(result: string): DownstreamArtifact[] {
         kind: "document",
         title: document[1],
         url: document[2],
+        id,
+      });
+      continue;
+    }
+
+    const dashboard = line.match(
+      /^- Dashboard(?:\s+"([^"]+)")?:\s+(\S+)\s+\(ID:\s*([A-Za-z0-9_-]+)\)$/,
+    );
+    if (dashboard) {
+      const id = dashboard[3];
+      if (!artifactUrlReferencesId(dashboard[2], "dashboard", id)) continue;
+      artifacts.push({
+        kind: "dashboard",
+        title: dashboard[1],
+        url: dashboard[2],
+        id,
+      });
+      continue;
+    }
+
+    const analysis = line.match(
+      /^- (?:Analysis|Report)(?:\s+"([^"]+)")?:\s+(\S+)\s+\(ID:\s*([A-Za-z0-9_-]+)\)$/,
+    );
+    if (analysis) {
+      const id = analysis[3];
+      if (!artifactUrlReferencesId(analysis[2], "analysis", id)) continue;
+      artifacts.push({
+        kind: "analysis",
+        title: analysis[1],
+        url: analysis[2],
         id,
       });
       continue;
@@ -453,6 +559,12 @@ function parseArtifactReferenceUrl(rawUrl: string): ReferencedArtifact | null {
   const document = path.match(/(?:^|\/)page\/([A-Za-z0-9_-]+)$/);
   if (document) return { kind: "document", id: document[1] };
 
+  const dashboard = path.match(/(?:^|\/)adhoc\/([A-Za-z0-9_-]+)$/);
+  if (dashboard) return { kind: "dashboard", id: dashboard[1] };
+
+  const analysis = path.match(/(?:^|\/)analyses\/([A-Za-z0-9_-]+)$/);
+  if (analysis) return { kind: "analysis", id: analysis[1] };
+
   return null;
 }
 
@@ -469,6 +581,24 @@ function formatDeckLine(
   baseUrl: string | undefined,
 ): string {
   return `- Deck: ${artifactUrlFromResult({ url: deck.url }, `/deck/${deck.id}`, baseUrl)} (ID: ${deck.id})`;
+}
+
+function formatDashboardLine(
+  dashboard: CreatedDashboardArtifact,
+  baseUrl: string | undefined,
+): string {
+  const label = dashboard.title
+    ? `Dashboard "${dashboard.title}"`
+    : "Dashboard";
+  return `- ${label}: ${artifactUrlFromResult({ url: dashboard.url }, `/adhoc/${dashboard.id}`, baseUrl)} (ID: ${dashboard.id})`;
+}
+
+function formatAnalysisLine(
+  analysis: CreatedAnalysisArtifact,
+  baseUrl: string | undefined,
+): string {
+  const label = analysis.title ? `Report "${analysis.title}"` : "Report";
+  return `- ${label}: ${artifactUrlFromResult({ url: analysis.url }, `/analyses/${analysis.id}`, baseUrl)} (ID: ${analysis.id})`;
 }
 
 function formatDesignLine(
@@ -496,14 +626,22 @@ function collectReferencedArtifacts(
   const refs = new Map<string, ReferencedArtifact>();
   const baseOrigin = safeOrigin(baseUrl);
   const artifactUrlPattern =
-    /(?:(https?:\/\/[^/\s<>()]+))?(?:\/[^\s<>()]*)?\/(deck|design|page)\/([A-Za-z0-9_-]+)/g;
+    /(?:(https?:\/\/[^/\s<>()]+))?(?:\/[^\s<>()]*)?\/(deck|design|page|adhoc|analyses)\/([A-Za-z0-9_-]+)/g;
 
   for (const match of text.matchAll(artifactUrlPattern)) {
     const origin = safeOrigin(match[1]);
     const route = match[2];
     const id = match[3];
     const kind: ReferencedArtifactKind =
-      route === "deck" ? "deck" : route === "design" ? "design" : "document";
+      route === "deck"
+        ? "deck"
+        : route === "design"
+          ? "design"
+          : route === "page"
+            ? "document"
+            : route === "adhoc"
+              ? "dashboard"
+              : "analysis";
     if (!shouldValidateArtifactReference(origin, baseOrigin, kind)) continue;
     refs.set(`${kind}:${id}`, { kind, id });
   }
@@ -527,6 +665,8 @@ const KNOWN_AGENT_NATIVE_ARTIFACT_HOSTS: Record<
   deck: new Set(["slides.agent-native.com"]),
   design: new Set(["design.agent-native.com"]),
   document: new Set(["content.agent-native.com"]),
+  dashboard: new Set(["analytics.agent-native.com"]),
+  analysis: new Set(["analytics.agent-native.com"]),
 };
 
 function safeHostnameFromOrigin(
@@ -556,15 +696,21 @@ function findUnverifiedArtifactReferences(
   baseUrl: string | undefined,
   documents: CreatedDocumentArtifact[],
   decks: CreatedDeckArtifact[],
+  dashboards: CreatedDashboardArtifact[],
+  analyses: CreatedAnalysisArtifact[],
   generatedDesigns: GeneratedDesignArtifact[],
 ): ReferencedArtifact[] {
   const documentIds = new Set(documents.map((document) => document.id));
   const deckIds = new Set(decks.map((deck) => deck.id));
+  const dashboardIds = new Set(dashboards.map((dashboard) => dashboard.id));
+  const analysisIds = new Set(analyses.map((analysis) => analysis.id));
   const designIds = new Set(generatedDesigns.map((design) => design.id));
 
   return collectReferencedArtifacts(text, baseUrl).filter((ref) => {
     if (ref.kind === "document") return !documentIds.has(ref.id);
     if (ref.kind === "deck") return !deckIds.has(ref.id);
+    if (ref.kind === "dashboard") return !dashboardIds.has(ref.id);
+    if (ref.kind === "analysis") return !analysisIds.has(ref.id);
     return !designIds.has(ref.id);
   });
 }
@@ -573,24 +719,34 @@ function formatUnverifiedArtifactMessage(
   refs: ReferencedArtifact[],
   documents: CreatedDocumentArtifact[],
   decks: CreatedDeckArtifact[],
+  dashboards: CreatedDashboardArtifact[],
+  analyses: CreatedAnalysisArtifact[],
   generatedDesigns: GeneratedDesignArtifact[],
   baseUrl: string | undefined,
 ): string {
   const hasOnlyDesigns = refs.every((ref) => ref.kind === "design");
   const hasOnlyDocuments = refs.every((ref) => ref.kind === "document");
   const hasOnlyDecks = refs.every((ref) => ref.kind === "deck");
+  const hasOnlyDashboards = refs.every((ref) => ref.kind === "dashboard");
+  const hasOnlyAnalyses = refs.every((ref) => ref.kind === "analysis");
   const label = hasOnlyDesigns
     ? "design URL"
     : hasOnlyDocuments
       ? "document URL"
       : hasOnlyDecks
         ? "deck URL"
-        : "artifact URL";
+        : hasOnlyDashboards
+          ? "dashboard URL"
+          : hasOnlyAnalyses
+            ? "report URL"
+            : "artifact URL";
   const plural = refs.length === 1 ? label : `${label}s`;
   const message = `I could not verify the ${plural} in the final answer against a successful artifact action that saved app data, so I cannot return it.`;
   const verifiedLines = [
     ...documents.map((document) => formatDocumentLine(document, baseUrl)),
     ...decks.map((deck) => formatDeckLine(deck, baseUrl)),
+    ...dashboards.map((dashboard) => formatDashboardLine(dashboard, baseUrl)),
+    ...analyses.map((analysis) => formatAnalysisLine(analysis, baseUrl)),
     ...generatedDesigns.map((design) => formatDesignLine(design, baseUrl)),
   ];
 
@@ -607,8 +763,14 @@ export function appendA2AArtifactLinks(
   const baseUrl = normalizeBaseUrl(options.baseUrl);
   const includeReferencedArtifacts =
     options.includeReferencedArtifacts ?? false;
-  const { documents, decks, designShells, generatedDesigns } =
-    collectArtifacts(toolResults);
+  const {
+    documents,
+    decks,
+    dashboards,
+    analyses,
+    designShells,
+    generatedDesigns,
+  } = collectArtifacts(toolResults);
   const generatedDesignIds = new Set(
     generatedDesigns.map((design) => design.id),
   );
@@ -635,6 +797,8 @@ export function appendA2AArtifactLinks(
     baseUrl,
     documents,
     decks,
+    dashboards,
+    analyses,
     generatedDesigns,
   );
   if (unverifiedRefs.length > 0) {
@@ -642,6 +806,8 @@ export function appendA2AArtifactLinks(
       unverifiedRefs,
       documents,
       decks,
+      dashboards,
+      analyses,
       generatedDesigns,
       baseUrl,
     );
@@ -666,6 +832,24 @@ export function appendA2AArtifactLinks(
       missingLines.push(formatDeckLine(deck, baseUrl));
     }
   }
+  for (const dashboard of dashboards) {
+    const path = `/adhoc/${dashboard.id}`;
+    if (
+      includeReferencedArtifacts ||
+      !responseAlreadyMentionsPath(text, path)
+    ) {
+      missingLines.push(formatDashboardLine(dashboard, baseUrl));
+    }
+  }
+  for (const analysis of analyses) {
+    const path = `/analyses/${analysis.id}`;
+    if (
+      includeReferencedArtifacts ||
+      !responseAlreadyMentionsPath(text, path)
+    ) {
+      missingLines.push(formatAnalysisLine(analysis, baseUrl));
+    }
+  }
   for (const design of generatedDesigns) {
     const path = `/design/${design.id}`;
     if (
@@ -686,10 +870,13 @@ export function buildA2ARecoverableArtifactMessage(
   options: A2AArtifactResponseOptions = {},
 ): string | null {
   const baseUrl = normalizeBaseUrl(options.baseUrl);
-  const { documents, decks, generatedDesigns } = collectArtifacts(toolResults);
+  const { documents, decks, dashboards, analyses, generatedDesigns } =
+    collectArtifacts(toolResults);
   const lines = [
     ...documents.map((document) => formatDocumentLine(document, baseUrl)),
     ...decks.map((deck) => formatDeckLine(deck, baseUrl)),
+    ...dashboards.map((dashboard) => formatDashboardLine(dashboard, baseUrl)),
+    ...analyses.map((analysis) => formatAnalysisLine(analysis, baseUrl)),
     ...generatedDesigns.map((design) => formatDesignLine(design, baseUrl)),
   ];
 

--- a/packages/core/src/client/NewWorkspaceAppFlow.spec.ts
+++ b/packages/core/src/client/NewWorkspaceAppFlow.spec.ts
@@ -20,6 +20,41 @@ vi.mock("./use-dev-mode.js", () => ({
   useDevMode: () => ({ isDevMode: devState.isDevMode }),
 }));
 
+vi.mock("./composer/PromptComposer.js", async () => {
+  const React = await import("react");
+  return {
+    PromptComposer: ({
+      onSubmit,
+      placeholder,
+    }: {
+      onSubmit: (text: string, files: File[], references: unknown[]) => void;
+      placeholder?: string;
+    }) => {
+      const [value, setValue] = React.useState("");
+      return React.createElement(
+        "div",
+        null,
+        React.createElement("textarea", {
+          "aria-label": "Prompt",
+          placeholder,
+          value,
+          onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) =>
+            setValue(event.target.value),
+        }),
+        React.createElement(
+          "button",
+          {
+            disabled: !value.trim(),
+            onClick: () => onSubmit(value, [], []),
+            type: "button",
+          },
+          "Create app",
+        ),
+      );
+    },
+  };
+});
+
 const vaultSecrets = [
   {
     id: "secret-openai",
@@ -112,10 +147,9 @@ describe("NewWorkspaceAppFlow", () => {
     });
 
     changeValue(
-      container.querySelector("textarea")!,
+      container.querySelector('textarea[aria-label="Prompt"]')!,
       "Build a quality dashboard",
     );
-    changeValue(container.querySelector("input")!, "qa-dashboard");
 
     act(() => {
       findButton(container, "OPENAI_API_KEY").click();

--- a/packages/core/src/client/NewWorkspaceAppFlow.tsx
+++ b/packages/core/src/client/NewWorkspaceAppFlow.tsx
@@ -3,16 +3,14 @@ import {
   IconArrowUpRight,
   IconCheck,
   IconChevronDown,
-  IconCode,
   IconKey,
-  IconLoader2,
-  IconPlus,
 } from "@tabler/icons-react";
 import { agentNativePath, appBasePath } from "./api-path.js";
 import { sendToAgentChat } from "./agent-chat.js";
 import { isInBuilderFrame } from "./builder-frame.js";
 import { useDevMode } from "./use-dev-mode.js";
 import { getWorkspaceAppIdValidationError } from "../shared/workspace-app-id.js";
+import { PromptComposer } from "./composer/PromptComposer.js";
 
 export interface VaultSecretOption {
   id: string;
@@ -27,20 +25,6 @@ export interface NewWorkspaceAppFlowProps {
   className?: string;
   dispatchBasePath?: string | null;
 }
-
-const TEMPLATE_OPTIONS = [
-  { value: "starter", label: "Starter" },
-  { value: "analytics", label: "Analytics" },
-  { value: "calendar", label: "Calendar" },
-  { value: "content", label: "Content" },
-  { value: "design", label: "Design" },
-  { value: "dispatch", label: "Dispatch" },
-  { value: "forms", label: "Forms" },
-  { value: "mail", label: "Mail" },
-  { value: "slides", label: "Slides" },
-  { value: "videos", label: "Videos" },
-  { value: "clips", label: "Clips" },
-] as const;
 
 function slugify(value: string): string {
   return value
@@ -87,7 +71,6 @@ async function fetchJson(url: string, init?: RequestInit): Promise<any> {
 function buildNewWorkspaceAppPrompt(input: {
   appId: string;
   prompt: string;
-  template: string;
   selectedKeys: string[];
 }): string {
   const keyList = input.selectedKeys.join(", ");
@@ -98,11 +81,11 @@ function buildNewWorkspaceAppPrompt(input: {
   return [
     `Create a new agent-native app in this workspace.`,
     ``,
-    `App name: ${input.appId}`,
-    `Template to start from: ${input.template}`,
+    `Suggested app name: ${input.appId} (you may adjust the slug if it conflicts)`,
     `User prompt: ${input.prompt.trim()}`,
     grantRequest,
     ``,
+    `Pick a starter template that fits the user's prompt — analytics, calendar, content, design, dispatch, forms, mail, slides, videos, clips, or starter when none of the others fit.`,
     `Use the workspace app layout: create it under apps/${input.appId}, mount it at /${input.appId}, keep it on the shared workspace database/hosting model, and avoid table-name collisions by namespacing any new domain tables to the app.`,
     keyList
       ? `After the app exists, grant the selected Dispatch vault keys to appId "${input.appId}" and sync them once the app server is available. Treat these as requested grants, not active grants before creation succeeds.`
@@ -122,10 +105,6 @@ export function NewWorkspaceAppFlow({
   className = "",
   dispatchBasePath,
 }: NewWorkspaceAppFlowProps) {
-  const [prompt, setPrompt] = useState("");
-  const [appName, setAppName] = useState("");
-  const [template, setTemplate] =
-    useState<(typeof TEMPLATE_OPTIONS)[number]["value"]>("starter");
   const [selectedSecretIds, setSelectedSecretIds] = useState<string[]>([]);
   const [secrets, setSecrets] = useState<VaultSecretOption[]>([]);
   const [secretsError, setSecretsError] = useState<string | null>(null);
@@ -161,11 +140,6 @@ export function NewWorkspaceAppFlow({
     };
   }, [effectiveDispatchBasePath]);
 
-  useEffect(() => {
-    if (appName || !prompt.trim()) return;
-    setAppName(titleFromPrompt(prompt));
-  }, [prompt, appName]);
-
   const selectedSecrets = useMemo(
     () => secrets.filter((secret) => selectedSecretIds.includes(secret.id)),
     [secrets, selectedSecretIds],
@@ -174,38 +148,22 @@ export function NewWorkspaceAppFlow({
     selectedSecretIds.length === 0
       ? "No keys selected"
       : `${selectedSecretIds.length} key${selectedSecretIds.length === 1 ? "" : "s"} selected`;
-  const hasAppNameCandidate =
-    appName.trim().length > 0 || prompt.trim().length > 0;
-  const safeAppName = slugify(appName) || titleFromPrompt(prompt);
-  const appNameError = hasAppNameCandidate
-    ? getWorkspaceAppIdValidationError(safeAppName)
-    : null;
 
-  const canSubmit =
-    prompt.trim().length > 0 && safeAppName.length > 0 && !appNameError;
-  const submitShortcut =
-    typeof navigator !== "undefined" &&
-    /Mac|iPhone|iPad/.test(navigator.userAgent)
-      ? "⌘"
-      : "Ctrl";
-
-  function buildMessage(): string {
-    return buildNewWorkspaceAppPrompt({
-      appId: safeAppName,
-      prompt,
-      template,
-      selectedKeys: selectedSecrets.map((s) => s.credentialKey),
-    });
-  }
-
-  async function submit() {
-    if (!canSubmit || isSubmitting) return;
-    const validationError = getWorkspaceAppIdValidationError(safeAppName);
+  async function submit(rawPrompt: string) {
+    const prompt = rawPrompt.trim();
+    if (!prompt || isSubmitting) return;
+    const appId = titleFromPrompt(prompt);
+    const validationError = getWorkspaceAppIdValidationError(appId);
     if (validationError) {
       setStatusMessage(validationError);
       return;
     }
-    const message = buildMessage();
+
+    const message = buildNewWorkspaceAppPrompt({
+      appId,
+      prompt,
+      selectedKeys: selectedSecrets.map((s) => s.credentialKey),
+    });
     setIsSubmitting(true);
     setStatusMessage(null);
     setBranchUrl(null);
@@ -224,9 +182,8 @@ export function NewWorkspaceAppFlow({
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              prompt: prompt.trim(),
-              appId: safeAppName,
-              template,
+              prompt,
+              appId,
               secretIds: selectedSecretIds,
             }),
           },
@@ -261,107 +218,30 @@ export function NewWorkspaceAppFlow({
       className={`mx-auto flex w-full max-w-5xl flex-col gap-5 px-4 py-6 ${className}`}
     >
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div className="rounded-lg border border-border bg-card">
-          <div className="border-b border-border px-4 py-3">
-            <div className="flex items-center gap-2 text-sm font-medium">
-              <IconPlus className="h-4 w-4" />
-              New app
-            </div>
-          </div>
-          <div className="space-y-4 p-4">
-            <label className="block space-y-2">
-              <span className="text-xs font-medium text-muted-foreground">
-                Prompt
-              </span>
-              <textarea
-                value={prompt}
-                onChange={(e) => setPrompt(e.target.value)}
-                onKeyDown={(e) => {
-                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                    e.preventDefault();
-                    submit();
-                  }
-                }}
-                placeholder="Describe the app your teammate should be able to use..."
-                rows={6}
-                className="min-h-36 w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus:border-ring"
-              />
-            </label>
+        <div className="flex flex-col gap-3">
+          <PromptComposer
+            autoFocus
+            disabled={isSubmitting}
+            placeholder="Describe the app your teammate should be able to use..."
+            draftScope="dispatch:new-app"
+            onSubmit={(text) => submit(text)}
+          />
 
-            <div className="grid gap-3 sm:grid-cols-2">
-              <label className="block space-y-2">
-                <span className="text-xs font-medium text-muted-foreground">
-                  App path
-                </span>
-                <input
-                  value={appName}
-                  onChange={(e) => setAppName(slugify(e.target.value))}
-                  placeholder="customer-health"
-                  className={`h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:border-ring ${
-                    appNameError ? "border-destructive" : "border-input"
-                  }`}
-                />
-                {appNameError ? (
-                  <span className="block text-xs text-destructive">
-                    {appNameError}
-                  </span>
-                ) : null}
-              </label>
-              <label className="block space-y-2">
-                <span className="text-xs font-medium text-muted-foreground">
-                  Starter template
-                </span>
-                <select
-                  value={template}
-                  onChange={(e) =>
-                    setTemplate(e.target.value as typeof template)
-                  }
-                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:border-ring"
+          {statusMessage ? (
+            <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+              {statusMessage}
+              {branchUrl ? (
+                <a
+                  href={branchUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="ml-2 inline-flex items-center gap-1 font-medium text-foreground underline"
                 >
-                  {TEMPLATE_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
+                  Open branch <IconArrowUpRight className="h-3 w-3" />
+                </a>
+              ) : null}
             </div>
-
-            <div className="flex items-center justify-end gap-3">
-              <span className="text-[11px] text-muted-foreground/75">
-                {submitShortcut}+Enter to submit
-              </span>
-              <button
-                type="button"
-                onClick={submit}
-                disabled={!canSubmit || isSubmitting}
-                className="inline-flex h-10 items-center gap-2 rounded-md bg-foreground px-4 text-sm font-medium text-background disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                {isSubmitting ? (
-                  <IconLoader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <IconCode className="h-4 w-4" />
-                )}
-                Create app
-              </button>
-            </div>
-
-            {statusMessage ? (
-              <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
-                {statusMessage}
-                {branchUrl ? (
-                  <a
-                    href={branchUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="ml-2 inline-flex items-center gap-1 font-medium text-foreground underline"
-                  >
-                    Open branch <IconArrowUpRight className="h-3 w-3" />
-                  </a>
-                ) : null}
-              </div>
-            ) : null}
-          </div>
+          ) : null}
         </div>
 
         <aside className="rounded-lg border border-border bg-card">
@@ -401,7 +281,7 @@ export function NewWorkspaceAppFlow({
                       type="button"
                       aria-pressed={selected}
                       onClick={() => toggleSecret(secret.id)}
-                      className="flex w-full items-start gap-3 rounded-md px-3 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+                      className="flex w-full cursor-pointer items-start gap-3 rounded-md px-3 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
                     >
                       <span
                         className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border transition ${

--- a/packages/core/src/client/composer/ComposerPlusMenu.tsx
+++ b/packages/core/src/client/composer/ComposerPlusMenu.tsx
@@ -28,11 +28,46 @@ import type { ComposerMode } from "./types.js";
 
 interface ComposerPlusMenuProps {
   onSelectMode?: (mode: ComposerMode) => void;
+  /**
+   * "full" (default): full + menu with Upload File, Create Skill, Scheduled Task,
+   * Automation, Tool, MCP Server. "upload-only": clicking + opens the file
+   * picker directly — no popover, no other modes. Use for prompt popovers
+   * (create tool, create deck, create dashboard, etc.) where the only thing
+   * to attach is a file.
+   */
+  mode?: "full" | "upload-only";
 }
 
 type View = "menu" | "mcp-server";
 
-export function ComposerPlusMenu({ onSelectMode }: ComposerPlusMenuProps) {
+function UploadOnlyAttachButton() {
+  return (
+    <ComposerPrimitive.AddAttachment asChild>
+      <button
+        type="button"
+        className="shrink-0 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 disabled:opacity-30 disabled:cursor-not-allowed"
+        title="Upload file"
+        aria-label="Upload file"
+      >
+        <IconPlus className="h-4 w-4" />
+      </button>
+    </ComposerPrimitive.AddAttachment>
+  );
+}
+
+export function ComposerPlusMenu({
+  onSelectMode,
+  mode = "full",
+}: ComposerPlusMenuProps) {
+  if (mode === "upload-only") {
+    return <UploadOnlyAttachButton />;
+  }
+  return <ComposerPlusMenuFull onSelectMode={onSelectMode} />;
+}
+
+function ComposerPlusMenuFull({
+  onSelectMode,
+}: Pick<ComposerPlusMenuProps, "onSelectMode">) {
   const [open, setOpen] = useState(false);
   const [view, setView] = useState<View>("menu");
 

--- a/packages/core/src/client/composer/PromptComposer.tsx
+++ b/packages/core/src/client/composer/PromptComposer.tsx
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useMemo, useRef, type Ref } from "react";
+import {
+  AssistantRuntimeProvider,
+  ComposerPrimitive,
+  ThreadPrimitive,
+  useAui,
+  useComposer,
+  useLocalRuntime,
+} from "@assistant-ui/react";
+import type {
+  Attachment,
+  AttachmentAdapter,
+  ChatModelAdapter,
+  CompleteAttachment,
+  PendingAttachment,
+} from "@assistant-ui/react";
+import {
+  CompositeAttachmentAdapter,
+  SimpleImageAttachmentAdapter,
+  SimpleTextAttachmentAdapter,
+} from "@assistant-ui/react";
+import { IconX } from "@tabler/icons-react";
+import { cn } from "../utils.js";
+import { TiptapComposer, type TiptapComposerHandle } from "./TiptapComposer.js";
+import type { Reference } from "./types.js";
+import { useChatModels } from "../use-chat-models.js";
+
+/**
+ * Files the user attached via the "+" button in PromptComposer. The host owns
+ * what to do with them — typically POST to a per-app upload endpoint and pass
+ * the resulting URLs/paths into the prompt that gets sent to the agent.
+ */
+export type PromptComposerFile = File;
+
+export interface PromptComposerProps {
+  /** Called when the user submits the composer. */
+  onSubmit: (
+    text: string,
+    files: PromptComposerFile[],
+    references: Reference[],
+  ) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  autoFocus?: boolean;
+  className?: string;
+  /** Forwarded to TiptapComposer for draft persistence. */
+  draftScope?: string;
+  /** Show the model selector (default: false). */
+  showModelSelector?: boolean;
+  /** Show the voice dictation button (default: true). */
+  voiceEnabled?: boolean;
+  /** Show file upload controls and pass submitted files to onSubmit. */
+  attachmentsEnabled?: boolean;
+  /** Imperative handle for focusing the composer. */
+  composerRef?: Ref<TiptapComposerHandle>;
+}
+
+// Minimal pass-through adapter. PromptComposer always submits through
+// onSubmitOverride, so the runtime never actually calls this — but
+// `useLocalRuntime` needs *something* shaped like a ChatModelAdapter.
+const NOOP_ADAPTER: ChatModelAdapter = {
+  async *run() {
+    return;
+  },
+};
+
+/**
+ * Local clone of AssistantChat's BinaryDocumentAttachmentAdapter so PDFs and
+ * PPTX files can be attached without dragging the whole assistant chat module
+ * into bundles that just want a prompt popover.
+ */
+class BinaryDocumentAttachmentAdapter implements AttachmentAdapter {
+  public accept =
+    "application/pdf,application/vnd.openxmlformats-officedocument.presentationml.presentation,.pdf,.pptx";
+
+  public async add(state: { file: File }): Promise<PendingAttachment> {
+    return {
+      id: state.file.name,
+      type: "document",
+      name: state.file.name,
+      contentType: state.file.type || "application/octet-stream",
+      file: state.file,
+      status: { type: "requires-action", reason: "composer-send" },
+    };
+  }
+
+  public async send(
+    attachment: PendingAttachment,
+  ): Promise<CompleteAttachment> {
+    return {
+      ...attachment,
+      status: { type: "complete" },
+      content: [],
+    };
+  }
+
+  public async remove() {
+    /* noop */
+  }
+}
+
+function getImageSrc(attachment: Attachment): string | null {
+  if (attachment.type !== "image") return null;
+  if ("file" in attachment && attachment.file) {
+    return URL.createObjectURL(attachment.file);
+  }
+  const imagePart = attachment.content?.find((part) => part.type === "image");
+  return imagePart && "image" in imagePart ? imagePart.image : null;
+}
+
+function AttachmentChip({
+  attachment,
+  onRemove,
+}: {
+  attachment: Attachment;
+  onRemove: (id: string) => void;
+}) {
+  const src = useMemo(() => getImageSrc(attachment), [attachment]);
+  useEffect(
+    () => () => {
+      if (src?.startsWith("blob:")) URL.revokeObjectURL(src);
+    },
+    [src],
+  );
+
+  if (src) {
+    return (
+      <div className="group relative h-16 w-16 overflow-hidden rounded-lg border border-border/70 bg-muted/50">
+        <img
+          src={src}
+          alt={attachment.name}
+          className="h-full w-full object-cover"
+        />
+        <button
+          type="button"
+          onClick={() => onRemove(attachment.id)}
+          aria-label={`Remove ${attachment.name}`}
+          className="absolute right-1 top-1 flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border border-border/60 bg-background/90 text-muted-foreground hover:text-foreground"
+        >
+          <IconX className="h-3 w-3" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="group relative inline-flex max-w-[200px] items-center gap-2 rounded-md border border-border/70 bg-muted/50 px-2 py-1.5 text-xs">
+      <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded bg-background text-[9px] font-semibold uppercase text-muted-foreground">
+        {attachment.name.split(".").pop() || "file"}
+      </div>
+      <span className="min-w-0 truncate font-medium">{attachment.name}</span>
+      <button
+        type="button"
+        onClick={() => onRemove(attachment.id)}
+        aria-label={`Remove ${attachment.name}`}
+        className="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground"
+      >
+        <IconX className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}
+
+function PromptAttachmentStrip() {
+  const attachments = useComposer((state) => state.attachments);
+  const aui = useAui();
+
+  const handleRemove = useCallback(
+    (id: string) => {
+      void aui.composer().attachment({ id }).remove();
+    },
+    [aui],
+  );
+
+  if (attachments.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-2 px-2 pt-2">
+      {attachments.map((attachment) => (
+        <AttachmentChip
+          key={attachment.id}
+          attachment={attachment}
+          onRemove={handleRemove}
+        />
+      ))}
+    </div>
+  );
+}
+
+function PromptComposerInner({
+  onSubmit,
+  placeholder,
+  disabled,
+  autoFocus,
+  className,
+  draftScope,
+  showModelSelector,
+  voiceEnabled = true,
+  attachmentsEnabled = false,
+  composerRef,
+}: PromptComposerProps) {
+  const localRef = useRef<TiptapComposerHandle>(null);
+  const handleRef = composerRef ?? localRef;
+  const models = useChatModels();
+
+  useEffect(() => {
+    if (!autoFocus) return;
+    const id = window.setTimeout(() => {
+      const target =
+        typeof handleRef === "object" && handleRef && "current" in handleRef
+          ? handleRef.current
+          : null;
+      target?.focus();
+    }, 50);
+    return () => window.clearTimeout(id);
+  }, [autoFocus, handleRef]);
+
+  const handleSubmit = useCallback(
+    (
+      text: string,
+      references: Reference[],
+      attachments?: ReadonlyArray<unknown>,
+    ) => {
+      const files: File[] = [];
+      for (const att of attachments ?? []) {
+        const a = att as Attachment;
+        if ("file" in a && a.file instanceof File) {
+          files.push(a.file);
+        }
+      }
+      onSubmit(text, files, references);
+    },
+    [onSubmit],
+  );
+
+  return (
+    <div
+      className={cn(
+        "agent-composer-area flex flex-col rounded-lg border border-input bg-background focus-within:ring-1 focus-within:ring-ring",
+        className,
+      )}
+    >
+      <ComposerPrimitive.Root className="flex flex-col">
+        <PromptAttachmentStrip />
+        <TiptapComposer
+          focusRef={handleRef}
+          disabled={disabled}
+          placeholder={placeholder}
+          onSubmit={handleSubmit}
+          plusMenuMode={attachmentsEnabled ? "upload-only" : "hidden"}
+          voiceEnabled={voiceEnabled}
+          draftScope={draftScope}
+          selectedModel={showModelSelector ? models.selectedModel : undefined}
+          selectedEffort={showModelSelector ? models.selectedEffort : undefined}
+          availableModels={
+            showModelSelector ? models.availableModels : undefined
+          }
+          onModelChange={showModelSelector ? models.onModelChange : undefined}
+          onEffortChange={showModelSelector ? models.onEffortChange : undefined}
+        />
+      </ComposerPrimitive.Root>
+    </div>
+  );
+}
+
+/**
+ * Standalone composer that mirrors the agent sidebar's input experience —
+ * voice dictation, file upload, model selector, submit-on-Enter — for use in
+ * popovers and inline prompt forms (create tool, create deck, create dashboard,
+ * the Dispatch new-app flow, etc.).
+ *
+ * The host owns submission: when the user presses Enter or clicks submit,
+ * `onSubmit(text, files, references)` is called. PromptComposer runs its own
+ * minimal assistant-ui runtime so it can be dropped into any subtree without
+ * needing the outer chat to be mounted.
+ */
+export function PromptComposer(props: PromptComposerProps) {
+  const attachmentAdapter = useMemo(
+    () =>
+      new CompositeAttachmentAdapter([
+        new SimpleImageAttachmentAdapter(),
+        new BinaryDocumentAttachmentAdapter(),
+        new SimpleTextAttachmentAdapter(),
+      ]),
+    [],
+  );
+  const runtime = useLocalRuntime(NOOP_ADAPTER, {
+    adapters: { attachments: attachmentAdapter },
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ThreadPrimitive.Root className="contents">
+        <PromptComposerInner {...props} />
+      </ThreadPrimitive.Root>
+    </AssistantRuntimeProvider>
+  );
+}

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -183,8 +183,16 @@ interface TiptapComposerProps {
   placeholder?: string;
   disabled?: boolean;
   focusRef?: React.Ref<TiptapComposerHandle>;
-  /** When provided, called instead of composerRuntime.send(). Used for queue mode. */
-  onSubmit?: (text: string, references: Reference[]) => void;
+  /**
+   * When provided, called instead of composerRuntime.send(). Used for queue
+   * mode and standalone prompt popovers. Receives the live composer
+   * attachments so callers (e.g. PromptComposer) can surface uploaded files.
+   */
+  onSubmit?: (
+    text: string,
+    references: Reference[],
+    attachments?: ReadonlyArray<unknown>,
+  ) => void;
   /** Custom action button (e.g. stop button) to render instead of the default send button. */
   actionButton?: React.ReactNode;
   /** Extra button to render alongside the default send button (e.g. stop while running). */
@@ -216,6 +224,13 @@ interface TiptapComposerProps {
   onEffortChange?: (effort: ReasoningEffort) => void;
   /** Stable scope for persisted drafts, usually the active thread or tab id. */
   draftScope?: string;
+  /**
+   * Controls the "+" menu next to the composer. `"full"` (default) shows the
+   * normal Upload / Skill / Job / Automation / Tool / MCP picker. `"upload-only"`
+   * collapses it to a single button that opens the file picker directly.
+   * `"hidden"` hides attachment controls for text-only prompt surfaces.
+   */
+  plusMenuMode?: "full" | "upload-only" | "hidden";
 }
 
 function ModeSelector({
@@ -632,6 +647,7 @@ export function TiptapComposer({
   onModelChange,
   onEffortChange,
   draftScope,
+  plusMenuMode = "full",
 }: TiptapComposerProps) {
   const [popover, setPopover] = useState<PopoverState>(null);
   const popoverRef = useRef<MentionPopoverRef>(null);
@@ -1171,7 +1187,9 @@ export function TiptapComposer({
     if (!ed) return;
 
     const { text, references } = syncComposerState();
-    if (!text.trim() && references.length === 0) return;
+    const attachments = composerRuntime.getState().attachments;
+    if (!text.trim() && references.length === 0 && attachments.length === 0)
+      return;
 
     // Intercept slash commands typed directly (e.g. "/clear" + Enter)
     const trimmed = text.trim();
@@ -1210,7 +1228,9 @@ export function TiptapComposer({
     }
 
     if (onSubmit) {
-      onSubmit(text, references);
+      onSubmit(text, references, attachments);
+      // Clear any pending attachments now that the host has them.
+      void composerRuntime.clearAttachments().catch(() => {});
     } else {
       composerRuntime.send();
     }
@@ -1455,7 +1475,13 @@ export function TiptapComposer({
       </div>
       {voiceEnabled && <VoiceRecordingOverlay voice={voice} />}
       <div className="flex items-center gap-1 px-2 py-1.5">
-        {attachButton ?? <ComposerPlusMenu onSelectMode={handleSelectMode} />}
+        {attachButton ??
+          (plusMenuMode === "hidden" ? null : (
+            <ComposerPlusMenu
+              onSelectMode={handleSelectMode}
+              mode={plusMenuMode}
+            />
+          ))}
         <div className="flex-1" />
         {actionButton ?? (
           <>

--- a/packages/core/src/client/composer/index.ts
+++ b/packages/core/src/client/composer/index.ts
@@ -2,6 +2,11 @@ export { FileReference } from "./extensions/FileReference.js";
 export { SkillReference } from "./extensions/SkillReference.js";
 export { MentionReference } from "./extensions/MentionReference.js";
 export { TiptapComposer } from "./TiptapComposer.js";
+export {
+  PromptComposer,
+  type PromptComposerProps,
+  type PromptComposerFile,
+} from "./PromptComposer.js";
 export { MentionPopover } from "./MentionPopover.js";
 export { useMentionSearch } from "./use-mention-search.js";
 export type {

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -74,6 +74,11 @@ export {
 } from "./MultiTabAssistantChat.js";
 export { createAgentChatAdapter } from "./agent-chat-adapter.js";
 export {
+  PromptComposer,
+  type PromptComposerProps,
+  type PromptComposerFile,
+} from "./composer/PromptComposer.js";
+export {
   useChatThreads,
   type ChatThreadSummary,
   type ChatThreadData,

--- a/packages/core/src/client/settings/AutomationsSection.tsx
+++ b/packages/core/src/client/settings/AutomationsSection.tsx
@@ -9,6 +9,7 @@ import {
   IconTrash,
 } from "@tabler/icons-react";
 import { sendToAgentChat } from "../agent-chat.js";
+import { PromptComposer } from "../composer/PromptComposer.js";
 
 interface TreeNode {
   name: string;
@@ -222,7 +223,6 @@ export function AutomationsSection() {
   }, [showToast]);
 
   const [newOpen, setNewOpen] = useState(false);
-  const [newPrompt, setNewPrompt] = useState("");
   const [newScope, setNewScope] = useState<"personal" | "organization">(
     "personal",
   );
@@ -257,24 +257,23 @@ export function AutomationsSection() {
   }, [newOpen]);
 
   const handleNewSubmit = useCallback(
-    (e: React.FormEvent) => {
-      e.preventDefault();
-      if (!newPrompt.trim()) return;
+    (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
       window.dispatchEvent(
         new CustomEvent("agent-panel:set-mode", {
           detail: { mode: "chat" },
         }),
       );
       sendToAgentChat({
-        message: newPrompt.trim(),
+        message: trimmed,
         context: `The user wants to create a new automation. Scope: ${newScope}. Use manage-automations with action=define to create it. Ask clarifying questions if needed about what event to trigger on, conditions, and what actions to take.`,
         submit: true,
         newTab: true,
       });
-      setNewPrompt("");
       setNewOpen(false);
     },
-    [newPrompt, newScope],
+    [newScope],
   );
 
   if (error) {
@@ -310,52 +309,29 @@ export function AutomationsSection() {
           {newOpen && (
             <div
               ref={newPopoverRef}
-              className="absolute left-0 top-full mt-1.5 z-[220] w-72 rounded-lg border border-border bg-popover p-3 shadow-lg"
+              className="absolute left-0 top-full mt-1.5 z-[220] w-[380px] rounded-lg border border-border bg-popover p-3 shadow-lg"
             >
-              <form onSubmit={handleNewSubmit} className="space-y-2.5">
-                <p className="text-sm font-semibold text-foreground">
-                  New automation
-                </p>
-                <textarea
-                  value={newPrompt}
-                  onChange={(e) => setNewPrompt(e.target.value)}
-                  placeholder="Describe what you want to automate..."
-                  className="w-full resize-y rounded-md border border-border bg-background px-2.5 py-2 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-ring/50 min-h-[100px]"
-                  autoFocus
-                  required
-                  onKeyDown={(e) => {
-                    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                      e.preventDefault();
-                      if (newPrompt.trim()) handleNewSubmit(e);
-                    }
-                  }}
-                />
-                <div>
-                  <select
-                    value={newScope}
-                    onChange={(e) =>
-                      setNewScope(e.target.value as "personal" | "organization")
-                    }
-                    className="w-full rounded-md border border-input bg-background px-3 py-1.5 text-[12px] text-foreground"
-                  >
-                    <option value="personal">Personal</option>
-                    <option value="organization">Organization</option>
-                  </select>
-                </div>
-                <div className="flex items-center justify-end gap-2">
-                  <span className="text-[11px] text-muted-foreground/70">
-                    {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
-                    +Enter to submit
-                  </span>
-                  <button
-                    type="submit"
-                    disabled={!newPrompt.trim()}
-                    className="rounded-md bg-primary px-3 py-1.5 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    Create
-                  </button>
-                </div>
-              </form>
+              <p className="px-1 pb-2 text-sm font-semibold text-foreground">
+                New automation
+              </p>
+              <PromptComposer
+                autoFocus
+                placeholder="Describe what you want to automate..."
+                draftScope="automations:create"
+                onSubmit={handleNewSubmit}
+              />
+              <div className="mt-2">
+                <select
+                  value={newScope}
+                  onChange={(e) =>
+                    setNewScope(e.target.value as "personal" | "organization")
+                  }
+                  className="w-full cursor-pointer rounded-md border border-input bg-background px-3 py-1.5 text-[12px] text-foreground"
+                >
+                  <option value="personal">Personal</option>
+                  <option value="organization">Organization</option>
+                </select>
+              </div>
             </div>
           )}
         </div>

--- a/packages/core/src/client/tools/EmbeddedTool.tsx
+++ b/packages/core/src/client/tools/EmbeddedTool.tsx
@@ -1,6 +1,18 @@
 import { agentNativePath } from "../api-path.js";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "react-router";
+import {
+  IconDots,
+  IconExternalLink,
+  IconLayoutSidebarRightCollapse,
+  IconTrash,
+} from "@tabler/icons-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../components/ui/popover.js";
 import {
   isAllowedToolPath,
   sanitizeToolRequestOptions,
@@ -212,20 +224,153 @@ export function EmbeddedTool({
   }
 
   return (
-    <iframe
-      ref={iframeRef}
-      key={`${toolId}-${tool.updatedAt ?? ""}`}
-      src={iframeSrc}
-      className={className}
-      title={tool.name}
-      sandbox="allow-scripts allow-forms"
-      style={{ width: "100%", border: 0, height }}
-      onLoad={() => {
-        iframeRef.current?.contentWindow?.postMessage(
-          { type: "agent-native-slot-context", context: context ?? {} },
-          "*",
-        );
+    <div className={`relative group/embedded-tool ${className ?? ""}`}>
+      <iframe
+        ref={iframeRef}
+        key={`${toolId}-${tool.updatedAt ?? ""}`}
+        src={iframeSrc}
+        title={tool.name}
+        sandbox="allow-scripts allow-forms"
+        style={{ width: "100%", border: 0, height, display: "block" }}
+        onLoad={() => {
+          iframeRef.current?.contentWindow?.postMessage(
+            { type: "agent-native-slot-context", context: context ?? {} },
+            "*",
+          );
+        }}
+      />
+      <EmbeddedToolMenu toolId={toolId} slotId={slotId} toolName={tool.name} />
+    </div>
+  );
+}
+
+function EmbeddedToolMenu({
+  toolId,
+  slotId,
+  toolName,
+}: {
+  toolId: string;
+  slotId: string;
+  toolName: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const closeMenu = () => {
+    setOpen(false);
+    setConfirmingDelete(false);
+  };
+
+  const removeFromSlot = async () => {
+    closeMenu();
+    queryClient.setQueryData<any[]>(["slot-installs", slotId], (old) =>
+      (old ?? []).filter((i) => i.toolId !== toolId),
+    );
+    try {
+      await fetch(
+        agentNativePath(
+          `/_agent-native/slots/${encodeURIComponent(slotId)}/install/${encodeURIComponent(toolId)}`,
+        ),
+        { method: "DELETE" },
+      );
+    } finally {
+      queryClient.invalidateQueries({ queryKey: ["slot-installs", slotId] });
+    }
+  };
+
+  const deleteTool = async () => {
+    closeMenu();
+    queryClient.setQueryData<any[]>(["slot-installs", slotId], (old) =>
+      (old ?? []).filter((i) => i.toolId !== toolId),
+    );
+    try {
+      await fetch(agentNativePath(`/_agent-native/tools/${toolId}`), {
+        method: "DELETE",
+      });
+    } finally {
+      queryClient.invalidateQueries({ queryKey: ["slot-installs", slotId] });
+      queryClient.invalidateQueries({ queryKey: ["tool", toolId] });
+      queryClient.invalidateQueries({ queryKey: ["tools"] });
+    }
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) setConfirmingDelete(false);
       }}
-    />
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="absolute top-1 right-1 flex h-6 w-6 items-center justify-center rounded-md bg-background/60 text-muted-foreground/60 opacity-0 hover:bg-accent hover:text-foreground hover:opacity-100 group-hover/embedded-tool:opacity-100 cursor-pointer transition-opacity"
+          title={`${toolName} options`}
+          aria-label={`${toolName} options`}
+        >
+          <IconDots className="h-3.5 w-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" sideOffset={4} className="w-56 p-1">
+        {!confirmingDelete ? (
+          <div className="flex flex-col">
+            <button
+              type="button"
+              onClick={() => {
+                closeMenu();
+                navigate(`/tools/${toolId}`);
+              }}
+              className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent cursor-pointer text-left"
+            >
+              <IconExternalLink className="h-3.5 w-3.5" />
+              <span>Open full view</span>
+            </button>
+            <button
+              type="button"
+              onClick={removeFromSlot}
+              className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] hover:bg-accent cursor-pointer text-left"
+            >
+              <IconLayoutSidebarRightCollapse className="h-3.5 w-3.5" />
+              <span>Remove from this widget area</span>
+            </button>
+            <div className="my-1 h-px bg-border/40" />
+            <button
+              type="button"
+              onClick={() => setConfirmingDelete(true)}
+              className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10 cursor-pointer text-left"
+            >
+              <IconTrash className="h-3.5 w-3.5" />
+              <span>Delete tool…</span>
+            </button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2 p-2">
+            <p className="text-[12px]">
+              Delete <span className="font-medium">{toolName}</span>? This
+              removes the tool everywhere, for everyone it's shared with.
+            </p>
+            <div className="flex justify-end gap-1">
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(false)}
+                className="rounded-md px-2 py-1 text-[12px] hover:bg-accent cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={deleteTool}
+                className="rounded-md bg-destructive px-2 py-1 text-[12px] text-destructive-foreground hover:bg-destructive/90 cursor-pointer"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/packages/core/src/client/tools/ToolViewer.tsx
+++ b/packages/core/src/client/tools/ToolViewer.tsx
@@ -1,10 +1,19 @@
 import { agentNativePath } from "../api-path.js";
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { IconLoader2, IconPencil, IconRefresh } from "@tabler/icons-react";
+import { useNavigate } from "react-router";
+import {
+  IconDots,
+  IconLoader2,
+  IconPencil,
+  IconRefresh,
+  IconTrash,
+  IconX,
+} from "@tabler/icons-react";
 import { ShareButton } from "../sharing/ShareButton.js";
 import { AgentToggleButton } from "../AgentPanel.js";
 import { sendToAgentChat } from "../agent-chat.js";
+import { PromptComposer } from "../composer/PromptComposer.js";
 import {
   Popover,
   PopoverContent,
@@ -72,17 +81,16 @@ export interface ToolViewerProps {
 
 function EditToolPopover({ tool }: { tool: Tool }) {
   const [open, setOpen] = useState(false);
-  const [editPrompt, setEditPrompt] = useState("");
 
-  const handleSubmit = () => {
-    if (!editPrompt.trim()) return;
+  const handleSubmit = (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
     sendToAgentChat({
-      message: editPrompt.trim(),
+      message: trimmed,
       context: `The user is viewing tool "${tool.name}" (id: ${tool.id}) and wants to edit it.`,
       submit: true,
       openSidebar: true,
     });
-    setEditPrompt("");
     setOpen(false);
   };
 
@@ -97,42 +105,16 @@ function EditToolPopover({ tool }: { tool: Tool }) {
           <IconPencil className="h-4 w-4" />
         </button>
       </PopoverTrigger>
-      <PopoverContent align="end" sideOffset={6} className="w-80 p-4">
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            handleSubmit();
-          }}
-          className="space-y-3"
-        >
-          <p className="text-sm font-semibold text-foreground">Edit tool</p>
-          <textarea
-            value={editPrompt}
-            onChange={(e) => setEditPrompt(e.target.value)}
-            placeholder="What would you like to change?"
-            className="flex w-full rounded-md border border-input bg-background px-3 py-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 min-h-[100px] resize-y"
-            autoFocus
-            onKeyDown={(e) => {
-              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                e.preventDefault();
-                if (editPrompt.trim()) handleSubmit();
-              }
-            }}
-          />
-          <div className="flex items-center justify-end gap-2">
-            <span className="text-[11px] text-muted-foreground/75">
-              {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
-              +Enter to submit
-            </span>
-            <button
-              type="submit"
-              disabled={!editPrompt.trim()}
-              className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-            >
-              Send
-            </button>
-          </div>
-        </form>
+      <PopoverContent align="end" sideOffset={6} className="w-[420px] p-3">
+        <p className="px-1 pb-2 text-sm font-semibold text-foreground">
+          Edit tool
+        </p>
+        <PromptComposer
+          autoFocus
+          placeholder="What would you like to change?"
+          draftScope={`tools:edit:${tool.id}`}
+          onSubmit={handleSubmit}
+        />
       </PopoverContent>
     </Popover>
   );
@@ -506,6 +488,7 @@ export function ToolViewer({ toolId }: ToolViewerProps) {
             resourceId={toolId}
             resourceTitle={tool.name}
           />
+          <ToolMoreMenu toolId={toolId} toolName={tool.name} />
           <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
         </div>
       </div>
@@ -533,5 +516,169 @@ export function ToolViewer({ toolId }: ToolViewerProps) {
         />
       </div>
     </div>
+  );
+}
+
+interface SlotDeclaration {
+  id: string;
+  toolId: string;
+  slotId: string;
+}
+
+function ToolMoreMenu({
+  toolId,
+  toolName,
+}: {
+  toolId: string;
+  toolName: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const { data: slots = [] } = useQuery<SlotDeclaration[]>({
+    queryKey: ["tool-slots", toolId],
+    queryFn: async () => {
+      const res = await fetch(
+        agentNativePath(`/_agent-native/slots/tool/${toolId}`),
+      );
+      if (!res.ok) return [];
+      return res.json();
+    },
+    enabled: open,
+  });
+
+  const closeMenu = () => {
+    setOpen(false);
+    setConfirmingDelete(false);
+  };
+
+  const removeFromSlot = async (slotId: string) => {
+    try {
+      await fetch(
+        agentNativePath(
+          `/_agent-native/slots/${encodeURIComponent(slotId)}/install/${encodeURIComponent(toolId)}`,
+        ),
+        { method: "DELETE" },
+      );
+    } finally {
+      queryClient.invalidateQueries({ queryKey: ["slot-installs", slotId] });
+    }
+  };
+
+  const deleteTool = async () => {
+    closeMenu();
+    try {
+      await fetch(agentNativePath(`/_agent-native/tools/${toolId}`), {
+        method: "DELETE",
+      });
+    } finally {
+      queryClient.invalidateQueries({ queryKey: ["tool", toolId] });
+      queryClient.invalidateQueries({ queryKey: ["tools"] });
+      slots.forEach((s) =>
+        queryClient.invalidateQueries({
+          queryKey: ["slot-installs", s.slotId],
+        }),
+      );
+      navigate("/tools");
+    }
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) setConfirmingDelete(false);
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
+          title="More options"
+          aria-label="More options"
+        >
+          <IconDots className="h-4 w-4" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" sideOffset={4} className="w-72 p-0">
+        {!confirmingDelete ? (
+          <>
+            <div className="px-3 py-2 border-b border-border/40">
+              <p className="text-[12px] font-medium">Appears in</p>
+              {slots.length === 0 ? (
+                <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                  Not installed in any widget areas. Ask the agent to add it
+                  somewhere.
+                </p>
+              ) : (
+                <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                  This tool can render in {slots.length} widget area
+                  {slots.length === 1 ? "" : "s"}.
+                </p>
+              )}
+            </div>
+            {slots.length > 0 && (
+              <div className="max-h-48 overflow-y-auto py-1">
+                {slots.map((s) => (
+                  <div
+                    key={s.id}
+                    className="flex items-center gap-2 px-3 py-1.5 text-[12px]"
+                  >
+                    <span className="flex-1 truncate font-mono text-[11px] text-muted-foreground">
+                      {s.slotId}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => removeFromSlot(s.slotId)}
+                      className="rounded p-1 text-muted-foreground/60 hover:bg-accent hover:text-foreground cursor-pointer"
+                      title="Remove from this widget area (for me)"
+                      aria-label="Remove from this widget area"
+                    >
+                      <IconX className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="border-t border-border/40 p-1">
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(true)}
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10 cursor-pointer text-left"
+              >
+                <IconTrash className="h-3.5 w-3.5" />
+                <span>Delete tool…</span>
+              </button>
+            </div>
+          </>
+        ) : (
+          <div className="flex flex-col gap-2 p-3">
+            <p className="text-[12px]">
+              Delete <span className="font-medium">{toolName}</span>? This
+              removes the tool everywhere, for everyone it's shared with.
+            </p>
+            <div className="flex justify-end gap-1">
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(false)}
+                className="rounded-md px-2 py-1 text-[12px] hover:bg-accent cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={deleteTool}
+                className="rounded-md bg-destructive px-2 py-1 text-[12px] text-destructive-foreground hover:bg-destructive/90 cursor-pointer"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/packages/core/src/client/tools/ToolsListPage.tsx
+++ b/packages/core/src/client/tools/ToolsListPage.tsx
@@ -6,6 +6,7 @@ import { IconPlus, IconTool } from "@tabler/icons-react";
 import { cn } from "../utils.js";
 import { AgentToggleButton } from "../AgentPanel.js";
 import { sendToAgentChat } from "../agent-chat.js";
+import { PromptComposer } from "../composer/PromptComposer.js";
 import {
   Popover,
   PopoverContent,
@@ -24,70 +25,33 @@ interface Tool {
   icon?: string;
 }
 
-function CreateToolInput({
-  className,
-  inputClassName,
-}: {
-  className?: string;
-  inputClassName?: string;
-}) {
-  const [prompt, setPrompt] = useState("");
+function submitCreateTool(prompt: string) {
+  const trimmed = prompt.trim();
+  if (!trimmed) return;
+  sendToAgentChat({
+    message: `Create a tool: ${trimmed}`,
+    submit: true,
+    openSidebar: true,
+    newTab: true,
+  });
+}
 
-  const handleCreate = () => {
-    if (!prompt.trim()) return;
-    sendToAgentChat({
-      message: `Create a tool: ${prompt.trim()}`,
-      submit: true,
-      openSidebar: true,
-      newTab: true,
-    });
-    setPrompt("");
-  };
-
+function CreateToolInput({ className }: { className?: string }) {
   return (
     <div className={cn("flex flex-col gap-2", className)}>
       <p className="text-sm font-semibold text-foreground">New tool</p>
-      <textarea
-        value={prompt}
-        onChange={(e) => setPrompt(e.target.value)}
-        placeholder={
-          "Describe what you'd like to build...\ne.g. a todo list, API dashboard, calculator"
-        }
-        className={cn(
-          "flex w-full rounded-md border border-input bg-background px-3 py-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 min-h-[100px] resize-y",
-          inputClassName,
-        )}
-        onKeyDown={(e) => {
-          if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-            e.preventDefault();
-            handleCreate();
-          }
-        }}
+      <PromptComposer
+        autoFocus
+        placeholder="Describe what you'd like to build... e.g. a todo list, API dashboard, calculator"
+        draftScope="tools:create"
+        onSubmit={(text) => submitCreateTool(text)}
       />
-      <div className="flex items-center justify-end gap-2">
-        <span className="text-[11px] text-muted-foreground/75">
-          {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}+Enter to
-          submit
-        </span>
-        <button
-          type="button"
-          onClick={handleCreate}
-          disabled={!prompt.trim()}
-          className={cn(
-            "rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 cursor-pointer",
-            !prompt.trim() && "opacity-60",
-          )}
-        >
-          Create
-        </button>
-      </div>
     </div>
   );
 }
 
 export function ToolsListPage() {
   const [showCreate, setShowCreate] = useState(false);
-  const [createPrompt, setCreatePrompt] = useState("");
   const [toolOrderState, setToolOrderState] = useState<string[]>(() =>
     typeof window !== "undefined" ? getToolsOrder() : [],
   );
@@ -125,15 +89,8 @@ export function ToolsListPage() {
       ? applyToolsOrder(tools ?? [], toolOrderState)
       : (tools ?? []);
 
-  const handleCreate = () => {
-    if (!createPrompt.trim()) return;
-    sendToAgentChat({
-      message: `Create a tool: ${createPrompt.trim()}`,
-      submit: true,
-      openSidebar: true,
-      newTab: true,
-    });
-    setCreatePrompt("");
+  const handleCreate = (text: string) => {
+    submitCreateTool(text);
     setShowCreate(false);
   };
 
@@ -152,44 +109,20 @@ export function ToolsListPage() {
                 New Tool
               </button>
             </PopoverTrigger>
-            <PopoverContent align="end" sideOffset={6} className="w-80 p-4">
-              <form
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  handleCreate();
-                }}
-                className="space-y-3"
-              >
-                <p className="text-sm font-semibold text-foreground">
-                  New tool
-                </p>
-                <textarea
-                  autoFocus
-                  value={createPrompt}
-                  onChange={(e) => setCreatePrompt(e.target.value)}
-                  placeholder="Describe what you'd like to build..."
-                  className="flex w-full rounded-md border border-input bg-background px-3 py-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 min-h-[140px] resize-y"
-                  onKeyDown={(e) => {
-                    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                      e.preventDefault();
-                      handleCreate();
-                    }
-                  }}
-                />
-                <div className="flex items-center justify-end gap-2">
-                  <span className="text-[11px] text-muted-foreground/75">
-                    {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
-                    +Enter to submit
-                  </span>
-                  <button
-                    type="submit"
-                    disabled={!createPrompt.trim()}
-                    className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-                  >
-                    Create
-                  </button>
-                </div>
-              </form>
+            <PopoverContent
+              align="end"
+              sideOffset={6}
+              className="w-[420px] p-3"
+            >
+              <p className="px-1 pb-2 text-sm font-semibold text-foreground">
+                New tool
+              </p>
+              <PromptComposer
+                autoFocus
+                placeholder="Describe what you'd like to build..."
+                draftScope="tools:create-popover"
+                onSubmit={handleCreate}
+              />
             </PopoverContent>
           </Popover>
           <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />

--- a/packages/core/src/client/tools/ToolsSidebarSection.tsx
+++ b/packages/core/src/client/tools/ToolsSidebarSection.tsx
@@ -15,6 +15,7 @@ import {
 } from "@tabler/icons-react";
 import { cn } from "../utils.js";
 import { sendToAgentChat } from "../agent-chat.js";
+import { PromptComposer } from "../composer/PromptComposer.js";
 import {
   Popover,
   PopoverContent,
@@ -61,7 +62,6 @@ export function ToolsSidebarSection() {
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const [showCreate, setShowCreate] = useState(false);
-  const [createPrompt, setCreatePrompt] = useState("");
   const [toolOrderState, setToolOrderState] = useState<string[]>(() =>
     typeof window !== "undefined" ? getToolsOrder() : [],
   );
@@ -205,15 +205,15 @@ export function ToolsSidebarSection() {
     [sortedTools],
   );
 
-  const handleCreate = () => {
-    if (!createPrompt.trim()) return;
+  const handleCreate = (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
     sendToAgentChat({
-      message: `Create a tool: ${createPrompt.trim()}`,
+      message: `Create a tool: ${trimmed}`,
       submit: true,
       openSidebar: true,
       newTab: true,
     });
-    setCreatePrompt("");
     setShowCreate(false);
   };
 
@@ -248,42 +248,16 @@ export function ToolsSidebarSection() {
               <IconPlus className="h-3.5 w-3.5" />
             </button>
           </PopoverTrigger>
-          <PopoverContent side="right" align="start" className="w-80 p-4">
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                handleCreate();
-              }}
-              className="space-y-3"
-            >
-              <p className="text-sm font-semibold text-foreground">New tool</p>
-              <textarea
-                autoFocus
-                value={createPrompt}
-                onChange={(e) => setCreatePrompt(e.target.value)}
-                placeholder="Describe what you'd like to build..."
-                className="flex w-full rounded-md border border-input bg-background px-3 py-3 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 min-h-[100px] resize-y"
-                onKeyDown={(e) => {
-                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                    e.preventDefault();
-                    handleCreate();
-                  }
-                }}
-              />
-              <div className="flex items-center justify-end gap-2">
-                <span className="text-[11px] text-muted-foreground/75">
-                  {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
-                  +Enter to submit
-                </span>
-                <button
-                  type="submit"
-                  disabled={!createPrompt.trim()}
-                  className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-                >
-                  Create
-                </button>
-              </div>
-            </form>
+          <PopoverContent side="right" align="start" className="w-[420px] p-3">
+            <p className="px-1 pb-2 text-sm font-semibold text-foreground">
+              New tool
+            </p>
+            <PromptComposer
+              autoFocus
+              placeholder="Describe what you'd like to build..."
+              draftScope="tools:sidebar-create"
+              onSubmit={handleCreate}
+            />
           </PopoverContent>
         </Popover>
       </div>

--- a/templates/analytics/actions/save-analysis.ts
+++ b/templates/analytics/actions/save-analysis.ts
@@ -89,6 +89,12 @@ export default defineAction({
       },
       { email, orgId },
     );
-    return `Analysis "${args.name}" saved as ${args.id}. Users can view it at /analyses/${args.id} and re-run it anytime for fresh results.`;
+    return {
+      id: args.id,
+      analysisId: args.id,
+      name: args.name,
+      urlPath: `/analyses/${args.id}`,
+      message: `Analysis "${args.name}" saved as ${args.id}. Users can view it at /analyses/${args.id} and re-run it anytime for fresh results.`,
+    };
   },
 });

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -375,7 +375,16 @@ export default defineAction({
       if (sqlError) return `Error: ${sqlError}`;
       await upsertDashboard(args.dashboardId, "sql", args.config, ctx);
       await syncToCollab(args.dashboardId, args.config);
-      return `Dashboard "${args.dashboardId}" replaced.`;
+      return {
+        id: args.dashboardId,
+        dashboardId: args.dashboardId,
+        name:
+          typeof args.config.name === "string"
+            ? args.config.name
+            : args.dashboardId,
+        urlPath: `/adhoc/${args.dashboardId}`,
+        message: `Dashboard "${args.dashboardId}" replaced.`,
+      };
     }
 
     const existing = await getDashboard(args.dashboardId, ctx);
@@ -404,10 +413,15 @@ export default defineAction({
     );
     await syncToCollab(args.dashboardId, root as Record<string, unknown>);
 
-    return (
-      `Dashboard "${args.dashboardId}" updated. ` +
-      `Applied ${details.length} op(s): ${details.join("; ")}. ` +
-      `Call refresh-screen to update the UI.`
-    );
+    return {
+      id: args.dashboardId,
+      dashboardId: args.dashboardId,
+      name: typeof root.name === "string" ? root.name : args.dashboardId,
+      urlPath: `/adhoc/${args.dashboardId}`,
+      message:
+        `Dashboard "${args.dashboardId}" updated. ` +
+        `Applied ${details.length} op(s): ${details.join("; ")}. ` +
+        `Call refresh-screen to update the UI.`,
+    };
   },
 });

--- a/templates/analytics/app/components/layout/NewAnalysisDialog.tsx
+++ b/templates/analytics/app/components/layout/NewAnalysisDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useSendToAgentChat } from "@agent-native/core/client";
+import { useSendToAgentChat, PromptComposer } from "@agent-native/core/client";
 import {
   Popover,
   PopoverContent,
@@ -8,29 +8,23 @@ import {
 import { IconPlus, IconLoader2 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 
+const ANALYSIS_CONTEXT =
+  "The user wants to kick off a new ad-hoc analysis. " +
+  "Read the `adhoc-analysis` skill first. Then: gather data from relevant sources, " +
+  "synthesize findings, and save via `save-analysis` with --id, --name, --question, " +
+  "--instructions (markdown recipe for re-running), --resultMarkdown (polished writeup), " +
+  "--sources (comma-separated data sources used), and --tags (comma-separated). " +
+  "After saving, call `navigate --view=analyses --analysisId=<id>` so the user sees it. " +
+  "No code files to create — analyses are persisted settings data.";
+
 export function NewAnalysisDialog() {
   const [open, setOpen] = useState(false);
-  const [prompt, setPrompt] = useState("");
   const { send, isGenerating } = useSendToAgentChat();
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!prompt.trim() || isGenerating) return;
-
-    send({
-      message: prompt.trim(),
-      context:
-        "The user wants to kick off a new ad-hoc analysis. " +
-        "Read the `adhoc-analysis` skill first. Then: gather data from relevant sources, " +
-        "synthesize findings, and save via `save-analysis` with --id, --name, --question, " +
-        "--instructions (markdown recipe for re-running), --resultMarkdown (polished writeup), " +
-        "--sources (comma-separated data sources used), and --tags (comma-separated). " +
-        "After saving, call `navigate --view=analyses --analysisId=<id>` so the user sees it. " +
-        "No code files to create — analyses are persisted settings data.",
-      submit: true,
-    });
-
-    setPrompt("");
+  function handleSubmit(text: string) {
+    const trimmed = text.trim();
+    if (!trimmed || isGenerating) return;
+    send({ message: trimmed, context: ANALYSIS_CONTEXT, submit: true });
     setOpen(false);
   }
 
@@ -40,7 +34,7 @@ export function NewAnalysisDialog() {
         <button
           disabled={isGenerating}
           className={cn(
-            "flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-xs transition-all",
+            "flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-1.5 text-xs transition-all",
             isGenerating
               ? "text-primary cursor-wait"
               : "text-muted-foreground/60 hover:text-primary hover:bg-sidebar-accent/50",
@@ -55,51 +49,20 @@ export function NewAnalysisDialog() {
         </button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[calc(100vw-2rem)] sm:w-96 p-4"
+        className="w-[calc(100vw-2rem)] p-3 sm:w-[420px]"
         side="right"
         align="start"
       >
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <p className="text-sm font-semibold text-foreground">New analysis</p>
-          <textarea
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            placeholder="Describe the question you want to investigate..."
-            className={cn(
-              "flex w-full rounded-md border border-input bg-background px-3 py-3 text-sm",
-              "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50",
-              "min-h-[140px] resize-y",
-            )}
-            autoFocus
-            required
-            onKeyDown={(e) => {
-              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                e.preventDefault();
-                if (prompt.trim()) handleSubmit(e);
-              }
-            }}
-          />
-          <div className="flex items-center justify-end gap-2">
-            <span className="text-[11px] text-muted-foreground">
-              {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
-              +Enter to submit
-            </span>
-            <button
-              type="submit"
-              disabled={!prompt.trim() || isGenerating}
-              className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isGenerating ? (
-                <span className="flex items-center gap-1.5">
-                  <IconLoader2 className="h-3 w-3 animate-spin" />
-                  Generating...
-                </span>
-              ) : (
-                "Create"
-              )}
-            </button>
-          </div>
-        </form>
+        <p className="px-1 pb-2 text-sm font-semibold text-foreground">
+          New analysis
+        </p>
+        <PromptComposer
+          autoFocus
+          disabled={isGenerating}
+          placeholder="Describe the question you want to investigate..."
+          draftScope="analytics:new-analysis"
+          onSubmit={handleSubmit}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/templates/analytics/app/components/layout/NewDashboardDialog.tsx
+++ b/templates/analytics/app/components/layout/NewDashboardDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useSendToAgentChat } from "@agent-native/core/client";
+import { useSendToAgentChat, PromptComposer } from "@agent-native/core/client";
 import {
   Popover,
   PopoverContent,
@@ -8,33 +8,27 @@ import {
 import { IconPlus, IconLoader2 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 
+const DASHBOARD_CONTEXT =
+  "The user wants to create a new analytics dashboard. " +
+  "Create a SQL-driven dashboard by saving a JSON config via PUT /api/sql-dashboards/{id}. " +
+  "The config shape is: { name: string, panels: [{ id, title, sql, source, chartType, width, config? }] }. " +
+  "Each panel needs: id (unique string), title, sql (the query), source ('bigquery' | 'ga4' | 'amplitude' | 'first-party'), " +
+  "chartType ('line' | 'area' | 'bar' | 'metric' | 'table' | 'pie'), width (1 or 2). " +
+  "Optional config: { xKey, yKey, yKeys, color, colors, yFormatter ('number'|'currency'|'percent'), description }. " +
+  "For first-party analytics, source is 'first-party' and sql may read analytics_events only; do not use db-query for datasource panels. " +
+  "First check /_agent-native/env-status to see which data sources are connected. " +
+  "Refer to AGENTS.md, .agents/skills, the data dictionary, and connected data-source instructions for SQL patterns and table names. " +
+  "NO code files need to be created — only the dashboard config JSON via the API. " +
+  "After saving, the dashboard will be accessible at /adhoc/{id}.";
+
 export function NewDashboardDialog() {
   const [open, setOpen] = useState(false);
-  const [prompt, setPrompt] = useState("");
   const { send, isGenerating } = useSendToAgentChat();
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!prompt.trim() || isGenerating) return;
-
-    send({
-      message: prompt.trim(),
-      context:
-        "The user wants to create a new analytics dashboard. " +
-        "Create a SQL-driven dashboard by saving a JSON config via PUT /api/sql-dashboards/{id}. " +
-        "The config shape is: { name: string, panels: [{ id, title, sql, source, chartType, width, config? }] }. " +
-        "Each panel needs: id (unique string), title, sql (the query), source ('bigquery' | 'ga4' | 'amplitude' | 'first-party'), " +
-        "chartType ('line' | 'area' | 'bar' | 'metric' | 'table' | 'pie'), width (1 or 2). " +
-        "Optional config: { xKey, yKey, yKeys, color, colors, yFormatter ('number'|'currency'|'percent'), description }. " +
-        "For first-party analytics, source is 'first-party' and sql may read analytics_events only; do not use db-query for datasource panels. " +
-        "First check /_agent-native/env-status to see which data sources are connected. " +
-        "Refer to AGENTS.md, .agents/skills, the data dictionary, and connected data-source instructions for SQL patterns and table names. " +
-        "NO code files need to be created — only the dashboard config JSON via the API. " +
-        "After saving, the dashboard will be accessible at /adhoc/{id}.",
-      submit: true,
-    });
-
-    setPrompt("");
+  function handleSubmit(text: string) {
+    const trimmed = text.trim();
+    if (!trimmed || isGenerating) return;
+    send({ message: trimmed, context: DASHBOARD_CONTEXT, submit: true });
     setOpen(false);
   }
 
@@ -44,7 +38,7 @@ export function NewDashboardDialog() {
         <button
           disabled={isGenerating}
           className={cn(
-            "flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-xs transition-all",
+            "flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-1.5 text-xs transition-all",
             isGenerating
               ? "text-primary cursor-wait"
               : "text-muted-foreground/60 hover:text-primary hover:bg-sidebar-accent/50",
@@ -59,51 +53,20 @@ export function NewDashboardDialog() {
         </button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[calc(100vw-2rem)] sm:w-96 p-4"
+        className="w-[calc(100vw-2rem)] p-3 sm:w-[420px]"
         side="right"
         align="start"
       >
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <p className="text-sm font-semibold text-foreground">New dashboard</p>
-          <textarea
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            placeholder="Describe the dashboard you want to create..."
-            className={cn(
-              "flex w-full rounded-md border border-input bg-background px-3 py-3 text-sm",
-              "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50",
-              "min-h-[140px] resize-y",
-            )}
-            autoFocus
-            required
-            onKeyDown={(e) => {
-              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                e.preventDefault();
-                if (prompt.trim()) handleSubmit(e);
-              }
-            }}
-          />
-          <div className="flex items-center justify-end gap-2">
-            <span className="text-[11px] text-muted-foreground">
-              {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
-              +Enter to submit
-            </span>
-            <button
-              type="submit"
-              disabled={!prompt.trim() || isGenerating}
-              className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isGenerating ? (
-                <span className="flex items-center gap-1.5">
-                  <IconLoader2 className="h-3 w-3 animate-spin" />
-                  Generating...
-                </span>
-              ) : (
-                "Create"
-              )}
-            </button>
-          </div>
-        </form>
+        <p className="px-1 pb-2 text-sm font-semibold text-foreground">
+          New dashboard
+        </p>
+        <PromptComposer
+          autoFocus
+          disabled={isGenerating}
+          placeholder="Describe the dashboard you want to create..."
+          draftScope="analytics:new-dashboard"
+          onSubmit={handleSubmit}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/templates/design/app/components/editor/PromptDialog.tsx
+++ b/templates/design/app/components/editor/PromptDialog.tsx
@@ -1,12 +1,6 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
-import {
-  IconLoader2,
-  IconPaperclip,
-  IconX,
-  IconArrowUp,
-} from "@tabler/icons-react";
-import { appBasePath } from "@agent-native/core/client";
+import { appBasePath, PromptComposer } from "@agent-native/core/client";
 
 export interface UploadedFile {
   path: string;
@@ -41,25 +35,8 @@ export default function PromptPopover({
   anchorRef,
   centered = false,
 }: PromptPopoverProps) {
-  const [prompt, setPrompt] = useState("");
-  const [files, setFiles] = useState<File[]>([]);
-  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const [uploading, setUploading] = useState(false);
-  const [dragging, setDragging] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (open) {
-      setTimeout(() => inputRef.current?.focus(), 50);
-    } else {
-      setPrompt("");
-      setFiles([]);
-      setUploadedFiles([]);
-      setDragging(false);
-    }
-  }, [open]);
 
   // Position the popover after render so we can measure its actual size
   useEffect(() => {
@@ -79,24 +56,17 @@ export default function PromptPopover({
     const vw = window.innerWidth;
     const vh = window.innerHeight;
 
-    // Vertical: prefer below, flip above if needed
     let top = anchor.bottom + MARGIN;
     if (top + panelRect.height > vh - MARGIN) {
       top = Math.max(MARGIN, anchor.top - panelRect.height - MARGIN);
     }
 
-    // Horizontal: center on anchor, then clamp to stay within viewport
     const anchorCenterX = anchor.left + anchor.width / 2;
     let left = anchorCenterX - panelRect.width / 2;
-
-    // Clamp: don't go off right edge
     if (left + panelRect.width > vw - MARGIN) {
       left = vw - panelRect.width - MARGIN;
     }
-    // Clamp: don't go off left edge
-    if (left < MARGIN) {
-      left = MARGIN;
-    }
+    if (left < MARGIN) left = MARGIN;
 
     panel.style.top = top + "px";
     panel.style.left = left + "px";
@@ -127,56 +97,33 @@ export default function PromptPopover({
     };
   }, [open, onOpenChange, anchorRef]);
 
-  const uploadFiles = useCallback(async (newFiles: File[]) => {
-    setFiles((prev) => [...prev, ...newFiles]);
-    setUploading(true);
-    try {
-      const formData = new FormData();
-      newFiles.forEach((f) => formData.append("files", f));
-      const res = await fetch(`${appBasePath()}/api/uploads`, {
-        method: "POST",
-        body: formData,
-      });
-      if (res.ok) {
-        const results: UploadedFile[] = await res.json();
-        setUploadedFiles((prev) => [...prev, ...results]);
+  const uploadFiles = useCallback(
+    async (files: File[]): Promise<UploadedFile[]> => {
+      if (files.length === 0) return [];
+      setUploading(true);
+      try {
+        const formData = new FormData();
+        files.forEach((f) => formData.append("files", f));
+        const res = await fetch(`${appBasePath()}/api/uploads`, {
+          method: "POST",
+          body: formData,
+        });
+        if (!res.ok) return [];
+        return (await res.json()) as UploadedFile[];
+      } finally {
+        setUploading(false);
       }
-    } catch {
-      /* silent */
-    } finally {
-      setUploading(false);
-    }
-  }, []);
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selected = e.target.files;
-    if (!selected || selected.length === 0) return;
-    uploadFiles(Array.from(selected));
-    e.target.value = "";
-  };
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      setDragging(false);
-      const droppedFiles = Array.from(e.dataTransfer.files);
-      if (droppedFiles.length > 0) uploadFiles(droppedFiles);
     },
-    [uploadFiles],
+    [],
   );
 
-  const removeFile = (index: number) => {
-    setFiles((prev) => prev.filter((_, i) => i !== index));
-    setUploadedFiles((prev) => prev.filter((_, i) => i !== index));
-  };
-
-  const handleSubmit = () => {
-    if (!prompt.trim() && uploadedFiles.length === 0) return;
-    onSubmit(prompt.trim(), uploadedFiles);
-  };
-
-  const busy = loading || uploading;
-  const hasContent = prompt.trim().length > 0 || uploadedFiles.length > 0;
+  const handleSubmit = useCallback(
+    async (text: string, files: File[]) => {
+      const uploaded = await uploadFiles(files);
+      onSubmit(text.trim(), uploaded);
+    },
+    [onSubmit, uploadFiles],
+  );
 
   if (!open) return null;
 
@@ -190,131 +137,39 @@ export default function PromptPopover({
       )}
       <div
         ref={panelRef}
-        className={`fixed z-[200] w-[min(400px,calc(100vw-24px))] rounded-xl border bg-popover shadow-2xl shadow-black/60 overflow-hidden transition-colors ${
-          dragging ? "border-[#609FF8]/50 bg-accent" : "border-border"
-        }`}
+        className="fixed z-[200] w-[min(420px,calc(100vw-24px))] rounded-xl border border-border bg-popover shadow-2xl shadow-black/60"
         style={{ top: 0, left: 0, visibility: "visible" }}
-        onDrop={handleDrop}
-        onDragOver={(e) => {
-          e.preventDefault();
-          setDragging(true);
-        }}
-        onDragLeave={(e) => {
-          e.preventDefault();
-          setDragging(false);
-        }}
       >
-        <div className="px-3.5 pt-3 pb-1.5">
+        <div className="px-3.5 pt-3 pb-2">
           <span className="text-sm font-medium text-foreground/90">
             {title}
           </span>
         </div>
 
-        <div className="px-3.5 pb-2">
-          <textarea
-            ref={inputRef}
-            value={prompt}
-            onChange={(e) => {
-              setPrompt(e.target.value);
-              const el = e.target;
-              el.style.height = "auto";
-              el.style.height =
-                Math.min(el.scrollHeight, window.innerHeight * 0.5) + "px";
-            }}
+        <div className="px-2 pb-2">
+          <PromptComposer
+            autoFocus
+            attachmentsEnabled
+            disabled={loading || uploading}
             placeholder={placeholder}
-            className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/70 outline-none resize-none"
-            rows={3}
-            style={{ maxHeight: "50vh" }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                e.preventDefault();
-                handleSubmit();
-              }
-            }}
+            onSubmit={handleSubmit}
           />
         </div>
 
-        {/* File chips */}
-        {files.length > 0 && (
-          <div className="px-3.5 pb-2 flex flex-wrap gap-1.5">
-            {files.map((file, i) => (
-              <div
-                key={i}
-                className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-accent border border-border text-[11px] text-muted-foreground"
-              >
-                <span className="max-w-[120px] truncate">{file.name}</span>
-                <button
-                  onClick={() => removeFile(i)}
-                  className="p-0.5 rounded hover:bg-accent"
-                  aria-label={`Remove ${file.name}`}
-                >
-                  <IconX className="w-2.5 h-2.5" />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Bottom bar */}
-        <div className="px-3.5 py-2 flex items-center justify-between border-t border-border">
-          <div className="flex items-center gap-1">
+        {onSkip && (
+          <div className="flex justify-end border-t border-border px-3.5 py-2">
             <button
               type="button"
-              onClick={() => fileInputRef.current?.click()}
-              className="p-1.5 rounded-md hover:bg-accent text-muted-foreground/70 hover:text-muted-foreground transition-colors"
-              title="Attach files"
-              aria-label="Attach files"
+              onClick={() => {
+                onSkip();
+                onOpenChange(false);
+              }}
+              className="cursor-pointer text-xs text-[#609FF8] hover:text-[#7AB2FA]"
             >
-              <IconPaperclip className="w-4 h-4" />
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              onChange={handleFileChange}
-              className="hidden"
-            />
-          </div>
-
-          <div className="flex items-center gap-3">
-            <span className="text-[10px] text-muted-foreground/70">
-              {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
-              +Enter to submit
-            </span>
-            {onSkip && (
-              <button
-                onClick={() => {
-                  onSkip();
-                  onOpenChange(false);
-                }}
-                className="text-xs text-[#609FF8] hover:text-[#7AB2FA] transition-colors"
-              >
-                {skipLabel}
-              </button>
-            )}
-            <button
-              onClick={handleSubmit}
-              disabled={busy || !hasContent}
-              className={`p-1.5 rounded-lg transition-colors ${
-                hasContent && !busy
-                  ? "bg-[#609FF8] hover:bg-[#7AB2FA] text-black"
-                  : "bg-accent hover:bg-accent/80 disabled:opacity-30 disabled:cursor-not-allowed"
-              }`}
-              title="Submit"
-              aria-label="Submit"
-            >
-              {busy ? (
-                <IconLoader2
-                  className={`w-4 h-4 animate-spin ${hasContent ? "text-black" : "text-foreground/70"}`}
-                />
-              ) : (
-                <IconArrowUp
-                  className={`w-4 h-4 ${hasContent ? "text-black" : "text-foreground/70"}`}
-                />
-              )}
+              {skipLabel}
             </button>
           </div>
-        </div>
+        )}
       </div>
     </>
   );

--- a/templates/dispatch/.env.example
+++ b/templates/dispatch/.env.example
@@ -49,6 +49,8 @@
 # BUILDER_PRIVATE_KEY=           # Builder private key
 # BUILDER_USER_ID=               # Optional Builder user id for deployment-managed branch creation
 # ENABLE_BUILDER=true            # Allow production app creation through Builder
+# Allow unlinked messaging users to create Builder apps as DISPATCH_DEFAULT_OWNER_EMAIL
+# DISPATCH_ALLOW_DEFAULT_OWNER_APP_CREATION=true
 
 # Custom health check message
 PING_MESSAGE=pong

--- a/templates/dispatch/app/components/create-app-popover.tsx
+++ b/templates/dispatch/app/components/create-app-popover.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
-import { sendToAgentChat } from "@agent-native/core/client";
-import { IconArrowUp, IconPlus } from "@tabler/icons-react";
+import { useState, type ReactNode } from "react";
+import { sendToAgentChat, PromptComposer } from "@agent-native/core/client";
+import { IconPlus } from "@tabler/icons-react";
 import {
   Popover,
   PopoverContent,
@@ -27,33 +27,18 @@ export function CreateAppPopover({
   align = "center",
 }: CreateAppPopoverProps) {
   const [open, setOpen] = useState(false);
-  const [prompt, setPrompt] = useState("");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const id = window.setTimeout(() => textareaRef.current?.focus(), 50);
-    return () => window.clearTimeout(id);
-  }, [open]);
-
-  function submit() {
-    const text = prompt.trim();
-    if (!text) return;
+  function submit(text: string) {
+    const trimmed = text.trim();
+    if (!trimmed) return;
     sendToAgentChat({
-      message: text,
+      message: trimmed,
       context: SUBMIT_CONTEXT,
       submit: true,
       newTab: true,
     });
-    setPrompt("");
     setOpen(false);
   }
-
-  const submitShortcut =
-    typeof navigator !== "undefined" &&
-    /Mac|iPhone|iPad/.test(navigator.userAgent)
-      ? "⌘"
-      : "Ctrl";
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -73,44 +58,17 @@ export function CreateAppPopover({
       <PopoverContent
         align={align}
         sideOffset={10}
-        className="w-[calc(100vw-2rem)] rounded-xl p-4 shadow-xl sm:w-96"
+        className="w-[calc(100vw-2rem)] rounded-xl p-3 shadow-xl sm:w-[420px]"
       >
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            submit();
-          }}
-          className="space-y-3"
-        >
-          <p className="text-sm font-semibold text-foreground">Create app</p>
-          <textarea
-            ref={textareaRef}
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            onKeyDown={(e) => {
-              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                e.preventDefault();
-                submit();
-              }
-            }}
-            placeholder="Describe the app you want to build…"
-            rows={5}
-            className="flex min-h-[140px] w-full resize-y rounded-md border border-input bg-background px-3 py-3 text-sm text-foreground placeholder:text-muted-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
-          />
-          <div className="flex items-center justify-end gap-2">
-            <span className="text-[11px] text-muted-foreground/75">
-              {submitShortcut}+Enter to submit
-            </span>
-            <button
-              type="submit"
-              disabled={!prompt.trim()}
-              aria-label="Submit prompt"
-              className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <IconArrowUp className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        </form>
+        <p className="px-1 pb-2 text-sm font-semibold text-foreground">
+          Create app
+        </p>
+        <PromptComposer
+          autoFocus
+          placeholder="Describe the app you want to build…"
+          draftScope="dispatch:create-app-popover"
+          onSubmit={(text) => submit(text)}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/templates/dispatch/server/lib/app-creation-store.spec.ts
+++ b/templates/dispatch/server/lib/app-creation-store.spec.ts
@@ -7,10 +7,18 @@ const createRequestMock = vi.hoisted(() => vi.fn());
 const grantSecretsToAppMock = vi.hoisted(() => vi.fn());
 const listSecretsMock = vi.hoisted(() => vi.fn());
 const isIntegrationCallerRequestMock = vi.hoisted(() => vi.fn());
+const getRequestContextMock = vi.hoisted(() => vi.fn());
 const currentOwnerEmailMock = vi.hoisted(() => vi.fn());
+const currentOrgIdMock = vi.hoisted(() => vi.fn());
+const resolveLinkedOwnerMock = vi.hoisted(() => vi.fn());
+const getDbExecMock = vi.hoisted(() => vi.fn());
 const originalNodeEnv = process.env.NODE_ENV;
 const originalWorkspaceAppsJson = process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
 const originalAppUrl = process.env.APP_URL;
+const originalDefaultOwner = process.env.DISPATCH_DEFAULT_OWNER_EMAIL;
+const originalAllowDefaultOwnerAppCreation =
+  process.env.DISPATCH_ALLOW_DEFAULT_OWNER_APP_CREATION;
+const originalEnableBuilder = process.env.ENABLE_BUILDER;
 const originalFetch = globalThis.fetch;
 
 vi.mock("@agent-native/core/settings", () => ({
@@ -20,15 +28,21 @@ vi.mock("@agent-native/core/settings", () => ({
 
 vi.mock("@agent-native/core/server", () => ({
   getBuilderBranchProjectId: vi.fn(() => null),
+  getRequestContext: getRequestContextMock,
   isIntegrationCallerRequest: isIntegrationCallerRequestMock,
   resolveBuilderCredentials: vi.fn(async () => null),
   runBuilderAgent: runBuilderAgentMock,
 }));
 
+vi.mock("@agent-native/core/db", () => ({
+  getDbExec: getDbExecMock,
+}));
+
 vi.mock("./dispatch-store.js", () => ({
-  currentOrgId: vi.fn(() => null),
+  currentOrgId: currentOrgIdMock,
   currentOwnerEmail: currentOwnerEmailMock,
   recordAudit: vi.fn(),
+  resolveLinkedOwner: resolveLinkedOwnerMock,
 }));
 
 vi.mock("./vault-store.js", () => ({
@@ -47,7 +61,11 @@ describe("startWorkspaceAppCreation", () => {
     grantSecretsToAppMock.mockReset();
     listSecretsMock.mockReset();
     isIntegrationCallerRequestMock.mockReset();
+    getRequestContextMock.mockReset();
     currentOwnerEmailMock.mockReset();
+    currentOrgIdMock.mockReset();
+    resolveLinkedOwnerMock.mockReset();
+    getDbExecMock.mockReset();
     getSettingMock.mockResolvedValue({ builderProjectId: "builder-project" });
     runBuilderAgentMock.mockResolvedValue({
       branchName: "branch",
@@ -57,9 +75,18 @@ describe("startWorkspaceAppCreation", () => {
     createRequestMock.mockResolvedValue({ status: "pending" });
     listSecretsMock.mockResolvedValue([]);
     isIntegrationCallerRequestMock.mockReturnValue(false);
+    getRequestContextMock.mockReturnValue(undefined);
     currentOwnerEmailMock.mockReturnValue("dispatch-test@example.com");
+    currentOrgIdMock.mockReturnValue(null);
+    resolveLinkedOwnerMock.mockResolvedValue(null);
+    getDbExecMock.mockReturnValue({
+      execute: vi.fn(async () => ({ rows: [] })),
+    });
     process.env.NODE_ENV = "production";
     process.env.APP_URL = "https://workspace.example.test";
+    delete process.env.DISPATCH_DEFAULT_OWNER_EMAIL;
+    delete process.env.DISPATCH_ALLOW_DEFAULT_OWNER_APP_CREATION;
+    delete process.env.ENABLE_BUILDER;
   });
 
   afterEach(() => {
@@ -73,6 +100,22 @@ describe("startWorkspaceAppCreation", () => {
       delete process.env.APP_URL;
     } else {
       process.env.APP_URL = originalAppUrl;
+    }
+    if (originalDefaultOwner === undefined) {
+      delete process.env.DISPATCH_DEFAULT_OWNER_EMAIL;
+    } else {
+      process.env.DISPATCH_DEFAULT_OWNER_EMAIL = originalDefaultOwner;
+    }
+    if (originalAllowDefaultOwnerAppCreation === undefined) {
+      delete process.env.DISPATCH_ALLOW_DEFAULT_OWNER_APP_CREATION;
+    } else {
+      process.env.DISPATCH_ALLOW_DEFAULT_OWNER_APP_CREATION =
+        originalAllowDefaultOwnerAppCreation;
+    }
+    if (originalEnableBuilder === undefined) {
+      delete process.env.ENABLE_BUILDER;
+    } else {
+      process.env.ENABLE_BUILDER = originalEnableBuilder;
     }
     vi.unstubAllGlobals();
     if (originalFetch) {
@@ -246,6 +289,108 @@ describe("startWorkspaceAppCreation", () => {
     expect(getSettingMock).not.toHaveBeenCalled();
     expect(runBuilderAgentMock).not.toHaveBeenCalled();
     expect(grantSecretsToAppMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks default-owner Builder starts for unlinked integration senders unless explicitly allowed", async () => {
+    process.env.DISPATCH_DEFAULT_OWNER_EMAIL = "dispatch-test@example.com";
+    process.env.ENABLE_BUILDER = "false";
+    isIntegrationCallerRequestMock.mockReturnValue(true);
+    getRequestContextMock.mockReturnValue({
+      integration: {
+        incoming: {
+          platform: "slack",
+          externalThreadId: "C1:1",
+          senderId: "UQA",
+          senderName: "QA User",
+          text: "make an app",
+          platformContext: { teamId: "TQA" },
+          timestamp: 100,
+        },
+      },
+    });
+    resolveLinkedOwnerMock.mockResolvedValue(null);
+
+    const { startWorkspaceAppCreation } =
+      await import("./app-creation-store.js");
+
+    const result = await startWorkspaceAppCreation({
+      prompt: "make a QA dashboard",
+      appId: "qa-dashboard",
+    });
+
+    expect(result).toMatchObject({
+      mode: "builder-unavailable",
+      appId: "qa-dashboard",
+      message: expect.stringContaining("deployment default Dispatch owner"),
+    });
+    expect(runBuilderAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("allows default-owner Builder starts when the integration sender is explicitly linked to that owner", async () => {
+    process.env.DISPATCH_DEFAULT_OWNER_EMAIL = "dispatch-test@example.com";
+    isIntegrationCallerRequestMock.mockReturnValue(true);
+    getRequestContextMock.mockReturnValue({
+      integration: {
+        incoming: {
+          platform: "slack",
+          externalThreadId: "C1:1",
+          senderId: "UQA",
+          senderName: "QA User",
+          text: "make an app",
+          platformContext: { teamId: "TQA" },
+          timestamp: 100,
+        },
+      },
+    });
+    resolveLinkedOwnerMock.mockResolvedValue("dispatch-test@example.com");
+
+    const { startWorkspaceAppCreation } =
+      await import("./app-creation-store.js");
+
+    const result = await startWorkspaceAppCreation({
+      prompt: "make a QA dashboard",
+      appId: "qa-dashboard",
+    });
+
+    expect(result).toMatchObject({
+      mode: "builder",
+      appId: "qa-dashboard",
+    });
+    expect(runBuilderAgentMock).toHaveBeenCalled();
+  });
+
+  it("allows default-owner Builder starts when the deployment explicitly opts in", async () => {
+    process.env.DISPATCH_DEFAULT_OWNER_EMAIL = "dispatch-test@example.com";
+    process.env.ENABLE_BUILDER = "true";
+    isIntegrationCallerRequestMock.mockReturnValue(true);
+    getRequestContextMock.mockReturnValue({
+      integration: {
+        incoming: {
+          platform: "slack",
+          externalThreadId: "C1:1",
+          senderId: "UQA",
+          senderName: "QA User",
+          text: "make an app",
+          platformContext: { teamId: "TQA" },
+          timestamp: 100,
+        },
+      },
+    });
+    resolveLinkedOwnerMock.mockResolvedValue(null);
+
+    const { startWorkspaceAppCreation } =
+      await import("./app-creation-store.js");
+
+    const result = await startWorkspaceAppCreation({
+      prompt: "make a QA dashboard",
+      appId: "qa-dashboard",
+    });
+
+    expect(result).toMatchObject({
+      mode: "builder",
+      appId: "qa-dashboard",
+    });
+    expect(runBuilderAgentMock).toHaveBeenCalled();
   });
 
   it("keeps local dev app creation ergonomic for synthetic integration owners", async () => {

--- a/templates/dispatch/server/lib/app-creation-store.ts
+++ b/templates/dispatch/server/lib/app-creation-store.ts
@@ -4,16 +4,20 @@ import { fileURLToPath } from "node:url";
 import { getSetting, putSetting } from "@agent-native/core/settings";
 import {
   getBuilderBranchProjectId,
+  getRequestContext,
   isIntegrationCallerRequest,
   resolveBuilderCredentials,
   runBuilderAgent,
 } from "@agent-native/core/server";
+import { getDbExec } from "@agent-native/core/db";
 import { assertValidWorkspaceAppId } from "@agent-native/core/shared";
 import {
   currentOrgId,
   currentOwnerEmail,
   recordAudit,
+  resolveLinkedOwner,
 } from "./dispatch-store.js";
+import { identityKeyForIncoming } from "./dispatch-integrations.js";
 import { createRequest, listSecrets } from "./vault-store.js";
 
 const SETTINGS_KEY = "dispatch-app-creation-settings";
@@ -569,6 +573,7 @@ export async function getAppCreationSettings(): Promise<AppCreationSettings> {
 export async function setAppCreationSettings(input: {
   builderProjectId?: string | null;
 }): Promise<AppCreationSettings> {
+  await assertCanManageAppCreationSettings();
   const builderProjectId = input.builderProjectId?.trim() || null;
   const raw = await readSettingsRecord();
   await putSetting(scopedSettingsKey(), { ...raw, builderProjectId });
@@ -613,6 +618,59 @@ function isSyntheticIntegrationOwner(ownerEmail: string): boolean {
   return (
     ownerEmail.startsWith("integration@") ||
     ownerEmail.endsWith("@integration.local")
+  );
+}
+
+async function requestOwnerRole(): Promise<string | null> {
+  const orgId = currentOrgId();
+  const ownerEmail = currentOwnerEmail();
+  if (!orgId) return null;
+  try {
+    const { rows } = await getDbExec().execute({
+      sql: `SELECT role FROM org_members WHERE org_id = ? AND LOWER(email) = ? LIMIT 1`,
+      args: [orgId, ownerEmail.toLowerCase()],
+    });
+    const role = (rows[0] as any)?.role;
+    return typeof role === "string" ? role : null;
+  } catch {
+    return null;
+  }
+}
+
+async function assertCanManageAppCreationSettings(): Promise<void> {
+  const orgId = currentOrgId();
+  if (!orgId) return;
+  const role = await requestOwnerRole();
+  if (role !== "owner" && role !== "admin") {
+    throw new Error(
+      "Only organization owners and admins can update app creation settings.",
+    );
+  }
+}
+
+async function isCurrentIntegrationExplicitlyLinked(): Promise<boolean> {
+  const incoming = getRequestContext()?.integration?.incoming;
+  if (!incoming) return true;
+  const externalUserId = identityKeyForIncoming(incoming);
+  const linkedOwner = await resolveLinkedOwner(
+    incoming.platform,
+    externalUserId,
+    {
+      allowAnyOrgFallback: true,
+    },
+  ).catch(() => null);
+  return linkedOwner === currentOwnerEmail();
+}
+
+async function defaultOwnerAppCreationAllowed(): Promise<boolean> {
+  const defaultOwner = process.env.DISPATCH_DEFAULT_OWNER_EMAIL?.trim();
+  if (!defaultOwner || defaultOwner !== currentOwnerEmail()) return false;
+  if (await isCurrentIntegrationExplicitlyLinked()) return true;
+  return (
+    process.env.DISPATCH_ALLOW_DEFAULT_OWNER_APP_CREATION === "true" ||
+    process.env.DISPATCH_ALLOW_DEFAULT_OWNER_APP_CREATION === "1" ||
+    process.env.ENABLE_BUILDER === "true" ||
+    process.env.ENABLE_BUILDER === "1"
   );
 }
 
@@ -666,20 +724,31 @@ function normalizeBuilderRunResult(result: unknown): {
   };
 }
 
-function remoteAppCreationAuthorization():
-  | { ok: true }
-  | { ok: false; message: string } {
+async function remoteAppCreationAuthorization(): Promise<
+  { ok: true } | { ok: false; message: string }
+> {
   const ownerEmail = currentOwnerEmail();
+  const isIntegrationCaller = isIntegrationCallerRequest();
+  const defaultOwner = process.env.DISPATCH_DEFAULT_OWNER_EMAIL?.trim();
+  if (isIntegrationCaller && defaultOwner && defaultOwner === ownerEmail) {
+    if (await defaultOwnerAppCreationAllowed()) return { ok: true };
+    return {
+      ok: false,
+      message:
+        "Messaging-triggered app creation is using the deployment default Dispatch owner. " +
+        "Link the messaging identity to a Dispatch user with /link, start the app from Dispatch while signed in, or explicitly set ENABLE_BUILDER=true for this deployment.",
+    };
+  }
   if (!isSyntheticIntegrationOwner(ownerEmail)) return { ok: true };
 
-  const source = isIntegrationCallerRequest()
+  const source = isIntegrationCaller
     ? "Messaging-triggered"
     : "Synthetic integration";
   return {
     ok: false,
     message:
       `${source} app creation needs a trusted Dispatch owner before Builder can start a branch. ` +
-      "Link the Slack identity to a Dispatch user with /link, configure DISPATCH_DEFAULT_OWNER_EMAIL for this Slack workspace, or start the app from Dispatch while signed in.",
+      "Link the messaging identity to a Dispatch user with /link, start the app from Dispatch while signed in, or explicitly set ENABLE_BUILDER=true for this deployment.",
   };
 }
 
@@ -758,7 +827,7 @@ export async function startWorkspaceAppCreation(input: {
   const isLocal = isLocalAppCreationRuntime();
 
   if (!isLocal) {
-    const authorization = remoteAppCreationAuthorization();
+    const authorization = await remoteAppCreationAuthorization();
     if (authorization.ok === false) {
       return {
         mode: "builder-unavailable",

--- a/templates/dispatch/server/lib/dispatch-integrations.ts
+++ b/templates/dispatch/server/lib/dispatch-integrations.ts
@@ -11,7 +11,9 @@ function contextString(value: unknown): string | null {
   return null;
 }
 
-function identityKeyForIncoming(incoming: IncomingMessage): string | null {
+export function identityKeyForIncoming(
+  incoming: IncomingMessage,
+): string | null {
   const senderId = contextString(incoming.senderId);
   if (!senderId) return null;
 

--- a/templates/dispatch/server/lib/pre-auth-routing.spec.ts
+++ b/templates/dispatch/server/lib/pre-auth-routing.spec.ts
@@ -44,6 +44,8 @@ describe("dispatch pre-auth routing", () => {
     expect(rootDispatchRedirect("/dispatch/tools/", "")).toBeNull();
     expect(rootDispatchRedirect("/dispatch/tools/tool-123", "")).toBeNull();
     expect(rootDispatchRedirect("/dispatch/tools/tool-123/", "")).toBeNull();
+    expect(rootDispatchRedirect("/dispatch/apps/analytics", "")).toBeNull();
+    expect(rootDispatchRedirect("/dispatch/apps/analytics/", "")).toBeNull();
   });
 
   it("allows React Router manifest patch requests through the mounted dispatch path", () => {
@@ -67,6 +69,17 @@ describe("dispatch pre-auth routing", () => {
 
     expect(response?.status).toBe(302);
     expect(response?.headers.get("location")).toBe("/dispatch/apps?tab=all");
+  });
+
+  it("redirects root app detail aliases to mounted Dispatch app details", () => {
+    useDispatchBasePath();
+
+    const response = rootDispatchRedirect("/apps/analytics", "?tab=activity");
+
+    expect(response?.status).toBe(302);
+    expect(response?.headers.get("location")).toBe(
+      "/dispatch/apps/analytics?tab=activity",
+    );
   });
 
   it("redirects embedded root aliases to mounted Dispatch routes", () => {

--- a/templates/dispatch/server/lib/pre-auth-routing.ts
+++ b/templates/dispatch/server/lib/pre-auth-routing.ts
@@ -42,7 +42,7 @@ const MOUNTED_DISPATCH_ALIASES = new Map<string, string>([
 function isDispatchPagePath(pathname: string): boolean {
   if (DISPATCH_PAGE_PATHS.has(pathname)) return true;
   if (pathname === "/approval" || pathname === "/tools") return true;
-  return /^\/tools\/[^/]+$/.test(pathname);
+  return /^\/tools\/[^/]+$/.test(pathname) || /^\/apps\/[^/]+$/.test(pathname);
 }
 
 function isDispatchAssetOrFrameworkPath(pathname: string): boolean {
@@ -136,6 +136,13 @@ export function rootDispatchRedirect(
     return new Response(null, {
       status: 302,
       headers: { Location: `${basePath}${rootAlias}${search}` },
+    });
+  }
+
+  if (/^\/apps\/[^/]+$/.test(normalizedPathname)) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `${basePath}${normalizedPathname}${search}` },
     });
   }
 

--- a/templates/slides/app/components/editor/PromptDialog.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.tsx
@@ -1,12 +1,6 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
-import {
-  IconLoader2,
-  IconPaperclip,
-  IconX,
-  IconArrowUp,
-} from "@tabler/icons-react";
-import { appBasePath } from "@agent-native/core/client";
+import { appBasePath, PromptComposer } from "@agent-native/core/client";
 
 export interface UploadedFile {
   path: string;
@@ -41,25 +35,8 @@ export default function PromptPopover({
   anchorRef,
   centered = false,
 }: PromptPopoverProps) {
-  const [prompt, setPrompt] = useState("");
-  const [files, setFiles] = useState<File[]>([]);
-  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const [uploading, setUploading] = useState(false);
-  const [dragging, setDragging] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (open) {
-      setTimeout(() => inputRef.current?.focus(), 50);
-    } else {
-      setPrompt("");
-      setFiles([]);
-      setUploadedFiles([]);
-      setDragging(false);
-    }
-  }, [open]);
 
   // Position the popover after render so we can measure its actual size
   useEffect(() => {
@@ -79,24 +56,17 @@ export default function PromptPopover({
     const vw = window.innerWidth;
     const vh = window.innerHeight;
 
-    // Vertical: prefer below, flip above if needed
     let top = anchor.bottom + MARGIN;
     if (top + panelRect.height > vh - MARGIN) {
       top = Math.max(MARGIN, anchor.top - panelRect.height - MARGIN);
     }
 
-    // Horizontal: center on anchor, then clamp to stay within viewport
     const anchorCenterX = anchor.left + anchor.width / 2;
     let left = anchorCenterX - panelRect.width / 2;
-
-    // Clamp: don't go off right edge
     if (left + panelRect.width > vw - MARGIN) {
       left = vw - panelRect.width - MARGIN;
     }
-    // Clamp: don't go off left edge
-    if (left < MARGIN) {
-      left = MARGIN;
-    }
+    if (left < MARGIN) left = MARGIN;
 
     panel.style.top = top + "px";
     panel.style.left = left + "px";
@@ -127,56 +97,33 @@ export default function PromptPopover({
     };
   }, [open, onOpenChange, anchorRef]);
 
-  const uploadFiles = useCallback(async (newFiles: File[]) => {
-    setFiles((prev) => [...prev, ...newFiles]);
-    setUploading(true);
-    try {
-      const formData = new FormData();
-      newFiles.forEach((f) => formData.append("files", f));
-      const res = await fetch(`${appBasePath()}/api/uploads`, {
-        method: "POST",
-        body: formData,
-      });
-      if (res.ok) {
-        const results: UploadedFile[] = await res.json();
-        setUploadedFiles((prev) => [...prev, ...results]);
+  const uploadFiles = useCallback(
+    async (files: File[]): Promise<UploadedFile[]> => {
+      if (files.length === 0) return [];
+      setUploading(true);
+      try {
+        const formData = new FormData();
+        files.forEach((f) => formData.append("files", f));
+        const res = await fetch(`${appBasePath()}/api/uploads`, {
+          method: "POST",
+          body: formData,
+        });
+        if (!res.ok) return [];
+        return (await res.json()) as UploadedFile[];
+      } finally {
+        setUploading(false);
       }
-    } catch {
-      /* silent */
-    } finally {
-      setUploading(false);
-    }
-  }, []);
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selected = e.target.files;
-    if (!selected || selected.length === 0) return;
-    uploadFiles(Array.from(selected));
-    e.target.value = "";
-  };
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      setDragging(false);
-      const droppedFiles = Array.from(e.dataTransfer.files);
-      if (droppedFiles.length > 0) uploadFiles(droppedFiles);
     },
-    [uploadFiles],
+    [],
   );
 
-  const removeFile = (index: number) => {
-    setFiles((prev) => prev.filter((_, i) => i !== index));
-    setUploadedFiles((prev) => prev.filter((_, i) => i !== index));
-  };
-
-  const handleSubmit = () => {
-    if (!prompt.trim() && uploadedFiles.length === 0) return;
-    onSubmit(prompt.trim(), uploadedFiles);
-  };
-
-  const busy = loading || uploading;
-  const hasContent = prompt.trim().length > 0 || uploadedFiles.length > 0;
+  const handleSubmit = useCallback(
+    async (text: string, files: File[]) => {
+      const uploaded = await uploadFiles(files);
+      onSubmit(text.trim(), uploaded);
+    },
+    [onSubmit, uploadFiles],
+  );
 
   if (!open) return null;
 
@@ -190,131 +137,39 @@ export default function PromptPopover({
       )}
       <div
         ref={panelRef}
-        className={`fixed z-[200] w-[min(400px,calc(100vw-24px))] rounded-xl border bg-popover shadow-2xl shadow-black/60 overflow-hidden transition-colors ${
-          dragging ? "border-[#609FF8]/50 bg-accent" : "border-border"
-        }`}
+        className="fixed z-[200] w-[min(420px,calc(100vw-24px))] rounded-xl border border-border bg-popover shadow-2xl shadow-black/60"
         style={{ top: 0, left: 0, visibility: "visible" }}
-        onDrop={handleDrop}
-        onDragOver={(e) => {
-          e.preventDefault();
-          setDragging(true);
-        }}
-        onDragLeave={(e) => {
-          e.preventDefault();
-          setDragging(false);
-        }}
       >
-        <div className="px-3.5 pt-3 pb-1.5">
+        <div className="px-3.5 pt-3 pb-2">
           <span className="text-sm font-medium text-foreground/90">
             {title}
           </span>
         </div>
 
-        <div className="px-3.5 pb-2">
-          <textarea
-            ref={inputRef}
-            value={prompt}
-            onChange={(e) => {
-              setPrompt(e.target.value);
-              const el = e.target;
-              el.style.height = "auto";
-              el.style.height =
-                Math.min(el.scrollHeight, window.innerHeight * 0.5) + "px";
-            }}
+        <div className="px-2 pb-2">
+          <PromptComposer
+            autoFocus
+            attachmentsEnabled
+            disabled={loading || uploading}
             placeholder={placeholder}
-            className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/70 outline-none resize-none"
-            rows={3}
-            style={{ maxHeight: "50vh" }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                e.preventDefault();
-                handleSubmit();
-              }
-            }}
+            onSubmit={handleSubmit}
           />
         </div>
 
-        {/* File chips */}
-        {files.length > 0 && (
-          <div className="px-3.5 pb-2 flex flex-wrap gap-1.5">
-            {files.map((file, i) => (
-              <div
-                key={i}
-                className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-accent border border-border text-[11px] text-muted-foreground"
-              >
-                <span className="max-w-[120px] truncate">{file.name}</span>
-                <button
-                  onClick={() => removeFile(i)}
-                  className="p-0.5 rounded hover:bg-accent"
-                  aria-label={`Remove ${file.name}`}
-                >
-                  <IconX className="w-2.5 h-2.5" />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Bottom bar */}
-        <div className="px-3.5 py-2 flex items-center justify-between border-t border-border">
-          <div className="flex items-center gap-1">
+        {onSkip && (
+          <div className="flex justify-end border-t border-border px-3.5 py-2">
             <button
               type="button"
-              onClick={() => fileInputRef.current?.click()}
-              className="p-1.5 rounded-md hover:bg-accent text-muted-foreground/70 hover:text-muted-foreground transition-colors"
-              title="Attach files"
-              aria-label="Attach files"
+              onClick={() => {
+                onSkip();
+                onOpenChange(false);
+              }}
+              className="cursor-pointer text-xs text-[#609FF8] hover:text-[#7AB2FA]"
             >
-              <IconPaperclip className="w-4 h-4" />
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              onChange={handleFileChange}
-              className="hidden"
-            />
-          </div>
-
-          <div className="flex items-center gap-3">
-            <span className="text-[10px] text-muted-foreground/70">
-              {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
-              +Enter to submit
-            </span>
-            {onSkip && (
-              <button
-                onClick={() => {
-                  onSkip();
-                  onOpenChange(false);
-                }}
-                className="text-xs text-[#609FF8] hover:text-[#7AB2FA] transition-colors"
-              >
-                {skipLabel}
-              </button>
-            )}
-            <button
-              onClick={handleSubmit}
-              disabled={busy || !hasContent}
-              className={`p-1.5 rounded-lg transition-colors ${
-                hasContent && !busy
-                  ? "bg-[#609FF8] hover:bg-[#7AB2FA] text-black"
-                  : "bg-accent hover:bg-accent/80 disabled:opacity-30 disabled:cursor-not-allowed"
-              }`}
-              title="Submit"
-              aria-label="Submit"
-            >
-              {busy ? (
-                <IconLoader2
-                  className={`w-4 h-4 animate-spin ${hasContent ? "text-black" : "text-foreground/70"}`}
-                />
-              ) : (
-                <IconArrowUp
-                  className={`w-4 h-4 ${hasContent ? "text-black" : "text-foreground/70"}`}
-                />
-              )}
+              {skipLabel}
             </button>
           </div>
-        </div>
+        )}
       </div>
     </>
   );

--- a/templates/videos/app/components/NewCompositionPopover.tsx
+++ b/templates/videos/app/components/NewCompositionPopover.tsx
@@ -1,19 +1,13 @@
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  IconPlus,
-  IconArrowUp,
-  IconX,
-  IconPaperclip,
-} from "@tabler/icons-react";
+import { IconPlus } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
-import { Textarea } from "@/components/ui/textarea";
-import { Button } from "@/components/ui/button";
 import {
+  PromptComposer,
   useAgentChatGenerating,
   useSendToAgentChat,
 } from "@agent-native/core/client";
@@ -24,161 +18,82 @@ type NewCompositionPopoverProps = {
   onGeneratingChange?: (generating: boolean) => void;
 };
 
-type Attachment = {
-  name: string;
-  path: string; // data URL
-};
-
 export function NewCompositionPopover({
   isNew,
   onNavigate,
   onGeneratingChange,
 }: NewCompositionPopoverProps) {
   const [open, setOpen] = useState(false);
-  const [prompt, setPrompt] = useState("");
-  const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [isGenerating, setIsGenerating] = useState(false);
   const { send, codeRequiredDialog } = useSendToAgentChat();
-  const promptRef = useRef<HTMLTextAreaElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Auto-focus prompt when popover opens
-  useEffect(() => {
-    if (open) {
-      setPrompt("");
-      setAttachments([]);
-      setTimeout(() => promptRef.current?.focus(), 50);
-    }
-  }, [open]);
-
-  // Listen for generation completion and auto-save
   const [agentGenerating] = useAgentChatGenerating();
 
+  // Auto-save after the agent finishes generating a new composition
   useEffect(() => {
-    if (!agentGenerating && isGenerating) {
-      setIsGenerating(false);
-      onGeneratingChange?.(false);
-
-      // Auto-save after AI generation completes
-      setTimeout(async () => {
-        const currentPath = window.location.pathname;
-        const match = currentPath.match(/\/c\/([^\/]+)/);
-
-        if (match && match[1] !== "new") {
-          const compositionId = match[1];
-          console.log("[AI Auto-Save] Saving changes for:", compositionId);
-
-          try {
-            window.dispatchEvent(
-              new CustomEvent("videos.auto-save", {
-                detail: { compositionId },
-              }),
-            );
-          } catch (error) {
-            console.error("[AI Auto-Save] Failed:", error);
-          }
+    if (agentGenerating || !isGenerating) return;
+    setIsGenerating(false);
+    onGeneratingChange?.(false);
+    setTimeout(() => {
+      const match = window.location.pathname.match(/\/c\/([^\/]+)/);
+      if (match && match[1] !== "new") {
+        try {
+          window.dispatchEvent(
+            new CustomEvent("videos.auto-save", {
+              detail: { compositionId: match[1] },
+            }),
+          );
+        } catch (error) {
+          console.error("[AI Auto-Save] Failed:", error);
         }
-      }, 2000); // Wait 2 seconds for localStorage and state to settle
-    }
+      }
+    }, 2000);
   }, [agentGenerating, isGenerating, onGeneratingChange]);
 
-  const submitChat = () => {
-    if (!prompt.trim()) return;
+  async function fileToDataUrl(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  }
 
-    // Build context with attachment references
+  async function handleSubmit(text: string, files: File[]) {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
     let context =
       "The user wants to generate a new Remotion video composition. Help them create the component, register it, and set up tracks.";
-    if (attachments.length > 0) {
+
+    const allowed = files.filter(
+      (f) => f.type.match(/^(image|video)\//) || f.name.endsWith(".svg"),
+    );
+    if (allowed.length > 0) {
+      const attachments = await Promise.all(
+        allowed.map(async (f) => ({
+          name: f.name,
+          path: await fileToDataUrl(f),
+        })),
+      );
       context +=
         "\n\nAttached files:\n" +
         attachments.map((a) => `- ${a.name}: ${a.path}`).join("\n");
     }
 
-    // Send to agent chat via @agent-native/core
     const result = send({
-      message: prompt.trim(),
+      message: trimmed,
       context,
       submit: true,
       requiresCode: true,
     });
-
-    // If gated by production mode, don't proceed
     if (result === null) return;
 
-    console.log("[NewComposition] Sent to agent chat:", {
-      message: prompt.trim(),
-      attachments: attachments.length,
-    });
-
-    // Update state
     setIsGenerating(true);
     onGeneratingChange?.(true);
     setOpen(false);
-    setPrompt("");
-    setAttachments([]);
-
-    // Navigate to /c/new for loading state
     onNavigate("/c/new");
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-      e.preventDefault();
-      submitChat();
-    }
-  };
-
-  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files || files.length === 0) return;
-
-    const newAttachments: Attachment[] = [];
-
-    for (let i = 0; i < files.length; i++) {
-      const file = files[i];
-
-      // Only allow images, videos, and SVGs
-      if (!file.type.match(/^(image|video)\//) && !file.name.endsWith(".svg")) {
-        continue;
-      }
-
-      try {
-        const dataUrl = await new Promise<string>((resolve, reject) => {
-          const reader = new FileReader();
-          reader.onload = () => resolve(reader.result as string);
-          reader.onerror = reject;
-          reader.readAsDataURL(file);
-        });
-
-        newAttachments.push({
-          name: file.name,
-          path: dataUrl,
-        });
-      } catch (error) {
-        console.error("Failed to read file:", file.name, error);
-      }
-    }
-
-    setAttachments((prev) => [...prev, ...newAttachments]);
-
-    // Reset input so same file can be selected again
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  };
-
-  const removeAttachment = (index: number) => {
-    setAttachments((prev) => prev.filter((_, i) => i !== index));
-  };
-
-  // Auto-resize textarea
-  useEffect(() => {
-    const textarea = promptRef.current;
-    if (!textarea) return;
-
-    textarea.style.height = "auto";
-    textarea.style.height = Math.min(textarea.scrollHeight, 200) + "px";
-  }, [prompt]);
+  }
 
   return (
     <>
@@ -187,7 +102,7 @@ export function NewCompositionPopover({
         <PopoverTrigger asChild>
           <button
             className={cn(
-              "w-full flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg border border-dashed transition-all text-xs font-medium",
+              "flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-dashed px-3 py-2.5 text-xs font-medium transition-all",
               isNew
                 ? "border-primary/40 bg-primary/8 text-primary"
                 : "border-border text-muted-foreground hover:border-primary/30 hover:text-primary/80 hover:bg-primary/5",
@@ -201,95 +116,23 @@ export function NewCompositionPopover({
           side="right"
           align="start"
           sideOffset={8}
-          className="w-[calc(100vw-2rem)] sm:w-[400px] max-w-[400px] p-3 sm:p-4 bg-card border-border shadow-xl rounded-xl"
+          className="w-[calc(100vw-2rem)] max-w-[420px] rounded-xl border-border bg-card p-3 shadow-xl sm:w-[420px]"
         >
-          <div className="space-y-4">
-            {/* Header */}
-            <div>
-              <h3 className="text-sm font-semibold text-foreground">
-                New composition
-              </h3>
-              <p className="text-xs text-muted-foreground mt-1">
-                Describe the video you want to create
-              </p>
-            </div>
-
-            {/* Prompt textarea */}
-            <div className="space-y-2">
-              <Textarea
-                ref={promptRef}
-                value={prompt}
-                onChange={(e) => setPrompt(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="Describe the video you want to create..."
-                className="min-h-[120px] max-h-[200px] text-sm resize-none"
-              />
-            </div>
-
-            {/* Attachments */}
-            {attachments.length > 0 && (
-              <div className="flex flex-wrap gap-2">
-                {attachments.map((attachment, index) => (
-                  <div
-                    key={index}
-                    className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-secondary/50 border border-border/50 text-xs"
-                  >
-                    <IconPaperclip className="w-3 h-3 text-muted-foreground" />
-                    <span className="text-foreground/80 max-w-[150px] truncate">
-                      {attachment.name}
-                    </span>
-                    <button
-                      onClick={() => removeAttachment(index)}
-                      aria-label={`Remove ${attachment.name}`}
-                      className="p-0.5 hover:bg-destructive/10 rounded transition-colors"
-                    >
-                      <IconX className="w-3 h-3 text-muted-foreground hover:text-destructive" />
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Actions */}
-            <div className="flex items-center justify-between gap-2 pt-2">
-              {/* File attachment button */}
-              <div>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/*,video/*,.svg"
-                  multiple
-                  onChange={handleFileSelect}
-                  className="hidden"
-                />
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => fileInputRef.current?.click()}
-                  className="h-8 text-xs"
-                >
-                  <IconPlus className="w-3.5 h-3.5 mr-1.5" />
-                  Attach
-                </Button>
-              </div>
-
-              <div className="flex items-center gap-2">
-                <span className="text-[11px] text-muted-foreground/70">
-                  {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
-                  +Enter to submit
-                </span>
-                <Button
-                  size="sm"
-                  onClick={submitChat}
-                  disabled={!prompt.trim()}
-                  aria-label="Submit"
-                  className="h-8 text-xs"
-                >
-                  <IconArrowUp className="w-3.5 h-3.5" />
-                </Button>
-              </div>
-            </div>
+          <div className="mb-2 px-1">
+            <h3 className="text-sm font-semibold text-foreground">
+              New composition
+            </h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Describe the video you want to create
+            </p>
           </div>
+          <PromptComposer
+            autoFocus
+            attachmentsEnabled
+            placeholder="Describe the video you want to create..."
+            draftScope="videos:new-composition"
+            onSubmit={handleSubmit}
+          />
         </PopoverContent>
       </Popover>
     </>


### PR DESCRIPTION
## Summary
- add dashboard/report artifact recovery for A2A continuations and structured analytics action returns
- harden Dispatch Builder app creation for messaging/default-owner flows and admin-gate app creation settings
- add a reusable PromptComposer and simplify prompt popovers across Dispatch, tools, analytics, design, slides, and videos
- bump @agent-native/core to 0.7.72

## Validation
- pnpm --filter @agent-native/core build
- pnpm --filter dispatch typecheck
- pnpm --filter analytics typecheck
- pnpm --filter design typecheck
- pnpm --filter slides typecheck
- pnpm --filter @agent-native/core exec vitest --run src/client/NewWorkspaceAppFlow.spec.ts src/a2a/artifact-response.spec.ts
- pnpm --filter dispatch exec vitest --run server/lib/app-creation-store.spec.ts server/lib/dispatch-integrations.spec.ts (passes; Vitest still reports known close-timeout warning)
- pnpm guards
- pnpm --filter dispatch build
