### PR TITLE
Composer pasted-text chip and parallel-safe agent actions

### DIFF
--- a/.agents/skills/actions/SKILL.md
+++ b/.agents/skills/actions/SKILL.md
@@ -75,6 +75,7 @@ Rules:
 - `http: { method: "GET" }` → read-only, does NOT trigger a refresh (inferred automatically).
 - Any other action (default `POST`, `PUT`, `DELETE`, or `http: false`) → treated as mutating, triggers a refresh on success.
 - To override the inference on an unusual action (e.g. a `POST` that only reads), pass `readOnly: true` on the action definition.
+- To let a mutating action run concurrently with other same-turn tool calls, pass `parallelSafe: true`. Only do this when the action is internally concurrency-safe and order-independent (for example, it uses an app-level lock or idempotent upsert semantics). Mutating actions remain serialized by default.
 
 Agents do NOT need to call `refresh-screen` after a normal action — it's already handled. `refresh-screen` is only needed when the agent mutates data via a path the framework can't see (e.g. writing to an external system the app mirrors) or when the agent wants to pass a `scope` hint for narrower invalidation.
 

--- a/packages/core/docs/content/actions.md
+++ b/packages/core/docs/content/actions.md
@@ -67,6 +67,7 @@ export default defineAction({
 - **`http: { path: "..." }`** — override the route path under `/_agent-native/actions/`. Defaults to the filename.
 - **`http: false`** — disable the HTTP endpoint entirely. Agent + CLI only.
 - **`readOnly: true`** — explicitly skip the poll-refresh even for POST actions that don't mutate.
+- **`parallelSafe: true`** — allow a mutating action to run concurrently with other same-turn tool calls. Only set this when the action is internally concurrency-safe and order-independent; mutating actions serialize by default.
 
 ### Tools callability {#tool-callable}
 

--- a/packages/core/docs/content/creating-templates.md
+++ b/packages/core/docs/content/creating-templates.md
@@ -157,7 +157,7 @@ export default defineAction({
 });
 ```
 
-Use `http: { method: "GET" }` or `readOnly: true` for read-only actions. Use `toolCallable: false` for high-blast-radius actions that should not run from sandboxed tools.
+Use `http: { method: "GET" }` or `readOnly: true` for read-only actions. Use `parallelSafe: true` only for mutating actions that are safe to run concurrently with same-turn tool calls. Use `toolCallable: false` for high-blast-radius actions that should not run from sandboxed tools.
 
 ## Build The UI {#ui}
 

--- a/packages/core/src/action.spec.ts
+++ b/packages/core/src/action.spec.ts
@@ -66,4 +66,14 @@ describe("defineAction — readOnly inference", () => {
     // refresh event even though the method is GET.
     expect(action.readOnly).toBe(false);
   });
+
+  it("preserves explicit parallelSafe metadata", () => {
+    const action = defineAction({
+      description: "safe same-turn write",
+      parameters: { x: { type: "string" } },
+      parallelSafe: true,
+      run: async () => "ok",
+    });
+    expect(action.parallelSafe).toBe(true);
+  });
 });

--- a/packages/core/src/action.ts
+++ b/packages/core/src/action.ts
@@ -46,6 +46,11 @@ interface DefineActionWithSchema<
    *  Only set this manually when you need to override the inference — e.g. a
    *  POST action that only reads data but can't use GET for a protocol reason. */
   readOnly?: boolean;
+  /** If true, the agent may execute this action concurrently with other
+   *  read-only or parallel-safe tool calls emitted in the same model turn.
+   *  Only set this for mutating actions that are internally concurrency-safe
+   *  and order-independent for same-turn execution. */
+  parallelSafe?: boolean;
   /** Whether this action may be invoked from the tools (Alpine iframe) bridge
    *  via `appAction(name, params)` — see `packages/core/docs/content/actions.md`
    *  ("Tools Callability"). **Default-allow opt-out**: undefined / `true` both
@@ -81,6 +86,9 @@ interface DefineActionWithParams<
   /** If true, the framework will NOT emit a screen-refresh poll event after a
    *  successful call. Auto-inferred as `true` when `http.method === "GET"`. */
   readOnly?: boolean;
+  /** If true, the agent may execute this action concurrently with other
+   *  read-only or parallel-safe tool calls emitted in the same model turn. */
+  parallelSafe?: boolean;
   /** Whether this action may be invoked from the tools (Alpine iframe) bridge
    *  via `appAction(name, params)`. See the schema overload above for details
    *  and the `toolCallable` section in actions.md. */
@@ -188,6 +196,10 @@ export function defineAction(options: any) {
     typeof options.toolCallable === "boolean"
       ? options.toolCallable
       : undefined;
+  const parallelSafe: boolean | undefined =
+    typeof options.parallelSafe === "boolean"
+      ? options.parallelSafe
+      : undefined;
 
   return {
     tool: {
@@ -198,6 +210,7 @@ export function defineAction(options: any) {
     ...(hasSchema ? { schema: options.schema } : {}),
     ...(options.http !== undefined ? { http: options.http } : {}),
     ...(typeof readOnly === "boolean" ? { readOnly } : {}),
+    ...(typeof parallelSafe === "boolean" ? { parallelSafe } : {}),
     ...(typeof toolCallable === "boolean" ? { toolCallable } : {}),
   };
 }

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -12,6 +12,7 @@ import type { AgentEngine, EngineEvent } from "./engine/types.js";
 function actionEntry(opts: {
   description?: string;
   readOnly?: boolean;
+  parallelSafe?: boolean;
   actions?: string[];
 }): ActionEntry {
   return {
@@ -34,6 +35,9 @@ function actionEntry(opts: {
           },
     },
     ...(typeof opts.readOnly === "boolean" ? { readOnly: opts.readOnly } : {}),
+    ...(typeof opts.parallelSafe === "boolean"
+      ? { parallelSafe: opts.parallelSafe }
+      : {}),
     run: async (args) => `ran:${JSON.stringify(args)}`,
   };
 }
@@ -257,6 +261,182 @@ describe("runAgentLoop", () => {
     });
 
     expect(order).toEqual(["a:start", "a:end", "b:start", "b:end"]);
+  });
+
+  it("runs parallel-safe mutating tool calls concurrently", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "tool-a",
+                name: "write-a",
+                input: {},
+              },
+              {
+                type: "tool-call" as const,
+                id: "tool-b",
+                name: "write-b",
+                input: {},
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    let active = 0;
+    let maxActive = 0;
+    const run = async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      active -= 1;
+      return "ok";
+    };
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "write-a": {
+          ...actionEntry({ readOnly: false, parallelSafe: true }),
+          run,
+        },
+        "write-b": {
+          ...actionEntry({ readOnly: false, parallelSafe: true }),
+          run,
+        },
+      },
+      send: () => {},
+      signal: new AbortController().signal,
+    });
+
+    expect(maxActive).toBe(2);
+  });
+
+  it("keeps reads ordered around parallel-safe mutating batches", async () => {
+    let streamCalls = 0;
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: true,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        streamCalls += 1;
+        if (streamCalls === 1) {
+          yield {
+            type: "assistant-content",
+            parts: [
+              {
+                type: "tool-call" as const,
+                id: "tool-a",
+                name: "write-a",
+                input: {},
+              },
+              {
+                type: "tool-call" as const,
+                id: "tool-read",
+                name: "read-state",
+                input: {},
+              },
+              {
+                type: "tool-call" as const,
+                id: "tool-b",
+                name: "write-b",
+                input: {},
+              },
+            ],
+          };
+          yield { type: "stop", reason: "tool_use" };
+          return;
+        }
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "done" }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const order: string[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {
+        "write-a": {
+          ...actionEntry({ readOnly: false, parallelSafe: true }),
+          run: async () => {
+            order.push("a:start");
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            order.push("a:end");
+            return "a";
+          },
+        },
+        "read-state": {
+          ...actionEntry({ readOnly: true }),
+          run: async () => {
+            order.push("read:start");
+            order.push("read:end");
+            return "read";
+          },
+        },
+        "write-b": {
+          ...actionEntry({ readOnly: false, parallelSafe: true }),
+          run: async () => {
+            order.push("b:start");
+            order.push("b:end");
+            return "b";
+          },
+        },
+      },
+      send: () => {},
+      signal: new AbortController().signal,
+    });
+
+    expect(order).toEqual([
+      "a:start",
+      "a:end",
+      "read:start",
+      "read:end",
+      "b:start",
+      "b:end",
+    ]);
   });
 
   it("emits loop_limit with the configured max iteration count", async () => {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -206,6 +206,10 @@ export interface ActionEntry {
   /** If true, completion does NOT trigger a screen-refresh poll event.
    *  Set automatically by `defineAction` when `http.method === "GET"`. */
   readOnly?: boolean;
+  /** If true, this action can run concurrently with other same-turn
+   *  read-only/parallel-safe tool calls. Only use for actions that handle
+   *  their own write ordering and idempotency. */
+  parallelSafe?: boolean;
   /** Whether this action may be invoked from the tools-iframe bridge.
    *  **Default-allow opt-out**: only an explicit `false` returns 403.
    *  - `true` / `undefined` — allow.
@@ -432,6 +436,10 @@ export interface ProductionAgentOptions {
   providerOptions?: EngineMessage extends never ? never : any;
   /** Called when a run completes (for server-side thread persistence) */
   onRunComplete?: (run: ActiveRun, threadId: string | undefined) => void;
+  /** Per-app soft timeout for agent runs. Defaults to AGENT_RUN_SOFT_TIMEOUT_MS
+   *  or the framework default. Set only when the hosting function timeout is
+   *  also configured higher than this value. */
+  runSoftTimeoutMs?: number;
   /** Called when a run starts, with the send function for emitting events and the threadId */
   onRunStart?: (
     send: (event: AgentChatEvent) => void,
@@ -1055,25 +1063,46 @@ export async function runAgentLoop(opts: {
       };
     };
 
-    const hasMutatingToolCall = toolCallParts.some((toolCall) => {
+    type ParallelBatchKind = "read" | "parallel-write";
+    const getParallelBatchKind = (
+      toolCall: import("./engine/types.js").EngineToolCallPart,
+    ): ParallelBatchKind | null => {
       const entry = actions[toolCall.name];
-      return entry && entry.readOnly !== true;
-    });
+      if (!entry || entry.readOnly === true) return "read";
+      if (entry.parallelSafe === true) return "parallel-write";
+      return null;
+    };
 
-    // Engines can emit several tool-call blocks in one turn. Keep read-only
-    // calls parallel for latency, but serialize any batch containing a mutating
-    // call so DB writes and UI refresh events preserve model order and do not
-    // interleave or partially race.
+    // Engines can emit several tool-call blocks in one turn. Read-only calls
+    // are always parallel. Mutating calls remain serialized by default, but
+    // consecutive actions that explicitly declare `parallelSafe` can run in a
+    // write batch. Reads and writes are separate batches so the model's stated
+    // order still controls what data a same-turn read can observe.
     const toolResultParts: EngineContentPart[] = [];
-    if (hasMutatingToolCall) {
-      for (const toolCall of toolCallParts) {
+    let parallelBatch: import("./engine/types.js").EngineToolCallPart[] = [];
+    let parallelBatchKind: ParallelBatchKind | null = null;
+    const flushParallelBatch = async () => {
+      if (parallelBatch.length === 0) return;
+      const batch = parallelBatch;
+      parallelBatch = [];
+      parallelBatchKind = null;
+      toolResultParts.push(...(await Promise.all(batch.map(runToolCall))));
+    };
+
+    for (const toolCall of toolCallParts) {
+      const batchKind = getParallelBatchKind(toolCall);
+      if (batchKind) {
+        if (parallelBatchKind && parallelBatchKind !== batchKind) {
+          await flushParallelBatch();
+        }
+        parallelBatchKind = batchKind;
+        parallelBatch.push(toolCall);
+      } else {
+        await flushParallelBatch();
         toolResultParts.push(await runToolCall(toolCall));
       }
-    } else {
-      toolResultParts.push(
-        ...(await Promise.all(toolCallParts.map(runToolCall))),
-      );
     }
+    await flushParallelBatch();
 
     messages.push({ role: "user", content: toolResultParts });
   }
@@ -1864,6 +1893,7 @@ export function createProductionAgentHandler(
       options.onRunComplete
         ? (run) => options.onRunComplete!(run, threadId)
         : undefined,
+      { softTimeoutMs: options.runSoftTimeoutMs },
     );
 
     // Subscribe to the run and stream events to the client

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentChatEvent } from "./types.js";
+
+vi.mock("./run-store.js", () => ({
+  insertRun: vi.fn(() => Promise.resolve()),
+  insertRunEvent: vi.fn(() => Promise.resolve()),
+  updateRunStatus: vi.fn(() => Promise.resolve()),
+  markRunAborted: vi.fn(() => Promise.resolve()),
+  isRunAborted: vi.fn(() => Promise.resolve(false)),
+  getRunEventsSince: vi.fn(() => Promise.resolve([])),
+  getRunById: vi.fn(() => Promise.resolve(null)),
+  getRunByThread: vi.fn(() => Promise.resolve(null)),
+  cleanupOldRuns: vi.fn(() => Promise.resolve()),
+  updateRunHeartbeat: vi.fn(() => Promise.resolve()),
+  reapIfStale: vi.fn(() => Promise.resolve(null)),
+}));
+
+import { resolveRunSoftTimeoutMs, startRun } from "./run-manager.js";
+
+const originalTimeoutEnv = process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
+
+describe("run manager soft timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    delete process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    if (originalTimeoutEnv === undefined) {
+      delete process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
+    } else {
+      process.env.AGENT_RUN_SOFT_TIMEOUT_MS = originalTimeoutEnv;
+    }
+    vi.useRealTimers();
+  });
+
+  it("emits a recoverable timeout error and aborts the run", async () => {
+    const events: AgentChatEvent[] = [];
+    let aborted = false;
+
+    const run = startRun(
+      "run-soft-timeout",
+      "thread-soft-timeout",
+      async (_send, signal) => {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => {
+            aborted = true;
+            resolve();
+          });
+        });
+      },
+      undefined,
+      { softTimeoutMs: 10 },
+    );
+    run.subscribers.add((event) => events.push(event.event));
+
+    await vi.advanceTimersByTimeAsync(11);
+
+    expect(aborted).toBe(true);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        errorCode: "run_timeout",
+        recoverable: true,
+      }),
+    );
+    expect(run.status).toBe("errored");
+  });
+
+  it("prefers an explicit soft timeout over the environment default", () => {
+    process.env.AGENT_RUN_SOFT_TIMEOUT_MS = "25000";
+
+    expect(resolveRunSoftTimeoutMs(5000)).toBe(5000);
+  });
+});

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -31,7 +31,17 @@ const threadToRun = new Map<string, string>();
 const CLEANUP_DELAY_MS = 5 * 60 * 1000;
 const DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000;
 
-function getRunSoftTimeoutMs(): number {
+export interface StartRunOptions {
+  /** Override the run soft timeout for this run. Must be lower than the
+   * hosting platform's hard function timeout so the framework can emit a
+   * recoverable event before the host kills the process. */
+  softTimeoutMs?: number;
+}
+
+export function resolveRunSoftTimeoutMs(overrideMs?: number): number {
+  if (typeof overrideMs === "number" && Number.isFinite(overrideMs)) {
+    return Math.max(0, overrideMs);
+  }
   const raw = Number(process.env.AGENT_RUN_SOFT_TIMEOUT_MS);
   if (Number.isFinite(raw) && raw >= 0) return raw;
   return DEFAULT_RUN_SOFT_TIMEOUT_MS;
@@ -52,6 +62,7 @@ export function startRun(
     signal: AbortSignal,
   ) => Promise<void>,
   onComplete?: (run: ActiveRun) => void | Promise<void>,
+  options?: StartRunOptions,
 ): ActiveRun {
   // If there's already a run for this thread, abort it
   const existingRunId = threadToRun.get(threadId);
@@ -84,7 +95,7 @@ export function startRun(
   const heartbeatTimer: ReturnType<typeof setInterval> = setInterval(() => {
     updateRunHeartbeat(runId).catch(() => {});
   }, 1500);
-  const softTimeoutMs = getRunSoftTimeoutMs();
+  const softTimeoutMs = resolveRunSoftTimeoutMs(options?.softTimeoutMs);
   const softTimeoutTimer =
     softTimeoutMs > 0
       ? setTimeout(() => {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -58,6 +58,8 @@ import {
   type TiptapComposerHandle,
 } from "./composer/TiptapComposer.js";
 import type { Reference } from "./composer/types.js";
+import { isPastedTextAttachmentName } from "./composer/pasted-text.js";
+import { PastedTextChip } from "./composer/PastedTextChip.js";
 import {
   IconMessage,
   IconX,
@@ -535,6 +537,10 @@ function ComposerAttachmentPreviewCard({
     };
   }, [attachment]);
 
+  if (isPastedTextAttachmentName(attachment.name)) {
+    return <PastedTextChip attachment={attachment} onRemove={onRemove} />;
+  }
+
   const isImage = !!imageSrc;
 
   return (
@@ -662,6 +668,11 @@ function ToolCallDisplay({
         return (
           <ConnectBuilderCard
             configured={!!parsed.configured}
+            builderEnabled={
+              typeof parsed.builderEnabled === "boolean"
+                ? parsed.builderEnabled
+                : true
+            }
             connectUrl={parsed.connectUrl || ""}
             orgName={parsed.orgName ?? null}
             prompt={typeof parsed.prompt === "string" ? parsed.prompt : ""}
@@ -1002,6 +1013,9 @@ function UserMessageAttachments() {
               />
             </div>
           );
+        }
+        if (isPastedTextAttachmentName(att.name)) {
+          return <PastedTextChip key={att.id} attachment={att} compact />;
         }
         return (
           <div
@@ -2814,13 +2828,29 @@ const AssistantChatInner = forwardRef<
     }
   }, []);
 
-  // Scroll to bottom when a restored thread finishes loading
+  // Scroll to bottom when a restored thread finishes loading.
+  // Re-scroll a few times because messages with images, code blocks, and
+  // markdown can change height after their initial paint — a single RAF
+  // call lands on the wrong position and leaves the user staring at the top.
   const wasRestoringRef = useRef(isRestoring);
   useEffect(() => {
     if (wasRestoringRef.current && !isRestoring) {
-      requestAnimationFrame(() => {
-        scrollToBottom();
-      });
+      const el = scrollRef.current;
+      if (el) {
+        // Immediate sync scroll so the first paint is already at the bottom.
+        el.scrollTop = el.scrollHeight;
+        isNearBottomRef.current = true;
+        setShowScrollToBottom(false);
+      }
+      // Then re-snap on the next frame and again after late content lays out.
+      requestAnimationFrame(() => scrollToBottom());
+      const t1 = setTimeout(() => scrollToBottom(), 100);
+      const t2 = setTimeout(() => scrollToBottom(), 400);
+      wasRestoringRef.current = isRestoring;
+      return () => {
+        clearTimeout(t1);
+        clearTimeout(t2);
+      };
     }
     wasRestoringRef.current = isRestoring;
   }, [isRestoring, scrollToBottom]);
@@ -3061,7 +3091,22 @@ const AssistantChatInner = forwardRef<
                                 : "Retry the previous request from a clean approach.",
                             );
                           }}
-                          onFork={onForkChat}
+                          onFork={
+                            onForkChat
+                              ? () => {
+                                  // Dismiss the error locally so the card
+                                  // disappears immediately (visual feedback)
+                                  // and doesn't reappear when the forked tab
+                                  // mounts with the same persisted error
+                                  // metadata in its thread_data.
+                                  if (visibleRunErrorKey) {
+                                    setDismissedRunErrorKey(visibleRunErrorKey);
+                                  }
+                                  setRunErrorInfo(null);
+                                  onForkChat();
+                                }
+                              : undefined
+                          }
                           onDismiss={() => {
                             if (visibleRunErrorKey) {
                               setDismissedRunErrorKey(visibleRunErrorKey);
@@ -3149,6 +3194,25 @@ const AssistantChatInner = forwardRef<
             <SelectionAttachedPill />
             {/* Input area */}
             <div className="agent-composer-area shrink-0 px-3 py-2">
+              {composerOnly && missingApiKey && (
+                <div className="mb-2 flex items-center justify-between gap-3 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                  <span className="min-w-0">
+                    Set up an AI engine to start chatting with the agent.
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      window.dispatchEvent(new CustomEvent("agent-panel:open"));
+                      window.dispatchEvent(
+                        new CustomEvent("agent-panel:open-settings"),
+                      );
+                    }}
+                    className="shrink-0 cursor-pointer rounded-md bg-foreground px-2.5 py-1 text-[11px] font-medium text-background hover:opacity-90"
+                  >
+                    Set up agent
+                  </button>
+                </div>
+              )}
               <ComposerPrimitive.Root
                 className={cn(
                   "flex flex-col rounded-lg border border-input bg-background focus-within:ring-1 focus-within:ring-ring",
@@ -3161,14 +3225,16 @@ const AssistantChatInner = forwardRef<
                   focusRef={tiptapRef}
                   disabled={missingApiKey}
                   placeholder={
-                    composerPlaceholder ??
-                    (missingApiKey
-                      ? "Connect an AI engine above to start chatting…"
-                      : isRunning
-                        ? queuedMessages.length > 0
-                          ? `${queuedMessages.length} queued — type another...`
-                          : "Queue a message..."
-                        : undefined)
+                    missingApiKey
+                      ? composerOnly
+                        ? "Set up an AI engine to start chatting…"
+                        : "Connect an AI engine above to start chatting…"
+                      : (composerPlaceholder ??
+                        (isRunning
+                          ? queuedMessages.length > 0
+                            ? `${queuedMessages.length} queued — type another...`
+                            : "Queue a message..."
+                          : undefined))
                   }
                   onSubmit={
                     onSubmitOverride

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1473,7 +1473,7 @@ function BuilderConnectCta({
           Connect Builder.io
         </div>
         <p className="text-[11px] text-muted-foreground mt-0.5 max-w-[220px]">
-          Managed LLM, hosting, and more — no API key needed
+          Free credits for LLM, hosting, and more — no API key needed
         </p>
         {error && <p className="mt-1 text-[10px] text-destructive">{error}</p>}
       </div>

--- a/packages/core/src/client/ConnectBuilderCard.tsx
+++ b/packages/core/src/client/ConnectBuilderCard.tsx
@@ -8,6 +8,12 @@ import { agentNativePath } from "./api-path.js";
 
 export interface ConnectBuilderCardProps {
   configured: boolean;
+  /**
+   * True when ENABLE_BUILDER / BUILDER_BRANCH_PROJECT_ID is set on the
+   * deploy. When false, the card shows a "coming soon" waitlist CTA instead
+   * of a Send button — the /builder/run endpoint would 403 anyway.
+   */
+  builderEnabled?: boolean;
   connectUrl: string;
   orgName?: string | null;
   /** The user's feature/change request, forwarded to Builder's cloud agent
@@ -29,6 +35,7 @@ interface BuilderRunResult {
  */
 export function ConnectBuilderCard({
   configured: initialConfigured,
+  builderEnabled: initialBuilderEnabled = true,
   connectUrl: initialConnectUrl,
   orgName: initialOrgName,
   prompt = "",
@@ -44,10 +51,17 @@ export function ConnectBuilderCard({
   const configured = flow.hasFetchedStatus
     ? flow.configured
     : initialConfigured;
+  const builderEnabled = flow.hasFetchedStatus
+    ? flow.builderEnabled
+    : initialBuilderEnabled;
   const orgName = flow.hasFetchedStatus
     ? flow.orgName
     : (initialOrgName ?? null);
   const connecting = flow.connecting;
+
+  const [waitlistJoined, setWaitlistJoined] = useState(false);
+  const [joiningWaitlist, setJoiningWaitlist] = useState(false);
+  const [waitlistErr, setWaitlistErr] = useState<string | null>(null);
 
   const [sending, setSending] = useState(false);
   const [runResult, setRunResult] = useState<BuilderRunResult | null>(null);
@@ -93,10 +107,45 @@ export function ConnectBuilderCard({
     }
   }, [prompt]);
 
-  // Combine connect-flow errors and send errors into one surface.
-  const err = sendErr ?? flow.error;
+  const handleJoinWaitlist = useCallback(async () => {
+    setJoiningWaitlist(true);
+    setWaitlistErr(null);
+    try {
+      const origin = getCallbackOrigin() || window.location.origin;
+      const res = await fetch(
+        new URL(
+          agentNativePath("/_agent-native/builder/branch-waitlist"),
+          origin,
+        ).href,
+        { method: "POST" },
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          typeof data?.error === "string"
+            ? data.error
+            : `Request failed (${res.status})`,
+        );
+      }
+      if (!mountedRef.current) return;
+      setWaitlistJoined(true);
+      setJoiningWaitlist(false);
+    } catch (e) {
+      if (!mountedRef.current) return;
+      setWaitlistErr(e instanceof Error ? e.message : "Couldn't join waitlist");
+      setJoiningWaitlist(false);
+    }
+  }, []);
 
-  const canSend = configured && prompt.trim().length > 0;
+  // Combine connect-flow errors, send errors, and waitlist errors.
+  const err = sendErr ?? waitlistErr ?? flow.error;
+
+  const hasPrompt = prompt.trim().length > 0;
+  const canSend = configured && builderEnabled && hasPrompt;
+  // Branch creation is gated by deploy env (ENABLE_BUILDER / project id).
+  // Show waitlist when the user has connected and has a prompt, but the
+  // deploy hasn't been opted in yet.
+  const showWaitlist = configured && !builderEnabled && hasPrompt;
 
   // Title + subtitle depend on which mode we're in. We compute them up front
   // so the render tree below stays flat.
@@ -111,6 +160,18 @@ export function ConnectBuilderCard({
           {runResult.branchName}
         </span>
         . Click through to watch progress in the Visual Editor.
+      </>
+    );
+  } else if (showWaitlist) {
+    title = waitlistJoined
+      ? "You're on the waitlist"
+      : "Builder branches — coming soon";
+    subtitle = waitlistJoined ? (
+      <>We'll let you know as soon as cloud branch creation is available.</>
+    ) : (
+      <>
+        Cloud branch creation isn't available on this deployment yet. Join the
+        waitlist and we'll let you know when it ships.
       </>
     );
   } else if (canSend) {
@@ -207,6 +268,26 @@ export function ConnectBuilderCard({
                   </>
                 ) : (
                   <>Send to Builder</>
+                )}
+              </button>
+            ) : showWaitlist && !waitlistJoined ? (
+              <button
+                type="button"
+                onClick={handleJoinWaitlist}
+                disabled={joiningWaitlist}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+                  "bg-foreground text-background hover:bg-foreground/90",
+                  joiningWaitlist && "opacity-70 cursor-wait",
+                )}
+              >
+                {joiningWaitlist ? (
+                  <>
+                    <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+                    Joining…
+                  </>
+                ) : (
+                  <>Join the waitlist</>
                 )}
               </button>
             ) : !configured ? (

--- a/packages/core/src/client/ErrorBoundary.tsx
+++ b/packages/core/src/client/ErrorBoundary.tsx
@@ -36,13 +36,28 @@ export function ErrorBoundary() {
       title = `${error.status} Error`;
       details = error.statusText || details;
     }
-  } else if (
-    typeof process !== "undefined" &&
-    process.env.NODE_ENV !== "production" &&
-    error instanceof Error
-  ) {
-    details = error.message;
-    stack = error.stack;
+  } else if (error instanceof Error) {
+    // Always surface the underlying error message — a generic
+    // "An unexpected error occurred." in production tells users (and us)
+    // nothing. The stack trace is still gated to dev so we don't leak
+    // internals to end users.
+    if (error.message) {
+      details = error.message;
+    }
+    if (
+      typeof process !== "undefined" &&
+      process.env.NODE_ENV !== "production"
+    ) {
+      stack = error.stack;
+    }
+  } else if (typeof error === "string" && error) {
+    details = error;
+  }
+
+  // Log to the console so the underlying failure is recoverable from
+  // browser devtools / Sentry even when the UI hides the stack.
+  if (typeof console !== "undefined" && error) {
+    console.error("[ErrorBoundary]", error);
   }
 
   return (

--- a/packages/core/src/client/FeedbackButton.tsx
+++ b/packages/core/src/client/FeedbackButton.tsx
@@ -10,6 +10,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { IconMessage2, IconCheck } from "@tabler/icons-react";
 import { cn } from "./utils.js";
+import { useSession } from "./use-session.js";
 
 const DEFAULT_FEEDBACK_URL =
   "https://forms.agent-native.com/f/agent-native-feedback/_16ewV";
@@ -115,6 +116,7 @@ export function FeedbackButton({
   placeholder,
 }: FeedbackButtonProps) {
   const target = parseTarget(url);
+  const { session } = useSession();
 
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState("");
@@ -168,6 +170,7 @@ export function FeedbackButton({
       setSubmitting(true);
       setError(null);
       try {
+        const submitterEmail = session?.email;
         const res = await fetch(
           `${target.endpoint}/api/submit/${encodeURIComponent(schema.formId)}`,
           {
@@ -177,6 +180,7 @@ export function FeedbackButton({
               data: { [schema.fieldId]: trimmed },
               _t: openedAtRef.current,
               _hp: honeypot,
+              ...(submitterEmail ? { _meta: { submitterEmail } } : {}),
             }),
           },
         );
@@ -193,7 +197,7 @@ export function FeedbackButton({
         setError(err instanceof Error ? err.message : "Couldn't send feedback");
       }
     },
-    [target, schema, value, honeypot, submitting],
+    [target, schema, value, honeypot, submitting, session?.email],
   );
 
   const trigger =

--- a/packages/core/src/client/composer/ComposerPlusMenu.tsx
+++ b/packages/core/src/client/composer/ComposerPlusMenu.tsx
@@ -41,17 +41,32 @@ interface ComposerPlusMenuProps {
 type View = "menu" | "mcp-server";
 
 function UploadOnlyAttachButton() {
+  // Mirrors the hidden-AddAttachment + visible-button pattern used in the full
+  // ComposerPlusMenu. Rendering AddAttachment directly as the visible button
+  // can disappear when the runtime reports no eligible adapter; the hidden
+  // delegate keeps the visible "+" button reliably mounted.
+  const hiddenRef = useRef<HTMLButtonElement>(null);
   return (
-    <ComposerPrimitive.AddAttachment asChild>
+    <>
+      <ComposerPrimitive.AddAttachment asChild>
+        <button
+          ref={hiddenRef}
+          type="button"
+          className="hidden"
+          tabIndex={-1}
+          aria-hidden
+        />
+      </ComposerPrimitive.AddAttachment>
       <button
         type="button"
-        className="shrink-0 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 disabled:opacity-30 disabled:cursor-not-allowed"
+        onClick={() => hiddenRef.current?.click()}
+        className="shrink-0 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
         title="Upload file"
         aria-label="Upload file"
       >
         <IconPlus className="h-4 w-4" />
       </button>
-    </ComposerPrimitive.AddAttachment>
+    </>
   );
 }
 

--- a/packages/core/src/client/composer/PastedTextChip.tsx
+++ b/packages/core/src/client/composer/PastedTextChip.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from "react";
+import { IconClipboardText, IconX } from "@tabler/icons-react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import type { Attachment } from "@assistant-ui/react";
+import { cn } from "../utils.js";
+import { countLines, unwrapAttachmentEnvelope } from "./pasted-text.js";
+
+function readAttachmentText(attachment: Attachment): Promise<string> | string {
+  if ("file" in attachment && attachment.file instanceof File) {
+    return attachment.file.text();
+  }
+  const textPart = attachment.content?.find(
+    (p): p is { type: "text"; text: string } =>
+      p.type === "text" && "text" in p && typeof p.text === "string",
+  );
+  return textPart ? unwrapAttachmentEnvelope(textPart.text) : "";
+}
+
+function usePastedAttachmentText(attachment: Attachment): {
+  text: string;
+  lines: number;
+  chars: number;
+} {
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    const result = readAttachmentText(attachment);
+    if (typeof result === "string") {
+      setText(result);
+      return;
+    }
+    result
+      .then((value) => {
+        if (!cancelled) setText(value);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [attachment]);
+
+  return { text, lines: countLines(text), chars: text.length };
+}
+
+export interface PastedTextChipProps {
+  attachment: Attachment;
+  onRemove?: (id: string) => void;
+  /** Compact variant rendered inside sent user messages. */
+  compact?: boolean;
+}
+
+export function PastedTextChip({
+  attachment,
+  onRemove,
+  compact = false,
+}: PastedTextChipProps) {
+  const [open, setOpen] = useState(false);
+  const { text, lines, chars } = usePastedAttachmentText(attachment);
+
+  const handleRemove = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      onRemove?.(attachment.id);
+    },
+    [attachment.id, onRemove],
+  );
+
+  const summary = lines > 0 ? `${lines} lines` : `${chars} chars`;
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Trigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "group relative inline-flex items-center gap-2 rounded-md border border-border/70 bg-muted/50 text-left text-foreground hover:bg-muted/70 cursor-pointer",
+            compact
+              ? "max-w-[220px] px-2 py-1.5 text-xs"
+              : "max-w-[260px] px-2.5 py-2 text-xs",
+            onRemove && !compact && "pr-7",
+          )}
+          aria-label="Preview pasted text"
+        >
+          <span
+            className={cn(
+              "flex shrink-0 items-center justify-center rounded bg-background text-muted-foreground",
+              compact ? "h-6 w-6" : "h-8 w-8",
+            )}
+          >
+            <IconClipboardText
+              className={compact ? "h-3.5 w-3.5" : "h-4 w-4"}
+            />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block truncate font-medium">Pasted text</span>
+            <span className="block text-[11px] text-muted-foreground">
+              {summary}
+            </span>
+          </span>
+          {onRemove && (
+            <span
+              role="button"
+              tabIndex={-1}
+              onClick={handleRemove}
+              aria-label="Remove pasted text"
+              className={cn(
+                "flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground",
+                compact ? "" : "absolute right-1.5 top-1.5",
+              )}
+            >
+              <IconX className="h-3 w-3" />
+            </span>
+          )}
+        </button>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          side="top"
+          align="start"
+          sideOffset={6}
+          collisionPadding={12}
+          className="z-50 w-[min(560px,calc(100vw-32px))] rounded-lg border border-border bg-popover text-popover-foreground shadow-lg animate-in fade-in-0 zoom-in-95"
+        >
+          <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <IconClipboardText className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="text-sm font-medium truncate">Pasted text</span>
+              <span className="text-[11px] text-muted-foreground shrink-0">
+                {lines} lines · {chars} chars
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close preview"
+              className="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground"
+            >
+              <IconX className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <pre className="max-h-[60vh] overflow-auto px-3 py-2 text-[12px] leading-[1.5] whitespace-pre-wrap break-words font-mono text-foreground">
+            {text}
+          </pre>
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}

--- a/packages/core/src/client/composer/PromptComposer.tsx
+++ b/packages/core/src/client/composer/PromptComposer.tsx
@@ -24,6 +24,8 @@ import { cn } from "../utils.js";
 import { TiptapComposer, type TiptapComposerHandle } from "./TiptapComposer.js";
 import type { Reference } from "./types.js";
 import { useChatModels } from "../use-chat-models.js";
+import { isPastedTextAttachmentName } from "./pasted-text.js";
+import { PastedTextChip } from "./PastedTextChip.js";
 
 /**
  * Files the user attached via the "+" button in PromptComposer. The host owns
@@ -45,11 +47,11 @@ export interface PromptComposerProps {
   className?: string;
   /** Forwarded to TiptapComposer for draft persistence. */
   draftScope?: string;
-  /** Show the model selector (default: false). */
+  /** Show the model selector (default: true). */
   showModelSelector?: boolean;
   /** Show the voice dictation button (default: true). */
   voiceEnabled?: boolean;
-  /** Show file upload controls and pass submitted files to onSubmit. */
+  /** Show file upload controls and pass submitted files to onSubmit (default: true). */
   attachmentsEnabled?: boolean;
   /** Imperative handle for focusing the composer. */
   composerRef?: Ref<TiptapComposerHandle>;
@@ -123,6 +125,10 @@ function AttachmentChip({
     [src],
   );
 
+  if (isPastedTextAttachmentName(attachment.name)) {
+    return <PastedTextChip attachment={attachment} onRemove={onRemove} />;
+  }
+
   if (src) {
     return (
       <div className="group relative h-16 w-16 overflow-hidden rounded-lg border border-border/70 bg-muted/50">
@@ -193,9 +199,9 @@ function PromptComposerInner({
   autoFocus,
   className,
   draftScope,
-  showModelSelector,
+  showModelSelector = true,
   voiceEnabled = true,
-  attachmentsEnabled = false,
+  attachmentsEnabled = true,
   composerRef,
 }: PromptComposerProps) {
   const localRef = useRef<TiptapComposerHandle>(null);

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -507,7 +507,7 @@ function ModelSelector({
                       : "Connect Builder.io"}
                   </span>
                   <span className="block text-[11px] text-muted-foreground">
-                    Free access to Claude, OpenAI &amp; Gemini
+                    Free credits for Claude, OpenAI &amp; Gemini
                   </span>
                 </span>
               </button>

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -50,6 +50,10 @@ import { ComposerPlusMenu } from "./ComposerPlusMenu.js";
 import { sendToAgentChat } from "../agent-chat.js";
 import { getComposerDraftKey } from "./draft-key.js";
 import {
+  createPastedTextFile,
+  shouldConvertPasteToAttachment,
+} from "./pasted-text.js";
+import {
   getReasoningEffortOptionsForModel,
   reasoningEffortLabel,
   type ReasoningEffort,
@@ -806,24 +810,39 @@ export function TiptapComposer({
         const files = Array.from(event.clipboardData?.files ?? []).filter(
           (file) => file.type.startsWith("image/"),
         );
-        if (files.length === 0) return false;
+        if (files.length > 0) {
+          event.preventDefault();
+          void Promise.all(
+            files.map((file) => {
+              // SimpleImageAttachmentAdapter uses file.name as the attachment id.
+              // Clipboard images (e.g. screenshots) are typically all named
+              // "image.png", so a second paste would replace the first instead of
+              // appending. Prepend a unique token so each paste gets a distinct id.
+              const uniqueName = `${Date.now()}-${Math.random().toString(36).slice(2)}-${file.name}`;
+              return composerRuntime.addAttachment(
+                new File([file], uniqueName, { type: file.type }),
+              );
+            }),
+          ).catch((error) => {
+            console.error("Error adding pasted attachment:", error);
+          });
+          return true;
+        }
 
-        event.preventDefault();
-        void Promise.all(
-          files.map((file) => {
-            // SimpleImageAttachmentAdapter uses file.name as the attachment id.
-            // Clipboard images (e.g. screenshots) are typically all named
-            // "image.png", so a second paste would replace the first instead of
-            // appending. Prepend a unique token so each paste gets a distinct id.
-            const uniqueName = `${Date.now()}-${Math.random().toString(36).slice(2)}-${file.name}`;
-            return composerRuntime.addAttachment(
-              new File([file], uniqueName, { type: file.type }),
-            );
-          }),
-        ).catch((error) => {
-          console.error("Error adding pasted attachment:", error);
-        });
-        return true;
+        // Large text pastes turn into a `Pasted text` attachment chip so the
+        // prompt stays readable. Matches Claude.ai / Claude Code's UX.
+        const pastedText = event.clipboardData?.getData("text/plain") ?? "";
+        if (shouldConvertPasteToAttachment(pastedText)) {
+          event.preventDefault();
+          void composerRuntime
+            .addAttachment(createPastedTextFile(pastedText))
+            .catch((error) => {
+              console.error("Error adding pasted-text attachment:", error);
+            });
+          return true;
+        }
+
+        return false;
       },
       handleKeyDown: (view, event) => {
         const pop = popoverStateRef.current;

--- a/packages/core/src/client/composer/VoiceButton.tsx
+++ b/packages/core/src/client/composer/VoiceButton.tsx
@@ -73,14 +73,36 @@ export interface VoiceRecordingOverlayProps {
 
 export function VoiceRecordingOverlay({ voice }: VoiceRecordingOverlayProps) {
   const { state, amplitude, durationMs, errorMessage, cancel } = voice;
+  const { dismissError, start } = voice;
 
   if (state === "error" && errorMessage) {
     return (
       <div
         role="alert"
-        className="mx-2 mt-1 rounded-md border border-red-500/40 bg-red-500/10 px-2 py-1.5 text-[11px] text-red-500"
+        className="mx-2 mt-1 flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 px-2 py-1.5 text-[11px] text-red-500"
       >
-        {errorMessage}
+        <span className="flex-1 min-w-0">{errorMessage}</span>
+        <button
+          type="button"
+          onClick={() => {
+            dismissError();
+            void start();
+          }}
+          className="shrink-0 cursor-pointer rounded px-1.5 py-0.5 text-[11px] font-medium text-red-500 hover:bg-red-500/20"
+          title="Try again"
+          aria-label="Try again"
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          onClick={dismissError}
+          className="shrink-0 flex h-4 w-4 cursor-pointer items-center justify-center rounded text-red-500 hover:bg-red-500/20"
+          title="Dismiss"
+          aria-label="Dismiss"
+        >
+          <IconX className="h-3 w-3" />
+        </button>
       </div>
     );
   }

--- a/packages/core/src/client/composer/pasted-text.ts
+++ b/packages/core/src/client/composer/pasted-text.ts
@@ -1,0 +1,51 @@
+// Pastes longer than this turn into a `Pasted text` attachment chip instead of
+// being dumped into the editor. Mirrors Claude.ai / Claude Code's UX: anything
+// that would visually drown the prompt becomes a clickable chip the user can
+// remove or preview.
+const PASTED_TEXT_MIN_CHARS = 1000;
+const PASTED_TEXT_MIN_LINES = 6;
+
+const PASTED_TEXT_FILENAME_PREFIX = "pasted-text-";
+
+export function shouldConvertPasteToAttachment(text: string): boolean {
+  if (!text) return false;
+  if (text.length >= PASTED_TEXT_MIN_CHARS) return true;
+  let lines = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) {
+      lines++;
+      if (lines >= PASTED_TEXT_MIN_LINES) return true;
+    }
+  }
+  return false;
+}
+
+export function createPastedTextFile(text: string): File {
+  const name = `${PASTED_TEXT_FILENAME_PREFIX}${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}.txt`;
+  return new File([text], name, { type: "text/plain" });
+}
+
+export function isPastedTextAttachmentName(name: string | undefined): boolean {
+  return !!name && name.startsWith(PASTED_TEXT_FILENAME_PREFIX);
+}
+
+// Strips the `<attachment name=...>\n` / `\n</attachment>` envelope that
+// SimpleTextAttachmentAdapter wraps the file body in when sending. Returns the
+// raw body for previewing.
+export function unwrapAttachmentEnvelope(text: string): string {
+  const match = text.match(
+    /^<attachment name=[^>]+>\n([\s\S]*)\n<\/attachment>$/,
+  );
+  return match ? match[1] : text;
+}
+
+export function countLines(text: string): number {
+  if (!text) return 0;
+  let lines = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) lines++;
+  }
+  return lines;
+}

--- a/packages/core/src/client/composer/useVoiceDictation.ts
+++ b/packages/core/src/client/composer/useVoiceDictation.ts
@@ -109,6 +109,7 @@ export interface VoiceDictationApi {
   start: () => Promise<void>;
   stop: () => void;
   cancel: () => void;
+  dismissError: () => void;
 }
 
 async function readVoicePrefs(): Promise<VoicePrefs> {
@@ -871,6 +872,23 @@ export function useVoiceDictation(
     setState("idle");
   }, [state, teardown]);
 
+  // Auto-dismiss error after 8s so a stale "permission denied" message doesn't
+  // sit forever after the user fixes the underlying permission. Manual dismiss
+  // (via dismissError) and click-to-retry both also clear the error sooner.
+  useEffect(() => {
+    if (state !== "error") return;
+    const handle = setTimeout(() => {
+      setErrorMessage(null);
+      setState("idle");
+    }, 8000);
+    return () => clearTimeout(handle);
+  }, [state]);
+
+  const dismissError = useCallback(() => {
+    setErrorMessage(null);
+    if (state === "error") setState("idle");
+  }, [state]);
+
   return {
     state,
     amplitude,
@@ -881,5 +899,6 @@ export function useVoiceDictation(
     start,
     stop,
     cancel,
+    dismissError,
   };
 }

--- a/packages/core/src/client/integrations/IntegrationCard.tsx
+++ b/packages/core/src/client/integrations/IntegrationCard.tsx
@@ -45,11 +45,13 @@ export function IntegrationCard({
   const [expanded, setExpanded] = useState(false);
   const [toggling, setToggling] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [toggleError, setToggleError] = useState<string | null>(null);
 
   const Icon = platformIcons[status.platform] || IconMessageCircle;
 
   const handleToggle = useCallback(async () => {
     setToggling(true);
+    setToggleError(null);
     try {
       const action = status.enabled ? "disable" : "enable";
       const res = await fetch(
@@ -60,11 +62,26 @@ export function IntegrationCard({
       );
       if (res.ok) {
         onRefresh();
+        return;
       }
+      const data = (await res.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      setToggleError(
+        data?.error ||
+          res.statusText ||
+          `Couldn't ${action} ${status.label} (HTTP ${res.status})`,
+      );
+    } catch (err) {
+      setToggleError(
+        err instanceof Error
+          ? err.message
+          : "Network error reaching the server",
+      );
     } finally {
       setToggling(false);
     }
-  }, [status.platform, status.enabled, onRefresh]);
+  }, [status.platform, status.enabled, status.label, onRefresh]);
 
   const handleCopy = useCallback(async () => {
     if (!status.webhookUrl) return;
@@ -121,6 +138,10 @@ export function IntegrationCard({
 
           {status.error && (
             <p className="text-[10px] text-destructive">{status.error}</p>
+          )}
+
+          {toggleError && (
+            <p className="text-[10px] text-destructive">{toggleError}</p>
           )}
 
           {!status.configured && !status.error && (

--- a/packages/core/src/client/integrations/IntegrationsPanel.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.tsx
@@ -148,20 +148,42 @@ function IntegrationDetail({
 }) {
   const [toggling, setToggling] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [toggleError, setToggleError] = useState<string | null>(null);
 
   const handleToggle = useCallback(async () => {
     setToggling(true);
+    setToggleError(null);
     try {
       const action = serverStatus?.enabled ? "disable" : "enable";
       const res = await fetch(
         agentNativePath(`/_agent-native/integrations/${platform.id}/${action}`),
         { method: "POST" },
       );
-      if (res.ok) onRefresh();
+      if (res.ok) {
+        onRefresh();
+        return;
+      }
+      // Surface the real reason instead of silently doing nothing.
+      // The endpoint returns `{ error }` for known failures (admin gating,
+      // missing secrets, etc.); fall back to status text otherwise.
+      const data = (await res.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      setToggleError(
+        data?.error ||
+          res.statusText ||
+          `Couldn't ${action} ${platform.label} (HTTP ${res.status})`,
+      );
+    } catch (err) {
+      setToggleError(
+        err instanceof Error
+          ? err.message
+          : "Network error reaching the server",
+      );
     } finally {
       setToggling(false);
     }
-  }, [platform.id, serverStatus?.enabled, onRefresh]);
+  }, [platform.id, platform.label, serverStatus?.enabled, onRefresh]);
 
   const handleCopy = useCallback(async (text: string) => {
     await navigator.clipboard.writeText(text);
@@ -304,6 +326,10 @@ function IntegrationDetail({
         <p className="text-[10px] text-destructive mt-2">
           {serverStatus.error}
         </p>
+      )}
+
+      {toggleError && (
+        <p className="text-[10px] text-destructive mt-2">{toggleError}</p>
       )}
     </div>
   );

--- a/packages/core/src/client/notifications/NotificationsBell.tsx
+++ b/packages/core/src/client/notifications/NotificationsBell.tsx
@@ -7,6 +7,11 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import { usePausingInterval } from "../use-pausing-interval.js";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../components/ui/popover.js";
 import type {
   Notification as NotificationDto,
   NotificationSeverity,
@@ -45,10 +50,6 @@ export function NotificationsBell({
   const [unreadCount, setUnreadCount] = useState(0);
   const [open, setOpen] = useState(false);
   const [items, setItems] = useState<NotificationDto[] | null>(null);
-  const [menuPosition, setMenuPosition] = useState<{
-    top: number;
-    left: number;
-  } | null>(null);
   // Init to "default" unconditionally so server and client render the same
   // HTML — reading Notification.permission at init would diverge between SSR
   // ("denied", no API) and hydration ("default"/"granted"), causing a mismatch
@@ -60,8 +61,6 @@ export function NotificationsBell({
   useEffect(() => {
     if (SUPPORTS_NOTIFICATION) setPermission(Notification.permission);
   }, []);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
   // Ids already popped as browser notifications. Seeded on first run so
   // existing unread don't pop retroactively on page load.
   const seenIdsRef = useRef<Set<string> | null>(null);
@@ -141,41 +140,6 @@ export function NotificationsBell({
     loadItems();
   }, [open, loadItems]);
 
-  useEffect(() => {
-    if (!open) return;
-    const updatePosition = () => {
-      const rect = triggerRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      const width = 320;
-      const margin = 12;
-      setMenuPosition({
-        top: rect.bottom + 8,
-        left: Math.min(
-          Math.max(rect.right - width, margin),
-          window.innerWidth - width - margin,
-        ),
-      });
-    };
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-    };
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onDocClick = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", onDocClick);
-    return () => document.removeEventListener("mousedown", onDocClick);
-  }, [open]);
-
   const markRead = async (id: string) => {
     try {
       await fetch(agentNativePath(`/_agent-native/notifications/${id}/read`), {
@@ -228,126 +192,118 @@ export function NotificationsBell({
   const Icon = hasUnread ? IconBellRinging : IconBell;
 
   return (
-    <div
-      ref={menuRef}
-      className={
-        "an-notifications-bell relative inline-flex" +
-        (className ? ` ${className}` : "")
-      }
-    >
-      <button
-        ref={triggerRef}
-        type="button"
-        aria-label={
-          hasUnread ? `${unreadCount} unread notifications` : "Notifications"
-        }
-        onClick={() => setOpen((v) => !v)}
-        className="an-notifications-bell__trigger relative inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/40 hover:text-foreground"
-      >
-        <Icon size={18} aria-hidden />
-        {hasUnread ? (
-          <span
-            aria-hidden
-            className="an-notifications-bell__badge absolute -right-0.5 -top-0.5 rounded-full bg-destructive px-1 text-[10px] leading-[14px] font-medium text-destructive-foreground"
-          >
-            {unreadCount > 99 ? "99+" : unreadCount}
-          </span>
-        ) : null}
-      </button>
-      {open ? (
-        <div
-          role="menu"
-          className="an-notifications-bell__menu fixed z-[2100] w-80 rounded-md border border-border bg-popover text-popover-foreground shadow-lg"
-          style={{
-            top: menuPosition?.top ?? 48,
-            left: menuPosition?.left ?? 12,
-          }}
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={
+            hasUnread ? `${unreadCount} unread notifications` : "Notifications"
+          }
+          className={
+            "an-notifications-bell__trigger relative inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/40 hover:text-foreground" +
+            (className ? ` ${className}` : "")
+          }
         >
-          <div className="flex items-center justify-between border-b border-border px-3 py-2 text-sm font-medium">
-            <span>Notifications</span>
-            {hasUnread ? (
-              <button
-                type="button"
-                onClick={markAllRead}
-                className="text-xs text-primary hover:underline"
-              >
-                Mark all read
-              </button>
-            ) : null}
-          </div>
-          {browserNotifications &&
-          SUPPORTS_NOTIFICATION &&
-          permission === "default" ? (
-            <div className="flex items-center justify-between gap-2 border-b border-border bg-accent/40 px-3 py-2 text-xs text-foreground">
-              <span>Get a system popup for new notifications.</span>
-              <button
-                type="button"
-                onClick={async () => {
-                  const result = await Notification.requestPermission();
-                  setPermission(result);
-                }}
-                className="shrink-0 rounded bg-primary px-2 py-0.5 font-medium text-primary-foreground hover:bg-primary/90"
-              >
-                Enable
-              </button>
-            </div>
+          <Icon size={18} aria-hidden />
+          {hasUnread ? (
+            <span
+              aria-hidden
+              className="an-notifications-bell__badge absolute -right-0.5 -top-0.5 rounded-full bg-destructive px-1 text-[10px] leading-[14px] font-medium text-destructive-foreground"
+            >
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
           ) : null}
-          <div className="max-h-96 overflow-y-auto">
-            {items === null ? (
-              <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
-                <IconLoader2 size={14} className="animate-spin" /> Loading…
-              </div>
-            ) : items.length > 0 ? (
-              items.map((n) => (
-                <div
-                  key={n.id}
-                  className={
-                    "group relative border-b border-border last:border-b-0 hover:bg-accent/40 " +
-                    (n.readAt ? "opacity-60" : "")
-                  }
-                >
-                  <button
-                    type="button"
-                    onClick={() => (n.readAt ? undefined : markRead(n.id))}
-                    className="flex w-full flex-col items-start gap-0.5 px-3 py-2 pr-8 text-left"
-                  >
-                    <div className="flex w-full items-center justify-between gap-2">
-                      <span className="truncate text-sm font-medium text-foreground">
-                        {n.title}
-                      </span>
-                      <SeverityBadge severity={n.severity} />
-                    </div>
-                    {n.body ? (
-                      <span className="line-clamp-2 text-xs text-muted-foreground">
-                        {n.body}
-                      </span>
-                    ) : null}
-                    <span className="text-[10px] text-muted-foreground/70">
-                      {new Date(n.createdAt).toLocaleString()}
-                    </span>
-                  </button>
-                  <button
-                    type="button"
-                    aria-label="Dismiss notification"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void dismiss(n.id);
-                    }}
-                    className="absolute right-2 top-2 hidden rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground group-hover:flex"
-                  >
-                    <IconX size={12} />
-                  </button>
-                </div>
-              ))
-            ) : (
-              <div className="p-4 text-sm text-muted-foreground">
-                No notifications.
-              </div>
-            )}
-          </div>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="an-notifications-bell__menu w-80 p-0"
+      >
+        <div className="flex items-center justify-between border-b border-border px-3 py-2 text-sm font-medium">
+          <span>Notifications</span>
+          {hasUnread ? (
+            <button
+              type="button"
+              onClick={markAllRead}
+              className="text-xs text-primary hover:underline"
+            >
+              Mark all read
+            </button>
+          ) : null}
         </div>
-      ) : null}
-    </div>
+        {browserNotifications &&
+        SUPPORTS_NOTIFICATION &&
+        permission === "default" ? (
+          <div className="flex items-center justify-between gap-2 border-b border-border bg-accent/40 px-3 py-2 text-xs text-foreground">
+            <span>Get a system popup for new notifications.</span>
+            <button
+              type="button"
+              onClick={async () => {
+                const result = await Notification.requestPermission();
+                setPermission(result);
+              }}
+              className="shrink-0 rounded bg-primary px-2 py-0.5 font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Enable
+            </button>
+          </div>
+        ) : null}
+        <div className="max-h-96 overflow-y-auto">
+          {items === null ? (
+            <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+              <IconLoader2 size={14} className="animate-spin" /> Loading…
+            </div>
+          ) : items.length > 0 ? (
+            items.map((n) => (
+              <div
+                key={n.id}
+                className={
+                  "group relative border-b border-border last:border-b-0 hover:bg-accent/40 " +
+                  (n.readAt ? "opacity-60" : "")
+                }
+              >
+                <button
+                  type="button"
+                  onClick={() => (n.readAt ? undefined : markRead(n.id))}
+                  className="flex w-full flex-col items-start gap-0.5 px-3 py-2 pr-8 text-left"
+                >
+                  <div className="flex w-full items-center justify-between gap-2">
+                    <span className="truncate text-sm font-medium text-foreground">
+                      {n.title}
+                    </span>
+                    <SeverityBadge severity={n.severity} />
+                  </div>
+                  {n.body ? (
+                    <span className="line-clamp-2 text-xs text-muted-foreground">
+                      {n.body}
+                    </span>
+                  ) : null}
+                  <span className="text-[10px] text-muted-foreground/70">
+                    {new Date(n.createdAt).toLocaleString()}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  aria-label="Dismiss notification"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    void dismiss(n.id);
+                  }}
+                  className="absolute right-2 top-2 hidden rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground group-hover:flex"
+                >
+                  <IconX size={12} />
+                </button>
+              </div>
+            ))
+          ) : (
+            <div className="p-4 text-sm text-muted-foreground">
+              No notifications.
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/packages/core/src/client/org/OrgSwitcher.tsx
+++ b/packages/core/src/client/org/OrgSwitcher.tsx
@@ -5,6 +5,7 @@ import {
   IconLoader2,
   IconPlus,
   IconSelector,
+  IconUser,
   IconUserPlus,
 } from "@tabler/icons-react";
 import {
@@ -111,7 +112,9 @@ export function OrgSwitcher({
     !!org.orgId && (org.role === "owner" || org.role === "admin");
 
   const personalLabel = personalLabelFromEmail(org.email);
-  const label = org.orgName ?? personalLabel;
+  const inOrg = !!org.orgId;
+  const label = org.orgName ?? "Personal";
+  const ButtonIcon = inOrg ? IconBuilding : IconUser;
 
   return (
     <div ref={ref} className={`relative ${className ?? ""}`}>
@@ -120,7 +123,7 @@ export function OrgSwitcher({
         onClick={() => setOpen((v) => !v)}
         className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground border border-border/50"
       >
-        <IconBuilding className="h-3.5 w-3.5 shrink-0" />
+        <ButtonIcon className="h-3.5 w-3.5 shrink-0" />
         <span className="truncate flex-1 text-left">{label}</span>
         <IconSelector className="h-3 w-3 shrink-0 opacity-50" />
       </button>
@@ -128,21 +131,20 @@ export function OrgSwitcher({
         <div className="absolute left-0 right-0 bottom-full mb-1 z-50 rounded-md border border-border bg-popover shadow-md py-1 min-w-[14rem]">
           {mode === "list" && (
             <>
-              {(orgs.length > 0 || !org.orgId) && (
-                <div className="px-2.5 pt-1 pb-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-                  Organization
-                </div>
-              )}
-              {orgs.length === 0 && !org.orgId && (
+              {!inOrg && (
                 <div
                   className="flex w-full items-center gap-2 px-2.5 py-1.5 text-xs text-muted-foreground"
                   aria-disabled="true"
                 >
-                  <IconBuilding className="h-3.5 w-3.5 shrink-0" />
+                  <IconUser className="h-3.5 w-3.5 shrink-0" />
                   <span className="truncate flex-1 text-left">
-                    {personalLabel}
+                    Personal ({personalLabel})
                   </span>
-                  <IconCheck className="h-3.5 w-3.5 shrink-0 opacity-50" />
+                </div>
+              )}
+              {orgs.length > 0 && (
+                <div className="px-2.5 pt-1 pb-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  Organization
                 </div>
               )}
               {orgs.map((o) => (

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -22,6 +22,7 @@ import {
 } from "@tabler/icons-react";
 import { cn } from "../utils.js";
 import { sendToAgentChat } from "../agent-chat.js";
+import { PromptComposer } from "../composer/PromptComposer.js";
 import { ResourceTree } from "./ResourceTree.js";
 import { ResourceEditor } from "./ResourceEditor.js";
 import { serializeFrontmatter } from "../../resources/metadata.js";
@@ -223,8 +224,8 @@ function CreateMenu({
     }
   };
 
-  const submitSkill = () => {
-    const trimmed = value.trim();
+  const submitSkill = (text: string = value) => {
+    const trimmed = text.trim();
     if (!trimmed) return;
 
     sendToAgentChat({
@@ -298,8 +299,8 @@ Keep the skill concise (under 500 lines) and actionable.`,
     onCreated?.();
   };
 
-  const submitJob = () => {
-    const trimmed = value.trim();
+  const submitJob = (text: string = value) => {
+    const trimmed = text.trim();
     if (!trimmed) return;
 
     sendToAgentChat({
@@ -320,8 +321,8 @@ The job will run automatically on the schedule. Make the instructions specific â
     setOpen(false);
   };
 
-  const submitAgentPrompt = () => {
-    const trimmed = value.trim();
+  const submitAgentPrompt = (text: string = value) => {
+    const trimmed = text.trim();
     if (!trimmed) return;
 
     sendToAgentChat({
@@ -535,7 +536,11 @@ The result should be a reusable agent profile, not a one-off task response.`,
         <div
           ref={popoverRef}
           className="absolute right-0 top-full mt-1.5 z-[220] rounded-lg border border-border bg-popover shadow-lg"
-          style={{ width: 260, fontSize: 13, lineHeight: "normal" }}
+          style={{
+            width: view === "menu" || view === "file" ? 260 : 380,
+            fontSize: 13,
+            lineHeight: "normal",
+          }}
         >
           {view === "menu" && (
             <div className="py-1">
@@ -599,33 +604,12 @@ The result should be a reusable agent profile, not a one-off task response.`,
                 Describe what kind of skill you want and the agent will create
                 it.
               </p>
-              <textarea
-                ref={inputRef as React.RefObject<HTMLTextAreaElement>}
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && !e.shiftKey) {
-                    e.preventDefault();
-                    submitSkill();
-                  }
-                  if (e.key === "Escape") {
-                    e.stopPropagation();
-                    setView("menu");
-                  }
-                }}
-                rows={3}
-                className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+              <PromptComposer
+                autoFocus
                 placeholder="e.g. A skill that reviews PRs for security issues and OWASP top 10 vulnerabilities"
+                draftScope="resources:create-skill"
+                onSubmit={(text) => submitSkill(text)}
               />
-              <div className="mt-2.5 flex justify-end">
-                <button
-                  onClick={submitSkill}
-                  disabled={!value.trim()}
-                  className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
-                >
-                  Create
-                </button>
-              </div>
             </div>
           )}
 
@@ -637,33 +621,12 @@ The result should be a reusable agent profile, not a one-off task response.`,
               <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
                 Describe what should happen and when.
               </p>
-              <textarea
-                ref={inputRef as React.RefObject<HTMLTextAreaElement>}
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && !e.shiftKey) {
-                    e.preventDefault();
-                    submitJob();
-                  }
-                  if (e.key === "Escape") {
-                    e.stopPropagation();
-                    setView("menu");
-                  }
-                }}
-                rows={3}
-                className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+              <PromptComposer
+                autoFocus
                 placeholder="e.g. Every weekday at 9am, check for overdue scorecards and send a Slack update"
+                draftScope="resources:create-job"
+                onSubmit={(text) => submitJob(text)}
               />
-              <div className="mt-2.5 flex justify-end">
-                <button
-                  onClick={submitJob}
-                  disabled={!value.trim()}
-                  className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
-                >
-                  Create
-                </button>
-              </div>
             </div>
           )}
 
@@ -718,33 +681,12 @@ The result should be a reusable agent profile, not a one-off task response.`,
                 Describe the agent you want. It will be saved under{" "}
                 <code>agents/</code>.
               </p>
-              <textarea
-                ref={inputRef as React.RefObject<HTMLTextAreaElement>}
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && !e.shiftKey) {
-                    e.preventDefault();
-                    submitAgentPrompt();
-                  }
-                  if (e.key === "Escape") {
-                    e.stopPropagation();
-                    setView("agent-mode");
-                  }
-                }}
-                rows={4}
-                className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+              <PromptComposer
+                autoFocus
                 placeholder="e.g. A design agent that critiques layouts, suggests UI direction, and prefers concise product reasoning"
+                draftScope="resources:create-agent"
+                onSubmit={(text) => submitAgentPrompt(text)}
               />
-              <div className="mt-2.5 flex justify-end">
-                <button
-                  onClick={submitAgentPrompt}
-                  disabled={!value.trim()}
-                  className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
-                >
-                  Create
-                </button>
-              </div>
             </div>
           )}
 

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -310,7 +310,7 @@ function UseBuilderCard({
   connected,
   orgName,
   label = "Connect Builder.io",
-  subtitle = "One click, no API key needed.",
+  subtitle = "Free credits to start — no API key needed.",
   dim,
 }: {
   connectUrl?: string;

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -109,6 +109,12 @@ export interface BuilderConnectFlow {
    * disconnect controls — `start()` will be a no-op.
    */
   envManaged: boolean;
+  /**
+   * True when ENABLE_BUILDER (or a BUILDER_BRANCH_PROJECT_ID) is set on the
+   * deploy, gating Builder cloud branch creation. When false, the card
+   * surfaces a "coming soon" waitlist CTA instead of a Send button.
+   */
+  builderEnabled: boolean;
   orgName: string | null;
   connecting: boolean;
   error: string | null;
@@ -134,6 +140,7 @@ export function useBuilderConnectFlow(
   const { popupUrl, onConnected } = opts;
   const [configured, setConfigured] = useState(false);
   const [envManaged, setEnvManaged] = useState(false);
+  const [builderEnabled, setBuilderEnabled] = useState(false);
   const [orgName, setOrgName] = useState<string | null>(null);
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -162,6 +169,7 @@ export function useBuilderConnectFlow(
       return (await r.json()) as {
         configured: boolean;
         envManaged?: boolean;
+        builderEnabled?: boolean;
         orgName?: string | null;
         connectError?: { message: string; at: number };
       };
@@ -188,6 +196,7 @@ export function useBuilderConnectFlow(
       if (!s) return;
       setConfigured(!!s.configured);
       setEnvManaged(!!s.envManaged);
+      setBuilderEnabled(!!s.builderEnabled);
       setOrgName(s.orgName ?? null);
     };
     refresh();
@@ -313,6 +322,7 @@ export function useBuilderConnectFlow(
   return {
     configured,
     envManaged,
+    builderEnabled,
     orgName,
     connecting,
     error,

--- a/packages/core/src/client/tools/ToolEditor.tsx
+++ b/packages/core/src/client/tools/ToolEditor.tsx
@@ -5,9 +5,22 @@ import { Link, useNavigate } from "react-router";
 import {
   IconArrowLeft,
   IconDeviceFloppy,
+  IconDots,
   IconTrash,
+  IconX,
 } from "@tabler/icons-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../components/ui/popover.js";
 import { cn } from "../utils.js";
+
+interface SlotDeclaration {
+  id: string;
+  toolId: string;
+  slotId: string;
+}
 
 interface Tool {
   id: string;
@@ -30,7 +43,20 @@ export function ToolEditor({ toolId }: ToolEditorProps) {
   const [content, setContent] = useState("");
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
-  const [deleteConfirm, setDeleteConfirm] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const { data: slots = [] } = useQuery<SlotDeclaration[]>({
+    queryKey: ["tool-slots", toolId],
+    queryFn: async () => {
+      const res = await fetch(
+        agentNativePath(`/_agent-native/slots/tool/${toolId}`),
+      );
+      if (!res.ok) return [];
+      return res.json();
+    },
+    enabled: isEdit && menuOpen,
+  });
 
   const { data: existingTool } = useQuery<Tool>({
     queryKey: ["tool", toolId],
@@ -112,10 +138,30 @@ export function ToolEditor({ toolId }: ToolEditorProps) {
       }
 
       queryClient.invalidateQueries({ queryKey: ["tools"] });
+      slots.forEach((s) =>
+        queryClient.invalidateQueries({
+          queryKey: ["slot-installs", s.slotId],
+        }),
+      );
       navigate("/tools");
     } finally {
       setDeleting(false);
-      setDeleteConfirm(false);
+      setConfirmingDelete(false);
+      setMenuOpen(false);
+    }
+  };
+
+  const handleRemoveFromSlot = async (slotId: string) => {
+    if (!toolId) return;
+    try {
+      await fetch(
+        agentNativePath(
+          `/_agent-native/slots/${encodeURIComponent(slotId)}/install/${encodeURIComponent(toolId)}`,
+        ),
+        { method: "DELETE" },
+      );
+    } finally {
+      queryClient.invalidateQueries({ queryKey: ["slot-installs", slotId] });
     }
   };
 
@@ -135,44 +181,6 @@ export function ToolEditor({ toolId }: ToolEditorProps) {
           </h1>
         </div>
         <div className="flex items-center gap-2">
-          {isEdit && (
-            <>
-              {deleteConfirm ? (
-                <div className="flex items-center gap-2">
-                  <span className="text-sm text-muted-foreground">
-                    Delete this tool?
-                  </span>
-                  <button
-                    type="button"
-                    onClick={handleDelete}
-                    disabled={deleting}
-                    className={cn(
-                      "inline-flex cursor-pointer items-center justify-center rounded-md bg-destructive px-3 py-1.5 text-sm text-destructive-foreground hover:bg-destructive/90",
-                      deleting && "opacity-60",
-                    )}
-                  >
-                    {deleting ? "Deleting..." : "Confirm"}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setDeleteConfirm(false)}
-                    className="inline-flex cursor-pointer items-center justify-center rounded-md border border-input bg-background px-3 py-1.5 text-sm hover:bg-accent"
-                  >
-                    Cancel
-                  </button>
-                </div>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setDeleteConfirm(true)}
-                  className="inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md border border-input bg-background px-3 py-1.5 text-sm text-destructive hover:bg-accent"
-                >
-                  <IconTrash className="h-3.5 w-3.5" />
-                  Delete
-                </button>
-              )}
-            </>
-          )}
           <button
             type="button"
             onClick={handleSave}
@@ -185,6 +193,107 @@ export function ToolEditor({ toolId }: ToolEditorProps) {
             <IconDeviceFloppy className="h-3.5 w-3.5" />
             {saving ? "Saving..." : isEdit ? "Save" : "Create"}
           </button>
+          {isEdit && (
+            <Popover
+              open={menuOpen}
+              onOpenChange={(o) => {
+                setMenuOpen(o);
+                if (!o) setConfirmingDelete(false);
+              }}
+            >
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                  title="More options"
+                  aria-label="More options"
+                >
+                  <IconDots className="h-4 w-4" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="end" sideOffset={4} className="w-72 p-0">
+                {!confirmingDelete ? (
+                  <>
+                    <div className="px-3 py-2 border-b border-border/40">
+                      <p className="text-[12px] font-medium">Appears in</p>
+                      {slots.length === 0 ? (
+                        <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                          Not installed in any widget areas. Ask the agent to
+                          add it somewhere.
+                        </p>
+                      ) : (
+                        <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                          This tool can render in {slots.length} widget area
+                          {slots.length === 1 ? "" : "s"}.
+                        </p>
+                      )}
+                    </div>
+                    {slots.length > 0 && (
+                      <div className="max-h-48 overflow-y-auto py-1">
+                        {slots.map((s) => (
+                          <div
+                            key={s.id}
+                            className="flex items-center gap-2 px-3 py-1.5 text-[12px]"
+                          >
+                            <span className="flex-1 truncate font-mono text-[11px] text-muted-foreground">
+                              {s.slotId}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => handleRemoveFromSlot(s.slotId)}
+                              className="rounded p-1 text-muted-foreground/60 hover:bg-accent hover:text-foreground cursor-pointer"
+                              title="Remove from this widget area (for me)"
+                              aria-label="Remove from this widget area"
+                            >
+                              <IconX className="h-3.5 w-3.5" />
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    <div className="border-t border-border/40 p-1">
+                      <button
+                        type="button"
+                        onClick={() => setConfirmingDelete(true)}
+                        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10 cursor-pointer text-left"
+                      >
+                        <IconTrash className="h-3.5 w-3.5" />
+                        <span>Delete tool…</span>
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex flex-col gap-2 p-3">
+                    <p className="text-[12px]">
+                      Delete <span className="font-medium">{name}</span>? This
+                      removes the tool everywhere, for everyone it's shared
+                      with.
+                    </p>
+                    <div className="flex justify-end gap-1">
+                      <button
+                        type="button"
+                        onClick={() => setConfirmingDelete(false)}
+                        className="rounded-md px-2 py-1 text-[12px] hover:bg-accent cursor-pointer"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleDelete}
+                        disabled={deleting}
+                        className={cn(
+                          "rounded-md bg-destructive px-2 py-1 text-[12px] text-destructive-foreground hover:bg-destructive/90 cursor-pointer",
+                          deleting && "opacity-60",
+                        )}
+                      >
+                        {deleting ? "Deleting…" : "Delete"}
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </PopoverContent>
+            </Popover>
+          )}
         </div>
       </header>
 

--- a/packages/core/src/client/tools/ToolViewer.tsx
+++ b/packages/core/src/client/tools/ToolViewer.tsx
@@ -12,6 +12,7 @@ import {
 } from "@tabler/icons-react";
 import { ShareButton } from "../sharing/ShareButton.js";
 import { AgentToggleButton } from "../AgentPanel.js";
+import { NotificationsBell } from "../notifications/NotificationsBell.js";
 import { sendToAgentChat } from "../agent-chat.js";
 import { PromptComposer } from "../composer/PromptComposer.js";
 import {
@@ -81,6 +82,23 @@ export interface ToolViewerProps {
 
 function EditToolPopover({ tool }: { tool: Tool }) {
   const [open, setOpen] = useState(false);
+
+  // Radix's outside-click detection runs in the parent document, so a click
+  // inside the tool iframe (or any other iframe) never fires it. The browser
+  // does shift focus to the iframe though, which blurs the parent window — we
+  // hook that to close the popover so it behaves like a normal click-outside.
+  useEffect(() => {
+    if (!open) return;
+    const handleBlur = () => {
+      // Defer until after the focus actually lands so document.activeElement
+      // reflects the iframe (or whatever the user clicked on).
+      setTimeout(() => {
+        if (document.activeElement?.tagName === "IFRAME") setOpen(false);
+      }, 0);
+    };
+    window.addEventListener("blur", handleBlur);
+    return () => window.removeEventListener("blur", handleBlur);
+  }, [open]);
 
   const handleSubmit = (text: string) => {
     const trimmed = text.trim();
@@ -489,6 +507,7 @@ export function ToolViewer({ toolId }: ToolViewerProps) {
             resourceTitle={tool.name}
           />
           <ToolMoreMenu toolId={toolId} toolName={tool.name} />
+          <NotificationsBell />
           <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
         </div>
       </div>

--- a/packages/core/src/client/tools/ToolsListPage.tsx
+++ b/packages/core/src/client/tools/ToolsListPage.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router";
 import { IconPlus, IconTool } from "@tabler/icons-react";
 import { cn } from "../utils.js";
 import { AgentToggleButton } from "../AgentPanel.js";
+import { NotificationsBell } from "../notifications/NotificationsBell.js";
 import { sendToAgentChat } from "../agent-chat.js";
 import { PromptComposer } from "../composer/PromptComposer.js";
 import {
@@ -125,6 +126,7 @@ export function ToolsListPage() {
               />
             </PopoverContent>
           </Popover>
+          <NotificationsBell />
           <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
         </div>
       </header>

--- a/packages/core/src/client/transcription/BuilderTranscriptionCta.tsx
+++ b/packages/core/src/client/transcription/BuilderTranscriptionCta.tsx
@@ -93,7 +93,7 @@ export function BuilderTranscriptionCta() {
       <span className="flex-1">
         {connecting
           ? "Waiting for Builder.io…"
-          : "Connect Builder.io for higher-quality transcription — free, no API key needed."}
+          : "Connect Builder.io for higher-quality transcription — free credits, no API key needed."}
       </span>
       {error ? (
         <span className="text-destructive text-[10px]">{error}</span>

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -221,7 +221,14 @@ export function useChatThreads(
             body: JSON.stringify({ id }),
           },
         );
-        if (!res.ok) return null;
+        if (!res.ok) {
+          // Surface failures so a click on the Fork button isn't a silent
+          // no-op when the source thread can't be found or auth has lapsed.
+          console.error(
+            `[chat] fork failed for ${sourceId}: ${res.status} ${res.statusText}`,
+          );
+          return null;
+        }
         const thread = await res.json();
         setThreads((prev) => [
           {
@@ -235,7 +242,8 @@ export function useChatThreads(
           ...prev,
         ]);
         return thread.id;
-      } catch {
+      } catch (err) {
+        console.error(`[chat] fork threw for ${sourceId}:`, err);
         return null;
       }
     },

--- a/packages/core/src/onboarding/default-steps.ts
+++ b/packages/core/src/onboarding/default-steps.ts
@@ -80,7 +80,7 @@ const llmStep: OnboardingStep = {
       kind: "builder-cli-auth",
       label: "Connect Builder",
       description:
-        "One click, no API key needed. Builder routes Claude, GPT, Gemini, and more.",
+        "Free credits for Claude, GPT, Gemini, and more — no API key needed.",
       primary: true,
       payload: {
         scope: "llm",

--- a/packages/core/src/server/action-discovery.spec.ts
+++ b/packages/core/src/server/action-discovery.spec.ts
@@ -29,4 +29,18 @@ describe("action discovery", () => {
 
     expect(registry["named-mutating-read"].readOnly).toBe(false);
   });
+
+  it("preserves explicit parallelSafe metadata", () => {
+    const registry = loadActionsFromStaticRegistry({
+      "safe-write": {
+        default: {
+          tool: { description: "Safe write", parameters: {} },
+          parallelSafe: true,
+          run: async () => ({ ok: true }),
+        },
+      },
+    });
+
+    expect(registry["safe-write"].parallelSafe).toBe(true);
+  });
 });

--- a/packages/core/src/server/action-discovery.ts
+++ b/packages/core/src/server/action-discovery.ts
@@ -134,6 +134,9 @@ function wrapDefaultExport(
 function preserveActionFlags(entry: Record<string, any>): Partial<ActionEntry> {
   const out: Partial<ActionEntry> = {};
   if (typeof entry.readOnly === "boolean") out.readOnly = entry.readOnly;
+  if (typeof entry.parallelSafe === "boolean") {
+    out.parallelSafe = entry.parallelSafe;
+  }
   if (typeof entry.toolCallable === "boolean") {
     out.toolCallable = entry.toolCallable;
   }
@@ -440,6 +443,7 @@ export async function mergeCoreSharingActions(
           run: def.run,
           ...(def.http !== undefined ? { http: def.http } : {}),
           ...(def.readOnly === true ? { readOnly: true } : {}),
+          ...(def.parallelSafe === true ? { parallelSafe: true } : {}),
         };
       }
     } catch {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -22,6 +22,7 @@ import {
   subscribeToRun,
   type ActionEntry,
 } from "../agent/production-agent.js";
+import { resolveRunSoftTimeoutMs } from "../agent/run-manager.js";
 import type { AgentEngine, EngineMessage } from "../agent/engine/types.js";
 import { resolveEngine, createAnthropicEngine } from "../agent/engine/index.js";
 import { DEFAULT_MODEL } from "../agent/default-model.js";
@@ -83,7 +84,10 @@ import {
 } from "../resources/store.js";
 import nodePath from "node:path";
 import { readBody } from "./h3-helpers.js";
-import { getBuilderBrowserConnectUrl } from "./builder-browser.js";
+import {
+  getBuilderBrowserConnectUrl,
+  isBuilderBranchingEnabled,
+} from "./builder-browser.js";
 import { captureCliOutput } from "./cli-capture.js";
 import { withConfiguredAppBasePath } from "./app-base-path.js";
 import {
@@ -151,6 +155,59 @@ function resolveArtifactBaseUrl(event: any | undefined): string | undefined {
   } catch {}
 
   return undefined;
+}
+
+async function runAgentLoopDirectWithSoftTimeout(
+  opts: Parameters<typeof runAgentLoop>[0],
+  softTimeoutMs?: number,
+): Promise<Awaited<ReturnType<typeof runAgentLoop>>> {
+  const timeoutMs = resolveRunSoftTimeoutMs(softTimeoutMs);
+  if (timeoutMs <= 0) return runAgentLoop(opts);
+
+  const upstreamSignal = opts.signal;
+  const controller = new AbortController();
+  const abortFromUpstream = () => controller.abort();
+  if (upstreamSignal.aborted) {
+    controller.abort();
+  } else {
+    upstreamSignal.addEventListener("abort", abortFromUpstream, {
+      once: true,
+    });
+  }
+
+  let softTimedOut = false;
+  const timer = setTimeout(() => {
+    if (controller.signal.aborted) return;
+    softTimedOut = true;
+    opts.send({
+      type: "error",
+      error: "The agent reached the run time limit before it could finish.",
+      errorCode: "run_timeout",
+      recoverable: true,
+      details: `The run exceeded ${Math.round(
+        timeoutMs / 1000,
+      )} seconds. Partial output and tool calls were preserved so you can continue or retry.`,
+    });
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    return await runAgentLoop({ ...opts, signal: controller.signal });
+  } catch (err) {
+    if (softTimedOut) {
+      return {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: opts.model,
+      };
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+    upstreamSignal.removeEventListener("abort", abortFromUpstream);
+  }
 }
 
 export function assembleA2AFinalResponse(
@@ -926,6 +983,7 @@ function createBuilderBrowserTool(deps: {
         return JSON.stringify({
           kind: "connect-builder-card",
           configured,
+          builderEnabled: isBuilderBranchingEnabled(),
           connectUrl: getBuilderBrowserConnectUrl(deps.getOrigin()),
           orgName: creds.orgName || null,
           prompt,
@@ -1243,6 +1301,10 @@ export interface AgentChatPluginOptions {
   devSystemPrompt?: string;
   /** Claude model to use. Default: claude-sonnet-4-6 */
   model?: string;
+  /** Per-app agent run soft timeout in milliseconds. Must stay below the
+   * hosting function timeout so the run can emit a recoverable timeout event
+   * instead of being killed by the platform. */
+  runSoftTimeoutMs?: number;
   /** Anthropic API key. Falls back to ANTHROPIC_API_KEY env var */
   apiKey?: string;
   /**
@@ -2793,55 +2855,58 @@ export function createAgentChatPlugin(
             `[A2A] Starting agent loop: ${a2aTools.length} tools, prompt ${systemPrompt.length} chars`,
           );
 
-          await runAgentLoop({
-            engine: a2aEngine,
-            model,
-            systemPrompt,
-            tools: a2aTools,
-            messages: a2aMessages,
-            actions: a2aActions,
-            send: (event) => {
-              a2aEvents.push(event);
-              if (event.type === "tool_start") {
-                console.log(`[A2A] Tool call: ${event.tool}`);
-              } else if (event.type === "tool_done") {
-                a2aToolResults.push({
-                  tool: event.tool,
-                  result: event.result,
-                });
-                const recoverableArtifactText =
-                  buildA2ARecoverableArtifactMessage(a2aToolResults, {
-                    baseUrl: resolveArtifactBaseUrl(context.event),
+          await runAgentLoopDirectWithSoftTimeout(
+            {
+              engine: a2aEngine,
+              model,
+              systemPrompt,
+              tools: a2aTools,
+              messages: a2aMessages,
+              actions: a2aActions,
+              send: (event) => {
+                a2aEvents.push(event);
+                if (event.type === "tool_start") {
+                  console.log(`[A2A] Tool call: ${event.tool}`);
+                } else if (event.type === "tool_done") {
+                  a2aToolResults.push({
+                    tool: event.tool,
+                    result: event.result,
                   });
-                if (
-                  recoverableArtifactText &&
-                  recoverableArtifactText !== lastRecoverableArtifactText
-                ) {
-                  lastRecoverableArtifactText = recoverableArtifactText;
-                  updateTaskStatusMessage(context.taskId, {
-                    role: "agent",
-                    metadata: { agentNativeRecoverableArtifacts: true },
-                    parts: [
-                      {
-                        type: "text",
-                        text: recoverableArtifactText,
-                      },
-                    ],
-                  }).catch((err) => {
-                    console.error(
-                      `[A2A] Failed to persist recoverable artifact message for task ${context.taskId}:`,
-                      err,
-                    );
-                  });
+                  const recoverableArtifactText =
+                    buildA2ARecoverableArtifactMessage(a2aToolResults, {
+                      baseUrl: resolveArtifactBaseUrl(context.event),
+                    });
+                  if (
+                    recoverableArtifactText &&
+                    recoverableArtifactText !== lastRecoverableArtifactText
+                  ) {
+                    lastRecoverableArtifactText = recoverableArtifactText;
+                    updateTaskStatusMessage(context.taskId, {
+                      role: "agent",
+                      metadata: { agentNativeRecoverableArtifacts: true },
+                      parts: [
+                        {
+                          type: "text",
+                          text: recoverableArtifactText,
+                        },
+                      ],
+                    }).catch((err) => {
+                      console.error(
+                        `[A2A] Failed to persist recoverable artifact message for task ${context.taskId}:`,
+                        err,
+                      );
+                    });
+                  }
+                } else if (event.type === "error") {
+                  console.error(`[A2A] Error: ${event.error}`);
+                } else if (event.type === "done") {
+                  console.log(`[A2A] Done. Events: ${a2aEvents.length}`);
                 }
-              } else if (event.type === "error") {
-                console.error(`[A2A] Error: ${event.error}`);
-              } else if (event.type === "done") {
-                console.log(`[A2A] Done. Events: ${a2aEvents.length}`);
-              }
+              },
+              signal: controller.signal,
             },
-            signal: controller.signal,
-          });
+            options?.runSoftTimeoutMs,
+          );
 
           const { responseText, finalText } = assembleA2AFinalResponse(
             a2aEvents,
@@ -2984,20 +3049,23 @@ export function createAgentChatPlugin(
           let accumulatedText = "";
           const controller = new AbortController();
 
-          await runAgentLoop({
-            engine: mcpEngine,
-            model,
-            systemPrompt,
-            tools: mcpTools,
-            messages: [
-              { role: "user", content: [{ type: "text", text: message }] },
-            ],
-            actions: mcpActions,
-            send: (event) => {
-              if (event.type === "text") accumulatedText += event.text;
+          await runAgentLoopDirectWithSoftTimeout(
+            {
+              engine: mcpEngine,
+              model,
+              systemPrompt,
+              tools: mcpTools,
+              messages: [
+                { role: "user", content: [{ type: "text", text: message }] },
+              ],
+              actions: mcpActions,
+              send: (event) => {
+                if (event.type === "text") accumulatedText += event.text;
+              },
+              signal: controller.signal,
             },
-            signal: controller.signal,
-          });
+            options?.runSoftTimeoutMs,
+          );
 
           return accumulatedText || "(no response)";
         },
@@ -3419,6 +3487,7 @@ export function createAgentChatPlugin(
         },
         model: options?.model ?? DEFAULT_MODEL,
         apiKey: options?.apiKey,
+        runSoftTimeoutMs: options?.runSoftTimeoutMs,
         skipFilesContext: leanPrompt,
         onEngineResolved: (engine, model) => {
           const runCtx = ensureRequestRunContext();
@@ -3510,6 +3579,7 @@ export function createAgentChatPlugin(
           },
           model: options?.model,
           apiKey: options?.apiKey,
+          runSoftTimeoutMs: options?.runSoftTimeoutMs,
           skipFilesContext: leanPrompt,
           onEngineResolved: (engine, model) => {
             const runCtx = ensureRequestRunContext();

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -731,6 +731,31 @@ export function createCoreRoutesPlugin(
       }),
     );
 
+    // Branch-creation waitlist signup. Used by ConnectBuilderCard when the
+    // deploy hasn't been opted into Builder branch creation (no
+    // ENABLE_BUILDER / BUILDER_BRANCH_PROJECT_ID) — instead of the raw 403
+    // from /builder/run, the card surfaces a "coming soon" CTA that POSTs
+    // here. Recorded as a tracking event so PostHog/Mixpanel/etc. capture
+    // demand without us standing up new storage.
+    getH3App(nitroApp).use(
+      `${P}/builder/branch-waitlist`,
+      defineEventHandler(async (event: H3Event) => {
+        if (getMethod(event) !== "POST") {
+          setResponseStatus(event, 405);
+          return { error: "Method not allowed" };
+        }
+        const session = await getSession(event).catch(() => null);
+        if (!session?.email) {
+          setResponseStatus(event, 401);
+          return { error: "Authentication required" };
+        }
+        trackBuilderLifecycle("builder branch waitlist joined", session.email, {
+          stage: "waitlist",
+        });
+        return { ok: true };
+      }),
+    );
+
     getH3App(nitroApp).use(
       `${P}/builder/callback`,
       defineEventHandler(async (event: H3Event) => {

--- a/packages/docs/app/components/DocsLayout.tsx
+++ b/packages/docs/app/components/DocsLayout.tsx
@@ -43,17 +43,17 @@ export default function DocsLayout({
   }, [children]);
 
   return (
-    <div className="mx-auto flex max-w-[1600px] px-0 lg:px-6">
+    <div className="mx-auto flex w-full max-w-[1600px] px-0 lg:px-6">
       <DocsSidebar />
       <main className="min-w-0 flex-1 border-0 border-[var(--docs-border)] px-4 pb-16 pt-0 sm:px-6 lg:border-x lg:px-12 lg:pt-8">
         <MobileDocsNav />
         <article
           ref={articleRef}
-          className="docs-content mx-auto max-w-[720px]"
+          className="docs-content mx-auto max-w-[900px]"
         >
           {children}
         </article>
-        <div className="mx-auto max-w-[720px]">
+        <div className="mx-auto max-w-[900px]">
           <DocsPrevNext />
         </div>
       </main>

--- a/packages/docs/app/components/Header.tsx
+++ b/packages/docs/app/components/Header.tsx
@@ -110,7 +110,7 @@ export default function Header() {
       <header
         className={`sticky top-0 z-50 transition-[background-color,border-color,backdrop-filter] duration-300 ${showHeaderBg ? "border-b border-[var(--docs-border)] bg-[var(--header-bg)] backdrop-blur-lg" : "border-b border-transparent bg-transparent"}`}
       >
-        <nav className="mx-auto flex h-16 max-w-[1600px] items-center gap-6 px-6">
+        <nav className="mx-auto flex h-16 w-full max-w-[1600px] items-center gap-6 px-6">
           <Link
             prefetch="render"
             to="/"

--- a/templates/analytics/app/components/layout/Layout.tsx
+++ b/templates/analytics/app/components/layout/Layout.tsx
@@ -19,7 +19,11 @@ export function Layout({ children }: LayoutProps) {
   if (BARE_ROUTES.has(location.pathname)) {
     return <>{children}</>;
   }
-  const isToolsRoute = location.pathname.startsWith("/tools/");
+  // Tools list (`/tools`) and viewer (`/tools/:id`) render their own h-12
+  // toolbar with NotificationsBell + AgentToggleButton. Skip the framework
+  // Header so there's no double-header.
+  const isToolsRoute =
+    location.pathname === "/tools" || location.pathname.startsWith("/tools/");
   return (
     <HeaderActionsProvider>
       <div className="flex h-screen w-full overflow-hidden bg-background text-foreground">

--- a/templates/analytics/netlify.toml
+++ b/templates/analytics/netlify.toml
@@ -9,6 +9,9 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Use Netlify's current standard synchronous function budget.
+# Aligned with the agent-run soft timeout in
+# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# so the framework's friendly "run_timeout" event fires before Netlify kills
+# the function.
 [functions."*"]
-  timeout = 60
+  timeout = 75

--- a/templates/calendar/app/components/layout/AppLayout.tsx
+++ b/templates/calendar/app/components/layout/AppLayout.tsx
@@ -28,6 +28,17 @@ const EVENT_DETAIL_MODE_KEY = "calendar-event-detail-mode";
 /** Routes that render without the full AppLayout chrome (sidebar, agent panel). */
 const BARE_ROUTES = new Set(["/event"]);
 
+/**
+ * Routes whose page renders its own toolbar (with NotificationsBell + AgentToggleButton).
+ * Layout still mounts Sidebar + AgentSidebar, but skips its own header so
+ * there's no double-header.
+ */
+function pageOwnsToolbar(pathname: string): boolean {
+  if (pathname === "/") return true;
+  if (pathname === "/tools" || pathname.startsWith("/tools/")) return true;
+  return false;
+}
+
 export type ViewMode = "month" | "week" | "day";
 
 interface CalendarContextValue {
@@ -200,28 +211,32 @@ export function AppLayout({ children }: AppLayoutProps) {
           ]}
         >
           <div className="flex flex-1 flex-col overflow-hidden">
-            <header className="flex h-12 items-center justify-between gap-3 border-b border-border px-3 shrink-0">
-              <div className="flex min-w-0 flex-1 items-center gap-2">
-                {headerControls?.left ?? (
-                  <div className="flex items-center lg:hidden">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-10 w-10"
-                      onClick={() => setSidebarOpen(true)}
-                    >
-                      <IconMenu className="h-5 w-5" />
-                    </Button>
-                    <span className="ml-2 text-sm font-semibold">Calendar</span>
-                  </div>
-                )}
-              </div>
-              <div className="flex shrink-0 items-center gap-2">
-                {headerControls?.right}
-                <NotificationsBell />
-                <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
-              </div>
-            </header>
+            {!pageOwnsToolbar(location.pathname) && (
+              <header className="flex h-12 items-center justify-between gap-3 border-b border-border px-3 shrink-0">
+                <div className="flex min-w-0 flex-1 items-center gap-2">
+                  {headerControls?.left ?? (
+                    <div className="flex items-center lg:hidden">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-10 w-10"
+                        onClick={() => setSidebarOpen(true)}
+                      >
+                        <IconMenu className="h-5 w-5" />
+                      </Button>
+                      <span className="ml-2 text-sm font-semibold">
+                        Calendar
+                      </span>
+                    </div>
+                  )}
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  {headerControls?.right}
+                  <NotificationsBell />
+                  <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
+                </div>
+              </header>
+            )}
 
             <HeaderControlsContext.Provider value={setHeaderControls}>
               <InvitationBanner />

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -696,6 +696,7 @@ export default function CalendarView() {
                 </TooltipContent>
               </Tooltip>
 
+              <NotificationsBell />
               <CreateEventPopover
                 open={createDialogOpen}
                 onOpenChange={(open) => {
@@ -709,7 +710,6 @@ export default function CalendarView() {
                 defaultStartTime={createDefaultStart}
                 defaultEndTime={createDefaultEnd}
               />
-              <NotificationsBell />
               <AgentToggleButton />
             </div>
           </div>

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -54,7 +54,10 @@ import {
 import { useOverlayPeople } from "@/hooks/use-overlay-people";
 import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
 import { useQueryClient } from "@tanstack/react-query";
-import { AgentToggleButton } from "@agent-native/core/client";
+import {
+  AgentToggleButton,
+  NotificationsBell,
+} from "@agent-native/core/client";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { toast } from "sonner";
 import { setUndoAction, runUndo } from "@/hooks/use-undo";
@@ -706,6 +709,7 @@ export default function CalendarView() {
                 defaultStartTime={createDefaultStart}
                 defaultEndTime={createDefaultEnd}
               />
+              <NotificationsBell />
               <AgentToggleButton />
             </div>
           </div>

--- a/templates/calendar/netlify.toml
+++ b/templates/calendar/netlify.toml
@@ -7,3 +7,11 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+
+# A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
+# Aligned with the agent-run soft timeout in
+# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# so the framework's friendly "run_timeout" event fires before Netlify kills
+# the function.
+[functions."*"]
+  timeout = 75

--- a/templates/calls/app/components/library/library-layout.tsx
+++ b/templates/calls/app/components/library/library-layout.tsx
@@ -18,7 +18,7 @@ interface LibraryLayoutProps {
 // Routes whose page renders its own custom toolbar (with AgentToggleButton).
 // Layout still mounts Sidebar + AgentSidebar, but skips its own Header so
 // there's no double-header.
-const NO_HEADER_PREFIXES = ["/calls/"];
+const NO_HEADER_PREFIXES = ["/calls/", "/tools"];
 
 function LibraryHeader({ onOpenSidebar }: { onOpenSidebar: () => void }) {
   const title = useHeaderTitle();

--- a/templates/calls/app/components/player/call-player.tsx
+++ b/templates/calls/app/components/player/call-player.tsx
@@ -26,6 +26,7 @@ import {
   useActionMutation,
   appBasePath,
   AgentToggleButton,
+  NotificationsBell,
 } from "@agent-native/core/client";
 import { formatMs } from "@/lib/timestamp-format";
 import { useCallPlayer } from "@/hooks/use-call-player";
@@ -373,6 +374,7 @@ export function CallPlayer({
             <IconMessage className="h-4 w-4" />
             Comments
           </Button>
+          <NotificationsBell />
           <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
         </div>
       </header>

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -84,6 +84,12 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [headerSlot, setHeaderSlot] = useState<HTMLElement | null>(null);
 
+  // Routes whose page renders its own h-12 toolbar (with NotificationsBell +
+  // AgentToggleButton). Layout still mounts Sidebar + AgentSidebar, but skips
+  // its own header so there's no double-header.
+  const pageOwnsToolbar =
+    location.pathname === "/tools" || location.pathname.startsWith("/tools/");
+
   useEffect(() => {
     setSidebarOpen(false);
   }, [location.pathname]);
@@ -302,21 +308,23 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
 
             {/* Main content area */}
             <div className="flex min-w-0 flex-1 flex-col">
-              <header className="flex min-h-[52px] items-center gap-3 border-b border-border px-5 py-2">
-                <button
-                  onClick={() => setSidebarOpen(true)}
-                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground md:hidden"
-                >
-                  <IconMenu2 className="h-4 w-4" />
-                </button>
-                <div
-                  ref={setHeaderSlot}
-                  className="flex min-w-0 flex-1 flex-wrap items-center gap-3"
-                />
-                <div className="ml-auto flex items-center gap-2">
-                  <AgentToggleButton />
-                </div>
-              </header>
+              {!pageOwnsToolbar && (
+                <header className="flex min-h-[52px] items-center gap-3 border-b border-border px-5 py-2">
+                  <button
+                    onClick={() => setSidebarOpen(true)}
+                    className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-background text-muted-foreground hover:text-foreground md:hidden"
+                  >
+                    <IconMenu2 className="h-4 w-4" />
+                  </button>
+                  <div
+                    ref={setHeaderSlot}
+                    className="flex min-w-0 flex-1 flex-wrap items-center gap-3"
+                  />
+                  <div className="ml-auto flex items-center gap-2">
+                    <AgentToggleButton />
+                  </div>
+                </header>
+              )}
               {shouldShowPromo && (
                 <div className="flex items-center gap-3 border-b border-border bg-primary/5 px-5 py-2.5 text-sm">
                   <IconAppWindow className="h-4 w-4 shrink-0 text-primary" />

--- a/templates/clips/app/components/player/transcript-panel.tsx
+++ b/templates/clips/app/components/player/transcript-panel.tsx
@@ -135,7 +135,8 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
           </Button>
         </div>
         <p className="text-[11px] text-muted-foreground">
-          Builder.io provides free transcription — no API key needed.
+          Builder.io includes free credits for transcription — no API key
+          needed.
         </p>
       </div>
     );

--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   IconCamera,
   IconDeviceScreen,
   IconMicrophone,
+  IconUpload,
   IconVideo,
 } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
@@ -21,6 +22,8 @@ export interface PreRecordPanelProps {
     micDeviceId: string | null;
     cameraDeviceId: string | null;
   }) => void;
+  /** Called when the user picks a local video file to upload. */
+  onUpload?: (file: File) => void;
   onCancel?: () => void;
   busy?: boolean;
 }
@@ -53,9 +56,11 @@ const MODE_OPTIONS: Array<{
 
 export function PreRecordPanel({
   onStart,
+  onUpload,
   onCancel,
   busy,
 }: PreRecordPanelProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [mode, setMode] = useState<RecordingMode>("screen+camera");
   const [mics, setMics] = useState<MediaDeviceInfo[]>([]);
   const [cameras, setCameras] = useState<MediaDeviceInfo[]>([]);
@@ -211,6 +216,38 @@ export function PreRecordPanel({
           Start recording
         </Button>
       </div>
+
+      {onUpload && (
+        <>
+          <div className="relative flex items-center">
+            <div className="flex-1 border-t border-border" />
+            <span className="px-3 text-[11px] uppercase tracking-wide text-muted-foreground">
+              or
+            </span>
+            <div className="flex-1 border-t border-border" />
+          </div>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => fileInputRef.current?.click()}
+            className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-background px-3 py-2.5 text-sm text-muted-foreground hover:border-foreground/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <IconUpload className="h-4 w-4" />
+            Upload a video file
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="video/mp4,video/webm,video/quicktime,video/*"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) onUpload(file);
+              if (fileInputRef.current) fileInputRef.current.value = "";
+            }}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -229,6 +229,12 @@ export class RecorderEngine {
         cameraStream: this.cameraStream,
       };
     } catch (err) {
+      // Release any tracks acquired before the failure so the browser's
+      // screen / camera / mic indicators don't linger after the caller's
+      // error handler. Without this, a screen-share that succeeded followed
+      // by a camera permission denial would leave the screen capture
+      // running until tab close.
+      this.cleanupTracks();
       this.transition("error", { reason: String(err) });
       throw this.friendlyError(err);
     }

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -300,6 +300,27 @@ export default function RecordRoute() {
       } catch (err) {
         const message =
           err instanceof Error ? err.message : "Could not start recording";
+        // If the recording row was created before the failure (i.e. media
+        // acquisition failed *after* create-recording), trash it so it
+        // doesn't sit in the library forever in 'uploading' status. This
+        // is the bug that produced "stuck UPLOADING" cards from failed
+        // record attempts.
+        const orphan = pendingRef.current;
+        if (orphan?.id) {
+          fetch(agentNativePath("/_agent-native/actions/trash-recording"), {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ id: orphan.id }),
+          }).catch(() => {});
+        }
+        // Release any tracks the engine grabbed before failing.
+        try {
+          await engineRef.current?.cancel();
+        } catch {
+          // ignore
+        }
+        pendingRef.current = null;
+        engineRef.current = null;
         setError(message);
         setUiState("error");
         if (
@@ -311,6 +332,181 @@ export default function RecordRoute() {
       }
     },
     [],
+  );
+
+  // -------------------------------------------------------------------------
+  // Upload a local video file as a Clip.
+  // Reads metadata via a hidden <video>, creates the recording row, then
+  // streams the file to /api/uploads/:id/chunk in 5MB slices (the chunk
+  // route caps at 6MB) with isFinal=1 on the last slice. Mirrors the
+  // recorder's upload pipeline so finalize-recording handles it identically.
+  // -------------------------------------------------------------------------
+  const UPLOAD_CHUNK_BYTES = 5 * 1024 * 1024; // 5 MiB; chunk route allows up to 6.
+
+  const probeVideoMetadata = useCallback(
+    (
+      file: File,
+    ): Promise<{ durationMs: number; width: number; height: number }> => {
+      return new Promise((resolve) => {
+        const url = URL.createObjectURL(file);
+        const video = document.createElement("video");
+        video.preload = "metadata";
+        video.muted = true;
+        const cleanup = () => {
+          URL.revokeObjectURL(url);
+        };
+        video.onloadedmetadata = () => {
+          resolve({
+            durationMs: Math.round((video.duration || 0) * 1000),
+            width: video.videoWidth || 0,
+            height: video.videoHeight || 0,
+          });
+          cleanup();
+        };
+        video.onerror = () => {
+          resolve({ durationMs: 0, width: 0, height: 0 });
+          cleanup();
+        };
+        video.src = url;
+      });
+    },
+    [],
+  );
+
+  const uploadFile = useCallback(
+    async (file: File) => {
+      setError(null);
+      setUiState("uploading");
+
+      const acceptedMime = new Set([
+        "video/mp4",
+        "video/webm",
+        "video/quicktime",
+      ]);
+      const baseType = (file.type || "").split(";")[0]?.trim().toLowerCase();
+      let mimeType = baseType && acceptedMime.has(baseType) ? baseType : null;
+      // Fallback by extension when the browser doesn't provide a type
+      // (rare on macOS .mov files dragged from Finder).
+      if (!mimeType) {
+        const lower = file.name.toLowerCase();
+        if (lower.endsWith(".mp4")) mimeType = "video/mp4";
+        else if (lower.endsWith(".webm")) mimeType = "video/webm";
+        else if (lower.endsWith(".mov")) mimeType = "video/quicktime";
+      }
+      if (!mimeType) {
+        const message =
+          "That file type isn't supported. Try MP4, WebM, or MOV.";
+        setError(message);
+        setUiState("error");
+        toast.error(message);
+        return;
+      }
+
+      let createdId: string | null = null;
+      try {
+        const meta = await probeVideoMetadata(file);
+
+        const res = await fetch(
+          agentNativePath("/_agent-native/actions/create-recording"),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              title: file.name.replace(/\.[^/.]+$/, "") || "Untitled recording",
+              hasCamera: false,
+              hasAudio: true,
+              width: meta.width,
+              height: meta.height,
+            }),
+          },
+        );
+        if (!res.ok) {
+          if (res.status === 401 || res.status === 403) {
+            throw new Error("SESSION_EXPIRED");
+          }
+          const body = (await res.json().catch(() => null)) as {
+            error?: string;
+          } | null;
+          throw new Error(
+            body?.error ?? `create-recording failed (${res.status})`,
+          );
+        }
+        const created = (await res.json()) as {
+          result?: { id: string; uploadChunkUrl: string };
+          id?: string;
+          uploadChunkUrl?: string;
+        };
+        const info =
+          created.result ?? (created as { id: string; uploadChunkUrl: string });
+        if (!info?.id) {
+          throw new Error("create-recording did not return an id");
+        }
+        createdId = info.id;
+        const uploadBase = `${appBasePath()}${info.uploadChunkUrl}`;
+
+        const totalChunks = Math.max(
+          1,
+          Math.ceil(file.size / UPLOAD_CHUNK_BYTES),
+        );
+        for (let i = 0; i < totalChunks; i++) {
+          const start = i * UPLOAD_CHUNK_BYTES;
+          const end = Math.min(start + UPLOAD_CHUNK_BYTES, file.size);
+          const slice = file.slice(start, end, mimeType);
+          const isFinal = i === totalChunks - 1;
+          const params = new URLSearchParams({
+            index: String(i),
+            total: String(totalChunks),
+            isFinal: isFinal ? "1" : "0",
+            mimeType,
+          });
+          if (isFinal) {
+            params.set("durationMs", String(meta.durationMs));
+            params.set("width", String(meta.width));
+            params.set("height", String(meta.height));
+            params.set("hasAudio", "1");
+            params.set("hasCamera", "0");
+          }
+          const chunkRes = await fetch(`${uploadBase}?${params.toString()}`, {
+            method: "POST",
+            headers: { "Content-Type": mimeType },
+            body: await slice.arrayBuffer(),
+          });
+          if (!chunkRes.ok) {
+            const text = await chunkRes.text().catch(() => "");
+            throw new Error(
+              `Upload failed at chunk ${i + 1}/${totalChunks}: ${
+                text || chunkRes.statusText
+              }`,
+            );
+          }
+        }
+
+        setUiState("complete");
+        toast.success("Video uploaded");
+        await writeAppState("navigate", {
+          view: "recording",
+          recordingId: createdId,
+        });
+        setTimeout(() => {
+          if (createdId) navigate(`/r/${createdId}`);
+        }, 50);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Upload failed";
+        // Trash the orphaned row so it doesn't sit in the library forever
+        // in 'uploading' status.
+        if (createdId) {
+          fetch(agentNativePath("/_agent-native/actions/trash-recording"), {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ id: createdId }),
+          }).catch(() => {});
+        }
+        setError(message);
+        setUiState("error");
+        if (message !== "SESSION_EXPIRED") toast.error(message);
+      }
+    },
+    [navigate, probeVideoMetadata],
   );
 
   // -------------------------------------------------------------------------
@@ -602,8 +798,11 @@ export default function RecordRoute() {
   // `/record` is a fullscreen route outside the `_app` shell, so it has no
   // sidebar back-affordance. Surface a back arrow whenever there's nothing in
   // flight — during recording/countdown/uploading the toolbar's stop flow is
-  // the exit path.
-  const showBackButton = uiState === "idle" || uiState === "error";
+  // the exit path. `pickingSources` is included so users aren't trapped
+  // when the browser's permission/source dialog hangs or they want to bail
+  // out before granting access.
+  const showBackButton =
+    uiState === "idle" || uiState === "error" || uiState === "pickingSources";
 
   return (
     <div className="relative min-h-screen bg-background">
@@ -644,7 +843,7 @@ export default function RecordRoute() {
               </span>
             </div>
             {storageConfigured === null ? null : storageConfigured ? (
-              <PreRecordPanel onStart={startFlow} />
+              <PreRecordPanel onStart={startFlow} onUpload={uploadFile} />
             ) : (
               <StorageSetupCard
                 onConfigured={() => setStorageConfigured(true)}

--- a/templates/clips/netlify.toml
+++ b/templates/clips/netlify.toml
@@ -9,6 +9,9 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Use Netlify's current standard synchronous function budget.
+# Aligned with the agent-run soft timeout in
+# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# so the framework's friendly "run_timeout" event fires before Netlify kills
+# the function.
 [functions."*"]
-  timeout = 60
+  timeout = 75

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -21,6 +21,7 @@ import {
 import { Button } from "@/components/ui/button";
 import {
   AgentToggleButton,
+  NotificationsBell,
   PresenceBar,
   type CollabUser,
 } from "@agent-native/core/client";
@@ -568,6 +569,7 @@ export function DocumentToolbar({
         </PopoverContent>
       </Popover>
 
+      <NotificationsBell />
       <AgentToggleButton />
     </div>
   );

--- a/templates/content/app/components/layout/Layout.tsx
+++ b/templates/content/app/components/layout/Layout.tsx
@@ -17,7 +17,7 @@ const MAX_SIDEBAR_WIDTH = 480;
 // Routes whose page renders its own custom toolbar (with AgentToggleButton).
 // Layout still mounts Sidebar + AgentSidebar, but skips its own Header so
 // there's no double-header.
-const NO_HEADER_PREFIXES = ["/page/"];
+const NO_HEADER_PREFIXES = ["/page/", "/tools"];
 
 function loadSidebarWidth(): number {
   try {

--- a/templates/content/netlify.toml
+++ b/templates/content/netlify.toml
@@ -9,6 +9,9 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Use Netlify's current standard synchronous function budget.
+# Aligned with the agent-run soft timeout in
+# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# so the framework's friendly "run_timeout" event fires before Netlify kills
+# the function.
 [functions."*"]
-  timeout = 60
+  timeout = 75

--- a/templates/design/app/components/layout/Layout.tsx
+++ b/templates/design/app/components/layout/Layout.tsx
@@ -18,9 +18,10 @@ const BARE_PREFIXES = ["/present/"];
 /**
  * Routes where the page renders its own toolbar instead of the global Header.
  * The Sidebar + AgentSidebar still render. The Header is hidden so the page
- * can supply a richer custom toolbar (e.g. DesignEditor mode/zoom/device).
+ * can supply a richer custom toolbar (e.g. DesignEditor mode/zoom/device,
+ * shared ToolViewer / ToolsListPage chrome).
  */
-const EDITOR_PREFIXES = ["/design/"];
+const EDITOR_PREFIXES = ["/design/", "/tools"];
 
 export function Layout({ children }: LayoutProps) {
   useNavigationState();

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -27,6 +27,7 @@ import {
   emailToName,
   PresenceBar,
   AgentToggleButton,
+  NotificationsBell,
   type CollabUser,
 } from "@agent-native/core/client";
 
@@ -518,6 +519,7 @@ export default function DesignEditor() {
             agentActive={agentActive}
             currentUserEmail={session?.email}
           />
+          <NotificationsBell />
           <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
         </div>
       </header>

--- a/templates/design/netlify.toml
+++ b/templates/design/netlify.toml
@@ -9,6 +9,9 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Use Netlify's current standard synchronous function budget.
+# Aligned with the agent-run soft timeout in
+# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# so the framework's friendly "run_timeout" event fires before Netlify kills
+# the function.
 [functions."*"]
-  timeout = 60
+  timeout = 75

--- a/templates/dispatch/app/components/create-app-popover.tsx
+++ b/templates/dispatch/app/components/create-app-popover.tsx
@@ -1,11 +1,36 @@
-import { useState, type ReactNode } from "react";
-import { sendToAgentChat, PromptComposer } from "@agent-native/core/client";
-import { IconPlus } from "@tabler/icons-react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  PromptComposer,
+  agentNativePath,
+  appBasePath,
+  isInBuilderFrame,
+  sendToAgentChat,
+  useDevMode,
+} from "@agent-native/core/client";
+import { getWorkspaceAppIdValidationError } from "@agent-native/core/shared";
+import {
+  IconArrowLeft,
+  IconArrowUpRight,
+  IconCheck,
+  IconChevronDown,
+  IconKey,
+  IconLoader2,
+  IconPlus,
+} from "@tabler/icons-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+
+interface VaultSecretOption {
+  id: string;
+  name: string;
+  credentialKey: string;
+  provider?: string | null;
+  description?: string | null;
+}
 
 interface CreateAppPopoverProps {
   /**
@@ -19,27 +44,358 @@ interface CreateAppPopoverProps {
   align?: "start" | "center" | "end";
 }
 
-const SUBMIT_CONTEXT =
-  "The user wants to create a new workspace app. Use the start-workspace-app-creation action with their description above to scaffold the app, then continue with whatever the action returns.";
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/^[^a-z]+/, "")
+    .slice(0, 48);
+}
+
+function titleFromPrompt(prompt: string): string {
+  const cleaned = prompt
+    .replace(/\b(build|create|make|an?|the|app|tool|dashboard)\b/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return slugify(cleaned || "new-app") || "new-app";
+}
+
+function buildAppCreationPrompt(input: {
+  appId: string;
+  prompt: string;
+  selectedKeys: string[];
+}): string {
+  const keyList = input.selectedKeys.join(", ");
+  const grantRequest = keyList
+    ? `Requested Dispatch vault key grants for this app: ${keyList}`
+    : `Requested Dispatch vault key grants for this app: none`;
+
+  return [
+    `Create a new agent-native app in this workspace.`,
+    ``,
+    `Suggested app name: ${input.appId} (you may adjust the slug if it conflicts)`,
+    `User prompt: ${input.prompt.trim()}`,
+    grantRequest,
+    ``,
+    `Pick a starter template that fits the user's prompt — analytics, calendar, content, design, dispatch, forms, mail, slides, videos, clips, or starter when none of the others fit.`,
+    `Use the workspace app layout: create it under apps/${input.appId}, mount it at /${input.appId}, keep it on the shared workspace database/hosting model, and avoid table-name collisions by namespacing any new domain tables to the app.`,
+    keyList
+      ? `After the app exists, grant the selected Dispatch vault keys to appId "${input.appId}" and sync them once the app server is available. Treat these as requested grants, not active grants before creation succeeds.`
+      : `Do not grant any Dispatch vault keys unless the user asks later.`,
+    ``,
+    `App readiness requirements before handing off:`,
+    `- Update the workspace app registry metadata for "${input.appId}" so Dispatch lists the app at /${input.appId} after merge/deploy.`,
+    `- Update the app manifest/package/deploy metadata needed by the existing workspace deployment model.`,
+    `- Verify the app's agent card/A2A metadata is ready so Dispatch can discover and delegate to the app after deployment.`,
+    `When it is ready, start or update the workspace dev server and navigate the user to /${input.appId}.`,
+  ].join("\n");
+}
+
+async function fetchJson(url: string, init?: RequestInit): Promise<any> {
+  const res = await fetch(url, init);
+  const data = await res.json().catch(() => null);
+  if (!res.ok) {
+    throw new Error(
+      data?.error || data?.message || `Request failed ${res.status}`,
+    );
+  }
+  return data;
+}
+
+function defaultDispatchBasePath(): string | null {
+  const base = appBasePath();
+  if (base === "/dispatch") return null;
+  return null;
+}
+
+function actionUrl(basePath: string | null, action: string): string {
+  const path = `/_agent-native/actions/${action}`;
+  if (basePath === null) return agentNativePath(path);
+  const normalized = basePath.replace(/\/+$/, "");
+  return `${normalized}${path}`;
+}
+
+/**
+ * Inline two-step app-creation flow: prompt → optional key picker → submit.
+ * Used both in the popover form and in the dedicated `/new-app` page so the
+ * same UX shows up everywhere a teammate kicks off a new workspace app.
+ */
+export function CreateAppFlow({
+  onClose,
+  className = "",
+}: {
+  onClose?: () => void;
+  className?: string;
+}) {
+  const [step, setStep] = useState<"prompt" | "keys">("prompt");
+  const [prompt, setPrompt] = useState("");
+  const [selectedSecretIds, setSelectedSecretIds] = useState<string[]>([]);
+  const [secrets, setSecrets] = useState<VaultSecretOption[]>([]);
+  const [secretsError, setSecretsError] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [branchUrl, setBranchUrl] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { isDevMode } = useDevMode();
+
+  const basePath = useMemo(() => defaultDispatchBasePath(), []);
+
+  // Fetch the vault keys eagerly so step 2 has them ready the moment the user
+  // taps "Choose keys" — no spinner, no pause between steps.
+  useEffect(() => {
+    let cancelled = false;
+    fetchJson(actionUrl(basePath, "list-vault-secret-options"))
+      .then((data) => {
+        if (cancelled) return;
+        setSecrets(Array.isArray(data) ? data : []);
+        setSecretsError(null);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setSecrets([]);
+        setSecretsError(err?.message || "Could not load Dispatch keys");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [basePath]);
+
+  const selectedSecrets = useMemo(
+    () => secrets.filter((s) => selectedSecretIds.includes(s.id)),
+    [secrets, selectedSecretIds],
+  );
+  const selectedSecretLabel =
+    selectedSecretIds.length === 0
+      ? "no keys"
+      : `${selectedSecretIds.length} key${selectedSecretIds.length === 1 ? "" : "s"}`;
+
+  function toggleSecret(id: string) {
+    setSelectedSecretIds((cur) =>
+      cur.includes(id) ? cur.filter((x) => x !== id) : [...cur, id],
+    );
+  }
+
+  async function submit(rawPrompt: string, selectedKeys: string[]) {
+    const trimmed = rawPrompt.trim();
+    if (!trimmed || isSubmitting) return;
+    const appId = titleFromPrompt(trimmed);
+    const validationError = getWorkspaceAppIdValidationError(appId);
+    if (validationError) {
+      setStatusMessage(validationError);
+      return;
+    }
+
+    const message = buildAppCreationPrompt({
+      appId,
+      prompt: trimmed,
+      selectedKeys,
+    });
+    setIsSubmitting(true);
+    setStatusMessage(null);
+    setBranchUrl(null);
+
+    try {
+      if (isInBuilderFrame()) {
+        sendToAgentChat({ message, submit: true, type: "code" });
+        setStatusMessage("Sent to Builder chat.");
+        onClose?.();
+      } else if (isDevMode) {
+        sendToAgentChat({ message, submit: true, type: "code", newTab: true });
+        setStatusMessage("Sent to the local agent.");
+        onClose?.();
+      } else {
+        const result = await fetchJson(
+          actionUrl(basePath, "start-workspace-app-creation"),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              prompt: trimmed,
+              appId,
+              secretIds: selectedKeys.length > 0 ? selectedSecretIds : [],
+            }),
+          },
+        );
+        if (result?.mode === "builder") {
+          setBranchUrl(result?.url || null);
+          setStatusMessage("Builder branch created.");
+        } else {
+          setStatusMessage(
+            result?.message ||
+              "Builder app creation is coming soon. Open this workspace in Builder to create an app from this prompt.",
+          );
+        }
+      }
+    } catch (err: any) {
+      setStatusMessage(err?.message || "Could not start the new app flow.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const submitWithSelectedKeys = () =>
+    submit(
+      prompt,
+      selectedSecrets.map((s) => s.credentialKey),
+    );
+
+  return (
+    <div className={`flex flex-col gap-3 ${className}`}>
+      {step === "prompt" ? (
+        <>
+          <div className="flex items-center justify-between gap-2 px-1">
+            <p className="text-sm font-semibold text-foreground">Create app</p>
+            <button
+              type="button"
+              onClick={() => setStep("keys")}
+              className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-background/40 px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground hover:bg-accent/50"
+            >
+              <IconKey size={11} />
+              {selectedSecretLabel}
+            </button>
+          </div>
+          <PromptComposer
+            autoFocus
+            disabled={isSubmitting}
+            placeholder="Describe the app your teammate should be able to use..."
+            draftScope="dispatch:create-app"
+            onSubmit={(text) => {
+              setPrompt(text);
+              submit(
+                text,
+                selectedSecrets.map((s) => s.credentialKey),
+              );
+            }}
+          />
+        </>
+      ) : (
+        <>
+          <div className="flex items-center justify-between gap-2 px-1">
+            <button
+              type="button"
+              onClick={() => setStep("prompt")}
+              className="inline-flex cursor-pointer items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <IconArrowLeft size={12} />
+              Back
+            </button>
+            <span className="text-[11px] text-muted-foreground/70">
+              {selectedSecretLabel} selected
+            </span>
+          </div>
+          <div className="max-h-[340px] space-y-2 overflow-y-auto rounded-md border border-border bg-card p-2">
+            {secretsError ? (
+              <p className="rounded-md border border-dashed border-border px-3 py-3 text-xs text-muted-foreground">
+                {secretsError}
+              </p>
+            ) : secrets.length === 0 ? (
+              <p className="rounded-md border border-dashed border-border px-3 py-3 text-xs text-muted-foreground">
+                No Dispatch vault keys found yet.
+              </p>
+            ) : (
+              secrets.map((secret) => {
+                const selected = selectedSecretIds.includes(secret.id);
+                return (
+                  <div
+                    key={secret.id}
+                    className={`group rounded-md border text-sm ${
+                      selected
+                        ? "border-primary/45 bg-primary/5"
+                        : "border-border hover:border-muted-foreground/40 hover:bg-accent/35"
+                    }`}
+                  >
+                    <button
+                      type="button"
+                      aria-pressed={selected}
+                      onClick={() => toggleSecret(secret.id)}
+                      className="flex w-full cursor-pointer items-start gap-3 rounded-md px-3 py-2 text-left"
+                    >
+                      <span
+                        className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded border ${
+                          selected
+                            ? "border-primary/60 bg-primary/10 text-primary"
+                            : "border-muted-foreground/35 text-transparent"
+                        }`}
+                      >
+                        {selected ? <IconCheck className="h-3 w-3" /> : null}
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate font-medium">
+                          {secret.credentialKey}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground/70">
+                          {selected
+                            ? "Will be requested for this app"
+                            : "Click to request"}
+                        </span>
+                      </span>
+                    </button>
+                    {(secret.provider || secret.name) && (
+                      <details className="group/details border-t border-border/60 px-3 py-1.5 text-xs text-muted-foreground/75">
+                        <summary className="flex cursor-pointer list-none items-center gap-1.5 text-[11px] hover:text-muted-foreground [&::-webkit-details-marker]:hidden">
+                          <IconChevronDown className="h-3 w-3 transition-transform group-open/details:rotate-180" />
+                          Details
+                        </summary>
+                        <div className="mt-1.5 space-y-1 pb-0.5 pl-4">
+                          <div className="truncate">
+                            Provider: {secret.provider || "Not specified"}
+                          </div>
+                          <div className="truncate">Name: {secret.name}</div>
+                        </div>
+                      </details>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </div>
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              size="sm"
+              onClick={submitWithSelectedKeys}
+              disabled={!prompt.trim() || isSubmitting}
+            >
+              {isSubmitting ? (
+                <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <IconPlus className="h-3.5 w-3.5" />
+              )}
+              Create app
+            </Button>
+          </div>
+          {!prompt.trim() ? (
+            <p className="px-1 text-[11px] text-muted-foreground/70">
+              Add a prompt on the previous step before creating the app.
+            </p>
+          ) : null}
+        </>
+      )}
+
+      {statusMessage ? (
+        <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+          {statusMessage}
+          {branchUrl ? (
+            <a
+              href={branchUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="ml-2 inline-flex items-center gap-1 font-medium text-foreground underline"
+            >
+              Open branch <IconArrowUpRight className="h-3 w-3" />
+            </a>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 export function CreateAppPopover({
   trigger,
   align = "center",
 }: CreateAppPopoverProps) {
   const [open, setOpen] = useState(false);
-
-  function submit(text: string) {
-    const trimmed = text.trim();
-    if (!trimmed) return;
-    sendToAgentChat({
-      message: trimmed,
-      context: SUBMIT_CONTEXT,
-      submit: true,
-      newTab: true,
-    });
-    setOpen(false);
-  }
-
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -58,17 +414,9 @@ export function CreateAppPopover({
       <PopoverContent
         align={align}
         sideOffset={10}
-        className="w-[calc(100vw-2rem)] rounded-xl p-3 shadow-xl sm:w-[420px]"
+        className="w-[calc(100vw-2rem)] rounded-xl p-3 shadow-xl sm:w-[460px]"
       >
-        <p className="px-1 pb-2 text-sm font-semibold text-foreground">
-          Create app
-        </p>
-        <PromptComposer
-          autoFocus
-          placeholder="Describe the app you want to build…"
-          draftScope="dispatch:create-app-popover"
-          onSubmit={(text) => submit(text)}
-        />
+        <CreateAppFlow onClose={() => setOpen(false)} />
       </PopoverContent>
     </Popover>
   );

--- a/templates/dispatch/app/components/layout/Layout.tsx
+++ b/templates/dispatch/app/components/layout/Layout.tsx
@@ -62,6 +62,14 @@ const SIDEBAR_SUGGESTIONS = [
 
 const CHROMELESS_PATHS = ["/approval"];
 
+// Routes whose page renders its own toolbar (with NotificationsBell + AgentToggleButton).
+// Layout still mounts the sidebar + AgentSidebar, but skips its own Header so
+// there's no double-header.
+function pageOwnsToolbar(pathname: string): boolean {
+  if (pathname === "/tools" || pathname.startsWith("/tools/")) return true;
+  return false;
+}
+
 function NavContent({ onNavigate }: { onNavigate?: () => void }) {
   const location = useLocation();
   const operationsOpen = OPERATIONS_NAV_ITEMS.some(
@@ -154,14 +162,19 @@ export function Layout({ children }: { children: ReactNode }) {
     return <>{children}</>;
   }
 
+  const showHeader = !pageOwnsToolbar(location.pathname);
   const appContent = (
     <div className="flex h-full flex-1 flex-col overflow-hidden">
-      <Header onOpenMobile={() => setMobileOpen(true)} />
+      {showHeader ? <Header onOpenMobile={() => setMobileOpen(true)} /> : null}
       <InvitationBanner />
       <main className="flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-7xl space-y-5 px-4 py-6 sm:px-6">
-          {children}
-        </div>
+        {showHeader ? (
+          <div className="mx-auto max-w-7xl space-y-5 px-4 py-6 sm:px-6">
+            {children}
+          </div>
+        ) : (
+          children
+        )}
       </main>
     </div>
   );

--- a/templates/dispatch/app/routes/apps.tsx
+++ b/templates/dispatch/app/routes/apps.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import { useActionQuery } from "@agent-native/core/client";
 import {
   IconArrowUpRight,
@@ -71,12 +70,15 @@ export default function AppsRoute() {
                 Workspace apps
               </h2>
             </div>
-            <Button asChild size="sm" variant="outline">
-              <Link to="/new-app">
-                <IconPlus size={15} className="mr-1.5" />
-                App
-              </Link>
-            </Button>
+            <CreateAppPopover
+              align="end"
+              trigger={
+                <Button size="sm" variant="outline">
+                  <IconPlus size={15} className="mr-1.5" />
+                  App
+                </Button>
+              }
+            />
           </div>
 
           <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">

--- a/templates/dispatch/app/routes/new-app.tsx
+++ b/templates/dispatch/app/routes/new-app.tsx
@@ -1,4 +1,4 @@
-import { NewWorkspaceAppFlow } from "@agent-native/core/client";
+import { CreateAppFlow } from "@/components/create-app-popover";
 import { DispatchShell } from "@/components/dispatch-shell";
 
 export function meta() {
@@ -11,7 +11,9 @@ export default function NewAppRoute() {
       title="New App"
       description="Create a workspace app from a prompt and grant it selected vault keys."
     >
-      <NewWorkspaceAppFlow sourceApp="dispatch" className="px-0 py-0" />
+      <div className="mx-auto w-full max-w-xl">
+        <CreateAppFlow />
+      </div>
     </DispatchShell>
   );
 }

--- a/templates/dispatch/netlify.toml
+++ b/templates/dispatch/netlify.toml
@@ -9,6 +9,9 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Use Netlify's current standard synchronous function budget.
+# Aligned with the agent-run soft timeout in
+# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# so the framework's friendly "run_timeout" event fires before Netlify kills
+# the function.
 [functions."*"]
-  timeout = 60
+  timeout = 75

--- a/templates/forms/actions/create-form.ts
+++ b/templates/forms/actions/create-form.ts
@@ -27,8 +27,17 @@ export default defineAction({
   schema: z.object({
     title: z.string().optional().describe("Form title"),
     description: z.string().optional().describe("Form description"),
-    fields: z.string().optional().describe("JSON array of form fields"),
-    settings: z.string().optional().describe("JSON object of form settings"),
+    // Accept either a JSON string (agent CLI / older callers) or an actual
+    // array/object — the UI POSTs JSON bodies via useActionMutation, which
+    // serializes the inputs directly.
+    fields: z
+      .union([z.string(), z.array(z.any())])
+      .optional()
+      .describe("Array of form fields (or JSON string of the same)"),
+    settings: z
+      .union([z.string(), z.record(z.string(), z.any())])
+      .optional()
+      .describe("Form settings object (or JSON string of the same)"),
     slug: z.string().optional().describe("Custom URL slug"),
     status: z
       .enum(["draft", "published", "closed"])

--- a/templates/forms/actions/export-responses.ts
+++ b/templates/forms/actions/export-responses.ts
@@ -34,6 +34,7 @@ export default defineAction({
       const data = responses.map((r) => ({
         id: r.id,
         submittedAt: r.submittedAt,
+        submitterEmail: r.submitterEmail ?? null,
         ...JSON.parse(r.data),
       }));
       fs.writeFileSync(outputPath, JSON.stringify(data, null, 2));
@@ -41,6 +42,7 @@ export default defineAction({
       const headers = [
         "ID",
         "Submitted At",
+        "Submitter Email",
         ...fields.map((f: any) => f.label),
       ];
       const rows = responses.map((r) => {
@@ -48,6 +50,7 @@ export default defineAction({
         return [
           r.id,
           r.submittedAt,
+          r.submitterEmail ?? "",
           ...fields.map((f: any) => {
             const val = data[f.id];
             if (Array.isArray(val)) return val.join("; ");

--- a/templates/forms/actions/update-form.ts
+++ b/templates/forms/actions/update-form.ts
@@ -21,8 +21,17 @@ export default defineAction({
     title: z.string().optional().describe("New title"),
     description: z.string().optional().describe("New description"),
     slug: z.string().optional().describe("New URL slug"),
-    fields: z.string().optional().describe("JSON array of form fields"),
-    settings: z.string().optional().describe("JSON object of form settings"),
+    // Accept fields as a JSON string (agent CLI / older callers) or as an
+    // actual array (UI POSTs JSON bodies via useActionMutation, which
+    // serializes the FormField[] directly — Zod must accept both).
+    fields: z
+      .union([z.string(), z.array(z.any())])
+      .optional()
+      .describe("Array of form fields (or JSON string of the same)"),
+    settings: z
+      .union([z.string(), z.record(z.string(), z.any())])
+      .optional()
+      .describe("Form settings object (or JSON string of the same)"),
     status: z
       .enum(["draft", "published", "closed"])
       .optional()
@@ -85,6 +94,63 @@ export default defineAction({
       assertIntegrationUrlsAllowed(parsedSettings);
     }
     if (args.status !== undefined) updates.status = args.status;
+
+    // Pre-publish validation. Reject the publish if the form is missing
+    // required configuration that would make it unsubmittable. This also
+    // catches the agent flipping status to "published" on an empty/broken
+    // form. We only validate on transition INTO published — leaving an
+    // already-published form alone (or unpublishing it) shouldn't error.
+    if (args.status === "published") {
+      // Use the incoming fields if provided, otherwise the existing row.
+      const effectiveFieldsRaw =
+        updates.fields !== undefined ? updates.fields : existing.fields;
+      let effectiveFields: FormField[] = [];
+      try {
+        effectiveFields =
+          typeof effectiveFieldsRaw === "string"
+            ? (JSON.parse(effectiveFieldsRaw) as FormField[])
+            : ((effectiveFieldsRaw as unknown as FormField[]) ?? []);
+      } catch {
+        effectiveFields = [];
+      }
+
+      const issues: string[] = [];
+      if (effectiveFields.length === 0) {
+        issues.push("form has no fields");
+      }
+      const optionTypes = new Set(["select", "multiselect", "radio"]);
+      for (const [idx, field] of effectiveFields.entries()) {
+        const label = String(field?.label ?? "").trim();
+        if (!label) {
+          issues.push(`field #${idx + 1} is missing a label`);
+        }
+        if (
+          optionTypes.has(field?.type) &&
+          (!Array.isArray(field?.options) || field.options.length === 0)
+        ) {
+          issues.push(`field "${label || `#${idx + 1}`}" has no options`);
+        }
+        // For required Number/Scale fields, conflicting min/max would
+        // render the field unsubmittable — block publish on that too.
+        if (
+          field?.required &&
+          (field?.type === "number" || field?.type === "scale") &&
+          field?.validation?.min !== undefined &&
+          field?.validation?.max !== undefined &&
+          Number(field.validation.min) > Number(field.validation.max)
+        ) {
+          issues.push(
+            `required field "${label || `#${idx + 1}`}" has min > max`,
+          );
+        }
+      }
+
+      if (issues.length > 0) {
+        throw new Error(
+          `Cannot publish: ${issues.join("; ")}. Fix these before publishing.`,
+        );
+      }
+    }
 
     await db
       .update(schema.forms)

--- a/templates/forms/app/components/layout/Layout.tsx
+++ b/templates/forms/app/components/layout/Layout.tsx
@@ -10,7 +10,7 @@ const BARE_ROUTES = new Set(["/form-preview"]);
 // Routes whose page renders its own custom toolbar (with AgentToggleButton).
 // Layout still mounts Sidebar + AgentSidebar, but skips its own Header so
 // there's no double-header.
-const NO_HEADER_PREFIXES = ["/forms/"];
+const NO_HEADER_PREFIXES = ["/forms/", "/tools"];
 
 interface LayoutProps {
   children: React.ReactNode;

--- a/templates/forms/app/hooks/use-forms.ts
+++ b/templates/forms/app/hooks/use-forms.ts
@@ -37,8 +37,17 @@ export function useUpdateForm() {
       qc.invalidateQueries({ queryKey: ["action", "list-forms"] });
       qc.invalidateQueries({ queryKey: ["action", "get-form"] });
     },
-    onError: () => {
-      toast.error("Failed to update form");
+    onError: (err: unknown) => {
+      // Surface the server's actual error message (e.g. publish validation
+      // failures like "Cannot publish: form has no fields") instead of a
+      // generic toast that hides the real problem. Callers can pass an
+      // inline `onError` to mutate() to suppress this toast if they want
+      // to show their own UI.
+      const message =
+        err instanceof Error && err.message
+          ? err.message.replace(/^Action update-form failed:\s*/, "")
+          : "Failed to update form";
+      toast.error(message);
     },
   });
 }

--- a/templates/forms/app/pages/FormBuilderPage.tsx
+++ b/templates/forms/app/pages/FormBuilderPage.tsx
@@ -41,6 +41,7 @@ import { useDbStatus } from "@/hooks/use-db-status";
 import { CloudUpgrade } from "@/components/CloudUpgrade";
 import {
   AgentToggleButton,
+  NotificationsBell,
   ShareButton,
   appPath,
   useSendToAgentChat,
@@ -357,6 +358,8 @@ export function FormBuilderPage() {
           toast.success(
             newStatus === "published" ? "Form published!" : "Form unpublished",
           ),
+        // Errors (including publish-validation failures) are surfaced by
+        // useUpdateForm's onError, which echoes the server's actual message.
       },
     );
   }
@@ -460,6 +463,7 @@ export function FormBuilderPage() {
           <Button size="sm" className="text-xs" onClick={handleTogglePublish}>
             {form.status === "published" ? "Unpublish" : "Publish"}
           </Button>
+          <NotificationsBell />
           <AgentToggleButton />
         </div>
       </div>

--- a/templates/forms/netlify.toml
+++ b/templates/forms/netlify.toml
@@ -9,6 +9,9 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Use Netlify's current standard synchronous function budget.
+# Aligned with the agent-run soft timeout in
+# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# so the framework's friendly "run_timeout" event fires before Netlify kills
+# the function.
 [functions."*"]
-  timeout = 60
+  timeout = 75

--- a/templates/forms/server/db/schema.ts
+++ b/templates/forms/server/db/schema.ts
@@ -29,6 +29,7 @@ export const responses = table("responses", {
   data: text("data").notNull(), // JSON object: { fieldId: value }
   submittedAt: text("submitted_at").notNull(),
   ip: text("ip"),
+  submitterEmail: text("submitter_email"),
 });
 
 export const formShares = createSharesTable("form_shares");

--- a/templates/forms/server/handlers/submissions.ts
+++ b/templates/forms/server/handlers/submissions.ts
@@ -183,12 +183,29 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
   const responseId = nanoid();
   const ip = getRequestIP(event) ?? null;
 
+  // Optional metadata sent by trusted clients (e.g. the framework's
+  // FeedbackButton, which forwards the logged-in user's email so we can see
+  // who sent feedback in Slack). Never required, never trusted as identity —
+  // anyone can claim any email — but useful as a hint when the client is ours.
+  const rawSubmitter =
+    typeof body._meta === "object" && body._meta !== null
+      ? (body._meta as { submitterEmail?: unknown }).submitterEmail
+      : undefined;
+  const submitterEmail =
+    typeof rawSubmitter === "string" &&
+    rawSubmitter.length > 0 &&
+    rawSubmitter.length <= 320 &&
+    rawSubmitter.includes("@")
+      ? rawSubmitter
+      : null;
+
   await db.insert(schema.responses).values({
     id: responseId,
     formId: id,
     data: JSON.stringify(data),
     submittedAt: now,
     ip,
+    submitterEmail,
   });
 
   // Write submission notification to application state (SQL-backed)
@@ -216,6 +233,7 @@ export const submitForm = defineEventHandler(async (event: H3Event) => {
         fields,
         data,
         submittedAt: now,
+        submitterEmail,
       }).catch(() => {});
     }
   } catch {
@@ -266,6 +284,7 @@ export const listResponses = defineEventHandler(async (event: H3Event) => {
           formId: r.formId,
           data: JSON.parse(r.data),
           submittedAt: r.submittedAt,
+          submitterEmail: r.submitterEmail,
         })) as FormResponse[],
         total: total?.count ?? 0,
         fields: JSON.parse(access.resource.fields),

--- a/templates/forms/server/lib/integrations.ts
+++ b/templates/forms/server/lib/integrations.ts
@@ -37,6 +37,8 @@ interface SubmissionPayload {
   fields: FormField[];
   data: Record<string, unknown>;
   submittedAt: string;
+  /** Email of the submitter, when known (claimed by the client, not verified). */
+  submitterEmail?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -67,6 +69,11 @@ function buildSlackPayload(submission: SubmissionPayload) {
       return `*${f.label}:* ${display}`;
     });
 
+  const tsContext = `Submitted <!date^${Math.floor(new Date(submission.submittedAt).getTime() / 1000)}^{date_short_pretty} at {time}|${submission.submittedAt}>`;
+  const contextText = submission.submitterEmail
+    ? `${tsContext} by *${submission.submitterEmail}*`
+    : tsContext;
+
   return {
     blocks: [
       {
@@ -89,7 +96,7 @@ function buildSlackPayload(submission: SubmissionPayload) {
         elements: [
           {
             type: "mrkdwn",
-            text: `Submitted <!date^${Math.floor(new Date(submission.submittedAt).getTime() / 1000)}^{date_short_pretty} at {time}|${submission.submittedAt}>`,
+            text: contextText,
           },
         ],
       },
@@ -106,6 +113,13 @@ function buildDiscordPayload(submission: SubmissionPayload) {
       const display = Array.isArray(val) ? val.join(", ") : String(val);
       return { name: f.label, value: display, inline: true };
     });
+  if (submission.submitterEmail) {
+    discordFields.push({
+      name: "Submitted by",
+      value: submission.submitterEmail,
+      inline: true,
+    });
+  }
 
   return {
     embeds: [
@@ -124,6 +138,7 @@ function buildGoogleSheetsPayload(submission: SubmissionPayload) {
   return {
     formTitle: submission.formTitle,
     submittedAt: submission.submittedAt,
+    submitterEmail: submission.submitterEmail ?? "",
     ...formatFields(submission.fields, submission.data),
   };
 }
@@ -136,6 +151,7 @@ function buildWebhookPayload(submission: SubmissionPayload) {
     formTitle: submission.formTitle,
     responseId: submission.responseId,
     submittedAt: submission.submittedAt,
+    submitterEmail: submission.submitterEmail ?? null,
     data: formatFields(submission.fields, submission.data),
     rawData: submission.data,
   };

--- a/templates/forms/server/plugins/db.ts
+++ b/templates/forms/server/plugins/db.ts
@@ -68,6 +68,13 @@ CREATE TABLE IF NOT EXISTS form_shares (
 )`,
       },
     },
+    {
+      version: 7,
+      sql: {
+        postgres: `ALTER TABLE responses ADD COLUMN IF NOT EXISTS submitter_email TEXT`,
+        sqlite: `ALTER TABLE responses ADD COLUMN submitter_email TEXT`,
+      },
+    },
   ],
   { table: "forms_migrations" },
 );

--- a/templates/forms/shared/types.ts
+++ b/templates/forms/shared/types.ts
@@ -99,4 +99,6 @@ export interface FormResponse {
   formId: string;
   data: Record<string, unknown>;
   submittedAt: string;
+  /** Email of the submitter when known (claimed by the client; not verified). */
+  submitterEmail?: string | null;
 }

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -128,6 +128,104 @@ export function InboxZero() {
   );
 }
 
+// ─── Error state ────────────────────────────────────────────────────────────
+// Rendered when the emails query fails. The "Try again" button must give
+// visible feedback during the refetch — without it, clicking on a persistent
+// rate-limit error looks like nothing happens (the same error re-renders
+// identically so the user assumes the button is broken). For 429/quota errors
+// we auto-schedule one retry after a short delay so recovery is hands-off,
+// and gate the manual button behind a 15s cooldown so a flurry of clicks
+// can't itself trip the rate limit.
+
+const RATE_LIMIT_RETRY_MS = 15_000;
+
+function EmailErrorState({
+  isQuotaError,
+  message,
+  isFetching,
+  onRetry,
+  containerRef,
+}: {
+  isQuotaError: boolean;
+  message: string;
+  isFetching: boolean;
+  onRetry: () => unknown;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const [cooldownRemaining, setCooldownRemaining] = useState(
+    isQuotaError ? RATE_LIMIT_RETRY_MS : 0,
+  );
+  const autoRetryFired = useRef(false);
+
+  // Tick the cooldown countdown every second.
+  useEffect(() => {
+    if (cooldownRemaining <= 0) return;
+    const handle = setInterval(() => {
+      setCooldownRemaining((prev) => Math.max(0, prev - 1000));
+    }, 1000);
+    return () => clearInterval(handle);
+  }, [cooldownRemaining]);
+
+  // Auto-retry once when a rate-limit cooldown elapses so the user doesn't
+  // have to babysit the screen waiting for Google to recover.
+  useEffect(() => {
+    if (!isQuotaError) return;
+    if (autoRetryFired.current) return;
+    if (cooldownRemaining > 0) return;
+    autoRetryFired.current = true;
+    void onRetry();
+  }, [cooldownRemaining, isQuotaError, onRetry]);
+
+  const handleClick = useCallback(() => {
+    if (cooldownRemaining > 0 || isFetching) return;
+    setCooldownRemaining(isQuotaError ? RATE_LIMIT_RETRY_MS : 0);
+    autoRetryFired.current = true;
+    void onRetry();
+  }, [cooldownRemaining, isFetching, isQuotaError, onRetry]);
+
+  const cooldownSeconds = Math.ceil(cooldownRemaining / 1000);
+  const buttonDisabled = isFetching || cooldownRemaining > 0;
+
+  let buttonLabel: string;
+  if (isFetching) {
+    buttonLabel = "Retrying…";
+  } else if (cooldownRemaining > 0) {
+    buttonLabel = `Try again in ${cooldownSeconds}s`;
+  } else {
+    buttonLabel = "Try again";
+  }
+
+  return (
+    <div className="flex h-full flex-col" ref={containerRef}>
+      <div className="flex flex-1 flex-col items-center justify-center px-8">
+        <div className="flex flex-col items-center gap-3 max-w-xs text-center">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-destructive/10">
+            <IconAlertCircle className="h-5 w-5 text-destructive" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-foreground">
+              {isQuotaError ? "Gmail rate limit hit" : "Unable to load emails"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {isQuotaError
+                ? "Too many recent requests to Google. Waiting a moment before retrying."
+                : message}
+            </p>
+          </div>
+          <button
+            onClick={handleClick}
+            disabled={buttonDisabled}
+            className="mt-1 inline-flex items-center justify-center gap-1.5 rounded-md bg-primary px-4 py-2 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isFetching && <Spinner className="h-3 w-3" />}
+            {buttonLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ─── Email List ─────────────────────────────────────────────────────────────
 
 export function EmailList({
@@ -156,6 +254,7 @@ export function EmailList({
   const {
     data: fetchedEmails = [],
     isLoading,
+    isFetching,
     error: emailsError,
     refetch,
     hasNextPage,
@@ -771,33 +870,13 @@ export function EmailList({
     );
 
     return (
-      <div className="flex h-full flex-col" ref={containerRef}>
-        <div className="flex flex-1 flex-col items-center justify-center px-8">
-          <div className="flex flex-col items-center gap-3 max-w-xs text-center">
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-destructive/10">
-              <IconAlertCircle className="h-5 w-5 text-destructive" />
-            </div>
-            <div className="space-y-1">
-              <p className="text-sm font-medium text-foreground">
-                {isQuotaError
-                  ? "Gmail rate limit hit"
-                  : "Unable to load emails"}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {isQuotaError
-                  ? "Too many recent requests to Google. Waiting a moment before retrying."
-                  : emailsError.message}
-              </p>
-            </div>
-            <button
-              onClick={() => refetch()}
-              className="mt-1 inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-xs font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
-            >
-              Try again
-            </button>
-          </div>
-        </div>
-      </div>
+      <EmailErrorState
+        isQuotaError={isQuotaError}
+        message={emailsError.message ?? ""}
+        isFetching={isFetching}
+        onRetry={refetch}
+        containerRef={containerRef}
+      />
     );
   }
 

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -157,14 +157,18 @@ function EmailErrorState({
   );
   const autoRetryFired = useRef(false);
 
-  // Tick the cooldown countdown every second.
+  // Tick the cooldown countdown every second. Depend on the boolean so the
+  // effect only re-runs when the cooldown starts or stops — not on every tick.
+  // The functional setter pattern reads `prev` from the latest state, so we
+  // don't need `cooldownRemaining` in the deps array.
+  const isCoolingDown = cooldownRemaining > 0;
   useEffect(() => {
-    if (cooldownRemaining <= 0) return;
+    if (!isCoolingDown) return;
     const handle = setInterval(() => {
       setCooldownRemaining((prev) => Math.max(0, prev - 1000));
     }, 1000);
     return () => clearInterval(handle);
-  }, [cooldownRemaining]);
+  }, [isCoolingDown]);
 
   // Auto-retry once when a rate-limit cooldown elapses so the user doesn't
   // have to babysit the screen waiting for Google to recover.

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -38,6 +38,7 @@ import {
   IconPlus,
   IconTool,
   IconClock,
+  IconRefresh,
 } from "@tabler/icons-react";
 import {
   Popover,
@@ -217,8 +218,11 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     : userPinnedLabels;
   const hasNoteToSelf = pinnedLabels.includes("note-to-self");
   const labelAliases = settings?.labelAliases ?? {};
-  const { data: rawInboxEmails = [], isLoading: emailsLoading } =
-    useEmails("inbox");
+  const {
+    data: rawInboxEmails = [],
+    isLoading: emailsLoading,
+    isFetching: inboxIsFetching,
+  } = useEmails("inbox");
   const { data: rawAllLocalEmails = [], isLoading: allLocalEmailsLoading } =
     useEmails("all", undefined, undefined, {
       enabled: googleStatusReady && !hasAccounts,
@@ -943,6 +947,26 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                 )}
               </Link>
 
+              {/* Manual refresh — auto-poll backs off on error, but users
+                  still want a button to force a fresh fetch on demand. */}
+              <button
+                onClick={() => {
+                  if (inboxIsFetching) return;
+                  qc.invalidateQueries({ queryKey: ["emails"] });
+                  qc.invalidateQueries({ queryKey: ["labels"] });
+                }}
+                disabled={inboxIsFetching}
+                className={cn(
+                  "flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors shrink-0 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground",
+                )}
+                aria-label="Refresh inbox"
+                title="Refresh inbox"
+              >
+                <IconRefresh
+                  className={cn("h-4 w-4", inboxIsFetching && "animate-spin")}
+                />
+              </button>
+
               {/* Tools */}
               <Link
                 to="/tools"
@@ -1416,6 +1440,12 @@ function StandardLayout({ children }: AppLayoutProps) {
   const queuedDrafts = useQueuedDraftCount();
   const view = location.pathname.split("/").filter(Boolean)[0] || "";
 
+  // Tools (`/tools` list and `/tools/:id` viewer) render their own h-12
+  // toolbar with NotificationsBell + AgentToggleButton inside the shared
+  // ToolViewer / ToolsListPage components. Skip our header to avoid stacking.
+  const pageOwnsToolbar =
+    location.pathname === "/tools" || location.pathname.startsWith("/tools/");
+
   const fallbackTitle = (() => {
     if (location.pathname === "/settings") return "Settings";
     if (location.pathname === "/team") return "Team";
@@ -1437,28 +1467,30 @@ function StandardLayout({ children }: AppLayoutProps) {
         ]}
       >
         <div className="relative flex flex-1 flex-col overflow-hidden">
-          <header className="relative z-20 flex h-12 shrink-0 items-center gap-2 border-b border-border bg-background px-3">
-            <button
-              onClick={() => setSidebarOpen(!sidebarOpen)}
-              className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors shrink-0 cursor-pointer"
-              aria-label="Toggle menu"
-              title="Menu"
-            >
-              <IconMenu2 className="h-4 w-4" />
-            </button>
-            <div className="flex min-w-0 flex-1 items-center gap-2">
-              {headerTitle ?? (
-                <h1 className="text-lg font-semibold tracking-tight truncate">
-                  {fallbackTitle}
-                </h1>
-              )}
-            </div>
-            <div className="flex shrink-0 items-center gap-2">
-              {headerActions}
-              <NotificationsBell />
-              <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
-            </div>
-          </header>
+          {!pageOwnsToolbar && (
+            <header className="relative z-20 flex h-12 shrink-0 items-center gap-2 border-b border-border bg-background px-3">
+              <button
+                onClick={() => setSidebarOpen(!sidebarOpen)}
+                className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors shrink-0 cursor-pointer"
+                aria-label="Toggle menu"
+                title="Menu"
+              >
+                <IconMenu2 className="h-4 w-4" />
+              </button>
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                {headerTitle ?? (
+                  <h1 className="text-lg font-semibold tracking-tight truncate">
+                    {fallbackTitle}
+                  </h1>
+                )}
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                {headerActions}
+                <NotificationsBell />
+                <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
+              </div>
+            </header>
+          )}
 
           {sidebarOpen && (
             <>

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -277,8 +277,19 @@ export function useEmails(
     // refetchOnWindowFocus stays off: with useInfiniteQuery it replays every
     // cached page (50+ Gmail calls each) on tab focus and trips the quota.
     staleTime: search ? 0 : 60_000,
-    refetchInterval: (query: { state: { status: string } }) =>
-      query.state.status === "error" ? false : 2 * 60_000,
+    // On error, back off (don't disable polling entirely). One transient
+    // 429 / network blip used to stop auto-refresh forever — now we stretch
+    // the interval based on consecutive failures, capped at 5 minutes, so the
+    // UI keeps trying without hammering Gmail.
+    refetchInterval: (query: {
+      state: { status: string; fetchFailureCount: number };
+    }) => {
+      const base = 2 * 60_000;
+      if (query.state.status === "error") {
+        return Math.min(base * (1 + query.state.fetchFailureCount), 5 * 60_000);
+      }
+      return base;
+    },
     refetchOnWindowFocus: false,
     retry: false,
     enabled: options?.enabled ?? true,
@@ -293,6 +304,8 @@ export function useEmails(
   return {
     data,
     isLoading: q.isLoading,
+    isFetching: q.isFetching,
+    isRefetching: q.isRefetching,
     isError: q.isError,
     error: q.error,
     refetch: q.refetch,

--- a/templates/mail/netlify.toml
+++ b/templates/mail/netlify.toml
@@ -7,3 +7,11 @@
 [build.environment]
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
+
+# A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
+# Aligned with the agent-run soft timeout in
+# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# so the framework's friendly "run_timeout" event fires before Netlify kills
+# the function.
+[functions."*"]
+  timeout = 75

--- a/templates/scheduling/app/components/layout/Layout.tsx
+++ b/templates/scheduling/app/components/layout/Layout.tsx
@@ -27,6 +27,7 @@ function isDetailRoute(pathname: string): boolean {
   if (/^\/availability\/[^/]+/.test(pathname)) return true;
   if (/^\/routing-forms\/[^/]+/.test(pathname)) return true;
   if (/^\/workflows\/[^/]+/.test(pathname)) return true;
+  if (pathname === "/tools" || pathname.startsWith("/tools/")) return true;
   return false;
 }
 

--- a/templates/scheduling/app/routes/_app.apps._index.tsx
+++ b/templates/scheduling/app/routes/_app.apps._index.tsx
@@ -1,6 +1,10 @@
 import { useMemo, useState } from "react";
 import { callAction } from "@/lib/api";
-import { agentNativePath, useSendToAgentChat } from "@agent-native/core/client";
+import {
+  agentNativePath,
+  PromptComposer,
+  useSendToAgentChat,
+} from "@agent-native/core/client";
 
 export function meta() {
   return [{ title: "Apps — Scheduling" }];
@@ -223,15 +227,13 @@ function IntegrationCard({
 }
 
 function AddIntegrationCTA() {
-  const [prompt, setPrompt] = useState("");
   const { send, isGenerating } = useSendToAgentChat();
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!prompt.trim() || isGenerating) return;
-
+  function handleSubmit(text: string) {
+    const trimmed = text.trim();
+    if (!trimmed || isGenerating) return;
     send({
-      message: prompt.trim(),
+      message: trimmed,
       context:
         "The user wants to add a new integration to the scheduling app. " +
         "Help them add it by: creating a new provider in `@agent-native/scheduling/server/providers/` (if it's a calendar or video integration), " +
@@ -240,8 +242,6 @@ function AddIntegrationCTA() {
         "and updating the relevant skill docs. Ask clarifying questions if you need to know which service or what capability they need.",
       submit: true,
     });
-
-    setPrompt("");
   }
 
   return (
@@ -256,33 +256,12 @@ function AddIntegrationCTA() {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <Textarea
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            placeholder='e.g. "Add Cronofy so we can sync with Exchange on-prem calendars"'
-            className="min-h-[80px] resize-y"
-            onKeyDown={(e) => {
-              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                e.preventDefault();
-                if (prompt.trim()) handleSubmit(e);
-              }
-            }}
-          />
-          <div className="flex items-center justify-end gap-2">
-            <span className="text-[11px] text-muted-foreground/70">
-              {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
-              +Enter to submit
-            </span>
-            <Button
-              type="submit"
-              size="sm"
-              disabled={!prompt.trim() || isGenerating}
-            >
-              {isGenerating ? "Sending…" : "Add integration"}
-            </Button>
-          </div>
-        </form>
+        <PromptComposer
+          disabled={isGenerating}
+          placeholder='e.g. "Add Cronofy so we can sync with Exchange on-prem calendars"'
+          draftScope="scheduling:add-integration"
+          onSubmit={handleSubmit}
+        />
       </CardContent>
     </Card>
   );

--- a/templates/scheduling/app/routes/_app.availability.$id.tsx
+++ b/templates/scheduling/app/routes/_app.availability.$id.tsx
@@ -27,7 +27,10 @@ import {
 import { Calendar } from "@/components/ui/calendar";
 import { callAction } from "@/lib/api";
 import { toast } from "sonner";
-import { AgentToggleButton } from "@agent-native/core/client";
+import {
+  AgentToggleButton,
+  NotificationsBell,
+} from "@agent-native/core/client";
 import {
   IconArrowLeft,
   IconCalendarPlus,
@@ -257,6 +260,7 @@ export default function ScheduleEditor() {
               />
               <span>Set as default</span>
             </div>
+            <NotificationsBell />
             <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
           </div>
         </div>

--- a/templates/scheduling/app/routes/_app.event-types.$id.tsx
+++ b/templates/scheduling/app/routes/_app.event-types.$id.tsx
@@ -31,7 +31,10 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { toast } from "sonner";
-import { AgentToggleButton } from "@agent-native/core/client";
+import {
+  AgentToggleButton,
+  NotificationsBell,
+} from "@agent-native/core/client";
 import {
   IconArrowLeft,
   IconBrandGoogle,
@@ -126,6 +129,7 @@ export default function EventTypeEditor() {
                 Preview
               </a>
             </Button>
+            <NotificationsBell />
             <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
           </div>
         </div>

--- a/templates/slides/actions/add-slide.test.ts
+++ b/templates/slides/actions/add-slide.test.ts
@@ -58,6 +58,10 @@ beforeEach(() => {
 });
 
 describe("add-slide", () => {
+  it("declares same-turn parallel execution as safe", () => {
+    expect(action.parallelSafe).toBe(true);
+  });
+
   it("accepts CLI-style string positions and inserts at the requested index", async () => {
     const result = await action.run({
       deckId: "deck-1",

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -14,12 +14,12 @@ const deckLocks = new Map<string, Promise<unknown>>();
 function withDeckLock<T>(deckId: string, fn: () => Promise<T>): Promise<T> {
   const prev = deckLocks.get(deckId) ?? Promise.resolve();
   const next = prev.then(fn, fn);
-  deckLocks.set(
-    deckId,
-    next.finally(() => {
+  deckLocks.set(deckId, next);
+  next
+    .finally(() => {
       if (deckLocks.get(deckId) === next) deckLocks.delete(deckId);
-    }),
-  );
+    })
+    .catch(() => {});
   return next;
 }
 
@@ -63,6 +63,10 @@ export default defineAction({
       ),
   }),
   http: false,
+  // The deck-level lock above serializes writes that target the same deck,
+  // while calls for different decks can proceed independently. This lets the
+  // agent build several slides from one model turn without wasting wall time.
+  parallelSafe: true,
   run: async ({ deckId, content, slideId, layout, notes, position }) =>
     withDeckLock(deckId, async () => {
       await assertAccess("deck", deckId, "editor");

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -12,9 +12,7 @@ import {
   IconCopy,
   IconTrash,
   IconLoader2,
-  IconPaperclip,
   IconX,
-  IconArrowUp,
 } from "@tabler/icons-react";
 import type { Slide } from "@/context/DeckContext";
 import type { AspectRatio } from "@/lib/aspect-ratios";
@@ -24,6 +22,7 @@ import type { UploadedFile } from "@/components/editor/PromptDialog";
 import { useCallback } from "react";
 import {
   appBasePath,
+  PromptComposer,
   type CollabUser,
   useAvatarUrl,
 } from "@agent-native/core/client";
@@ -233,7 +232,6 @@ function AddSlidePopover({
   activeSlideId,
   slideCount,
   activeSlideIndex,
-  generating,
   agentSubmit,
 }: {
   open: boolean;
@@ -247,69 +245,7 @@ function AddSlidePopover({
   generating: boolean;
   agentSubmit: (message: string, context: string) => void;
 }) {
-  const [prompt, setPrompt] = useState("");
-  const [files, setFiles] = useState<File[]>([]);
-  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
-  const [uploading, setUploading] = useState(false);
-  const [dragging, setDragging] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (open && inputRef.current) {
-      setTimeout(() => inputRef.current?.focus(), 50);
-    }
-    if (!open) {
-      setPrompt("");
-      setFiles([]);
-      setUploadedFiles([]);
-      setDragging(false);
-    }
-  }, [open]);
-
-  const doUpload = useCallback(async (newFiles: File[]) => {
-    setFiles((prev) => [...prev, ...newFiles]);
-    setUploading(true);
-    try {
-      const formData = new FormData();
-      newFiles.forEach((f) => formData.append("files", f));
-      const res = await fetch(`${appBasePath()}/api/uploads`, {
-        method: "POST",
-        body: formData,
-      });
-      if (res.ok) {
-        const results: UploadedFile[] = await res.json();
-        setUploadedFiles((prev) => [...prev, ...results]);
-      }
-    } catch {
-      /* silent */
-    } finally {
-      setUploading(false);
-    }
-  }, []);
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selected = e.target.files;
-    if (!selected || selected.length === 0) return;
-    doUpload(Array.from(selected));
-    e.target.value = "";
-  };
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      setDragging(false);
-      const dropped = Array.from(e.dataTransfer.files);
-      if (dropped.length > 0) doUpload(dropped);
-    },
-    [doUpload],
-  );
-
-  const removeFile = (index: number) => {
-    setFiles((prev) => prev.filter((_, i) => i !== index));
-    setUploadedFiles((prev) => prev.filter((_, i) => i !== index));
-  };
 
   useEffect(() => {
     if (!open) return;
@@ -334,149 +270,78 @@ function AddSlidePopover({
     };
   }, [open, onOpenChange, anchorRef]);
 
-  const handleSubmit = () => {
-    const description = prompt.trim() || "a new slide";
-    const fileContext =
-      uploadedFiles.length > 0
-        ? `\n\nThe user uploaded ${uploadedFiles.length} file(s) for context:\n${uploadedFiles.map((f) => `- ${f.originalName} (${f.type}, ${(f.size / 1024).toFixed(1)}KB) at path: ${f.path}`).join("\n")}`
-        : "";
-    const context = [
-      `Add a new slide to deck "${deckTitle}" (id: ${deckId}).`,
-      `Insert after slide ${activeSlideIndex + 1} of ${slideCount} (active slide id: ${activeSlideId}).`,
-      `User request: "${description}"`,
-      fileContext,
-      "",
-      "Create the slide content and insert it at the correct position using the app's slide data structure.",
-    ].join("\n");
+  const handleSubmit = useCallback(
+    async (text: string, files: File[]) => {
+      let uploaded: UploadedFile[] = [];
+      if (files.length > 0) {
+        try {
+          const formData = new FormData();
+          files.forEach((f) => formData.append("files", f));
+          const res = await fetch(`${appBasePath()}/api/uploads`, {
+            method: "POST",
+            body: formData,
+          });
+          if (res.ok) uploaded = (await res.json()) as UploadedFile[];
+        } catch {
+          /* silent */
+        }
+      }
 
-    agentSubmit(`Add slide: ${description}`, context);
-    setPrompt("");
-    setFiles([]);
-    setUploadedFiles([]);
-    onOpenChange(false);
-  };
+      const description = text.trim() || "a new slide";
+      const fileContext =
+        uploaded.length > 0
+          ? `\n\nThe user uploaded ${uploaded.length} file(s) for context:\n${uploaded.map((f) => `- ${f.originalName} (${f.type}, ${(f.size / 1024).toFixed(1)}KB) at path: ${f.path}`).join("\n")}`
+          : "";
+      const context = [
+        `Add a new slide to deck "${deckTitle}" (id: ${deckId}).`,
+        `Insert after slide ${activeSlideIndex + 1} of ${slideCount} (active slide id: ${activeSlideId}).`,
+        `User request: "${description}"`,
+        fileContext,
+        "",
+        "Create the slide content and insert it at the correct position using the app's slide data structure.",
+      ].join("\n");
+
+      agentSubmit(`Add slide: ${description}`, context);
+      onOpenChange(false);
+    },
+    [
+      activeSlideId,
+      activeSlideIndex,
+      agentSubmit,
+      deckId,
+      deckTitle,
+      onOpenChange,
+      slideCount,
+    ],
+  );
 
   if (!open || !anchorRef.current) return null;
 
   const rect = anchorRef.current.getBoundingClientRect();
-  const panelWidth = Math.min(384, window.innerWidth - 24);
+  const panelWidth = Math.min(420, window.innerWidth - 24);
   const left = Math.max(
     12,
     Math.min(rect.left, window.innerWidth - panelWidth - 12),
   );
 
-  const busy = generating || uploading;
-
   return createPortal(
     <div
       ref={panelRef}
-      className={`fixed w-[min(24rem,calc(100vw-24px))] rounded-xl border bg-popover shadow-2xl shadow-black/60 z-[200] overflow-hidden transition-colors ${
-        dragging ? "border-[#609FF8]/50 bg-accent" : "border-border"
-      }`}
+      className="fixed w-[min(420px,calc(100vw-24px))] rounded-xl border border-border bg-popover shadow-2xl shadow-black/60 z-[200] p-3"
       style={{
         top: rect.bottom + 8,
         left,
       }}
-      onDrop={handleDrop}
-      onDragOver={(e) => {
-        e.preventDefault();
-        setDragging(true);
-      }}
-      onDragLeave={(e) => {
-        e.preventDefault();
-        setDragging(false);
-      }}
     >
-      <div className="px-3.5 pt-3 pb-1.5">
-        <span className="text-sm font-medium text-foreground/90">
-          Add slides
-        </span>
-      </div>
-
-      <div className="px-3.5 pb-2">
-        <textarea
-          ref={inputRef}
-          value={prompt}
-          onChange={(e) => {
-            setPrompt(e.target.value);
-            const el = e.target;
-            el.style.height = "auto";
-            el.style.height =
-              Math.min(el.scrollHeight, window.innerHeight * 0.5) + "px";
-          }}
-          placeholder="Describe the slides you want..."
-          className="w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground/70 outline-none resize-none"
-          rows={3}
-          style={{ maxHeight: "50vh" }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-              e.preventDefault();
-              handleSubmit();
-            }
-          }}
-        />
-      </div>
-
-      {/* File chips */}
-      {files.length > 0 && (
-        <div className="px-3.5 pb-2 flex flex-wrap gap-1.5">
-          {files.map((file, i) => (
-            <div
-              key={i}
-              className="flex items-center gap-1 px-2 py-0.5 rounded-md bg-accent border border-border text-[11px] text-muted-foreground"
-            >
-              <span className="max-w-[100px] truncate">{file.name}</span>
-              <button
-                onClick={() => removeFile(i)}
-                className="p-0.5 rounded hover:bg-accent"
-                aria-label={`Remove ${file.name}`}
-              >
-                <IconX className="w-2.5 h-2.5" />
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Bottom bar */}
-      <div className="px-3.5 py-2 flex items-center justify-between border-t border-border">
-        <button
-          type="button"
-          onClick={() => fileInputRef.current?.click()}
-          className="p-2 rounded-md hover:bg-accent text-muted-foreground/70 hover:text-foreground"
-          title="Attach files"
-          aria-label="Attach files"
-        >
-          <IconPaperclip className="w-4 h-4" />
-        </button>
-        <input
-          ref={fileInputRef}
-          type="file"
-          multiple
-          onChange={handleFileChange}
-          className="hidden"
-        />
-
-        <div className="flex items-center gap-2">
-          <span className="text-[10px] text-muted-foreground/70">
-            {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}+Enter
-            to submit
-          </span>
-          <button
-            onClick={handleSubmit}
-            disabled={busy}
-            className="p-2 rounded-lg bg-accent hover:bg-accent/80 disabled:opacity-30 disabled:cursor-not-allowed"
-            title="Generate"
-            aria-label="Generate slides"
-          >
-            {busy ? (
-              <IconLoader2 className="w-4 h-4 text-foreground/90 animate-spin" />
-            ) : (
-              <IconArrowUp className="w-4 h-4 text-foreground/90" />
-            )}
-          </button>
-        </div>
-      </div>
+      <p className="px-1 pb-2 text-sm font-medium text-foreground/90">
+        Add slides
+      </p>
+      <PromptComposer
+        autoFocus
+        placeholder="Describe the slides you want..."
+        draftScope={`slides:add-slide:${deckId}`}
+        onSubmit={handleSubmit}
+      />
     </div>,
     document.body,
   );

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -35,6 +35,7 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 
 import {
   AgentToggleButton,
+  NotificationsBell,
   ShareButton,
   PresenceBar,
   type CollabUser,
@@ -716,6 +717,7 @@ graph TD
         <span className="hidden sm:inline">Present</span>
       </Link>
       <ThemeToggle className="flex-shrink-0" />
+      <NotificationsBell />
       <AgentToggleButton className="flex-shrink-0 text-muted-foreground hover:text-foreground/70 hover:bg-accent" />
     </div>
   );

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useMemo } from "react";
+import { flushSync } from "react-dom";
 import { useNavigate } from "react-router";
 import { IconPlus, IconStack2 } from "@tabler/icons-react";
 import { useDecks } from "@/context/DeckContext";
@@ -42,7 +43,11 @@ export default function Index() {
   }, []);
 
   const handleCreateDeckBlank = () => {
-    const deck = createDeck();
+    let deck: ReturnType<typeof createDeck> | undefined;
+    flushSync(() => {
+      deck = createDeck();
+    });
+    if (!deck) return;
     navigate(`/deck/${deck.id}`);
   };
 
@@ -50,7 +55,11 @@ export default function Index() {
     prompt: string,
     files: UploadedFile[],
   ) => {
-    const deck = createDeck(undefined, { noDefaultSlides: true });
+    let deck: ReturnType<typeof createDeck> | undefined;
+    flushSync(() => {
+      deck = createDeck(undefined, { noDefaultSlides: true });
+    });
+    if (!deck) return;
 
     const fileContext =
       files.length > 0

--- a/templates/slides/netlify.toml
+++ b/templates/slides/netlify.toml
@@ -8,10 +8,9 @@
   NITRO_PRESET = "netlify"
   NPM_CONFIG_PRODUCTION = "false"
 
-# A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
-# so the framework's friendly "run_timeout" event fires before Netlify kills
+# Slides builds can legitimately need several model/tool iterations. Keep this
+# above templates/slides/server/plugins/agent-chat.ts (runSoftTimeoutMs =
+# 240_000) so the framework can emit a recoverable timeout before Netlify kills
 # the function.
 [functions."*"]
-  timeout = 75
+  timeout = 300

--- a/templates/slides/server/plugins/agent-chat.ts
+++ b/templates/slides/server/plugins/agent-chat.ts
@@ -9,6 +9,7 @@ import "../register-secrets.js";
 export default createAgentChatPlugin({
   appId: "slides",
   actions: loadActionsFromStaticRegistry(actionsRegistry),
+  runSoftTimeoutMs: 240_000,
   resolveOrgId: async (event) => (await getOrgContext(event)).orgId,
   mentionProviders: async () => {
     const { getDb } = await import("../db/index.js");

--- a/templates/starter/app/routes/_index.tsx
+++ b/templates/starter/app/routes/_index.tsx
@@ -1,7 +1,6 @@
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import { Link } from "react-router";
 import {
-  IconArrowUp,
   IconArrowUpRight,
   IconBolt,
   IconBook2,
@@ -9,7 +8,11 @@ import {
   IconPlus,
 } from "@tabler/icons-react";
 import { useTheme } from "next-themes";
-import { sendToAgentChat, openAgentSidebar } from "@agent-native/core/client";
+import {
+  PromptComposer,
+  openAgentSidebar,
+  sendToAgentChat,
+} from "@agent-native/core/client";
 import {
   Popover,
   PopoverContent,
@@ -40,35 +43,21 @@ export function HydrateFallback() {
 export default function IndexPage() {
   useSetPageTitle("Home");
   const { theme, setTheme } = useTheme();
-  const [prompt, setPrompt] = useState("");
   const [startOpen, setStartOpen] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
-    if (!startOpen) return;
-    setTimeout(() => textareaRef.current?.focus(), 50);
-  }, [startOpen]);
-
-  function submit() {
-    const text = prompt.trim();
-    if (!text) return;
+  function submit(text: string) {
+    const trimmed = text.trim();
+    if (!trimmed) return;
     openAgentSidebar();
     sendToAgentChat({
-      message: text,
+      message: trimmed,
       context:
         "The user is starting from the Agent-Native starter template and wants you to customize this app. Make the requested app changes directly in the starter template code.",
       submit: true,
       type: "code",
     });
-    setPrompt("");
     setStartOpen(false);
   }
-
-  const submitShortcut =
-    typeof navigator !== "undefined" &&
-    /Mac|iPhone|iPad/.test(navigator.userAgent)
-      ? "⌘"
-      : "Ctrl";
 
   return (
     <div className="flex flex-1 flex-col overflow-y-auto">
@@ -109,46 +98,17 @@ export default function IndexPage() {
             <PopoverContent
               align="center"
               sideOffset={10}
-              className="w-[calc(100vw-2rem)] rounded-xl p-4 shadow-xl sm:w-96"
+              className="w-[calc(100vw-2rem)] rounded-xl p-3 shadow-xl sm:w-[420px]"
             >
-              <form
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  submit();
-                }}
-                className="space-y-3"
-              >
-                <p className="text-sm font-semibold text-foreground">
-                  Start building
-                </p>
-                <textarea
-                  ref={textareaRef}
-                  value={prompt}
-                  onChange={(e) => setPrompt(e.target.value)}
-                  onKeyDown={(e) => {
-                    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                      e.preventDefault();
-                      submit();
-                    }
-                  }}
-                  placeholder="Describe what you want to add or change..."
-                  rows={5}
-                  className="flex min-h-[140px] w-full resize-y rounded-md border border-input bg-background px-3 py-3 text-sm text-foreground placeholder:text-muted-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
-                />
-                <div className="flex items-center justify-end gap-2">
-                  <span className="text-[11px] text-muted-foreground/75">
-                    {submitShortcut}+Enter to submit
-                  </span>
-                  <button
-                    type="submit"
-                    disabled={!prompt.trim()}
-                    aria-label="Submit prompt"
-                    className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md bg-primary text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    <IconArrowUp className="h-3.5 w-3.5" />
-                  </button>
-                </div>
-              </form>
+              <p className="px-1 pb-2 text-sm font-semibold text-foreground">
+                Start building
+              </p>
+              <PromptComposer
+                autoFocus
+                placeholder="Describe what you want to add or change..."
+                draftScope="starter:start-building"
+                onSubmit={(text) => submit(text)}
+              />
             </PopoverContent>
           </Popover>
 

--- a/templates/videos/app/components/StudioHeader.tsx
+++ b/templates/videos/app/components/StudioHeader.tsx
@@ -4,7 +4,10 @@ import {
   IconLayoutSidebar,
   IconShare2,
 } from "@tabler/icons-react";
-import { AgentToggleButton } from "@agent-native/core/client";
+import {
+  AgentToggleButton,
+  NotificationsBell,
+} from "@agent-native/core/client";
 import { useDbStatus } from "@/hooks/use-db-status";
 import { CloudUpgrade } from "@/components/CloudUpgrade";
 import {
@@ -80,6 +83,7 @@ export function StudioHeader({
             <span className="hidden sm:inline">Share</span>
           </button>
         )}
+        <NotificationsBell />
         <AgentToggleButton />
       </div>
     </header>

--- a/templates/videos/netlify.toml
+++ b/templates/videos/netlify.toml
@@ -9,6 +9,9 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Use Netlify's current standard synchronous function budget.
+# Aligned with the agent-run soft timeout in
+# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# so the framework's friendly "run_timeout" event fires before Netlify kills
+# the function.
 [functions."*"]
-  timeout = 60
+  timeout = 75


### PR DESCRIPTION
## Summary

- **Composer — pasted text → chip.** Large text pastes (≥1000 chars or ≥6 lines) now turn into a `Pasted text` attachment chip with a popover preview, instead of dumping thousands of characters into the editor. Mirrors Claude.ai's UX. New `pasted-text.ts` helpers + `PastedTextChip.tsx` component, wired through `TiptapComposer`, `PromptComposer`, and `AssistantChat`.
- **Composer — voice button error UX.** Error state now has *Try again* / *Dismiss* buttons and auto-clears after 8s so a stale "permission denied" message doesn't persist after the user fixes the underlying permission. New `dismissError()` on `useVoiceDictation`.
- **Composer — defaults.** `PromptComposer` now defaults `attachmentsEnabled` and `showModelSelector` to `true`. `UploadOnlyAttachButton` uses the hidden-delegate pattern so the visible "+" button stays mounted even when no eligible adapter is reported.
- **Agent — `parallelSafe` flag.** Mutating actions can now opt into same-turn concurrent execution via `parallelSafe: true` on `defineAction`. Reads and writes still run as separate batches so the model's stated order controls what same-turn reads can observe.
- **Agent — per-app run soft timeout.** New `runSoftTimeoutMs` option threaded through the `agent-chat` plugin and `runAgentLoop`. Bumped Netlify function timeout to **75s** across every public template (analytics, calendar, clips, content, design, dispatch, forms, mail, slides, videos) so the framework's friendly `run_timeout` event fires before the platform kills the function.
- **Agent — restored thread scroll.** Re-snaps to bottom on RAF + 100ms + 400ms to handle late-laying-out images / code blocks; was leaving users staring at the top after a thread restored.
- **Agent — fork dismisses error locally.** Forking a chat from an error card now hides the card immediately so the visual feedback is instant and the error doesn't reappear on the new tab.
- **Builder — branch-creation waitlist.** `ConnectBuilderCard` now exposes a "join the waitlist" CTA when the deploy hasn't been opted into Builder branch creation. Server records a tracking event so demand shows up in PostHog/Mixpanel without new storage. New `POST /_agent-native/builder/branch-waitlist` route.
- **Forms.** Pre-publish validation rejects empty / unlabeled / option-less / `min > max` forms with a clear error before flipping `status: published`. Action schemas accept either JSON strings or actual arrays/objects so UI POSTs and agent CLI calls both work. Responses now capture `submitterEmail`.
- **Templates polish.** Assorted Layout / route / sidebar improvements across calendar, calls, clips, content, design, dispatch, mail, scheduling, slides, starter, videos.

## Test plan

- [ ] CI passes (typecheck, prep, guards, framework tests)
- [ ] Paste a long block of text into the agent composer → chip appears, popover preview shows the full text, X removes the chip
- [ ] Paste a short block of text into the agent composer → still inserts inline (no chip)
- [ ] Paste an image → still becomes an image attachment (not a text chip)
- [ ] Voice button — deny mic permission → error shows with *Try again* / *Dismiss*; auto-clears after 8s
- [ ] Forms publish with no fields → error: "form has no fields"
- [ ] Forms publish with required number field where `min > max` → error
- [ ] Long-running agent run on Netlify → emits `run_timeout` event before the platform kills the function (no more "Lambda timed out" with no recovery)
- [ ] Same-turn agent emits a `parallelSafe` mutating action twice → both run concurrently in one batch
- [ ] Reading from `application_state` after a `parallelSafe` write in the same turn → still serialized after the write batch