### PR TITLE
Clarify async A2A delegation handling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.74",
+  "version": "0.7.75",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -718,6 +718,48 @@ describe("integration webhook handler engine resolution", () => {
     );
   });
 
+  it("sends substantive partial answers even when one A2A continuation will post separately", async () => {
+    const { processIntegrationTask } = await import("./webhook-handler.js");
+    const { A2A_CONTINUATION_QUEUED_MARKER } =
+      await import("./a2a-continuation-marker.js");
+    const sendResponse = vi.fn();
+    const partialAnswer =
+      "Analytics completed: 259,850 page views and 9,337 unique visitors from BigQuery. " +
+      "Content page was created successfully with document id abc123. " +
+      "Slides will post its result separately.";
+    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
+      send({
+        type: "tool_start",
+        tool: "call-agent",
+        input: { agent: "slides", message: "create deck" },
+      });
+      send({
+        type: "tool_done",
+        tool: "call-agent",
+        result: `${A2A_CONTINUATION_QUEUED_MARKER}\nThe Slides agent accepted this delegated subtask and will post its own final result.`,
+      });
+      send({
+        type: "text",
+        text: partialAnswer,
+      });
+    });
+
+    await processIntegrationTask(pendingTask({ id: "task-partial-final" }), {
+      adapter: createAdapter(sendResponse),
+      systemPrompt: "system",
+      actions: {},
+      model: "claude-sonnet-4-6",
+      apiKey: "",
+      ownerEmail: "dispatch+qa@integration.local",
+    });
+
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ text: partialAnswer }),
+      expect.any(Object),
+      expect.objectContaining({ placeholderRef: undefined }),
+    );
+  });
+
   it("sends verified recoverable A2A artifact tool results when no final text is emitted", async () => {
     const { processIntegrationTask } = await import("./webhook-handler.js");
     const sendResponse = vi.fn();

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -718,10 +718,28 @@ function extractRecoverableA2AArtifactToolResult(
 function isQueuedA2AContinuationDeferral(text: string): boolean {
   const normalized = text.replace(/\s+/g, " ").trim();
   if (!normalized) return true;
+  if (hasSubstantiveA2APartialAnswer(text)) return false;
   if (normalized.includes(A2A_CONTINUATION_QUEUED_MARKER)) return true;
   return /\b(?:still (?:working|processing)|is working on|taking longer than expected|will (?:post|update|surface|show up)|(?:it'?ll|it will|the result will|the final result will) (?:post|be posted|update|be updated|surface|show up)|will be (?:posted|updated|sent|shared)|final result when it finishes|while you wait|as soon as (?:it|it'?s|it is|the result|the artifact) (?:comes back|is ready|ready)|hang tight|relay from the .* agent)\b/i.test(
     normalized,
   );
+}
+
+function hasSubstantiveA2APartialAnswer(text: string): boolean {
+  const withoutMarker = text
+    .replaceAll(A2A_CONTINUATION_QUEUED_MARKER, "")
+    .trim();
+  if (!withoutMarker) return false;
+  if (/https?:\/\//i.test(withoutMarker)) return true;
+  if (/\|\s*[-:]+\s*\|/.test(withoutMarker)) return true;
+  if (
+    /\b(?:page\s*views?|unique\s+visitors?|dashboard|artifact id|document id|deck id|source|query|bigquery|created successfully)\b/i.test(
+      withoutMarker,
+    )
+  ) {
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -250,7 +250,10 @@ export async function run(
             callerEmail,
           );
           if (queued) {
-            responseText = `${A2A_CONTINUATION_QUEUED_MARKER}\nThe ${agent.name} agent is still working. Do not send an interim reply to the user; the final result will be posted to the originating integration thread automatically.`;
+            responseText =
+              `${A2A_CONTINUATION_QUEUED_MARKER}\n` +
+              `The ${agent.name} agent accepted this delegated subtask and will post its own final result to the originating integration thread automatically. ` +
+              `Do not call ${agent.name} again for this same subtask. Continue any other requested work, then answer with the completed results you have; if needed, mention that ${agent.name} is posting its result separately.`;
           } else {
             const reason = pollErr?.message ?? "unknown error";
             responseText = `The ${agent.name} agent is taking longer than expected and didn't reply in time. (${reason})`;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1490,7 +1490,9 @@ The \`call-agent\` tool sends a message to a DIFFERENT, separately-deployed app'
 
 **ONLY use \`call-agent\` when:**
 - The user explicitly asks you to communicate with a different app
-- You need data that only another deployed app can provide`,
+- You need data that only another deployed app can provide
+
+If \`call-agent\` says a downstream agent accepted the subtask and will post its result separately, do not call that same agent again for the same subtask. Continue any remaining work and answer with the completed results you have.`,
 
   memory: `### Structured Memory
 
@@ -1672,6 +1674,7 @@ The \`call-agent\` tool sends a message to a DIFFERENT, separately-deployed app'
 - You are coordinating across genuinely separate apps
 
 If \`call-agent\` returns an error saying the agent is yourself — stop and use your own tools instead.
+If \`call-agent\` says a downstream agent accepted a subtask and will post its result separately, do not call that same agent again for the same subtask. Continue any remaining work and answer with the completed results you have.
 
 ### Structured Memory
 


### PR DESCRIPTION
## Summary
- tell agents not to retry the same delegated call-agent subtask after an A2A continuation is queued
- allow integration replies that contain real partial results even when another A2A continuation will post separately
- bump @agent-native/core to 0.7.75

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/integrations/webhook-handler-engine.spec.ts src/integrations/a2a-continuation-processor.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- git diff --check