### PR TITLE
fix(release): add publishConfig.provenance to publishable packages

### DIFF
--- a/.changeset/provenance-publishconfig.md
+++ b/.changeset/provenance-publishconfig.md
@@ -1,0 +1,8 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+"@agent-native/scheduling": patch
+"@agent-native/pinpoint": patch
+---
+
+Add `publishConfig.provenance: true` so `pnpm publish` (called by `changeset publish` from the auto-publish workflow) requests an OIDC token from GitHub Actions and publishes via npm trusted publisher. Without this, `pnpm publish` looked for token-based auth and failed with `ENEEDAUTH`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,10 @@
     "url": "https://github.com/BuilderIO/agent-native/issues"
   },
   "homepage": "https://github.com/BuilderIO/agent-native#readme",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "bin": {
     "agent-native": "dist/cli/index.js"
   },

--- a/packages/dispatch/package.json
+++ b/packages/dispatch/package.json
@@ -13,6 +13,10 @@
     "url": "https://github.com/BuilderIO/agent-native/issues"
   },
   "homepage": "https://github.com/BuilderIO/agent-native#readme",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "exports": {
     ".": "./dist/index.js",
     "./routes": "./dist/routes/index.js",

--- a/packages/pinpoint/package.json
+++ b/packages/pinpoint/package.json
@@ -13,6 +13,10 @@
     "url": "https://github.com/BuilderIO/agent-native/issues"
   },
   "homepage": "https://github.com/BuilderIO/agent-native#readme",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/scheduling/package.json
+++ b/packages/scheduling/package.json
@@ -13,6 +13,10 @@
     "url": "https://github.com/BuilderIO/agent-native/issues"
   },
   "homepage": "https://github.com/BuilderIO/agent-native#readme",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "exports": {
     ".": "./dist/index.js",
     "./schema": "./dist/schema/index.js",


### PR DESCRIPTION
## Summary

Fixes the publish failure on \`Release npm packages\` job from PR #495's merge: \`pnpm publish\` was hitting \`ENEEDAUTH\` because it didn't request an OIDC token from GitHub Actions.

The auto-publish workflow's \`pnpm changeset:publish\` step calls \`pnpm publish\` per package. Without \`--provenance\`, pnpm doesn't trigger the npm trusted-publisher OIDC handshake and falls back to token-based auth — which isn't configured.

\`publishConfig.provenance: true\` in each package.json makes pnpm pass the flag automatically.

## What ships

- \`packages/core\` 0.7.84 → 0.7.85
- \`packages/dispatch\` 0.2.0 → 0.2.1
- \`packages/scheduling\` 0.1.1 → 0.1.2
- \`packages/pinpoint\` 0.1.2 → 0.1.3

(0.7.84 / 0.2.0 are stranded — they exist in package.json on main but were never published. The next release uses fresh versions.)

## Required: trusted publishers must be configured

For each of the 4 packages, on npmjs.com:
- Trusted Publisher → GitHub Actions
- Owner: \`BuilderIO\`
- Repo: \`agent-native\`
- Workflow: \`auto-publish.yml\`
- Environment: \`npm-publish\`

\`@agent-native/dispatch\` already has this from the bootstrap publish setup. The other three (\`core\`, \`scheduling\`, \`pinpoint\`) had per-package job names in the OLD workflow's trust config; need to be updated to the new consolidated workflow + environment combo.

## Test plan

- [ ] Merge → publish workflow runs → opens new Version Packages PR with the 4 patch bumps
- [ ] Merge that PR → publish workflow runs again → all 4 packages publish successfully to npm with provenance
- [ ] Verify \`npm view @agent-native/core@0.7.85\` etc. all return 200