### PR TITLE
Fix slides PDF export: drop @vite-ignore on package dynamic imports

### DIFF
--- a/templates/slides/app/lib/export-pdf-client.ts
+++ b/templates/slides/app/lib/export-pdf-client.ts
@@ -72,8 +72,8 @@ export async function exportDeckAsPdf(
   // JPEG (vs PNG) keeps a typical 8-slide deck under ~10 MB instead of
   // ~100 MB — at 0.92 quality the difference is invisible on slide content.
   const [{ domToJpeg }, { jsPDF }] = await Promise.all([
-    import(/* @vite-ignore */ "modern-screenshot"),
-    import(/* @vite-ignore */ "jspdf"),
+    import("modern-screenshot"),
+    import("jspdf"),
   ]);
 
   // Web fonts (Poppins) must finish loading before capture — otherwise


### PR DESCRIPTION
## Bug

Production "Export to PDF" in slides fails immediately:

```
client-BuNwWvWM.js:1 [pdf-export] failed: TypeError: Failed to resolve module specifier 'modern-screenshot'
    at deck._id-CfnNFREx.js:22:50010
    at preload-helper-Bf_JiD2A.js:1:1163
    at async Promise.all (/deck/index 0)
    at async Ls (deck._id-CfnNFREx.js:22:49985)
    at async onExportPdf (deck._id-CfnNFREx.js:24:5755)
```

## Root cause

`templates/slides/app/lib/export-pdf-client.ts:75-76` carried `/* @vite-ignore */` on the dynamic imports of `modern-screenshot` and `jspdf`:

```ts
const [{ domToJpeg }, { jsPDF }] = await Promise.all([
  import(/* @vite-ignore */ "modern-screenshot"),
  import(/* @vite-ignore */ "jspdf"),
]);
```

`@vite-ignore` is the right escape hatch for **runtime-determined** import paths — `import(filePath)` where `filePath` is a variable Vite can't analyze. It's the **wrong** escape hatch for plain npm package names. With the comment, Vite leaves the literal bare specifier in the production bundle:

```js
// .output/public/assets/deck._id-AdYTvFwN.js (before fix)
[u]=await Promise.all([u(()=>import(`modern-screenshot`),[]),u(()=>import(`jspdf`),[])])
```

The browser's native ES module loader can't resolve `"modern-screenshot"` without an import map, and an `Uncaught (in promise) TypeError: Failed to resolve module specifier 'modern-screenshot'` falls out of `Promise.all` straight into `onExportPdf`'s `.catch`. That's exactly the user-visible stack.

The comment was introduced in commit `050ce849` (a 120-fix daily-branch bundle, no per-fix rationale). The original commit `6cfefa0b` that brought `modern-screenshot` into the codebase used plain `await import("modern-screenshot")` and worked correctly.

## Fix

Drop the comments so Vite processes the imports normally:

```diff
   const [{ domToJpeg }, { jsPDF }] = await Promise.all([
-    import(/* @vite-ignore */ "modern-screenshot"),
-    import(/* @vite-ignore */ "jspdf"),
+    import("modern-screenshot"),
+    import("jspdf"),
   ]);
```

Vite then code-splits both libs into hashed chunks (`./dist-X_GcgW-G.js` ≈ 26 KB for modern-screenshot, `./jspdf.es.min-BTakdwHV.js` ≈ 400 KB for jspdf) which the browser resolves via the deck route's `__vitePreload` helper. The bare-specifier reference disappears from the production bundle.

## Why removing it is safe

There were two plausible reasons the comment might have been load-bearing:

1. **SSR build error** — if `modern-screenshot` references browser-only globals at module top-level, `pnpm build` could fail when Vite crawls the SSR entry point. Tested: `pnpm build` is clean after removing the comments.
2. **Dev-only resolution issue** — handled by Vite's dep prebundling once the imports are visible to the analyzer.

Neither is in evidence; the comments simply blocked Vite from doing its job.

## Verification

- `pnpm typecheck` (slides) — clean.
- `pnpm build` (slides) — clean. No SSR error, no `[vite] warning: Cannot analyze dynamic import` warnings.
- Bundle inspection over `.output/public/assets/*.js`:
  - **Before:** 1 file (`deck._id-*.js`) contained `import(\`modern-screenshot\`)` and `import(\`jspdf\`)` as literal bare specifiers.
  - **After:** 0 files contain those bare-specifier imports. The deck-route chunk now contains `import(\`./dist-X_GcgW-G.js\`)` and `import(\`./jspdf.es.min-BTakdwHV.js\`)`.

## Test plan

- [ ] Deploy to a Netlify preview off this branch.
- [ ] Open any deck with images, click **Export → PDF**.
- [ ] Confirm: download starts, PDF opens, all slides rendered with correct aspect ratio and content.
- [ ] Repeat on a deck containing cross-origin images (CORS preload path) and a deck without images (clean fallback path).
- [ ] Browser console: no `Failed to resolve module specifier` errors.

Cannot complete the browser end-to-end here (no live deck + provider keys locally); preview deploy is the authoritative test.

## Out of scope

- `packages/core/src/client/settings/VoiceTranscriptionSection.tsx:837,913` — same `import(/* @vite-ignore */ "@tauri-apps/api/core")` pattern. **Likely** legitimate: that import is gated behind a runtime Tauri-detection check and `@tauri-apps/api/core` is only resolvable inside the desktop shell — different rationale, different code path. Not touched in this PR; should get its own once-over from someone who owns the desktop integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)