### PR TITLE
clips desktop: custom shortcuts, capture sharing, pill stop UX

### DIFF
--- a/.agents/skills/new-branch/SKILL.md
+++ b/.agents/skills/new-branch/SKILL.md
@@ -1,10 +1,18 @@
 ---
 name: new-branch
-description: Stash, pull latest main, and create a new branch — fast, to minimize disruption to concurrent agents
+description: Only when explicitly asked for /new-branch or a fresh git branch: stash local changes, update main, and create it. Do not auto-run for normal coding, PR, Builder.io, or Fusion branch workflows.
 user_invocable: true
 ---
 
 # New Branch
+
+## Activation guard
+
+Use this skill only when the user explicitly invokes `/new-branch`, mentions this skill as the workflow to run, or directly asks you to create a fresh git branch from main.
+
+Do not use this skill just because the current branch looks wrong, a PR/send-PR flow is involved, a branch name appears in context, or the agent is running inside Builder.io/Fusion/project containers. Those environments may provide platform-managed branches such as `ai_*`, `ci/*`, or task-specific branches, and moving away from them can make completed work appear missing.
+
+If this skill was loaded without an explicit user request to create a new branch, stop here. Report that branch movement requires explicit confirmation, then continue the original task on the current branch.
 
 Quickly stash any local changes, pull latest from origin/main, and create a new working branch. Designed to be as fast as possible since other agents may be working concurrently on this repo.
 

--- a/.changeset/core-usage-subpath.md
+++ b/.changeset/core-usage-subpath.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": minor
+"@agent-native/dispatch": patch
+---
+
+Add `@agent-native/core/usage` subpath export for `getUsageSummary` so server-side consumers (Cloudflare Workers / Pages) can import it without hitting the curated browser entry. Switch dispatch's usage-metrics store to the new subpath, fixing the dispatch CF Pages build failure.

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -68,6 +68,14 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+
+      # npm Trusted Publishing (OIDC auth, no NPM_TOKEN) requires npm
+      # >= 11.5.1. Node 22 ships with npm 10.x, which silently falls back
+      # to token auth and ENEEDAUTHs the publish. Force-upgrade the runner's
+      # npm before any publish call.
+      - name: Upgrade npm for Trusted Publishing (>= 11.5.1)
+        run: npm install -g npm@latest
 
       - run: pnpm install --frozen-lockfile
 
@@ -82,21 +90,22 @@ jobs:
         uses: changesets/action@v1
         with:
           # When changesets/action finds no pending changesets, it runs
-          # `publish` — which builds + `pnpm changeset publish` to push
-          # newly-bumped versions to npm via OIDC trusted publisher.
-          publish: pnpm changeset:publish
+          # `publish` — which shells out to `npm publish` per package.
+          # We invoke `changeset publish` directly via npx (NOT
+          # `pnpm changeset publish`); pnpm's publish path bypasses npm's
+          # OIDC trusted-publishing handshake and fails ENEEDAUTH.
+          # See pnpm#9812, changesets/changesets#1914.
+          publish: npx changeset publish
           # When pending changesets exist, opens this PR with the version
           # bumps + changelog updates. Merging it triggers the publish run.
           title: "chore: version packages"
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          # `pnpm publish` (called by `changeset publish`) only requests
-          # an OIDC token when --provenance is passed. publishConfig.provenance
-          # in package.json isn't honored across all pnpm versions, so set the
-          # env var instead — both npm and pnpm read NPM_CONFIG_PROVENANCE.
-          # Without this, publish falls back to token auth and fails with
-          # ENEEDAUTH.
+          # `npm publish` (called by `changeset publish`) requests an OIDC
+          # token when --provenance is set. publishConfig.provenance in
+          # package.json isn't honored everywhere, so set the env var —
+          # both npm and pnpm read NPM_CONFIG_PROVENANCE.
           NPM_CONFIG_PROVENANCE: "true"
 
       - name: Trigger Builder workspace package update

--- a/.github/workflows/clips-desktop-release.yml
+++ b/.github/workflows/clips-desktop-release.yml
@@ -147,6 +147,27 @@ jobs:
           args: ${{ matrix.target != '' && format('--target {0}', matrix.target) || '' }}
           updaterJsonPreferNsis: false
 
+      - name: Verify macOS permission metadata
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP_PATH=$(find "$TAURI_APP_PATH/src-tauri/target" -path '*/bundle/macos/Clips.app' -type d | head -n 1)
+          if [ -z "$APP_PATH" ]; then
+            echo "::error::Could not find built Clips.app bundle"
+            exit 1
+          fi
+
+          INFO="$APP_PATH/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Print :NSCameraUsageDescription" "$INFO" >/dev/null
+          /usr/libexec/PlistBuddy -c "Print :NSMicrophoneUsageDescription" "$INFO" >/dev/null
+          /usr/libexec/PlistBuddy -c "Print :NSScreenCaptureUsageDescription" "$INFO" >/dev/null
+          /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$INFO" | grep -qx 'com.clips.tray'
+
+          ENTITLEMENTS=$(codesign -d --entitlements :- "$APP_PATH" 2>/dev/null)
+          grep -q '<key>com.apple.security.device.camera</key>' <<< "$ENTITLEMENTS"
+          grep -q '<key>com.apple.security.device.audio-input</key>' <<< "$ENTITLEMENTS"
+
   publish-release:
     needs: build-tauri
     runs-on: ubuntu-latest
@@ -161,7 +182,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release edit "clips-v${{ steps.v.outputs.version }}" \
+          retry() {
+            local attempts="$1"
+            shift
+            local delay=2
+            local n=1
+            until "$@"; do
+              if [ "$n" -ge "$attempts" ]; then
+                return 1
+              fi
+              echo "Attempt $n failed; retrying in ${delay}s..."
+              sleep "$delay"
+              n=$((n + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          retry 5 gh release edit "clips-v${{ steps.v.outputs.version }}" \
             --draft=false \
             --latest=false
 
@@ -169,6 +206,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          retry() {
+            local attempts="$1"
+            shift
+            local delay=2
+            local n=1
+            until "$@"; do
+              if [ "$n" -ge "$attempts" ]; then
+                return 1
+              fi
+              echo "Attempt $n failed; retrying in ${delay}s..."
+              sleep "$delay"
+              n=$((n + 1))
+              delay=$((delay * 2))
+            done
+          }
+
           RELEASE_TAG="clips-v${{ steps.v.outputs.version }}"
           mkdir -p manifest
 
@@ -181,20 +234,20 @@ jobs:
           }
 
           if [ "$HAS_MANIFEST" = "true" ]; then
-            gh release download "$RELEASE_TAG" --pattern 'latest.json' --dir manifest
+            retry 5 gh release download "$RELEASE_TAG" --pattern 'latest.json' --dir manifest
             mv manifest/latest.json manifest/clips-latest.json
 
             MANIFEST_TITLE="Clips Desktop — latest (updater manifest)"
             MANIFEST_NOTES="Stable URL for the Clips auto-updater. Overwritten on every release. Versioned bundles live in clips-v* releases."
 
             if gh release view clips-latest --json tagName -q .tagName >/dev/null 2>&1; then
-              gh release delete-asset clips-latest clips-latest.json --yes || true
-              gh release upload clips-latest manifest/clips-latest.json
-              gh release edit clips-latest \
+              retry 5 gh release delete-asset clips-latest clips-latest.json --yes || true
+              retry 5 gh release upload clips-latest manifest/clips-latest.json
+              retry 5 gh release edit clips-latest \
                 --title "$MANIFEST_TITLE" \
                 --notes "$MANIFEST_NOTES"
             else
-              gh release create clips-latest manifest/clips-latest.json \
+              retry 5 gh release create clips-latest manifest/clips-latest.json \
                 --title "$MANIFEST_TITLE" \
                 --notes "$MANIFEST_NOTES" \
                 --latest=false

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,6 +73,7 @@
     "./mcp": "./dist/mcp/index.js",
     "./mcp-client": "./dist/mcp-client/index.js",
     "./tracking": "./dist/tracking/index.js",
+    "./usage": "./dist/usage/store.js",
     "./notifications": "./dist/notifications/index.js",
     "./client/notifications": "./dist/client/notifications/index.js",
     "./progress": "./dist/progress/index.js",

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -339,6 +339,7 @@ function getCoreSourceAliases(
       coreSrc,
       "adapters/cli/index.ts",
     ),
+    "@agent-native/core/usage": path.join(coreSrc, "usage/store.ts"),
   };
 
   // Escape special regex chars in the key and anchor with $

--- a/packages/dispatch/src/server/lib/usage-metrics-store.ts
+++ b/packages/dispatch/src/server/lib/usage-metrics-store.ts
@@ -1,4 +1,4 @@
-import { getUsageSummary } from "@agent-native/core";
+import { getUsageSummary } from "@agent-native/core/usage";
 import { getDbExec } from "@agent-native/core/db";
 import { currentOrgId, currentOwnerEmail } from "./dispatch-store.js";
 import {

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -16,7 +16,7 @@ use crate::state::{
 };
 use crate::util::{
     build_overlay_url, hide_voice_wake_popover, mark_popover_shown, primary_monitor_physical_size,
-    set_capture_excluded, set_dictation_active,
+    set_capture_excluded, set_capture_included, set_dictation_active,
 };
 
 /// Native overlay windows for the recording experience. These render the same
@@ -475,7 +475,7 @@ pub async fn close_bubble(app: AppHandle) -> Result<(), String> {
 /// whenever the height changes — gives us auto-sizing without having to
 /// pick a fixed popover size that fits every state.
 #[tauri::command]
-pub async fn resize_popover(app: AppHandle, height: f64) -> Result<(), String> {
+pub async fn resize_popover(app: AppHandle, height: f64, width: Option<f64>) -> Result<(), String> {
     // CRITICAL: bail out when the popover is parked at 2x2 for voice
     // wake-up. The React shell's ResizeObserver fires on every mount
     // and would un-park the window back to full size, making the
@@ -491,8 +491,9 @@ pub async fn resize_popover(app: AppHandle, height: f64) -> Result<(), String> {
     }
     if let Some(w) = app.get_webview_window("popover") {
         let clamped = height.clamp(200.0, 820.0);
+        let width = width.unwrap_or(360.0).clamp(320.0, 480.0);
         let _ = w.set_size(tauri::Size::Logical(tauri::LogicalSize::new(
-            360.0, clamped,
+            width, clamped,
         )));
         // Re-anchor to the tray icon so the window doesn't drift below the
         // bottom of the monitor after a growth.
@@ -859,6 +860,7 @@ pub async fn save_bubble_position(app: AppHandle, x: i32, y: i32) -> Result<(), 
 #[tauri::command]
 pub async fn show_popover(app: AppHandle) -> Result<(), String> {
     if let Some(window) = app.get_webview_window("popover") {
+        set_capture_included(&window);
         // Restore the popover's normal size — it may have been shrunk to 2×2
         // during recording by `park_popover_offscreen` (kept the JS alive
         // while keeping the window out of the way). The content's
@@ -899,6 +901,7 @@ pub async fn show_popover(app: AppHandle) -> Result<(), String> {
 #[tauri::command]
 pub async fn park_popover_offscreen(app: AppHandle) -> Result<(), String> {
     if let Some(window) = app.get_webview_window("popover") {
+        set_capture_excluded(&window);
         // Anchor near the top-left of the primary display. We avoid (0,0)
         // exactly because on some macOS versions that corner falls under the
         // menu-bar cutout — 2,2 is safely inside every real display's bounds.
@@ -949,6 +952,7 @@ pub fn toggle_popover(app: &AppHandle) {
     // Restore normal size in case the window was shrunk to a pinhole
     // during recording / voice-wake — otherwise it would reappear as a
     // 2x2 dot.
+    set_capture_included(&window);
     let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(360.0, 520.0)));
     position_popover(app, &window);
     mark_popover_shown(app);

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ use state::{
     DictationActive, DictationEnabled, LastTranscript, MeetingActive, PopoverShownAt,
     RecordingActive, TrayAnchor, VoiceWakePopover,
 };
-use util::{is_recording_active, set_capture_excluded};
+use util::{is_recording_active, set_capture_included};
 
 // Embedded fallback icon — a tiny 16x16 solid purple PNG so the binary always
 // has *something* to display even if `icons/tray.png` is missing on disk. The
@@ -44,6 +44,7 @@ pub fn run() {
             // instance. Prevents the "two tray icons" UX where clicks fight
             // over focus and neither popover shows.
             if let Some(window) = app.get_webview_window("popover") {
+                set_capture_included(&window);
                 position_popover(app, &window);
                 let _ = window.show();
                 let _ = window.set_focus();
@@ -109,6 +110,8 @@ pub fn run() {
             // silence detector — Granola-style auto-stop heuristics
             silence_detector::silence_detector_start,
             silence_detector::silence_detector_stop,
+            // custom global shortcuts configured from Settings
+            shortcuts::set_custom_shortcuts,
         ])
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_process::init())
@@ -151,12 +154,6 @@ pub fn run() {
             // itself macOS briefly steals focus from the popover, which would
             // fire Focused(false) and hide the window we literally just showed.
             if let Some(window) = app.get_webview_window("popover") {
-                // Exclude the popover from screen recordings and from the macOS
-                // screen / window picker. See `set_capture_excluded` docs. This
-                // is what lets us keep the popover visible (and its JS alive)
-                // during `getDisplayMedia` without the popover leaking into the
-                // recorded video.
-                set_capture_excluded(&window);
                 let handle = window.clone();
                 let app_handle = app.handle().clone();
                 // NOTE: Intentionally NOT calling window.open_devtools()

--- a/templates/clips/desktop/src-tauri/src/shortcuts.rs
+++ b/templates/clips/desktop/src-tauri/src/shortcuts.rs
@@ -74,8 +74,15 @@ fn swap_custom_shortcut<R: tauri::Runtime>(
     if let Some(next) = next {
         if let Err(err) = gs.register(next) {
             if let Some(old) = old {
-                let _ = gs.register(old);
-                *current = Some(old);
+                // Only restore the prior state if re-registration actually
+                // succeeded — otherwise the OS rejected `old` and there is
+                // nothing registered for this slot. Tracking it as Some(old)
+                // would lie to future operations (is_registered/unregister
+                // would fail); leaving it None keeps state and reality in
+                // sync at the cost of forgetting the prior shortcut.
+                if gs.register(old).is_ok() {
+                    *current = Some(old);
+                }
             }
             return Err(format!("failed to register {label} shortcut: {err}"));
         }

--- a/templates/clips/desktop/src-tauri/src/shortcuts.rs
+++ b/templates/clips/desktop/src-tauri/src/shortcuts.rs
@@ -1,6 +1,8 @@
+use std::str::FromStr;
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
-use tauri::{Emitter, Listener, Manager, PhysicalPosition, PhysicalSize};
+use tauri::{AppHandle, Emitter, Listener, Manager, PhysicalPosition, PhysicalSize};
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut};
 
 use crate::clips::toggle_popover;
@@ -13,6 +15,102 @@ use crate::util::{
 
 fn escape_shortcut() -> Shortcut {
     Shortcut::new(None, Code::Escape)
+}
+
+static CUSTOM_VOICE_SHORTCUT: OnceLock<Mutex<Option<Shortcut>>> = OnceLock::new();
+static CUSTOM_POPOVER_SHORTCUT: OnceLock<Mutex<Option<Shortcut>>> = OnceLock::new();
+
+fn custom_voice_shortcut() -> &'static Mutex<Option<Shortcut>> {
+    CUSTOM_VOICE_SHORTCUT.get_or_init(|| Mutex::new(None))
+}
+
+fn custom_popover_shortcut() -> &'static Mutex<Option<Shortcut>> {
+    CUSTOM_POPOVER_SHORTCUT.get_or_init(|| Mutex::new(None))
+}
+
+fn current_custom_voice_shortcut() -> Option<Shortcut> {
+    custom_voice_shortcut().lock().ok().and_then(|g| *g)
+}
+
+fn current_custom_popover_shortcut() -> Option<Shortcut> {
+    custom_popover_shortcut().lock().ok().and_then(|g| *g)
+}
+
+fn parse_optional_shortcut(value: Option<String>) -> Result<Option<Shortcut>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    Shortcut::from_str(trimmed)
+        .map(Some)
+        .map_err(|err| err.to_string())
+}
+
+#[tauri::command]
+pub async fn set_custom_shortcuts(
+    app: AppHandle,
+    voice: Option<String>,
+    popover: Option<String>,
+) -> Result<(), String> {
+    let voice = parse_optional_shortcut(voice)?;
+    let popover = parse_optional_shortcut(popover)?;
+    if voice.is_some() && voice == popover {
+        return Err("Voice dictation and Open Clips need different shortcuts.".to_string());
+    }
+    let gs = app.global_shortcut();
+
+    {
+        let mut current = custom_voice_shortcut()
+            .lock()
+            .map_err(|_| "failed to lock custom voice shortcut state".to_string())?;
+        if *current != voice {
+            let old = current.take();
+            if let Some(old) = old {
+                if gs.is_registered(old) {
+                    let _ = gs.unregister(old);
+                }
+            }
+            if let Some(next) = voice {
+                if let Err(err) = gs.register(next) {
+                    if let Some(old) = old {
+                        let _ = gs.register(old);
+                        *current = Some(old);
+                    }
+                    return Err(format!("failed to register voice shortcut: {err}"));
+                }
+            }
+            *current = voice;
+        }
+    }
+
+    {
+        let mut current = custom_popover_shortcut()
+            .lock()
+            .map_err(|_| "failed to lock custom Clips shortcut state".to_string())?;
+        if *current != popover {
+            let old = current.take();
+            if let Some(old) = old {
+                if gs.is_registered(old) {
+                    let _ = gs.unregister(old);
+                }
+            }
+            if let Some(next) = popover {
+                if let Err(err) = gs.register(next) {
+                    if let Some(old) = old {
+                        let _ = gs.register(old);
+                        *current = Some(old);
+                    }
+                    return Err(format!("failed to register Clips shortcut: {err}"));
+                }
+            }
+            *current = popover;
+        }
+    }
+
+    Ok(())
 }
 
 pub fn register_shortcuts(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
@@ -84,6 +182,12 @@ pub fn build_shortcut_plugin() -> tauri_plugin_global_shortcut::Builder<tauri::W
         let is_voice_cmd_space = shortcut.matches(Modifiers::SUPER | Modifiers::SHIFT, Code::Space);
         let is_voice_ctrl_space =
             shortcut.matches(Modifiers::CONTROL | Modifiers::SHIFT, Code::Space);
+        let is_custom_voice = current_custom_voice_shortcut()
+            .map(|custom| custom == *shortcut)
+            .unwrap_or(false);
+        let is_custom_popover = current_custom_popover_shortcut()
+            .map(|custom| custom == *shortcut)
+            .unwrap_or(false);
         let is_escape = shortcut.matches(Modifiers::empty(), Code::Escape);
         if is_escape {
             if event.state() != tauri_plugin_global_shortcut::ShortcutState::Pressed {
@@ -100,8 +204,10 @@ pub fn build_shortcut_plugin() -> tauri_plugin_global_shortcut::Builder<tauri::W
             let _ = app.emit("clips:popover-visible", false);
             return;
         }
-        if is_voice_cmd_space || is_voice_ctrl_space {
-            let source = if is_voice_cmd_space {
+        if is_voice_cmd_space || is_voice_ctrl_space || is_custom_voice {
+            let source = if is_custom_voice {
+                "custom"
+            } else if is_voice_cmd_space {
                 "cmd-shift-space"
             } else {
                 "ctrl-shift-space"
@@ -137,7 +243,7 @@ pub fn build_shortcut_plugin() -> tauri_plugin_global_shortcut::Builder<tauri::W
         if event.state() != tauri_plugin_global_shortcut::ShortcutState::Pressed {
             return;
         }
-        if is_cmd || is_ctrl {
+        if is_cmd || is_ctrl || is_custom_popover {
             // Loom-style: if a recording is already active, the
             // global shortcut stops it rather than re-opening the
             // popover. Keeps parity with the tray-icon click

--- a/templates/clips/desktop/src-tauri/src/shortcuts.rs
+++ b/templates/clips/desktop/src-tauri/src/shortcuts.rs
@@ -49,6 +49,41 @@ fn parse_optional_shortcut(value: Option<String>) -> Result<Option<Shortcut>, St
         .map_err(|err| err.to_string())
 }
 
+/// Swap a stored custom shortcut to `next`, returning the previous value on
+/// success so the caller can roll back later if a sibling registration fails.
+/// On failure the previous shortcut is re-registered locally and `state` is
+/// left untouched.
+fn swap_custom_shortcut<R: tauri::Runtime>(
+    gs: &tauri_plugin_global_shortcut::GlobalShortcut<R>,
+    state: &Mutex<Option<Shortcut>>,
+    next: Option<Shortcut>,
+    label: &str,
+) -> Result<Option<Shortcut>, String> {
+    let mut current = state
+        .lock()
+        .map_err(|_| format!("failed to lock {label} shortcut state"))?;
+    if *current == next {
+        return Ok(*current);
+    }
+    let old = current.take();
+    if let Some(old) = old {
+        if gs.is_registered(old) {
+            let _ = gs.unregister(old);
+        }
+    }
+    if let Some(next) = next {
+        if let Err(err) = gs.register(next) {
+            if let Some(old) = old {
+                let _ = gs.register(old);
+                *current = Some(old);
+            }
+            return Err(format!("failed to register {label} shortcut: {err}"));
+        }
+    }
+    *current = next;
+    Ok(old)
+}
+
 #[tauri::command]
 pub async fn set_custom_shortcuts(
     app: AppHandle,
@@ -62,52 +97,15 @@ pub async fn set_custom_shortcuts(
     }
     let gs = app.global_shortcut();
 
-    {
-        let mut current = custom_voice_shortcut()
-            .lock()
-            .map_err(|_| "failed to lock custom voice shortcut state".to_string())?;
-        if *current != voice {
-            let old = current.take();
-            if let Some(old) = old {
-                if gs.is_registered(old) {
-                    let _ = gs.unregister(old);
-                }
-            }
-            if let Some(next) = voice {
-                if let Err(err) = gs.register(next) {
-                    if let Some(old) = old {
-                        let _ = gs.register(old);
-                        *current = Some(old);
-                    }
-                    return Err(format!("failed to register voice shortcut: {err}"));
-                }
-            }
-            *current = voice;
-        }
-    }
-
-    {
-        let mut current = custom_popover_shortcut()
-            .lock()
-            .map_err(|_| "failed to lock custom Clips shortcut state".to_string())?;
-        if *current != popover {
-            let old = current.take();
-            if let Some(old) = old {
-                if gs.is_registered(old) {
-                    let _ = gs.unregister(old);
-                }
-            }
-            if let Some(next) = popover {
-                if let Err(err) = gs.register(next) {
-                    if let Some(old) = old {
-                        let _ = gs.register(old);
-                        *current = Some(old);
-                    }
-                    return Err(format!("failed to register Clips shortcut: {err}"));
-                }
-            }
-            *current = popover;
-        }
+    let prev_voice = swap_custom_shortcut(gs, custom_voice_shortcut(), voice, "voice")?;
+    if let Err(err) = swap_custom_shortcut(gs, custom_popover_shortcut(), popover, "Clips") {
+        // Popover registration failed after voice already mutated — roll the
+        // voice slot back to its previous value so callers see all-or-nothing
+        // behaviour. If the rollback itself fails we surface only the
+        // original popover error to the user; the local state always
+        // reflects whatever actually got registered.
+        let _ = swap_custom_shortcut(gs, custom_voice_shortcut(), prev_voice, "voice");
+        return Err(err);
     }
 
     Ok(())

--- a/templates/clips/desktop/src-tauri/src/util.rs
+++ b/templates/clips/desktop/src-tauri/src/util.rs
@@ -4,37 +4,26 @@ use crate::dlog;
 use crate::state::{DictationActive, PopoverShownAt, RecordingActive, VoiceWakePopover};
 
 // ---------------------------------------------------------------------------
-// Exclude-from-capture helper (macOS only)
+// Capture-sharing helpers (macOS only)
 // ---------------------------------------------------------------------------
 //
-// Every Clips-owned overlay window (popover / bubble / toolbar / countdown /
-// signin) gets `NSWindow.sharingType = NSWindowSharingNone` flipped on right
-// after build. This has two effects on macOS:
-//
-//   1. **Screen pickers don't list it.** When the user clicks "Start Recording"
-//      the popover stays open on screen while macOS shows the screen / window
-//      picker. Because the popover is marked non-sharable, the picker doesn't
-//      enumerate it as a potential capture source — the user can't accidentally
-//      record the Clips UI itself.
-//
-//   2. **Full-screen captures omit it.** Even when the user picks a full
-//      display, the compositor doesn't composite the overlay windows into the
-//      captured frame. The final recording shows the screen content beneath
-//      the popover / bubble / toolbar / countdown, not the overlays.
-//
-// This is the same mechanism Loom, 1Password, and CleanShot use to keep their
-// own chrome out of captures. It also sidesteps a nasty WebKit bug we hit
-// earlier: hiding the popover's webview mid-`getDisplayMedia` suspends JS
-// execution and the recorder promise never resolves — freezing the tray.
-// By leaving the popover VISIBLE (but non-sharable) during the screen picker,
-// JS keeps running and the promise resolves cleanly.
+// Clips-owned recording chrome (toolbar / countdown / finalizing /
+// recording-pill) gets `NSWindow.sharingType = NSWindowSharingNone` so it does
+// not leak into the recorded video. The main popover is different: users expect
+// to screenshot it for feedback, so it stays shareable during normal idle /
+// settings use and is flipped to NSWindowSharingNone only while it is parked as
+// the hidden recording controller.
+// Recording-time exclusion has two effects on macOS: screen pickers don't list
+// excluded windows, and full-screen captures omit them from the compositor
+// output. This is the same mechanism Loom, 1Password, and CleanShot use to keep
+// their own chrome out of captures.
 //
 // Caveat: on macOS 15.4+ (Sequoia), ScreenCaptureKit-based apps can sometimes
 // still capture `NSWindowSharingNone` windows — Apple has acknowledged this as
 // a platform bug with no public workaround. Everything up to macOS 14 works
 // correctly, and on 15.4+ the majority of capture apps still honour it.
 #[cfg(target_os = "macos")]
-pub fn set_capture_excluded(window: &WebviewWindow) {
+fn set_window_capture_excluded(window: &WebviewWindow, excluded: bool) {
     // AppKit's `-[NSWindow setSharingType:]` is strictly main-thread-only, and
     // macOS 15.5+ hard-asserts it (the process crashes in
     // `-[NSWMWindowCoordinator performTransactionUsingBlock:]` otherwise).
@@ -48,16 +37,18 @@ pub fn set_capture_excluded(window: &WebviewWindow) {
         let ns_window_ptr = match win.ns_window() {
             Ok(p) => p,
             Err(err) => {
-                eprintln!("[clips-tray] set_capture_excluded({label}): ns_window() failed: {err}");
+                eprintln!(
+                    "[clips-tray] set_window_capture_excluded({label}): ns_window() failed: {err}"
+                );
                 return;
             }
         };
         if ns_window_ptr.is_null() {
-            eprintln!("[clips-tray] set_capture_excluded({label}): ns_window is null");
+            eprintln!("[clips-tray] set_window_capture_excluded({label}): ns_window is null");
             return;
         }
-        // 0 == NSWindowSharingNone, 1 == NSWindowSharingReadOnly (default). We
-        // want 0. Pass as NSUInteger (usize) to match the Objective-C selector
+        // 0 == NSWindowSharingNone, 1 == NSWindowSharingReadOnly (default).
+        // Pass as NSUInteger (usize) to match the Objective-C selector
         // signature.
         // SAFETY: ns_window() returns a live NSWindow* owned by Tauri. We're
         // guaranteed to be on the main thread here (run_on_main_thread), which
@@ -65,18 +56,39 @@ pub fn set_capture_excluded(window: &WebviewWindow) {
         // and has no return value.
         unsafe {
             let obj = ns_window_ptr as *mut objc2::runtime::AnyObject;
-            let _: () = objc2::msg_send![&*obj, setSharingType: 0usize];
+            let sharing_type = if excluded { 0usize } else { 1usize };
+            let _: () = objc2::msg_send![&*obj, setSharingType: sharing_type];
         }
-        dlog!("[clips-tray] set_capture_excluded({label}): NSWindowSharingNone applied");
+        let mode = if excluded {
+            "NSWindowSharingNone"
+        } else {
+            "NSWindowSharingReadOnly"
+        };
+        dlog!("[clips-tray] set_window_capture_excluded({label}): {mode} applied");
     }) {
-        eprintln!("[clips-tray] set_capture_excluded: run_on_main_thread failed: {err}");
+        eprintln!("[clips-tray] set_window_capture_excluded: run_on_main_thread failed: {err}");
     }
+}
+
+#[cfg(target_os = "macos")]
+pub fn set_capture_excluded(window: &WebviewWindow) {
+    set_window_capture_excluded(window, true);
+}
+
+#[cfg(target_os = "macos")]
+pub fn set_capture_included(window: &WebviewWindow) {
+    set_window_capture_excluded(window, false);
 }
 
 #[cfg(not(target_os = "macos"))]
 pub fn set_capture_excluded(_window: &WebviewWindow) {
     // No-op on non-macOS platforms. Screen-capture exclusion isn't a public
     // Windows API; Linux doesn't even have a universal screen-capture API.
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn set_capture_included(_window: &WebviewWindow) {
+    // No-op on non-macOS platforms.
 }
 
 /// Show a Tauri WebviewWindow on screen WITHOUT making it the key window or

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -34,6 +34,8 @@ const STORAGE_KEY = "clips:server-url";
 const MODE_KEY = "clips:last-mode";
 const VOICE_SHORTCUT_KEY = "clips:voice-shortcut";
 const VOICE_SHORTCUT_CONFIGURED_KEY = "clips:voice-shortcut-configured";
+const VOICE_CUSTOM_SHORTCUT_KEY = "clips:voice-custom-shortcut";
+const POPOVER_CUSTOM_SHORTCUT_KEY = "clips:popover-custom-shortcut";
 const VOICE_MODE_KEY = "clips:voice-mode";
 const VOICE_PROVIDER_KEY = "clips:voice-provider";
 const VOICE_INSTRUCTIONS_KEY = "clips:voice-instructions";
@@ -60,6 +62,16 @@ function loadString(key: string, fallback: string): string {
   try {
     const v = localStorage.getItem(key);
     if (v && v.trim()) return v;
+  } catch {
+    // ignore
+  }
+  return fallback;
+}
+
+function loadStringAllowEmpty(key: string, fallback: string): string {
+  try {
+    const v = localStorage.getItem(key);
+    if (v !== null) return v;
   } catch {
     // ignore
   }
@@ -175,9 +187,38 @@ function saveBool(key: string, value: boolean): void {
 
 type ByokVoiceProvider = Extract<VoiceProvider, "gemini" | "openai" | "groq">;
 type VoiceProviderMode = "native" | "builder" | "byok";
+type MacosPrivacyPane =
+  | "camera"
+  | "microphone"
+  | "screen"
+  | "speech"
+  | "accessibility"
+  | "input-monitoring";
+
+const MACOS_PRIVACY_URLS: Record<MacosPrivacyPane, string> = {
+  camera:
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera",
+  microphone:
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+  screen:
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+  speech:
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition",
+  accessibility:
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+  "input-monitoring":
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent",
+};
 
 function isMacPlatform(): boolean {
   return typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+}
+
+function openMacosPrivacySettings(pane: MacosPrivacyPane): void {
+  if (!isMacPlatform()) return;
+  openExternal(MACOS_PRIVACY_URLS[pane]).catch((err) => {
+    console.error("[clips-tray] open macOS privacy settings failed:", err);
+  });
 }
 
 function nativeVoiceProvider(): VoiceProvider {
@@ -249,10 +290,17 @@ export function App() {
       return saved === "fn" ||
         saved === "cmd-shift-space" ||
         saved === "ctrl-shift-space" ||
+        saved === "custom" ||
         saved === "both"
         ? saved
         : "both";
     },
+  );
+  const [voiceCustomShortcut, setVoiceCustomShortcut] = useState<string>(() =>
+    loadStringAllowEmpty(VOICE_CUSTOM_SHORTCUT_KEY, "Cmd+Shift+D"),
+  );
+  const [popoverCustomShortcut, setPopoverCustomShortcut] = useState<string>(
+    () => loadStringAllowEmpty(POPOVER_CUSTOM_SHORTCUT_KEY, ""),
   );
   const [voiceMode, setVoiceMode] = useState<VoiceMode>(() => {
     const saved = loadString(VOICE_MODE_KEY, "push-to-talk");
@@ -273,6 +321,9 @@ export function App() {
   const [recorder, setRecorder] = useState<RecorderHandle | null>(null);
   const [recError, setRecError] = useState<string | null>(null);
   const [cameraError, setCameraError] = useState<string | null>(null);
+  const [shortcutRegistrationError, setShortcutRegistrationError] = useState<
+    string | null
+  >(null);
   // Latched true the moment the user clicks Start Recording and cleared
   // when the recorder fully stops/cancels. We use this to suppress the
   // popover auto-hide during the macOS screen-picker focus dance.
@@ -317,6 +368,28 @@ export function App() {
     voiceProvider,
     voiceInstructions,
   ]);
+
+  useEffect(() => {
+    let cancelled = false;
+    invoke("set_custom_shortcuts", {
+      voice: voiceShortcut === "custom" ? voiceCustomShortcut : null,
+      popover: popoverCustomShortcut.trim() ? popoverCustomShortcut : null,
+    })
+      .then(() => {
+        if (!cancelled) setShortcutRegistrationError(null);
+      })
+      .catch((err) => {
+        console.warn("[clips-tray] set_custom_shortcuts failed:", err);
+        if (!cancelled) {
+          setShortcutRegistrationError(
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [popoverCustomShortcut, voiceCustomShortcut, voiceShortcut]);
 
   // ---- auth status --------------------------------------------------------
   // The Tauri WebView has its own cookie jar (separate from the user's
@@ -918,17 +991,27 @@ export function App() {
     if (!el) return;
     let last = 0;
     const push = () => {
-      const h = Math.ceil(el.getBoundingClientRect().height);
+      const rect = el.getBoundingClientRect();
+      const settingsContent =
+        showSettings && el.firstElementChild instanceof HTMLElement
+          ? el.firstElementChild.scrollHeight + 2
+          : 0;
+      const h = Math.ceil(
+        Math.max(rect.height, el.scrollHeight, settingsContent),
+      );
       if (h && Math.abs(h - last) >= 2) {
         last = h;
-        invoke("resize_popover", { height: h }).catch(() => {});
+        invoke("resize_popover", {
+          height: h,
+          width: showSettings ? 440 : 360,
+        }).catch(() => {});
       }
     };
     push();
     const ro = new ResizeObserver(push);
     ro.observe(el);
     return () => ro.disconnect();
-  }, []);
+  }, [showSettings]);
 
   // ---- recent list --------------------------------------------------------
 
@@ -964,6 +1047,14 @@ export function App() {
   useEffect(
     () => saveString(VOICE_SHORTCUT_KEY, voiceShortcut),
     [voiceShortcut],
+  );
+  useEffect(
+    () => saveString(VOICE_CUSTOM_SHORTCUT_KEY, voiceCustomShortcut),
+    [voiceCustomShortcut],
+  );
+  useEffect(
+    () => saveString(POPOVER_CUSTOM_SHORTCUT_KEY, popoverCustomShortcut),
+    [popoverCustomShortcut],
   );
   useEffect(() => saveString(VOICE_MODE_KEY, voiceMode), [voiceMode]);
   useEffect(
@@ -1265,6 +1356,38 @@ export function App() {
   // we just render the normal pre-record panel so the user at least knows
   // where they are. No recording-only UI lives here.
 
+  if (showSettings) {
+    return (
+      <div className="app app-settings" ref={appRef}>
+        <Setup
+          initial={serverUrl}
+          serverUrl={serverUrl}
+          signedInAs={signedInAs}
+          voiceShortcut={voiceShortcut}
+          voiceCustomShortcut={voiceCustomShortcut}
+          popoverCustomShortcut={popoverCustomShortcut}
+          voiceMode={voiceMode}
+          voiceProvider={voiceProvider}
+          voiceInstructions={voiceInstructions}
+          shortcutRegistrationError={shortcutRegistrationError}
+          onVoiceShortcutChange={updateVoiceShortcut}
+          onVoiceCustomShortcutChange={setVoiceCustomShortcut}
+          onPopoverCustomShortcutChange={setPopoverCustomShortcut}
+          onVoiceModeChange={setVoiceMode}
+          onVoiceProviderChange={setVoiceProvider}
+          onVoiceInstructionsChange={setVoiceInstructions}
+          onSignOut={signOut}
+          onConnect={(url) => {
+            saveString(STORAGE_KEY, url.replace(/\/+$/, ""));
+            setServerUrl(url.replace(/\/+$/, ""));
+            setShowSettings(false);
+          }}
+          onCancel={() => setShowSettings(false)}
+        />
+      </div>
+    );
+  }
+
   // When unauthenticated, render the sign-in form INLINE in the popover
   // (not a separate Tauri window). This avoids Tauri 2's separate-WebKit-
   // data-store-per-WebviewWindow cookie-jar issue — the cookie is set in
@@ -1316,26 +1439,6 @@ export function App() {
             Settings
           </a>
         </div>
-        {showSettings ? (
-          <Setup
-            initial={serverUrl}
-            serverUrl={serverUrl}
-            voiceShortcut={voiceShortcut}
-            voiceMode={voiceMode}
-            voiceProvider={voiceProvider}
-            voiceInstructions={voiceInstructions}
-            onVoiceShortcutChange={updateVoiceShortcut}
-            onVoiceModeChange={setVoiceMode}
-            onVoiceProviderChange={setVoiceProvider}
-            onVoiceInstructionsChange={setVoiceInstructions}
-            onConnect={(url) => {
-              saveString(STORAGE_KEY, url.replace(/\/+$/, ""));
-              setServerUrl(url.replace(/\/+$/, ""));
-              setShowSettings(false);
-            }}
-            onCancel={() => setShowSettings(false)}
-          />
-        ) : null}
       </div>
     );
   }
@@ -1374,9 +1477,19 @@ export function App() {
       <button className="primary start" onClick={startRecording}>
         Start recording
       </button>
-      {recError ? <div className="error-banner">{recError}</div> : null}
+      {recError ? (
+        recError === MACOS_CAPTURE_PERMISSION_MESSAGE ? (
+          <PermissionErrorBanner message={recError} defaultPane="screen" />
+        ) : (
+          <div className="error-banner">{recError}</div>
+        )
+      ) : null}
       {cameraError && !recError ? (
-        <div className="error-banner">{cameraError}</div>
+        cameraError === MACOS_CAPTURE_PERMISSION_MESSAGE ? (
+          <PermissionErrorBanner message={cameraError} defaultPane="camera" />
+        ) : (
+          <div className="error-banner">{cameraError}</div>
+        )
       ) : null}
 
       <div className="bottom-row">
@@ -1427,29 +1540,6 @@ export function App() {
           ))}
         </div>
       ) : null}
-
-      {showSettings ? (
-        <Setup
-          initial={serverUrl}
-          serverUrl={serverUrl}
-          signedInAs={signedInAs}
-          voiceShortcut={voiceShortcut}
-          voiceMode={voiceMode}
-          voiceProvider={voiceProvider}
-          voiceInstructions={voiceInstructions}
-          onVoiceShortcutChange={updateVoiceShortcut}
-          onVoiceModeChange={setVoiceMode}
-          onVoiceProviderChange={setVoiceProvider}
-          onVoiceInstructionsChange={setVoiceInstructions}
-          onSignOut={signOut}
-          onConnect={(url) => {
-            saveString(STORAGE_KEY, url.replace(/\/+$/, ""));
-            setServerUrl(url.replace(/\/+$/, ""));
-            setShowSettings(false);
-          }}
-          onCancel={() => setShowSettings(false)}
-        />
-      ) : null}
     </div>
   );
 }
@@ -1463,6 +1553,44 @@ function hidePopover() {
     .hide()
     .catch(() => {});
   emit("clips:popover-visible", false).catch(() => {});
+}
+
+function PermissionErrorBanner({
+  message,
+  defaultPane,
+}: {
+  message: string;
+  defaultPane: MacosPrivacyPane;
+}) {
+  useEffect(() => {
+    openMacosPrivacySettings(defaultPane);
+  }, [defaultPane]);
+
+  return (
+    <div className="error-banner permission-banner">
+      <div>{message}</div>
+      <div className="permission-actions" aria-label="Open macOS permissions">
+        <button
+          type="button"
+          onClick={() => openMacosPrivacySettings("camera")}
+        >
+          Camera
+        </button>
+        <button
+          type="button"
+          onClick={() => openMacosPrivacySettings("microphone")}
+        >
+          Microphone
+        </button>
+        <button
+          type="button"
+          onClick={() => openMacosPrivacySettings("screen")}
+        >
+          Screen
+        </button>
+      </div>
+    </div>
+  );
 }
 
 function Header({
@@ -2189,10 +2317,15 @@ function Setup({
   serverUrl,
   signedInAs,
   voiceShortcut,
+  voiceCustomShortcut,
+  popoverCustomShortcut,
   voiceMode,
   voiceProvider,
   voiceInstructions,
+  shortcutRegistrationError,
   onVoiceShortcutChange,
+  onVoiceCustomShortcutChange,
+  onPopoverCustomShortcutChange,
   onVoiceModeChange,
   onVoiceProviderChange,
   onVoiceInstructionsChange,
@@ -2204,10 +2337,15 @@ function Setup({
   serverUrl?: string;
   signedInAs?: string | null;
   voiceShortcut: VoiceShortcutPreference;
+  voiceCustomShortcut: string;
+  popoverCustomShortcut: string;
   voiceMode: VoiceMode;
   voiceProvider: VoiceProvider;
   voiceInstructions: string;
+  shortcutRegistrationError: string | null;
   onVoiceShortcutChange: (value: VoiceShortcutPreference) => void;
+  onVoiceCustomShortcutChange: (value: string) => void;
+  onPopoverCustomShortcutChange: (value: string) => void;
   onVoiceModeChange: (value: VoiceMode) => void;
   onVoiceProviderChange: (value: VoiceProvider) => void;
   onVoiceInstructionsChange: (value: string) => void;
@@ -2312,6 +2450,7 @@ function Setup({
     fn: "Press the Fn / globe key to dictate.",
     "cmd-shift-space": "Press Cmd+Shift+Space to dictate.",
     "ctrl-shift-space": "Press Ctrl+Shift+Space to dictate.",
+    custom: `Press ${voiceCustomShortcut || "your recorded shortcut"} to dictate.`,
     both: "Any of Fn, Cmd+Shift+Space, or Ctrl+Shift+Space.",
   };
   const modeHint: Record<VoiceMode, string> = {
@@ -2470,6 +2609,78 @@ function Setup({
         </div>
       </div>
 
+      <div className="setup-section">
+        <SettingLabel
+          label="Open Clips shortcut"
+          hint="Optional extra global shortcut for opening the tray popover. Cmd+Shift+L remains available."
+        />
+        <ShortcutRecorder
+          value={popoverCustomShortcut}
+          placeholder="Record shortcut"
+          onChange={onPopoverCustomShortcutChange}
+        />
+        <p className="setup-hint">
+          Use a modifier combination like Cmd+Shift+K. Leave empty to use only
+          Cmd+Shift+L.
+        </p>
+        {shortcutRegistrationError ? (
+          <p className="setup-warning">{shortcutRegistrationError}</p>
+        ) : null}
+      </div>
+
+      {isMacPlatform() ? (
+        <div className="setup-section">
+          <SettingLabel
+            label="macOS permissions"
+            hint="Open the exact Privacy & Security pane for each permission Clips can need."
+          />
+          <div className="setup-permission-grid">
+            <button
+              type="button"
+              className="setup-permission-button"
+              onClick={() => openMacosPrivacySettings("camera")}
+            >
+              Camera
+            </button>
+            <button
+              type="button"
+              className="setup-permission-button"
+              onClick={() => openMacosPrivacySettings("microphone")}
+            >
+              Microphone
+            </button>
+            <button
+              type="button"
+              className="setup-permission-button"
+              onClick={() => openMacosPrivacySettings("screen")}
+            >
+              Screen
+            </button>
+            <button
+              type="button"
+              className="setup-permission-button"
+              onClick={() => openMacosPrivacySettings("speech")}
+            >
+              Speech
+            </button>
+            <button
+              type="button"
+              className="setup-permission-button"
+              onClick={() => openMacosPrivacySettings("accessibility")}
+            >
+              Accessibility
+            </button>
+            <button
+              type="button"
+              className="setup-permission-button"
+              onClick={() => openMacosPrivacySettings("input-monitoring")}
+            >
+              Input Monitoring
+            </button>
+          </div>
+        </div>
+      ) : null}
+
       {voiceEnabled ? (
         <>
           <div className="setup-section">
@@ -2619,8 +2830,16 @@ function Setup({
               <option value="fn">Fn (globe) key</option>
               <option value="cmd-shift-space">Cmd+Shift+Space</option>
               <option value="ctrl-shift-space">Ctrl+Shift+Space</option>
+              <option value="custom">Custom shortcut</option>
               <option value="both">All shortcuts</option>
             </select>
+            {voiceShortcut === "custom" ? (
+              <ShortcutRecorder
+                value={voiceCustomShortcut}
+                placeholder="Record voice shortcut"
+                onChange={onVoiceCustomShortcutChange}
+              />
+            ) : null}
             <p className="setup-hint">{shortcutHint[voiceShortcut]}</p>
           </div>
 
@@ -2678,5 +2897,102 @@ function SettingLabel({
         <IconInfoCircle size={14} stroke={1.75} />
       </span>
     </label>
+  );
+}
+
+function formatShortcutKey(key: string): string {
+  if (key === " ") return "Space";
+  if (key.length === 1) return key.toUpperCase();
+  const aliases: Record<string, string> = {
+    ArrowDown: "ArrowDown",
+    ArrowLeft: "ArrowLeft",
+    ArrowRight: "ArrowRight",
+    ArrowUp: "ArrowUp",
+    Escape: "Escape",
+    " ": "Space",
+  };
+  return aliases[key] ?? key;
+}
+
+function shortcutFromKeyboardEvent(event: React.KeyboardEvent): string | null {
+  const modifierKeys = new Set(["Alt", "Control", "Meta", "Shift", "Fn"]);
+  if (modifierKeys.has(event.key)) return null;
+
+  const parts: string[] = [];
+  if (event.metaKey) parts.push("Cmd");
+  if (event.ctrlKey) parts.push("Ctrl");
+  if (event.altKey) parts.push("Alt");
+  if (event.shiftKey) parts.push("Shift");
+  if (!parts.length) return null;
+
+  return [...parts, formatShortcutKey(event.key)].join("+");
+}
+
+function ShortcutRecorder({
+  value,
+  placeholder,
+  onChange,
+}: {
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+}) {
+  const [recording, setRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+  return (
+    <div className="setup-shortcut-row">
+      <button
+        ref={buttonRef}
+        type="button"
+        className={`setup-shortcut-recorder ${recording ? "recording" : ""}`}
+        onClick={() => {
+          setError(null);
+          setRecording(true);
+          requestAnimationFrame(() => buttonRef.current?.focus());
+        }}
+        onBlur={() => setRecording(false)}
+        onKeyDown={(event) => {
+          if (!recording) return;
+          event.preventDefault();
+          event.stopPropagation();
+          if (event.key === "Escape") {
+            setRecording(false);
+            setError(null);
+            return;
+          }
+          if (event.key === "Backspace" || event.key === "Delete") {
+            onChange("");
+            setRecording(false);
+            setError(null);
+            return;
+          }
+          const next = shortcutFromKeyboardEvent(event);
+          if (!next) {
+            setError("Use at least one modifier plus a key.");
+            return;
+          }
+          onChange(next);
+          setRecording(false);
+          setError(null);
+        }}
+      >
+        {recording ? "Press shortcut..." : value || placeholder}
+      </button>
+      {value ? (
+        <button
+          type="button"
+          className="setup-shortcut-clear"
+          onClick={() => {
+            onChange("");
+            setError(null);
+          }}
+        >
+          Clear
+        </button>
+      ) : null}
+      {error ? <p className="setup-warning">{error}</p> : null}
+    </div>
   );
 }

--- a/templates/clips/desktop/src/lib/voice-dictation.ts
+++ b/templates/clips/desktop/src/lib/voice-dictation.ts
@@ -12,6 +12,7 @@ export type VoiceShortcutPreference =
   | "fn"
   | "cmd-shift-space"
   | "ctrl-shift-space"
+  | "custom"
   | "both";
 export type VoiceMode = "push-to-talk" | "toggle";
 
@@ -40,7 +41,11 @@ type ServerVoiceProvider =
   | "groq";
 
 type FlowState = "idle" | "recording" | "processing" | "complete" | "error";
-type VoiceShortcutSource = "fn" | "cmd-shift-space" | "ctrl-shift-space";
+type VoiceShortcutSource =
+  | "fn"
+  | "cmd-shift-space"
+  | "ctrl-shift-space"
+  | "custom";
 
 interface ProviderStatus {
   builder: boolean;
@@ -1558,13 +1563,13 @@ export function installDesktopVoiceDictation(
   const isMainWindow = (label?: string) =>
     label === "main" || label === "popover";
   listen<FocusEventPayload>("tauri://blur", (ev) => {
-    if (!isMainWindow(ev.windowLabel)) return;
+    if (!isMainWindow(ev.payload.windowLabel)) return;
     invoke("recording_pill_set_detached", { detached: true }).catch(() => {});
   })
     .then((u) => unlistens.push(u))
     .catch(() => {});
   listen<FocusEventPayload>("tauri://focus", (ev) => {
-    if (!isMainWindow(ev.windowLabel)) return;
+    if (!isMainWindow(ev.payload.windowLabel)) return;
     invoke("recording_pill_set_detached", { detached: false }).catch(() => {});
   })
     .then((u) => unlistens.push(u))

--- a/templates/clips/desktop/src/main.tsx
+++ b/templates/clips/desktop/src/main.tsx
@@ -17,9 +17,18 @@ import "./styles.css";
  * on the URL hash so each Tauri window (spawned from Rust with
  * `index.html#<name>`) renders only what it needs.
  */
-function pickRoute(): React.ReactElement {
+function currentRoute(): string {
   const hash = window.location.hash.replace(/^#/, "").toLowerCase();
-  switch (hash) {
+  return hash || "popover";
+}
+
+function installRouteAttributes(route: string): void {
+  document.documentElement.dataset.clipsRoute = route;
+  document.body.dataset.clipsRoute = route;
+}
+
+function pickRoute(route: string): React.ReactElement {
+  switch (route) {
     case "countdown":
       return <Countdown />;
     case "toolbar":
@@ -119,7 +128,7 @@ function installHeapDebugLog(): void {
     };
   };
   if (!perf.memory) return;
-  const tag = window.location.hash.replace(/^#/, "").toLowerCase() || "popover";
+  const tag = currentRoute();
   const fmt = (n: number | undefined) =>
     n == null ? "?" : `${(n / (1024 * 1024)).toFixed(1)}MB`;
   setInterval(() => {
@@ -133,6 +142,8 @@ function installHeapDebugLog(): void {
 
 const rootEl = document.getElementById("root");
 if (rootEl) {
+  const route = currentRoute();
+  installRouteAttributes(route);
   installBeforeUnloadCleanup();
   installHeapDebugLog();
   // NOTE: intentionally NOT wrapping in React.StrictMode. StrictMode
@@ -142,5 +153,5 @@ if (rootEl) {
   // camera bubble re-created itself ~30 times a second. Tauri windows
   // are real OS resources — not an environment where double-mount is
   // harmless.
-  ReactDOM.createRoot(rootEl).render(pickRoute());
+  ReactDOM.createRoot(rootEl).render(pickRoute(route));
 }

--- a/templates/clips/desktop/src/overlays/recording-pill.tsx
+++ b/templates/clips/desktop/src/overlays/recording-pill.tsx
@@ -83,6 +83,15 @@ export function RecordingPill() {
         // Reset timer on new context.
         startedAtRef.current = Date.now();
         setElapsed(0);
+        // The Rust side reuses the pill window across recordings, so the
+        // component never unmounts. Reset stop state explicitly when a
+        // new recording session begins, otherwise the Stop button stays
+        // disabled and a stale fallback timer can fire mid-session.
+        setStopping(false);
+        if (stopFallbackRef.current) {
+          clearTimeout(stopFallbackRef.current);
+          stopFallbackRef.current = null;
+        }
       }),
     );
     trackListen(

--- a/templates/clips/desktop/src/overlays/recording-pill.tsx
+++ b/templates/clips/desktop/src/overlays/recording-pill.tsx
@@ -5,6 +5,7 @@ import {
   IconChevronDown,
   IconChevronUp,
   IconPlayerPauseFilled,
+  IconPlayerPlayFilled,
   IconPlayerStopFilled,
 } from "@tabler/icons-react";
 
@@ -33,6 +34,7 @@ export function RecordingPill() {
   const [paused, setPaused] = useState(false);
   const [elapsed, setElapsed] = useState(0);
   const [ctx, setCtx] = useState<PillContext>({ mode: "clip" });
+  const [stopping, setStopping] = useState(false);
   // Detached / "floating" mode — Wispr-style pill that auto-moves to the
   // top-right when the main app loses focus, with a drag handle. Driven by
   // the `clips:pill-detached` event from Rust (toggled by JS via
@@ -54,6 +56,7 @@ export function RecordingPill() {
   const micCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const sysCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const rafRef = useRef<number | null>(null);
+  const stopFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const unlistens: Array<() => void> = [];
@@ -114,6 +117,10 @@ export function RecordingPill() {
           // ignore
         }
       });
+      if (stopFallbackRef.current) {
+        clearTimeout(stopFallbackRef.current);
+        stopFallbackRef.current = null;
+      }
     };
   }, []);
 
@@ -210,19 +217,24 @@ export function RecordingPill() {
   }
 
   async function onPauseClick() {
-    setPaused((p) => !p);
-    emit("clips:pill-pause", { paused: !paused }).catch(() => {});
+    const nextPaused = !paused;
+    setPaused(nextPaused);
+    emit(nextPaused ? "clips:recorder-pause" : "clips:recorder-resume").catch(
+      () => {},
+    );
+    emit("clips:pill-pause", { paused: nextPaused }).catch(() => {});
   }
 
   async function onStopClick() {
+    if (stopping) return;
+    setStopping(true);
+    emit("clips:recorder-stop").catch(() => {});
     emit("clips:pill-stop", { meetingId: ctx.meetingId ?? null }).catch(
       () => {},
     );
-    try {
-      await invoke("recording_pill_hide");
-    } catch {
-      // ignore
-    }
+    stopFallbackRef.current = setTimeout(() => {
+      invoke("recording_pill_hide").catch(() => {});
+    }, 3_000);
   }
 
   // Click on the drag handle (detached mode) un-detaches the pill and
@@ -242,11 +254,13 @@ export function RecordingPill() {
   return (
     <div className="flex h-full w-full items-stretch justify-stretch">
       <div
-        className="flex h-full w-full flex-col rounded-2xl bg-zinc-900/95 text-white shadow-2xl ring-1 ring-white/10 backdrop-blur-md"
+        className="relative flex h-full w-full flex-col rounded-2xl bg-zinc-900/95 text-white shadow-2xl ring-1 ring-white/10 backdrop-blur-md"
         data-tauri-drag-region
       >
-        {/* Collapsed header — always visible */}
-        <div className="flex h-[56px] shrink-0 items-center gap-2 px-3">
+        {/* Collapsed header — always visible, including a one-click stop. */}
+        <div
+          className={`flex shrink-0 items-center gap-2 ${detached ? "h-10 px-2" : "h-11 px-3"}`}
+        >
           <span
             className={`inline-block h-2 w-2 rounded-full ${
               paused ? "bg-zinc-400" : "bg-red-500 animate-pulse"
@@ -287,6 +301,17 @@ export function RecordingPill() {
           </span>
           <button
             type="button"
+            onClick={onStopClick}
+            disabled={stopping}
+            data-no-drag
+            className="ml-1 inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full bg-red-500 text-white hover:bg-red-400 disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label="Stop recording"
+            title="Stop recording"
+          >
+            <IconPlayerStopFilled size={14} />
+          </button>
+          <button
+            type="button"
             onClick={toggleExpanded}
             data-no-drag
             className="ml-1 inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-full text-zinc-200 hover:bg-white/10"
@@ -309,7 +334,7 @@ export function RecordingPill() {
             onClick={onHandleClick}
             data-no-drag
             aria-label="Re-attach pill to main window"
-            className="mx-auto mb-1 mt-auto h-1 w-10 shrink-0 cursor-pointer rounded-full bg-white/30 hover:bg-white/50"
+            className="absolute bottom-1 left-1/2 h-1 w-10 -translate-x-1/2 cursor-pointer rounded-full bg-white/30 hover:bg-white/50"
           />
         ) : null}
 
@@ -326,14 +351,19 @@ export function RecordingPill() {
                 data-no-drag
                 className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-full bg-white/10 px-3 text-[12px] font-medium text-white hover:bg-white/20"
               >
-                <IconPlayerPauseFilled size={14} />
+                {paused ? (
+                  <IconPlayerPlayFilled size={14} />
+                ) : (
+                  <IconPlayerPauseFilled size={14} />
+                )}
                 {paused ? "Resume" : "Pause"}
               </button>
               <button
                 type="button"
                 onClick={onStopClick}
+                disabled={stopping}
                 data-no-drag
-                className="ml-auto inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-full bg-red-500 px-3 text-[12px] font-medium text-white hover:bg-red-400"
+                className="ml-auto inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-full bg-red-500 px-3 text-[12px] font-medium text-white hover:bg-red-400 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 <IconPlayerStopFilled size={14} />
                 Stop

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -75,6 +75,13 @@ body {
   overflow: visible;
 }
 
+html[data-clips-route]:not([data-clips-route="popover"]),
+body[data-clips-route]:not([data-clips-route="popover"]) {
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
 button {
   font-family: inherit;
   font-size: inherit;
@@ -84,6 +91,11 @@ button {
 #root {
   width: 100vw;
   background: transparent;
+}
+
+body[data-clips-route]:not([data-clips-route="popover"]) #root {
+  height: 100vh;
+  overflow: hidden;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -106,6 +118,12 @@ button {
   max-height: 100vh;
   overflow-y: auto;
   overscroll-behavior: contain;
+}
+
+.app-settings {
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
 }
 
 /* Header — logo + mode toggle + close */
@@ -799,16 +817,14 @@ button {
 /* ------------------------------------------------------------------------- */
 
 .setup {
-  position: fixed;
-  inset: 0;
+  width: 100%;
   background: var(--bg);
   border-radius: 14px;
   padding: 16px;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  z-index: 10;
-  max-height: 100vh;
+  max-height: calc(100vh - 2px);
   overflow-y: auto;
   overscroll-behavior: contain;
 }
@@ -917,6 +933,83 @@ button {
   gap: 12px;
 }
 
+.setup-shortcut-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.setup-shortcut-row .setup-warning {
+  grid-column: 1 / -1;
+}
+
+.setup-shortcut-recorder,
+.setup-shortcut-clear,
+.setup-permission-button {
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  color: var(--fg);
+  cursor: pointer;
+  transition:
+    background 120ms,
+    border-color 120ms,
+    color 120ms,
+    box-shadow 120ms;
+}
+
+.setup-shortcut-recorder {
+  min-width: 0;
+  height: 38px;
+  padding: 0 12px;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.setup-shortcut-recorder:hover,
+.setup-shortcut-clear:hover,
+.setup-permission-button:hover {
+  background: var(--surface-hover);
+}
+
+.setup-shortcut-recorder:focus-visible,
+.setup-shortcut-clear:focus-visible,
+.setup-permission-button:focus-visible {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px var(--brand-ring);
+}
+
+.setup-shortcut-recorder.recording {
+  border-color: var(--brand);
+  background: var(--bg);
+  color: var(--brand);
+}
+
+.setup-shortcut-clear {
+  height: 38px;
+  padding: 0 12px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.setup-permission-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.setup-permission-button {
+  min-height: 34px;
+  padding: 7px 9px;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: center;
+}
+
 .setup-hint {
   margin: 0;
   font-size: 11px;
@@ -1013,11 +1106,53 @@ button {
   font-size: 12px;
 }
 
+.permission-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.permission-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.permission-actions button {
+  border: 1px solid #fecaca;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.65);
+  color: #991b1b;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 5px 8px;
+  transition:
+    background 120ms,
+    border-color 120ms;
+}
+
+.permission-actions button:hover {
+  background: white;
+  border-color: #fca5a5;
+}
+
 @media (prefers-color-scheme: dark) {
   .error-banner {
     background: rgba(185, 28, 28, 0.14);
     border-color: rgba(239, 68, 68, 0.5);
     color: #fca5a5;
+  }
+
+  .permission-actions button {
+    background: rgba(239, 68, 68, 0.1);
+    border-color: rgba(239, 68, 68, 0.4);
+    color: #fecaca;
+  }
+
+  .permission-actions button:hover {
+    background: rgba(239, 68, 68, 0.18);
+    border-color: rgba(248, 113, 113, 0.6);
   }
 }
 


### PR DESCRIPTION
## Summary
- **Custom global shortcuts** — voice dictation and popover toggle are now configurable from Settings, registered via a new `set_custom_shortcuts` Tauri command with proper rollback on failure.
- **Capture-sharing refactor** — split `set_capture_excluded` / `set_capture_included` so the popover stays shareable while idle (users can screenshot it for feedback) and only flips to `NSWindowSharingNone` while parked as the recording controller. Recording chrome (toolbar / countdown / pill) stays excluded as before.
- **Recording pill UX** — always-visible one-click stop in the collapsed header, pause/resume icon swap, repositioned drag handle (absolute-positioned so it does not steal click area), 3s fallback timer for hide.
- **Popover auto-resize** — widens to 440px in settings view, accounts for `scrollHeight` so the settings tab no longer clips.
- **macOS privacy deeplinks** — camera / mic / screen / speech / accessibility / input-monitoring panes via `x-apple.systempreferences:` URLs so users jump straight to the right Settings pane.
- **Tauri focus event fix** — `ev.payload.windowLabel` (not `ev.windowLabel`) so detached pill state actually toggles.
- **Per-window CSS targeting** — `data-clips-route` on `<html>` / `<body>`.
- **Release CI hardening** — verify `NSCameraUsageDescription` / `NSMicrophoneUsageDescription` / `NSScreenCaptureUsageDescription` Info.plist keys + camera/audio entitlements after the macOS bundle build, and wrap `gh release` operations in a retry loop to absorb transient API blips.
- **`new-branch` skill guard** — explicit activation guard so the skill only fires on `/new-branch`, not as a side-effect of PR/Builder/Fusion workflows.

## Test plan
- [ ] CI green (lint, typecheck, tests, guards, clips-desktop-release dry-runs the new plist verification on macOS)
- [ ] Build clips desktop locally; popover is screenshottable while idle, recorded captures still omit the recording chrome
- [ ] Configure a custom voice shortcut + custom popover shortcut in Settings, restart, confirm both fire
- [ ] Pause / resume / stop on the recording pill (collapsed and expanded), verify single-click stop in collapsed header works
- [ ] Settings tab opens at 440px width, content fully visible
- [ ] On macOS, click each privacy pane link, confirm correct System Settings pane opens