### PR TITLE
fix(cli): tolerate changesets package tags when scaffolding

### DIFF
--- a/.changeset/cli-template-tag-fallback.md
+++ b/.changeset/cli-template-tag-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix `agent-native create` failing with "Unrecognized archive format" on freshly published versions. The CLI now tries the changesets per-package tag (`@agent-native/core@<version>`) first, falls back to the legacy `v<version>` tag, and finally to `main` — so it keeps working through the release-tag scheme shift introduced when the framework adopted changesets.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,16 @@ jobs:
           fi
           pnpm install
 
-      - name: Scaffold workspace (starter + calendar) and verify pnpm install + build
+      - name: Scaffold workspace (starter + calendar + dispatch) and verify pnpm install + build
+        # Dispatch is in the combo because it exercises the
+        # workspacify.ts dispatch-rewrite path (workspace:* → "latest" for
+        # @agent-native/dispatch, the only published package consumed as a
+        # workspace app). Calendar covers the requiredPackages →
+        # packages/scheduling scaffold path. Together they guard the two
+        # distinct ways a workspace template can break `pnpm install`.
         run: |
           cd "$(mktemp -d)"
-          node "$GITHUB_WORKSPACE/packages/core/dist/cli/index.js" create test-workspace --template starter,calendar
+          node "$GITHUB_WORKSPACE/packages/core/dist/cli/index.js" create test-workspace --template starter,calendar,dispatch
           cd test-workspace
           # Required package must be scaffolded
           if [ ! -d "packages/scheduling" ]; then
@@ -130,11 +136,53 @@ jobs:
             echo "::error::postinstall script missing for required packages"
             exit 1
           fi
-          # No workspace:* on @agent-native/core in any package.json
-          if grep -r '"@agent-native/core": "workspace:' apps/ packages/; then
-            echo "::error::@agent-native/core still has workspace:* in scaffold"
-            exit 1
-          fi
+          # Every workspace:* dep in scaffolded apps must resolve to a
+          # package actually present in the workspace. Catches the class of
+          # bug Sami hit: a template depended on @agent-native/dispatch
+          # (a published package, not a workspace member) and `pnpm install`
+          # blew up with ERR_PNPM_WORKSPACE_PKG_NOT_FOUND. We allow
+          # workspace:* for @<workspace-scope>/* (the shared package).
+          node -e '
+            const fs = require("fs");
+            const path = require("path");
+            const wsPkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const wsScope = wsPkg.name ? "@" + wsPkg.name + "/" : "";
+            const wsMembers = new Set();
+            for (const dir of ["apps", "packages"]) {
+              if (!fs.existsSync(dir)) continue;
+              for (const sub of fs.readdirSync(dir)) {
+                const pj = path.join(dir, sub, "package.json");
+                if (fs.existsSync(pj)) {
+                  const n = JSON.parse(fs.readFileSync(pj, "utf8")).name;
+                  if (n) wsMembers.add(n);
+                }
+              }
+            }
+            const offenders = [];
+            for (const dir of ["apps", "packages"]) {
+              if (!fs.existsSync(dir)) continue;
+              for (const sub of fs.readdirSync(dir)) {
+                const pj = path.join(dir, sub, "package.json");
+                if (!fs.existsSync(pj)) continue;
+                const pkg = JSON.parse(fs.readFileSync(pj, "utf8"));
+                for (const dt of ["dependencies","devDependencies","peerDependencies"]) {
+                  for (const [name, ver] of Object.entries(pkg[dt] || {})) {
+                    if (typeof ver === "string" && ver.startsWith("workspace:")) {
+                      if (wsScope && name.startsWith(wsScope)) continue;
+                      if (!wsMembers.has(name)) {
+                        offenders.push(pj + ": " + dt + "." + name + "=" + ver);
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            if (offenders.length) {
+              console.error("::error::dangling workspace:* refs in scaffold (no matching workspace member):");
+              for (const o of offenders) console.error("  " + o);
+              process.exit(1);
+            }
+          '
           pnpm install
           # Build the calendar app — catches missing peer/runtime deps that
           # `pnpm install` alone won't surface (e.g. core importing a peer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,13 +140,10 @@ jobs:
           # package actually present in the workspace. Catches the class of
           # bug Sami hit: a template depended on @agent-native/dispatch
           # (a published package, not a workspace member) and `pnpm install`
-          # blew up with ERR_PNPM_WORKSPACE_PKG_NOT_FOUND. We allow
-          # workspace:* for @<workspace-scope>/* (the shared package).
+          # blew up with ERR_PNPM_WORKSPACE_PKG_NOT_FOUND.
           node -e '
             const fs = require("fs");
             const path = require("path");
-            const wsPkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
-            const wsScope = wsPkg.name ? "@" + wsPkg.name + "/" : "";
             const wsMembers = new Set();
             for (const dir of ["apps", "packages"]) {
               if (!fs.existsSync(dir)) continue;
@@ -168,7 +165,6 @@ jobs:
                 for (const dt of ["dependencies","devDependencies","peerDependencies"]) {
                   for (const [name, ver] of Object.entries(pkg[dt] || {})) {
                     if (typeof ver === "string" && ver.startsWith("workspace:")) {
-                      if (wsScope && name.startsWith(wsScope)) continue;
                       if (!wsMembers.has(name)) {
                         offenders.push(pj + ": " + dt + "." + name + "=" + ver);
                       }

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -26,6 +26,7 @@ import {
   _rewriteNetlifyToml,
   _getCoreDependencyVersion,
   _getGitHubTemplateRef,
+  _getGitHubTemplateRefCandidates,
   _shouldSkipScaffoldEntry,
 } from "./create.js";
 import { workspacifyApp } from "./workspacify.js";
@@ -334,7 +335,19 @@ describe("template/core version compatibility", () => {
   });
 
   it("downloads first-party templates from the CLI package version tag", () => {
-    expect(_getGitHubTemplateRef()).toMatch(/^v\d+\.\d+\.\d+(?:-.+)?$/);
+    const candidates = _getGitHubTemplateRefCandidates();
+    // Changesets per-package tag MUST be tried first — without it, fresh
+    // 0.8.0+ publishes 404 because the legacy `v<version>` tag no longer
+    // exists. See PR for context (Sami's `pnpm i` failure was a downstream
+    // symptom of this same release-tooling shift).
+    expect(candidates[0]).toMatch(
+      /^@agent-native\/core@\d+\.\d+\.\d+(?:-.+)?$/,
+    );
+    // Legacy `v<version>` tag stays as a fallback so any older release that
+    // only has the repo-wide tag (≤ 0.7.83) keeps working when re-run.
+    expect(candidates).toContain(`v${candidates[0].split("@").slice(-1)[0]}`);
+    // `main` is the last-resort fallback for unreleased dev builds.
+    expect(candidates[candidates.length - 1]).toBe("main");
   });
 });
 

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -885,6 +885,7 @@ export {
   rewriteNetlifyToml as _rewriteNetlifyToml,
   getCoreDependencyVersion as _getCoreDependencyVersion,
   getGitHubTemplateRef as _getGitHubTemplateRef,
+  getGitHubTemplateRefCandidates as _getGitHubTemplateRefCandidates,
   shouldSkipScaffoldEntry as _shouldSkipScaffoldEntry,
 };
 
@@ -902,7 +903,10 @@ function validateRepoName(repo: string): void {
 
 function downloadAndExtract(url: string, destDir: string): void {
   fs.mkdirSync(destDir, { recursive: true });
-  const tarball = execFileSync("curl", ["-sL", url], {
+  // --fail-with-body so curl exits non-zero on HTTP 4xx/5xx instead of writing
+  // the error body (HTML/JSON) to disk where tar then fails with the opaque
+  // "Unrecognized archive format" message.
+  const tarball = execFileSync("curl", ["--fail-with-body", "-sL", url], {
     maxBuffer: 100 * 1024 * 1024,
   });
   const tarPath = path.join(destDir, ".download.tar.gz");
@@ -924,19 +928,36 @@ async function downloadGitHubSubdir(
   targetDir: string,
 ): Promise<void> {
   validateRepoName(repo);
-  const ref = getGitHubTemplateRef();
-  const tarUrl = `https://api.github.com/repos/${repo}/tarball/${encodeURIComponent(ref)}`;
-  const tmpDir = path.join(targetDir, "..", `.agent-native-tmp-${Date.now()}`);
-  try {
-    downloadAndExtract(tarUrl, tmpDir);
-    const srcDir = path.join(tmpDir, subdir);
-    if (!fs.existsSync(srcDir)) {
-      throw new Error(`Template directory "${subdir}" not found in ${repo}.`);
+  const refs = getGitHubTemplateRefCandidates();
+  const errors: string[] = [];
+  for (const ref of refs) {
+    const tarUrl = `https://api.github.com/repos/${repo}/tarball/${encodeURIComponent(ref)}`;
+    const tmpDir = path.join(
+      targetDir,
+      "..",
+      `.agent-native-tmp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    );
+    try {
+      downloadAndExtract(tarUrl, tmpDir);
+      const srcDir = path.join(tmpDir, subdir);
+      if (!fs.existsSync(srcDir)) {
+        throw new Error(
+          `Template directory "${subdir}" not found at ref "${ref}".`,
+        );
+      }
+      copyDir(srcDir, targetDir);
+      return;
+    } catch (err) {
+      errors.push(
+        `  ${ref}: ${err instanceof Error ? err.message.split("\n")[0] : String(err)}`,
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
     }
-    copyDir(srcDir, targetDir);
-  } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
+  throw new Error(
+    `Failed to download templates from ${repo}. Tried refs:\n${errors.join("\n")}`,
+  );
 }
 
 async function downloadGitHubRepo(
@@ -1044,12 +1065,34 @@ function getCorePackageVersion(): string | undefined {
   }
 }
 
-function getGitHubTemplateRef(): string {
+/**
+ * Git refs to try, in priority order, when downloading templates from the
+ * framework repo. The release tag scheme has shifted over time:
+ *
+ *   - ≤ 0.7.83: single repo-wide tag `v<version>` (legacy).
+ *   - ≥ 0.8.0:  changesets per-package tags
+ *               `@agent-native/core@<version>` (current).
+ *
+ * `main` is the final fallback so dev builds and brand-new releases (where
+ * the tag has not propagated yet) still work — at the cost of pulling
+ * potentially newer template code than the running CLI was built against.
+ */
+function getGitHubTemplateRefCandidates(): string[] {
   const version = getCorePackageVersion();
+  const candidates: string[] = [];
   if (version && /^\d+\.\d+\.\d+(?:-.+)?$/.test(version)) {
-    return `v${version}`;
+    candidates.push(`@agent-native/core@${version}`);
+    candidates.push(`v${version}`);
   }
-  return "main";
+  candidates.push("main");
+  return candidates;
+}
+
+/** @deprecated Kept for backward-compatible test imports. Returns the
+ *  highest-priority candidate; callers that need the full fallback list
+ *  should use `getGitHubTemplateRefCandidates()`. */
+function getGitHubTemplateRef(): string {
+  return getGitHubTemplateRefCandidates()[0]!;
 }
 
 function rewriteCoreDependencyVersions(projectDir: string): void {


### PR DESCRIPTION
## Summary
- try changesets per-package tags before legacy repo-wide tags when downloading first-party templates
- keep legacy v<version> and main fallbacks for old/dev builds
- expand Scaffold E2E to catch dangling workspace:* dependencies with dispatch + calendar workspace scaffolds

## Verification
- pnpm --filter @agent-native/core test -- src/cli/create-e2e.spec.ts
- pnpm --filter @agent-native/core typecheck
- npx prettier --check .changeset/cli-template-tag-fallback.md .github/workflows/ci.yml packages/core/src/cli/create-e2e.spec.ts packages/core/src/cli/create.ts