### PR TITLE
Fix desktop auth CORS middleware

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.7.81",
+  "version": "0.7.82",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -419,6 +419,80 @@ describe("server/auth", () => {
       expect(event.res.headers.get("access-control-allow-origin")).toBeNull();
     });
 
+    it("handles Tauri auth preflights before route-specific auth handlers", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const calls = app.use.mock.calls;
+      const corsIndex = calls.findIndex(
+        (call: any[]) => call[0] === "/_agent-native/auth",
+      );
+      const loginIndex = calls.findIndex(
+        (call: any[]) => call[0] === "/_agent-native/auth/login",
+      );
+      expect(corsIndex).toBeGreaterThanOrEqual(0);
+      expect(loginIndex).toBeGreaterThan(corsIndex);
+
+      const corsHandler = calls[corsIndex][1];
+      const event = createMockEvent({
+        path: "/_agent-native/auth/login",
+        headers: {
+          origin: "tauri://localhost",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "content-type",
+        },
+      });
+      event.req.method = "OPTIONS";
+      event.node.req.method = "OPTIONS";
+
+      const result = await corsHandler(event);
+
+      expect(result).toBe("");
+      expect(event.res.status).toBe(204);
+      expect(event.res.headers.get("access-control-allow-origin")).toBe(
+        "tauri://localhost",
+      );
+      expect(event.res.headers.get("access-control-allow-methods")).toContain(
+        "POST",
+      );
+      expect(event.res.headers.get("access-control-allow-headers")).toContain(
+        "Content-Type",
+      );
+    });
+
+    it("adds CORS headers to Tauri auth GETs while allowing the route to continue", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const corsHandler = app.use.mock.calls.find(
+        (call: any[]) => call[0] === "/_agent-native/auth",
+      )?.[1];
+      expect(corsHandler).toBeTypeOf("function");
+
+      const event = createMockEvent({
+        path: "/_agent-native/auth/desktop-exchange",
+        headers: { origin: "tauri://localhost" },
+      });
+
+      const result = await corsHandler(event);
+
+      expect(result).toBeUndefined();
+      expect(event.res.headers.get("access-control-allow-origin")).toBe(
+        "tauri://localhost",
+      );
+      expect(event.res.headers.get("access-control-allow-credentials")).toBe(
+        "true",
+      );
+    });
+
     it("accepts HEAD on the auth session endpoint", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("ACCESS_TOKEN", "my-secret");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -719,6 +719,27 @@ function applyCorsHeaders(event: H3Event): {
   return { hasOrigin: true, allowed: true };
 }
 
+function createAuthCorsHandler() {
+  return defineEventHandler((event) => {
+    const cors = applyCorsHeaders(event);
+    if (getMethod(event) !== "OPTIONS") return;
+
+    if (cors.hasOrigin && !cors.allowed) {
+      setResponseStatus(event, 403);
+      return "";
+    }
+
+    setResponseStatus(event, 204);
+    return "";
+  });
+}
+
+function mountAuthCorsMiddleware(app: H3App): void {
+  const handler = createAuthCorsHandler();
+  app.use("/_agent-native/auth", handler);
+  app.use("/_agent-native/google", handler);
+}
+
 function createAuthGuardFn(): (
   event: H3Event,
 ) => Promise<Response | object | string | void> {
@@ -2111,6 +2132,8 @@ export async function autoMountAuth(
   customGetSession = null;
   sessionMaxAge = options.maxAge ?? DEFAULT_MAX_AGE;
   const publicPaths = options.publicPaths ?? [];
+
+  mountAuthCorsMiddleware(app);
 
   if (options.getSession) {
     customGetSession = options.getSession;


### PR DESCRIPTION
## Summary
- mount auth-prefix CORS middleware before route-specific auth handlers
- cover Tauri desktop preflights and desktop-exchange GET responses
- add regression tests for auth CORS ordering and headers

## Verification
- pnpm --filter @agent-native/core test -- auth.spec.ts
- pnpm --filter clips typecheck

## Production check
Before this patch, live Clips auth endpoints still returned no Access-Control-Allow-Origin for Origin: tauri://localhost, which keeps both Google desktop handoff and email/password login stuck in the Tauri app.