### PR TITLE
Shorten Netlify integration A2A wait budget

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.75",
+  "version": "0.7.76",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -21,7 +21,7 @@ import {
 import { getOrgDomain, getOrgA2ASecret } from "../org/context.js";
 
 const DEFAULT_SERVERLESS_INTEGRATION_A2A_TIMEOUT_MS = 18_000;
-const NETLIFY_INTEGRATION_A2A_TIMEOUT_MS = 15_000;
+const NETLIFY_INTEGRATION_A2A_TIMEOUT_MS = 5_000;
 const INTEGRATION_A2A_TOKEN_TTL = "30m";
 
 function parseTimeoutMs(value: string | undefined): number | undefined {


### PR DESCRIPTION
## Summary
- lower the Netlify integration call-agent wait budget to 5s so multi-agent Slack jobs have time to queue continuations, compose a final response, and deliver it before the function limit
- bump @agent-native/core to 0.7.76

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/integrations/webhook-handler-engine.spec.ts src/integrations/a2a-continuation-processor.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- git diff --check