### PR TITLE
fix(dispatch): bump 0.1.1 + pass with no tests

### DIFF
--- a/packages/dispatch/package.json
+++ b/packages/dispatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/dispatch",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Dispatch — workspace control plane for agent-native apps. Vault, integrations, destinations, scheduled jobs, and cross-app delegation, shipped as a single drop-in package.",
   "license": "MIT",
@@ -30,7 +30,7 @@
     "build": "tsc && tsc-alias",
     "dev": "tsc --watch & tsc-alias --watch",
     "typecheck": "tsc --noEmit",
-    "test": "vitest --run src",
+    "test": "vitest --run src --passWithNoTests",
     "prepack": "cp ../../README.md ./README.md",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
## Summary

Unblocks @agent-native/dispatch publishing.

The 0.1.0 publish job failed at the test step because `vitest --run src` exits 1 when no test files are found, and the dispatch package doesn't ship tests yet. Two changes:

- Add `--passWithNoTests` to the test script so an empty glob is treated as success.
- Bump version to 0.1.1 so the publish workflow's detect-changes step actually re-fires the publish-dispatch job (it triggers on package.json version diff between HEAD~1 and HEAD).

## Why this matters

builder-workspace [PR #62](https://github.com/BuilderIO/builder-agent-native-workspace/pull/62) is blocked on \`@agent-native/dispatch@0.1.x\` resolving on npm. Until this lands and publishes, that PR's CI stays red.

## Test plan

- [ ] Merge → \`Publish @agent-native/dispatch\` job in publish-packages workflow turns green
- [ ] \`npm view @agent-native/dispatch version\` returns 0.1.1
- [ ] builder-workspace PR #62 CI goes green after lockfile bump