### PR TITLE
Parallelize slides image-gen reference fetches and variants

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3731,6 +3731,9 @@ importers:
       nanoid:
         specifier: ^5.1.9
         version: 5.1.9
+      p-limit:
+        specifier: ^7.3.0
+        version: 7.3.0
       pdf-parse:
         specifier: ^2.4.5
         version: 2.4.5

--- a/templates/slides/actions/generate-image.ts
+++ b/templates/slides/actions/generate-image.ts
@@ -28,6 +28,7 @@ const config = async () => {
 };
 import { readFileSync, writeFileSync, mkdirSync, readdirSync } from "fs";
 import { dirname, join } from "path";
+import pLimit from "p-limit";
 import { DEFAULT_STYLE_REFERENCE_URLS } from "../shared/api.js";
 
 function parseArgs(args: string[]): Record<string, string> {
@@ -164,26 +165,38 @@ Options:
     ...extraReferenceUrls,
   ];
 
-  // Load reference images from URLs
-  const refImages: Array<{ data: string; mimeType: string }> = [];
-  for (const url of referenceUrls) {
-    try {
-      console.log(`Loading reference image: ${url}`);
-      const res = await fetch(url);
-      if (!res.ok) {
-        console.warn(`Failed to load reference image: ${url}`);
-        continue;
-      }
-      const contentType = res.headers.get("content-type") || "image/png";
-      const buffer = Buffer.from(await res.arrayBuffer());
-      refImages.push({
-        data: buffer.toString("base64"),
-        mimeType: contentType.split(";")[0].trim(),
-      });
-    } catch (err: any) {
-      console.warn(`Error loading reference image ${url}: ${err.message}`);
-    }
-  }
+  // Load reference images from URLs in parallel (capped concurrency to avoid
+  // overwhelming the network and to keep the agent within its run budget).
+  const refFetchLimit = pLimit(4);
+  const refImages = (
+    await Promise.all(
+      referenceUrls.map((url) =>
+        refFetchLimit(async () => {
+          try {
+            console.log(`Loading reference image: ${url}`);
+            const res = await fetch(url, {
+              signal: AbortSignal.timeout(8000),
+            });
+            if (!res.ok) {
+              console.warn(`Failed to load reference image: ${url}`);
+              return null;
+            }
+            const contentType = res.headers.get("content-type") || "image/png";
+            const buffer = Buffer.from(await res.arrayBuffer());
+            return {
+              data: buffer.toString("base64"),
+              mimeType: contentType.split(";")[0].trim(),
+            };
+          } catch (err: any) {
+            console.warn(
+              `Error loading reference image ${url}: ${err.message}`,
+            );
+            return null;
+          }
+        }),
+      ),
+    )
+  ).filter((r): r is { data: string; mimeType: string } => r !== null);
 
   console.log(`\nGenerating ${count} image(s) with prompt: "${prompt}"`);
   console.log(
@@ -200,31 +213,46 @@ Options:
     mkdirSync(dirname(outputPrefix), { recursive: true });
   }
 
+  // Generate variations concurrently. Default to 2 in flight to stay under the
+  // image-provider rate limits (Gemini and OpenAI both have low TPM/RPM caps);
+  // tunable via IMAGE_GEN_CONCURRENCY without redeploying.
+  const genLimit = pLimit(
+    Math.max(1, Number(process.env.IMAGE_GEN_CONCURRENCY) || 2),
+  );
+  const variantResults = await Promise.allSettled(
+    Array.from({ length: count }, (_, i) =>
+      genLimit(async () => {
+        console.log(`\nGenerating variation ${i + 1}/${count}...`);
+        const result = await provider.generate(prompt, refImages, context);
+        return { i, result };
+      }),
+    ),
+  );
+
   const generatedFiles: string[] = [];
 
-  for (let i = 0; i < count; i++) {
-    try {
-      console.log(`\nGenerating variation ${i + 1}/${count}...`);
-      const result = await provider.generate(prompt, refImages, context);
-
-      if (outputPrefix) {
-        const filePath = `${outputPrefix}-v${i + 1}.png`;
-        writeFileSync(filePath, result.imageData);
-        generatedFiles.push(filePath);
-        console.log(
-          `Saved: ${filePath} (${Math.round(result.imageData.length / 1024)}KB)`,
-        );
-      } else {
-        const dataUrl = `data:${result.mimeType};base64,${result.imageData.toString("base64")}`;
-        console.log(`\nGenerated image ${i + 1}:`);
-        console.log(`  MIME type: ${result.mimeType}`);
-        console.log(`  Size: ${Math.round(result.imageData.length / 1024)}KB`);
-        console.log(
-          `  Data URL (first 100 chars): ${dataUrl.substring(0, 100)}...`,
-        );
-      }
-    } catch (err: any) {
-      console.error(`Failed to generate variation ${i + 1}: ${err.message}`);
+  for (const settled of variantResults) {
+    if (settled.status === "rejected") {
+      const err = settled.reason as { message?: string } | undefined;
+      console.error(`Failed to generate variation: ${err?.message ?? err}`);
+      continue;
+    }
+    const { i, result } = settled.value;
+    if (outputPrefix) {
+      const filePath = `${outputPrefix}-v${i + 1}.png`;
+      writeFileSync(filePath, result.imageData);
+      generatedFiles.push(filePath);
+      console.log(
+        `Saved: ${filePath} (${Math.round(result.imageData.length / 1024)}KB)`,
+      );
+    } else {
+      const dataUrl = `data:${result.mimeType};base64,${result.imageData.toString("base64")}`;
+      console.log(`\nGenerated image ${i + 1}:`);
+      console.log(`  MIME type: ${result.mimeType}`);
+      console.log(`  Size: ${Math.round(result.imageData.length / 1024)}KB`);
+      console.log(
+        `  Data URL (first 100 chars): ${dataUrl.substring(0, 100)}...`,
+      );
     }
   }
 

--- a/templates/slides/package.json
+++ b/templates/slides/package.json
@@ -55,6 +55,7 @@
     "mermaid": "^11.14.0",
     "modern-screenshot": "^4.7.0",
     "nanoid": "^5.1.9",
+    "p-limit": "^7.3.0",
     "pdf-parse": "^2.4.5",
     "pptxgenjs": "4.0.1",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Why

The slides app routinely hits the agent's **75-second soft run timeout** (`packages/core/src/agent/run-manager.ts:32`) when the user asks the agent to generate a deck — the run aborts before the deck finishes and the user is left with a half-built thread.

The dominant cost on that path is image generation in `templates/slides/actions/generate-image.ts`:

1. **Reference-image fetches** loop one URL at a time, awaiting each fetch before the next.
2. **Variant generation** loops once per `--count`, awaiting the image provider sequentially. Gemini / OpenAI image calls regularly take 10–40 s each plus retry; three variants alone can blow the cap.

This PR is **Layer 1** of a layered timeout-mitigation plan agreed with Matt — a pure perf change, no schema, no infra, no new agent surface. Layer 3 (auto-continuation safety net for in-chat run timeouts that survives across function executions) will follow as a separate PR.

## What changed

### `templates/slides/actions/generate-image.ts`

- **Reference-image fetches** now run through `pLimit(4)` `Promise.all` with `AbortSignal.timeout(8000)` per request. A slow CDN can no longer wedge the whole action; failures fall through to a warning and the action continues with whatever loaded successfully (matches the old per-URL try/catch semantics, just in parallel).
- **Variant generation** is now `Promise.allSettled` + `pLimit(IMAGE_GEN_CONCURRENCY ?? 2)`:
  - `allSettled` so one bad variant doesn't kill the rest of the batch — matches the old `for`-loop's per-iteration `try { ... } catch` behaviour where each variant could fail independently.
  - Default concurrency is **2**, set conservatively because both Gemini's image API and OpenAI's image API have low TPM/RPM caps; ops can raise `IMAGE_GEN_CONCURRENCY` without redeploying if a given account has headroom.
  - `Math.max(1, Number(env) || 2)` clamps so an empty / garbage env value falls back to the default and a value of 0 doesn't deadlock the limiter.

### Dependencies

- Added `p-limit ^7.3.0` to `templates/slides/package.json`. Already a transitive dep of `@agent-native/core`, so no new external surface area.

## Expected impact

- **`generate-image --count 3`** before this PR: three serial provider calls back-to-back (each 10–40 s). After: 2 in flight, the third starts as soon as one finishes — roughly **half the wall time** at default concurrency.
- A single failing variant or unreachable reference URL no longer cancels the rest of the batch.

This doesn't eliminate the 75-second cap but it reclaims enough budget that typical deck-generation flows fit comfortably under it. The auto-continuation work in the follow-up PR will handle the cases where they still don't.

## Verification

- `pnpm typecheck` (slides template) — clean.
- `pnpm test actions/` — 22/22 pass.
- `npx prettier --write` on changed files — clean.
- `pnpm guards` — no new violations on the changed files. (The pre-existing `run-manager.spec.ts` env-credential hits and the `Sidebar.test.tsx` failures on `main` are both unrelated to this PR — verified by re-running both on `main`.)

## Test plan

- [ ] Generate a deck via the agent that previously hit `run_timeout`; confirm it now completes inside the 75s cap.
- [ ] `pnpm action generate-image --prompt foo --count 3 --output /tmp/imgtest` locally with `GEMINI_API_KEY` set; time before/after, confirm output files written and warnings still fire on failure.
- [ ] Run with `IMAGE_GEN_CONCURRENCY=1` and confirm sequential behaviour matches the old code path (sanity check the env knob).
- [ ] Deploy to a Netlify preview and run a 5-image deck via the UI; confirm no `run_timeout` event emitted.

## Out of scope

- The single-call `generate-slides-ai.ts` is not parallelized — it's one Gemini call. The framework-level improvement here is the existing slide-by-slide `add-slide` fanout pattern documented in `templates/slides/CLAUDE.md`, which is already correct.
- The PPTX export path (`export-pptx.ts`) was originally bundled in here but **reverted** — it's not on the deck-generation hot path the user is currently testing, so it doesn't belong in this PR. If/when export starts mattering, it'll get its own change.
- Auto-continuation when a run still does exceed the cap is the next PR in the plan.
- A generic background-job queue for jobs that genuinely take more than 75 s is deferred until the first two PRs' telemetry is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)