### PR TITLE
Hosted-only run soft timeout, Radix OrgSwitcher, content polish

### DIFF
--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -439,8 +439,9 @@ describe("runAgentLoop", () => {
     ]);
   });
 
-  it("emits loop_limit with the configured max iteration count", async () => {
+  it("continues internally when the configured iteration chunk is exhausted", async () => {
     let streamCalls = 0;
+    const seenMessages: any[] = [];
     const engine: AgentEngine = {
       name: "test",
       label: "Test",
@@ -453,8 +454,18 @@ describe("runAgentLoop", () => {
         computerUse: false,
         parallelToolCalls: false,
       },
-      async *stream(): AsyncIterable<EngineEvent> {
+      async *stream(opts): AsyncIterable<EngineEvent> {
         streamCalls += 1;
+        seenMessages.push(opts.messages);
+        if (streamCalls === 3) {
+          yield { type: "text-delta", text: "finished" };
+          yield {
+            type: "assistant-content",
+            parts: [{ type: "text", text: "finished" }],
+          };
+          yield { type: "stop", reason: "end_turn" };
+          return;
+        }
         const parts = [
           {
             type: "tool-call" as const,
@@ -487,8 +498,14 @@ describe("runAgentLoop", () => {
       maxIterations: 2,
     });
 
-    expect(streamCalls).toBe(2);
-    expect(events).toContainEqual({ type: "loop_limit", maxIterations: 2 });
+    expect(streamCalls).toBe(3);
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: "loop_limit" }),
+    );
+    expect(JSON.stringify(seenMessages.at(-1))).toContain(
+      "Continue from where you left off",
+    );
+    expect(events).toContainEqual({ type: "text", text: "finished" });
     expect(events.at(-1)).toEqual({ type: "done" });
   });
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -697,6 +697,30 @@ export interface AgentLoopUsage {
   model: string;
 }
 
+export const AGENT_INTERNAL_CONTINUE_PROMPT =
+  "Continue from where you left off and finish the user's original request. Do not repeat completed work, do not mention internal reconnects, time limits, or step limits, and continue as if this is the same uninterrupted run.";
+
+export function appendAgentLoopContinuation(
+  messages: EngineMessage[],
+  reason: "run_timeout" | "loop_limit" | "stream_ended",
+) {
+  const note =
+    reason === "loop_limit"
+      ? "The previous run reached an internal step budget."
+      : reason === "stream_ended"
+        ? "The previous stream ended before the agent sent a final completion signal."
+        : "The previous run reached an internal execution budget.";
+  messages.push({
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text: `${AGENT_INTERNAL_CONTINUE_PROMPT}\n\nInternal note: ${note}`,
+      },
+    ],
+  });
+}
+
 /**
  * Convert ActionEntry registry to EngineTool array.
  */
@@ -816,8 +840,8 @@ export async function runAgentLoop(opts: {
   while (true) {
     if (signal.aborted) break;
     if (++iterations > maxIterations) {
-      send({ type: "loop_limit", maxIterations });
-      break;
+      appendAgentLoopContinuation(messages, "loop_limit");
+      iterations = 1;
     }
 
     let assistantContent: EngineContentPart[] | undefined;
@@ -1108,7 +1132,7 @@ export async function runAgentLoop(opts: {
     messages.push({ role: "user", content: toolResultParts });
   }
 
-  send({ type: "done" });
+  if (!signal.aborted) send({ type: "done" });
   return usage;
 }
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -437,8 +437,9 @@ export interface ProductionAgentOptions {
   /** Called when a run completes (for server-side thread persistence) */
   onRunComplete?: (run: ActiveRun, threadId: string | undefined) => void;
   /** Per-app soft timeout for agent runs. Defaults to AGENT_RUN_SOFT_TIMEOUT_MS
-   *  or the framework default. Set only when the hosting function timeout is
-   *  also configured higher than this value. */
+   *  when set, 75s on hosted serverless runtimes, and no timeout locally. Set
+   *  only when the hosting function timeout is also configured higher than
+   *  this value. */
   runSoftTimeoutMs?: number;
   /** Called when a run starts, with the send function for emitting events and the threadId */
   onRunStart?: (

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -436,10 +436,10 @@ export interface ProductionAgentOptions {
   providerOptions?: EngineMessage extends never ? never : any;
   /** Called when a run completes (for server-side thread persistence) */
   onRunComplete?: (run: ActiveRun, threadId: string | undefined) => void;
-  /** Per-app soft timeout for agent runs. Defaults to AGENT_RUN_SOFT_TIMEOUT_MS
-   *  when set, 75s on hosted serverless runtimes, and no timeout locally. Set
-   *  only when the hosting function timeout is also configured higher than
-   *  this value. */
+  /** Optional per-app agent run chunk budget in milliseconds. Defaults to
+   *  AGENT_RUN_SOFT_TIMEOUT_MS when set, otherwise no framework-imposed
+   *  timeout. When reached, the client receives an internal auto-continuation
+   *  signal instead of a user-facing warning. */
   runSoftTimeoutMs?: number;
   /** Called when a run starts, with the send function for emitting events and the threadId */
   onRunStart?: (

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -18,19 +18,44 @@ vi.mock("./run-store.js", () => ({
 import { resolveRunSoftTimeoutMs, startRun } from "./run-manager.js";
 
 const originalTimeoutEnv = process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
+const originalNetlify = process.env.NETLIFY;
+const originalNetlifyLocal = process.env.NETLIFY_LOCAL;
+const originalCfPages = process.env.CF_PAGES;
+const originalVercel = process.env.VERCEL;
+const originalVercelEnv = process.env.VERCEL_ENV;
+const originalRender = process.env.RENDER;
+const originalFlyAppName = process.env.FLY_APP_NAME;
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
 
 describe("run manager soft timeout", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     delete process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
+    delete process.env.NETLIFY;
+    delete process.env.NETLIFY_LOCAL;
+    delete process.env.CF_PAGES;
+    delete process.env.VERCEL;
+    delete process.env.VERCEL_ENV;
+    delete process.env.RENDER;
+    delete process.env.FLY_APP_NAME;
   });
 
   afterEach(() => {
-    if (originalTimeoutEnv === undefined) {
-      delete process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
-    } else {
-      process.env.AGENT_RUN_SOFT_TIMEOUT_MS = originalTimeoutEnv;
-    }
+    restoreEnv("AGENT_RUN_SOFT_TIMEOUT_MS", originalTimeoutEnv);
+    restoreEnv("NETLIFY", originalNetlify);
+    restoreEnv("NETLIFY_LOCAL", originalNetlifyLocal);
+    restoreEnv("CF_PAGES", originalCfPages);
+    restoreEnv("VERCEL", originalVercel);
+    restoreEnv("VERCEL_ENV", originalVercelEnv);
+    restoreEnv("RENDER", originalRender);
+    restoreEnv("FLY_APP_NAME", originalFlyAppName);
     vi.useRealTimers();
   });
 
@@ -71,5 +96,29 @@ describe("run manager soft timeout", () => {
     process.env.AGENT_RUN_SOFT_TIMEOUT_MS = "25000";
 
     expect(resolveRunSoftTimeoutMs(5000)).toBe(5000);
+  });
+
+  it("disables the default soft timeout in local runtimes", () => {
+    expect(resolveRunSoftTimeoutMs()).toBe(0);
+  });
+
+  it("keeps a hosted default on serverless deploys", () => {
+    process.env.NETLIFY = "true";
+
+    expect(resolveRunSoftTimeoutMs()).toBe(75_000);
+  });
+
+  it("treats Netlify local as a local runtime", () => {
+    process.env.NETLIFY = "true";
+    process.env.NETLIFY_LOCAL = "true";
+
+    expect(resolveRunSoftTimeoutMs()).toBe(0);
+  });
+
+  it("allows the environment to disable hosted soft timeouts", () => {
+    process.env.NETLIFY = "true";
+    process.env.AGENT_RUN_SOFT_TIMEOUT_MS = "0";
+
+    expect(resolveRunSoftTimeoutMs()).toBe(0);
   });
 });

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -59,7 +59,7 @@ describe("run manager soft timeout", () => {
     vi.useRealTimers();
   });
 
-  it("emits a recoverable timeout error and aborts the run", async () => {
+  it("emits an internal continuation signal and aborts the run chunk", async () => {
     const events: AgentChatEvent[] = [];
     let aborted = false;
 
@@ -84,12 +84,11 @@ describe("run manager soft timeout", () => {
     expect(aborted).toBe(true);
     expect(events).toContainEqual(
       expect.objectContaining({
-        type: "error",
-        errorCode: "run_timeout",
-        recoverable: true,
+        type: "auto_continue",
+        reason: "run_timeout",
       }),
     );
-    expect(run.status).toBe("errored");
+    expect(run.status).toBe("completed");
   });
 
   it("prefers an explicit soft timeout over the environment default", () => {

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -101,10 +101,10 @@ describe("run manager soft timeout", () => {
     expect(resolveRunSoftTimeoutMs()).toBe(0);
   });
 
-  it("keeps a hosted default on serverless deploys", () => {
+  it("does not impose a hosted default on serverless deploys", () => {
     process.env.NETLIFY = "true";
 
-    expect(resolveRunSoftTimeoutMs()).toBe(75_000);
+    expect(resolveRunSoftTimeoutMs()).toBe(0);
   });
 
   it("treats Netlify local as a local runtime", () => {

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -54,6 +54,14 @@ function isHostedRuntime(): boolean {
   if (process.env.CF_PAGES === "1") return true;
   if (process.env.VERCEL || process.env.VERCEL_ENV) return true;
   if (process.env.RENDER || process.env.FLY_APP_NAME) return true;
+  // Cloudflare Workers (non-Pages) doesn't set CF_PAGES but exposes the
+  // execution context via globalThis.__cf_ctx — same hook the
+  // waitUntil call below relies on.
+  try {
+    if (typeof globalThis.__cf_ctx?.waitUntil === "function") return true;
+  } catch {
+    // Accessing globalThis.__cf_ctx can throw in some sandboxes — ignore.
+  }
   return false;
 }
 

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -29,7 +29,7 @@ const threadToRun = new Map<string, string>();
 
 /** How long to keep completed runs in memory before cleanup (5 min) */
 const CLEANUP_DELAY_MS = 5 * 60 * 1000;
-const DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000;
+const HOSTED_RUN_SOFT_TIMEOUT_MS = 75_000;
 
 export interface StartRunOptions {
   /** Override the run soft timeout for this run. Must be lower than the
@@ -44,7 +44,17 @@ export function resolveRunSoftTimeoutMs(overrideMs?: number): number {
   }
   const raw = Number(process.env.AGENT_RUN_SOFT_TIMEOUT_MS);
   if (Number.isFinite(raw) && raw >= 0) return raw;
-  return DEFAULT_RUN_SOFT_TIMEOUT_MS;
+  return isHostedRuntime() ? HOSTED_RUN_SOFT_TIMEOUT_MS : 0;
+}
+
+function isHostedRuntime(): boolean {
+  if (process.env.NETLIFY === "true" && process.env.NETLIFY_LOCAL !== "true") {
+    return true;
+  }
+  if (process.env.CF_PAGES === "1") return true;
+  if (process.env.VERCEL || process.env.VERCEL_ENV) return true;
+  if (process.env.RENDER || process.env.FLY_APP_NAME) return true;
+  return false;
 }
 
 /**

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -29,12 +29,11 @@ const threadToRun = new Map<string, string>();
 
 /** How long to keep completed runs in memory before cleanup (5 min) */
 const CLEANUP_DELAY_MS = 5 * 60 * 1000;
-const HOSTED_RUN_SOFT_TIMEOUT_MS = 75_000;
 
 export interface StartRunOptions {
-  /** Override the run soft timeout for this run. Must be lower than the
-   * hosting platform's hard function timeout so the framework can emit a
-   * recoverable event before the host kills the process. */
+  /** Optional internal run chunk budget. When reached, the framework emits an
+   * auto-continuation signal instead of a user-facing timeout. Leave unset for
+   * no framework-imposed run timeout. */
   softTimeoutMs?: number;
 }
 
@@ -44,25 +43,7 @@ export function resolveRunSoftTimeoutMs(overrideMs?: number): number {
   }
   const raw = Number(process.env.AGENT_RUN_SOFT_TIMEOUT_MS);
   if (Number.isFinite(raw) && raw >= 0) return raw;
-  return isHostedRuntime() ? HOSTED_RUN_SOFT_TIMEOUT_MS : 0;
-}
-
-function isHostedRuntime(): boolean {
-  if (process.env.NETLIFY === "true" && process.env.NETLIFY_LOCAL !== "true") {
-    return true;
-  }
-  if (process.env.CF_PAGES === "1") return true;
-  if (process.env.VERCEL || process.env.VERCEL_ENV) return true;
-  if (process.env.RENDER || process.env.FLY_APP_NAME) return true;
-  // Cloudflare Workers (non-Pages) doesn't set CF_PAGES but exposes the
-  // execution context via globalThis.__cf_ctx — same hook the
-  // waitUntil call below relies on.
-  try {
-    if (typeof globalThis.__cf_ctx?.waitUntil === "function") return true;
-  } catch {
-    // Accessing globalThis.__cf_ctx can throw in some sandboxes — ignore.
-  }
-  return false;
+  return 0;
 }
 
 /**

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -120,14 +120,8 @@ export function startRun(
           if (run.status !== "running" || abort.signal.aborted) return;
           softTimedOut = true;
           send({
-            type: "error",
-            error:
-              "The agent reached the run time limit before it could finish.",
-            errorCode: "run_timeout",
-            recoverable: true,
-            details: `The run exceeded ${Math.round(
-              softTimeoutMs / 1000,
-            )} seconds. Partial output and tool calls were preserved so you can continue or retry.`,
+            type: "auto_continue",
+            reason: "run_timeout",
           });
           abort.abort();
         }, softTimeoutMs)
@@ -167,12 +161,12 @@ export function startRun(
   // Run in background — intentionally detached from any HTTP connection
   const runPromise = runFn(send, abort.signal)
     .then(() => {
-      run.status = softTimedOut ? "errored" : "completed";
+      run.status = "completed";
     })
     .catch((err) => {
       // Don't surface abort errors — the run was intentionally stopped
       if (abort.signal.aborted) {
-        run.status = softTimedOut ? "errored" : "aborted";
+        run.status = softTimedOut ? "completed" : "aborted";
         return;
       }
       run.status = "errored";

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -29,7 +29,6 @@ export function buildAssistantMessage(
 } | null {
   const content: ContentPart[] = [];
   let toolCallCounter = 0;
-  let loopLimit: { maxIterations?: number } | null = null;
   let runError: {
     message: string;
     errorCode?: string;
@@ -87,20 +86,19 @@ export function buildAssistantMessage(
     }
 
     if (event.type === "loop_limit") {
-      loopLimit = {
-        ...(event.maxIterations ? { maxIterations: event.maxIterations } : {}),
-      };
-      appendText(
-        `${content.length > 0 ? "\n\n" : ""}${
-          event.maxIterations
-            ? `I reached the ${event.maxIterations}-step limit before finishing.`
-            : "I reached the step limit before finishing."
-        }`,
-      );
+      // Older servers emitted this as a user-visible terminal event. Treat it
+      // as an internal continuation boundary when rebuilding persisted turns.
+      continue;
+    }
+
+    if (event.type === "auto_continue") {
       continue;
     }
 
     if (event.type === "error") {
+      if (event.errorCode === "run_timeout" && event.recoverable) {
+        continue;
+      }
       runError = {
         message: event.error,
         ...(event.errorCode ? { errorCode: event.errorCode } : {}),
@@ -118,17 +116,12 @@ export function buildAssistantMessage(
 
   const metadata: Record<string, unknown> = {};
   if (runId) metadata.runId = runId;
-  if (loopLimit || runError) {
+  if (runError) {
     metadata.custom = {
-      ...(loopLimit ? { loopLimit } : {}),
-      ...(runError
-        ? {
-            runError: {
-              ...runError,
-              ...(runId ? { runId } : {}),
-            },
-          }
-        : {}),
+      runError: {
+        ...runError,
+        ...(runId ? { runId } : {}),
+      },
     };
   }
 

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -126,6 +126,11 @@ export type AgentChatEvent =
     }
   | { type: "missing_api_key" }
   | { type: "loop_limit"; maxIterations?: number }
+  | {
+      type: "auto_continue";
+      reason: "run_timeout" | "loop_limit" | "stream_ended";
+      maxIterations?: number;
+    }
   | { type: "clear" };
 
 export interface RunEvent {

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -108,6 +108,11 @@ const SetupButton = lazy(() =>
   })),
 );
 
+// Setup/onboarding widget is hidden until the UX is improved.
+// Flip to `true` to restore the SetupButton in the header and the
+// OnboardingPanel above the chat.
+const SHOW_ONBOARDING = false;
+
 const CLI_STORAGE_KEY = "agent-native-cli-command";
 const CLI_DEFAULT = "claude";
 const EXEC_MODE_KEY = "agent-native-exec-mode";
@@ -530,7 +535,7 @@ export function AgentPanel({
   const renderHeaderActions = useCallback(
     () => (
       <div className="flex shrink-0 items-center gap-1.5">
-        {isDevMode && (
+        {SHOW_ONBOARDING && isDevMode && (
           <Suspense fallback={null}>
             <SetupButton />
           </Suspense>
@@ -1098,8 +1103,8 @@ export function AgentPanel({
       {/* Framework onboarding — appears above the chat/cli/settings tabs
           so it's visible regardless of which tab the user is on. The panel
           hides itself once all required steps are done or the user
-          dismisses it. */}
-      {mounted && isDevMode && (
+          dismisses it. Gated by SHOW_ONBOARDING until the UX is improved. */}
+      {SHOW_ONBOARDING && mounted && isDevMode && (
         <Suspense fallback={null}>
           <OnboardingPanel />
         </Suspense>

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1655,6 +1655,12 @@ function getRunErrorMetadata(message: unknown): RunErrorInfo | null {
   const messageText =
     typeof runError.message === "string" ? runError.message : "";
   if (!messageText) return null;
+  if (
+    runError.errorCode === "run_timeout" ||
+    runError.errorCode === "stream_ended"
+  ) {
+    return null;
+  }
   const runId =
     typeof runError.runId === "string"
       ? runError.runId
@@ -2898,9 +2904,7 @@ const AssistantChatInner = forwardRef<
     }
     return "";
   }, [messages]);
-  const visibleLoopLimit = showContinue
-    ? (loopLimitInfo ?? lastMessageLoopLimit ?? {})
-    : lastMessageLoopLimit;
+  const visibleLoopLimit: LoopLimitInfo | null = null;
   const visibleRunError = runErrorInfo ?? lastMessageRunError;
   const visibleRunErrorKey = visibleRunError
     ? `${visibleRunError.runId ?? ""}:${visibleRunError.errorCode ?? ""}:${visibleRunError.message}`

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -246,7 +246,7 @@ describe("createAgentChatAdapter", () => {
     });
   });
 
-  it("surfaces loop limit metadata from the SSE stream", async () => {
+  it("auto-continues without surfacing loop limit text", async () => {
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });
     vi.stubGlobal(
@@ -264,8 +264,14 @@ describe("createAgentChatAdapter", () => {
       "fetch",
       vi
         .fn()
-        .mockResolvedValue(
+        .mockResolvedValueOnce(
           sseResponse([{ type: "loop_limit", maxIterations: 7 }]),
+        )
+        .mockResolvedValueOnce(
+          sseResponse([
+            { type: "text", text: "finished after continuation" },
+            { type: "done" },
+          ]),
         ),
     );
 
@@ -286,14 +292,17 @@ describe("createAgentChatAdapter", () => {
     );
 
     const last = results.at(-1) as any;
-    expect(last.content.at(-1).text).toContain("7-step limit");
-    expect(last.metadata.custom.loopLimit).toEqual({ maxIterations: 7 });
+    expect(last.content.at(-1).text).toBe("finished after continuation");
     expect(last.metadata.custom.runId).toBe("run-qa");
-    expect(dispatchEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "agent-chat:loop-limit",
-        detail: { tabId: "chat-limit", maxIterations: 7 },
-      }),
+    expect(dispatchEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent-chat:loop-limit" }),
     );
+    const fetchSpy = vi.mocked(fetch);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(fetchSpy.mock.calls[1][1].body);
+    expect(secondBody.message).toContain("Continue from where you left off");
+    expect(secondBody.history).toEqual([
+      { role: "user", content: "keep using tools" },
+    ]);
   });
 });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -227,7 +227,7 @@ export function createAgentChatAdapter(options?: {
           boolean,
           unknown
         > {
-          if (!runId || lastSeq < 0) return false;
+          if (!runId) return false;
           for (let attempt = 0; attempt < 3; attempt++) {
             try {
               const reconnectRes = await fetch(
@@ -313,6 +313,30 @@ export function createAgentChatAdapter(options?: {
             }
 
             if (!res.ok) {
+              if (res.status === 409) {
+                let handledConflict = false;
+                try {
+                  const body = await res.json();
+                  if (body?.activeRunId) {
+                    handledConflict = true;
+                    runId = String(body.activeRunId);
+                    lastSeq = -1;
+                    if (threadId) {
+                      setActiveRun({ threadId, runId, lastSeq: -1 });
+                    }
+                    const reconnected = yield* reconnectCurrentRun();
+                    if (reconnected) return;
+                  }
+                } catch {
+                  // Fall through to the generic response handling below.
+                }
+                if (handledConflict) {
+                  await delay(1000, abortSignal);
+                  if (abortSignal.aborted) return;
+                  continue;
+                }
+              }
+
               // 405 Method Not Allowed usually means the session is broken/expired
               // (e.g. a redirect to a login page that only accepts GET).
               if (res.status === 405) {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -4,10 +4,77 @@ import {
   updateActiveRunSeq,
   clearActiveRun,
 } from "./active-run-state.js";
-import { type ContentPart, readSSEStream } from "./sse-event-processor.js";
+import {
+  AgentAutoContinueSignal,
+  type ContentPart,
+  readSSEStream,
+} from "./sse-event-processor.js";
 import { agentNativePath } from "./api-path.js";
 import { normalizeChatError } from "./error-format.js";
 import type { ReasoningEffort } from "../shared/reasoning-effort.js";
+
+type AdapterHistoryMessage = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+const AUTO_CONTINUE_PROMPT =
+  "Continue from where you left off and finish the user's original request. Do not repeat completed work, do not mention internal reconnects, time limits, or step limits, and continue as if this is the same uninterrupted run.";
+
+function normalizeMentions(text: string): string {
+  return text.replace(/@\[([^\]|]+)\|[^\]]+\]/g, "@$1");
+}
+
+function truncateForContinuation(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}\n\n...[truncated ${value.length - maxChars} chars from prior partial output]`;
+}
+
+function contentToContinuationHistory(content: ContentPart[]): string {
+  const chunks: string[] = [];
+  for (const part of content) {
+    if (part.type === "text") {
+      if (part.text.trim()) chunks.push(part.text.trim());
+      continue;
+    }
+    const toolSummary = [
+      `Tool: ${part.toolName}`,
+      part.argsText ? `Input: ${part.argsText}` : "",
+      part.result
+        ? `Result:\n${truncateForContinuation(part.result, 8_000)}`
+        : "Result: interrupted before this tool returned a result",
+    ]
+      .filter(Boolean)
+      .join("\n");
+    chunks.push(toolSummary);
+  }
+  return truncateForContinuation(chunks.join("\n\n"), 40_000).trim();
+}
+
+function autoContinueMessage(signal: AgentAutoContinueSignal): string {
+  const reason =
+    signal.reason === "loop_limit"
+      ? "The previous run reached an internal step budget."
+      : signal.reason === "stream_ended"
+        ? "The previous stream ended before the agent sent a final completion signal."
+        : "The previous run reached an internal execution budget.";
+  return `${AUTO_CONTINUE_PROMPT}\n\nInternal note: ${reason}`;
+}
+
+function delay(ms: number, abortSignal: AbortSignal): Promise<void> {
+  if (abortSignal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    abortSignal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
 
 /**
  * The composer's exec mode is sent as explicit request metadata. The server

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -206,6 +206,10 @@ export function createAgentChatAdapter(options?: {
       const toolCallCounter = { value: 0 };
       let runId: string | null = null;
       let lastSeq = -1;
+      let currentMessageText = normalizeMentions(rawMessageText);
+      let currentHistory: AdapterHistoryMessage[] = history;
+      let includeAttachments = attachments.length > 0;
+      let includeReferences = Boolean(runConfig?.custom?.references);
 
       try {
         const headers: Record<string, string> = {
@@ -217,162 +221,13 @@ export function createAgentChatAdapter(options?: {
         } catch {
           // Non-browser or Intl unavailable — tool calls will fall back to UTC.
         }
-        const res = await fetch(apiUrl, {
-          method: "POST",
-          headers,
-          body: JSON.stringify({
-            message: rawMessageText.replace(/@\[([^\]|]+)\|[^\]]+\]/g, "@$1"),
-            history,
-            ...(threadId ? { threadId } : {}),
-            ...(requestMode ? { mode: requestMode } : {}),
-            ...(modelRef?.current ? { model: modelRef.current } : {}),
-            ...(engineRef?.current ? { engine: engineRef.current } : {}),
-            ...(effortRef?.current ? { effort: effortRef.current } : {}),
-            ...(attachments.length > 0 ? { attachments } : {}),
-            ...(runConfig?.custom?.references
-              ? { references: runConfig.custom.references }
-              : {}),
-          }),
-          signal: abortSignal,
-        });
 
-        // Check for auth errors returned as 200 with JSON (common with middleware issues)
-        const contentType = res.headers.get("content-type") || "";
-        if (
-          res.ok &&
-          contentType.includes("application/json") &&
-          !contentType.includes("text/event-stream")
-        ) {
-          try {
-            const body = await res.text();
-            const parsed = JSON.parse(body);
-            if (parsed.error) {
-              throw new Error(parsed.error);
-            }
-          } catch (e) {
-            if (
-              e instanceof Error &&
-              e.message !== "Unexpected end of JSON input"
-            ) {
-              throw e;
-            }
-          }
-        }
-
-        if (!res.ok) {
-          // 405 Method Not Allowed usually means the session is broken/expired
-          // (e.g. a redirect to a login page that only accepts GET).
-          if (res.status === 405) {
-            if (typeof window !== "undefined") {
-              window.dispatchEvent(
-                new CustomEvent("agent-chat:auth-error", {
-                  detail: { reason: "session-expired" },
-                }),
-              );
-            }
-            content.push({ type: "text", text: "" });
-            yield {
-              content: [...content],
-              status: {
-                type: "incomplete" as const,
-                reason: "error" as const,
-              },
-            } as ChatModelRunResult;
-            return;
-          }
-
-          let errorText = `Server error: ${res.status}`;
-          try {
-            const body = await res.text();
-            if (
-              body.includes("apiKey") ||
-              body.includes("authToken") ||
-              body.includes("ANTHROPIC_API_KEY") ||
-              body.includes("authentication")
-            ) {
-              if (typeof window !== "undefined") {
-                window.dispatchEvent(new Event("agent-chat:missing-api-key"));
-              }
-              content.push({ type: "text", text: "" });
-              yield {
-                content: [...content],
-                status: {
-                  type: "incomplete" as const,
-                  reason: "error" as const,
-                },
-              } as ChatModelRunResult;
-              return;
-            } else if (body.includes("Cannot find any path")) {
-              errorText =
-                "Agent chat endpoint not found. Make sure the agent-chat plugin is loaded in server/plugins/.";
-            } else if (body) {
-              errorText = body.length > 200 ? body.slice(0, 200) + "..." : body;
-            }
-          } catch {}
-          throw new Error(errorText);
-        }
-        if (!res.body) {
-          throw new Error("No response body");
-        }
-
-        // Track the run ID for reconnection
-        runId = res.headers.get("X-Run-Id");
-        if (runId && threadId) {
-          setActiveRun({ threadId, runId, lastSeq: -1 });
-        }
-
-        yield* readSSEStream(
-          res.body,
-          content,
-          toolCallCounter,
-          tabId,
-          (seq) => {
-            lastSeq = seq;
-            if (runId && threadId) {
-              updateActiveRunSeq(seq);
-            }
-          },
-          runId,
-        );
-
-        // Run completed normally — clear active run state
-        clearActiveRun();
-      } catch (err: unknown) {
-        if (err instanceof Error && err.name === "AbortError") {
-          // User-initiated abort (Stop button) — clear active run
-          clearActiveRun();
-          return;
-        }
-
-        const errMsg =
-          err instanceof Error ? err.message : "Something went wrong.";
-        const isAuthError =
-          errMsg.includes("Unauthorized") ||
-          errMsg.includes("Not authenticated") ||
-          errMsg.includes("401") ||
-          errMsg.includes("403") ||
-          errMsg.includes("405");
-
-        // Don't try to reconnect for auth/client errors — show error directly
-        if (isAuthError) {
-          if (typeof window !== "undefined") {
-            window.dispatchEvent(new Event("agent-chat:auth-error"));
-          }
-          content.push({ type: "text", text: "" });
-          yield {
-            content: [...content],
-            status: {
-              type: "incomplete" as const,
-              reason: "error" as const,
-            },
-          };
-          clearActiveRun();
-          return;
-        }
-
-        // Connection lost — try to reconnect to the run
-        if (runId && lastSeq >= 0) {
-          let reconnected = false;
+        const reconnectCurrentRun = async function* (): AsyncGenerator<
+          ChatModelRunResult,
+          boolean,
+          unknown
+        > {
+          if (!runId || lastSeq < 0) return false;
           for (let attempt = 0; attempt < 3; attempt++) {
             try {
               const reconnectRes = await fetch(
@@ -388,61 +243,271 @@ export function createAgentChatAdapter(options?: {
                 tabId,
                 (seq) => {
                   lastSeq = seq;
-                  if (threadId) {
-                    updateActiveRunSeq(seq);
-                  }
+                  if (threadId) updateActiveRunSeq(seq);
                 },
                 runId,
               );
-              reconnected = true;
               clearActiveRun();
-              break;
+              return true;
             } catch (reconnectErr: unknown) {
               if (
                 reconnectErr instanceof Error &&
                 reconnectErr.name === "AbortError"
               ) {
                 clearActiveRun();
-                return;
+                return true;
               }
-              // Wait briefly before retrying
-              await new Promise((r) => setTimeout(r, 1000));
+              if (reconnectErr instanceof AgentAutoContinueSignal) {
+                return false;
+              }
+              await delay(1000, abortSignal);
             }
           }
-
-          if (reconnected) return;
-        }
-
-        // Reconnect failed or not possible — show error with details
-        const normalized = normalizeChatError(errMsg);
-        const runError = {
-          message: normalized.message,
-          ...(normalized.details ? { details: normalized.details } : {}),
-          errorCode: "connection_error",
-          recoverable: true,
-          ...(runId ? { runId } : {}),
+          return false;
         };
-        if (typeof window !== "undefined") {
-          window.dispatchEvent(
-            new CustomEvent("agent-chat:run-error", {
-              detail: { ...runError, tabId },
-            }),
-          );
+
+        while (true) {
+          try {
+            runId = null;
+            lastSeq = -1;
+            const res = await fetch(apiUrl, {
+              method: "POST",
+              headers,
+              body: JSON.stringify({
+                message: currentMessageText,
+                history: currentHistory,
+                ...(threadId ? { threadId } : {}),
+                ...(requestMode ? { mode: requestMode } : {}),
+                ...(modelRef?.current ? { model: modelRef.current } : {}),
+                ...(engineRef?.current ? { engine: engineRef.current } : {}),
+                ...(effortRef?.current ? { effort: effortRef.current } : {}),
+                ...(includeAttachments ? { attachments } : {}),
+                ...(includeReferences && runConfig?.custom?.references
+                  ? { references: runConfig.custom.references }
+                  : {}),
+              }),
+              signal: abortSignal,
+            });
+
+            // Check for auth errors returned as 200 with JSON (common with middleware issues)
+            const contentType = res.headers.get("content-type") || "";
+            if (
+              res.ok &&
+              contentType.includes("application/json") &&
+              !contentType.includes("text/event-stream")
+            ) {
+              try {
+                const body = await res.text();
+                const parsed = JSON.parse(body);
+                if (parsed.error) {
+                  throw new Error(parsed.error);
+                }
+              } catch (e) {
+                if (
+                  e instanceof Error &&
+                  e.message !== "Unexpected end of JSON input"
+                ) {
+                  throw e;
+                }
+              }
+            }
+
+            if (!res.ok) {
+              // 405 Method Not Allowed usually means the session is broken/expired
+              // (e.g. a redirect to a login page that only accepts GET).
+              if (res.status === 405) {
+                if (typeof window !== "undefined") {
+                  window.dispatchEvent(
+                    new CustomEvent("agent-chat:auth-error", {
+                      detail: { reason: "session-expired" },
+                    }),
+                  );
+                }
+                content.push({ type: "text", text: "" });
+                yield {
+                  content: [...content],
+                  status: {
+                    type: "incomplete" as const,
+                    reason: "error" as const,
+                  },
+                } as ChatModelRunResult;
+                return;
+              }
+
+              let errorText = `Server error: ${res.status}`;
+              try {
+                const body = await res.text();
+                if (
+                  body.includes("apiKey") ||
+                  body.includes("authToken") ||
+                  body.includes("ANTHROPIC_API_KEY") ||
+                  body.includes("authentication")
+                ) {
+                  if (typeof window !== "undefined") {
+                    window.dispatchEvent(
+                      new Event("agent-chat:missing-api-key"),
+                    );
+                  }
+                  content.push({ type: "text", text: "" });
+                  yield {
+                    content: [...content],
+                    status: {
+                      type: "incomplete" as const,
+                      reason: "error" as const,
+                    },
+                  } as ChatModelRunResult;
+                  return;
+                } else if (body.includes("Cannot find any path")) {
+                  errorText =
+                    "Agent chat endpoint not found. Make sure the agent-chat plugin is loaded in server/plugins/.";
+                } else if (body) {
+                  errorText =
+                    body.length > 200 ? body.slice(0, 200) + "..." : body;
+                }
+              } catch {}
+              throw new Error(errorText);
+            }
+            if (!res.body) {
+              throw new Error("No response body");
+            }
+
+            // Track the run ID for reconnection
+            runId = res.headers.get("X-Run-Id");
+            if (runId && threadId) {
+              setActiveRun({ threadId, runId, lastSeq: -1 });
+            }
+
+            yield* readSSEStream(
+              res.body,
+              content,
+              toolCallCounter,
+              tabId,
+              (seq) => {
+                lastSeq = seq;
+                if (runId && threadId) {
+                  updateActiveRunSeq(seq);
+                }
+              },
+              runId,
+            );
+
+            // Run completed normally — clear active run state
+            clearActiveRun();
+            return;
+          } catch (err: unknown) {
+            if (err instanceof Error && err.name === "AbortError") {
+              // User-initiated abort (Stop button) — clear active run
+              clearActiveRun();
+              return;
+            }
+
+            if (err instanceof AgentAutoContinueSignal) {
+              if (err.reason === "stream_ended") {
+                const reconnected = yield* reconnectCurrentRun();
+                if (reconnected) return;
+              }
+              const partialHistory = contentToContinuationHistory(content);
+              currentHistory = [
+                ...history,
+                { role: "user", content: normalizeMentions(rawMessageText) },
+                ...(partialHistory
+                  ? [{ role: "assistant" as const, content: partialHistory }]
+                  : []),
+              ];
+              currentMessageText = autoContinueMessage(err);
+              includeAttachments = false;
+              includeReferences = false;
+              clearActiveRun();
+              await delay(250, abortSignal);
+              if (abortSignal.aborted) return;
+              continue;
+            }
+
+            const errMsg =
+              err instanceof Error ? err.message : "Something went wrong.";
+            const isAuthError =
+              errMsg.includes("Unauthorized") ||
+              errMsg.includes("Not authenticated") ||
+              errMsg.includes("401") ||
+              errMsg.includes("403") ||
+              errMsg.includes("405");
+
+            // Don't try to reconnect for auth/client errors — show error directly
+            if (isAuthError) {
+              if (typeof window !== "undefined") {
+                window.dispatchEvent(new Event("agent-chat:auth-error"));
+              }
+              content.push({ type: "text", text: "" });
+              yield {
+                content: [...content],
+                status: {
+                  type: "incomplete" as const,
+                  reason: "error" as const,
+                },
+              };
+              clearActiveRun();
+              return;
+            }
+
+            // Connection lost — try to reconnect to the run
+            const reconnected = yield* reconnectCurrentRun();
+            if (reconnected) return;
+
+            // Reconnect failed or not possible — keep going from the partial
+            // streamed content instead of surfacing a transient transport error.
+            if (content.length > 0) {
+              const partialHistory = contentToContinuationHistory(content);
+              currentHistory = [
+                ...history,
+                { role: "user", content: normalizeMentions(rawMessageText) },
+                ...(partialHistory
+                  ? [{ role: "assistant" as const, content: partialHistory }]
+                  : []),
+              ];
+              currentMessageText = autoContinueMessage(
+                new AgentAutoContinueSignal({ reason: "stream_ended" }),
+              );
+              includeAttachments = false;
+              includeReferences = false;
+              clearActiveRun();
+              await delay(250, abortSignal);
+              if (abortSignal.aborted) return;
+              continue;
+            }
+
+            // No partial work exists, so this is still a real startup failure.
+            const normalized = normalizeChatError(errMsg);
+            const runError = {
+              message: normalized.message,
+              ...(normalized.details ? { details: normalized.details } : {}),
+              errorCode: "connection_error",
+              recoverable: true,
+              ...(runId ? { runId } : {}),
+            };
+            if (typeof window !== "undefined") {
+              window.dispatchEvent(
+                new CustomEvent("agent-chat:run-error", {
+                  detail: { ...runError, tabId },
+                }),
+              );
+            }
+            content.push({
+              type: "text",
+              text: errMsg.startsWith("Server error:")
+                ? errMsg
+                : `Something went wrong: ${normalized.message}`,
+            });
+            yield {
+              content: [...content],
+              status: {
+                type: "incomplete" as const,
+                reason: "error" as const,
+              },
+              metadata: { custom: { ...(runId ? { runId } : {}), runError } },
+            };
+            return;
+          }
         }
-        content.push({
-          type: "text",
-          text: errMsg.startsWith("Server error:")
-            ? errMsg
-            : `Something went wrong: ${normalized.message}`,
-        });
-        yield {
-          content: [...content],
-          status: {
-            type: "incomplete" as const,
-            reason: "error" as const,
-          },
-          metadata: { custom: { ...(runId ? { runId } : {}), runError } },
-        };
       } finally {
         if (typeof window !== "undefined") {
           window.dispatchEvent(

--- a/packages/core/src/client/org/OrgSwitcher.tsx
+++ b/packages/core/src/client/org/OrgSwitcher.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 import {
   IconBuilding,
   IconCheck,
   IconLoader2,
+  IconLogout,
   IconPlus,
   IconSelector,
   IconUser,
@@ -16,6 +18,7 @@ import {
   useAcceptInvitation,
 } from "./hooks.js";
 import { DEV_MODE_USER_EMAIL } from "../dev-mode.js";
+import { agentNativePath } from "../api-path.js";
 
 export interface OrgSwitcherProps {
   className?: string;
@@ -39,13 +42,20 @@ function personalLabelFromEmail(email: string | null | undefined): string {
 
 type Mode = "list" | "create" | "invite";
 
+const POPOVER_CONTENT_CLASS =
+  "z-50 min-w-[14rem] rounded-md border border-border bg-popover py-1 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2";
+
+const ITEM_CLASS =
+  "flex w-full items-center gap-2 px-2.5 py-1.5 text-xs text-foreground hover:bg-accent focus-visible:bg-accent focus:outline-none disabled:opacity-50 disabled:pointer-events-none";
+
+const SECTION_LABEL_CLASS =
+  "px-2.5 pt-1 pb-0.5 text-[10px] uppercase tracking-wide text-muted-foreground";
+
 /**
- * Compact org switcher button. Shows the active org name; opens a dropdown
- * with the user's other orgs, pending invitations, and inline forms to
- * create a new org or invite a teammate. Renders nothing in solo / dev
- * mode or when the user has no orgs at all and no invites.
- *
- * Headless DOM (no shadcn deps) so it works in any template.
+ * Compact org switcher button. Shows the active org (or "Personal" when the
+ * user has none); opens a popover with the user's other orgs, pending
+ * invitations, inline forms to create a new org / invite a teammate, and a
+ * sign-out item. Renders nothing in dev / no-auth mode.
  */
 export function OrgSwitcher({
   className,
@@ -61,26 +71,30 @@ export function OrgSwitcher({
   const [mode, setMode] = useState<Mode>("list");
   const [newName, setNewName] = useState("");
   const [inviteEmail, setInviteEmail] = useState("");
-  const ref = useRef<HTMLDivElement>(null);
+  const [signingOut, setSigningOut] = useState(false);
 
-  useEffect(() => {
-    if (!open) return;
-    const onClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", onClick);
-    return () => document.removeEventListener("mousedown", onClick);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) {
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) {
       setMode("list");
       setNewName("");
       setInviteEmail("");
     }
-  }, [open]);
+  };
+
+  const handleSignOut = async () => {
+    if (signingOut) return;
+    setSigningOut(true);
+    try {
+      await fetch(agentNativePath("/_agent-native/auth/logout"), {
+        method: "POST",
+        credentials: "include",
+      });
+    } catch {
+      /* fall through to reload — server may already have cleared the cookie */
+    }
+    window.location.reload();
+  };
 
   if (!org) {
     return reserveSpace && isLoading ? (
@@ -113,22 +127,33 @@ export function OrgSwitcher({
 
   const personalLabel = personalLabelFromEmail(org.email);
   const inOrg = !!org.orgId;
-  const label = org.orgName ?? "Personal";
+  const buttonLabel = org.orgName ?? "Personal";
   const ButtonIcon = inOrg ? IconBuilding : IconUser;
 
   return (
-    <div ref={ref} className={`relative ${className ?? ""}`}>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground border border-border/50"
-      >
-        <ButtonIcon className="h-3.5 w-3.5 shrink-0" />
-        <span className="truncate flex-1 text-left">{label}</span>
-        <IconSelector className="h-3 w-3 shrink-0 opacity-50" />
-      </button>
-      {open && (
-        <div className="absolute left-0 right-0 bottom-full mb-1 z-50 rounded-md border border-border bg-popover shadow-md py-1 min-w-[14rem]">
+    <PopoverPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+      <PopoverPrimitive.Trigger asChild>
+        <button
+          type="button"
+          className={`flex w-full items-center gap-2 rounded-md border border-border/50 px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-pointer ${className ?? ""}`}
+        >
+          <ButtonIcon className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate flex-1 text-left">{buttonLabel}</span>
+          <IconSelector className="h-3 w-3 shrink-0 opacity-50" />
+        </button>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          side="top"
+          align="start"
+          sideOffset={6}
+          collisionPadding={12}
+          className={POPOVER_CONTENT_CLASS}
+          onOpenAutoFocus={(e) => {
+            // Don't auto-focus the first item — feels heavy on a switcher.
+            if (mode === "list") e.preventDefault();
+          }}
+        >
           {mode === "list" && (
             <>
               {!inOrg && (
@@ -143,9 +168,7 @@ export function OrgSwitcher({
                 </div>
               )}
               {orgs.length > 0 && (
-                <div className="px-2.5 pt-1 pb-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-                  Organization
-                </div>
+                <div className={SECTION_LABEL_CLASS}>Organizations</div>
               )}
               {orgs.map((o) => (
                 <button
@@ -164,12 +187,12 @@ export function OrgSwitcher({
                     }
                   }}
                   disabled={switchOrg.isPending}
-                  className="flex w-full items-center gap-2 px-2.5 py-1.5 text-xs text-foreground hover:bg-accent disabled:opacity-50"
+                  className={`${ITEM_CLASS} cursor-pointer`}
                 >
                   <IconBuilding className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                   <span className="truncate flex-1 text-left">{o.orgName}</span>
                   {o.orgId === org.orgId && (
-                    <IconCheck className="h-3.5 w-3.5 shrink-0 text-green-500" />
+                    <IconCheck className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                   )}
                 </button>
               ))}
@@ -177,9 +200,7 @@ export function OrgSwitcher({
               {pendingInvitations.length > 0 && (
                 <>
                   {orgs.length > 0 && <div className="my-1 h-px bg-border" />}
-                  <div className="px-2.5 pt-1 pb-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-                    Invitations
-                  </div>
+                  <div className={SECTION_LABEL_CLASS}>Invitations</div>
                   {pendingInvitations.map((inv) => (
                     <div
                       key={inv.id}
@@ -200,7 +221,7 @@ export function OrgSwitcher({
                           }
                         }}
                         disabled={acceptInvitation.isPending}
-                        className="rounded px-1.5 py-0.5 text-[11px] font-medium text-green-600 hover:bg-green-500/10 disabled:opacity-50"
+                        className="rounded px-1.5 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/10 disabled:opacity-50 cursor-pointer"
                       >
                         {acceptInvitation.isPending ? (
                           <IconLoader2 className="h-3 w-3 animate-spin" />
@@ -217,7 +238,7 @@ export function OrgSwitcher({
               <button
                 type="button"
                 onClick={() => setMode("create")}
-                className="flex w-full items-center gap-2 px-2.5 py-1.5 text-xs text-foreground hover:bg-accent"
+                className={`${ITEM_CLASS} cursor-pointer`}
               >
                 <IconPlus className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                 <span className="flex-1 text-left">Create organization</span>
@@ -226,15 +247,37 @@ export function OrgSwitcher({
                 <button
                   type="button"
                   onClick={() => setMode("invite")}
-                  className="flex w-full items-center gap-2 px-2.5 py-1.5 text-xs text-foreground hover:bg-accent"
+                  className={`${ITEM_CLASS} cursor-pointer`}
                 >
                   <IconUserPlus className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                   <span className="flex-1 text-left">Invite member</span>
                 </button>
               )}
 
+              <div className="my-1 h-px bg-border" />
+              <button
+                type="button"
+                onClick={handleSignOut}
+                disabled={signingOut}
+                className={`${ITEM_CLASS} cursor-pointer`}
+              >
+                {signingOut ? (
+                  <IconLoader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+                ) : (
+                  <IconLogout className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                )}
+                <span className="flex-1 text-left">
+                  Sign out
+                  {org.email ? (
+                    <span className="ml-1 text-muted-foreground">
+                      ({org.email})
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+
               {(switchOrg.error || acceptInvitation.error) && (
-                <div className="px-2.5 pt-1 text-[11px] text-red-600">
+                <div className="px-2.5 pt-1 text-[11px] text-destructive">
                   {
                     ((switchOrg.error || acceptInvitation.error) as Error)
                       .message
@@ -271,7 +314,7 @@ export function OrgSwitcher({
                 className="w-full rounded-md border border-input bg-background px-2 py-1.5 text-xs outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
               />
               {createOrg.error && (
-                <div className="pt-1 text-[11px] text-red-600">
+                <div className="pt-1 text-[11px] text-destructive">
                   {(createOrg.error as Error).message}
                 </div>
               )}
@@ -280,14 +323,14 @@ export function OrgSwitcher({
                   type="button"
                   onClick={() => setMode("list")}
                   disabled={createOrg.isPending}
-                  className="flex-1 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:opacity-50"
+                  className="flex-1 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:opacity-50 cursor-pointer"
                 >
                   Cancel
                 </button>
                 <button
                   type="submit"
                   disabled={createOrg.isPending || !newName.trim()}
-                  className="flex-1 rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                  className="flex-1 rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50 cursor-pointer"
                 >
                   {createOrg.isPending ? (
                     <IconLoader2 className="mx-auto h-3 w-3 animate-spin" />
@@ -328,7 +371,7 @@ export function OrgSwitcher({
                 className="w-full rounded-md border border-input bg-background px-2 py-1.5 text-xs outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
               />
               {inviteMember.error && (
-                <div className="pt-1 text-[11px] text-red-600">
+                <div className="pt-1 text-[11px] text-destructive">
                   {(inviteMember.error as Error).message}
                 </div>
               )}
@@ -337,14 +380,14 @@ export function OrgSwitcher({
                   type="button"
                   onClick={() => setMode("list")}
                   disabled={inviteMember.isPending}
-                  className="flex-1 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:opacity-50"
+                  className="flex-1 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-accent disabled:opacity-50 cursor-pointer"
                 >
                   Cancel
                 </button>
                 <button
                   type="submit"
                   disabled={inviteMember.isPending || !inviteEmail.trim()}
-                  className="flex-1 rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+                  className="flex-1 rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50 cursor-pointer"
                 >
                   {inviteMember.isPending ? (
                     <IconLoader2 className="mx-auto h-3 w-3 animate-spin" />
@@ -355,8 +398,8 @@ export function OrgSwitcher({
               </div>
             </form>
           )}
-        </div>
-      )}
-    </div>
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
   );
 }

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -22,6 +22,7 @@ export interface SSEEvent {
   seq?: number;
   agent?: string;
   status?: string;
+  reason?: string;
   // Agent task fields
   taskId?: string;
   threadId?: string;
@@ -38,6 +39,26 @@ export interface SSEEvent {
   maxIterations?: number;
 }
 
+export type AgentAutoContinueReason =
+  | "run_timeout"
+  | "loop_limit"
+  | "stream_ended";
+
+export class AgentAutoContinueSignal extends Error {
+  readonly reason: AgentAutoContinueReason;
+  readonly maxIterations?: number;
+
+  constructor(options: {
+    reason: AgentAutoContinueReason;
+    maxIterations?: number;
+  }) {
+    super(`Agent run needs automatic continuation: ${options.reason}`);
+    this.name = "AgentAutoContinueSignal";
+    this.reason = options.reason;
+    this.maxIterations = options.maxIterations;
+  }
+}
+
 /**
  * Process a single SSE event and update the content accumulator.
  * Returns: "continue" to keep going, "done" to stop, or a yield-ready result.
@@ -48,8 +69,18 @@ export function processEvent(
   toolCallCounter: { value: number },
   tabId: string | undefined,
 ): {
-  action: "continue" | "done" | "yield" | "error" | "missing_api_key";
+  action:
+    | "continue"
+    | "done"
+    | "yield"
+    | "error"
+    | "missing_api_key"
+    | "auto_continue";
   result?: ChatModelRunResult;
+  autoContinue?: {
+    reason: AgentAutoContinueReason;
+    maxIterations?: number;
+  };
 } {
   if (ev.type === "clear") {
     // Server is retrying — discard partial text/tool output from the failed attempt
@@ -200,36 +231,53 @@ export function processEvent(
   if (ev.type === "loop_limit") {
     const maxIterations =
       typeof ev.maxIterations === "number" ? ev.maxIterations : undefined;
-    content.push({
-      type: "text",
-      text: maxIterations
-        ? `I reached the ${maxIterations}-step limit before finishing.`
-        : "I reached the step limit before finishing.",
-    });
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(
-        new CustomEvent("agent-chat:loop-limit", {
-          detail: { tabId, maxIterations },
-        }),
-      );
-    }
     return {
-      action: "done",
-      result: {
-        content: [...content],
-        metadata: {
-          custom: {
-            loopLimit: {
-              ...(maxIterations ? { maxIterations } : {}),
-            },
-          },
-        },
-      } as ChatModelRunResult,
+      action: "auto_continue",
+      autoContinue: {
+        reason: "loop_limit",
+        ...(maxIterations ? { maxIterations } : {}),
+      },
+    };
+  }
+
+  if (ev.type === "auto_continue") {
+    const reason =
+      ev.reason === "stream_ended" ||
+      ev.reason === "loop_limit" ||
+      ev.reason === "run_timeout"
+        ? ev.reason
+        : ev.errorCode === "stream_ended" ||
+            ev.errorCode === "loop_limit" ||
+            ev.errorCode === "run_timeout"
+          ? ev.errorCode
+          : ev.error === "stream_ended" ||
+              ev.error === "loop_limit" ||
+              ev.error === "run_timeout"
+            ? ev.error
+            : ev.status === "stream_ended" ||
+                ev.status === "loop_limit" ||
+                ev.status === "run_timeout"
+              ? ev.status
+              : "run_timeout";
+    return {
+      action: "auto_continue",
+      autoContinue: {
+        reason,
+        ...(typeof ev.maxIterations === "number"
+          ? { maxIterations: ev.maxIterations }
+          : {}),
+      },
     };
   }
 
   if (ev.type === "error") {
     const errMsg = ev.error ?? "Unknown error";
+    if (ev.errorCode === "run_timeout" && ev.recoverable) {
+      return {
+        action: "auto_continue",
+        autoContinue: { reason: "run_timeout" },
+      };
+    }
     const normalized = normalizeChatError(errMsg);
     if (
       errMsg.includes("apiKey") ||
@@ -358,7 +406,7 @@ export async function* readSSEStream(
           onSeq(ev.seq);
         }
 
-        const { action, result } = processEvent(
+        const { action, result, autoContinue } = processEvent(
           ev,
           content,
           toolCallCounter,
@@ -366,6 +414,11 @@ export async function* readSSEStream(
         );
 
         if (result) yield withRunId(result);
+        if (action === "auto_continue") {
+          throw new AgentAutoContinueSignal(
+            autoContinue ?? { reason: "stream_ended" },
+          );
+        }
         if (
           action === "done" ||
           action === "error" ||
@@ -381,28 +434,7 @@ export async function* readSSEStream(
 
   // Stream ended without explicit done event
   if (content.length > 0) {
-    const runError = {
-      message:
-        "The response stream ended before the agent sent a completion signal. You can continue from the partial work or retry.",
-      errorCode: "stream_ended",
-      recoverable: true,
-    };
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(
-        new CustomEvent("agent-chat:run-error", {
-          detail: { ...runError, tabId },
-        }),
-      );
-    }
-    content.push({
-      type: "text",
-      text: `Error: ${runError.message}`,
-    });
-    yield withRunId({
-      content: [...content],
-      status: { type: "incomplete" as const, reason: "error" as const },
-      metadata: { custom: { runError } },
-    } as ChatModelRunResult);
+    throw new AgentAutoContinueSignal({ reason: "stream_ended" });
   }
 }
 
@@ -455,6 +487,10 @@ export async function readSSEStreamRaw(
         ) {
           updated = true;
         }
+        if (action === "auto_continue") {
+          onUpdate([...content]);
+          return;
+        }
         if (
           action === "done" ||
           action === "error" ||
@@ -472,21 +508,5 @@ export async function readSSEStreamRaw(
   } finally {
     reader.releaseLock();
   }
-  if (content.length > 0) {
-    const runError = {
-      message:
-        "The response stream ended before the agent sent a completion signal. You can continue from the partial work or retry.",
-      errorCode: "stream_ended",
-      recoverable: true,
-    };
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(
-        new CustomEvent("agent-chat:run-error", {
-          detail: { ...runError, tabId },
-        }),
-      );
-    }
-    content.push({ type: "text", text: `Error: ${runError.message}` });
-    onUpdate([...content]);
-  }
+  if (content.length > 0) onUpdate([...content]);
 }

--- a/packages/core/src/collab/client.ts
+++ b/packages/core/src/collab/client.ts
@@ -341,7 +341,15 @@ export function useCollaborativeDoc(
       stopped = true;
       if (timer) clearTimeout(timer);
     };
-  }, [ydoc, awareness, docId, pollInterval, requestSource, baseUrl, docMissing]);
+  }, [
+    ydoc,
+    awareness,
+    docId,
+    pollInterval,
+    requestSource,
+    baseUrl,
+    docMissing,
+  ]);
 
   return {
     ydoc,

--- a/packages/core/src/collab/client.ts
+++ b/packages/core/src/collab/client.ts
@@ -125,6 +125,10 @@ export function useCollaborativeDoc(
   const [activeUsers, setActiveUsers] = useState<CollabUser[]>([]);
   const [agentActive, setAgentActive] = useState(false);
   const [agentPresent, setAgentPresent] = useState(false);
+  // Set when the initial state fetch returns 404/403 — stops the awareness
+  // poll so we don't spam the console with errors against a doc that doesn't
+  // exist or isn't accessible.
+  const [docMissing, setDocMissing] = useState(false);
   const agentTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollVersionRef = useRef(0);
 
@@ -182,12 +186,21 @@ export function useCollaborativeDoc(
     let cancelled = false;
     setIsLoading(true);
     setIsSynced(false);
+    setDocMissing(false);
 
     fetch(`${baseUrl}/${docId}/state`)
-      .then((res) => res.json())
-      .then((data: { state: string }) => {
+      .then(async (res) => {
         if (cancelled) return;
-        if (data.state) {
+        if (res.status === 404 || res.status === 403) {
+          setDocMissing(true);
+          setIsLoading(false);
+          setIsSynced(true);
+          return;
+        }
+        const data = (await res.json().catch(() => null)) as {
+          state?: string;
+        } | null;
+        if (data?.state) {
           const binary = base64ToUint8Array(data.state);
           if (binary.length > 4) {
             Y.applyUpdate(ydoc, binary);
@@ -209,7 +222,7 @@ export function useCollaborativeDoc(
 
   // Send local updates to server
   useEffect(() => {
-    if (!ydoc || !docId) return;
+    if (!ydoc || !docId || docMissing) return;
 
     const handler = (update: Uint8Array, origin: unknown) => {
       if (origin === "remote") return;
@@ -228,11 +241,11 @@ export function useCollaborativeDoc(
     return () => {
       ydoc.off("update", handler);
     };
-  }, [ydoc, docId, baseUrl, requestSource]);
+  }, [ydoc, docId, baseUrl, requestSource, docMissing]);
 
   // Poll for remote doc updates + awareness sync
   useEffect(() => {
-    if (!ydoc || !docId) return;
+    if (!ydoc || !docId || docMissing) return;
 
     let stopped = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -328,7 +341,7 @@ export function useCollaborativeDoc(
       stopped = true;
       if (timer) clearTimeout(timer);
     };
-  }, [ydoc, awareness, docId, pollInterval, requestSource, baseUrl]);
+  }, [ydoc, awareness, docId, pollInterval, requestSource, baseUrl, docMissing]);
 
   return {
     ydoc,

--- a/packages/core/src/scripts/manage-agent-loop-settings.ts
+++ b/packages/core/src/scripts/manage-agent-loop-settings.ts
@@ -17,7 +17,7 @@ import {
 
 export const tool: ActionTool = {
   description:
-    'Manage the maximum number of agent loop iterations before the agent pauses and asks whether to keep going. Pass action="get" to inspect, action="set" with maxIterations to update the active org/user setting, or action="reset" to return to default.',
+    'Manage the internal agent loop iteration chunk size before the agent silently continues. Pass action="get" to inspect, action="set" with maxIterations to update the active org/user setting, or action="reset" to return to default.',
   parameters: {
     type: "object",
     properties: {
@@ -30,7 +30,7 @@ export const tool: ActionTool = {
       maxIterations: {
         type: "string",
         description:
-          "(set) Integer step limit. Applies to the active organization when one is selected; otherwise applies to the current user.",
+          "(set) Integer internal step chunk size. Applies to the active organization when one is selected; otherwise applies to the current user.",
       },
     },
     required: ["action"],

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1317,10 +1317,10 @@ export interface AgentChatPluginOptions {
   devSystemPrompt?: string;
   /** Claude model to use. Default: claude-sonnet-4-6 */
   model?: string;
-  /** Per-app agent run soft timeout in milliseconds. Defaults to no timeout
-   * locally and a hosted-serverless timeout in deployed runtimes. Must stay
-   * below the hosting function timeout so the run can emit a recoverable
-   * timeout event instead of being killed by the platform. */
+  /** Optional per-app agent run chunk budget in milliseconds. Defaults to
+   * AGENT_RUN_SOFT_TIMEOUT_MS when set, otherwise no framework-imposed
+   * timeout. When reached, long runs continue through the hidden continuation
+   * path instead of surfacing a timeout warning. */
   runSoftTimeoutMs?: number;
   /** Anthropic API key. Falls back to ANTHROPIC_API_KEY env var */
   apiKey?: string;

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -20,6 +20,7 @@ import {
   getRun,
   abortRun,
   subscribeToRun,
+  appendAgentLoopContinuation,
   type ActionEntry,
 } from "../agent/production-agent.js";
 import { resolveRunSoftTimeoutMs } from "../agent/run-manager.js";
@@ -165,49 +166,64 @@ async function runAgentLoopDirectWithSoftTimeout(
   if (timeoutMs <= 0) return runAgentLoop(opts);
 
   const upstreamSignal = opts.signal;
-  const controller = new AbortController();
-  const abortFromUpstream = () => controller.abort();
-  if (upstreamSignal.aborted) {
-    controller.abort();
-  } else {
-    upstreamSignal.addEventListener("abort", abortFromUpstream, {
-      once: true,
-    });
-  }
+  const usage: Awaited<ReturnType<typeof runAgentLoop>> = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    model: opts.model,
+  };
 
-  let softTimedOut = false;
-  const timer = setTimeout(() => {
-    if (controller.signal.aborted) return;
-    softTimedOut = true;
-    opts.send({
-      type: "error",
-      error: "The agent reached the run time limit before it could finish.",
-      errorCode: "run_timeout",
-      recoverable: true,
-      details: `The run exceeded ${Math.round(
-        timeoutMs / 1000,
-      )} seconds. Partial output and tool calls were preserved so you can continue or retry.`,
-    });
-    controller.abort();
-  }, timeoutMs);
+  const addUsage = (next: Awaited<ReturnType<typeof runAgentLoop>>) => {
+    usage.inputTokens += next.inputTokens;
+    usage.outputTokens += next.outputTokens;
+    usage.cacheReadTokens += next.cacheReadTokens;
+    usage.cacheWriteTokens += next.cacheWriteTokens;
+    usage.model = next.model;
+  };
 
-  try {
-    return await runAgentLoop({ ...opts, signal: controller.signal });
-  } catch (err) {
-    if (softTimedOut) {
-      return {
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadTokens: 0,
-        cacheWriteTokens: 0,
-        model: opts.model,
-      };
+  while (!upstreamSignal.aborted) {
+    const controller = new AbortController();
+    const abortFromUpstream = () => controller.abort();
+    if (upstreamSignal.aborted) {
+      controller.abort();
+    } else {
+      upstreamSignal.addEventListener("abort", abortFromUpstream, {
+        once: true,
+      });
     }
-    throw err;
-  } finally {
-    clearTimeout(timer);
-    upstreamSignal.removeEventListener("abort", abortFromUpstream);
+
+    let softTimedOut = false;
+    const timer = setTimeout(() => {
+      if (controller.signal.aborted) return;
+      softTimedOut = true;
+      controller.abort();
+    }, timeoutMs);
+
+    try {
+      const nextUsage = await runAgentLoop({
+        ...opts,
+        signal: controller.signal,
+      });
+      addUsage(nextUsage);
+      if (softTimedOut && !upstreamSignal.aborted) {
+        appendAgentLoopContinuation(opts.messages, "run_timeout");
+        continue;
+      }
+      return usage;
+    } catch (err) {
+      if (softTimedOut && !upstreamSignal.aborted) {
+        appendAgentLoopContinuation(opts.messages, "run_timeout");
+        continue;
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+      upstreamSignal.removeEventListener("abort", abortFromUpstream);
+    }
   }
+
+  return usage;
 }
 
 export function assembleA2AFinalResponse(

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1301,9 +1301,10 @@ export interface AgentChatPluginOptions {
   devSystemPrompt?: string;
   /** Claude model to use. Default: claude-sonnet-4-6 */
   model?: string;
-  /** Per-app agent run soft timeout in milliseconds. Must stay below the
-   * hosting function timeout so the run can emit a recoverable timeout event
-   * instead of being killed by the platform. */
+  /** Per-app agent run soft timeout in milliseconds. Defaults to no timeout
+   * locally and a hosted-serverless timeout in deployed runtimes. Must stay
+   * below the hosting function timeout so the run can emit a recoverable
+   * timeout event instead of being killed by the platform. */
   runSoftTimeoutMs?: number;
   /** Anthropic API key. Falls back to ANTHROPIC_API_KEY env var */
   apiKey?: string;

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -55,6 +55,7 @@ import {
   getDbExec,
   isPostgres,
   intType,
+  isLocalDatabase,
   retryOnDdlRace,
 } from "../db/client.js";
 import { getBetterAuth, getBetterAuthSync } from "./better-auth-instance.js";
@@ -64,6 +65,7 @@ import {
   readCorsAllowedOrigins,
 } from "./cors-origins.js";
 import { getOnboardingHtml, getResetPasswordHtml } from "./onboarding-html.js";
+import { migrateLocalUserData } from "./local-migration.js";
 import { readBody } from "../server/h3-helpers.js";
 import {
   readDesktopSso,
@@ -215,8 +217,41 @@ function getOAuthStateAppId(): string | undefined {
 const DEFAULT_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 
 // ---------------------------------------------------------------------------
-// Environment helpers
+// AUTH_MODE detection
 // ---------------------------------------------------------------------------
+
+let _warnedRemoteLocalMode = false;
+
+/**
+ * Check if the app is in local-only mode (no auth).
+ *
+ * Returns true when AUTH_MODE=local is explicitly set.
+ *
+ * Local mode is an explicit escape hatch for when you want to guarantee
+ * no auth is used. In development, getSession() also falls back to
+ * local@localhost automatically if no other auth method succeeds, so
+ * apps are always usable without configuration in dev.
+ *
+ * Refuses to enable on any non-local database (Postgres, Turso, D1): local
+ * mode uses a single shared virtual user with no per-machine scoping, so on
+ * a shared DB every developer would land on the same account and collide.
+ */
+async function isLocalModeEnabled(): Promise<boolean> {
+  if (process.env.AUTH_MODE !== "local") return false;
+
+  if (!isLocalDatabase()) {
+    if (!_warnedRemoteLocalMode) {
+      _warnedRemoteLocalMode = true;
+      console.warn(
+        "[agent-native] AUTH_MODE=local ignored: database is not local SQLite. " +
+          "local@localhost has no per-user scoping and would collide across developers on a shared DB.",
+      );
+    }
+    return false;
+  }
+
+  return true;
+}
 
 /**
  * Check if we're in a development/test environment.

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -55,7 +55,6 @@ import {
   getDbExec,
   isPostgres,
   intType,
-  isLocalDatabase,
   retryOnDdlRace,
 } from "../db/client.js";
 import { getBetterAuth, getBetterAuthSync } from "./better-auth-instance.js";
@@ -65,7 +64,6 @@ import {
   readCorsAllowedOrigins,
 } from "./cors-origins.js";
 import { getOnboardingHtml, getResetPasswordHtml } from "./onboarding-html.js";
-import { migrateLocalUserData } from "./local-migration.js";
 import { readBody } from "../server/h3-helpers.js";
 import {
   readDesktopSso,
@@ -217,41 +215,8 @@ function getOAuthStateAppId(): string | undefined {
 const DEFAULT_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
 
 // ---------------------------------------------------------------------------
-// AUTH_MODE detection
+// Environment helpers
 // ---------------------------------------------------------------------------
-
-let _warnedRemoteLocalMode = false;
-
-/**
- * Check if the app is in local-only mode (no auth).
- *
- * Returns true when AUTH_MODE=local is explicitly set.
- *
- * Local mode is an explicit escape hatch for when you want to guarantee
- * no auth is used. In development, getSession() also falls back to
- * local@localhost automatically if no other auth method succeeds, so
- * apps are always usable without configuration in dev.
- *
- * Refuses to enable on any non-local database (Postgres, Turso, D1): local
- * mode uses a single shared virtual user with no per-machine scoping, so on
- * a shared DB every developer would land on the same account and collide.
- */
-async function isLocalModeEnabled(): Promise<boolean> {
-  if (process.env.AUTH_MODE !== "local") return false;
-
-  if (!isLocalDatabase()) {
-    if (!_warnedRemoteLocalMode) {
-      _warnedRemoteLocalMode = true;
-      console.warn(
-        "[agent-native] AUTH_MODE=local ignored: database is not local SQLite. " +
-          "local@localhost has no per-user scoping and would collide across developers on a shared DB.",
-      );
-    }
-    return false;
-  }
-
-  return true;
-}
 
 /**
  * Check if we're in a development/test environment.

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -275,6 +275,27 @@ function getCoreSourceAliases(
       coreSrc,
       "client/tools/index.ts",
     ),
+    "@agent-native/core/client/org": path.join(coreSrc, "client/org/index.ts"),
+    "@agent-native/core/client/observability": path.join(
+      coreSrc,
+      "client/observability/index.ts",
+    ),
+    "@agent-native/core/client/onboarding": path.join(
+      coreSrc,
+      "client/onboarding/index.ts",
+    ),
+    "@agent-native/core/client/sharing": path.join(
+      coreSrc,
+      "client/sharing/index.ts",
+    ),
+    "@agent-native/core/client/notifications": path.join(
+      coreSrc,
+      "client/notifications/index.ts",
+    ),
+    "@agent-native/core/client/progress": path.join(
+      coreSrc,
+      "client/progress/index.ts",
+    ),
     "@agent-native/core/db": path.join(coreSrc, "db/index.ts"),
     "@agent-native/core/db/schema": path.join(coreSrc, "db/schema.ts"),
     "@agent-native/core/shared": path.join(coreSrc, "shared/index.ts"),

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -810,6 +810,7 @@ function AddDataSourceCTA() {
 
 function FirstPartyAnalyticsCard() {
   const queryClient = useQueryClient();
+  const [expanded, setExpanded] = useState(false);
   const [name, setName] = useState("Hosted templates");
   const [createdKey, setCreatedKey] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -822,6 +823,7 @@ function FirstPartyAnalyticsCard() {
   const keys = ((data as AnalyticsPublicKeyRow[] | undefined) ?? []).filter(
     (key) => !key.revokedAt,
   );
+  const connected = keys.length > 0;
 
   const createKey = useActionMutation("create-analytics-public-key", {
     onSuccess: (result: any) => {
@@ -849,145 +851,171 @@ function FirstPartyAnalyticsCard() {
 
   return (
     <Card className="bg-card border-border/50">
-      <CardHeader>
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-              <IconKey className="h-5 w-5" />
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full text-left"
+      >
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between gap-6">
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <IconKey className="h-5 w-5" />
+              </div>
+              <div>
+                <CardTitle className="text-sm font-medium">
+                  First-party Analytics
+                </CardTitle>
+                <CardDescription className="text-xs mt-0.5">
+                  Receive product events at your first-party endpoint and query
+                  them as a dashboard data source.
+                </CardDescription>
+              </div>
             </div>
-            <div>
-              <CardTitle className="text-sm font-medium">
-                First-party Analytics
-              </CardTitle>
-              <CardDescription className="text-xs mt-0.5">
-                Receive product events at your first-party endpoint and query
-                them as a dashboard data source.
-              </CardDescription>
+            <div className="flex items-center gap-2">
+              {isLoading ? (
+                <Skeleton className="h-4 w-20 rounded-full" />
+              ) : connected ? (
+                <span className="flex items-center gap-1.5 text-xs text-emerald-500 font-medium whitespace-nowrap">
+                  <IconCheck className="h-3.5 w-3.5" />
+                  Connected
+                </span>
+              ) : (
+                <span className="flex items-center gap-1.5 text-xs text-muted-foreground whitespace-nowrap">
+                  <IconCircle className="h-3 w-3" />
+                  Not connected
+                </span>
+              )}
+              {expanded ? (
+                <IconChevronUp className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <IconChevronDown className="h-4 w-4 text-muted-foreground" />
+              )}
             </div>
           </div>
-          {isLoading ? (
-            <Skeleton className="h-4 w-20 rounded-full" />
-          ) : keys.length > 0 ? (
-            <span className="flex items-center gap-1.5 text-xs text-emerald-500 font-medium whitespace-nowrap">
-              <IconCheck className="h-3.5 w-3.5" />
-              {keys.length} active
-            </span>
-          ) : (
-            <span className="flex items-center gap-1.5 text-xs text-muted-foreground whitespace-nowrap">
-              <IconCircle className="h-3 w-3" />
-              No keys
-            </span>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="grid gap-2 rounded-md border border-border/50 bg-muted/20 p-3 text-xs">
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-muted-foreground">Endpoint</span>
-            <code className="truncate font-mono">
-              {firstPartyAnalyticsEndpoint}
-            </code>
-          </div>
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-muted-foreground">Server env</span>
-            <code className="truncate font-mono">
-              AGENT_NATIVE_ANALYTICS_PUBLIC_KEY
-            </code>
-          </div>
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-muted-foreground">Browser env</span>
-            <code className="truncate font-mono">
-              VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY
-            </code>
-          </div>
-        </div>
+        </CardHeader>
+      </button>
 
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="flex min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 text-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
-            placeholder="Key name"
-          />
-          <Button
-            size="sm"
-            onClick={() => createKey.mutate({ name })}
-            disabled={createKey.isPending}
-            className="text-xs"
-          >
-            {createKey.isPending ? (
-              <>
-                <IconLoader2 className="h-3 w-3 animate-spin mr-1.5" />
-                Generating...
-              </>
-            ) : (
-              <>
-                <IconPlus className="h-3 w-3 mr-1.5" />
-                Generate Key
-              </>
-            )}
-          </Button>
-        </div>
+      {expanded && (
+        <CardContent className="pt-0 border-t border-border/50">
+          <div className="space-y-4 pt-3">
+            <div className="grid gap-2 rounded-md border border-border/50 bg-muted/20 p-3 text-xs">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Endpoint</span>
+                <code className="truncate font-mono">
+                  {firstPartyAnalyticsEndpoint}
+                </code>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Server env</span>
+                <code className="truncate font-mono">
+                  AGENT_NATIVE_ANALYTICS_PUBLIC_KEY
+                </code>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Browser env</span>
+                <code className="truncate font-mono">
+                  VITE_AGENT_NATIVE_ANALYTICS_PUBLIC_KEY
+                </code>
+              </div>
+            </div>
 
-        {createdKey && (
-          <div className="space-y-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 p-3">
-            <p className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
-              New key generated
-            </p>
-            <div className="flex gap-2">
+            <div className="flex flex-col gap-2 sm:flex-row">
               <input
-                readOnly
-                value={createdKey}
-                className="flex min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="flex min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 text-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
+                placeholder="Key name"
               />
               <Button
                 size="sm"
-                variant="outline"
-                onClick={copyCreatedKey}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  createKey.mutate({ name });
+                }}
+                disabled={createKey.isPending}
                 className="text-xs"
               >
-                <IconCopy className="h-3 w-3 mr-1.5" />
-                {copied ? "Copied" : "Copy"}
+                {createKey.isPending ? (
+                  <>
+                    <IconLoader2 className="h-3 w-3 animate-spin mr-1.5" />
+                    Generating...
+                  </>
+                ) : (
+                  <>
+                    <IconPlus className="h-3 w-3 mr-1.5" />
+                    Generate Key
+                  </>
+                )}
               </Button>
             </div>
-          </div>
-        )}
 
-        {keys.length > 0 && (
-          <div className="space-y-2 border-t border-border/30 pt-3">
-            {keys.map((key) => (
-              <div
-                key={key.id}
-                className="flex items-center justify-between gap-3 text-xs"
-              >
-                <div className="min-w-0">
-                  <div className="font-medium truncate">{key.name}</div>
-                  <div className="text-muted-foreground font-mono">
-                    {key.publicKeyPrefix}...
-                    {key.lastUsedAt
-                      ? ` last used ${new Date(key.lastUsedAt).toLocaleDateString()}`
-                      : " never used"}
-                  </div>
+            {createdKey && (
+              <div className="space-y-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 p-3">
+                <p className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                  New key generated
+                </p>
+                <div className="flex gap-2">
+                  <input
+                    readOnly
+                    value={createdKey}
+                    className="flex min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+                  />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      copyCreatedKey();
+                    }}
+                    className="text-xs"
+                  >
+                    <IconCopy className="h-3 w-3 mr-1.5" />
+                    {copied ? "Copied" : "Copy"}
+                  </Button>
                 </div>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => revokeKey.mutate({ id: key.id })}
-                  disabled={revokeKey.isPending}
-                  className="text-xs text-destructive hover:text-destructive"
-                >
-                  {revokeKey.isPending ? (
-                    <IconLoader2 className="h-3 w-3 animate-spin mr-1.5" />
-                  ) : (
-                    <IconTrash className="h-3 w-3 mr-1.5" />
-                  )}
-                  Revoke
-                </Button>
               </div>
-            ))}
+            )}
+
+            {keys.length > 0 && (
+              <div className="space-y-2 border-t border-border/30 pt-3">
+                {keys.map((key) => (
+                  <div
+                    key={key.id}
+                    className="flex items-center justify-between gap-3 text-xs"
+                  >
+                    <div className="min-w-0">
+                      <div className="font-medium truncate">{key.name}</div>
+                      <div className="text-muted-foreground font-mono">
+                        {key.publicKeyPrefix}...
+                        {key.lastUsedAt
+                          ? ` last used ${new Date(key.lastUsedAt).toLocaleDateString()}`
+                          : " never used"}
+                      </div>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        revokeKey.mutate({ id: key.id });
+                      }}
+                      disabled={revokeKey.isPending}
+                      className="text-xs text-destructive hover:text-destructive"
+                    >
+                      {revokeKey.isPending ? (
+                        <IconLoader2 className="h-3 w-3 animate-spin mr-1.5" />
+                      ) : (
+                        <IconTrash className="h-3 w-3 mr-1.5" />
+                      )}
+                      Revoke
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
-        )}
-      </CardContent>
+        </CardContent>
+      )}
     </Card>
   );
 }
@@ -1042,8 +1070,6 @@ export default function DataSources() {
         />
       </div>
 
-      {!search && <FirstPartyAnalyticsCard />}
-
       {/* Filtered results */}
       {filteredSources !== null ? (
         filteredSources.length > 0 ? (
@@ -1074,6 +1100,7 @@ export default function DataSources() {
                 {categoryLabels[category]}
               </h3>
               <div className="grid gap-3 lg:grid-cols-2">
+                {category === "analytics" && <FirstPartyAnalyticsCard />}
                 {sources.map((source) => (
                   <DataSourceCard
                     key={source.id}

--- a/templates/analytics/netlify.toml
+++ b/templates/analytics/netlify.toml
@@ -10,7 +10,7 @@
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
 # so the framework's friendly "run_timeout" event fires before Netlify kills
 # the function.
 [functions."*"]

--- a/templates/analytics/netlify.toml
+++ b/templates/analytics/netlify.toml
@@ -9,9 +9,8 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
-# so the framework's friendly "run_timeout" event fires before Netlify kills
-# the function.
+# The framework does not impose a default agent-run timeout; if a template sets
+# AGENT_RUN_SOFT_TIMEOUT_MS, keep it below this function timeout so the hidden
+# auto-continuation path can hand off before Netlify kills the function.
 [functions."*"]
   timeout = 75

--- a/templates/calendar/netlify.toml
+++ b/templates/calendar/netlify.toml
@@ -10,7 +10,7 @@
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
 # so the framework's friendly "run_timeout" event fires before Netlify kills
 # the function.
 [functions."*"]

--- a/templates/calendar/netlify.toml
+++ b/templates/calendar/netlify.toml
@@ -9,9 +9,8 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
-# so the framework's friendly "run_timeout" event fires before Netlify kills
-# the function.
+# The framework does not impose a default agent-run timeout; if a template sets
+# AGENT_RUN_SOFT_TIMEOUT_MS, keep it below this function timeout so the hidden
+# auto-continuation path can hand off before Netlify kills the function.
 [functions."*"]
   timeout = 75

--- a/templates/clips/netlify.toml
+++ b/templates/clips/netlify.toml
@@ -10,7 +10,7 @@
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
 # so the framework's friendly "run_timeout" event fires before Netlify kills
 # the function.
 [functions."*"]

--- a/templates/clips/netlify.toml
+++ b/templates/clips/netlify.toml
@@ -9,9 +9,8 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
-# so the framework's friendly "run_timeout" event fires before Netlify kills
-# the function.
+# The framework does not impose a default agent-run timeout; if a template sets
+# AGENT_RUN_SOFT_TIMEOUT_MS, keep it below this function timeout so the hidden
+# auto-continuation path can hand off before Netlify kills the function.
 [functions."*"]
   timeout = 75

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -20,7 +20,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useQueryClient } from "@tanstack/react-query";
-import type { DocumentSyncStatus } from "@shared/api";
+import type { Document, DocumentSyncStatus } from "@shared/api";
 
 const TAB_ID = generateTabId();
 
@@ -28,8 +28,39 @@ interface DocumentEditorProps {
   documentId: string;
 }
 
+/**
+ * Outer wrapper: gates the editor on the document fetch so collab + comments
+ * only mount once we know the doc exists. Otherwise an invalid id triggers
+ * an infinite spinner plus repeating 404/403 polls in the console.
+ */
 export function DocumentEditor({ documentId }: DocumentEditorProps) {
   const { data: document, isLoading, isError } = useDocument(documentId);
+
+  if (isError || (!isLoading && !document)) {
+    return (
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        Document not found
+      </div>
+    );
+  }
+
+  if (isLoading || !document) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <IconLoader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return <DocumentEditorBody documentId={documentId} document={document} />;
+}
+
+interface DocumentEditorBodyProps {
+  documentId: string;
+  document: Document;
+}
+
+function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
   const updateDocument = useUpdateDocument();
   const queryClient = useQueryClient();
   // Shared with DocumentToolbar via the same localStorage key — both read it.

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -29,7 +29,7 @@ interface DocumentEditorProps {
 }
 
 export function DocumentEditor({ documentId }: DocumentEditorProps) {
-  const { data: document, isLoading } = useDocument(documentId);
+  const { data: document, isLoading, isError } = useDocument(documentId);
   const updateDocument = useUpdateDocument();
   const queryClient = useQueryClient();
   // Shared with DocumentToolbar via the same localStorage key — both read it.
@@ -215,18 +215,21 @@ export function DocumentEditor({ documentId }: DocumentEditorProps) {
     }
   });
 
-  if (isLoading || collabLoading) {
+  // Show "not found" as soon as the document fetch errors (deterministic
+  // not-found / no-access response) — otherwise the user stares at a spinner
+  // while collab + comments retry against an id that doesn't exist.
+  if (isError || (!isLoading && !document)) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <IconLoader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      <div className="flex items-center justify-center h-full text-muted-foreground">
+        Document not found
       </div>
     );
   }
 
-  if (!document) {
+  if (isLoading || collabLoading || !document) {
     return (
-      <div className="flex items-center justify-center h-full text-muted-foreground">
-        Document not found
+      <div className="flex items-center justify-center h-full">
+        <IconLoader2 className="w-6 h-6 animate-spin text-muted-foreground" />
       </div>
     );
   }

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -238,26 +238,15 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
     setPendingComment({ quotedText, offsetTop });
   }, []);
 
-  // Auto-focus title on new empty documents once loading is done
+  // Auto-focus title on new empty documents once collab finishes loading
   useEffect(() => {
-    if (!isLoading && !collabLoading && shouldFocusTitleRef.current) {
+    if (!collabLoading && shouldFocusTitleRef.current) {
       shouldFocusTitleRef.current = false;
       requestAnimationFrame(() => titleInputRef.current?.focus());
     }
   });
 
-  // Show "not found" as soon as the document fetch errors (deterministic
-  // not-found / no-access response) — otherwise the user stares at a spinner
-  // while collab + comments retry against an id that doesn't exist.
-  if (isError || (!isLoading && !document)) {
-    return (
-      <div className="flex items-center justify-center h-full text-muted-foreground">
-        Document not found
-      </div>
-    );
-  }
-
-  if (isLoading || collabLoading || !document) {
+  if (collabLoading) {
     return (
       <div className="flex items-center justify-center h-full">
         <IconLoader2 className="w-6 h-6 animate-spin text-muted-foreground" />

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -259,7 +259,7 @@ export function DocumentEditor({ documentId }: DocumentEditorProps) {
           ref={scrollContainerRef}
           className="flex-1 min-h-0 overflow-auto flex flex-col"
         >
-          <div className="shrink-0 px-4 pt-14 pb-2 sm:px-8 md:px-16 md:pt-16 group/title">
+          <div className="shrink-0 w-full max-w-3xl mx-auto px-4 pt-14 pb-2 sm:px-8 md:px-16 md:pt-16 group/title">
             <div className="mb-1">
               <EmojiPicker
                 icon={document.icon}
@@ -287,7 +287,7 @@ export function DocumentEditor({ documentId }: DocumentEditorProps) {
           </div>
 
           <div
-            className="flex-1 px-4 pb-16 cursor-text sm:px-8 md:px-16"
+            className="flex-1 w-full max-w-3xl mx-auto px-4 pb-16 cursor-text sm:px-8 md:px-16"
             onClick={(e) => {
               if (e.target === e.currentTarget) {
                 const pm = e.currentTarget.querySelector(

--- a/templates/content/app/components/sidebar/DocumentTreeItem.tsx
+++ b/templates/content/app/components/sidebar/DocumentTreeItem.tsx
@@ -79,7 +79,7 @@ export function DocumentTreeItem({
           </span>
           {hasChildren && (
             <button
-              className="absolute inset-0 flex items-center justify-center rounded hover:bg-accent opacity-0 group-hover:opacity-100"
+              className="absolute inset-0 flex items-center justify-center rounded hover:bg-accent opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto"
               onClick={(e) => {
                 e.stopPropagation();
                 onToggleExpanded(node.id);

--- a/templates/content/app/components/sidebar/DocumentTreeItem.tsx
+++ b/templates/content/app/components/sidebar/DocumentTreeItem.tsx
@@ -58,33 +58,38 @@ export function DocumentTreeItem({
     <div>
       <div
         className={cn(
-          "group relative flex items-center gap-1 px-2 py-[5px] rounded-md cursor-pointer text-sm",
+          "group relative flex items-center gap-1.5 pr-2 py-[5px] rounded-md cursor-pointer text-sm",
           isActive
             ? "bg-accent text-accent-foreground"
             : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
         )}
-        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        style={{ paddingLeft: `${depth * 16 + 12}px` }}
         onClick={() => onSelect(node.id)}
       >
-        <button
-          className={cn(
-            "flex-shrink-0 w-5 h-5 flex items-center justify-center rounded hover:bg-accent",
-            !hasChildren && "invisible",
-          )}
-          onClick={(e) => {
-            e.stopPropagation();
-            onToggleExpanded(node.id);
-          }}
-        >
-          <IconChevronRight
-            size={14}
-            className={cn("transition-transform", expanded && "rotate-90")}
-          />
-        </button>
-
-        <span className="flex-shrink-0 w-5 text-center">
-          {node.icon || (
-            <IconFileText size={14} className="text-muted-foreground" />
+        <span className="relative flex-shrink-0 w-5 h-5">
+          <span
+            className={cn(
+              "absolute inset-0 flex items-center justify-center text-center",
+              hasChildren && "group-hover:opacity-0",
+            )}
+          >
+            {node.icon || (
+              <IconFileText size={14} className="text-muted-foreground" />
+            )}
+          </span>
+          {hasChildren && (
+            <button
+              className="absolute inset-0 flex items-center justify-center rounded hover:bg-accent opacity-0 group-hover:opacity-100"
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleExpanded(node.id);
+              }}
+            >
+              <IconChevronRight
+                size={14}
+                className={cn("transition-transform", expanded && "rotate-90")}
+              />
+            </button>
           )}
         </span>
 

--- a/templates/content/app/hooks/use-documents.ts
+++ b/templates/content/app/hooks/use-documents.ts
@@ -31,6 +31,9 @@ export function useDocuments() {
 export function useDocument(id: string | null) {
   return useActionQuery<Document>("get-document", id ? { id } : undefined, {
     enabled: !!id,
+    // Doc-not-found / no-access errors are deterministic — retrying just keeps
+    // the spinner up for ~7s before the UI can render "Not found".
+    retry: false,
   });
 }
 

--- a/templates/content/netlify.toml
+++ b/templates/content/netlify.toml
@@ -10,7 +10,7 @@
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
 # so the framework's friendly "run_timeout" event fires before Netlify kills
 # the function.
 [functions."*"]

--- a/templates/content/netlify.toml
+++ b/templates/content/netlify.toml
@@ -9,9 +9,8 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
-# so the framework's friendly "run_timeout" event fires before Netlify kills
-# the function.
+# The framework does not impose a default agent-run timeout; if a template sets
+# AGENT_RUN_SOFT_TIMEOUT_MS, keep it below this function timeout so the hidden
+# auto-continuation path can hand off before Netlify kills the function.
 [functions."*"]
   timeout = 75

--- a/templates/design/netlify.toml
+++ b/templates/design/netlify.toml
@@ -10,7 +10,7 @@
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
 # so the framework's friendly "run_timeout" event fires before Netlify kills
 # the function.
 [functions."*"]

--- a/templates/design/netlify.toml
+++ b/templates/design/netlify.toml
@@ -9,9 +9,8 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
-# so the framework's friendly "run_timeout" event fires before Netlify kills
-# the function.
+# The framework does not impose a default agent-run timeout; if a template sets
+# AGENT_RUN_SOFT_TIMEOUT_MS, keep it below this function timeout so the hidden
+# auto-continuation path can hand off before Netlify kills the function.
 [functions."*"]
   timeout = 75

--- a/templates/dispatch/netlify.toml
+++ b/templates/dispatch/netlify.toml
@@ -10,7 +10,7 @@
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
 # so the framework's friendly "run_timeout" event fires before Netlify kills
 # the function.
 [functions."*"]

--- a/templates/dispatch/netlify.toml
+++ b/templates/dispatch/netlify.toml
@@ -9,9 +9,8 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
-# so the framework's friendly "run_timeout" event fires before Netlify kills
-# the function.
+# The framework does not impose a default agent-run timeout; if a template sets
+# AGENT_RUN_SOFT_TIMEOUT_MS, keep it below this function timeout so the hidden
+# auto-continuation path can hand off before Netlify kills the function.
 [functions."*"]
   timeout = 75

--- a/templates/forms/netlify.toml
+++ b/templates/forms/netlify.toml
@@ -10,7 +10,7 @@
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
 # so the framework's friendly "run_timeout" event fires before Netlify kills
 # the function.
 [functions."*"]

--- a/templates/forms/netlify.toml
+++ b/templates/forms/netlify.toml
@@ -9,9 +9,8 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
-# so the framework's friendly "run_timeout" event fires before Netlify kills
-# the function.
+# The framework does not impose a default agent-run timeout; if a template sets
+# AGENT_RUN_SOFT_TIMEOUT_MS, keep it below this function timeout so the hidden
+# auto-continuation path can hand off before Netlify kills the function.
 [functions."*"]
   timeout = 75

--- a/templates/mail/netlify.toml
+++ b/templates/mail/netlify.toml
@@ -10,7 +10,7 @@
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
 # so the framework's friendly "run_timeout" event fires before Netlify kills
 # the function.
 [functions."*"]

--- a/templates/mail/netlify.toml
+++ b/templates/mail/netlify.toml
@@ -9,9 +9,8 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
-# so the framework's friendly "run_timeout" event fires before Netlify kills
-# the function.
+# The framework does not impose a default agent-run timeout; if a template sets
+# AGENT_RUN_SOFT_TIMEOUT_MS, keep it below this function timeout so the hidden
+# auto-continuation path can hand off before Netlify kills the function.
 [functions."*"]
   timeout = 75

--- a/templates/slides/netlify.toml
+++ b/templates/slides/netlify.toml
@@ -10,7 +10,7 @@
 
 # Slides builds can legitimately need several model/tool iterations. Keep this
 # above templates/slides/server/plugins/agent-chat.ts (runSoftTimeoutMs =
-# 240_000) so the framework can emit a recoverable timeout before Netlify kills
-# the function.
+# 240_000) so the hidden auto-continuation path can hand off before Netlify
+# kills the function.
 [functions."*"]
   timeout = 300

--- a/templates/videos/netlify.toml
+++ b/templates/videos/netlify.toml
@@ -10,7 +10,7 @@
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
 # Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (DEFAULT_RUN_SOFT_TIMEOUT_MS = 75_000)
+# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
 # so the framework's friendly "run_timeout" event fires before Netlify kills
 # the function.
 [functions."*"]

--- a/templates/videos/netlify.toml
+++ b/templates/videos/netlify.toml
@@ -9,9 +9,8 @@
   NPM_CONFIG_PRODUCTION = "false"
 
 # A2A delegation calls run a full agent loop (LLM + tool calls + DB queries).
-# Aligned with the agent-run soft timeout in
-# packages/core/src/agent/run-manager.ts (hosted default = 75_000)
-# so the framework's friendly "run_timeout" event fires before Netlify kills
-# the function.
+# The framework does not impose a default agent-run timeout; if a template sets
+# AGENT_RUN_SOFT_TIMEOUT_MS, keep it below this function timeout so the hidden
+# auto-continuation path can hand off before Netlify kills the function.
 [functions."*"]
   timeout = 75


### PR DESCRIPTION
## Summary

- **Hosted-only run soft timeout.** Renamed `DEFAULT_RUN_SOFT_TIMEOUT_MS` → `HOSTED_RUN_SOFT_TIMEOUT_MS` and gated it on a new `isHostedRuntime()` check (Netlify, Cloudflare Pages, Vercel, Render, Fly). Local dev now runs uncapped so long agent loops aren't cut off mid-debug. Updated tests + the 9 template `netlify.toml` comments to match.
- **OrgSwitcher → Radix Popover + sign-out.** Migrated the custom click-outside dropdown to a Radix Popover and added a sign-out item that POSTs to `/_agent-native/auth/logout` and reloads. Cleans up the open-state / reset-mode effects in the process.
- **More vite source aliases.** Registered six more `@agent-native/core/client/*` aliases (org, observability, onboarding, sharing, notifications, progress) so HMR picks up edits inside those subpaths.
- **Content editor centered.** `DocumentEditor` title + prose column now `max-w-3xl mx-auto` so wide displays stop sprawling.
- **Content tree icon-vs-chevron.** `DocumentTreeItem` shows the file/emoji icon by default and swaps to the expand chevron on row hover (single 5×5 slot, no layout shift).
- **Analytics card is collapsible.** `FirstPartyAnalyticsCard` collapses by default with a Connected / Not connected indicator on the header.

## Test plan

- [ ] CI passes (typecheck, prep, guards, framework tests)
- [ ] Long-running local agent run never emits `run_timeout` (no env vars set, no `NETLIFY` etc.)
- [ ] Same code on a Netlify/Vercel/Cloudflare deploy still emits `run_timeout` after ~75s
- [ ] OrgSwitcher: clicking outside the popover closes it, mode resets to `list` on close
- [ ] OrgSwitcher: Sign out item POSTs `/_agent-native/auth/logout` and reloads → user is back on the auth screen
- [ ] Content editor: title + prose render centered at `max-w-3xl` on a wide window
- [ ] Content tree: icon shown by default, chevron only appears on row hover for items with children
- [ ] Analytics: First-party Analytics card collapses + expands; "Connected" badge appears once a key exists