### PR TITLE
Queue Netlify integration agent calls sooner

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.76",
+  "version": "0.7.77",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -16,7 +16,6 @@ const resolveEngineMock = vi.hoisted(() => vi.fn());
 const getStoredModelForEngineMock = vi.hoisted(() => vi.fn());
 const isLocalDatabaseMock = vi.hoisted(() => vi.fn());
 const readDeployCredentialEnvMock = vi.hoisted(() => vi.fn());
-const getA2AContinuationForIntegrationTaskMock = vi.hoisted(() => vi.fn());
 const originalNodeEnv = process.env.NODE_ENV;
 
 vi.mock("./thread-mapping-store.js", () => ({
@@ -61,11 +60,6 @@ vi.mock("../db/client.js", async () => {
 
 vi.mock("../server/credential-provider.js", () => ({
   readDeployCredentialEnv: readDeployCredentialEnvMock,
-}));
-
-vi.mock("./a2a-continuations-store.js", () => ({
-  getA2AContinuationForIntegrationTask:
-    getA2AContinuationForIntegrationTaskMock,
 }));
 
 vi.mock("../agent/run-manager.js", () => ({
@@ -167,7 +161,6 @@ describe("integration webhook handler engine resolution", () => {
     getOwnerApiKeyMock.mockResolvedValue(undefined);
     isLocalDatabaseMock.mockReturnValue(true);
     readDeployCredentialEnvMock.mockReturnValue(undefined);
-    getA2AContinuationForIntegrationTaskMock.mockResolvedValue(null);
     actionsToEngineToolsMock.mockReturnValue([]);
     getStoredModelForEngineMock.mockResolvedValue(undefined);
     resolveEngineMock.mockResolvedValue({
@@ -544,30 +537,31 @@ describe("integration webhook handler engine resolution", () => {
     );
   });
 
-  it("does not rerun the agent loop when retrying a task that already queued an A2A continuation", async () => {
+  it("reruns the agent loop when a previously queued continuation task is retried", async () => {
     const { processIntegrationTask } = await import("./webhook-handler.js");
     const { A2A_CONTINUATION_QUEUED_MARKER } =
       await import("./a2a-continuation-marker.js");
     const sendResponse = vi.fn();
     const task = pendingTask({ id: "task-retry-existing-continuation" });
-    getA2AContinuationForIntegrationTaskMock
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({
-        id: "cont-existing",
-        integrationTaskId: task.id,
+    runAgentLoopMock
+      .mockImplementationOnce(async ({ send }) => {
+        send({
+          type: "tool_start",
+          tool: "call-agent",
+          input: { agent: "starter", message: "finish the setup" },
+        });
+        send({
+          type: "tool_done",
+          tool: "call-agent",
+          result: `${A2A_CONTINUATION_QUEUED_MARKER}\nThe Starter agent is still working.`,
+        });
+      })
+      .mockImplementationOnce(async ({ send }) => {
+        send({
+          type: "text",
+          text: "Recovered final answer after the retry.",
+        });
       });
-    runAgentLoopMock.mockImplementationOnce(async ({ send }) => {
-      send({
-        type: "tool_start",
-        tool: "call-agent",
-        input: { agent: "starter", message: "finish the setup" },
-      });
-      send({
-        type: "tool_done",
-        tool: "call-agent",
-        result: `${A2A_CONTINUATION_QUEUED_MARKER}\nThe Starter agent is still working.`,
-      });
-    });
 
     await processIntegrationTask(task, {
       adapter: createAdapter(sendResponse),
@@ -586,11 +580,13 @@ describe("integration webhook handler engine resolution", () => {
       ownerEmail: "dispatch+qa@integration.local",
     });
 
-    expect(getA2AContinuationForIntegrationTaskMock).toHaveBeenCalledWith(
-      task.id,
+    expect(runAgentLoopMock).toHaveBeenCalledTimes(2);
+    expect(sendResponse).toHaveBeenCalledTimes(1);
+    expect(sendResponse.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        text: "Recovered final answer after the retry.",
+      }),
     );
-    expect(runAgentLoopMock).toHaveBeenCalledTimes(1);
-    expect(sendResponse).not.toHaveBeenCalled();
   });
 
   it("suppresses stale A2A continuation deferral replies", async () => {

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -40,7 +40,6 @@ import { signInternalToken } from "./internal-token.js";
 import { FRAMEWORK_ROUTE_PREFIX } from "../server/core-routes-plugin.js";
 import { withConfiguredAppBasePath } from "../server/app-base-path.js";
 import { A2A_CONTINUATION_QUEUED_MARKER } from "./a2a-continuation-marker.js";
-import { getA2AContinuationForIntegrationTask } from "./a2a-continuations-store.js";
 import { collectFinalResponseTextFromAgentEvents } from "../a2a/response-text.js";
 import {
   appendA2AArtifactLinks,
@@ -402,15 +401,6 @@ export async function processIntegrationTask(
     incoming: IncomingMessage;
     placeholderRef?: string;
   };
-  const existingContinuation = await getA2AContinuationForIntegrationTask(
-    task.id,
-  );
-  if (existingContinuation) {
-    console.log(
-      `[integrations] Skipping integration task ${task.id}; A2A continuation ${existingContinuation.id} already exists`,
-    );
-    return;
-  }
 
   await processIncomingMessage(parsed.incoming, options, {
     taskId: task.id,

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -21,7 +21,7 @@ import {
 import { getOrgDomain, getOrgA2ASecret } from "../org/context.js";
 
 const DEFAULT_SERVERLESS_INTEGRATION_A2A_TIMEOUT_MS = 18_000;
-const NETLIFY_INTEGRATION_A2A_TIMEOUT_MS = 5_000;
+const NETLIFY_INTEGRATION_A2A_TIMEOUT_MS = 2_000;
 const INTEGRATION_A2A_TOKEN_TTL = "30m";
 
 function parseTimeoutMs(value: string | undefined): number | undefined {
@@ -51,9 +51,10 @@ function getIntegrationCallTimeoutMs(): number | undefined {
   );
   if (configured !== undefined) return configured;
 
-  // Netlify's current synchronous function budget is 60s. Keep each delegated
-  // call short so multi-agent integration requests can queue continuations for
-  // more than one downstream app before the parent function is killed.
+  // Netlify's current synchronous function budget is 60s. Keep delegated
+  // calls very short so multi-agent integration requests queue downstream
+  // continuations quickly instead of spending the parent Slack/email processor
+  // budget waiting on separately deployed apps one-by-one.
   if (process.env.NETLIFY) return NETLIFY_INTEGRATION_A2A_TIMEOUT_MS;
 
   return DEFAULT_SERVERLESS_INTEGRATION_A2A_TIMEOUT_MS;


### PR DESCRIPTION
Multi-app Slack/email integration requests can burn most of Netlify's function budget waiting synchronously for downstream A2A calls. This lowers the default Netlify integration A2A wait window so downstream apps queue continuations quickly and post verified results back to the originating thread instead of leaving the parent processor to time out after doing real work.\n\nValidated locally:\n- pnpm --filter @agent-native/core exec vitest --run src/integrations/webhook-handler-engine.spec.ts src/integrations/a2a-continuation-processor.spec.ts\n- pnpm --filter @agent-native/core typecheck\n- pnpm --filter @agent-native/core build\n- git diff --check