### PR TITLE
Fix Netlify auth session cookie proto

### DIFF
--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -794,6 +794,50 @@ describe("server/auth", () => {
       expect(event.res.headers.get("set-cookie")).toContain("mobile-token-abc");
     });
 
+    it("marks promoted cross-site session cookies secure on forwarded HTTPS requests", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      delete process.env.APP_URL;
+      delete process.env.BETTER_AUTH_URL;
+
+      const mockExecute = vi.fn().mockImplementation(({ sql, args }: any) => {
+        if (
+          typeof sql === "string" &&
+          sql.includes("SELECT") &&
+          args?.[0] === "desktop-token-abc"
+        ) {
+          return {
+            rows: [{ email: "user@gmail.com", created_at: Date.now() }],
+          };
+        }
+        return { rows: [] };
+      });
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => false,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+
+      const { getSession } = await import("./auth.js");
+      const event = createMockEvent({
+        query: { _session: "desktop-token-abc" },
+        headers: { "x-forwarded-proto": "https" },
+      });
+      // Netlify/H3 exposes headers through the web Request/H3 accessors, but
+      // not always through the legacy Node request object.
+      delete event.node.req.headers["x-forwarded-proto"];
+
+      expect(await getSession(event)).toEqual({
+        email: "user@gmail.com",
+        token: "desktop-token-abc",
+      });
+      const setCookie = event.res.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain("desktop-token-abc");
+      expect(setCookie).toContain("SameSite=None");
+      expect(setCookie).toContain("Secure");
+    });
+
     it("falls through to _session query param when custom getSession returns null", async () => {
       vi.stubEnv("NODE_ENV", "production");
       delete process.env.ACCESS_TOKEN;

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1049,20 +1049,11 @@ function setFrameworkSessionCookie(event: H3Event, token: string): void {
 
 function isHttpsRequest(event: H3Event): boolean {
   try {
-    const req: any = (event as any).req ?? event.node?.req;
-    const headers: any = req?.headers;
-    const get = (k: string): string | undefined => {
-      if (!headers) return undefined;
-      if (typeof headers.get === "function") {
-        return headers.get(k) ?? undefined;
-      }
-      const v = headers[k];
-      return Array.isArray(v) ? v[0] : v;
-    };
-    const xfProto = get("x-forwarded-proto");
+    const xfProto = getHeader(event, "x-forwarded-proto");
     if (xfProto && String(xfProto).split(",")[0].trim() === "https") {
       return true;
     }
+    const req: any = (event as any).req ?? event.node?.req;
     const url: string | undefined = req?.url;
     if (typeof url === "string" && url.startsWith("https://")) return true;
     const appUrl = process.env.APP_URL || process.env.BETTER_AUTH_URL || "";


### PR DESCRIPTION
## Summary
- use H3 getHeader() for x-forwarded-proto when deciding auth session cookie attributes
- keep cross-site desktop/Tauri session cookies as SameSite=None; Secure on Netlify/H3 runtime
- add a regression test for _session promotion when legacy event.node.req.headers is missing the forwarded proto

## Why
The previous CORS fix made the desktop OAuth exchange readable from the Tauri origin, but the follow-up session promotion could still emit a Lax/non-secure cookie on Netlify because HTTPS detection read event.node.req.headers directly. That matches the current symptom: browser says sign-in succeeded, desktop polls/continues, but the app remains logged out because the WebView never stores/sends the session cookie.

## Test plan
- pnpm --filter @agent-native/core test -- auth.spec.ts
- pnpm --filter clips typecheck