### PR TITLE
Queue continuations for bundled timeout errors

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.79",
+  "version": "0.7.80",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/scripts/call-agent.spec.ts
+++ b/packages/core/src/scripts/call-agent.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callAgentMock = vi.hoisted(() => vi.fn());
+const insertA2AContinuationMock = vi.hoisted(() => vi.fn());
+const dispatchA2AContinuationMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../server/agent-discovery.js", () => ({
+  findAgent: vi.fn(async () => ({
+    name: "Slides",
+    url: "https://slides.agent-native.test",
+  })),
+  discoverAgents: vi.fn(async () => []),
+}));
+
+vi.mock("../a2a/client.js", () => ({
+  A2ATaskTimeoutError: class A2ATaskTimeoutError extends Error {
+    taskId: string;
+    constructor(taskId: string) {
+      super(`A2A task ${taskId} did not complete within 18000ms`);
+      this.name = "A2ATaskTimeoutError";
+      this.taskId = taskId;
+    }
+  },
+  A2AClient: class A2AClient {},
+  callAgent: callAgentMock,
+  signA2AToken: vi.fn(async () => "signed-token"),
+}));
+
+vi.mock("../org/context.js", () => ({
+  getOrgDomain: vi.fn(async () => "builder.io"),
+  getOrgA2ASecret: vi.fn(async () => "org-secret"),
+}));
+
+vi.mock("../server/request-context.js", () => ({
+  getRequestUserEmail: () => "alice+qa@agent-native.test",
+  getRequestOrgId: () => "org-qa",
+  isIntegrationCallerRequest: () => true,
+  getIntegrationRequestContext: () => ({
+    taskId: "integration-task-1",
+    attempts: 1,
+    incoming: {
+      platform: "slack",
+      externalThreadId: "C123:123.456",
+      text: "make a deck",
+      platformContext: {},
+      timestamp: 123,
+    },
+    placeholderRef: "placeholder-1",
+  }),
+}));
+
+vi.mock("../integrations/a2a-continuations-store.js", () => ({
+  insertA2AContinuation: insertA2AContinuationMock,
+  getA2AContinuationsForIntegrationTaskAgent: vi.fn(async () => []),
+}));
+
+vi.mock("../integrations/a2a-continuation-processor.js", () => ({
+  dispatchA2AContinuation: dispatchA2AContinuationMock,
+}));
+
+describe("call-agent action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.NETLIFY;
+    insertA2AContinuationMock.mockResolvedValue({ id: "cont-1" });
+    dispatchA2AContinuationMock.mockResolvedValue(undefined);
+  });
+
+  it("queues an integration continuation for structurally equivalent timeout errors", async () => {
+    process.env.NETLIFY = "true";
+    const timeout = Object.assign(
+      new Error(
+        "A2A task remote-task-1 did not complete within 18000ms (last state: processing)",
+      ),
+      {
+        name: "A2ATaskTimeoutError",
+        taskId: "remote-task-1",
+      },
+    );
+    callAgentMock.mockRejectedValueOnce(timeout);
+    const { run } = await import("./call-agent.js");
+
+    const result = await run(
+      { agent: "slides", message: "create the QA deck" },
+      { send: vi.fn() } as any,
+    );
+
+    expect(result).toContain("[agent-native:a2a-continuation-queued]");
+    expect(insertA2AContinuationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationTaskId: "integration-task-1",
+        agentName: "Slides",
+        agentUrl: "https://slides.agent-native.test",
+        a2aTaskId: "remote-task-1",
+        dedupeKey: expect.any(String),
+      }),
+    );
+    expect(dispatchA2AContinuationMock).toHaveBeenCalledWith("cont-1");
+  });
+});

--- a/packages/core/src/scripts/call-agent.ts
+++ b/packages/core/src/scripts/call-agent.ts
@@ -248,9 +248,10 @@ export async function run(
         // Mirror the response into the streaming UI so the user sees it.
         if (responseText) emitNewText(responseText);
       } catch (pollErr: any) {
-        if (pollErr instanceof A2ATaskTimeoutError) {
+        const timeoutTaskId = getA2ATaskTimeoutTaskId(pollErr);
+        if (timeoutTaskId) {
           const queued = await enqueueIntegrationContinuationIfPossible(
-            pollErr,
+            timeoutTaskId,
             agent,
             message,
             callerEmail,
@@ -320,7 +321,7 @@ export async function run(
 }
 
 async function enqueueIntegrationContinuationIfPossible(
-  error: A2ATaskTimeoutError,
+  taskId: string,
   agent: { name: string; url: string },
   message: string,
   ownerEmail: string | undefined,
@@ -345,7 +346,7 @@ async function enqueueIntegrationContinuationIfPossible(
       agentName: agent.name,
       agentUrl: agent.url,
       dedupeKey: getIntegrationContinuationDedupeKey(message),
-      a2aTaskId: error.taskId,
+      a2aTaskId: taskId,
       // Do not persist the short-lived JWT used for the initial send. The
       // continuation processor can mint a fresh token for each poll.
       a2aAuthToken: null,
@@ -361,6 +362,25 @@ async function enqueueIntegrationContinuationIfPossible(
     console.error("[call-agent] Failed to enqueue A2A continuation:", err);
     return false;
   }
+}
+
+function getA2ATaskTimeoutTaskId(err: unknown): string | null {
+  if (err instanceof A2ATaskTimeoutError) return err.taskId;
+
+  const candidate = err as
+    | { name?: unknown; taskId?: unknown; message?: unknown }
+    | null
+    | undefined;
+  const message = String(candidate?.message ?? "");
+  if (
+    candidate?.name === "A2ATaskTimeoutError" &&
+    typeof candidate.taskId === "string"
+  ) {
+    return candidate.taskId;
+  }
+
+  const match = message.match(/^A2A task ([^\s]+) did not complete\b/);
+  return match?.[1] ?? null;
 }
 
 async function formatExistingIntegrationContinuationIfRetry(


### PR DESCRIPTION
## Summary
- structurally detect A2A timeout errors in call-agent so production bundles still queue integration continuations when instanceof fails
- add regression coverage for a plain timeout-shaped error object
- bump @agent-native/core to 0.7.80

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/scripts/call-agent.spec.ts src/a2a/client.spec.ts src/integrations/a2a-continuations-store.spec.ts src/integrations/webhook-handler-engine.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- git diff --check