### PR TITLE
Fix org A2A continuation auth

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.77",
+  "version": "0.7.78",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/a2a/client.spec.ts
+++ b/packages/core/src/a2a/client.spec.ts
@@ -233,6 +233,46 @@ describe("A2AClient", () => {
       jose.jwtVerify(token, new TextEncoder().encode("org-a2a-secret")),
     ).rejects.toThrow();
   });
+
+  it("auto-signs delegated calls with the org secret when one is available", async () => {
+    process.env.A2A_SECRET = "global-a2a-secret";
+    let bearerToken = "";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        if (!init) return new Response("not found", { status: 404 });
+        bearerToken = String(
+          new Headers(init.headers).get("authorization") ?? "",
+        ).replace(/^Bearer\s+/i, "");
+        const body = JSON.parse(String(init.body));
+        return completedResponse(body, "signed with org secret");
+      }),
+    );
+
+    await expect(
+      callAgent("https://agent.test", "hello", {
+        async: false,
+        userEmail: "alice+qa@agent-native.test",
+        orgDomain: "builder.io",
+        orgSecret: "org-a2a-secret",
+      }),
+    ).resolves.toBe("signed with org secret");
+
+    await expect(
+      jose.jwtVerify(bearerToken, new TextEncoder().encode("org-a2a-secret")),
+    ).resolves.toMatchObject({
+      payload: {
+        sub: "alice+qa@agent-native.test",
+        org_domain: "builder.io",
+      },
+    });
+    await expect(
+      jose.jwtVerify(
+        bearerToken,
+        new TextEncoder().encode("global-a2a-secret"),
+      ),
+    ).rejects.toThrow();
+  });
 });
 
 function completedResponse(body: any, text: string): Response {

--- a/packages/core/src/a2a/client.ts
+++ b/packages/core/src/a2a/client.ts
@@ -469,7 +469,7 @@ export async function callAgent(
         opts.userEmail,
         opts.orgDomain,
         opts.orgSecret,
-        { preferGlobalSecret: true },
+        { preferGlobalSecret: !opts.orgSecret },
       );
     } catch {
       // Fall back to unsigned call

--- a/packages/core/src/integrations/a2a-continuation-processor.spec.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.spec.ts
@@ -129,6 +129,7 @@ describe("A2A continuation processor", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.doUnmock("../org/context.js");
     process.env = originalEnv;
   });
 
@@ -447,6 +448,38 @@ describe("A2A continuation processor", () => {
       { requestTimeoutMs: 8_000 },
     );
     expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+  });
+
+  it("prefers the org A2A secret for continuation polling when one is available", async () => {
+    process.env.A2A_SECRET = "workspace-global-a2a-secret";
+    vi.doMock("../org/context.js", () => ({
+      getOrgDomain: vi.fn(async () => "builder.io"),
+      getOrgA2ASecret: vi.fn(async () => "builder-org-a2a-secret"),
+    }));
+    const sendResponse = vi.fn(async () => undefined);
+    claimA2AContinuationMock.mockResolvedValueOnce(
+      continuation({ orgId: "builder_io" }),
+    );
+    const { processA2AContinuationById } =
+      await import("./a2a-continuation-processor.js");
+
+    await processA2AContinuationById("cont-1", {
+      adapters: new Map([["slack", adapter(sendResponse)]]),
+    });
+
+    expect(signA2ATokenMock).toHaveBeenCalledWith(
+      "alice+qa@agent-native.test",
+      "builder.io",
+      "builder-org-a2a-secret",
+      { expiresIn: "30m", preferGlobalSecret: false },
+    );
+    expect(A2AClientMock).toHaveBeenCalledWith(
+      "https://slides.agent-native.test",
+      "signed-a2a-token",
+      { requestTimeoutMs: 8_000 },
+    );
+    expect(completeA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+    vi.doUnmock("../org/context.js");
   });
 
   it("preserves an originally unsigned A2A call when polling a continuation", async () => {

--- a/packages/core/src/integrations/a2a-continuation-processor.ts
+++ b/packages/core/src/integrations/a2a-continuation-processor.ts
@@ -478,7 +478,7 @@ async function signFreshContinuationToken(
   try {
     return await signA2AToken(continuation.ownerEmail, orgDomain, orgSecret, {
       expiresIn: "30m",
-      preferGlobalSecret: true,
+      preferGlobalSecret: !orgSecret,
     });
   } catch {
     return undefined;

--- a/packages/core/src/integrations/pending-tasks-retry-job.spec.ts
+++ b/packages/core/src/integrations/pending-tasks-retry-job.spec.ts
@@ -18,6 +18,7 @@ async function loadRetryJob() {
 describe("pending task retry job", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response("ok", { status: 200 })),
@@ -73,6 +74,24 @@ describe("pending task retry job", () => {
       }),
     );
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses a shorter processing-stuck cutoff on serverless hosts", async () => {
+    vi.stubEnv("NETLIFY", "true");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-04T04:00:00.000Z"));
+    const { retryStuckPendingTasks } = await loadRetryJob();
+    executeMock.mockResolvedValueOnce({ rows: [] });
+
+    await retryStuckPendingTasks("https://app.test");
+
+    expect(executeMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        args: [Date.now() - 90_000, Date.now() - 75_000],
+      }),
+    );
+    vi.useRealTimers();
   });
 
   it("uses status-guarded updates so stale retry sweeps cannot clobber completed tasks", async () => {

--- a/packages/core/src/integrations/pending-tasks-retry-job.ts
+++ b/packages/core/src/integrations/pending-tasks-retry-job.ts
@@ -17,7 +17,8 @@ import { signInternalToken } from "./internal-token.js";
  * This job runs every 60s and re-fires the processor endpoint for tasks that
  * look stuck:
  *   - status='pending' AND created_at older than 90s (initial dispatch lost)
- *   - status='processing' AND updated_at older than 5min (killed mid-flight)
+ *   - status='processing' AND updated_at older than the host-specific
+ *     function budget (75s on serverless, 5min elsewhere)
  *
  * Retries are capped at MAX_ATTEMPTS attempts; after that the row is marked
  * `failed` permanently so it stops being retried.
@@ -30,8 +31,9 @@ import { signInternalToken } from "./internal-token.js";
 const RETRY_INTERVAL_MS = 60_000;
 /** Tasks pending longer than this are considered stuck on initial dispatch */
 const PENDING_STUCK_AFTER_MS = 90_000;
-/** Tasks "processing" longer than this are considered killed mid-flight */
-const PROCESSING_STUCK_AFTER_MS = 5 * 60 * 1000;
+/** Tasks "processing" longer than this are considered killed mid-flight. */
+const DEFAULT_PROCESSING_STUCK_AFTER_MS = 5 * 60 * 1000;
+const SERVERLESS_PROCESSING_STUCK_AFTER_MS = 75_000;
 /** After this many attempts we give up and mark the task failed */
 const MAX_ATTEMPTS = 3;
 
@@ -62,7 +64,7 @@ export async function retryStuckPendingTasks(
   const client = getDbExec();
   const now = Date.now();
   const pendingCutoff = now - PENDING_STUCK_AFTER_MS;
-  const processingCutoff = now - PROCESSING_STUCK_AFTER_MS;
+  const processingCutoff = now - getProcessingStuckAfterMs();
 
   let stuckRows: StuckTaskRow[];
   try {
@@ -148,6 +150,18 @@ export async function retryStuckPendingTasks(
       );
     }
   }
+}
+
+function getProcessingStuckAfterMs(): number {
+  if (
+    process.env.NETLIFY ||
+    process.env.AWS_LAMBDA_FUNCTION_NAME ||
+    process.env.VERCEL ||
+    "__cf_env" in globalThis
+  ) {
+    return SERVERLESS_PROCESSING_STUCK_AFTER_MS;
+  }
+  return DEFAULT_PROCESSING_STUCK_AFTER_MS;
 }
 
 /**

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -164,7 +164,7 @@ export async function run(
             callerOrgSecret,
             {
               expiresIn: INTEGRATION_A2A_TOKEN_TTL,
-              preferGlobalSecret: true,
+              preferGlobalSecret: !callerOrgSecret,
             },
           );
         } catch {}


### PR DESCRIPTION
Fixes production Slack continuation polling for org-connected apps.\n\nChanges:\n- Prefer the org A2A secret over an app-local global A2A_SECRET when an org secret is available for call-agent and continuation polling.\n- Keep global A2A_SECRET fallback for non-org / shared-secret deployments.\n- Retry serverless integration tasks sooner when a processor is killed mid-flight.\n- Bump @agent-native/core to 0.7.78.\n\nValidated locally:\n- pnpm --filter @agent-native/core exec vitest --run src/a2a/client.spec.ts src/integrations/a2a-continuation-processor.spec.ts src/integrations/pending-tasks-retry-job.spec.ts src/integrations/webhook-handler-engine.spec.ts\n- pnpm --filter @agent-native/core typecheck\n- pnpm --filter @agent-native/core build\n- git diff --check