### PR TITLE
fix(agent-chat): auto-recover dropped streams

### DIFF
--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -515,7 +515,9 @@ function isRetryableError(err: unknown): boolean {
 
 /** Wait with exponential backoff, respecting abort signal */
 function retryDelay(attempt: number, signal: AbortSignal): Promise<void> {
-  const ms = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+  const baseMs = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+  const jitter = baseMs * 0.1;
+  const ms = Math.max(0, baseMs + (Math.random() * 2 - 1) * jitter);
   return new Promise((resolve, reject) => {
     if (signal.aborted) return reject(new Error("aborted"));
     const timer = setTimeout(resolve, ms);
@@ -907,12 +909,10 @@ export async function runAgentLoop(opts: {
         }
         if (retry < MAX_RETRIES && isRetryableError(err)) {
           // Clear partial text from the failed attempt so the retry
-          // doesn't produce garbled duplicate output
+          // doesn't produce garbled duplicate output. Keep the retry itself
+          // silent so transient provider/backend failures do not leak into
+          // the assistant's final answer.
           send({ type: "clear" });
-          send({
-            type: "text",
-            text: `*Retrying in ${(RETRY_BASE_DELAY_MS * Math.pow(2, retry)) / 1000}s...*\n\n`,
-          });
           await retryDelay(retry, signal);
           continue;
         }
@@ -1550,8 +1550,8 @@ export function createProductionAgentHandler(
     // If there's already an active run for this thread, reject with 409 so
     // the client can queue or wait rather than silently aborting the existing run.
     if (threadId) {
-      const existingRun = getActiveRunForThread(threadId);
-      if (existingRun && existingRun.status === "running") {
+      const existingRun = await getActiveRunForThreadAsync(threadId);
+      if (existingRun?.status === "running") {
         setResponseStatus(event, 409);
         return {
           error: "Run already in progress for this thread",

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -20,6 +20,30 @@ function sseResponse(events: unknown[]): Response {
   );
 }
 
+function emptySseResponse(runId = "run-empty"): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "X-Run-Id": runId,
+      },
+    },
+  );
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 async function drain(iterable: AsyncIterable<unknown>) {
   const results: unknown[] = [];
   for await (const result of iterable) {
@@ -30,6 +54,7 @@ async function drain(iterable: AsyncIterable<unknown>) {
 
 describe("createAgentChatAdapter", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -304,5 +329,198 @@ describe("createAgentChatAdapter", () => {
     expect(secondBody.history).toEqual([
       { role: "user", content: "keep using tools" },
     ]);
+  });
+
+  it("reconnects to an active run when the initial POST loses its response", async () => {
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        throw new TypeError("Failed to fetch");
+      }
+      if (url.includes("/runs/active")) {
+        return jsonResponse({
+          active: true,
+          runId: "run-existing",
+          threadId: "thread-recover",
+          status: "running",
+          heartbeatAt: Date.now(),
+        });
+      }
+      if (url.includes("/runs/run-existing/events")) {
+        return sseResponse([
+          { type: "text", text: "recovered from active run" },
+          { type: "done" },
+        ]);
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-recover",
+      threadId: "thread-recover",
+    });
+
+    const results = await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "keep going" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/_agent-native/agent-chat/runs/active?threadId=thread-recover",
+      expect.any(Object),
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/_agent-native/agent-chat/runs/run-existing/events?after=0",
+      expect.any(Object),
+    );
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toBe("recovered from active run");
+  });
+
+  it("continues automatically when an SSE stream closes before any terminal event", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        postCount += 1;
+        return postCount === 1
+          ? emptySseResponse("run-empty")
+          : sseResponse([
+              { type: "text", text: "finished after empty-stream recovery" },
+              { type: "done" },
+            ]);
+      }
+      if (url.includes("/runs/run-empty/events")) {
+        return jsonResponse({ error: "gone" }, 404);
+      }
+      if (url.includes("/runs/active")) {
+        return jsonResponse({ active: false, status: "idle" });
+      }
+      return jsonResponse({ error: "unexpected" }, 500);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-empty",
+      threadId: "thread-empty",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "do the thing" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const results = await promise;
+
+    expect(postCount).toBe(2);
+    const secondBody = JSON.parse(fetchSpy.mock.calls[3][1].body);
+    expect(secondBody.message).toContain("Continue from where you left off");
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toBe(
+      "finished after empty-stream recovery",
+    );
+  });
+
+  it("continues automatically after a recoverable gateway timeout event", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sseResponse([
+          {
+            type: "error",
+            error: "Builder gateway timed out after 45s",
+            errorCode: "builder_gateway_timeout",
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        sseResponse([
+          { type: "text", text: "finished after timeout recovery" },
+          { type: "done" },
+        ]),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-timeout",
+      threadId: "thread-timeout",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "long analytics query" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const results = await promise;
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(fetchSpy.mock.calls[1][1].body);
+    expect(secondBody.message).toContain("Continue from where you left off");
+    const last = results.at(-1) as any;
+    expect(last.content.at(-1).text).toBe("finished after timeout recovery");
   });
 });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -20,6 +20,11 @@ type AdapterHistoryMessage = {
 
 const AUTO_CONTINUE_PROMPT =
   "Continue from where you left off and finish the user's original request. Do not repeat completed work, do not mention internal reconnects, time limits, or step limits, and continue as if this is the same uninterrupted run.";
+const MAX_RECONNECT_ATTEMPTS = 5;
+const MAX_STARTUP_RECOVERY_ATTEMPTS = 8;
+const MAX_TRANSIENT_CONTINUATIONS = 8;
+const RETRY_BASE_DELAY_MS = 500;
+const RETRY_MAX_DELAY_MS = 8_000;
 
 function normalizeMentions(text: string): string {
   return text.replace(/@\[([^\]|]+)\|[^\]]+\]/g, "@$1");
@@ -74,6 +79,63 @@ function delay(ms: number, abortSignal: AbortSignal): Promise<void> {
       { once: true },
     );
   });
+}
+
+function retryDelay(attempt: number, abortSignal: AbortSignal): Promise<void> {
+  const base = Math.min(
+    RETRY_MAX_DELAY_MS,
+    RETRY_BASE_DELAY_MS * Math.pow(2, attempt),
+  );
+  const jitter = base * 0.2;
+  const ms = Math.max(0, base + (Math.random() * 2 - 1) * jitter);
+  return delay(ms, abortSignal);
+}
+
+function isRetryableStartupError(message: string): boolean {
+  const msg = message.toLowerCase();
+  if (
+    msg.includes("unauthorized") ||
+    msg.includes("not authenticated") ||
+    msg.includes("401") ||
+    msg.includes("403") ||
+    msg.includes("404") ||
+    msg.includes("405") ||
+    msg.includes("missing api key") ||
+    msg.includes("api key") ||
+    msg.includes("context_length") ||
+    msg.includes("input_too_long") ||
+    msg.includes("too many tokens") ||
+    msg.includes("prompt is too long") ||
+    msg.includes("credits-limit") ||
+    msg.includes("billing") ||
+    msg.includes("permission")
+  ) {
+    return false;
+  }
+  return (
+    msg.includes("failed to fetch") ||
+    msg.includes("network") ||
+    msg.includes("connection") ||
+    msg.includes("reset") ||
+    msg.includes("econnreset") ||
+    msg.includes("socket") ||
+    msg.includes("timeout") ||
+    msg.includes("gateway timeout") ||
+    msg.includes("inactivity timeout") ||
+    msg.includes("temporarily unavailable") ||
+    msg.includes("server error: 408") ||
+    msg.includes("server error: 429") ||
+    msg.includes("server error: 500") ||
+    msg.includes("server error: 502") ||
+    msg.includes("server error: 503") ||
+    msg.includes("server error: 504") ||
+    msg.includes("429") ||
+    msg.includes("500") ||
+    msg.includes("502") ||
+    msg.includes("503") ||
+    msg.includes("504") ||
+    msg.includes("529")
+  );
 }
 
 /**
@@ -210,6 +272,8 @@ export function createAgentChatAdapter(options?: {
       let currentHistory: AdapterHistoryMessage[] = history;
       let includeAttachments = attachments.length > 0;
       let includeReferences = Boolean(runConfig?.custom?.references);
+      let startupRecoveryAttempts = 0;
+      let transientContinuationAttempts = 0;
 
       try {
         const headers: Record<string, string> = {
@@ -228,7 +292,7 @@ export function createAgentChatAdapter(options?: {
           unknown
         > {
           if (!runId) return false;
-          for (let attempt = 0; attempt < 3; attempt++) {
+          for (let attempt = 0; attempt < MAX_RECONNECT_ATTEMPTS; attempt++) {
             try {
               const reconnectRes = await fetch(
                 `${apiUrl}/runs/${encodeURIComponent(runId)}/events?after=${lastSeq + 1}`,
@@ -260,10 +324,73 @@ export function createAgentChatAdapter(options?: {
               if (reconnectErr instanceof AgentAutoContinueSignal) {
                 return false;
               }
-              await delay(1000, abortSignal);
+              await retryDelay(attempt, abortSignal);
             }
           }
           return false;
+        };
+
+        const reconnectActiveRunForThread = async function* (): AsyncGenerator<
+          ChatModelRunResult,
+          boolean,
+          unknown
+        > {
+          if (!threadId) return false;
+          for (let attempt = 0; attempt < MAX_RECONNECT_ATTEMPTS; attempt++) {
+            try {
+              const activeRes = await fetch(
+                `${apiUrl}/runs/active?threadId=${encodeURIComponent(threadId)}`,
+                { signal: abortSignal },
+              );
+              if (!activeRes.ok) return false;
+              const active = await activeRes.json();
+              if (active?.active && active.runId) {
+                const activeRunId = String(active.runId);
+                runId = activeRunId;
+                lastSeq = -1;
+                setActiveRun({ threadId, runId: activeRunId, lastSeq: -1 });
+                const reconnected = yield* reconnectCurrentRun();
+                if (reconnected) return true;
+              }
+              return false;
+            } catch (activeErr: unknown) {
+              if (
+                activeErr instanceof Error &&
+                activeErr.name === "AbortError"
+              ) {
+                clearActiveRun();
+                return true;
+              }
+              await retryDelay(attempt, abortSignal);
+            }
+          }
+          return false;
+        };
+
+        const prepareAutoContinuation = (
+          signal: AgentAutoContinueSignal,
+        ): boolean => {
+          if (signal.reason === "loop_limit") {
+            transientContinuationAttempts = 0;
+          } else if (
+            ++transientContinuationAttempts > MAX_TRANSIENT_CONTINUATIONS
+          ) {
+            return false;
+          }
+          const partialHistory = contentToContinuationHistory(content);
+          currentHistory = [
+            ...history,
+            { role: "user", content: normalizeMentions(rawMessageText) },
+            ...(partialHistory
+              ? [{ role: "assistant" as const, content: partialHistory }]
+              : []),
+          ];
+          currentMessageText = autoContinueMessage(signal);
+          includeAttachments = false;
+          includeReferences = false;
+          startupRecoveryAttempts = 0;
+          clearActiveRun();
+          return true;
         };
 
         while (true) {
@@ -429,19 +556,42 @@ export function createAgentChatAdapter(options?: {
               if (err.reason === "stream_ended") {
                 const reconnected = yield* reconnectCurrentRun();
                 if (reconnected) return;
+                const activeReconnected = yield* reconnectActiveRunForThread();
+                if (activeReconnected) return;
               }
-              const partialHistory = contentToContinuationHistory(content);
-              currentHistory = [
-                ...history,
-                { role: "user", content: normalizeMentions(rawMessageText) },
-                ...(partialHistory
-                  ? [{ role: "assistant" as const, content: partialHistory }]
-                  : []),
-              ];
-              currentMessageText = autoContinueMessage(err);
-              includeAttachments = false;
-              includeReferences = false;
-              clearActiveRun();
+              if (!prepareAutoContinuation(err)) {
+                const message =
+                  "The agent connection kept failing after several automatic recovery attempts.";
+                const runError = {
+                  message,
+                  errorCode: "connection_error",
+                  recoverable: true,
+                  ...(runId ? { runId } : {}),
+                };
+                if (typeof window !== "undefined") {
+                  window.dispatchEvent(
+                    new CustomEvent("agent-chat:run-error", {
+                      detail: { ...runError, tabId },
+                    }),
+                  );
+                }
+                content.push({
+                  type: "text",
+                  text: `Something went wrong: ${message}`,
+                });
+                yield {
+                  content: [...content],
+                  status: {
+                    type: "incomplete" as const,
+                    reason: "error" as const,
+                  },
+                  metadata: {
+                    custom: { ...(runId ? { runId } : {}), runError },
+                  },
+                };
+                clearActiveRun();
+                return;
+              }
               await delay(250, abortSignal);
               if (abortSignal.aborted) return;
               continue;
@@ -476,25 +626,59 @@ export function createAgentChatAdapter(options?: {
             // Connection lost — try to reconnect to the run
             const reconnected = yield* reconnectCurrentRun();
             if (reconnected) return;
+            const activeReconnected = yield* reconnectActiveRunForThread();
+            if (activeReconnected) return;
 
             // Reconnect failed or not possible — keep going from the partial
             // streamed content instead of surfacing a transient transport error.
             if (content.length > 0) {
-              const partialHistory = contentToContinuationHistory(content);
-              currentHistory = [
-                ...history,
-                { role: "user", content: normalizeMentions(rawMessageText) },
-                ...(partialHistory
-                  ? [{ role: "assistant" as const, content: partialHistory }]
-                  : []),
-              ];
-              currentMessageText = autoContinueMessage(
-                new AgentAutoContinueSignal({ reason: "stream_ended" }),
-              );
-              includeAttachments = false;
-              includeReferences = false;
-              clearActiveRun();
+              if (
+                !prepareAutoContinuation(
+                  new AgentAutoContinueSignal({ reason: "stream_ended" }),
+                )
+              ) {
+                const message =
+                  "The agent connection kept failing after several automatic recovery attempts.";
+                const runError = {
+                  message,
+                  errorCode: "connection_error",
+                  recoverable: true,
+                  ...(runId ? { runId } : {}),
+                };
+                if (typeof window !== "undefined") {
+                  window.dispatchEvent(
+                    new CustomEvent("agent-chat:run-error", {
+                      detail: { ...runError, tabId },
+                    }),
+                  );
+                }
+                content.push({
+                  type: "text",
+                  text: `Something went wrong: ${message}`,
+                });
+                yield {
+                  content: [...content],
+                  status: {
+                    type: "incomplete" as const,
+                    reason: "error" as const,
+                  },
+                  metadata: {
+                    custom: { ...(runId ? { runId } : {}), runError },
+                  },
+                };
+                clearActiveRun();
+                return;
+              }
               await delay(250, abortSignal);
+              if (abortSignal.aborted) return;
+              continue;
+            }
+
+            if (
+              isRetryableStartupError(errMsg) &&
+              startupRecoveryAttempts < MAX_STARTUP_RECOVERY_ATTEMPTS
+            ) {
+              await retryDelay(startupRecoveryAttempts++, abortSignal);
               if (abortSignal.aborted) return;
               continue;
             }

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -59,6 +59,68 @@ export class AgentAutoContinueSignal extends Error {
   }
 }
 
+function isAutoRecoverableError(ev: SSEEvent, errMsg: string): boolean {
+  const code = String(ev.errorCode ?? "").toLowerCase();
+  const msg = errMsg.toLowerCase();
+
+  if (
+    code === "context_length_exceeded" ||
+    code === "input_too_long" ||
+    code.startsWith("credits-limit") ||
+    code === "billing_error" ||
+    code === "unauthorized" ||
+    code === "authentication_error" ||
+    code === "permission_error" ||
+    code === "gateway_not_enabled" ||
+    code === "missing_api_key" ||
+    code === "missing_credentials" ||
+    code === "invalid_request_error" ||
+    code === "request_too_large" ||
+    code === "not_found_error" ||
+    code === "model_not_found"
+  ) {
+    return false;
+  }
+
+  if (
+    code === "builder_gateway_timeout" ||
+    code === "stale_run" ||
+    code === "timeout" ||
+    code === "timeout_error" ||
+    code === "http_408" ||
+    code === "http_429" ||
+    code === "http_500" ||
+    code === "http_502" ||
+    code === "http_503" ||
+    code === "http_504" ||
+    code === "rate_limited" ||
+    code === "too_many_concurrent_requests" ||
+    code === "overloaded_error"
+  ) {
+    return true;
+  }
+
+  if (ev.recoverable === true) return true;
+
+  return (
+    msg.includes("overloaded") ||
+    msg.includes("rate_limit") ||
+    msg.includes("too many requests") ||
+    msg.includes("timeout") ||
+    msg.includes("gateway timeout") ||
+    msg.includes("inactivity timeout") ||
+    msg.includes("connection") ||
+    msg.includes("network") ||
+    msg.includes("stream closed") ||
+    msg.includes("stream ended") ||
+    msg.includes("temporarily unavailable") ||
+    msg.includes("502") ||
+    msg.includes("503") ||
+    msg.includes("504") ||
+    msg.includes("529")
+  );
+}
+
 /**
  * Process a single SSE event and update the content accumulator.
  * Returns: "continue" to keep going, "done" to stop, or a yield-ready result.
@@ -272,10 +334,20 @@ export function processEvent(
 
   if (ev.type === "error") {
     const errMsg = ev.error ?? "Unknown error";
-    if (ev.errorCode === "run_timeout" && ev.recoverable) {
+    if (
+      (ev.errorCode === "run_timeout" && ev.recoverable) ||
+      isAutoRecoverableError(ev, errMsg)
+    ) {
       return {
         action: "auto_continue",
-        autoContinue: { reason: "run_timeout" },
+        autoContinue: {
+          reason:
+            ev.errorCode === "builder_gateway_timeout" ||
+            ev.errorCode === "run_timeout" ||
+            errMsg.toLowerCase().includes("timeout")
+              ? "run_timeout"
+              : "stream_ended",
+        },
       };
     }
     const normalized = normalizeChatError(errMsg);
@@ -432,10 +504,11 @@ export async function* readSSEStream(
     reader.releaseLock();
   }
 
-  // Stream ended without explicit done event
-  if (content.length > 0) {
-    throw new AgentAutoContinueSignal({ reason: "stream_ended" });
-  }
+  // Stream ended without explicit done event. Even an empty content array is
+  // abnormal here: a healthy run emits a terminal `done` event. Treat this as
+  // recoverable so the adapter can first reconnect to the run, then continue
+  // from durable history if the producer is gone.
+  throw new AgentAutoContinueSignal({ reason: "stream_ended" });
 }
 
 /**


### PR DESCRIPTION
## Summary
- retry lost agent-chat startup responses by discovering any active run for the thread before sending a fresh POST
- treat unexpected SSE closure, stale runs, and gateway timeouts as hidden auto-continuations instead of terminal chat errors
- make provider retries jittered and silent, and check durable active-run state server-side to avoid duplicate runs across isolates

## Local verification
- pnpm --filter @agent-native/core test -- src/client/agent-chat-adapter.spec.ts src/agent/production-agent.spec.ts
- pnpm --filter @agent-native/core typecheck
- pnpm --filter @agent-native/core build

## Notes
- I intentionally left the unrelated untracked packages/dispatch/README.md out of this PR.
- Follow-up babysitting will include CI, review feedback, local e2e-style stream recovery checks, and production validation after merge.