### PR TITLE
Reuse delegated work on integration retries

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/integrations/a2a-continuations-store.spec.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.spec.ts
@@ -39,6 +39,7 @@ function continuationRow(overrides: Record<string, unknown> = {}) {
     org_id: null,
     agent_name: "Slides",
     agent_url: "https://slides.agent-native.test",
+    dedupe_key: "message-hash-1",
     a2a_task_id: "a2a-task-1",
     a2a_auth_token: null,
     status: "processing",
@@ -88,6 +89,71 @@ describe("A2A continuations store", () => {
 
     expect(continuation?.id).toBe("cont-existing");
     expect(continuation?.integrationTaskId).toBe("task-existing");
+  });
+
+  it("lists continuations for an integration task, agent URL, and dedupe key", async () => {
+    const { getA2AContinuationsForIntegrationTaskAgent } = await loadStore();
+    executeMock.mockImplementation(
+      async (query: string | { sql: string; args?: unknown[] }) => {
+        const sql = querySql(query);
+        const args = queryArgs(query);
+        if (
+          sql.includes(
+            "WHERE integration_task_id = ? AND agent_url = ? AND dedupe_key = ?",
+          ) &&
+          sql.includes("ORDER BY created_at ASC")
+        ) {
+          return {
+            rows: [
+              continuationRow({
+                id: "cont-first",
+                integration_task_id: args[0],
+                agent_url: args[1],
+                dedupe_key: args[2],
+                created_at: 10,
+              }),
+              continuationRow({
+                id: "cont-second",
+                integration_task_id: args[0],
+                agent_url: args[1],
+                dedupe_key: args[2],
+                status: "completed",
+                created_at: 20,
+                completed_at: 30,
+              }),
+            ],
+            rowsAffected: 0,
+          };
+        }
+        return { rows: [], rowsAffected: 0 };
+      },
+    );
+
+    const continuations = await getA2AContinuationsForIntegrationTaskAgent(
+      "task-existing",
+      "https://slides.agent-native.test",
+      "message-hash-1",
+    );
+
+    expect(continuations.map((continuation) => continuation.id)).toEqual([
+      "cont-first",
+      "cont-second",
+    ]);
+    expect(
+      executeMock.mock.calls.some(([query]) => {
+        const sql = querySql(query);
+        return (
+          sql.includes(
+            "integration_task_id = ? AND agent_url = ? AND dedupe_key = ?",
+          ) && sql.includes("ORDER BY created_at ASC")
+        );
+      }),
+    ).toBe(true);
+    expect(queryArgs(executeMock.mock.calls.at(-1)![0])).toEqual([
+      "task-existing",
+      "https://slides.agent-native.test",
+      "message-hash-1",
+    ]);
   });
 
   it("allows multiple downstream continuations for one integration task", async () => {

--- a/packages/core/src/integrations/a2a-continuations-store.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.ts
@@ -21,6 +21,7 @@ async function ensureTable(): Promise<void> {
           org_id TEXT,
           agent_name TEXT NOT NULL,
           agent_url TEXT NOT NULL,
+          dedupe_key TEXT,
           a2a_task_id TEXT NOT NULL,
           a2a_auth_token TEXT,
           status TEXT NOT NULL,
@@ -41,9 +42,19 @@ async function ensureTable(): Promise<void> {
       await client.execute(
         `CREATE UNIQUE INDEX IF NOT EXISTS idx_a2a_continuations_remote_task ON integration_a2a_continuations(integration_task_id, agent_url, a2a_task_id)`,
       );
+      await client.execute(
+        `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_dedupe_key ON integration_a2a_continuations(integration_task_id, agent_url, dedupe_key)`,
+      );
       try {
         await client.execute(
           `ALTER TABLE integration_a2a_continuations ADD COLUMN a2a_auth_token TEXT`,
+        );
+      } catch {
+        // Column already exists.
+      }
+      try {
+        await client.execute(
+          `ALTER TABLE integration_a2a_continuations ADD COLUMN dedupe_key TEXT`,
         );
       } catch {
         // Column already exists.
@@ -71,6 +82,7 @@ export interface A2AContinuation {
   orgId: string | null;
   agentName: string;
   agentUrl: string;
+  dedupeKey: string | null;
   a2aTaskId: string;
   a2aAuthToken: string | null;
   status: A2AContinuationStatus;
@@ -94,6 +106,7 @@ function rowToContinuation(row: Record<string, unknown>): A2AContinuation {
     orgId: (row.org_id as string | null) ?? null,
     agentName: row.agent_name as string,
     agentUrl: row.agent_url as string,
+    dedupeKey: (row.dedupe_key as string | null) ?? null,
     a2aTaskId: row.a2a_task_id as string,
     a2aAuthToken: (row.a2a_auth_token as string | null) ?? null,
     status: row.status as A2AContinuationStatus,
@@ -117,6 +130,7 @@ export async function insertA2AContinuation(input: {
   orgId?: string | null;
   agentName: string;
   agentUrl: string;
+  dedupeKey?: string | null;
   a2aTaskId: string;
   a2aAuthToken?: string | null;
 }): Promise<A2AContinuation> {
@@ -130,9 +144,9 @@ export async function insertA2AContinuation(input: {
     await client.execute({
       sql: `INSERT INTO integration_a2a_continuations
         (id, integration_task_id, platform, external_thread_id, incoming_payload,
-         placeholder_ref, owner_email, org_id, agent_name, agent_url, a2a_task_id, a2a_auth_token,
+         placeholder_ref, owner_email, org_id, agent_name, agent_url, dedupe_key, a2a_task_id, a2a_auth_token,
          status, attempts, next_check_at, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       args: [
         id,
         input.integrationTaskId,
@@ -144,6 +158,7 @@ export async function insertA2AContinuation(input: {
         input.orgId ?? null,
         input.agentName,
         input.agentUrl,
+        input.dedupeKey ?? null,
         input.a2aTaskId,
         input.a2aAuthToken ?? null,
         "pending",
@@ -179,6 +194,31 @@ export async function getA2AContinuationForIntegrationTask(
     args: [integrationTaskId],
   });
   return rows[0] ? rowToContinuation(rows[0] as Record<string, unknown>) : null;
+}
+
+export async function getA2AContinuationsForIntegrationTaskAgent(
+  integrationTaskId: string,
+  agentUrl: string,
+  dedupeKey?: string | null,
+): Promise<A2AContinuation[]> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute(
+    dedupeKey
+      ? {
+          sql: `SELECT * FROM integration_a2a_continuations
+                WHERE integration_task_id = ? AND agent_url = ? AND dedupe_key = ?
+                ORDER BY created_at ASC`,
+          args: [integrationTaskId, agentUrl, dedupeKey],
+        }
+      : {
+          sql: `SELECT * FROM integration_a2a_continuations
+                WHERE integration_task_id = ? AND agent_url = ?
+                ORDER BY created_at ASC`,
+          args: [integrationTaskId, agentUrl],
+        },
+  );
+  return rows.map((row) => rowToContinuation(row as Record<string, unknown>));
 }
 
 function isDuplicateContinuationError(err: unknown): boolean {

--- a/packages/core/src/integrations/webhook-handler-engine.spec.ts
+++ b/packages/core/src/integrations/webhook-handler-engine.spec.ts
@@ -509,7 +509,7 @@ describe("integration webhook handler engine resolution", () => {
       ownerEmail: "dispatch+qa@integration.local",
       orgId: "org-qa",
       status: "processing",
-      attempts: 1,
+      attempts: 2,
       errorMessage: null,
       createdAt: Date.now(),
       updatedAt: Date.now(),
@@ -528,6 +528,7 @@ describe("integration webhook handler engine resolution", () => {
     expect(captured).toEqual(
       expect.objectContaining({
         taskId: "task-context",
+        attempts: 2,
         placeholderRef: "placeholder-qa",
         incoming: expect.objectContaining({
           platform: "fake",

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -404,6 +404,7 @@ export async function processIntegrationTask(
 
   await processIncomingMessage(parsed.incoming, options, {
     taskId: task.id,
+    attempts: task.attempts,
     placeholderRef: parsed.placeholderRef,
   });
 }
@@ -415,7 +416,7 @@ export async function processIntegrationTask(
 async function processIncomingMessage(
   incoming: IncomingMessage,
   options: WebhookHandlerOptions,
-  opts: { taskId?: string; placeholderRef?: string } = {},
+  opts: { taskId?: string; attempts?: number; placeholderRef?: string } = {},
 ): Promise<void> {
   const {
     adapter,
@@ -535,6 +536,7 @@ async function processIncomingMessage(
             integration: opts.taskId
               ? {
                   taskId: opts.taskId,
+                  attempts: opts.attempts,
                   incoming,
                   placeholderRef: opts.placeholderRef,
                 }

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -1,5 +1,6 @@
 import type { ActionTool } from "../agent/types.js";
 import type { ActionRunContext } from "../agent/production-agent.js";
+import { createHash } from "node:crypto";
 import { findAgent, discoverAgents } from "../server/agent-discovery.js";
 import {
   A2AClient,
@@ -189,6 +190,9 @@ export async function run(
 
       let responseText = "";
       let lastSentLength = 0;
+      const existingContinuationText =
+        await formatExistingIntegrationContinuationIfRetry(agent, message);
+      if (existingContinuationText) return existingContinuationText;
 
       context.send({
         type: "agent_call",
@@ -248,6 +252,7 @@ export async function run(
           const queued = await enqueueIntegrationContinuationIfPossible(
             pollErr,
             agent,
+            message,
             callerEmail,
           );
           if (queued) {
@@ -317,6 +322,7 @@ export async function run(
 async function enqueueIntegrationContinuationIfPossible(
   error: A2ATaskTimeoutError,
   agent: { name: string; url: string },
+  message: string,
   ownerEmail: string | undefined,
 ): Promise<boolean> {
   const integration = getIntegrationRequestContext();
@@ -338,6 +344,7 @@ async function enqueueIntegrationContinuationIfPossible(
       orgId: getRequestOrgId() ?? null,
       agentName: agent.name,
       agentUrl: agent.url,
+      dedupeKey: getIntegrationContinuationDedupeKey(message),
       a2aTaskId: error.taskId,
       // Do not persist the short-lived JWT used for the initial send. The
       // continuation processor can mint a fresh token for each poll.
@@ -354,6 +361,50 @@ async function enqueueIntegrationContinuationIfPossible(
     console.error("[call-agent] Failed to enqueue A2A continuation:", err);
     return false;
   }
+}
+
+async function formatExistingIntegrationContinuationIfRetry(
+  agent: {
+    name: string;
+    url: string;
+  },
+  message: string,
+): Promise<string | null> {
+  const integration = getIntegrationRequestContext();
+  if (!integration || (integration.attempts ?? 1) <= 1) return null;
+
+  try {
+    const { getA2AContinuationsForIntegrationTaskAgent } =
+      await import("../integrations/a2a-continuations-store.js");
+    const continuations = await getA2AContinuationsForIntegrationTaskAgent(
+      integration.taskId,
+      agent.url,
+      getIntegrationContinuationDedupeKey(message),
+    );
+    const active = continuations.find((continuation) =>
+      ["pending", "processing", "delivering", "completed"].includes(
+        continuation.status,
+      ),
+    );
+    if (!active) return null;
+
+    const state =
+      active.status === "completed"
+        ? "already completed this delegated subtask and posted its result to the originating integration thread"
+        : "already accepted this delegated subtask and is still working on it for the originating integration thread";
+    return (
+      `${A2A_CONTINUATION_QUEUED_MARKER}\n` +
+      `The ${agent.name} agent ${state}. Do not call ${agent.name} again for this same subtask. Continue any other requested work, then answer with the completed results you have; if needed, mention that ${agent.name} is posting or has posted its result separately.`
+    );
+  } catch (err) {
+    console.error("[call-agent] Failed to inspect existing continuation:", err);
+    return null;
+  }
+}
+
+function getIntegrationContinuationDedupeKey(message: string): string {
+  const normalized = message.trim().replace(/\s+/g, " ");
+  return createHash("sha256").update(normalized).digest("hex");
 }
 
 // Expand bare leading-slash paths (e.g. "/deck/abc") into fully-qualified URLs

--- a/packages/core/src/server/request-context.ts
+++ b/packages/core/src/server/request-context.ts
@@ -64,6 +64,7 @@ export interface RequestContext {
    */
   integration?: {
     taskId: string;
+    attempts?: number;
     incoming: import("../integrations/types.js").IncomingMessage;
     placeholderRef?: string;
   };


### PR DESCRIPTION
## Summary
- carry integration task attempt counts into request context
- have call-agent reuse existing A2A continuations on retried integration tasks instead of spawning duplicate downstream work
- add tests for continuation lookup and retry attempt context
- bump @agent-native/core to 0.7.79

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/integrations/a2a-continuations-store.spec.ts src/integrations/webhook-handler-engine.spec.ts src/integrations/a2a-continuation-processor.spec.ts src/integrations/pending-tasks-retry-job.spec.ts src/a2a/client.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- git diff --check

## Notes
This is a conservative retry guard keyed by integration task and downstream agent URL. It prevents duplicate Slack retry fanout for the same downstream agent while leaving a future deeper resume mechanism room to persist continuation result text and link integration tasks to run history.