### PR TITLE
fix(agent-chat): recover idle streams automatically

### DIFF
--- a/.changeset/agent-chat-idle-recovery.md
+++ b/.changeset/agent-chat-idle-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Recover agent chat runs automatically when streams time out, disconnect, or stay open without producing progress.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
   scaffold-e2e:
     name: Scaffold E2E — create + pnpm install
     runs-on: ubuntu-latest
+    env:
+      AGENT_NATIVE_CREATE_USE_LOCAL_CORE: "1"
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1916,7 +1916,10 @@ export function createProductionAgentHandler(
       options.onRunComplete
         ? (run) => options.onRunComplete!(run, threadId)
         : undefined,
-      { softTimeoutMs: options.runSoftTimeoutMs },
+      {
+        softTimeoutMs: options.runSoftTimeoutMs,
+        useHostedSoftTimeoutDefault: true,
+      },
     );
 
     // Subscribe to the run and stream events to the client

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -123,28 +123,41 @@ describe("run manager soft timeout", () => {
     expect(resolveRunSoftTimeoutMs()).toBe(0);
   });
 
-  it("uses a hosted default on serverless deploys", () => {
+  it("does not use a hosted default unless the caller opts in", () => {
     process.env.NETLIFY = "true";
 
-    expect(resolveRunSoftTimeoutMs()).toBe(DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS);
+    expect(resolveRunSoftTimeoutMs()).toBe(0);
+  });
+
+  it("uses a hosted default for callers that opt in", () => {
+    process.env.NETLIFY = "true";
+
+    expect(resolveRunSoftTimeoutMs(undefined, { useHostedDefault: true })).toBe(
+      DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS,
+    );
   });
 
   it("treats Netlify local as a local runtime", () => {
     process.env.NETLIFY = "true";
     process.env.NETLIFY_LOCAL = "true";
 
-    expect(resolveRunSoftTimeoutMs()).toBe(0);
+    expect(resolveRunSoftTimeoutMs(undefined, { useHostedDefault: true })).toBe(
+      0,
+    );
   });
 
   it("allows the environment to disable hosted soft timeouts", () => {
     process.env.NETLIFY = "true";
     process.env.AGENT_RUN_SOFT_TIMEOUT_MS = "0";
 
-    expect(resolveRunSoftTimeoutMs()).toBe(0);
+    expect(resolveRunSoftTimeoutMs(undefined, { useHostedDefault: true })).toBe(
+      0,
+    );
   });
 
   it("retires explicitly aborted in-memory runs while preserving completion callbacks", async () => {
     const onComplete = vi.fn();
+    const terminalEvents: AgentChatEvent[] = [];
     const run = startRun(
       "run-explicit-abort",
       "thread-explicit-abort",
@@ -157,6 +170,7 @@ describe("run manager soft timeout", () => {
       onComplete,
       { softTimeoutMs: 0 },
     );
+    run.subscribers.add((event) => terminalEvents.push(event.event));
 
     expect(abortRun("run-explicit-abort")).toBe(true);
     await Promise.resolve();
@@ -164,6 +178,8 @@ describe("run manager soft timeout", () => {
 
     expect(run.status).toBe("aborted");
     expect(run.events).toHaveLength(0);
+    expect(run.subscribers.size).toBe(0);
+    expect(terminalEvents).toContainEqual({ type: "done" });
     await vi.waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
     expect(markRunAborted).toHaveBeenCalledWith("run-explicit-abort", "user");
   });

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -7,6 +7,7 @@ vi.mock("./run-store.js", () => ({
   updateRunStatus: vi.fn(() => Promise.resolve()),
   markRunAborted: vi.fn(() => Promise.resolve()),
   isRunAborted: vi.fn(() => Promise.resolve(false)),
+  getRunAbortState: vi.fn(() => Promise.resolve({ aborted: false })),
   getRunEventsSince: vi.fn(() => Promise.resolve([])),
   getRunById: vi.fn(() => Promise.resolve(null)),
   getRunByThread: vi.fn(() => Promise.resolve(null)),
@@ -21,6 +22,7 @@ import {
   resolveRunSoftTimeoutMs,
   startRun,
 } from "./run-manager.js";
+import { getRunAbortState, markRunAborted } from "./run-store.js";
 
 const originalTimeoutEnv = process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
 const originalNetlify = process.env.NETLIFY;
@@ -32,38 +34,50 @@ const originalRender = process.env.RENDER;
 const originalFlyAppName = process.env.FLY_APP_NAME;
 const originalKService = process.env.K_SERVICE;
 
-function restoreEnv(key: string, value: string | undefined) {
-  if (value === undefined) {
-    delete process.env[key];
-  } else {
-    process.env[key] = value;
-  }
+function clearHostedEnvForTest() {
+  delete process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
+  delete process.env.NETLIFY;
+  delete process.env.NETLIFY_LOCAL;
+  delete process.env.CF_PAGES;
+  delete process.env.VERCEL;
+  delete process.env.VERCEL_ENV;
+  delete process.env.RENDER;
+  delete process.env.FLY_APP_NAME;
+  delete process.env.K_SERVICE;
+}
+
+function restoreHostedEnvAfterTest() {
+  if (originalTimeoutEnv === undefined)
+    delete process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
+  else process.env.AGENT_RUN_SOFT_TIMEOUT_MS = originalTimeoutEnv;
+  if (originalNetlify === undefined) delete process.env.NETLIFY;
+  else process.env.NETLIFY = originalNetlify;
+  if (originalNetlifyLocal === undefined) delete process.env.NETLIFY_LOCAL;
+  else process.env.NETLIFY_LOCAL = originalNetlifyLocal;
+  if (originalCfPages === undefined) delete process.env.CF_PAGES;
+  else process.env.CF_PAGES = originalCfPages;
+  if (originalVercel === undefined) delete process.env.VERCEL;
+  else process.env.VERCEL = originalVercel;
+  if (originalVercelEnv === undefined) delete process.env.VERCEL_ENV;
+  else process.env.VERCEL_ENV = originalVercelEnv;
+  if (originalRender === undefined) delete process.env.RENDER;
+  else process.env.RENDER = originalRender;
+  if (originalFlyAppName === undefined) delete process.env.FLY_APP_NAME;
+  else process.env.FLY_APP_NAME = originalFlyAppName;
+  if (originalKService === undefined) delete process.env.K_SERVICE;
+  else process.env.K_SERVICE = originalKService;
 }
 
 describe("run manager soft timeout", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    delete process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
-    delete process.env.NETLIFY;
-    delete process.env.NETLIFY_LOCAL;
-    delete process.env.CF_PAGES;
-    delete process.env.VERCEL;
-    delete process.env.VERCEL_ENV;
-    delete process.env.RENDER;
-    delete process.env.FLY_APP_NAME;
-    delete process.env.K_SERVICE;
+    clearHostedEnvForTest();
+    vi.mocked(getRunAbortState).mockResolvedValue({ aborted: false });
+    vi.mocked(markRunAborted).mockClear();
   });
 
   afterEach(() => {
-    restoreEnv("AGENT_RUN_SOFT_TIMEOUT_MS", originalTimeoutEnv);
-    restoreEnv("NETLIFY", originalNetlify);
-    restoreEnv("NETLIFY_LOCAL", originalNetlifyLocal);
-    restoreEnv("CF_PAGES", originalCfPages);
-    restoreEnv("VERCEL", originalVercel);
-    restoreEnv("VERCEL_ENV", originalVercelEnv);
-    restoreEnv("RENDER", originalRender);
-    restoreEnv("FLY_APP_NAME", originalFlyAppName);
-    restoreEnv("K_SERVICE", originalKService);
+    restoreHostedEnvAfterTest();
     vi.useRealTimers();
   });
 
@@ -129,7 +143,7 @@ describe("run manager soft timeout", () => {
     expect(resolveRunSoftTimeoutMs()).toBe(0);
   });
 
-  it("retires explicitly aborted in-memory runs without completing them", async () => {
+  it("retires explicitly aborted in-memory runs while preserving completion callbacks", async () => {
     const onComplete = vi.fn();
     const run = startRun(
       "run-explicit-abort",
@@ -150,6 +164,65 @@ describe("run manager soft timeout", () => {
 
     expect(run.status).toBe("aborted");
     expect(run.events).toHaveLength(0);
+    await vi.waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    expect(markRunAborted).toHaveBeenCalledWith("run-explicit-abort", "user");
+  });
+
+  it("skips completion callbacks for no-progress recovery aborts", async () => {
+    const onComplete = vi.fn();
+    const run = startRun(
+      "run-no-progress-abort",
+      "thread-no-progress-abort",
+      async (_send, signal) => {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+      onComplete,
+      { softTimeoutMs: 0 },
+    );
+
+    expect(abortRun("run-no-progress-abort", "no_progress")).toBe(true);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(run.status).toBe("aborted");
     expect(onComplete).not.toHaveBeenCalled();
+    expect(markRunAborted).toHaveBeenCalledWith(
+      "run-no-progress-abort",
+      "no_progress",
+    );
+  });
+
+  it("observes cross-isolate SQL aborts even when the run is idle", async () => {
+    vi.mocked(getRunAbortState).mockResolvedValue({
+      aborted: true,
+      reason: "no_progress",
+    });
+    let abortReason: unknown;
+
+    const run = startRun(
+      "run-sql-abort",
+      "thread-sql-abort",
+      async (_send, signal) => {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              abortReason = signal.reason;
+              resolve();
+            },
+            { once: true },
+          );
+        });
+      },
+      undefined,
+      { softTimeoutMs: 0 },
+    );
+
+    await vi.advanceTimersByTimeAsync(1501);
+
+    expect(abortReason).toBe("no_progress");
+    expect(run.abortReason).toBe("no_progress");
   });
 });

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -21,8 +21,14 @@ import {
   DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS,
   resolveRunSoftTimeoutMs,
   startRun,
+  subscribeToRun,
 } from "./run-manager.js";
-import { getRunAbortState, markRunAborted } from "./run-store.js";
+import {
+  getRunAbortState,
+  getRunById,
+  getRunEventsSince,
+  markRunAborted,
+} from "./run-store.js";
 
 const originalTimeoutEnv = process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
 const originalNetlify = process.env.NETLIFY;
@@ -73,6 +79,8 @@ describe("run manager soft timeout", () => {
     vi.useFakeTimers();
     clearHostedEnvForTest();
     vi.mocked(getRunAbortState).mockResolvedValue({ aborted: false });
+    vi.mocked(getRunById).mockResolvedValue(null);
+    vi.mocked(getRunEventsSince).mockResolvedValue([]);
     vi.mocked(markRunAborted).mockClear();
   });
 
@@ -240,5 +248,59 @@ describe("run manager soft timeout", () => {
 
     expect(abortReason).toBe("no_progress");
     expect(run.abortReason).toBe("no_progress");
+  });
+
+  it("normalizes missing SQL abort reasons to user aborts", async () => {
+    vi.mocked(getRunAbortState).mockResolvedValue({ aborted: true });
+    let abortReason: unknown;
+
+    const run = startRun(
+      "run-sql-abort-default",
+      "thread-sql-abort-default",
+      async (_send, signal) => {
+        await new Promise<void>((resolve) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              abortReason = signal.reason;
+              resolve();
+            },
+            { once: true },
+          );
+        });
+      },
+      undefined,
+      { softTimeoutMs: 0 },
+    );
+
+    await vi.advanceTimersByTimeAsync(1501);
+
+    expect(abortReason).toBe("user");
+    expect(run.abortReason).toBe("user");
+  });
+
+  it("closes SQL subscriptions cleanly for aborted runs without terminal events", async () => {
+    vi.mocked(getRunById).mockResolvedValue({
+      id: "run-sql-aborted",
+      threadId: "thread-sql-aborted",
+      status: "aborted",
+      startedAt: Date.now(),
+    });
+    vi.mocked(getRunEventsSince).mockResolvedValue([]);
+
+    const stream = subscribeToRun("run-sql-aborted", 0);
+    expect(stream).not.toBeNull();
+    const reader = stream!.getReader();
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+
+    for (let i = 0; i < 5; i++) {
+      const next = await reader.read();
+      if (next.done) break;
+      chunks.push(decoder.decode(next.value));
+    }
+
+    expect(chunks.join("")).toContain('data: {"type":"done","seq":0}');
+    expect(getRunEventsSince).toHaveBeenCalledWith("run-sql-aborted", 0);
   });
 });

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -39,6 +39,13 @@ export interface StartRunOptions {
    * auto-continuation signal instead of a user-facing timeout. Leave unset for
    * no framework-imposed run timeout. */
   softTimeoutMs?: number;
+  /** Opt into the hosted/serverless default chunk budget. Only callers with
+   * automatic continuation support should enable this. */
+  useHostedSoftTimeoutDefault?: boolean;
+}
+
+export interface ResolveRunSoftTimeoutOptions {
+  useHostedDefault?: boolean;
 }
 
 function isHostedRuntime(): boolean {
@@ -55,7 +62,10 @@ function isHostedRuntime(): boolean {
   );
 }
 
-export function resolveRunSoftTimeoutMs(overrideMs?: number): number {
+export function resolveRunSoftTimeoutMs(
+  overrideMs?: number,
+  options?: ResolveRunSoftTimeoutOptions,
+): number {
   if (typeof overrideMs === "number" && Number.isFinite(overrideMs)) {
     return Math.max(0, overrideMs);
   }
@@ -64,7 +74,9 @@ export function resolveRunSoftTimeoutMs(overrideMs?: number): number {
     const raw = Number(envValue);
     if (Number.isFinite(raw) && raw >= 0) return raw;
   }
-  return isHostedRuntime() ? DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS : 0;
+  return options?.useHostedDefault && isHostedRuntime()
+    ? DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS
+    : 0;
 }
 
 function isTerminalRunEvent(event: AgentChatEvent): boolean {
@@ -85,8 +97,13 @@ function abortInMemoryRun(run: ActiveRun, reason: string = "user") {
   }
   run.abort.abort(reason);
   for (const subscriber of run.subscribers) {
-    run.subscribers.delete(subscriber);
+    try {
+      subscriber({ seq: run.events.length, event: { type: "done" } });
+    } catch {
+      // ignore — subscriber is being removed below
+    }
   }
+  run.subscribers.clear();
 }
 
 /**
@@ -153,7 +170,9 @@ export function startRun(
     updateRunHeartbeat(runId).catch(() => {});
     checkSqlAbort();
   }, 1500);
-  const softTimeoutMs = resolveRunSoftTimeoutMs(options?.softTimeoutMs);
+  const softTimeoutMs = resolveRunSoftTimeoutMs(options?.softTimeoutMs, {
+    useHostedDefault: options?.useHostedSoftTimeoutDefault === true,
+  });
   const softTimeoutTimer =
     softTimeoutMs > 0
       ? setTimeout(() => {

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -156,7 +156,7 @@ export function startRun(
     getRunAbortState(runId)
       .then((state) => {
         if (state.aborted && !abort.signal.aborted) {
-          abortInMemoryRun(run, state.reason);
+          abortInMemoryRun(run, state.reason ?? "user");
         }
       })
       .catch(() => {});
@@ -473,7 +473,7 @@ function subscribeFromSQL(
               cancelled = true;
               return;
             }
-            lastSeq = seq;
+            lastSeq = seq + 1;
 
             // Close on terminal events
             if (isTerminalRunEvent(parsed)) {
@@ -504,6 +504,24 @@ function subscribeFromSQL(
                   controller.enqueue(
                     encoder.encode(
                       `data: ${JSON.stringify({ ...parsed, seq })}\n\n`,
+                    ),
+                  );
+                } catch {
+                  cancelled = true;
+                  return;
+                }
+                lastSeq = seq + 1;
+                if (isTerminalRunEvent(parsed)) {
+                  if (pingTimer) clearInterval(pingTimer);
+                  controller.close();
+                  return;
+                }
+              }
+              if (run?.status === "aborted") {
+                try {
+                  controller.enqueue(
+                    encoder.encode(
+                      `data: ${JSON.stringify({ type: "done", seq: lastSeq })}\n\n`,
                     ),
                   );
                 } catch {

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -77,6 +77,18 @@ function isTerminalRunEvent(event: AgentChatEvent): boolean {
   );
 }
 
+function abortInMemoryRun(run: ActiveRun, reason: string = "user") {
+  run.abortReason = reason;
+  run.status = "aborted";
+  if (threadToRun.get(run.threadId) === run.runId) {
+    threadToRun.delete(run.threadId);
+  }
+  run.abort.abort(reason);
+  for (const subscriber of run.subscribers) {
+    run.subscribers.delete(subscriber);
+  }
+}
+
 /**
  * Start a new agent run in the background.
  * `runFn` receives a `send` callback and an `AbortSignal`.
@@ -119,16 +131,15 @@ export function startRun(
   insertRun(runId, threadId).catch(() => {});
 
   // Periodic SQL abort check interval (for cross-isolate abort on Workers)
-  let lastAbortCheck = 0;
+  let lastAbortCheck = Date.now() - 3000;
   const checkSqlAbort = () => {
     const now = Date.now();
-    if (now - lastAbortCheck <= 3000) return;
+    if (now - lastAbortCheck < 3000) return;
     lastAbortCheck = now;
     getRunAbortState(runId)
       .then((state) => {
         if (state.aborted && !abort.signal.aborted) {
-          run.abortReason = state.reason;
-          abort.abort(state.reason);
+          abortInMemoryRun(run, state.reason);
         }
       })
       .catch(() => {});
@@ -591,15 +602,7 @@ export function getRun(runId: string): ActiveRun | null {
 export function abortRun(runId: string, reason: string = "user"): boolean {
   const run = activeRuns.get(runId);
   if (run) {
-    run.abortReason = reason;
-    run.status = "aborted";
-    if (threadToRun.get(run.threadId) === runId) {
-      threadToRun.delete(run.threadId);
-    }
-    run.abort.abort(reason);
-    for (const subscriber of run.subscribers) {
-      run.subscribers.delete(subscriber);
-    }
+    abortInMemoryRun(run, reason);
   }
   // Also mark as aborted in SQL (for cross-isolate abort on Workers)
   markRunAborted(runId, reason).catch(() => {});

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -5,7 +5,7 @@ import {
   insertRunEvent,
   updateRunStatus,
   markRunAborted,
-  isRunAborted,
+  getRunAbortState,
   getRunEventsSince,
   getRunById,
   getRunByThread,
@@ -21,6 +21,7 @@ export interface ActiveRun {
   status: RunStatus;
   subscribers: Set<(event: RunEvent) => void>;
   abort: AbortController;
+  abortReason?: string;
   startedAt: number;
 }
 
@@ -117,12 +118,29 @@ export function startRun(
   // Persist run to SQL (fire-and-forget — don't block the response)
   insertRun(runId, threadId).catch(() => {});
 
+  // Periodic SQL abort check interval (for cross-isolate abort on Workers)
+  let lastAbortCheck = 0;
+  const checkSqlAbort = () => {
+    const now = Date.now();
+    if (now - lastAbortCheck <= 3000) return;
+    lastAbortCheck = now;
+    getRunAbortState(runId)
+      .then((state) => {
+        if (state.aborted && !abort.signal.aborted) {
+          run.abortReason = state.reason;
+          abort.abort(state.reason);
+        }
+      })
+      .catch(() => {});
+  };
+
   // Heartbeat: bump heartbeat_at every 1.5s so watchers can detect a dead
   // producer (process crash, HMR restart, isolate eviction) quickly and
   // reap the row. Paired with RUN_STALE_MS (6s) — 4x the interval to
   // tolerate transient DB slowness without false positives.
   const heartbeatTimer: ReturnType<typeof setInterval> = setInterval(() => {
     updateRunHeartbeat(runId).catch(() => {});
+    checkSqlAbort();
   }, 1500);
   const softTimeoutMs = resolveRunSoftTimeoutMs(options?.softTimeoutMs);
   const softTimeoutTimer =
@@ -137,9 +155,6 @@ export function startRun(
           abort.abort();
         }, softTimeoutMs)
       : null;
-
-  // Periodic SQL abort check interval (for cross-isolate abort on Workers)
-  let lastAbortCheck = Date.now();
 
   const send = (event: AgentChatEvent) => {
     if (run.status === "aborted" && abort.signal.aborted) return;
@@ -159,16 +174,7 @@ export function startRun(
     // Persist event to SQL (fire-and-forget)
     insertRunEvent(runId, runEvent.seq, JSON.stringify(event)).catch(() => {});
 
-    // Check SQL for cross-isolate abort every 3 seconds
-    const now = Date.now();
-    if (now - lastAbortCheck > 3000) {
-      lastAbortCheck = now;
-      isRunAborted(runId)
-        .then((aborted) => {
-          if (aborted && !abort.signal.aborted) abort.abort();
-        })
-        .catch(() => {});
-    }
+    checkSqlAbort();
   };
 
   // Run in background — intentionally detached from any HTTP connection
@@ -242,7 +248,10 @@ export function startRun(
       //    still ticking so the run doesn't look stale to any concurrent
       //    /runs/active check while we wait for SQL writes to land.
       let completionError: unknown = null;
-      if (onComplete && run.status !== "aborted") {
+      if (
+        onComplete &&
+        !(run.status === "aborted" && run.abortReason === "no_progress")
+      ) {
         try {
           await onComplete(run);
         } catch (err) {
@@ -579,19 +588,20 @@ export function getRun(runId: string): ActiveRun | null {
 }
 
 /** Explicitly abort a run (e.g. Stop button) */
-export function abortRun(runId: string): boolean {
+export function abortRun(runId: string, reason: string = "user"): boolean {
   const run = activeRuns.get(runId);
   if (run) {
+    run.abortReason = reason;
     run.status = "aborted";
     if (threadToRun.get(run.threadId) === runId) {
       threadToRun.delete(run.threadId);
     }
-    run.abort.abort();
+    run.abort.abort(reason);
     for (const subscriber of run.subscribers) {
       run.subscribers.delete(subscriber);
     }
   }
   // Also mark as aborted in SQL (for cross-isolate abort on Workers)
-  markRunAborted(runId).catch(() => {});
+  markRunAborted(runId, reason).catch(() => {});
   return !!run;
 }

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface ExecCall {
+  sql: string;
+  args: unknown[];
+}
+
+const execCalls: ExecCall[] = [];
+let latestEventRows: Array<{ seq: number; event_data: string }> = [];
+
+const mockDb = {
+  execute: vi.fn(async (sql: string | { sql: string; args?: unknown[] }) => {
+    const rawSql = typeof sql === "string" ? sql : sql.sql;
+    const args = typeof sql === "string" ? [] : (sql.args ?? []);
+    execCalls.push({ sql: rawSql, args });
+
+    if (/SELECT seq, event_data FROM agent_run_events/i.test(rawSql)) {
+      return { rows: latestEventRows, rowsAffected: 0 };
+    }
+
+    return {
+      rows: [],
+      rowsAffected: /^\s*UPDATE\b/i.test(rawSql) ? 1 : 0,
+    };
+  }),
+};
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => mockDb,
+  intType: () => "INTEGER",
+  isPostgres: () => false,
+}));
+
+const { markRunAborted } = await import("./run-store.js");
+
+describe("run store", () => {
+  beforeEach(() => {
+    execCalls.length = 0;
+    latestEventRows = [];
+    vi.clearAllMocks();
+  });
+
+  it("persists a terminal event when marking a run aborted", async () => {
+    await markRunAborted("run-abort");
+
+    const update = execCalls.find((call) =>
+      /UPDATE agent_runs SET status = 'aborted'/i.test(call.sql),
+    );
+    expect(update?.args[0]).toBe("user");
+    expect(update?.args[2]).toBe("run-abort");
+
+    const insert = execCalls.find((call) =>
+      /INSERT INTO agent_run_events/i.test(call.sql),
+    );
+    expect(insert?.args).toEqual(["run-abort", 0, '{"type":"done"}']);
+  });
+
+  it("does not append another terminal event after auto_continue", async () => {
+    latestEventRows = [
+      {
+        seq: 4,
+        event_data: JSON.stringify({
+          type: "auto_continue",
+          reason: "run_timeout",
+        }),
+      },
+    ];
+
+    await markRunAborted("run-abort-after-terminal", "no_progress");
+
+    const eventInserts = execCalls.filter((call) =>
+      /INSERT INTO agent_run_events/i.test(call.sql),
+    );
+    expect(eventInserts).toHaveLength(0);
+  });
+});

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -148,6 +148,7 @@ export async function markRunAborted(
     sql: `UPDATE agent_runs SET status = 'aborted', abort_reason = ?, completed_at = ? WHERE id = ?`,
     args: [reason ?? "user", Date.now(), runId],
   });
+  await appendTerminalRunEvent(runId, { type: "done" }).catch(() => {});
 }
 
 export async function isRunAborted(runId: string): Promise<boolean> {
@@ -357,7 +358,8 @@ async function appendTerminalRunEvent(
         parsed?.type === "done" ||
         parsed?.type === "error" ||
         parsed?.type === "missing_api_key" ||
-        parsed?.type === "loop_limit"
+        parsed?.type === "loop_limit" ||
+        parsed?.type === "auto_continue"
       ) {
         return;
       }

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -34,6 +34,7 @@ async function ensureRunTables(): Promise<void> {
           id TEXT PRIMARY KEY,
           thread_id TEXT NOT NULL,
           status TEXT NOT NULL DEFAULT 'running',
+          abort_reason TEXT,
           started_at ${intType()} NOT NULL,
           completed_at ${intType()},
           heartbeat_at ${intType()}
@@ -45,9 +46,21 @@ async function ensureRunTables(): Promise<void> {
           await client.execute(
             `ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS heartbeat_at ${intType()}`,
           );
+          await client.execute(
+            `ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS abort_reason TEXT`,
+          );
         } else {
           await client.execute(
             `ALTER TABLE agent_runs ADD COLUMN heartbeat_at ${intType()}`,
+          );
+        }
+      } catch {
+        // Column already exists — ignore
+      }
+      try {
+        if (!isPostgres()) {
+          await client.execute(
+            `ALTER TABLE agent_runs ADD COLUMN abort_reason TEXT`,
           );
         }
       } catch {
@@ -125,25 +138,38 @@ export async function updateRunStatus(
   });
 }
 
-export async function markRunAborted(runId: string): Promise<void> {
+export async function markRunAborted(
+  runId: string,
+  reason?: string,
+): Promise<void> {
   await ensureRunTables();
   const client = getDbExec();
   await client.execute({
-    sql: `UPDATE agent_runs SET status = 'aborted', completed_at = ? WHERE id = ?`,
-    args: [Date.now(), runId],
+    sql: `UPDATE agent_runs SET status = 'aborted', abort_reason = ?, completed_at = ? WHERE id = ?`,
+    args: [reason ?? "user", Date.now(), runId],
   });
 }
 
 export async function isRunAborted(runId: string): Promise<boolean> {
+  return (await getRunAbortState(runId)).aborted;
+}
+
+export async function getRunAbortState(
+  runId: string,
+): Promise<{ aborted: boolean; reason?: string }> {
   await ensureRunTables();
   const client = getDbExec();
   const { rows } = await client.execute({
-    sql: `SELECT status FROM agent_runs WHERE id = ?`,
+    sql: `SELECT status, abort_reason FROM agent_runs WHERE id = ?`,
     args: [runId],
   });
-  return (
-    rows.length > 0 && (rows[0] as { status: string }).status === "aborted"
-  );
+  if (rows.length === 0) return { aborted: false };
+  const row = rows[0] as { status: string; abort_reason?: string | null };
+  if (row.status !== "aborted") return { aborted: false };
+  return {
+    aborted: true,
+    ...(row.abort_reason ? { reason: row.abort_reason } : {}),
+  };
 }
 
 export async function insertRunEvent(

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -9,10 +9,14 @@ describe("buildAssistantMessage", () => {
       { seq: 1, event: { type: "auto_continue", reason: "run_timeout" } },
     ];
 
-    expect(buildAssistantMessage(events, "run-timeout")).toBeNull();
+    expect(
+      buildAssistantMessage(events, "run-timeout", {
+        suppressInternalContinuation: true,
+      }),
+    ).toBeNull();
   });
 
-  it("does not persist partial output from recoverable gateway errors", () => {
+  it("does not persist partial output from recoverable gateway errors when suppressed", () => {
     const events: RunEvent[] = [
       { seq: 0, event: { type: "text", text: "checking..." } },
       {
@@ -25,7 +29,35 @@ describe("buildAssistantMessage", () => {
       },
     ];
 
-    expect(buildAssistantMessage(events, "run-gateway-timeout")).toBeNull();
+    expect(
+      buildAssistantMessage(events, "run-gateway-timeout", {
+        suppressInternalContinuation: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("persists recoverable errors by default for non-continuation server paths", () => {
+    const events: RunEvent[] = [
+      { seq: 0, event: { type: "text", text: "checking..." } },
+      {
+        seq: 1,
+        event: {
+          type: "error",
+          error: "Builder gateway timed out after 45s",
+          errorCode: "builder_gateway_timeout",
+        },
+      },
+    ];
+
+    const message = buildAssistantMessage(events, "run-gateway-timeout");
+
+    expect(message?.content).toEqual([
+      {
+        type: "text",
+        text: "checking...\n\nError: Builder gateway timed out after 45s",
+      },
+    ]);
+    expect(message?.status).toEqual({ type: "incomplete", reason: "error" });
   });
 
   it("still persists non-recoverable errors", () => {

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { buildAssistantMessage } from "./thread-data-builder.js";
+import type { RunEvent } from "./types.js";
+
+describe("buildAssistantMessage", () => {
+  it("does not persist partial output from internal continuation boundaries", () => {
+    const events: RunEvent[] = [
+      { seq: 0, event: { type: "text", text: "partial answer" } },
+      { seq: 1, event: { type: "auto_continue", reason: "run_timeout" } },
+    ];
+
+    expect(buildAssistantMessage(events, "run-timeout")).toBeNull();
+  });
+
+  it("does not persist partial output from recoverable gateway errors", () => {
+    const events: RunEvent[] = [
+      { seq: 0, event: { type: "text", text: "checking..." } },
+      {
+        seq: 1,
+        event: {
+          type: "error",
+          error: "Builder gateway timed out after 45s",
+          errorCode: "builder_gateway_timeout",
+        },
+      },
+    ];
+
+    expect(buildAssistantMessage(events, "run-gateway-timeout")).toBeNull();
+  });
+
+  it("still persists non-recoverable errors", () => {
+    const events: RunEvent[] = [
+      { seq: 0, event: { type: "text", text: "checking..." } },
+      {
+        seq: 1,
+        event: {
+          type: "error",
+          error: "Missing API key",
+          errorCode: "missing_api_key",
+        },
+      },
+    ];
+
+    const message = buildAssistantMessage(events, "run-missing-key");
+
+    expect(message?.content).toEqual([
+      { type: "text", text: "checking...\n\nError: Missing API key" },
+    ]);
+    expect(message?.status).toEqual({ type: "incomplete", reason: "error" });
+  });
+});

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -16,6 +16,19 @@ describe("buildAssistantMessage", () => {
     ).toBeNull();
   });
 
+  it("does not persist partial output from suppressed loop-limit boundaries", () => {
+    const events: RunEvent[] = [
+      { seq: 0, event: { type: "text", text: "partial answer" } },
+      { seq: 1, event: { type: "loop_limit", maxIterations: 50 } },
+    ];
+
+    expect(
+      buildAssistantMessage(events, "run-loop-limit", {
+        suppressInternalContinuation: true,
+      }),
+    ).toBeNull();
+  });
+
   it("does not persist partial output from recoverable gateway errors when suppressed", () => {
     const events: RunEvent[] = [
       { seq: 0, event: { type: "text", text: "checking..." } },

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -10,6 +10,10 @@ interface ContentPart {
   result?: string;
 }
 
+interface BuildAssistantMessageOptions {
+  suppressInternalContinuation?: boolean;
+}
+
 function isInternalContinuationError(event: {
   error: string;
   errorCode?: string;
@@ -53,6 +57,7 @@ function isInternalContinuationError(event: {
 export function buildAssistantMessage(
   events: RunEvent[],
   runId?: string,
+  options: BuildAssistantMessageOptions = {},
 ): {
   id: string;
   role: "assistant";
@@ -124,18 +129,28 @@ export function buildAssistantMessage(
     if (event.type === "loop_limit") {
       // Older servers emitted this as a user-visible terminal event. Treat it
       // as an internal continuation boundary when rebuilding persisted turns.
-      endedAtInternalContinuationBoundary = true;
+      if (options.suppressInternalContinuation) {
+        endedAtInternalContinuationBoundary = true;
+      }
       continue;
     }
 
     if (event.type === "auto_continue") {
-      endedAtInternalContinuationBoundary = true;
+      if (options.suppressInternalContinuation) {
+        endedAtInternalContinuationBoundary = true;
+      }
       continue;
     }
 
     if (event.type === "error") {
-      if (isInternalContinuationError(event)) {
+      if (
+        options.suppressInternalContinuation &&
+        isInternalContinuationError(event)
+      ) {
         endedAtInternalContinuationBoundary = true;
+        continue;
+      }
+      if (event.errorCode === "run_timeout" && event.recoverable) {
         continue;
       }
       runError = {

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -10,6 +10,41 @@ interface ContentPart {
   result?: string;
 }
 
+function isInternalContinuationError(event: {
+  error: string;
+  errorCode?: string;
+  recoverable?: boolean;
+}): boolean {
+  const code = String(event.errorCode ?? "").toLowerCase();
+  const msg = event.error.toLowerCase();
+  return (
+    event.recoverable === true ||
+    code === "builder_gateway_timeout" ||
+    code === "stale_run" ||
+    code === "timeout" ||
+    code === "timeout_error" ||
+    code === "http_408" ||
+    code === "http_429" ||
+    code === "http_500" ||
+    code === "http_502" ||
+    code === "http_503" ||
+    code === "http_504" ||
+    code === "rate_limited" ||
+    code === "too_many_concurrent_requests" ||
+    code === "overloaded_error" ||
+    msg.includes("timeout") ||
+    msg.includes("gateway timeout") ||
+    msg.includes("inactivity timeout") ||
+    msg.includes("stream ended") ||
+    msg.includes("stream closed") ||
+    msg.includes("temporarily unavailable") ||
+    msg.includes("502") ||
+    msg.includes("503") ||
+    msg.includes("504") ||
+    msg.includes("529")
+  );
+}
+
 /**
  * Reconstruct an assistant-ui message from raw agent run events.
  * Mirrors the client-side processEvent logic so the server can persist
@@ -35,6 +70,7 @@ export function buildAssistantMessage(
     details?: string;
     recoverable?: boolean;
   } | null = null;
+  let endedAtInternalContinuationBoundary = false;
 
   const appendText = (text: string) => {
     const last = content[content.length - 1];
@@ -88,15 +124,18 @@ export function buildAssistantMessage(
     if (event.type === "loop_limit") {
       // Older servers emitted this as a user-visible terminal event. Treat it
       // as an internal continuation boundary when rebuilding persisted turns.
+      endedAtInternalContinuationBoundary = true;
       continue;
     }
 
     if (event.type === "auto_continue") {
+      endedAtInternalContinuationBoundary = true;
       continue;
     }
 
     if (event.type === "error") {
-      if (event.errorCode === "run_timeout" && event.recoverable) {
+      if (isInternalContinuationError(event)) {
+        endedAtInternalContinuationBoundary = true;
         continue;
       }
       runError = {
@@ -112,7 +151,7 @@ export function buildAssistantMessage(
     // done, missing_api_key — terminal signals, not content
   }
 
-  if (content.length === 0) return null;
+  if (content.length === 0 || endedAtInternalContinuationBoundary) return null;
 
   const metadata: Record<string, unknown> = {};
   if (runId) metadata.runId = runId;

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -363,6 +363,8 @@ export function createAgentChatAdapter(options?: {
           try {
             await fetch(`${apiUrl}/runs/${encodeURIComponent(runId)}/abort`, {
               method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ reason: "no_progress" }),
               signal: abortSignal,
             });
           } catch {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -4268,7 +4268,16 @@ export function createAgentChatPlugin(
             url.match(/^\/([^/?]+)\/abort/);
           if (abortMatch && method === "POST") {
             const runId = decodeURIComponent(abortMatch[1]);
-            abortRun(runId); // Aborts in-memory + marks aborted in SQL
+            let reason = "user";
+            try {
+              const body = await readBody(event);
+              if (body?.reason === "no_progress") {
+                reason = "no_progress";
+              }
+            } catch {
+              // Empty/invalid body — keep the default user abort reason.
+            }
+            abortRun(runId, reason); // Aborts in-memory + marks aborted in SQL
             return { ok: true };
           }
 

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -3149,6 +3149,7 @@ export function createAgentChatPlugin(
             const assistantMsg = buildAssistantMessage(
               run.events ?? [],
               run.runId,
+              { suppressInternalContinuation: true },
             );
             if (!assistantMsg) {
               // No content produced — just bump timestamp

--- a/scripts/guard-no-env-credentials.mjs
+++ b/scripts/guard-no-env-credentials.mjs
@@ -76,6 +76,13 @@ const ALLOWLIST_EXACT = new Set([
   "NODE_ENV",
   "CI",
   "DEBUG",
+  // Hosting/runtime detection flags. These are deployment metadata, not user
+  // credentials.
+  "NETLIFY",
+  "VERCEL",
+  "RENDER",
+  "FLY_APP_NAME",
+  "K_SERVICE",
   // Better-auth
   "BETTER_AUTH_SECRET",
   "BETTER_AUTH_URL",

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -35,6 +35,16 @@ const FLOW_BAR_LABEL: &str = "flow-bar";
 const BUBBLE_SIZE_SMALL: u32 = 360;
 const BUBBLE_SIZE_MEDIUM: u32 = 504;
 
+#[cfg(target_os = "macos")]
+#[link(name = "AppKit", kind = "framework")]
+extern "C" {}
+
+#[derive(Clone, Copy, Debug)]
+enum TextInsertionStrategy {
+    ClipboardPaste,
+    UnicodeType,
+}
+
 /// Extra vertical real-estate reserved beneath the circular bubble for the
 /// hover-controls pill (small-dot + medium-dot). The Tauri window is
 /// `transparent: true`, so the budget paints through as empty space until the
@@ -639,24 +649,96 @@ pub async fn complete_voice_dictation(app: AppHandle, text: String) -> Result<()
         eprintln!("[clips-tray] complete_voice_dictation: empty text — nothing to paste");
         return Ok(());
     }
+    #[cfg(target_os = "macos")]
+    let frontmost_bundle_id = frontmost_bundle_identifier();
+    #[cfg(target_os = "macos")]
+    let strategy = text_insertion_strategy(frontmost_bundle_id.as_deref());
+    #[cfg(target_os = "macos")]
     eprintln!(
-        "[clips-tray] complete_voice_dictation: typing {} chars via CGEvent unicode",
-        trimmed.chars().count()
+        "[clips-tray] complete_voice_dictation: inserting {} chars via {:?} (frontmost={})",
+        trimmed.chars().count(),
+        strategy,
+        frontmost_bundle_id.as_deref().unwrap_or("unknown"),
+    );
+    #[cfg(not(target_os = "macos"))]
+    eprintln!(
+        "[clips-tray] complete_voice_dictation: inserting {} chars",
+        trimmed.chars().count(),
     );
     if let Some(last) = app.try_state::<LastTranscript>() {
         if let Ok(mut g) = last.0.lock() {
             *g = Some(trimmed.clone());
         }
     }
-    // Keep the clipboard updated so users can ⌘V again to repeat the last
-    // dictation, but don't rely on Cmd+V for the actual insertion — many
-    // terminals (Ghostty, iTerm with custom keybindings, etc.) intercept
-    // Cmd+V or only accept paste through their own copy/paste pipeline.
-    // CGEvent unicode injection types the characters directly into the
-    // focused field and works in every terminal + editor we've tested.
+    // Keep the clipboard updated so users can Cmd+V again to repeat the
+    // last dictation. For normal GUI apps, paste via the clipboard so
+    // Chrome/Gmail receives one ordinary paste operation instead of a long
+    // stream of synthetic Unicode key events through AppKit text input.
+    // Known terminal apps still use direct Unicode typing because custom
+    // terminal paste bindings can intercept Cmd+V or bypass paste handling.
     write_clipboard(&trimmed)?;
+    #[cfg(target_os = "macos")]
+    match strategy {
+        TextInsertionStrategy::ClipboardPaste => paste_clipboard(),
+        TextInsertionStrategy::UnicodeType => type_text_unicode(&trimmed),
+    }
+    #[cfg(not(target_os = "macos"))]
     type_text_unicode(&trimmed);
     Ok(())
+}
+
+fn text_insertion_strategy(bundle_id: Option<&str>) -> TextInsertionStrategy {
+    if bundle_id.map(is_terminal_bundle).unwrap_or(false) {
+        TextInsertionStrategy::UnicodeType
+    } else {
+        TextInsertionStrategy::ClipboardPaste
+    }
+}
+
+fn is_terminal_bundle(bundle_id: &str) -> bool {
+    matches!(
+        bundle_id,
+        "com.apple.Terminal"
+            | "com.googlecode.iterm2"
+            | "com.mitchellh.ghostty"
+            | "dev.warp.Warp-Stable"
+            | "dev.warp.Warp-Preview"
+            | "com.github.wez.wezterm"
+            | "org.wezfurlong.wezterm"
+            | "io.alacritty"
+            | "org.alacritty"
+            | "net.kovidgoyal.kitty"
+            | "co.zeit.hyper"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{text_insertion_strategy, TextInsertionStrategy};
+
+    #[test]
+    fn uses_clipboard_paste_for_chrome() {
+        assert!(matches!(
+            text_insertion_strategy(Some("com.google.Chrome")),
+            TextInsertionStrategy::ClipboardPaste
+        ));
+    }
+
+    #[test]
+    fn uses_unicode_typing_for_terminal_apps() {
+        assert!(matches!(
+            text_insertion_strategy(Some("com.mitchellh.ghostty")),
+            TextInsertionStrategy::UnicodeType
+        ));
+    }
+
+    #[test]
+    fn defaults_to_clipboard_paste_when_frontmost_app_is_unknown() {
+        assert!(matches!(
+            text_insertion_strategy(None),
+            TextInsertionStrategy::ClipboardPaste
+        ));
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -684,6 +766,69 @@ fn write_clipboard(text: &str) -> Result<(), String> {
 #[cfg(not(target_os = "macos"))]
 fn write_clipboard(_text: &str) -> Result<(), String> {
     Err("voice dictation is currently macOS-only".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn frontmost_bundle_identifier() -> Option<String> {
+    use objc2::msg_send;
+    use objc2::runtime::{AnyClass, AnyObject};
+
+    unsafe {
+        let class_name = std::ffi::CString::new("NSWorkspace").ok()?;
+        let cls: &AnyClass = AnyClass::get(&class_name)?;
+        let workspace: *mut AnyObject = msg_send![cls, sharedWorkspace];
+        if workspace.is_null() {
+            return None;
+        }
+        let app: *mut AnyObject = msg_send![workspace, frontmostApplication];
+        if app.is_null() {
+            return None;
+        }
+        let bundle_id: *mut AnyObject = msg_send![app, bundleIdentifier];
+        ns_string_to_owned(bundle_id)
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn ns_string_to_owned(ptr: *mut objc2::runtime::AnyObject) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    let utf8_ptr: *const i8 = objc2::msg_send![ptr, UTF8String];
+    if utf8_ptr.is_null() {
+        return None;
+    }
+    let cstr = std::ffi::CStr::from_ptr(utf8_ptr);
+    Some(cstr.to_string_lossy().into_owned())
+}
+
+#[cfg(target_os = "macos")]
+fn paste_clipboard() {
+    use core_graphics::event::{CGEvent, CGEventFlags, CGEventTapLocation};
+    use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
+
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(40));
+        let Ok(source) = CGEventSource::new(CGEventSourceStateID::HIDSystemState) else {
+            eprintln!("[clips-tray] paste failed: no CGEventSource");
+            return;
+        };
+        // macOS virtual keycode 9 is "V".
+        let Ok(down) = CGEvent::new_keyboard_event(source.clone(), 9, true) else {
+            eprintln!("[clips-tray] paste failed: no keydown event");
+            return;
+        };
+        let Ok(up) = CGEvent::new_keyboard_event(source, 9, false) else {
+            eprintln!("[clips-tray] paste failed: no keyup event");
+            return;
+        };
+        let flags = CGEventFlags::CGEventFlagCommand;
+        down.set_flags(flags);
+        up.set_flags(flags);
+        down.post(CGEventTapLocation::HID);
+        thread::sleep(Duration::from_millis(8));
+        up.post(CGEventTapLocation::HID);
+    });
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
- detect SSE streams that remain connected but stop producing data events, then auto-continue without surfacing an error
- abort the stuck run before hidden continuation so a live-but-idle producer does not block the follow-up run
- default hosted/serverless runs to a 55s soft timeout, while preserving local/no-timeout behavior and env override

## Verification
- pnpm --filter @agent-native/core test -- src/client/sse-event-processor.spec.ts src/client/agent-chat-adapter.spec.ts src/agent/run-manager.spec.ts
- pnpm --filter @agent-native/core typecheck