### PR TITLE
fix(clips): generate updater artifacts

### DIFF
--- a/templates/clips/desktop/src-tauri/tauri.conf.json
+++ b/templates/clips/desktop/src-tauri/tauri.conf.json
@@ -37,6 +37,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": ["dmg", "app", "msi", "nsis"],
     "icon": ["icons/icon.png", "icons/icon.ico", "icons/icon.icns"],
     "macOS": {


### PR DESCRIPTION
## Summary
- enable Tauri v2 updater artifacts for the Clips desktop bundle so release builds produce latest.json/signature artifacts

## Why
- PR #487 published Clips v0.1.52 successfully, but the release workflow logged: No latest.json in clips-v0.1.52. Official Tauri v2 updater docs require bundle.createUpdaterArtifacts=true for updater artifacts.

## Verification
- jq '.bundle.createUpdaterArtifacts' templates/clips/desktop/src-tauri/tauri.conf.json
- pnpm --filter clips-desktop build
- pnpm --filter clips-desktop tauri build --no-bundle