### PR TITLE
[PARKED — awaiting team discussion] Layer 3 foundation: agent run-continuation queue

### DIFF
--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1916,7 +1916,15 @@ export function createProductionAgentHandler(
       options.onRunComplete
         ? (run) => options.onRunComplete!(run, threadId)
         : undefined,
-      { softTimeoutMs: options.runSoftTimeoutMs },
+      {
+        softTimeoutMs: options.runSoftTimeoutMs,
+        // Identify the run's owner so the run-manager can enqueue an
+        // auto-continuation row keyed to this user when the soft timeout
+        // fires. Falls back to the request context if the plugin didn't
+        // resolve it explicitly.
+        ownerEmail: ownerEmail ?? getRequestUserEmail() ?? undefined,
+        orgId: getRequestOrgId() ?? null,
+      },
     );
 
     // Subscribe to the run and stream events to the client

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -15,6 +15,26 @@ vi.mock("./run-store.js", () => ({
   reapIfStale: vi.fn(() => Promise.resolve(null)),
 }));
 
+const enqueueRunContinuationMock = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve()),
+);
+const countRecentRunContinuationsForThreadMock = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve(0)),
+);
+const dispatchRunContinuationMock = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve()),
+);
+
+vi.mock("../run-continuations/store.js", () => ({
+  enqueueRunContinuation: enqueueRunContinuationMock,
+  countRecentRunContinuationsForThread:
+    countRecentRunContinuationsForThreadMock,
+}));
+
+vi.mock("../run-continuations/dispatch.js", () => ({
+  dispatchRunContinuation: dispatchRunContinuationMock,
+}));
+
 import { resolveRunSoftTimeoutMs, startRun } from "./run-manager.js";
 
 const originalTimeoutEnv = process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
@@ -34,6 +54,8 @@ function restoreEnv(key: string, value: string | undefined) {
   }
 }
 
+const originalAutoContinuation = process.env.AGENT_AUTO_CONTINUATION;
+
 describe("run manager soft timeout", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -45,6 +67,11 @@ describe("run manager soft timeout", () => {
     delete process.env.VERCEL_ENV;
     delete process.env.RENDER;
     delete process.env.FLY_APP_NAME;
+    delete process.env.AGENT_AUTO_CONTINUATION;
+    enqueueRunContinuationMock.mockClear();
+    countRecentRunContinuationsForThreadMock.mockClear();
+    countRecentRunContinuationsForThreadMock.mockResolvedValue(0);
+    dispatchRunContinuationMock.mockClear();
   });
 
   afterEach(() => {
@@ -56,6 +83,7 @@ describe("run manager soft timeout", () => {
     restoreEnv("VERCEL_ENV", originalVercelEnv);
     restoreEnv("RENDER", originalRender);
     restoreEnv("FLY_APP_NAME", originalFlyAppName);
+    restoreEnv("AGENT_AUTO_CONTINUATION", originalAutoContinuation);
     vi.useRealTimers();
   });
 
@@ -119,5 +147,112 @@ describe("run manager soft timeout", () => {
     process.env.AGENT_RUN_SOFT_TIMEOUT_MS = "0";
 
     expect(resolveRunSoftTimeoutMs()).toBe(0);
+  });
+
+  // Helper for the auto-continuation suite below: drives the run to its
+  // soft-timeout abort, then awaits the .finally() chain so the post-status
+  // enqueue logic has a chance to run. Returns the run handle.
+  async function startTimedOutRun(
+    opts: {
+      runId?: string;
+      threadId?: string;
+      ownerEmail?: string;
+      orgId?: string | null;
+    } = {},
+  ) {
+    const run = startRun(
+      opts.runId ?? "run-x",
+      opts.threadId ?? "thread-x",
+      async (_send, signal) => {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve());
+        });
+      },
+      undefined,
+      {
+        softTimeoutMs: 10,
+        ownerEmail: opts.ownerEmail,
+        orgId: opts.orgId ?? null,
+      },
+    );
+    await vi.advanceTimersByTimeAsync(11);
+    // Two extra ticks let the .finally() chain (await onComplete, await
+    // updateRunStatus, await enqueueRunContinuation) all settle before we
+    // assert against the mocks.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(0);
+    return run;
+  }
+
+  it("enqueues a continuation when soft timeout fires and ownerEmail is provided", async () => {
+    await startTimedOutRun({
+      threadId: "thread-cont",
+      ownerEmail: "alice+qa@agent-native.test",
+      orgId: "org-1",
+    });
+
+    expect(enqueueRunContinuationMock).toHaveBeenCalledTimes(1);
+    expect(enqueueRunContinuationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: "thread-cont",
+        ownerEmail: "alice+qa@agent-native.test",
+        orgId: "org-1",
+        parentRunId: "run-x",
+      }),
+    );
+    expect(dispatchRunContinuationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not enqueue when ownerEmail is missing", async () => {
+    await startTimedOutRun({ threadId: "thread-noowner" });
+
+    expect(enqueueRunContinuationMock).not.toHaveBeenCalled();
+    expect(dispatchRunContinuationMock).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue when AGENT_AUTO_CONTINUATION=false", async () => {
+    process.env.AGENT_AUTO_CONTINUATION = "false";
+
+    await startTimedOutRun({
+      threadId: "thread-killswitch",
+      ownerEmail: "alice+qa@agent-native.test",
+    });
+
+    expect(enqueueRunContinuationMock).not.toHaveBeenCalled();
+    expect(dispatchRunContinuationMock).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue past the cascade limit (3 in 10 minutes)", async () => {
+    countRecentRunContinuationsForThreadMock.mockResolvedValue(3);
+
+    await startTimedOutRun({
+      threadId: "thread-cascade",
+      ownerEmail: "alice+qa@agent-native.test",
+    });
+
+    expect(enqueueRunContinuationMock).not.toHaveBeenCalled();
+    expect(dispatchRunContinuationMock).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue when the run completed normally (no soft timeout)", async () => {
+    const run = startRun(
+      "run-normal",
+      "thread-normal",
+      async (_send, _signal) => {
+        // Resolve immediately — no soft timeout, no abort.
+      },
+      undefined,
+      {
+        softTimeoutMs: 10,
+        ownerEmail: "alice+qa@agent-native.test",
+      },
+    );
+    // Allow the .finally() chain to settle.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(run.status).toBe("completed");
+
+    expect(enqueueRunContinuationMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -13,6 +13,11 @@ import {
   updateRunHeartbeat,
   reapIfStale,
 } from "./run-store.js";
+import {
+  countRecentRunContinuationsForThread,
+  enqueueRunContinuation,
+} from "../run-continuations/store.js";
+import { dispatchRunContinuation } from "../run-continuations/dispatch.js";
 
 export interface ActiveRun {
   runId: string;
@@ -35,6 +40,27 @@ export interface StartRunOptions {
    * auto-continuation signal instead of a user-facing timeout. Leave unset for
    * no framework-imposed run timeout. */
   softTimeoutMs?: number;
+  /**
+   * Identity of the run's owner. Required for the run-continuations queue
+   * (see Layer 3 of the timeout-mitigation plan): when the soft timeout
+   * fires, the framework enqueues a continuation row keyed to this user so
+   * a fresh function execution can resume the thread on their behalf.
+   * If omitted, soft-timeout aborts behave as before — no auto-continue.
+   */
+  ownerEmail?: string;
+  orgId?: string | null;
+}
+
+/** Maximum cascading continuation attempts within `CONTINUATION_CASCADE_WINDOW_MS`
+ * for a single thread before we stop auto-continuing. Each soft-timeout fires
+ * a continuation; if the resumed run also times out, that's a second
+ * continuation, etc. Hard-cap so a buggy agent loop can't burn unbounded
+ * spend re-firing itself. */
+const CONTINUATION_CASCADE_LIMIT = 3;
+const CONTINUATION_CASCADE_WINDOW_MS = 10 * 60 * 1000;
+
+function autoContinuationsEnabled(): boolean {
+  return process.env.AGENT_AUTO_CONTINUATION !== "false";
 }
 
 export function resolveRunSoftTimeoutMs(overrideMs?: number): number {
@@ -242,6 +268,55 @@ export function startRun(
       } catch {
         // Best-effort — reapIfStale will eventually clean this up via
         // the heartbeat-stale path.
+      }
+
+      // 4.5. Auto-continue: if this run hit the soft timeout, enqueue a
+      //      continuation row and fire-and-forget a dispatch to the
+      //      processor route so a fresh function execution can resume
+      //      the thread. Runs AFTER updateRunStatus so observers seeing
+      //      the agent_runs row in a terminal state can already trust
+      //      thread_data is durable. Best-effort: a dropped dispatch is
+      //      caught by the recurring sweep ~60s later.
+      if (softTimedOut && autoContinuationsEnabled() && options?.ownerEmail) {
+        try {
+          const sinceMs = Date.now() - CONTINUATION_CASCADE_WINDOW_MS;
+          const cascade = await countRecentRunContinuationsForThread(
+            threadId,
+            sinceMs,
+          );
+          if (cascade >= CONTINUATION_CASCADE_LIMIT) {
+            console.warn(
+              `[run-manager] thread ${threadId} hit cascade limit (${cascade}/${CONTINUATION_CASCADE_LIMIT}) — not auto-continuing`,
+            );
+          } else {
+            const continuationId = `cont-${Date.now()}-${Math.random()
+              .toString(36)
+              .slice(2, 10)}`;
+            await enqueueRunContinuation({
+              id: continuationId,
+              threadId,
+              parentRunId: runId,
+              ownerEmail: options.ownerEmail,
+              orgId: options.orgId ?? null,
+            });
+            // Fire-and-forget — the sweep is the safety net if dispatch
+            // is dropped (network blip, function frozen mid-handshake).
+            void dispatchRunContinuation(continuationId).catch((err) => {
+              if (process.env.DEBUG) {
+                console.log(
+                  `[run-manager] dispatch ${continuationId} failed:`,
+                  err instanceof Error ? err.message : err,
+                );
+              }
+            });
+          }
+        } catch (err) {
+          // Don't let the auto-continue path crash run completion.
+          console.error(
+            "[run-manager] auto-continuation enqueue failed:",
+            err instanceof Error ? err.message : err,
+          );
+        }
       }
 
       // 5. Schedule in-memory cleanup + opportunistic old-run pruning.

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -423,6 +423,22 @@ export function createIntegrationsPlugin(
       }),
     );
 
+    // ─── Process run continuation (auto-continue after soft timeout) ─
+    // POST /_agent-native/runs/_continue-run
+    // Internal endpoint invoked from run-manager.ts (after a soft timeout
+    // fires and aborts a chat run) and from the recurring sweep (for
+    // dropped dispatches). Auth: HMAC bearer signed with A2A_SECRET, just
+    // like process-task. Mounted here (rather than in core-routes) because
+    // this plugin is the existing home for "background work that needs a
+    // fresh function execution" infrastructure.
+    {
+      const {
+        createRunContinuationRouteHandler,
+        RUN_CONTINUATIONS_ROUTE_PATH,
+      } = await import("../run-continuations/route.js");
+      h3.use(RUN_CONTINUATIONS_ROUTE_PATH, createRunContinuationRouteHandler());
+    }
+
     // ─── Process deferred A2A continuation ──────────────────────────
     // POST /_agent-native/integrations/process-a2a-continuation
     // Internal endpoint invoked when call-agent timed out inside an
@@ -703,6 +719,20 @@ export function createIntegrationsPlugin(
       webhookBaseUrl: process.env.WEBHOOK_BASE_URL,
     });
     startA2AContinuationRetryJob(adapterMap);
+
+    // ─── Start run-continuations retry sweeper ───────────────────
+    // Mirrors the pending-tasks sweep: re-fires any agent_run_continuations
+    // rows stuck in pending/processing state (initial dispatch lost or
+    // processor killed mid-flight). 75s cutoff on serverless, 5min on
+    // Node. After MAX_ATTEMPTS the row is marked `gave_up` and stops
+    // being re-fired.
+    {
+      const { startRunContinuationsRetryJob } =
+        await import("../run-continuations/retry-job.js");
+      startRunContinuationsRetryJob({
+        baseUrl: process.env.WEBHOOK_BASE_URL,
+      });
+    }
 
     // ─── Start Google Docs poller/push ────────────────────────────
     if (adapterMap.has("google-docs")) {

--- a/packages/core/src/run-continuations/dispatch.ts
+++ b/packages/core/src/run-continuations/dispatch.ts
@@ -1,0 +1,86 @@
+/**
+ * Fire-and-forget dispatch for the run-continuations queue.
+ *
+ * After a row is enqueued in `agent_run_continuations`, we POST to a separate
+ * processor endpoint so the resume runs in a fresh function execution with
+ * its own timeout budget — the original run already exhausted its budget.
+ *
+ * Mirrors the pattern in `pending-tasks-retry-job.ts:refireProcessor`. The
+ * recurring sweep is the safety net: if this dispatch is dropped (network
+ * blip, function frozen mid-handshake), the sweep re-fires it 60s later.
+ */
+import { signInternalToken } from "../integrations/internal-token.js";
+import { withConfiguredAppBasePath } from "../server/app-base-path.js";
+import { FRAMEWORK_ROUTE_PREFIX } from "../server/core-routes-plugin.js";
+
+export const RUN_CONTINUATION_PROCESSOR_PATH = `${FRAMEWORK_ROUTE_PREFIX}/runs/_continue-run`;
+
+function resolveBaseUrl(override?: string): string {
+  return (
+    override ||
+    process.env.WEBHOOK_BASE_URL ||
+    process.env.APP_URL ||
+    process.env.URL ||
+    process.env.DEPLOY_URL ||
+    `http://localhost:${process.env.PORT || 3000}`
+  );
+}
+
+/**
+ * Fire-and-forget POST to the run-continuation processor endpoint.
+ *
+ * Production must have A2A_SECRET configured — an unsigned dispatch in
+ * production lets anyone with the URL re-trigger any queued continuation.
+ * Dev falls back to unsigned so contributors can iterate without secrets.
+ */
+export async function dispatchRunContinuation(
+  continuationId: string,
+  options?: { baseUrl?: string },
+): Promise<void> {
+  const baseUrl = resolveBaseUrl(options?.baseUrl);
+  const url = `${withConfiguredAppBasePath(baseUrl)}${RUN_CONTINUATION_PROCESSOR_PATH}`;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  try {
+    headers["Authorization"] = `Bearer ${signInternalToken(continuationId)}`;
+  } catch (err) {
+    if (process.env.NODE_ENV === "production") {
+      console.error(
+        `[run-continuations] Refusing to dispatch ${continuationId} — A2A_SECRET not configured.`,
+      );
+      return;
+    }
+    if (err instanceof Error && !/A2A_SECRET/i.test(err.message)) {
+      console.error(
+        `[run-continuations] signInternalToken failed unexpectedly for ${continuationId}:`,
+        err,
+      );
+    }
+  }
+
+  // 5s timeout so the dispatch loop can't hang if the processor freezes.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
+
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ continuationId }),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    // The sweep is the safety net — log and move on. Don't propagate, since
+    // callers (run-manager .finally(), sweep) treat dispatch as best-effort.
+    if (process.env.DEBUG) {
+      console.log(
+        `[run-continuations] dispatch ${continuationId} failed (sweep will retry):`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/core/src/run-continuations/resumer.ts
+++ b/packages/core/src/run-continuations/resumer.ts
@@ -1,0 +1,51 @@
+/**
+ * Module-level singleton for the resume callback that knows how to drive a
+ * fresh agent run on an existing thread.
+ *
+ * The continuation processor route is generic — it claims a row, then
+ * delegates the actual "run agent loop again" work to whichever resumer was
+ * registered at startup. The agent-chat plugin registers one when it knows
+ * the model, API key, system prompt, and action set; templates that don't
+ * use the chat plugin can register their own resumer or leave it unset (the
+ * processor logs and marks completed without retrying — better to fail open
+ * than to crash on a missing handler).
+ */
+
+export interface RunContinuationResumerInput {
+  continuationId: string;
+  threadId: string;
+  parentRunId: string;
+  ownerEmail: string;
+  orgId: string | null;
+  /**
+   * 1-indexed attempt counter for this row. The resumer uses this to decide
+   * how aggressive to be (e.g. shorter loop limits on later attempts).
+   */
+  attempt: number;
+}
+
+export type RunContinuationResumer = (
+  input: RunContinuationResumerInput,
+) => Promise<void>;
+
+let registered: RunContinuationResumer | null = null;
+
+/**
+ * Register the resume callback. Idempotent: re-registering replaces the
+ * previous callback so plugins can be re-initialized in dev / HMR without
+ * leaking stale closures.
+ */
+export function setRunContinuationResumer(
+  resumer: RunContinuationResumer,
+): void {
+  registered = resumer;
+}
+
+export function getRunContinuationResumer(): RunContinuationResumer | null {
+  return registered;
+}
+
+/** Test-only helper: reset the registered resumer between specs. */
+export function clearRunContinuationResumer(): void {
+  registered = null;
+}

--- a/packages/core/src/run-continuations/retry-job.spec.ts
+++ b/packages/core/src/run-continuations/retry-job.spec.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const executeMock = vi.hoisted(() => vi.fn());
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({ execute: executeMock }),
+  isPostgres: () => false,
+  intType: () => "INTEGER",
+}));
+
+vi.mock("./dispatch.js", () => ({
+  RUN_CONTINUATION_PROCESSOR_PATH: "/_agent-native/runs/_continue-run",
+  dispatchRunContinuation: fetchMock,
+}));
+
+async function loadRetryJob() {
+  vi.resetModules();
+  return import("./retry-job.js");
+}
+
+describe("run-continuations retry job", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete (process.env as Record<string, string | undefined>).NETLIFY;
+  });
+
+  it("re-fires dispatch for a stuck pending row and bumps updated_at", async () => {
+    executeMock.mockImplementation(async (query: any) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (sql.includes("SELECT id, status, attempts")) {
+        return {
+          rows: [
+            {
+              id: "cont-stuck",
+              status: "pending",
+              attempts: 1,
+            },
+          ],
+        };
+      }
+      return { rows: [], rowsAffected: 1 };
+    });
+
+    const { retryStuckRunContinuations } = await loadRetryJob();
+    await retryStuckRunContinuations();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("cont-stuck", expect.anything());
+
+    // Pending rows get a touch on updated_at — same status, new updated_at —
+    // so the next sweep tick doesn't immediately re-fire them.
+    const touchCall = executeMock.mock.calls.find(([q]) => {
+      const sql = typeof q === "string" ? q : q.sql;
+      const args = (q as { args?: unknown[] }).args ?? [];
+      return (
+        sql.includes("UPDATE agent_run_continuations") && args[0] === "pending"
+      );
+    });
+    expect(touchCall).toBeDefined();
+  });
+
+  it("resets a stuck processing row back to pending so atomic claim can win", async () => {
+    executeMock.mockImplementation(async (query: any) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (sql.includes("SELECT id, status, attempts")) {
+        return {
+          rows: [
+            {
+              id: "cont-frozen",
+              status: "processing",
+              attempts: 1,
+            },
+          ],
+        };
+      }
+      return { rows: [], rowsAffected: 1 };
+    });
+
+    const { retryStuckRunContinuations } = await loadRetryJob();
+    await retryStuckRunContinuations();
+
+    const resetCall = executeMock.mock.calls.find(([q]) => {
+      const args = (q as { args?: unknown[] }).args ?? [];
+      // Reset: status was 'processing', new status arg is 'pending'
+      return args[0] === "pending" && args[3] === "processing";
+    });
+    expect(resetCall).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a row gave_up after MAX_ATTEMPTS and stops dispatching", async () => {
+    executeMock.mockImplementation(async (query: any) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (sql.includes("SELECT id, status, attempts")) {
+        return {
+          rows: [
+            {
+              id: "cont-exhausted",
+              status: "pending",
+              attempts: 3, // already at MAX_ATTEMPTS
+            },
+          ],
+        };
+      }
+      return { rows: [], rowsAffected: 1 };
+    });
+
+    const { retryStuckRunContinuations } = await loadRetryJob();
+    await retryStuckRunContinuations();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const gaveUpCall = executeMock.mock.calls.find(([q]) => {
+      const args = (q as { args?: unknown[] }).args ?? [];
+      return args[0] === "gave_up";
+    });
+    expect(gaveUpCall).toBeDefined();
+  });
+
+  it("no-ops when the table doesn't exist yet", async () => {
+    executeMock.mockImplementation(async () => {
+      throw new Error("no such table: agent_run_continuations");
+    });
+
+    const { retryStuckRunContinuations } = await loadRetryJob();
+    await expect(retryStuckRunContinuations()).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses 75s processing-stuck threshold on Netlify", async () => {
+    process.env.NETLIFY = "true";
+    executeMock.mockResolvedValue({ rows: [] });
+
+    const { retryStuckRunContinuations } = await loadRetryJob();
+    await retryStuckRunContinuations();
+
+    const selectCall = executeMock.mock.calls.find(([q]) => {
+      const sql = typeof q === "string" ? q : q.sql;
+      return sql.includes("SELECT id, status, attempts");
+    });
+    expect(selectCall).toBeDefined();
+    const args = (selectCall![0] as { args: number[] }).args;
+    // args = [pendingCutoff, processingCutoff]; processingCutoff
+    // should be roughly now - 75_000 (within reasonable test slop).
+    const now = Date.now();
+    const processingCutoff = args[1];
+    expect(now - processingCutoff).toBeGreaterThanOrEqual(74_000);
+    expect(now - processingCutoff).toBeLessThanOrEqual(76_000);
+  });
+});

--- a/packages/core/src/run-continuations/retry-job.ts
+++ b/packages/core/src/run-continuations/retry-job.ts
@@ -1,0 +1,173 @@
+/**
+ * Sweep for stuck rows in `agent_run_continuations`.
+ *
+ * Mirrors `pending-tasks-retry-job.ts` exactly (modulo names): every 60s,
+ * find rows that look stuck and re-fire the processor. Hard cap at
+ * MAX_ATTEMPTS to prevent runaway retry loops.
+ *
+ * Stuck criteria:
+ *   - status='pending' AND created_at <= now - 90s (initial dispatch lost)
+ *   - status='processing' AND updated_at <= now - X
+ *       where X = 75s on serverless / 5min on Node
+ *
+ * Mark `gave_up` (terminal) once attempts >= MAX_ATTEMPTS so this row
+ * stops appearing in subsequent sweeps. `gave_up` is intentionally a
+ * distinct state from `failed` so operators can tell at a glance whether
+ * the resumer kept blowing up vs. the sweep stopped trying.
+ *
+ * If the table doesn't exist yet (e.g. older deploy that never enqueued
+ * a continuation), this sweep silently no-ops rather than spamming logs.
+ */
+import { getDbExec } from "../db/client.js";
+import { dispatchRunContinuation } from "./dispatch.js";
+
+const RETRY_INTERVAL_MS = 60_000;
+const PENDING_STUCK_AFTER_MS = 90_000;
+const DEFAULT_PROCESSING_STUCK_AFTER_MS = 5 * 60 * 1000;
+const SERVERLESS_PROCESSING_STUCK_AFTER_MS = 75_000;
+const MAX_ATTEMPTS = 3;
+
+let retryInterval: ReturnType<typeof setInterval> | null = null;
+let activeBaseUrl: string | undefined;
+let tableExists: boolean | null = null;
+
+interface StuckRow {
+  id: string;
+  status: string;
+  attempts: number;
+}
+
+export async function retryStuckRunContinuations(
+  baseUrl?: string,
+): Promise<void> {
+  const dispatchBaseUrl = baseUrl ?? activeBaseUrl;
+  const client = getDbExec();
+  const now = Date.now();
+  const pendingCutoff = now - PENDING_STUCK_AFTER_MS;
+  const processingCutoff = now - getProcessingStuckAfterMs();
+
+  let stuckRows: StuckRow[];
+  try {
+    const { rows } = await client.execute({
+      sql: `
+        SELECT id, status, attempts
+          FROM agent_run_continuations
+         WHERE (status = 'pending' AND created_at <= ?)
+            OR (status = 'processing' AND updated_at <= ?)
+      `,
+      args: [pendingCutoff, processingCutoff],
+    });
+    stuckRows = rows.map((r) => ({
+      id: r.id as string,
+      status: r.status as string,
+      attempts: Number(r.attempts ?? 0),
+    }));
+    tableExists = true;
+  } catch {
+    if (tableExists !== false) {
+      tableExists = false;
+      if (process.env.DEBUG) {
+        console.log(
+          "[run-continuations] retry job: table not present yet, skipping",
+        );
+      }
+    }
+    return;
+  }
+
+  if (stuckRows.length === 0) return;
+
+  for (const row of stuckRows) {
+    try {
+      if (row.attempts >= MAX_ATTEMPTS) {
+        await client.execute({
+          sql: `
+            UPDATE agent_run_continuations
+               SET status = ?, updated_at = ?,
+                   error_message = COALESCE(error_message, ?)
+             WHERE id = ?
+               AND status = ?
+          `,
+          args: [
+            "gave_up",
+            Date.now(),
+            `Retry job: exceeded ${MAX_ATTEMPTS} attempts`,
+            row.id,
+            row.status,
+          ],
+        });
+        console.warn(
+          `[run-continuations] ${row.id} exceeded ${MAX_ATTEMPTS} attempts — marking gave_up`,
+        );
+        continue;
+      }
+
+      // Reset stuck processing rows so the atomic claim (which only matches
+      // pending) can re-acquire them. For pending rows, just touch updated_at
+      // so the next tick doesn't immediately re-fire the same set.
+      const newStatus = row.status === "processing" ? "pending" : row.status;
+      await client.execute({
+        sql: `
+          UPDATE agent_run_continuations
+             SET status = ?, updated_at = ?
+           WHERE id = ?
+             AND status = ?
+        `,
+        args: [newStatus, Date.now(), row.id, row.status],
+      });
+
+      await dispatchRunContinuation(row.id, { baseUrl: dispatchBaseUrl });
+    } catch (err) {
+      console.error(
+        `[run-continuations] Failed to retry ${row.id}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}
+
+function getProcessingStuckAfterMs(): number {
+  if (
+    process.env.NETLIFY ||
+    process.env.AWS_LAMBDA_FUNCTION_NAME ||
+    process.env.VERCEL ||
+    "__cf_env" in globalThis
+  ) {
+    return SERVERLESS_PROCESSING_STUCK_AFTER_MS;
+  }
+  return DEFAULT_PROCESSING_STUCK_AFTER_MS;
+}
+
+/** Start the periodic sweep. Idempotent — second call is a no-op. */
+export function startRunContinuationsRetryJob(options?: {
+  baseUrl?: string;
+}): void {
+  if (retryInterval) return;
+  activeBaseUrl = options?.baseUrl;
+
+  setTimeout(() => {
+    void retryStuckRunContinuations().catch((err) => {
+      console.error("[run-continuations] retry job error:", err);
+    });
+  }, 10_000);
+
+  retryInterval = setInterval(() => {
+    void retryStuckRunContinuations().catch((err) => {
+      console.error("[run-continuations] retry job error:", err);
+    });
+  }, RETRY_INTERVAL_MS);
+
+  if (process.env.DEBUG) {
+    console.log(
+      `[run-continuations] retry job started (every ${RETRY_INTERVAL_MS / 1000}s)`,
+    );
+  }
+}
+
+export function stopRunContinuationsRetryJob(): void {
+  if (retryInterval) {
+    clearInterval(retryInterval);
+    retryInterval = null;
+  }
+  activeBaseUrl = undefined;
+}

--- a/packages/core/src/run-continuations/route.ts
+++ b/packages/core/src/run-continuations/route.ts
@@ -1,0 +1,115 @@
+/**
+ * POST /_agent-native/runs/_continue-run
+ *
+ * Internal processor endpoint hit by the run-manager (after a soft timeout)
+ * and by the recurring sweep (for stuck rows). Verifies the HMAC bearer
+ * token, atomically claims the continuation row, then hands off to the
+ * registered resumer. The route itself owns lifecycle bookkeeping
+ * (markCompleted / markFailed / markGaveUp) so the resumer can stay focused
+ * on actually running the agent loop.
+ *
+ * Auth posture matches the integrations process-task route: production
+ * requires A2A_SECRET; dev allows unsigned dispatches.
+ */
+import {
+  defineEventHandler,
+  getMethod,
+  getRequestHeader,
+  readBody,
+  setResponseStatus,
+} from "h3";
+import {
+  extractBearerToken,
+  verifyInternalToken,
+} from "../integrations/internal-token.js";
+import {
+  claimRunContinuation,
+  getRunContinuation,
+  markRunContinuationCompleted,
+  markRunContinuationFailed,
+} from "./store.js";
+import { getRunContinuationResumer } from "./resumer.js";
+import { RUN_CONTINUATION_PROCESSOR_PATH } from "./dispatch.js";
+
+export const RUN_CONTINUATIONS_ROUTE_PATH = RUN_CONTINUATION_PROCESSOR_PATH;
+
+export function createRunContinuationRouteHandler() {
+  return defineEventHandler(async (event) => {
+    if (getMethod(event) !== "POST") {
+      setResponseStatus(event, 405);
+      return { error: "Method not allowed" };
+    }
+
+    let body: { continuationId?: string } | null = null;
+    try {
+      body = (await readBody(event)) as { continuationId?: string } | null;
+    } catch {
+      setResponseStatus(event, 400);
+      return { error: "Invalid JSON body" };
+    }
+    const continuationId = body?.continuationId;
+    if (!continuationId || typeof continuationId !== "string") {
+      setResponseStatus(event, 400);
+      return { error: "Missing or invalid continuationId" };
+    }
+
+    // Auth: HMAC required in production, optional in dev. Mirror the
+    // integrations process-task posture.
+    if (process.env.A2A_SECRET || process.env.NODE_ENV === "production") {
+      const tok = extractBearerToken(getRequestHeader(event, "authorization"));
+      if (!tok || !verifyInternalToken(continuationId, tok)) {
+        setResponseStatus(event, 401);
+        return { error: "Invalid or expired internal token" };
+      }
+    }
+
+    // Atomic claim — only one processor wins. Already-claimed / completed /
+    // failed / gave_up rows return null and we silently skip.
+    const claimed = await claimRunContinuation(continuationId);
+    if (!claimed) {
+      return { ok: true, skipped: "already-claimed-or-terminal" };
+    }
+
+    const resumer = getRunContinuationResumer();
+    if (!resumer) {
+      // No resumer registered: mark completed so we don't retry forever, but
+      // surface the misconfiguration in logs. Templates that opt into this
+      // queue must register a resumer at plugin init.
+      console.warn(
+        `[run-continuations] No resumer registered — marking ${continuationId} completed without resuming. ` +
+          "Register one via setRunContinuationResumer() during plugin init.",
+      );
+      await markRunContinuationCompleted(continuationId);
+      return { ok: true, skipped: "no-resumer" };
+    }
+
+    try {
+      await resumer({
+        continuationId: claimed.id,
+        threadId: claimed.threadId,
+        parentRunId: claimed.parentRunId,
+        ownerEmail: claimed.ownerEmail,
+        orgId: claimed.orgId,
+        attempt: claimed.attempts,
+      });
+      await markRunContinuationCompleted(continuationId);
+      return { ok: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await markRunContinuationFailed(continuationId, message);
+      // Log full error for ops; sweep handles retry up to MAX_ATTEMPTS.
+      console.error(
+        `[run-continuations] Resumer failed for ${continuationId}:`,
+        err,
+      );
+      // Surface the row for tests / integration assertions, but never the
+      // raw error string (don't leak internals).
+      const refreshed = await getRunContinuation(continuationId);
+      setResponseStatus(event, 500);
+      return {
+        error: "Resumer failed",
+        attempts: refreshed?.attempts ?? claimed.attempts,
+      };
+    }
+  });
+}

--- a/packages/core/src/run-continuations/store.spec.ts
+++ b/packages/core/src/run-continuations/store.spec.ts
@@ -1,0 +1,250 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const executeMock = vi.hoisted(() => vi.fn());
+const isPostgresMock = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({ execute: executeMock }),
+  isPostgres: isPostgresMock,
+  intType: () => "INTEGER",
+}));
+
+async function loadStore() {
+  vi.resetModules();
+  return import("./store.js");
+}
+
+describe("agent run continuations store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isPostgresMock.mockReturnValue(false);
+  });
+
+  it("enqueues a continuation row with status=pending and attempts=0", async () => {
+    const { enqueueRunContinuation } = await loadStore();
+    executeMock.mockResolvedValue({ rows: [] });
+
+    await enqueueRunContinuation({
+      id: "cont-1",
+      threadId: "thread-1",
+      parentRunId: "run-1",
+      ownerEmail: "alice+qa@agent-native.test",
+      orgId: null,
+    });
+
+    const insertCall = executeMock.mock.calls.find(([query]) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      return sql.includes("INSERT INTO agent_run_continuations");
+    });
+    expect(insertCall).toBeDefined();
+    expect(insertCall?.[0]).toEqual(
+      expect.objectContaining({
+        args: expect.arrayContaining([
+          "cont-1",
+          "thread-1",
+          "run-1",
+          "alice+qa@agent-native.test",
+          null,
+          "pending",
+          0,
+        ]),
+      }),
+    );
+  });
+
+  it("claims pending continuations and increments attempts (SQLite re-read)", async () => {
+    const { claimRunContinuation } = await loadStore();
+    executeMock.mockImplementation(async (query: string | { sql: string }) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (sql.includes("SELECT id, thread_id")) {
+        return {
+          rows: [
+            {
+              id: "cont-1",
+              thread_id: "thread-1",
+              parent_run_id: "run-1",
+              owner_email: "alice+qa@agent-native.test",
+              org_id: null,
+              status: "processing",
+              attempts: 1,
+              error_message: null,
+              created_at: 1,
+              updated_at: 2,
+              completed_at: null,
+            },
+          ],
+        };
+      }
+      if (sql.includes("UPDATE agent_run_continuations")) {
+        return { rows: [], rowsAffected: 1 };
+      }
+      return { rows: [] };
+    });
+
+    const cont = await claimRunContinuation("cont-1");
+
+    expect(cont?.id).toBe("cont-1");
+    expect(cont?.status).toBe("processing");
+    expect(cont?.attempts).toBe(1);
+    const updateCall = executeMock.mock.calls.find(([query]) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      return sql.includes("UPDATE agent_run_continuations");
+    });
+    expect(updateCall?.[0]).toEqual(
+      expect.objectContaining({
+        sql: expect.stringContaining("WHERE id = ? AND status = 'pending'"),
+      }),
+    );
+  });
+
+  it("returns null when SQLite claim loses the conditional-update race", async () => {
+    const { claimRunContinuation } = await loadStore();
+    executeMock.mockImplementation(async (query: string | { sql: string }) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (sql.includes("UPDATE agent_run_continuations")) {
+        return { rows: [], rowsAffected: 0 };
+      }
+      // Even though a re-read would show the row, the rowsAffected=0 short-
+      // circuit must prevent us from reading it (we lost the race).
+      return { rows: [] };
+    });
+
+    await expect(claimRunContinuation("cont-raced")).resolves.toBeNull();
+
+    const selectCall = executeMock.mock.calls.find(([query]) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      return sql.includes("SELECT id, thread_id");
+    });
+    expect(selectCall).toBeUndefined();
+  });
+
+  it("uses Postgres RETURNING when isPostgres()=true", async () => {
+    isPostgresMock.mockReturnValue(true);
+    const { claimRunContinuation } = await loadStore();
+    executeMock.mockImplementation(async (query: string | { sql: string }) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (sql.includes("UPDATE agent_run_continuations")) {
+        return {
+          rows: [
+            {
+              id: "cont-pg",
+              thread_id: "thread-1",
+              parent_run_id: "run-1",
+              owner_email: "alice+qa@agent-native.test",
+              org_id: null,
+              status: "processing",
+              attempts: 1,
+              error_message: null,
+              created_at: 1,
+              updated_at: 2,
+              completed_at: null,
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const cont = await claimRunContinuation("cont-pg");
+    expect(cont?.id).toBe("cont-pg");
+
+    const updateCall = executeMock.mock.calls.find(([query]) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      return sql.includes("UPDATE agent_run_continuations");
+    });
+    expect(updateCall?.[0]).toEqual(
+      expect.objectContaining({
+        sql: expect.stringContaining("RETURNING"),
+      }),
+    );
+  });
+
+  it("does not re-claim a row already in a terminal state", async () => {
+    const { claimRunContinuation } = await loadStore();
+    executeMock.mockImplementation(async (query: string | { sql: string }) => {
+      const sql = typeof query === "string" ? query : query.sql;
+      if (sql.includes("UPDATE agent_run_continuations")) {
+        // The conditional WHERE status='pending' is what filters out
+        // 'completed' / 'failed' / 'gave_up' rows — the executor reports 0.
+        return { rows: [], rowsAffected: 0 };
+      }
+      return { rows: [] };
+    });
+
+    await expect(claimRunContinuation("cont-done")).resolves.toBeNull();
+  });
+
+  it("marks completed and failed and gave_up with terminal updates", async () => {
+    const {
+      markRunContinuationCompleted,
+      markRunContinuationFailed,
+      markRunContinuationGaveUp,
+    } = await loadStore();
+    executeMock.mockResolvedValue({ rows: [] });
+
+    await markRunContinuationCompleted("cont-1");
+    await markRunContinuationFailed("cont-2", "boom");
+    await markRunContinuationGaveUp("cont-3", "exceeded 3 attempts");
+
+    const completedCall = executeMock.mock.calls.find(([q]) => {
+      const args = (q as { args?: unknown[] }).args ?? [];
+      return args[0] === "completed";
+    });
+    expect(completedCall).toBeDefined();
+
+    const failedCall = executeMock.mock.calls.find(([q]) => {
+      const args = (q as { args?: unknown[] }).args ?? [];
+      return args[0] === "failed" && args[2] === "boom";
+    });
+    expect(failedCall).toBeDefined();
+
+    const gaveUpCall = executeMock.mock.calls.find(([q]) => {
+      const args = (q as { args?: unknown[] }).args ?? [];
+      return args[0] === "gave_up" && args[2] === "exceeded 3 attempts";
+    });
+    expect(gaveUpCall).toBeDefined();
+  });
+
+  it("getActiveRunContinuationForThread returns the most recent in-flight row", async () => {
+    const { getActiveRunContinuationForThread } = await loadStore();
+    executeMock.mockResolvedValue({
+      rows: [
+        {
+          id: "cont-active",
+          thread_id: "thread-1",
+          parent_run_id: "run-1",
+          owner_email: "alice+qa@agent-native.test",
+          org_id: null,
+          status: "pending",
+          attempts: 1,
+          error_message: null,
+          created_at: 1,
+          updated_at: 2,
+          completed_at: null,
+        },
+      ],
+    });
+
+    const cont = await getActiveRunContinuationForThread("thread-1");
+    expect(cont?.id).toBe("cont-active");
+
+    const selectCall = executeMock.mock.calls.find(([q]) => {
+      const sql = typeof q === "string" ? q : q.sql;
+      return (
+        sql.includes("FROM agent_run_continuations") &&
+        sql.includes("thread_id = ?") &&
+        sql.includes("status IN")
+      );
+    });
+    expect(selectCall).toBeDefined();
+  });
+
+  it("getActiveRunContinuationForThread returns null when no in-flight row", async () => {
+    const { getActiveRunContinuationForThread } = await loadStore();
+    executeMock.mockResolvedValue({ rows: [] });
+
+    await expect(
+      getActiveRunContinuationForThread("thread-empty"),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/core/src/run-continuations/store.ts
+++ b/packages/core/src/run-continuations/store.ts
@@ -1,0 +1,278 @@
+/**
+ * SQL-backed queue for in-chat agent run continuations.
+ *
+ * When the agent's run-time soft timeout fires, the run-manager emits an
+ * `auto_continue` event and aborts the run — the user is left with whatever
+ * partial output and tool calls had streamed so far. Without this queue the
+ * user has to manually say "continue" for the agent to pick up where it left
+ * off; with it, the framework enqueues a row here, dispatches a fresh
+ * function execution to the `_continue-run` route, and the agent resumes
+ * automatically.
+ *
+ * The shape mirrors `integration_pending_tasks` (see pending-tasks-store.ts).
+ * The lifecycle differs in one place: continuations have a `gave_up` terminal
+ * state distinct from `failed`, used when we hit MAX_ATTEMPTS. That lets the
+ * sweep distinguish "individual run blew up" from "we stopped trying."
+ */
+import { getDbExec, isPostgres, intType } from "../db/client.js";
+
+let _initPromise: Promise<void> | undefined;
+
+async function ensureTable(): Promise<void> {
+  if (!_initPromise) {
+    _initPromise = (async () => {
+      const client = getDbExec();
+      await client.execute(`
+        CREATE TABLE IF NOT EXISTS agent_run_continuations (
+          id TEXT PRIMARY KEY,
+          thread_id TEXT NOT NULL,
+          parent_run_id TEXT NOT NULL,
+          owner_email TEXT NOT NULL,
+          org_id TEXT,
+          status TEXT NOT NULL,
+          attempts ${intType()} NOT NULL DEFAULT 0,
+          error_message TEXT,
+          created_at ${intType()} NOT NULL,
+          updated_at ${intType()} NOT NULL,
+          completed_at ${intType()}
+        )
+      `);
+      await client.execute(
+        `CREATE INDEX IF NOT EXISTS idx_run_cont_status_created ON agent_run_continuations(status, created_at)`,
+      );
+      await client.execute(
+        `CREATE INDEX IF NOT EXISTS idx_run_cont_thread_status ON agent_run_continuations(thread_id, status)`,
+      );
+    })();
+  }
+  return _initPromise;
+}
+
+export type RunContinuationStatus =
+  | "pending"
+  | "processing"
+  | "completed"
+  | "failed"
+  | "gave_up";
+
+export interface RunContinuation {
+  id: string;
+  threadId: string;
+  parentRunId: string;
+  ownerEmail: string;
+  orgId: string | null;
+  status: RunContinuationStatus;
+  attempts: number;
+  errorMessage: string | null;
+  createdAt: number;
+  updatedAt: number;
+  completedAt: number | null;
+}
+
+const SELECT_COLUMNS = `id, thread_id, parent_run_id, owner_email, org_id, status, attempts, error_message, created_at, updated_at, completed_at`;
+
+function rowToContinuation(row: Record<string, unknown>): RunContinuation {
+  return {
+    id: row.id as string,
+    threadId: row.thread_id as string,
+    parentRunId: row.parent_run_id as string,
+    ownerEmail: row.owner_email as string,
+    orgId: (row.org_id as string | null) ?? null,
+    status: row.status as RunContinuationStatus,
+    attempts: Number(row.attempts ?? 0),
+    errorMessage: (row.error_message as string | null) ?? null,
+    createdAt: Number(row.created_at ?? 0),
+    updatedAt: Number(row.updated_at ?? 0),
+    completedAt:
+      row.completed_at == null ? null : Number(row.completed_at as number),
+  };
+}
+
+/**
+ * Insert a fresh continuation row in the `pending` state. The processor
+ * route claims it atomically; the sweep retries it if the dispatch was lost.
+ */
+export async function enqueueRunContinuation(input: {
+  id: string;
+  threadId: string;
+  parentRunId: string;
+  ownerEmail: string;
+  orgId?: string | null;
+}): Promise<void> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  await client.execute({
+    sql: `INSERT INTO agent_run_continuations
+      (id, thread_id, parent_run_id, owner_email, org_id, status, attempts, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      input.id,
+      input.threadId,
+      input.parentRunId,
+      input.ownerEmail,
+      input.orgId ?? null,
+      "pending",
+      0,
+      now,
+      now,
+    ],
+  });
+}
+
+/** Fetch a single continuation by id. */
+export async function getRunContinuation(
+  id: string,
+): Promise<RunContinuation | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT ${SELECT_COLUMNS} FROM agent_run_continuations WHERE id = ? LIMIT 1`,
+    args: [id],
+  });
+  if (rows.length === 0) return null;
+  return rowToContinuation(rows[0] as Record<string, unknown>);
+}
+
+/**
+ * Atomically claim a continuation: transition pending → processing and
+ * increment attempts. Returns the updated row if the conditional update
+ * matched, otherwise null (already-claimed, terminal, or missing).
+ *
+ * The conditional `WHERE status = 'pending'` is the load-bearing piece —
+ * concurrent processors can't both claim the same row.
+ */
+export async function claimRunContinuation(
+  id: string,
+): Promise<RunContinuation | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+
+  const result = await client.execute({
+    sql: isPostgres()
+      ? `UPDATE agent_run_continuations
+         SET status = ?, attempts = attempts + 1, updated_at = ?
+         WHERE id = ? AND status = 'pending'
+         RETURNING ${SELECT_COLUMNS}`
+      : `UPDATE agent_run_continuations
+         SET status = ?, attempts = attempts + 1, updated_at = ?
+         WHERE id = ? AND status = 'pending'`,
+    args: ["processing", now, id],
+  });
+  const rows = result.rows ?? [];
+
+  if (isPostgres()) {
+    if (rows.length === 0) return null;
+    return rowToContinuation(rows[0] as Record<string, unknown>);
+  }
+
+  // SQLite: no RETURNING, so re-read after confirming we won the race.
+  const affected =
+    (result as { rowsAffected?: number; rowCount?: number }).rowsAffected ??
+    (result as { rowsAffected?: number; rowCount?: number }).rowCount;
+  if (affected === 0) return null;
+  const fetched = await getRunContinuation(id);
+  if (!fetched || fetched.status !== "processing") return null;
+  return fetched;
+}
+
+/** Mark a continuation as completed (resume succeeded). */
+export async function markRunContinuationCompleted(id: string): Promise<void> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  await client.execute({
+    sql: `UPDATE agent_run_continuations
+          SET status = ?, updated_at = ?, completed_at = ?
+          WHERE id = ?`,
+    args: ["completed", now, now, id],
+  });
+}
+
+/**
+ * Mark a continuation as failed (transient error during resume). The sweep
+ * may still re-fire while attempts < MAX_ATTEMPTS — the sweep flips the row
+ * back to `pending` before re-dispatch.
+ */
+export async function markRunContinuationFailed(
+  id: string,
+  errorMessage: string,
+): Promise<void> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  await client.execute({
+    sql: `UPDATE agent_run_continuations
+          SET status = ?, updated_at = ?, error_message = ?
+          WHERE id = ?`,
+    args: ["failed", now, errorMessage.slice(0, 2000), id],
+  });
+}
+
+/**
+ * Mark a continuation as `gave_up` — exhausted MAX_ATTEMPTS. Distinct from
+ * `failed` so operators can tell at a glance whether the sweep stopped
+ * trying or a single attempt blew up.
+ */
+export async function markRunContinuationGaveUp(
+  id: string,
+  errorMessage: string,
+): Promise<void> {
+  await ensureTable();
+  const client = getDbExec();
+  const now = Date.now();
+  await client.execute({
+    sql: `UPDATE agent_run_continuations
+          SET status = ?, updated_at = ?, error_message = ?
+          WHERE id = ?`,
+    args: ["gave_up", now, errorMessage.slice(0, 2000), id],
+  });
+}
+
+/**
+ * Return the newest in-flight continuation for a thread (status pending or
+ * processing), or null. Used by the run-manager to avoid double-enqueuing
+ * for the same thread (a second timeout firing while the first
+ * continuation is still in flight).
+ */
+export async function getActiveRunContinuationForThread(
+  threadId: string,
+): Promise<RunContinuation | null> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT ${SELECT_COLUMNS}
+          FROM agent_run_continuations
+          WHERE thread_id = ? AND status IN ('pending', 'processing')
+          ORDER BY created_at DESC
+          LIMIT 1`,
+    args: [threadId],
+  });
+  if (rows.length === 0) return null;
+  return rowToContinuation(rows[0] as Record<string, unknown>);
+}
+
+/**
+ * Count continuations enqueued for a thread since `sinceMs` (any status).
+ * The run-manager uses this as a cascade guard — if a single user turn keeps
+ * timing out, the resumed run, and the resumed-resumed run, etc., this
+ * count climbs and we eventually stop auto-continuing rather than loop
+ * forever burning Anthropic spend.
+ */
+export async function countRecentRunContinuationsForThread(
+  threadId: string,
+  sinceMs: number,
+): Promise<number> {
+  await ensureTable();
+  const client = getDbExec();
+  const { rows } = await client.execute({
+    sql: `SELECT COUNT(*) AS n
+          FROM agent_run_continuations
+          WHERE thread_id = ? AND created_at >= ?`,
+    args: [threadId, sinceMs],
+  });
+  if (rows.length === 0) return 0;
+  const row = rows[0] as Record<string, unknown>;
+  return Number(row.n ?? row.count ?? 0);
+}


### PR DESCRIPTION
> # ⏸ PARKED — awaiting team discussion
>
> **Do not review or merge yet.** This PR is being held open intentionally so the team can talk through whether this approach is the right one before any review effort goes in. The blast radius — new SQL table, new framework route, new recurring sweep, run-manager wiring — is large enough that the author flagged it for design alignment first.
>
> The branch and tests are stable; nothing is at risk by leaving this open. When the team is ready, this banner can be removed and the draft promoted normally.

---

## Why

When the agent's run-time soft timeout fires, the run-manager today emits an `auto_continue` event and aborts the run — the user is left with whatever partial output and tool calls had streamed so far, and has to manually say "continue" for the agent to pick up where it left off. On Netlify and other serverless hosts the 75s function cap means a sufficiently long task (deck generation in slides, multi-step research, etc.) is functionally broken: the function freezes the moment we return, so any background fire-and-forget retry inside the same execution dies on the next request.

This is **Layer 3** of the layered timeout-mitigation plan agreed offline. Layer 1 (slides image-gen parallelization, #479) is already merged; this is the framework-level safety net for runs that still exceed the cap.

## What this PR adds

A complete SQL-backed continuation queue and processor. When a run hits the soft timeout, the framework enqueues a row in `agent_run_continuations` and fire-and-forgets a POST to the new `/_agent-native/runs/_continue-run` route. That endpoint runs in a fresh function execution with its own timeout budget — same pattern the integrations webhook → process-task flow already uses.

Every piece mirrors `pending-tasks-store.ts` / `pending-tasks-retry-job.ts` so the operational shape is familiar:

| File | Purpose |
| --- | --- |
| `run-continuations/store.ts` | SQL queue: lazy `ensureTable`, `intType()`-based portable schema, atomic claim with SQLite/Postgres `RETURNING` split, per-row `attempts` counter. Statuses: `pending → processing → completed | failed | gave_up`. `gave_up` is a distinct terminal state from `failed` so an operator can tell at a glance whether the resumer kept blowing up vs. the sweep stopped trying. |
| `run-continuations/dispatch.ts` | Fire-and-forget POST to the processor. HMAC-signed via the existing `signInternalToken` (A2A_SECRET is the single source of truth for internal-call auth). Production refuses unsigned dispatches; dev allows unsigned. |
| `run-continuations/route.ts` | `POST /_agent-native/runs/_continue-run`. Verifies HMAC, atomically claims the row, hands off to the registered resumer. The route owns lifecycle bookkeeping (`markCompleted` / `markFailed`) so the resumer stays focused on the agent loop. |
| `run-continuations/resumer.ts` | Module-level singleton holding the resume callback. Templates / plugins call `setRunContinuationResumer()` during init when they have all the agent-loop context (model, apiKey, system prompt, actions). When no resumer is registered, the route logs a warning and marks the row completed — graceful degradation rather than infinite retries. |
| `run-continuations/retry-job.ts` | Recurring 60s sweep. Re-fires stuck rows; gives up after `MAX_ATTEMPTS = 3`. Same host-branched stuck thresholds as pending-tasks (75s serverless, 5min Node). No-ops gracefully if the table doesn't exist yet. |

## Wiring

`agent/run-manager.ts` enqueues inside the `.finally()` block **after** `updateRunStatus` lands — by that point `thread_data` is already durable (the `onComplete` callback runs earlier), so the fresh resume run reads a consistent snapshot. The enqueue is gated on:

- `softTimedOut === true` — only auto-continue on actual timeout, not normal completion or external abort.
- `process.env.AGENT_AUTO_CONTINUATION !== "false"` — kill switch (default ON).
- `options.ownerEmail` provided — without identity we can't enqueue.
- Cascade count for this thread in the last 10 minutes `< 3` — a buggy agent loop cannot burn unbounded spend re-firing itself.

`production-agent.ts` now passes `ownerEmail` / `orgId` from the request context into `startRun`'s options so the enqueue path has them. The new route and sweep get mounted from `integrations/plugin.ts` — that plugin is already the home for "background work that needs a fresh function execution" infrastructure.

## Tests

- `run-continuations/store.spec.ts` — **8 tests** covering enqueue, claim race (SQLite re-read), Postgres `RETURNING` path, terminal-state guard, marker fns, `getActiveRunContinuationForThread`.
- `run-continuations/retry-job.spec.ts` — **5 tests** covering pending re-fire, processing reset, MAX_ATTEMPTS `gave_up`, missing-table no-op, Netlify 75s cutoff.
- `agent/run-manager.spec.ts` — **5 new tests** covering enqueue happy path, missing-ownerEmail skip, `AGENT_AUTO_CONTINUATION=false` kill switch, cascade-limit skip, normal-completion no-enqueue.
- All **227** core package tests pass.

## What's deferred to a follow-up PR

**No resumer is registered yet.** The infrastructure is in place but auto-continuations are observably "claim row, log a warning, mark completed without resuming." The follow-up will add `setRunContinuationResumer()` inside `agent-chat-plugin.ts` so the resumer can re-invoke `runAgentLoop` with the existing `thread_data` and a synthetic continue prompt. That requires factoring some of `production-agent.ts`'s dispatch out of its HTTP handler closure, which is a bigger mechanical change than fits cleanly in this PR.

This split is intentional: shipping the foundation first lets the queue + processor + sweep + kill switch get reviewed and merged in isolation, with no behavior change observable to users until the resumer lands. The follow-up becomes a small, focused diff that wires the resumer into the existing plugin init.

## Operational shape after this lands

- New SQL table `agent_run_continuations` lazy-created on first enqueue.
- New env var `AGENT_AUTO_CONTINUATION` (default ON, set to `"false"` to disable).
- New recurring sweep starts on every cold start of the integrations plugin (mirrors `startPendingTasksRetryJob`).
- Telemetry: log warnings on cascade-limit hits, on no-resumer, on resumer failure. Easy to wire into a counter once we have an outage worth tracking.

## Verification

- `pnpm typecheck` (core + slides) — clean.
- `pnpm vitest --run src/agent/ src/run-continuations/ src/integrations/` — **227 / 227** pass.
- `pnpm guards` — no new violations from this PR's files. (Pre-existing hits in `run-manager.spec.ts` from PR #475 remain; not in scope.)
- Slides template builds against this branch — clean.
- `npx prettier --write` — clean.

## Test plan (post-merge, with follow-up resumer wired)

- [ ] Set `AGENT_RUN_SOFT_TIMEOUT_MS=5000` locally, ask the agent to do a multi-minute task, confirm the run pauses at 5s, a continuation row is enqueued, the processor fires, and the agent resumes.
- [ ] Same flow on a Netlify deploy preview — confirm the dispatch survives the function freeze and the sweep retries dropped dispatches.
- [ ] Set `AGENT_AUTO_CONTINUATION=false`, repeat — confirm timeouts behave as before (no enqueue, no resume).
- [ ] Engineer a forever-timing-out resumer, confirm we hit `gave_up` after 3 attempts and stop firing.
- [ ] Two browser tabs on the same thread: kill the producer mid-run, confirm exactly one continuation runs (atomic claim primitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
