### PR TITLE
Slides Google Doc import + mail search ranking + composer paste fix

### DIFF
--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -819,22 +819,31 @@ export function TiptapComposer({
           "flex-1 resize-none bg-transparent text-sm text-foreground outline-none leading-[1.625rem] min-h-[3.25rem] max-h-[10rem] overflow-y-auto",
       },
       handlePaste: (_view, event) => {
+        const pastedText = event.clipboardData?.getData("text/plain") ?? "";
         const files = Array.from(event.clipboardData?.files ?? []).filter(
           (file) => file.type.startsWith("image/"),
         );
         if (files.length > 0) {
           event.preventDefault();
+          const attachments: File[] = files.map((file) => {
+            // SimpleImageAttachmentAdapter uses file.name as the attachment id.
+            // Clipboard images (e.g. screenshots) are typically all named
+            // "image.png", so a second paste would replace the first instead of
+            // appending. Prepend a unique token so each paste gets a distinct id.
+            const uniqueName = `${Date.now()}-${Math.random().toString(36).slice(2)}-${file.name}`;
+            return new File([file], uniqueName, { type: file.type });
+          });
+
+          // Google Docs rich clipboard payloads can contain both embedded
+          // image files and the document text. Since handling files means we
+          // prevent Tiptap's default paste, preserve any text as its own chip
+          // instead of silently dropping the source material.
+          if (pastedText.trim()) {
+            attachments.push(createPastedTextFile(pastedText));
+          }
+
           void Promise.all(
-            files.map((file) => {
-              // SimpleImageAttachmentAdapter uses file.name as the attachment id.
-              // Clipboard images (e.g. screenshots) are typically all named
-              // "image.png", so a second paste would replace the first instead of
-              // appending. Prepend a unique token so each paste gets a distinct id.
-              const uniqueName = `${Date.now()}-${Math.random().toString(36).slice(2)}-${file.name}`;
-              return composerRuntime.addAttachment(
-                new File([file], uniqueName, { type: file.type }),
-              );
-            }),
+            attachments.map((file) => composerRuntime.addAttachment(file)),
           ).catch((error) => {
             console.error("Error adding pasted attachment:", error);
           });
@@ -843,7 +852,6 @@ export function TiptapComposer({
 
         // Large text pastes turn into a `Pasted text` attachment chip so the
         // prompt stays readable. Matches Claude.ai / Claude Code's UX.
-        const pastedText = event.clipboardData?.getData("text/plain") ?? "";
         if (shouldConvertPasteToAttachment(pastedText)) {
           event.preventDefault();
           void composerRuntime

--- a/packages/core/src/client/integrations/IntegrationsPanel.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.tsx
@@ -193,6 +193,10 @@ function IntegrationDetail({
 
   const isConfigured = serverStatus?.configured ?? false;
   const isEnabled = serverStatus?.enabled ?? false;
+  const serviceAccountEmail =
+    typeof serverStatus?.details?.serviceAccountEmail === "string"
+      ? serverStatus.details.serviceAccountEmail
+      : null;
 
   return (
     <div>
@@ -235,6 +239,26 @@ function IntegrationDetail({
           ))}
         </ol>
       </div>
+
+      {serviceAccountEmail && (
+        <div className="mb-3">
+          <div className="text-[10px] font-medium text-muted-foreground mb-1">
+            Share documents with
+          </div>
+          <div className="flex items-center gap-1">
+            <code className="flex-1 truncate rounded bg-muted px-1.5 py-0.5 text-[10px] text-foreground">
+              {serviceAccountEmail}
+            </code>
+            <button
+              onClick={() => handleCopy(serviceAccountEmail)}
+              className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50"
+              title="Copy service account email"
+            >
+              {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Required secrets */}
       {platform.envVars.length > 0 && (

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -979,6 +979,13 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
           // and triggers a server restart when those files change.
           noExternal: [
             /^@agent-native\/core(\/.*)?$/,
+            // Radix UI primitives are transitive deps of @agent-native/core
+            // (used by FeedbackButton, AgentSidebar, ShareDialog, etc.). When
+            // a consumer app SSRs a component that imports Radix, Node's
+            // externalized resolver can't find @radix-ui/* from the app cwd
+            // because pnpm doesn't hoist transitive deps. Bundling them
+            // through Vite resolves them via the workspace store.
+            /^@radix-ui\//,
             // scheduling ships tsc-compiled dist files that contain literal
             // `@/` path-alias imports (e.g. `import { Input } from
             // "@/components/ui/input"`). In standalone (published) mode Node

--- a/packages/docs/app/components/Header.tsx
+++ b/packages/docs/app/components/Header.tsx
@@ -75,8 +75,6 @@ export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const isHome = useLocation().pathname === "/";
   const [scrolled, setScrolled] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
 
   useEffect(() => {
     if (!isHome) return;
@@ -133,7 +131,7 @@ export default function Header() {
           </Link>
 
           {/* Desktop nav links */}
-          <div className="hidden sm:flex items-center gap-5 text-sm">
+          <div className="hidden lg:flex items-center gap-5 text-sm">
             <NavLink
               prefetch="render"
               to="/docs"
@@ -186,14 +184,12 @@ export default function Header() {
           </div>
 
           <div className="ml-auto flex items-center gap-3">
-            {mounted && (
-              <FeedbackButton
-                variant="outlined"
-                className="hidden sm:flex border-[var(--docs-border)] text-[var(--fg-secondary)] hover:border-[var(--fg-secondary)] hover:text-[var(--fg)]"
-                align="end"
-                side="bottom"
-              />
-            )}
+            <FeedbackButton
+              variant="outlined"
+              className="hidden lg:flex border-[var(--docs-border)] text-[var(--fg-secondary)] hover:border-[var(--fg-secondary)] hover:text-[var(--fg)]"
+              align="end"
+              side="bottom"
+            />
             <SearchTrigger onClick={() => setOpen(true)} />
             <ThemeToggle />
             <button

--- a/packages/docs/app/components/Header.tsx
+++ b/packages/docs/app/components/Header.tsx
@@ -206,7 +206,7 @@ export default function Header() {
             {/* Mobile hamburger */}
             <button
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              className="sm:hidden flex items-center justify-center w-8 h-8 text-[var(--fg-secondary)] hover:text-[var(--fg)] transition"
+              className="lg:hidden flex items-center justify-center w-8 h-8 text-[var(--fg-secondary)] hover:text-[var(--fg)] transition"
               aria-label="Toggle navigation menu"
               aria-expanded={mobileMenuOpen}
             >
@@ -217,7 +217,7 @@ export default function Header() {
 
         {/* Mobile dropdown menu */}
         {mobileMenuOpen && (
-          <div className="sm:hidden border-t border-[var(--docs-border)] bg-[var(--header-bg)] backdrop-blur-lg px-6 py-4 flex flex-col gap-4">
+          <div className="lg:hidden border-t border-[var(--docs-border)] bg-[var(--header-bg)] backdrop-blur-lg px-6 py-4 flex flex-col gap-4">
             <NavLink
               prefetch="render"
               to="/docs"
@@ -270,6 +270,12 @@ export default function Header() {
                 ↗
               </span>
             </a>
+            <FeedbackButton
+              variant="outlined"
+              className="self-start border-[var(--docs-border)] text-[var(--fg-secondary)] hover:border-[var(--fg-secondary)] hover:text-[var(--fg)]"
+              align="start"
+              side="bottom"
+            />
           </div>
         )}
       </header>

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -86,6 +86,9 @@
   --table-header-bg: #fafafa;
   --sidebar-hover: #f5f5f5;
   --selection: rgba(0, 114, 245, 0.15);
+  --approaches-good: #15803d;
+  --approaches-warn: #b45309;
+  --approaches-bad: #b91c1c;
 }
 
 :root[data-theme="dark"] {
@@ -102,6 +105,9 @@
   --table-header-bg: #0a0a0a;
   --sidebar-hover: #111;
   --selection: rgba(82, 168, 255, 0.2);
+  --approaches-good: #86efac;
+  --approaches-warn: #fcd34d;
+  --approaches-bad: #fca5a5;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -119,6 +125,9 @@
     --table-header-bg: #0a0a0a;
     --sidebar-hover: #111;
     --selection: rgba(82, 168, 255, 0.2);
+    --approaches-good: #86efac;
+    --approaches-warn: #fcd34d;
+    --approaches-bad: #fca5a5;
   }
 }
 
@@ -605,15 +614,15 @@ html.dark .shiki span {
 }
 
 .approaches-td--good {
-  color: #86efac;
+  color: var(--approaches-good);
 }
 
 .approaches-td--warn {
-  color: #fcd34d;
+  color: var(--approaches-warn);
 }
 
 .approaches-td--bad {
-  color: #fca5a5;
+  color: var(--approaches-bad);
 }
 
 .approaches-solution {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -21,6 +21,8 @@
   },
   "dependencies": {
     "@agent-native/core": "workspace:*",
+    "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@react-router/dev": "^7.6.1",
     "@react-router/fs-routes": "^7.6.1",
     "@tabler/icons-react": "^3.40.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,6 +397,12 @@ importers:
       '@agent-native/core':
         specifier: workspace:*
         version: link:../core
+      '@radix-ui/react-popover':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@react-router/dev':
         specifier: ^7.6.1
         version: 7.14.0(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.1)(tsx@4.21.0)(typescript@6.0.3)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(wrangler@4.81.0)(yaml@2.8.3)
@@ -18193,6 +18199,12 @@ snapshots:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@floating-ui/react-dom@2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@floating-ui/dom': 1.7.6
@@ -19063,6 +19075,15 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -19181,6 +19202,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       react: 19.2.5
@@ -19209,6 +19236,12 @@ snapshots:
   '@radix-ui/react-context@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -19257,6 +19290,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -19304,6 +19350,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       react: 19.2.5
@@ -19317,6 +19369,17 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19373,6 +19436,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -19503,6 +19573,29 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -19567,6 +19660,24 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -19591,6 +19702,16 @@ snapshots:
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19623,6 +19744,16 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
@@ -19645,6 +19776,15 @@ snapshots:
       '@radix-ui/react-slot': 1.1.2(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -19833,6 +19973,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
@@ -19953,6 +20100,26 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -19984,6 +20151,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       react: 19.2.5
@@ -20003,11 +20176,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -20022,6 +20210,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -20050,6 +20245,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       react: 19.2.5
@@ -20069,6 +20270,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/rect': 1.1.1
@@ -20083,12 +20291,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       react: 19.2.5
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -27416,11 +27640,30 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       react: 19.2.5
       react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
       tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -27455,6 +27698,14 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.5(react@19.2.5)
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:
@@ -28636,6 +28887,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -28667,6 +28925,14 @@ snapshots:
     dependencies:
       react: 19.2.5
       use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
 

--- a/templates/mail/server/lib/google-auth.spec.ts
+++ b/templates/mail/server/lib/google-auth.spec.ts
@@ -117,8 +117,24 @@ describe("listGmailMessages", () => {
       historyId: String(index + 1),
     }));
     threads[59] = { id: "thread-slack-marketplace", historyId: "999" };
+    const candidateMetadata = threads.map((thread, index) => ({
+      id: thread.id,
+      data: {
+        messages: [
+          {
+            id: `meta-${thread.id}`,
+            threadId: thread.id,
+            internalDate:
+              thread.id === "thread-slack-marketplace"
+                ? "999"
+                : String(index + 1),
+          },
+        ],
+      },
+    }));
     vi.mocked(gmailListThreads).mockResolvedValue({ threads } as any);
     vi.mocked(gmailBatchGetThreads)
+      .mockResolvedValueOnce(candidateMetadata as any)
       .mockResolvedValueOnce([
         {
           id: "thread-slack-marketplace",
@@ -167,7 +183,14 @@ describe("listGmailMessages", () => {
       maxResults: 100,
       pageToken: undefined,
     });
-    expect(gmailBatchGetThreads).toHaveBeenCalledWith(
+    expect(gmailBatchGetThreads).toHaveBeenNthCalledWith(
+      1,
+      "access-token",
+      threads.map((thread) => thread.id),
+      "metadata",
+    );
+    expect(gmailBatchGetThreads).toHaveBeenNthCalledWith(
+      2,
       "access-token",
       ["thread-slack-marketplace", "thread-59"],
       "full",
@@ -194,6 +217,77 @@ describe("listGmailMessages", () => {
       "full",
     );
     expect(nextResult.messages.map((m) => m.id)).toEqual(["next-a", "next-b"]);
+  });
+
+  it("ranks search candidates by latest message time instead of history mutations", async () => {
+    const threads = [
+      { id: "old-label-touched", historyId: "9999" },
+      { id: "recent-message", historyId: "1" },
+    ];
+    vi.mocked(gmailListThreads).mockResolvedValue({ threads } as any);
+    vi.mocked(gmailBatchGetThreads)
+      .mockResolvedValueOnce([
+        {
+          id: "old-label-touched",
+          data: {
+            messages: [
+              {
+                id: "old-meta",
+                threadId: "old-label-touched",
+                internalDate: "100",
+              },
+            ],
+          },
+        },
+        {
+          id: "recent-message",
+          data: {
+            messages: [
+              {
+                id: "recent-meta",
+                threadId: "recent-message",
+                internalDate: "900",
+              },
+            ],
+          },
+        },
+      ] as any)
+      .mockResolvedValueOnce([
+        {
+          id: "recent-message",
+          data: {
+            messages: [
+              {
+                id: "recent-full",
+                threadId: "recent-message",
+                internalDate: "900",
+              },
+            ],
+          },
+        },
+      ] as any);
+
+    const result = await listGmailMessages(
+      "slack-history-mismatch",
+      1,
+      "owner@example.com",
+      undefined,
+      { mode: "threads", threadCandidateLimit: 100 },
+    );
+
+    expect(gmailBatchGetThreads).toHaveBeenNthCalledWith(
+      1,
+      "access-token",
+      ["old-label-touched", "recent-message"],
+      "metadata",
+    );
+    expect(gmailBatchGetThreads).toHaveBeenNthCalledWith(
+      2,
+      "access-token",
+      ["recent-message"],
+      "full",
+    );
+    expect(result.messages.map((m) => m.id)).toEqual(["recent-full"]);
   });
 
   it("refills missing thread batch parts before returning search results", async () => {

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -488,9 +488,9 @@ type ListOptions = {
   /**
    * Search result order from threads.list is not enough to mimic Gmail's UI:
    * an old thread can match because its first message has the search term,
-   * while the thread itself was modified recently. Listing a wider candidate
-   * window is cheap (thread IDs only); we then hydrate the most recently
-   * modified candidates.
+   * while the thread itself has a newer reply. Listing a wider candidate
+   * window is cheap (thread IDs only); we then hydrate metadata and rank by
+   * each thread's newest message time, which is what Gmail visibly sorts by.
    */
   threadCandidateLimit?: number;
 };
@@ -608,6 +608,102 @@ async function storeThreadCandidatePage(
   };
   await writeThreadCandidatePageStore(ownerEmail, pages);
   return key;
+}
+
+function latestThreadMessageTime(thread: any): number {
+  let latest = 0;
+  for (const message of thread?.messages || []) {
+    const internalDate = Number(message.internalDate || 0);
+    if (Number.isFinite(internalDate) && internalDate > latest) {
+      latest = internalDate;
+    }
+
+    const headerDate = Date.parse(
+      getHeader(message.payload?.headers || [], "Date"),
+    );
+    if (Number.isFinite(headerDate) && headerDate > latest) {
+      latest = headerDate;
+    }
+  }
+  return latest;
+}
+
+async function fetchThreadBatchWithRefill(
+  accessToken: string,
+  threadIds: string[],
+  format: "full" | "metadata" | "minimal",
+): Promise<Array<{ id: string; data: any | null; error?: string }>> {
+  const batchResults = await gmailBatchGetThreads(
+    accessToken,
+    threadIds,
+    format,
+  );
+
+  // A missing thread part should not make search look incomplete when an
+  // individual retry can recover it.
+  const missing = batchResults.filter((r) => !r.data).map((r) => r.id);
+  if (missing.length > 0) {
+    const refills = await Promise.all(
+      missing.map(async (id) => {
+        try {
+          const data = await gmailGetThread(accessToken, id, format);
+          return { id, data };
+        } catch {
+          return { id, data: null as any };
+        }
+      }),
+    );
+    const byId = new Map(refills.map((r) => [r.id, r.data]));
+    for (const r of batchResults) {
+      if (!r.data && byId.has(r.id)) r.data = byId.get(r.id);
+    }
+  }
+
+  return batchResults;
+}
+
+function messagesFromThreadBatchResults(
+  batchResults: Array<{ id: string; data: any | null; error?: string }>,
+  email: string,
+): any[] {
+  const messages: any[] = [];
+  for (const r of batchResults) {
+    for (const message of r.data?.messages || []) {
+      messages.push({ ...message, _accountEmail: email });
+    }
+  }
+  return messages;
+}
+
+async function rankThreadCandidatesByLatestMessage(
+  accessToken: string,
+  candidateIds: string[],
+): Promise<{
+  ids: string[];
+  metadataById: Map<string, any>;
+}> {
+  const originalIndex = new Map(
+    candidateIds.map((id, index) => [id, index] as const),
+  );
+  const batchResults = await fetchThreadBatchWithRefill(
+    accessToken,
+    candidateIds,
+    "metadata",
+  );
+  const metadataById = new Map<string, any>();
+  for (const result of batchResults) {
+    if (result.data) metadataById.set(result.id, result.data);
+  }
+
+  const ids = [...candidateIds].sort((a, b) => {
+    const diff =
+      latestThreadMessageTime(metadataById.get(b)) -
+      latestThreadMessageTime(metadataById.get(a));
+    if (diff !== 0) return diff;
+    return (originalIndex.get(a) ?? 0) - (originalIndex.get(b) ?? 0);
+  });
+
+  return { ids, metadataById };
 }
 
 function listCacheKey(
@@ -1213,19 +1309,17 @@ async function fetchAccountThreads(
   onEstimate(listRes.resultSizeEstimate || 0);
 
   const threadStubs = listRes.threads || [];
-  if (useCandidateWindow && threadStubs.some((t: any) => t.historyId)) {
-    threadStubs.sort((a: any, b: any) => {
-      try {
-        const ah = BigInt(a.historyId || 0);
-        const bh = BigInt(b.historyId || 0);
-        return ah === bh ? 0 : ah > bh ? -1 : 1;
-      } catch {
-        return Number(b.historyId || 0) - Number(a.historyId || 0);
-      }
-    });
+  let candidateIds = threadStubs.map((t: any) => t.id).filter(Boolean);
+  let candidateMetadataById: Map<string, any> | undefined;
+  if (useCandidateWindow && candidateIds.length > maxResults) {
+    const ranked = await rankThreadCandidatesByLatestMessage(
+      accessToken,
+      candidateIds,
+    );
+    candidateIds = ranked.ids;
+    candidateMetadataById = ranked.metadataById;
   }
 
-  const candidateIds = threadStubs.map((t: any) => t.id).filter(Boolean);
   const threadIds = candidateIds.slice(0, maxResults);
   if (threadIds.length === 0) return [];
 
@@ -1241,6 +1335,16 @@ async function fetchAccountThreads(
     onNextPageToken(listRes.nextPageToken);
   }
 
+  if (format === "metadata" && candidateMetadataById) {
+    return messagesFromThreadBatchResults(
+      threadIds.map((id) => ({
+        id,
+        data: candidateMetadataById.get(id) ?? null,
+      })),
+      email,
+    );
+  }
+
   return fetchThreadMessagesForIds(accessToken, email, threadIds, format);
 }
 
@@ -1251,40 +1355,12 @@ async function fetchThreadMessagesForIds(
   format: "full" | "metadata" | "minimal",
 ): Promise<any[]> {
   if (threadIds.length === 0) return [];
-
-  const batchResults = await gmailBatchGetThreads(
+  const batchResults = await fetchThreadBatchWithRefill(
     accessToken,
     threadIds,
     format,
   );
-
-  // Same partial-batch guard as messages: a missing thread part should not
-  // make search look incomplete when an individual retry can recover it.
-  const missing = batchResults.filter((r) => !r.data).map((r) => r.id);
-  if (missing.length > 0) {
-    const refills = await Promise.all(
-      missing.map(async (id) => {
-        try {
-          const data = await gmailGetThread(accessToken, id, format);
-          return { id, data };
-        } catch {
-          return { id, data: null as any };
-        }
-      }),
-    );
-    const byId = new Map(refills.map((r) => [r.id, r.data]));
-    for (const r of batchResults) {
-      if (!r.data && byId.has(r.id)) r.data = byId.get(r.id);
-    }
-  }
-
-  const messages: any[] = [];
-  for (const r of batchResults) {
-    for (const message of r.data?.messages || []) {
-      messages.push({ ...message, _accountEmail: email });
-    }
-  }
-  return messages;
+  return messagesFromThreadBatchResults(batchResults, email);
 }
 
 async function listGmailMessagesUncached(

--- a/templates/slides/.agents/skills/create-deck/SKILL.md
+++ b/templates/slides/.agents/skills/create-deck/SKILL.md
@@ -13,6 +13,11 @@ description: How to create a new deck with slides from scratch. Read this before
 2. Call `create-deck` action with all slides in one shot
 3. Navigate to the new deck
 
+If the user provides a Google Docs URL as source material, call
+`import-google-doc --url <url>` first and build from the returned text. If the
+action cannot read a private document, relay its sharing instructions instead
+of generating from the URL alone.
+
 ```bash
 pnpm action create-deck --title "My Deck" --slides '[
   { "id": "slide-1", "layout": "title", "content": "..." },

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -290,14 +290,17 @@ When generating slides for a deck that has a design system, **always use the des
 
 ### Import / Export
 
-| Action           | Args                                           | Purpose                           |
-| ---------------- | ---------------------------------------------- | --------------------------------- |
-| `import-file`    | `--filePath <path> [--format auto] [--deckId]` | Import PPTX/DOCX/PDF to deck      |
-| `import-pptx`    | `--filePath <path> [--deckId] [--title]`       | Direct PPTX import to deck        |
-| `import-docx`    | `--filePath <path>`                            | Extract DOCX content for slides   |
-| `export-pptx`    | `--deckId <id> [--includeNotes]`               | Export deck as PowerPoint         |
-| `export-html`    | `--deckId <id>`                                | Export as standalone HTML         |
-| `duplicate-deck` | `--deckId <id> [--title]`                      | Create a copy of an existing deck |
+| Action              | Args                                              | Purpose                             |
+| ------------------- | ------------------------------------------------- | ----------------------------------- |
+| `import-file`       | `--filePath <path> [--format auto] [--deckId]`    | Import PPTX/DOCX/PDF to deck        |
+| `import-google-doc` | `--url <google-doc-url-or-id> [--maxChars 60000]` | Extract text from a Google Doc link |
+| `import-pptx`       | `--filePath <path> [--deckId] [--title]`          | Direct PPTX import to deck          |
+| `import-docx`       | `--filePath <path>`                               | Extract DOCX content for slides     |
+| `export-pptx`       | `--deckId <id> [--includeNotes]`                  | Export deck as PowerPoint           |
+| `export-html`       | `--deckId <id>`                                   | Export as standalone HTML           |
+| `duplicate-deck`    | `--deckId <id> [--title]`                         | Create a copy of an existing deck   |
+
+If the user provides a Google Docs URL while asking for a deck, call `import-google-doc` before creating slides. Use the returned `text` as source material. If the action cannot read a private doc, relay its sharing instruction (usually share with the configured service account email or make the link viewable) and do not invent slides from the URL alone.
 
 ### Sharing
 
@@ -347,6 +350,7 @@ Same rule for `/deck/<id>/present` (presentation mode), `/share/<token>` (share 
 | "Open deck abc123"                    | `pnpm action navigate --deckId=abc123`                                                                                    |
 | "Go to the deck list"                 | `pnpm action navigate --view=list`                                                                                        |
 | "Find the company logo for X"         | `pnpm action logo-lookup --domain x.com`                                                                                  |
+| "Create a deck from this Google Doc"  | `import-google-doc --url <url>` first, then build slides from the returned text                                           |
 | "Import a PPTX file"                  | Upload file, then `import-pptx --filePath <path>`                                                                         |
 | "Export this deck as PowerPoint"      | `export-pptx --deckId <id>`                                                                                               |
 | "Set up brand identity"               | `analyze-brand-assets --websiteUrl "..."` then use results to `create-design-system`                                      |

--- a/templates/slides/actions/import-google-doc.test.ts
+++ b/templates/slides/actions/import-google-doc.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractGoogleDocId,
+  extractGoogleDocUrls,
+  normalizeGoogleDocText,
+} from "../shared/google-docs";
+
+describe("import-google-doc helpers", () => {
+  it("extracts document IDs from standard Google Docs URLs", () => {
+    expect(
+      extractGoogleDocId(
+        "https://docs.google.com/document/d/1SnfJv9xjLG558fcfDG6Hj-WhWaOxo7bImMJGmIvWvSk/edit?pli=1&tab=t.0",
+      ),
+    ).toBe("1SnfJv9xjLG558fcfDG6Hj-WhWaOxo7bImMJGmIvWvSk");
+  });
+
+  it("accepts raw document IDs", () => {
+    expect(
+      extractGoogleDocId("1SnfJv9xjLG558fcfDG6Hj-WhWaOxo7bImMJGmIvWvSk"),
+    ).toBe("1SnfJv9xjLG558fcfDG6Hj-WhWaOxo7bImMJGmIvWvSk");
+  });
+
+  it("rejects non-Google URLs", () => {
+    expect(
+      extractGoogleDocId("https://example.com/document/d/not-a-doc"),
+    ).toBeNull();
+  });
+
+  it("extracts Google Docs URLs from pasted prose", () => {
+    expect(
+      extractGoogleDocUrls(
+        "Please use https://docs.google.com/document/d/1SnfJv9xjLG558fcfDG6Hj-WhWaOxo7bImMJGmIvWvSk/edit?tab=t.0.",
+      ),
+    ).toEqual([
+      "https://docs.google.com/document/d/1SnfJv9xjLG558fcfDG6Hj-WhWaOxo7bImMJGmIvWvSk/edit?tab=t.0",
+    ]);
+  });
+
+  it("normalizes exported document text", () => {
+    expect(normalizeGoogleDocText("A\r\nB\t \n\n\u0000C\n")).toBe("A\nB\n\nC");
+  });
+});

--- a/templates/slides/actions/import-google-doc.ts
+++ b/templates/slides/actions/import-google-doc.ts
@@ -1,0 +1,222 @@
+import fs from "node:fs";
+import crypto from "node:crypto";
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import {
+  extractGoogleDocId,
+  normalizeGoogleDocText,
+} from "../shared/google-docs.js";
+
+const DEFAULT_MAX_CHARS = 60_000;
+
+interface ServiceAccountKey {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+interface AccessTokenResult {
+  token: string;
+  serviceAccountEmail: string;
+}
+
+class GoogleDocAccessError extends Error {}
+
+function parseServiceAccountKey(): ServiceAccountKey | null {
+  const raw = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw) as ServiceAccountKey;
+  } catch {
+    try {
+      return JSON.parse(fs.readFileSync(raw, "utf-8")) as ServiceAccountKey;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+async function getServiceAccountAccessToken(): Promise<AccessTokenResult | null> {
+  const key = parseServiceAccountKey();
+  if (!key?.client_email || !key.private_key) return null;
+
+  const now = Math.floor(Date.now() / 1000);
+  const unsigned = [
+    base64UrlJson({ alg: "RS256", typ: "JWT" }),
+    base64UrlJson({
+      iss: key.client_email,
+      scope: "https://www.googleapis.com/auth/drive.readonly",
+      aud: key.token_uri || "https://oauth2.googleapis.com/token",
+      iat: now,
+      exp: now + 3600,
+    }),
+  ].join(".");
+
+  const signer = crypto.createSign("RSA-SHA256");
+  signer.update(unsigned);
+  const jwt = `${unsigned}.${signer.sign(key.private_key, "base64url")}`;
+
+  const response = await fetchWithTimeout(
+    "https://oauth2.googleapis.com/token",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: jwt,
+      }),
+    },
+  );
+
+  if (!response.ok) return null;
+  const data = (await response.json()) as { access_token?: string };
+  if (!data.access_token) return null;
+
+  return {
+    token: data.access_token,
+    serviceAccountEmail: key.client_email,
+  };
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 20_000);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function isGoogleHtmlAccessPage(text: string, contentType: string | null) {
+  const sample = text.slice(0, 2000).toLowerCase();
+  return (
+    contentType?.toLowerCase().includes("text/html") ||
+    sample.includes("<html") ||
+    sample.includes("<!doctype html")
+  );
+}
+
+async function readExportText(response: Response): Promise<string> {
+  const text = await response.text();
+  if (!response.ok) {
+    throw new GoogleDocAccessError(
+      `Google returned HTTP ${response.status} while exporting the document.`,
+    );
+  }
+  if (isGoogleHtmlAccessPage(text, response.headers.get("content-type"))) {
+    throw new GoogleDocAccessError(
+      "Google returned a sign-in or access page instead of document text.",
+    );
+  }
+  const normalized = normalizeGoogleDocText(text);
+  if (!normalized) {
+    throw new GoogleDocAccessError("Google returned an empty document export.");
+  }
+  return normalized;
+}
+
+async function exportWithServiceAccount(
+  documentId: string,
+  token: string,
+): Promise<string> {
+  const params = new URLSearchParams({ mimeType: "text/plain" });
+  const response = await fetchWithTimeout(
+    `https://www.googleapis.com/drive/v3/files/${documentId}/export?${params}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return readExportText(response);
+}
+
+async function exportPublicDocument(documentId: string): Promise<string> {
+  const response = await fetchWithTimeout(
+    `https://docs.google.com/document/d/${documentId}/export?format=txt`,
+  );
+  return readExportText(response);
+}
+
+export default defineAction({
+  description:
+    "Import plain text from a Google Docs document URL or document ID. " +
+    "Works for public Docs links, and for private Docs shared with the " +
+    "configured GOOGLE_SERVICE_ACCOUNT_KEY service account.",
+  schema: z.object({
+    url: z.string().describe("Google Docs URL or raw document ID"),
+    maxChars: z.coerce
+      .number()
+      .int()
+      .min(1000)
+      .max(100_000)
+      .optional()
+      .describe("Maximum characters to return (default 60000)"),
+  }),
+  readOnly: true,
+  http: { method: "GET" },
+  run: async ({ url, maxChars }) => {
+    const documentId = extractGoogleDocId(url);
+    if (!documentId) {
+      throw new Error("That does not look like a Google Docs document URL.");
+    }
+
+    const limit = maxChars ?? DEFAULT_MAX_CHARS;
+    const errors: string[] = [];
+    let serviceAccount: AccessTokenResult | null = null;
+    try {
+      serviceAccount = await getServiceAccountAccessToken();
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    }
+
+    let text: string | null = null;
+    let source: "service-account" | "public-export" | null = null;
+
+    if (serviceAccount) {
+      try {
+        text = await exportWithServiceAccount(documentId, serviceAccount.token);
+        source = "service-account";
+      } catch (error) {
+        errors.push(error instanceof Error ? error.message : String(error));
+      }
+    }
+
+    if (!text) {
+      try {
+        text = await exportPublicDocument(documentId);
+        source = "public-export";
+      } catch (error) {
+        errors.push(error instanceof Error ? error.message : String(error));
+      }
+    }
+
+    if (!text || !source) {
+      const shareTarget = serviceAccount?.serviceAccountEmail;
+      const shareHint = shareTarget
+        ? `Share the document with ${shareTarget}, or set the link to "Anyone with the link can view", then try again.`
+        : 'Set GOOGLE_SERVICE_ACCOUNT_KEY so private Docs can be shared with the service account, set the link to "Anyone with the link can view", or upload an exported .docx file.';
+      throw new Error(
+        `Could not read that Google Doc. ${shareHint} ${errors.join(" ")}`,
+      );
+    }
+
+    const truncated = text.length > limit;
+    return {
+      documentId,
+      source,
+      text: truncated ? text.slice(0, limit) : text,
+      charCount: text.length,
+      truncated,
+      serviceAccountEmail: serviceAccount?.serviceAccountEmail,
+      note: truncated
+        ? `Returned the first ${limit} characters. Ask for a higher maxChars value if more context is needed.`
+        : undefined,
+    };
+  },
+});

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -26,6 +26,7 @@ import {
   type CollabUser,
   useAvatarUrl,
 } from "@agent-native/core/client";
+import { extractGoogleDocUrls } from "@shared/google-docs";
 import { ToolsSidebarSection } from "@agent-native/core/client/tools";
 import {
   Tooltip,
@@ -45,6 +46,21 @@ interface EditorSidebarProps {
   slidePresence?: Map<string, CollabUser[]>;
   /** Deck aspect ratio (defaults to 16:9 when omitted) */
   aspectRatio?: AspectRatio;
+}
+
+const MAX_SOURCE_CONTEXT_CHARS = 60_000;
+
+function truncateSourceForContext(prompt: string): {
+  text: string;
+  truncated: boolean;
+} {
+  if (prompt.length <= MAX_SOURCE_CONTEXT_CHARS) {
+    return { text: prompt, truncated: false };
+  }
+  return {
+    text: prompt.slice(0, MAX_SOURCE_CONTEXT_CHARS),
+    truncated: true,
+  };
 }
 
 /** Small presence avatar circle with hover card showing name + email */
@@ -288,20 +304,37 @@ function AddSlidePopover({
       }
 
       const description = text.trim() || "a new slide";
+      const sourceForContext = truncateSourceForContext(description);
+      const googleDocUrls = extractGoogleDocUrls(text);
       const fileContext =
         uploaded.length > 0
           ? `\n\nThe user uploaded ${uploaded.length} file(s) for context:\n${uploaded.map((f) => `- ${f.originalName} (${f.type}, ${(f.size / 1024).toFixed(1)}KB) at path: ${f.path}`).join("\n")}`
           : "";
+      const googleDocContext =
+        googleDocUrls.length > 0
+          ? [
+              "",
+              "The request includes Google Docs URL(s):",
+              ...googleDocUrls.map((url) => `- ${url}`),
+              "Before adding slides, call `import-google-doc` for each URL and use the returned text as source material.",
+              "If the action cannot read a private document, tell the user the exact sharing step from the action error instead of generating from the URL alone.",
+            ].join("\n")
+          : "";
       const context = [
         `Add a new slide to deck "${deckTitle}" (id: ${deckId}).`,
         `Insert after slide ${activeSlideIndex + 1} of ${slideCount} (active slide id: ${activeSlideId}).`,
-        `User request: "${description}"`,
+        "The text below is the user's request and/or pasted source material for the new slide(s). Treat pasted memo content as source material even if the user did not explicitly say they are pasting it.",
+        `User request / source material:\n${sourceForContext.text}`,
+        sourceForContext.truncated
+          ? `The pasted source was longer than ${MAX_SOURCE_CONTEXT_CHARS} characters, so only the first ${MAX_SOURCE_CONTEXT_CHARS} characters were included to keep the agent request reliable.`
+          : "",
+        googleDocContext,
         fileContext,
         "",
         "Create the slide content and insert it at the correct position using the app's slide data structure.",
       ].join("\n");
 
-      agentSubmit(`Add slide: ${description}`, context);
+      agentSubmit(`Add slide: ${summarizePromptForChat(description)}`, context);
       onOpenChange(false);
     },
     [
@@ -345,6 +378,13 @@ function AddSlidePopover({
     </div>,
     document.body,
   );
+}
+
+function summarizePromptForChat(prompt: string): string {
+  const singleLine = prompt.trim().replace(/\s+/g, " ");
+  if (!singleLine) return "a new slide";
+  if (singleLine.length <= 180) return singleLine;
+  return `${singleLine.slice(0, 177)}...`;
 }
 
 export default function EditorSidebar({

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -12,6 +12,7 @@ import {
   useSetPageTitle,
 } from "@/components/layout/HeaderActions";
 import { agentNativePath } from "@agent-native/core/client";
+import { extractGoogleDocUrls } from "@shared/google-docs";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -24,6 +25,28 @@ import {
 } from "@/components/ui/alert-dialog";
 
 import { Button } from "@/components/ui/button";
+
+const MAX_SOURCE_CONTEXT_CHARS = 60_000;
+
+function summarizePromptForChat(prompt: string): string {
+  const singleLine = prompt.trim().replace(/\s+/g, " ");
+  if (!singleLine) return "new deck";
+  if (singleLine.length <= 180) return singleLine;
+  return `${singleLine.slice(0, 177)}...`;
+}
+
+function truncateSourceForContext(prompt: string): {
+  text: string;
+  truncated: boolean;
+} {
+  if (prompt.length <= MAX_SOURCE_CONTEXT_CHARS) {
+    return { text: prompt, truncated: false };
+  }
+  return {
+    text: prompt.slice(0, MAX_SOURCE_CONTEXT_CHARS),
+    truncated: true,
+  };
+}
 
 export default function Index() {
   const { decks, createDeck, deleteDeck, updateDeck, loading } = useDecks();
@@ -61,14 +84,34 @@ export default function Index() {
     });
     if (!deck) return;
 
+    const trimmedPrompt = prompt.trim();
+    const sourceForContext = truncateSourceForContext(trimmedPrompt);
+    const googleDocUrls = extractGoogleDocUrls(trimmedPrompt);
     const fileContext =
       files.length > 0
         ? `\n\nThe user uploaded ${files.length} file(s) for context:\n${files.map((f) => `- ${f.originalName} (${f.type}, ${(f.size / 1024).toFixed(1)}KB) at path: ${f.path}`).join("\n")}`
         : "";
+    const googleDocContext =
+      googleDocUrls.length > 0
+        ? [
+            "",
+            "The request includes Google Docs URL(s):",
+            ...googleDocUrls.map((url) => `- ${url}`),
+            "Before adding slides, call `import-google-doc` for each URL and use the returned text as source material.",
+            "If the action cannot read a private document, tell the user the exact sharing step from the action error instead of generating from the URL alone.",
+          ].join("\n")
+        : "";
 
     const context = [
       `The user just created a new empty deck (id: "${deck.id}") and wants to fill it with slides.`,
-      `User request: "${prompt}"`,
+      "The text below is the user's request and/or pasted source material for the deck. Treat pasted memo content as source material even if the user did not explicitly say they are pasting it.",
+      trimmedPrompt
+        ? `User request / source material:\n${sourceForContext.text}`
+        : "User request / source material: create a new deck.",
+      sourceForContext.truncated
+        ? `The pasted source was longer than ${MAX_SOURCE_CONTEXT_CHARS} characters, so only the first ${MAX_SOURCE_CONTEXT_CHARS} characters were included to keep the agent request reliable.`
+        : "",
+      googleDocContext,
       fileContext,
       "",
       "Add slides ONE AT A TIME using the `add-slide` action with --deckId=" +
@@ -78,7 +121,10 @@ export default function Index() {
       "Do NOT use create-deck (the deck already exists). Do NOT call db-schema, resource-read, or search-files.",
     ].join("\n");
 
-    agentSubmit(`Create deck: ${prompt}`, context);
+    agentSubmit(
+      `Create deck: ${summarizePromptForChat(trimmedPrompt)}`,
+      context,
+    );
     setShowNewDeckPrompt(false);
     navigate(`/deck/${deck.id}?generating=1`);
   };

--- a/templates/slides/shared/google-docs.ts
+++ b/templates/slides/shared/google-docs.ts
@@ -1,0 +1,42 @@
+const GOOGLE_DOC_ID_RE = /^[a-zA-Z0-9_-]{20,}$/;
+
+export function extractGoogleDocId(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  if (GOOGLE_DOC_ID_RE.test(trimmed)) return trimmed;
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (!/(\.|^)google\.com$/i.test(url.hostname)) return null;
+
+  const standardMatch = url.pathname.match(
+    /\/document\/(?:u\/\d+\/)?d\/([a-zA-Z0-9_-]+)/,
+  );
+  if (standardMatch) return standardMatch[1];
+
+  const idParam = url.searchParams.get("id");
+  return idParam && GOOGLE_DOC_ID_RE.test(idParam) ? idParam : null;
+}
+
+export function extractGoogleDocUrls(text: string): string[] {
+  const urls = new Set<string>();
+  const pattern = /https:\/\/docs\.google\.com\/document\/[^\s<>"'`),\]]+/gi;
+  for (const match of text.matchAll(pattern)) {
+    const url = match[0].replace(/[.,;:!?]+$/, "");
+    if (extractGoogleDocId(url)) urls.add(url);
+  }
+  return [...urls];
+}
+
+export function normalizeGoogleDocText(text: string): string {
+  return text
+    .replace(/\u0000/g, "")
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+}


### PR DESCRIPTION
## Summary

- **Slides**: new `import-google-doc` action (and shared `google-docs` URL/text helpers) so users can paste a Google Docs URL when creating a deck. Index page hooks the URL out of the prompt and pulls source text via the action; AGENTS.md and the create-deck skill teach the agent to call it. Editor sidebar gains the connector affordance.
- **Mail**: search ranking now sorts the historyId-sorted candidate window by each thread's newest message time so recent activity wins instead of Gmail's first-message-age default. Spec covers the new ordering.
- **Composer**: clipboard paste now preserves trailing text alongside pasted images (Google Docs rich clipboard payloads no longer drop the text body).
- **Integrations panel**: surfaces the service-account email with copy-to-clipboard so users know which address to share docs with.
- **Vite**: bundle `@radix-ui/*` through Vite SSR so transitive Radix deps from `@agent-native/core` resolve from the workspace store on consumer apps (fixes SSR resolver miss).

## Test plan

- [ ] `pnpm action import-google-doc --url <docs-url>` returns text and serviceAccountEmail when configured
- [ ] Slides Index pre-fills source text from a pasted Docs URL
- [ ] Mail search returns recent-activity-first ordering across multiple pages
- [ ] Paste a screenshot + caption from Google Docs into the composer — both an image chip and a text chip appear
- [ ] Integrations panel shows the service-account email with a working copy button
- [ ] SSR builds that depend on `@agent-native/core` Radix-using components resolve cleanly