### PR TITLE
Fix A2A continuation migration ordering

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.80",
+  "version": "0.7.81",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/integrations/a2a-continuations-store.spec.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.spec.ts
@@ -7,6 +7,14 @@ vi.mock("../db/client.js", () => ({
   getDbExec: () => ({ execute: executeMock }),
   isPostgres: isPostgresMock,
   intType: () => "INTEGER",
+  retryOnDdlRace: <T>(fn: () => Promise<T>) => fn(),
+}));
+
+vi.mock("../db/migrations.js", () => ({
+  isDuplicateColumnError: (err: unknown) =>
+    /duplicate column name|column .* already exists/i.test(
+      (err as Error | undefined)?.message ?? "",
+    ),
 }));
 
 async function loadStore() {
@@ -57,6 +65,42 @@ describe("A2A continuations store", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     isPostgresMock.mockReturnValue(false);
+  });
+
+  it("adds migrated columns before indexing them", async () => {
+    const { getA2AContinuationForIntegrationTask } = await loadStore();
+    executeMock.mockResolvedValue({ rows: [], rowsAffected: 0 });
+
+    await getA2AContinuationForIntegrationTask("task-existing");
+
+    const calls = executeMock.mock.calls.map(([query]) => querySql(query));
+    const dedupeAlterIndex = calls.findIndex((sql) =>
+      sql.includes("ADD COLUMN dedupe_key"),
+    );
+    const dedupeIndexIndex = calls.findIndex((sql) =>
+      sql.includes("idx_a2a_continuations_dedupe_key"),
+    );
+    expect(dedupeAlterIndex).toBeGreaterThan(-1);
+    expect(dedupeIndexIndex).toBeGreaterThan(-1);
+    expect(dedupeAlterIndex).toBeLessThan(dedupeIndexIndex);
+  });
+
+  it("does not swallow non-duplicate column migration errors", async () => {
+    const { getA2AContinuationForIntegrationTask } = await loadStore();
+    const migrationError = new Error("permission denied for table");
+    executeMock.mockImplementation(
+      async (query: string | { sql: string; args?: unknown[] }) => {
+        const sql = querySql(query);
+        if (sql.includes("ADD COLUMN a2a_auth_token")) {
+          throw migrationError;
+        }
+        return { rows: [], rowsAffected: 0 };
+      },
+    );
+
+    await expect(
+      getA2AContinuationForIntegrationTask("task-existing"),
+    ).rejects.toThrow("permission denied");
   });
 
   it("finds an existing continuation for an integration task", async () => {

--- a/packages/core/src/integrations/a2a-continuations-store.ts
+++ b/packages/core/src/integrations/a2a-continuations-store.ts
@@ -1,4 +1,10 @@
-import { getDbExec, isPostgres, intType } from "../db/client.js";
+import {
+  getDbExec,
+  isPostgres,
+  intType,
+  retryOnDdlRace,
+} from "../db/client.js";
+import { isDuplicateColumnError } from "../db/migrations.js";
 import type { IncomingMessage } from "./types.js";
 
 let _initPromise: Promise<void> | undefined;
@@ -9,7 +15,8 @@ async function ensureTable(): Promise<void> {
   if (!_initPromise) {
     _initPromise = (async () => {
       const client = getDbExec();
-      await client.execute(`
+      await retryOnDdlRace(() =>
+        client.execute(`
         CREATE TABLE IF NOT EXISTS integration_a2a_continuations (
           id TEXT PRIMARY KEY,
           integration_task_id TEXT NOT NULL,
@@ -32,36 +39,46 @@ async function ensureTable(): Promise<void> {
           updated_at ${intType()} NOT NULL,
           completed_at ${intType()}
         )
-      `);
-      await client.execute(
-        `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_status_next ON integration_a2a_continuations(status, next_check_at)`,
+      `),
       );
-      await client.execute(
-        `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_integration_task ON integration_a2a_continuations(integration_task_id)`,
+      await retryOnDdlRace(() =>
+        client.execute(
+          `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_status_next ON integration_a2a_continuations(status, next_check_at)`,
+        ),
       );
-      await client.execute(
-        `CREATE UNIQUE INDEX IF NOT EXISTS idx_a2a_continuations_remote_task ON integration_a2a_continuations(integration_task_id, agent_url, a2a_task_id)`,
+      await retryOnDdlRace(() =>
+        client.execute(
+          `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_integration_task ON integration_a2a_continuations(integration_task_id)`,
+        ),
       );
-      await client.execute(
-        `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_dedupe_key ON integration_a2a_continuations(integration_task_id, agent_url, dedupe_key)`,
+      await retryOnDdlRace(() =>
+        client.execute(
+          `CREATE UNIQUE INDEX IF NOT EXISTS idx_a2a_continuations_remote_task ON integration_a2a_continuations(integration_task_id, agent_url, a2a_task_id)`,
+        ),
       );
-      try {
-        await client.execute(
-          `ALTER TABLE integration_a2a_continuations ADD COLUMN a2a_auth_token TEXT`,
-        );
-      } catch {
-        // Column already exists.
-      }
-      try {
-        await client.execute(
-          `ALTER TABLE integration_a2a_continuations ADD COLUMN dedupe_key TEXT`,
-        );
-      } catch {
-        // Column already exists.
-      }
+      await addColumnIfMissing("a2a_auth_token", "TEXT");
+      await addColumnIfMissing("dedupe_key", "TEXT");
+      await retryOnDdlRace(() =>
+        client.execute(
+          `CREATE INDEX IF NOT EXISTS idx_a2a_continuations_dedupe_key ON integration_a2a_continuations(integration_task_id, agent_url, dedupe_key)`,
+        ),
+      );
     })();
   }
   return _initPromise;
+}
+
+async function addColumnIfMissing(name: string, definition: string) {
+  try {
+    await retryOnDdlRace(() =>
+      getDbExec().execute(
+        `ALTER TABLE integration_a2a_continuations ADD COLUMN ${name} ${definition}`,
+      ),
+    );
+  } catch (err) {
+    if (isDuplicateColumnError(err)) return;
+    throw err;
+  }
 }
 
 export type A2AContinuationStatus =


### PR DESCRIPTION
## Summary
- create the A2A continuation dedupe index only after the dedupe_key column migration runs
- add a regression test for migration/index ordering
- bump @agent-native/core to 0.7.81

## Validation
- pnpm --filter @agent-native/core exec vitest --run src/integrations/a2a-continuations-store.spec.ts src/scripts/call-agent.spec.ts src/a2a/client.spec.ts src/integrations/webhook-handler-engine.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build
- git diff --check