### PR TITLE
Fix Netlify auth CORS origin headers

### DIFF
--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -481,6 +481,7 @@ describe("server/auth", () => {
         path: "/_agent-native/auth/desktop-exchange",
         headers: { origin: "tauri://localhost" },
       });
+      delete event.node.req.headers.origin;
 
       const result = await corsHandler(event);
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -10,6 +10,7 @@ import {
   getCookie,
   setCookie,
   deleteCookie,
+  getHeader,
 } from "h3";
 import type { H3Event } from "h3";
 import type { H3AppShim } from "./framework-request-handler.js";
@@ -691,12 +692,7 @@ function applyCorsHeaders(event: H3Event): {
   // response would be missing the Allow-Origin header and the browser
   // blocks the response body (making it look like a network error
   // rather than "unauthenticated").
-  const reqHeaders = (event.node?.req?.headers ?? {}) as Record<
-    string,
-    string | string[] | undefined
-  >;
-  const originRaw = reqHeaders["origin"];
-  const origin = Array.isArray(originRaw) ? originRaw[0] : originRaw;
+  const origin = getHeader(event, "origin");
   if (!origin) return { hasOrigin: false, allowed: true };
   const allowedOrigin = getAllowedCorsOrigin(origin, {
     allowedOrigins: readCorsAllowedOrigins(),

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -304,12 +304,7 @@ export function createCoreRoutesPlugin(
             String(event.node?.req?.url ?? event.path ?? "/").split("?")[0],
         );
         if (!pathname.startsWith(P) && !pathname.startsWith("/api/")) return;
-        const reqHeaders = (event.node?.req?.headers ?? {}) as Record<
-          string,
-          string | string[] | undefined
-        >;
-        const originRaw = reqHeaders["origin"];
-        const origin = Array.isArray(originRaw) ? originRaw[0] : originRaw;
+        const origin = getHeader(event, "origin");
         const method = getMethod(event);
 
         // Decide whether this origin is allowed. We never fall back to the


### PR DESCRIPTION
## Summary
- read Origin via H3 getHeader instead of event.node.req.headers in auth/framework CORS middleware
- covers Netlify/H3 runtime shape where the web request headers are not mirrored onto node.req.headers
- keeps the previous Tauri auth CORS middleware fix, but makes it effective in production

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @agent-native/core test -- auth.spec.ts
- pnpm --filter clips typecheck

## Investigation
- PR #477 is deployed on agent-native-clips at commit 7488187, published 2026-05-04T17:50:36Z
- prod still emitted security headers but no CORS headers for any Origin, including http://localhost:1420
- local Netlify CLI link for templates/clips points to agent-native-starter, but DNS/API confirm prod site is agent-native-clips (7e3f4fee-258d-4d16-9aaf-154a714e87e2)