### PR TITLE
feat(analytics): marketing-funnel v2 + theme init + agent panel chat notice

### DIFF
--- a/.changeset/core-agent-panel-chat-notice.md
+++ b/.changeset/core-agent-panel-chat-notice.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add an optional AgentPanel chat notice render slot.

--- a/.changeset/core-theme-init-export.md
+++ b/.changeset/core-theme-init-export.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Export a reusable client theme initialization script helper.

--- a/.changeset/core-vite-source-prebundle.md
+++ b/.changeset/core-vite-source-prebundle.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Avoid stale Vite prebundles for core source aliases in monorepo development.

--- a/.changeset/fix-template-theme-init.md
+++ b/.changeset/fix-template-theme-init.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Initialize template light/dark classes before hydration and normalize legacy theme storage.

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -227,6 +227,8 @@ export interface AgentPanelProps extends Omit<
   devAppUrl?: string;
   /** Namespace for localStorage keys — used to isolate chat state per app in the frame. */
   storageKey?: string;
+  /** Optional notice rendered below the main header while Chat mode is active. */
+  chatNotice?: React.ReactNode;
 }
 
 function useClientOnly() {
@@ -247,6 +249,7 @@ function AgentPanelInner({
   onToggleFullscreen,
   devAppUrl,
   storageKey,
+  chatNotice,
 }: AgentPanelProps) {
   const mounted = useClientOnly();
   const keyPrefix = storageKey ? `:${storageKey}` : "";
@@ -621,6 +624,9 @@ function AgentPanelInner({
             {renderHeaderActions()}
           </div>
         </div>
+        {mode === "chat" && chatNotice ? (
+          <div className="border-b border-border">{chatNotice}</div>
+        ) : null}
         {/* Tab bar: always visible for chat and CLI */}
         {(mode === "chat" || mode === "cli") &&
           (() => {
@@ -1060,6 +1066,7 @@ function AgentPanelInner({
       mode,
       renderHeaderActions,
       renderModeButtons,
+      chatNotice,
       cliTabs,
       activeCliTab,
       addCliTab,

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -113,6 +113,11 @@ export { ErrorBoundary } from "./ErrorBoundary.js";
 export { installRouteChunkRecovery } from "./route-chunk-recovery.js";
 export { ClientOnly } from "./ClientOnly.js";
 export { DefaultSpinner } from "./DefaultSpinner.js";
+export {
+  getThemeInitScript,
+  themeInitScript,
+  type ThemePreference,
+} from "./theme.js";
 export { AgentTerminal, type AgentTerminalProps } from "./terminal/index.js";
 export {
   trackEvent,

--- a/packages/core/src/client/theme.spec.ts
+++ b/packages/core/src/client/theme.spec.ts
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getThemeInitScript } from "./theme.js";
+
+function setPrefersDark(prefersDark: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(prefers-color-scheme: dark)" && prefersDark,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function runThemeScript(script: string) {
+  new Function(script)();
+}
+
+describe("getThemeInitScript", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.classList.remove("light", "dark");
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.style.colorScheme = "";
+  });
+
+  it("resolves system theme before the app mounts", () => {
+    setPrefersDark(true);
+
+    runThemeScript(getThemeInitScript());
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.getAttribute("data-theme")).toBe(null);
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+  });
+
+  it("lets an explicit stored theme override the browser preference", () => {
+    setPrefersDark(true);
+    window.localStorage.setItem("theme", "light");
+
+    runThemeScript(getThemeInitScript());
+
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("uses the configured default when there is no stored theme", () => {
+    setPrefersDark(false);
+
+    runThemeScript(getThemeInitScript("dark"));
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+  });
+
+  it("falls back from stored system when system themes are disabled", () => {
+    setPrefersDark(false);
+    window.localStorage.setItem("theme", "system");
+
+    runThemeScript(getThemeInitScript("dark", false));
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(window.localStorage.getItem("theme")).toBe("dark");
+  });
+
+  it("normalizes legacy auto storage before next-themes reads it", () => {
+    setPrefersDark(true);
+    window.localStorage.setItem("theme", "auto");
+
+    runThemeScript(getThemeInitScript());
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(window.localStorage.getItem("theme")).toBe("system");
+  });
+
+  it("removes invalid stored themes so the provider can use the default", () => {
+    setPrefersDark(false);
+    window.localStorage.setItem("theme", "sepia");
+
+    runThemeScript(getThemeInitScript("dark"));
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(window.localStorage.getItem("theme")).toBe(null);
+  });
+});

--- a/packages/core/src/client/theme.ts
+++ b/packages/core/src/client/theme.ts
@@ -1,0 +1,20 @@
+export type ThemePreference = "light" | "dark" | "system";
+
+function normalizeDefaultTheme(theme: ThemePreference): ThemePreference {
+  if (theme === "light" || theme === "dark" || theme === "system") {
+    return theme;
+  }
+  return "system";
+}
+
+export function getThemeInitScript(
+  defaultTheme: ThemePreference = "system",
+  enableSystem = true,
+) {
+  const safeDefaultTheme = normalizeDefaultTheme(defaultTheme);
+  const systemEnabled = enableSystem ? "true" : "false";
+
+  return `(function(){try{var defaultTheme=${JSON.stringify(safeDefaultTheme)};var enableSystem=${systemEnabled};var stored=window.localStorage.getItem('theme');var valid=stored==='light'||stored==='dark'||stored==='system'||stored==='auto';var mode=valid?stored:defaultTheme;if(mode==='auto')mode='system';if(!enableSystem&&mode==='system')mode=defaultTheme==='system'?'light':defaultTheme;if(!valid){window.localStorage.removeItem('theme')}else if(stored!==mode){window.localStorage.setItem('theme',mode)}var prefersDark=enableSystem&&mode==='system'&&window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches;var resolved=mode==='system'?(prefersDark?'dark':'light'):mode;var root=document.documentElement;root.classList.remove('light','dark');root.classList.add(resolved);if(mode==='system'){root.removeAttribute('data-theme')}else{root.setAttribute('data-theme',mode)}root.style.colorScheme=resolved;}catch(e){}})();`;
+}
+
+export const themeInitScript = getThemeInitScript();

--- a/packages/core/src/templates/default/app/root.tsx
+++ b/packages/core/src/templates/default/app/root.tsx
@@ -17,6 +17,7 @@ import {
 import { ThemeProvider } from "next-themes";
 import { useDbSync } from "@agent-native/core";
 import { ClientOnly, DefaultSpinner } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 import { Toaster } from "sonner";
 import { configureTracking } from "@agent-native/core/client";
 configureTracking({
@@ -27,6 +28,8 @@ configureTracking({
 });
 import "./global.css";
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -36,6 +39,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="manifest" href="/manifest.json" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="theme-color" content="#111111" />

--- a/packages/core/src/templates/default/app/routes/_index.tsx
+++ b/packages/core/src/templates/default/app/routes/_index.tsx
@@ -18,7 +18,8 @@ export function HydrateFallback() {
 }
 
 export default function IndexPage() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen px-6">
@@ -52,7 +53,7 @@ export default function IndexPage() {
             </p>
           </a>
           <button
-            onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+            onClick={() => setTheme(isDark ? "light" : "dark")}
             className="rounded-lg border border-border/50 px-4 py-3 hover:bg-accent/50 transition-colors text-left"
           >
             <p className="text-[13px] font-medium text-foreground">Theme</p>

--- a/packages/core/src/vite/client.ts
+++ b/packages/core/src/vite/client.ts
@@ -173,27 +173,75 @@ function getClientDedupe(cwd: string): string[] {
   return [...always];
 }
 
+/**
+ * Locate `packages/core/src` if we're inside the framework monorepo.
+ * Shared between `getCoreSourceAliases` (which redirects imports to src/)
+ * and `getDefaultOptimizeDeps` (which must NOT prebundle from dist/ when
+ * the alias is active — otherwise the prebundle is built from a snapshot
+ * of dist/ at startup and never picks up new exports).
+ */
+function findCoreSrcDir(cwd: string): string | null {
+  const candidates = [
+    path.resolve(cwd, "../../packages/core"), // templates/<name>/
+    path.resolve(cwd, "../core"), // packages/<name>/
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(candidate, "src/index.ts"))) {
+      return path.join(candidate, "src");
+    }
+  }
+  return null;
+}
+
+/**
+ * Every `@agent-native/core` subpath that gets a source alias. Must stay in
+ * sync with `getCoreSourceAliases`. Used by `getDefaultOptimizeDeps` to skip
+ * prebundling in monorepo mode, and by the consumer config to add them to
+ * `optimizeDeps.exclude` so Vite always resolves them through the source
+ * alias on every request — never from a stale dist/ snapshot.
+ */
+const CORE_CLIENT_SUBPATHS = [
+  "@agent-native/core",
+  "@agent-native/core/client",
+  "@agent-native/core/client/extensions",
+  "@agent-native/core/client/tools", // legacy alias
+  "@agent-native/core/client/org",
+  "@agent-native/core/client/observability",
+  "@agent-native/core/client/onboarding",
+  "@agent-native/core/client/sharing",
+  "@agent-native/core/client/notifications",
+  "@agent-native/core/client/progress",
+];
+
 function getDefaultOptimizeDeps(cwd: string): string[] {
+  const inMonorepo = findCoreSrcDir(cwd) !== null;
   const entries: Array<{ specifier: string; packageName?: string }> = [
-    { specifier: "@agent-native/core" },
-    {
-      specifier: "@agent-native/core/client",
-      packageName: "@agent-native/core",
-    },
-    {
-      specifier: "@agent-native/core/client/org",
-      packageName: "@agent-native/core",
-    },
-    {
-      specifier: "@agent-native/core/client/extensions",
-      packageName: "@agent-native/core",
-    },
-    {
-      // Legacy alias — prior name for @agent-native/core/client/extensions.
-      // Keep so deployed templates that haven't been updated still resolve.
-      specifier: "@agent-native/core/client/tools",
-      packageName: "@agent-native/core",
-    },
+    // In monorepo mode the source alias resolves these to src/ on every
+    // import, so prebundling from dist/ would just create a stale snapshot.
+    // Skip them entirely — `optimizeDeps.exclude` below makes that explicit.
+    ...(inMonorepo
+      ? []
+      : ([
+          { specifier: "@agent-native/core" },
+          {
+            specifier: "@agent-native/core/client",
+            packageName: "@agent-native/core",
+          },
+          {
+            specifier: "@agent-native/core/client/org",
+            packageName: "@agent-native/core",
+          },
+          {
+            specifier: "@agent-native/core/client/extensions",
+            packageName: "@agent-native/core",
+          },
+          {
+            // Legacy alias — prior name for @agent-native/core/client/extensions.
+            // Keep so deployed templates that haven't been updated still resolve.
+            specifier: "@agent-native/core/client/tools",
+            packageName: "@agent-native/core",
+          },
+        ] as Array<{ specifier: string; packageName?: string }>)),
     { specifier: "@libsql/client" },
     { specifier: "@radix-ui/react-accordion" },
     { specifier: "@radix-ui/react-alert-dialog" },
@@ -255,20 +303,7 @@ function getDefaultOptimizeDeps(cwd: string): string[] {
 function getCoreSourceAliases(
   cwd: string,
 ): Array<{ find: RegExp; replacement: string }> {
-  // Detect monorepo: walk up to find packages/core/src/
-  const candidates = [
-    path.resolve(cwd, "../../packages/core"), // templates/<name>/
-    path.resolve(cwd, "../core"), // packages/<name>/
-  ];
-
-  let coreSrc = "";
-  for (const candidate of candidates) {
-    if (fs.existsSync(path.join(candidate, "src/index.ts"))) {
-      coreSrc = path.join(candidate, "src");
-      break;
-    }
-  }
-
+  const coreSrc = findCoreSrcDir(cwd);
   if (!coreSrc) return []; // Not in monorepo — use dist as normal
 
   // Map every @agent-native/core/* export to its src/ equivalent.
@@ -1057,9 +1092,16 @@ export function defineConfig(options: ClientConfigOptions = {}): UserConfig {
           : []),
         ...(options.optimizeDeps?.include ?? []),
       ],
-      ...(options.optimizeDeps?.exclude
-        ? { exclude: options.optimizeDeps.exclude }
-        : {}),
+      // In monorepo mode: explicitly exclude @agent-native/core subpaths so
+      // Vite never prebundles them from dist/. The source alias above
+      // (`getCoreSourceAliases`) resolves every import to src/ on every
+      // request, so HMR picks up new exports immediately. Without exclude,
+      // the prebundle is built from dist/ once at startup and silently
+      // serves stale code even after the source / dist is updated.
+      exclude: [
+        ...(findCoreSrcDir(cwd) !== null ? CORE_CLIENT_SUBPATHS : []),
+        ...(options.optimizeDeps?.exclude ?? []),
+      ],
     },
     resolve: {
       // Dedupe all client-side packages that core shares with the consuming

--- a/packages/frame/client/App.tsx
+++ b/packages/frame/client/App.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useEffect, useRef, lazy, Suspense } from "react";
 import { TEMPLATES, getTemplate } from "@agent-native/shared-app-config";
+import { IconAppWindow, IconX } from "@tabler/icons-react";
 
 // Lazy-load heavy components
 const MultiTabAssistantChat = lazy(() =>
@@ -38,6 +39,7 @@ const SIDEBAR_WIDTH_KEY = "frame-sidebar-width";
 const FRAME_MODE_KEY = "frame-mode";
 const SIDEBAR_OPEN_KEY = "frame-sidebar-open";
 const SIDEBAR_FULLSCREEN_KEY = "frame-sidebar-fullscreen";
+const DESKTOP_APP_NUDGE_DISMISSED_KEY = "frame.desktop-app-nudge.dismissed";
 
 function getAppId(): string {
   const params = new URLSearchParams(window.location.search);
@@ -60,6 +62,65 @@ function getAppDevUrl(appId: string): string {
     typeof window !== "undefined" ? window.location.hostname : "localhost";
   const port = app?.devPort || 8080;
   return `http://${host}:${port}`;
+}
+
+function isAgentNativeDesktop() {
+  if (typeof navigator === "undefined") return false;
+  return /AgentNativeDesktop/i.test(navigator.userAgent);
+}
+
+function DesktopAppNudge() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (isAgentNativeDesktop()) return;
+    try {
+      if (localStorage.getItem(DESKTOP_APP_NUDGE_DISMISSED_KEY) === "1") {
+        return;
+      }
+    } catch {}
+    setVisible(true);
+  }, []);
+
+  function dismiss() {
+    setVisible(false);
+    try {
+      localStorage.setItem(DESKTOP_APP_NUDGE_DISMISSED_KEY, "1");
+    } catch {}
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div className="mx-2 my-1.5 rounded-md border border-border/70 bg-muted/35 px-2.5 py-2 text-[11px] leading-snug text-muted-foreground">
+      <div className="flex items-start gap-2">
+        <IconAppWindow className="mt-0.5 h-3.5 w-3.5 shrink-0 text-foreground/70" />
+        <p className="min-w-0 flex-1">
+          <span className="font-medium text-foreground">
+            Using local dev agents?
+          </span>{" "}
+          The desktop app keeps this chat together while your app reloads.{" "}
+          <a
+            href="https://agent-native.com/download"
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium text-foreground underline-offset-2 hover:underline"
+          >
+            Download
+          </a>
+        </p>
+        <button
+          type="button"
+          onClick={dismiss}
+          title="Dismiss desktop app tip"
+          aria-label="Dismiss desktop app tip"
+          className="-mr-1 -mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+        >
+          <IconX className="h-3 w-3" />
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export function App() {
@@ -361,6 +422,7 @@ export function App() {
                 onToggleFullscreen={() => setSidebarFullscreen((prev) => !prev)}
                 devAppUrl={appUrl}
                 storageKey={appId}
+                chatNotice={<DesktopAppNudge />}
               />
             </Suspense>
           </div>

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -261,7 +261,8 @@ async function validatePanelSql(
   const vars = buildDryRunVars(config);
   for (let i = 0; i < panels.length; i++) {
     const p = panels[i] as Record<string, unknown>;
-    // Sections are layout-only — no SQL, nothing to validate.
+    // Sections are layout-only — no SQL to dry-run. heatmap, callout, and other
+    // query panels still validate normally below.
     if (p.chartType === "section") continue;
     if (p.source === "amplitude") {
       const raw = typeof p.sql === "string" ? p.sql : "";

--- a/templates/analytics/app/components/dashboard/SqlChart.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type CSSProperties } from "react";
+import { useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import {
   Area,
   AreaChart,
@@ -24,6 +24,11 @@ import {
   IconSortDescending,
   IconChevronLeft,
   IconChevronRight,
+  IconAlertTriangle,
+  IconInfoCircle,
+  IconTrendingUp,
+  IconTrendingDown,
+  IconDownload,
 } from "@tabler/icons-react";
 import {
   Select,
@@ -83,6 +88,13 @@ function formatYValue(
     return `${pct.toFixed(2)}%`;
   }
   return value.toLocaleString();
+}
+
+function csvEscape(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
 }
 
 function formatXLabel(value: string): string {
@@ -253,6 +265,18 @@ export function SqlChart({ panel, resolvedSql }: SqlChartProps) {
     );
   }
 
+  if (chartType === "heatmap") {
+    return <HeatmapRenderer rows={rows} panel={panel} />;
+  }
+
+  if (chartType === "callout") {
+    return <CalloutRenderer rows={rows} />;
+  }
+
+  if (chartType !== "line" && chartType !== "area") {
+    return <TableRenderer rows={rows} panel={panel} />;
+  }
+
   return (
     <TimeSeriesRenderer
       rows={rows}
@@ -315,6 +339,10 @@ function formatCell(value: unknown, format: ColumnFormat | undefined): string {
     const pct = value <= 1 && value >= -1 ? value * 100 : value;
     return `${pct.toFixed(2)}%`;
   }
+  if (format === "delta" && typeof value === "number") {
+    const sign = value > 0 ? "+" : "";
+    return `${sign}${value.toFixed(1)}%`;
+  }
   if (format === "date") {
     const d = new Date(String(value));
     if (!isNaN(d.getTime())) {
@@ -326,6 +354,36 @@ function formatCell(value: unknown, format: ColumnFormat | undefined): string {
     }
   }
   return String(value);
+}
+
+function renderDeltaCell(value: unknown): ReactNode {
+  if (value == null || typeof value !== "number" || Number.isNaN(value)) {
+    return <span className="text-muted-foreground">-</span>;
+  }
+  const sign = value > 0 ? "+" : "";
+  const text = `${sign}${value.toFixed(1)}%`;
+  const isPositive = value > 0;
+  const isNegative = value < 0;
+  const colorClass = isPositive
+    ? "text-emerald-500"
+    : isNegative
+      ? "text-red-500"
+      : "text-muted-foreground";
+  const Arrow = isPositive
+    ? IconTrendingUp
+    : isNegative
+      ? IconTrendingDown
+      : null;
+  const critical = Math.abs(value) > 30;
+  return (
+    <span
+      className={`inline-flex items-center justify-end gap-1 ${colorClass}`}
+    >
+      {Arrow && <Arrow className="h-3.5 w-3.5" />}
+      <span>{text}</span>
+      {critical && <IconAlertTriangle className="h-3.5 w-3.5" />}
+    </span>
+  );
 }
 
 function TableRenderer({
@@ -390,9 +448,39 @@ function TableRenderer({
     setPage(0);
   };
 
+  const handleExportCsv = () => {
+    const headers = columns.map((col) => col.label ?? col.key);
+    const rowsCsv = sortedRows.map((row) =>
+      columns.map((col) => formatCell(row[col.key], col.format)).map(csvEscape),
+    );
+    const csv = [
+      headers.map(csvEscape).join(","),
+      ...rowsCsv.map((r) => r.join(",")),
+    ].join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    const date = new Date().toISOString().slice(0, 10);
+    a.href = url;
+    a.download = `${panel.id}-${date}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="space-y-1">
-      <div className="overflow-x-auto">
+      <div className="relative overflow-x-auto">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="absolute right-1 top-1 h-6 w-6 z-10"
+          onClick={handleExportCsv}
+          title="Export CSV"
+        >
+          <IconDownload className="h-3.5 w-3.5" />
+        </Button>
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-border">
@@ -432,8 +520,8 @@ function TableRenderer({
               <tr key={i} className="border-b border-border/50">
                 {columns.map((col) => {
                   const raw = row[col.key];
-                  const formatted = formatCell(raw, col.format);
                   if (col.format === "link") {
+                    const formatted = formatCell(raw, col.format);
                     const href = col.linkKey
                       ? String(row[col.linkKey] ?? "")
                       : String(raw ?? "");
@@ -456,7 +544,12 @@ function TableRenderer({
                   const numeric =
                     col.format === "number" ||
                     col.format === "currency" ||
-                    col.format === "percent";
+                    col.format === "percent" ||
+                    col.format === "delta";
+                  const content: ReactNode =
+                    col.format === "delta"
+                      ? renderDeltaCell(raw)
+                      : formatCell(raw, col.format);
                   return (
                     <td
                       key={col.key}
@@ -464,7 +557,7 @@ function TableRenderer({
                         numeric ? "text-right tabular-nums" : ""
                       }`}
                     >
-                      {formatted}
+                      {content}
                     </td>
                   );
                 })}
@@ -765,6 +858,210 @@ function TimeSeriesRenderer({
           ))}
         </AreaChart>
       </ResponsiveContainer>
+    </div>
+  );
+}
+
+// Heatmap config: `xKey` = x-axis column, `yKey` = numeric value column,
+// `color` = optional row-label column. If `color` is omitted, the renderer
+// auto-detects the row-label as the first non-x non-value string column.
+function HeatmapRenderer({
+  rows,
+  panel,
+}: {
+  rows: Record<string, unknown>[];
+  panel: SqlPanel;
+}) {
+  const cfg = panel.config;
+  const yFormatter = cfg?.yFormatter;
+
+  const { xKey, valueKey, rowKey, xValues, yValues, grid, stats } =
+    useMemo(() => {
+      if (rows.length === 0) {
+        return {
+          xKey: "",
+          valueKey: "",
+          rowKey: "",
+          xValues: [] as string[],
+          yValues: [] as string[],
+          grid: new Map<string, number>(),
+          stats: new Map<string, { mean: number; std: number }>(),
+        };
+      }
+      const cols = Object.keys(rows[0]);
+      const sample = rows[0] as Record<string, unknown>;
+      const xK =
+        cfg?.xKey || cols.find((c) => typeof sample[c] === "string") || cols[0];
+      const valK =
+        cfg?.yKey ||
+        cols.find((c) => c !== xK && typeof sample[c] === "number") ||
+        cols[1] ||
+        "";
+      const rowK =
+        cfg?.color ||
+        cols.find(
+          (c) => c !== xK && c !== valK && typeof sample[c] === "string",
+        ) ||
+        "";
+
+      const xs: string[] = [];
+      const ys: string[] = [];
+      const seenX = new Set<string>();
+      const seenY = new Set<string>();
+      const g = new Map<string, number>();
+      for (const r of rows) {
+        const xv = String(r[xK] ?? "");
+        const yv = rowK ? String(r[rowK] ?? "") : "";
+        const v = Number(r[valK]);
+        if (!seenX.has(xv)) {
+          seenX.add(xv);
+          xs.push(xv);
+        }
+        if (!seenY.has(yv)) {
+          seenY.add(yv);
+          ys.push(yv);
+        }
+        if (Number.isFinite(v)) g.set(`${xv}\u0000${yv}`, v);
+      }
+
+      const s = new Map<string, { mean: number; std: number }>();
+      for (const xv of xs) {
+        const vals: number[] = [];
+        for (const yv of ys) {
+          const v = g.get(`${xv}\u0000${yv}`);
+          if (v != null) vals.push(v);
+        }
+        if (vals.length === 0) {
+          s.set(xv, { mean: 0, std: 0 });
+          continue;
+        }
+        const mean = vals.reduce((a, b) => a + b, 0) / vals.length;
+        const variance =
+          vals.reduce((a, b) => a + (b - mean) ** 2, 0) / vals.length;
+        s.set(xv, { mean, std: Math.sqrt(variance) });
+      }
+      return {
+        xKey: xK,
+        valueKey: valK,
+        rowKey: rowK,
+        xValues: xs,
+        yValues: ys,
+        grid: g,
+        stats: s,
+      };
+    }, [rows, cfg?.xKey, cfg?.yKey, cfg?.color]);
+
+  if (rows.length === 0 || !valueKey) {
+    return (
+      <div className="flex min-h-[250px] items-center justify-center py-8">
+        <p className="text-sm text-muted-foreground text-center">No data</p>
+      </div>
+    );
+  }
+
+  const cellColor = (xv: string, v: number | undefined) => {
+    if (v == null) return undefined;
+    const stat = stats.get(xv);
+    if (!stat) return undefined;
+    const baseline = stat.std > 0 ? stat.std : Math.abs(stat.mean) || 1;
+    const z = Math.max(-2, Math.min(2, (v - stat.mean) / baseline));
+    const intensity = Math.min(2, Math.abs(z));
+    const lightness = 90 - intensity * 25;
+    const hue = z >= 0 ? 140 : 0;
+    return `hsl(${hue}, 60%, ${lightness}%)`;
+  };
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b border-border">
+            <th className="text-left py-1.5 px-2 font-medium text-muted-foreground whitespace-nowrap">
+              {rowKey || ""}
+            </th>
+            {xValues.map((xv) => (
+              <th
+                key={xv}
+                className="text-right py-1.5 px-2 font-medium text-muted-foreground whitespace-nowrap"
+              >
+                {formatXLabel(xv)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {yValues.map((yv) => (
+            <tr key={yv} className="border-b border-border/50">
+              <td className="py-1.5 px-2 font-medium text-muted-foreground whitespace-nowrap">
+                {yv || "—"}
+              </td>
+              {xValues.map((xv) => {
+                const v = grid.get(`${xv}\u0000${yv}`);
+                const bg = cellColor(xv, v);
+                return (
+                  <td
+                    key={xv}
+                    className="py-1.5 px-2 text-right tabular-nums whitespace-nowrap"
+                    style={bg ? { backgroundColor: bg } : undefined}
+                  >
+                    {v != null ? formatYValue(v, yFormatter) : ""}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+type CalloutSeverity = "info" | "warning" | "critical";
+
+function CalloutRenderer({ rows }: { rows: Record<string, unknown>[] }) {
+  if (rows.length === 0) return null;
+
+  const styleFor = (severity: CalloutSeverity) => {
+    if (severity === "critical") {
+      return {
+        wrapper:
+          "border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300",
+        Icon: IconAlertTriangle,
+      };
+    }
+    if (severity === "warning") {
+      return {
+        wrapper:
+          "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+        Icon: IconAlertTriangle,
+      };
+    }
+    return {
+      wrapper: "border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+      Icon: IconInfoCircle,
+    };
+  };
+
+  return (
+    <div className="space-y-2">
+      {rows.map((row, i) => {
+        const sevRaw = String(row.severity ?? "info").toLowerCase();
+        const severity: CalloutSeverity =
+          sevRaw === "critical" || sevRaw === "warning" || sevRaw === "info"
+            ? (sevRaw as CalloutSeverity)
+            : "info";
+        const message = String(row.message ?? "");
+        const { wrapper, Icon } = styleFor(severity);
+        return (
+          <div
+            key={i}
+            className={`flex items-start gap-2 rounded-md border px-3 py-2 text-sm ${wrapper}`}
+          >
+            <Icon className="h-4 w-4 mt-0.5 shrink-0" />
+            <span className="break-words">{message}</span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/templates/analytics/app/components/layout/CommandPalette.tsx
+++ b/templates/analytics/app/components/layout/CommandPalette.tsx
@@ -80,7 +80,8 @@ async function fetchSqlDashboards(): Promise<{ id: string; name: string }[]> {
 export function CommandPalette() {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
 
   const { data: savedCharts = [] } = useQuery({
     queryKey: ["explorer-configs-palette"],
@@ -179,15 +180,15 @@ export function CommandPalette() {
 
         <CommandGroup heading="Appearance">
           <CommandItem
-            onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+            onSelect={() => setTheme(isDark ? "light" : "dark")}
             keywords={["theme", "dark", "light", "mode"]}
           >
-            {theme === "dark" ? (
+            {isDark ? (
               <IconSun className="mr-2 h-4 w-4 text-muted-foreground" />
             ) : (
               <IconMoon className="mr-2 h-4 w-4 text-muted-foreground" />
             )}
-            Toggle {theme === "dark" ? "light" : "dark"} mode
+            Toggle {isDark ? "light" : "dark"} mode
           </CommandItem>
         </CommandGroup>
 

--- a/templates/analytics/app/entry.client.tsx
+++ b/templates/analytics/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
@@ -77,7 +77,7 @@ export function SqlChartCard({
       <div
         ref={setNodeRef}
         style={style}
-        className="group relative md:col-span-2 mt-2 first:mt-0"
+        className="group relative mt-2 first:mt-0"
       >
         <div className="flex items-center gap-2 border-b border-border pb-2">
           <h2 className="text-base font-semibold flex-1">{panel.title}</h2>

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -18,6 +18,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { IconPencil, IconPlus, IconTrash } from "@tabler/icons-react";
 import {
   ShareButton,
@@ -475,6 +476,53 @@ export default function SqlDashboardPage() {
     return { ...(dashboard?.variables ?? {}), ...filterValues };
   }, [dashboard?.variables, dashboard?.filters, searchParams]);
 
+  // Distinct tab values across panels in declaration order. When this is
+  // non-empty the dashboard renders a tab strip and filters panels by tab.
+  const tabs = useMemo<string[]>(() => {
+    if (!dashboard) return [];
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const panel of dashboard.panels) {
+      const t = panel.tab;
+      if (t && !seen.has(t)) {
+        seen.add(t);
+        ordered.push(t);
+      }
+    }
+    return ordered;
+  }, [dashboard]);
+
+  const requestedTab = searchParams.get("tab");
+  const activeTab =
+    tabs.length > 0
+      ? requestedTab && tabs.includes(requestedTab)
+        ? requestedTab
+        : tabs[0]
+      : null;
+
+  const handleTabChange = useCallback(
+    (value: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set("tab", value);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  // Panels visible under the current tab. Untagged panels appear on every
+  // tab; tagged panels only on their own tab. When no tabs are defined the
+  // dashboard shows every panel as before.
+  const visiblePanels = useMemo(() => {
+    if (!dashboard) return [];
+    if (!activeTab) return dashboard.panels;
+    return dashboard.panels.filter((p) => !p.tab || p.tab === activeTab);
+  }, [dashboard, activeTab]);
+
   const handleDelete = useCallback(async () => {
     if (!dashboardId) return;
     await fetchWithAuth(`/api/sql-dashboards/${dashboardId}`, {
@@ -652,6 +700,22 @@ export default function SqlDashboardPage() {
         </button>
       )}
 
+      {/* Tabs */}
+      {tabs.length > 0 && activeTab && (
+        <Tabs value={activeTab} onValueChange={handleTabChange}>
+          <TabsList
+            className="grid w-full"
+            style={{ gridTemplateColumns: `repeat(${tabs.length}, 1fr)` }}
+          >
+            {tabs.map((t) => (
+              <TabsTrigger key={t} value={t}>
+                {t}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      )}
+
       {/* Filters */}
       {dashboard.filters && dashboard.filters.length > 0 && (
         <DashboardFilterBar
@@ -685,11 +749,11 @@ export default function SqlDashboardPage() {
           onDragEnd={handleDragEnd}
         >
           <SortableContext
-            items={dashboard.panels.map((p) => p.id)}
+            items={visiblePanels.map((p) => p.id)}
             strategy={rectSortingStrategy}
           >
             <div className="grid auto-rows-auto grid-cols-1 items-stretch gap-4 md:grid-cols-2">
-              {dashboard.panels.map((panel) => {
+              {visiblePanels.map((panel) => {
                 const resolved = panel.config?.description
                   ? {
                       ...panel,
@@ -703,10 +767,13 @@ export default function SqlDashboardPage() {
                     }
                   : panel;
                 const remoteEditor = remoteEditingPanels.get(panel.id);
+                const isSection = panel.chartType === "section";
                 return (
                   <div
                     key={panel.id}
-                    className="relative h-full"
+                    className={
+                      isSection ? "relative md:col-span-2" : "relative h-full"
+                    }
                     style={
                       remoteEditor
                         ? {

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/types.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/types.ts
@@ -7,7 +7,9 @@ export type ChartType =
   | "metric"
   | "table"
   | "pie"
-  | "section";
+  | "section"
+  | "heatmap"
+  | "callout";
 
 export type FilterType =
   | "date"
@@ -36,7 +38,8 @@ export type ColumnFormat =
   | "percent"
   | "date"
   | "link"
-  | "text";
+  | "text"
+  | "delta";
 
 export interface TableColumnConfig {
   key: string;
@@ -76,6 +79,14 @@ export interface SqlPanel {
   chartType: ChartType;
   width: 1 | 2;
   config?: SqlPanelConfig;
+  /**
+   * Optional tab assignment. When any panel in a dashboard declares a `tab`,
+   * the dashboard renders a tab strip and shows only panels matching the
+   * selected tab. Tabs are derived from the distinct `tab` values across
+   * panels in declaration order. Section panels can also carry a tab to
+   * group their header under the right tab.
+   */
+  tab?: string;
 }
 
 export interface SqlDashboardConfig {

--- a/templates/analytics/app/root.tsx
+++ b/templates/analytics/app/root.tsx
@@ -10,6 +10,7 @@ import {
   appPath,
   useDbSync,
 } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 import { ThemeProvider } from "next-themes";
 import { AuthProvider } from "@/components/auth/AuthProvider";
 import { CommandPalette } from "./components/layout/CommandPalette";
@@ -28,6 +29,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript("dark", true);
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -37,6 +40,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#F59E0B" />
         <meta name="mobile-web-app-capable" content="yes" />

--- a/templates/analytics/public/_marketing-funnel-config.json
+++ b/templates/analytics/public/_marketing-funnel-config.json
@@ -1,6 +1,6 @@
 {
   "name": "Marketing Funnel Health",
-  "description": "Consolidated Marketing funnel view: traffic, contacts, QLs, SAL conversion. Migrated from fusion-analytics.",
+  "description": "Consolidated Marketing funnel view: traffic, contacts, QLs, SAL conversion. Migrated from fusion-analytics. Now with tabs, heatmap, and spike alerts.",
   "filters": [
     {
       "id": "date",
@@ -20,15 +20,6 @@
   },
   "panels": [
     {
-      "id": "section-traffic",
-      "title": "1. Traffic & Demand",
-      "chartType": "section",
-      "width": 2,
-      "config": {
-        "description": "Top-of-funnel signals: page performance, blog signups, AI-referrer trend."
-      }
-    },
-    {
       "id": "page-performance",
       "title": "Page Performance — New Visitors → Signup → MQL/SAL",
       "source": "bigquery",
@@ -38,24 +29,48 @@
       "config": {
         "limit": 100,
         "columns": [
-          { "key": "base_url", "label": "Page" },
+          {
+            "key": "base_url",
+            "label": "Page"
+          },
           {
             "key": "new_visitors",
             "label": "New Visitors",
             "format": "number"
           },
-          { "key": "signups", "label": "Signups", "format": "number" },
-          { "key": "pct_signups", "label": "Sign-up %", "format": "number" },
+          {
+            "key": "signups",
+            "label": "Signups",
+            "format": "number"
+          },
+          {
+            "key": "pct_signups",
+            "label": "Sign-up %",
+            "format": "number"
+          },
           {
             "key": "mkt_contacts",
             "label": "Mkt Contacts",
             "format": "number"
           },
-          { "key": "icp_signups", "label": "ICP Signups", "format": "number" },
-          { "key": "mql", "label": "MQL", "format": "number" },
-          { "key": "sal", "label": "SAL", "format": "number" }
+          {
+            "key": "icp_signups",
+            "label": "ICP Signups",
+            "format": "number"
+          },
+          {
+            "key": "mql",
+            "label": "MQL",
+            "format": "number"
+          },
+          {
+            "key": "sal",
+            "label": "SAL",
+            "format": "number"
+          }
         ]
-      }
+      },
+      "tab": "Traffic"
     },
     {
       "id": "blog-signups",
@@ -67,13 +82,32 @@
       "config": {
         "limit": 50,
         "columns": [
-          { "key": "blog_post", "label": "Blog Post" },
-          { "key": "pub_date", "label": "Published" },
-          { "key": "traffic", "label": "Traffic", "format": "number" },
-          { "key": "signups", "label": "Signups", "format": "number" },
-          { "key": "signup_pct", "label": "Sign-up %", "format": "number" }
+          {
+            "key": "blog_post",
+            "label": "Blog Post"
+          },
+          {
+            "key": "pub_date",
+            "label": "Published"
+          },
+          {
+            "key": "traffic",
+            "label": "Traffic",
+            "format": "number"
+          },
+          {
+            "key": "signups",
+            "label": "Signups",
+            "format": "number"
+          },
+          {
+            "key": "signup_pct",
+            "label": "Sign-up %",
+            "format": "number"
+          }
         ]
-      }
+      },
+      "tab": "Traffic"
     },
     {
       "id": "ai-referrer-signups",
@@ -88,16 +122,8 @@
           "seriesKey": "ai_source",
           "valueKey": "signups"
         }
-      }
-    },
-    {
-      "id": "section-contacts",
-      "title": "2. Contacts & Enrichment",
-      "chartType": "section",
-      "width": 2,
-      "config": {
-        "description": "Inbound contacts, persona/job-function breakdown, and the enrichment funnel through Clay."
-      }
+      },
+      "tab": "Traffic"
     },
     {
       "id": "contacts-by-persona",
@@ -113,7 +139,8 @@
           "valueKey": "contacts"
         },
         "stacked": true
-      }
+      },
+      "tab": "Contacts"
     },
     {
       "id": "fit-score-distribution",
@@ -121,7 +148,8 @@
       "source": "bigquery",
       "chartType": "pie",
       "width": 1,
-      "sql": "SELECT\n  CASE\n    WHEN c.company_fit_score IS NULL OR c.company_fit_score < 4 THEN 'Ineligible (<4)'\n    WHEN c.company_fit_score <= 5 THEN 'Eligible (4-5)'\n    WHEN c.company_fit_score <= 7 THEN 'Eligible (6-7)'\n    ELSE 'Full Weight (8+)'\n  END AS fit_bucket,\n  COUNT(DISTINCT c.contact_id) AS contacts\nFROM {{HS_CONTACTS}} c\nLEFT JOIN (\n  SELECT CAST(company_id AS INT64) AS company_id\n  FROM {{ENT_COMPANIES}}\n  WHERE account_profile = 'Enterprise Active Customer'\n) aec ON CAST(c.company_id AS INT64) = aec.company_id\nWHERE c.sign_up_time_stamp >= DATE('{{dateStart}}')\n  AND c.sign_up_time_stamp <= DATE('{{dateEnd}}')\n  AND c.sign_up_time_stamp <= CURRENT_DATE()\n  AND aec.company_id IS NULL\nGROUP BY 1\nORDER BY CASE fit_bucket\n  WHEN 'Full Weight (8+)' THEN 1\n  WHEN 'Eligible (6-7)' THEN 2\n  WHEN 'Eligible (4-5)' THEN 3\n  ELSE 4\nEND"
+      "sql": "SELECT\n  CASE\n    WHEN c.company_fit_score IS NULL OR c.company_fit_score < 4 THEN 'Ineligible (<4)'\n    WHEN c.company_fit_score <= 5 THEN 'Eligible (4-5)'\n    WHEN c.company_fit_score <= 7 THEN 'Eligible (6-7)'\n    ELSE 'Full Weight (8+)'\n  END AS fit_bucket,\n  COUNT(DISTINCT c.contact_id) AS contacts\nFROM {{HS_CONTACTS}} c\nLEFT JOIN (\n  SELECT CAST(company_id AS INT64) AS company_id\n  FROM {{ENT_COMPANIES}}\n  WHERE account_profile = 'Enterprise Active Customer'\n) aec ON CAST(c.company_id AS INT64) = aec.company_id\nWHERE c.sign_up_time_stamp >= DATE('{{dateStart}}')\n  AND c.sign_up_time_stamp <= DATE('{{dateEnd}}')\n  AND c.sign_up_time_stamp <= CURRENT_DATE()\n  AND aec.company_id IS NULL\nGROUP BY 1\nORDER BY CASE fit_bucket\n  WHEN 'Full Weight (8+)' THEN 1\n  WHEN 'Eligible (6-7)' THEN 2\n  WHEN 'Eligible (4-5)' THEN 3\n  ELSE 4\nEND",
+      "tab": "Contacts"
     },
     {
       "id": "enrichment-funnel",
@@ -132,8 +160,15 @@
       "sql": "WITH contact_job_functions AS (\n  SELECT\n    CAST(hs_object_id AS INT64) AS contact_id,\n    CASE\n      WHEN STARTS_WITH(TRIM(COALESCE(jobfunctions, '')), '[') THEN COALESCE(NULLIF(INITCAP(TRIM(REGEXP_EXTRACT(jobfunctions, r'\"([^\"]+)\"'))), ''), 'Unknown')\n      WHEN STRPOS(COALESCE(jobfunctions, ''), ';') > 0 THEN INITCAP(TRIM(SPLIT(jobfunctions, ';')[SAFE_OFFSET(0)]))\n      WHEN TRIM(COALESCE(jobfunctions, '')) NOT IN ('', 'null', '[]') THEN INITCAP(TRIM(jobfunctions))\n      ELSE 'Unknown'\n    END AS job_function\n  FROM {{HS_RAW}}\n),\nactive_enterprise_companies AS (\n  SELECT CAST(company_id AS INT64) AS company_id\n  FROM {{ENT_COMPANIES}}\n  WHERE account_profile = 'Enterprise Active Customer'\n),\ncontacts_base AS (\n  SELECT\n    c.contact_id,\n    CASE\n      WHEN LOWER(COALESCE(cjf.job_function, 'Unknown')) = 'developer' THEN 'Developer'\n      WHEN LOWER(COALESCE(cjf.job_function, 'Unknown')) = 'designer' THEN 'Designer'\n      ELSE 'Other'\n    END AS funnel_segment,\n    COALESCE(r.personal_email_, FALSE) AS is_personal_email,\n    (r.city_clay IS NOT NULL OR r.company_domain_clay IS NOT NULL OR r.phone_number_clay IS NOT NULL OR r.work_email_clay IS NOT NULL) AS sent_to_clay,\n    (r.work_email_clay IS NOT NULL AND TRIM(r.work_email_clay) NOT IN ('', 'null', 'NULL')) AS is_enriched\n  FROM {{HS_CONTACTS}} c\n  LEFT JOIN contact_job_functions cjf ON c.contact_id = cjf.contact_id\n  LEFT JOIN {{HS_RAW}} r ON CAST(r.hs_object_id AS INT64) = c.contact_id\n  LEFT JOIN active_enterprise_companies aec ON CAST(c.company_id AS INT64) = aec.company_id\n  WHERE c.sign_up_time_stamp >= DATE('{{dateStart}}')\n    AND c.sign_up_time_stamp <= DATE('{{dateEnd}}')\n    AND c.sign_up_time_stamp <= CURRENT_DATE()\n    AND aec.company_id IS NULL\n)\nSELECT\n  funnel_segment,\n  COUNT(DISTINCT contact_id) AS total,\n  COUNT(DISTINCT CASE WHEN is_personal_email THEN contact_id END) AS personal_email,\n  COUNT(DISTINCT CASE WHEN sent_to_clay THEN contact_id END) AS sent_to_clay,\n  COUNT(DISTINCT CASE WHEN is_enriched THEN contact_id END) AS enriched\nFROM contacts_base\nGROUP BY 1\nORDER BY CASE funnel_segment WHEN 'Developer' THEN 1 WHEN 'Designer' THEN 2 ELSE 3 END",
       "config": {
         "columns": [
-          { "key": "funnel_segment", "label": "Segment" },
-          { "key": "total", "label": "Total", "format": "number" },
+          {
+            "key": "funnel_segment",
+            "label": "Segment"
+          },
+          {
+            "key": "total",
+            "label": "Total",
+            "format": "number"
+          },
           {
             "key": "personal_email",
             "label": "Personal Email",
@@ -144,9 +179,14 @@
             "label": "Sent to Clay",
             "format": "number"
           },
-          { "key": "enriched", "label": "Enriched", "format": "number" }
+          {
+            "key": "enriched",
+            "label": "Enriched",
+            "format": "number"
+          }
         ]
-      }
+      },
+      "tab": "Contacts"
     },
     {
       "id": "contacts-needing-review",
@@ -158,25 +198,53 @@
       "config": {
         "limit": 200,
         "columns": [
-          { "key": "contact_name", "label": "Name" },
-          { "key": "email", "label": "Email" },
-          { "key": "company", "label": "Company" },
-          { "key": "persona", "label": "Persona" },
-          { "key": "fit", "label": "Fit", "format": "number" },
-          { "key": "ql_score", "label": "QL Score", "format": "number" },
-          { "key": "lead_source", "label": "Source" },
-          { "key": "created", "label": "Created", "format": "date" }
+          {
+            "key": "contact_name",
+            "label": "Name"
+          },
+          {
+            "key": "email",
+            "label": "Email"
+          },
+          {
+            "key": "company",
+            "label": "Company"
+          },
+          {
+            "key": "persona",
+            "label": "Persona"
+          },
+          {
+            "key": "fit",
+            "label": "Fit",
+            "format": "number"
+          },
+          {
+            "key": "ql_score",
+            "label": "QL Score",
+            "format": "number"
+          },
+          {
+            "key": "lead_source",
+            "label": "Source"
+          },
+          {
+            "key": "created",
+            "label": "Created",
+            "format": "date"
+          }
         ]
-      }
+      },
+      "tab": "Contacts"
     },
     {
-      "id": "section-qls",
-      "title": "3. Marketing-Qualified Leads (QLs)",
-      "chartType": "section",
+      "id": "ql-spike-callout",
+      "title": "QL Spike Detection",
+      "source": "bigquery",
+      "chartType": "callout",
       "width": 2,
-      "config": {
-        "description": "Weekly QL volume by motion/persona/source, plus a contact-level drill-down."
-      }
+      "tab": "QLs",
+      "sql": "WITH daily AS (\n  SELECT\n    date AS d,\n    SUM(IFNULL(num_qls, 0)) AS qls\n  FROM {{REVENUE_FUNNEL}}\n  WHERE date >= DATE('{{dateStart}}')\n    AND date <= DATE('{{dateEnd}}')\n  GROUP BY 1\n),\nstats AS (\n  SELECT AVG(qls) AS avg_qls FROM daily\n)\nSELECT\n  CONCAT(\n    'Spike on ', CAST(daily.d AS STRING), ': ',\n    CAST(daily.qls AS STRING), ' QLs (',\n    CAST(ROUND(SAFE_DIVIDE(daily.qls, stats.avg_qls), 1) AS STRING),\n    'x daily average) — likely bulk import.'\n  ) AS message,\n  'warning' AS severity\nFROM daily, stats\nWHERE daily.qls >= 20\n  AND daily.qls >= 3 * stats.avg_qls\nORDER BY daily.d DESC"
     },
     {
       "id": "qls-by-motion",
@@ -192,7 +260,8 @@
           "valueKey": "qls"
         },
         "stacked": true
-      }
+      },
+      "tab": "QLs"
     },
     {
       "id": "qls-by-persona",
@@ -208,7 +277,8 @@
           "valueKey": "qls"
         },
         "stacked": true
-      }
+      },
+      "tab": "QLs"
     },
     {
       "id": "qls-by-source",
@@ -224,7 +294,8 @@
           "valueKey": "qls"
         },
         "stacked": true
-      }
+      },
+      "tab": "QLs"
     },
     {
       "id": "ql-drilldown",
@@ -236,26 +307,100 @@
       "config": {
         "limit": 500,
         "columns": [
-          { "key": "full_name", "label": "Name" },
-          { "key": "email", "label": "Email" },
-          { "key": "company", "label": "Company" },
-          { "key": "persona", "label": "Persona" },
-          { "key": "lead_source", "label": "Source" },
-          { "key": "seniority", "label": "Seniority" },
-          { "key": "job_title", "label": "Job Title" },
-          { "key": "ql_score", "label": "QL", "format": "number" },
-          { "key": "fit", "label": "Fit", "format": "number" },
-          { "key": "ql_date", "label": "QL Date", "format": "date" }
+          {
+            "key": "full_name",
+            "label": "Name"
+          },
+          {
+            "key": "email",
+            "label": "Email"
+          },
+          {
+            "key": "company",
+            "label": "Company"
+          },
+          {
+            "key": "persona",
+            "label": "Persona"
+          },
+          {
+            "key": "lead_source",
+            "label": "Source"
+          },
+          {
+            "key": "seniority",
+            "label": "Seniority"
+          },
+          {
+            "key": "job_title",
+            "label": "Job Title"
+          },
+          {
+            "key": "ql_score",
+            "label": "QL",
+            "format": "number"
+          },
+          {
+            "key": "fit",
+            "label": "Fit",
+            "format": "number"
+          },
+          {
+            "key": "ql_date",
+            "label": "QL Date",
+            "format": "date"
+          }
         ]
-      }
+      },
+      "tab": "QLs"
     },
     {
-      "id": "section-sals",
-      "title": "4. SAL Conversion",
-      "chartType": "section",
+      "id": "nurture-candidates",
+      "title": "Nurture Candidates (Fit 4+, QL'd in 14d, QL Score <7)",
+      "source": "bigquery",
+      "chartType": "table",
       "width": 2,
+      "tab": "QLs",
+      "sql": "WITH contact_job_functions AS (\n  SELECT\n    CAST(hs_object_id AS INT64) AS contact_id,\n    CASE\n      WHEN STARTS_WITH(TRIM(COALESCE(jobfunctions, '')), '[') THEN COALESCE(NULLIF(INITCAP(TRIM(REGEXP_EXTRACT(jobfunctions, r'\"([^\"]+)\"'))), ''), 'Unknown')\n      WHEN STRPOS(COALESCE(jobfunctions, ''), ';') > 0 THEN INITCAP(TRIM(SPLIT(jobfunctions, ';')[SAFE_OFFSET(0)]))\n      WHEN TRIM(COALESCE(jobfunctions, '')) NOT IN ('', 'null', '[]') THEN INITCAP(TRIM(jobfunctions))\n      ELSE 'Unknown'\n    END AS job_function\n  FROM {{HS_RAW}}\n)\nSELECT\n  TRIM(CONCAT(COALESCE(r.firstname, ''), ' ', COALESCE(r.lastname, ''))) AS contact_name,\n  c.email,\n  COALESCE(r.company, '') AS company,\n  COALESCE(cjf.job_function, 'Unknown') AS persona,\n  c.company_fit_score AS fit,\n  CAST(SAFE_CAST(r.new_2026_ql_score AS FLOAT64) AS FLOAT64) AS ql_score,\n  DATE(c.date_entered_mql) AS ql_date,\n  COALESCE(r.lifecycle_stage_name, '') AS stage\nFROM {{HS_CONTACTS}} c\nLEFT JOIN contact_job_functions cjf ON c.contact_id = cjf.contact_id\nLEFT JOIN {{HS_RAW}} r ON CAST(r.hs_object_id AS INT64) = c.contact_id\nWHERE c.company_fit_score >= 4\n  AND SAFE_CAST(r.new_2026_ql_score AS FLOAT64) IS NOT NULL\n  AND SAFE_CAST(r.new_2026_ql_score AS FLOAT64) < 7\n  AND cjf.job_function IS NOT NULL AND cjf.job_function != 'Unknown'\n  AND c.date_entered_mql IS NOT NULL\n  AND DATE(c.date_entered_mql) >= DATE_SUB(CURRENT_DATE(), INTERVAL 14 DAY)\n  AND c.date_entered_mql <= CURRENT_TIMESTAMP()\nORDER BY c.company_fit_score DESC, SAFE_CAST(r.new_2026_ql_score AS FLOAT64) DESC\nLIMIT 200",
       "config": {
-        "description": "QL→SAL conversion, owner throughput, aging, and rejection reasons."
+        "limit": 200,
+        "columns": [
+          {
+            "key": "contact_name",
+            "label": "Name"
+          },
+          {
+            "key": "email",
+            "label": "Email"
+          },
+          {
+            "key": "company",
+            "label": "Company"
+          },
+          {
+            "key": "persona",
+            "label": "Persona"
+          },
+          {
+            "key": "fit",
+            "label": "Fit",
+            "format": "number"
+          },
+          {
+            "key": "ql_score",
+            "label": "QL Score",
+            "format": "number"
+          },
+          {
+            "key": "ql_date",
+            "label": "QL Date",
+            "format": "date"
+          },
+          {
+            "key": "stage",
+            "label": "Stage"
+          }
+        ]
       }
     },
     {
@@ -272,7 +417,8 @@
           "valueKey": "sals"
         },
         "stacked": true
-      }
+      },
+      "tab": "SALs"
     },
     {
       "id": "sals-by-persona",
@@ -288,7 +434,8 @@
           "valueKey": "sals"
         },
         "stacked": true
-      }
+      },
+      "tab": "SALs"
     },
     {
       "id": "ql-to-sal-conversion",
@@ -304,6 +451,22 @@
           "valueKey": "conversion_pct"
         },
         "yFormatter": "percent"
+      },
+      "tab": "SALs"
+    },
+    {
+      "id": "ql-to-sal-heatmap",
+      "title": "QL → SAL Conversion Heatmap by Persona (last 8 weeks)",
+      "source": "bigquery",
+      "chartType": "heatmap",
+      "width": 2,
+      "tab": "SALs",
+      "sql": "WITH contact_job_functions AS (\n  SELECT\n    CAST(hs_object_id AS INT64) AS contact_id,\n    CASE\n      WHEN STARTS_WITH(TRIM(COALESCE(jobfunctions, '')), '[') THEN COALESCE(NULLIF(INITCAP(TRIM(REGEXP_EXTRACT(jobfunctions, r'\"([^\"]+)\"'))), ''), 'Unknown')\n      WHEN STRPOS(COALESCE(jobfunctions, ''), ';') > 0 THEN INITCAP(TRIM(SPLIT(jobfunctions, ';')[SAFE_OFFSET(0)]))\n      WHEN TRIM(COALESCE(jobfunctions, '')) NOT IN ('', 'null', '[]') THEN INITCAP(TRIM(jobfunctions))\n      ELSE 'Unknown'\n    END AS job_function\n  FROM {{HS_RAW}}\n)\nSELECT\n  FORMAT_DATE('%Y-%m-%d', DATE_TRUNC(DATE(c.date_entered_mql), WEEK(MONDAY))) AS week,\n  COALESCE(cjf.job_function, 'Unknown') AS persona,\n  ROUND(SAFE_DIVIDE(\n    COUNT(DISTINCT CASE WHEN c.date_entered_sal IS NOT NULL THEN c.contact_id END),\n    COUNT(DISTINCT c.contact_id)\n  ) * 100, 1) AS conversion_pct\nFROM {{HS_CONTACTS}} c\nLEFT JOIN contact_job_functions cjf ON c.contact_id = cjf.contact_id\nWHERE c.date_entered_mql IS NOT NULL\n  AND DATE(c.date_entered_mql) >= DATE_SUB(CURRENT_DATE(), INTERVAL 8 WEEK)\n  AND DATE(c.date_entered_mql) < CURRENT_DATE()\n  AND c.date_entered_mql <= CURRENT_TIMESTAMP()\nGROUP BY 1, 2\nHAVING COUNT(DISTINCT c.contact_id) >= 3\nORDER BY 1, 2",
+      "config": {
+        "xKey": "week",
+        "yKey": "conversion_pct",
+        "color": "persona",
+        "yFormatter": "percent"
       }
     },
     {
@@ -316,14 +479,38 @@
       "config": {
         "limit": 50,
         "columns": [
-          { "key": "owner_name", "label": "Owner" },
-          { "key": "d_0_1", "label": "0-1d", "format": "number" },
-          { "key": "d_2_3", "label": "2-3d", "format": "number" },
-          { "key": "d_4_7", "label": "4-7d", "format": "number" },
-          { "key": "d_7_plus", "label": "7+d", "format": "number" },
-          { "key": "pending", "label": "Pending", "format": "number" }
+          {
+            "key": "owner_name",
+            "label": "Owner"
+          },
+          {
+            "key": "d_0_1",
+            "label": "0-1d",
+            "format": "number"
+          },
+          {
+            "key": "d_2_3",
+            "label": "2-3d",
+            "format": "number"
+          },
+          {
+            "key": "d_4_7",
+            "label": "4-7d",
+            "format": "number"
+          },
+          {
+            "key": "d_7_plus",
+            "label": "7+d",
+            "format": "number"
+          },
+          {
+            "key": "pending",
+            "label": "Pending",
+            "format": "number"
+          }
         ]
-      }
+      },
+      "tab": "SALs"
     },
     {
       "id": "owner-throughput",
@@ -335,32 +522,66 @@
       "config": {
         "limit": 50,
         "columns": [
-          { "key": "owner_name", "label": "Owner" },
-          { "key": "assigned", "label": "Assigned", "format": "number" },
-          { "key": "accepted", "label": "Accepted", "format": "number" },
+          {
+            "key": "owner_name",
+            "label": "Owner"
+          },
+          {
+            "key": "assigned",
+            "label": "Assigned",
+            "format": "number"
+          },
+          {
+            "key": "accepted",
+            "label": "Accepted",
+            "format": "number"
+          },
           {
             "key": "likely_rejected",
             "label": "Likely Rejected",
             "format": "number"
           },
-          { "key": "acceptance_rate", "label": "Conv %", "format": "number" }
+          {
+            "key": "acceptance_rate",
+            "label": "Conv %",
+            "format": "number"
+          }
         ]
-      }
+      },
+      "tab": "SALs"
     },
     {
       "id": "rejection-reasons",
-      "title": "QL Rejection Reasons (selected range)",
+      "title": "QL Rejection Reasons (this period vs prior period)",
       "source": "bigquery",
       "chartType": "table",
       "width": 2,
-      "sql": "SELECT\n  COALESCE(NULLIF(TRIM(r.hs_lead_status), ''), 'Unknown') AS reason,\n  COUNT(DISTINCT c.contact_id) AS rejected\nFROM {{HS_CONTACTS}} c\nLEFT JOIN {{HS_RAW}} r ON CAST(r.hs_object_id AS INT64) = c.contact_id\nWHERE c.date_entered_mql IS NOT NULL\n  AND DATE(c.date_entered_mql) >= DATE('{{dateStart}}')\n  AND DATE(c.date_entered_mql) <= DATE('{{dateEnd}}')\n  AND c.date_entered_mql <= CURRENT_TIMESTAMP()\n  AND c.date_entered_sal IS NULL\n  AND c.lifecycle_stage_name != 'MQL'\nGROUP BY 1\nORDER BY rejected DESC\nLIMIT 30",
+      "sql": "WITH this_period AS (\n  SELECT\n    COALESCE(NULLIF(TRIM(r.hs_lead_status), ''), 'Unknown') AS reason,\n    COUNT(DISTINCT c.contact_id) AS cnt\n  FROM {{HS_CONTACTS}} c\n  LEFT JOIN {{HS_RAW}} r ON CAST(r.hs_object_id AS INT64) = c.contact_id\n  WHERE c.date_entered_mql IS NOT NULL\n    AND DATE(c.date_entered_mql) >= DATE('{{dateStart}}')\n    AND DATE(c.date_entered_mql) <= DATE('{{dateEnd}}')\n    AND c.date_entered_mql <= CURRENT_TIMESTAMP()\n    AND c.date_entered_sal IS NULL\n    AND c.lifecycle_stage_name != 'MQL'\n  GROUP BY 1\n),\nprev_period AS (\n  SELECT\n    COALESCE(NULLIF(TRIM(r.hs_lead_status), ''), 'Unknown') AS reason,\n    COUNT(DISTINCT c.contact_id) AS cnt\n  FROM {{HS_CONTACTS}} c\n  LEFT JOIN {{HS_RAW}} r ON CAST(r.hs_object_id AS INT64) = c.contact_id\n  WHERE c.date_entered_mql IS NOT NULL\n    AND DATE(c.date_entered_mql) >= DATE_SUB(DATE('{{dateStart}}'), INTERVAL DATE_DIFF(DATE('{{dateEnd}}'), DATE('{{dateStart}}'), DAY) + 1 DAY)\n    AND DATE(c.date_entered_mql) < DATE('{{dateStart}}')\n    AND c.date_entered_mql <= CURRENT_TIMESTAMP()\n    AND c.date_entered_sal IS NULL\n    AND c.lifecycle_stage_name != 'MQL'\n  GROUP BY 1\n)\nSELECT\n  COALESCE(t.reason, p.reason) AS reason,\n  COALESCE(t.cnt, 0) AS this_period,\n  COALESCE(p.cnt, 0) AS prev_period,\n  ROUND(SAFE_DIVIDE(\n    COALESCE(t.cnt, 0) - COALESCE(p.cnt, 0),\n    NULLIF(COALESCE(p.cnt, 0), 0)\n  ) * 100, 1) AS wow_delta\nFROM this_period t\nFULL OUTER JOIN prev_period p USING (reason)\nORDER BY this_period DESC, prev_period DESC\nLIMIT 30",
       "config": {
         "limit": 30,
         "columns": [
-          { "key": "reason", "label": "Reason" },
-          { "key": "rejected", "label": "Rejected", "format": "number" }
+          {
+            "key": "reason",
+            "label": "Reason"
+          },
+          {
+            "key": "this_period",
+            "label": "This Period",
+            "format": "number"
+          },
+          {
+            "key": "prev_period",
+            "label": "Prev Period",
+            "format": "number"
+          },
+          {
+            "key": "wow_delta",
+            "label": "Δ %",
+            "format": "delta"
+          }
         ]
-      }
+      },
+      "tab": "SALs"
     }
   ]
 }

--- a/templates/analytics/server/handlers/sql-dashboards.ts
+++ b/templates/analytics/server/handlers/sql-dashboards.ts
@@ -166,7 +166,8 @@ async function validatePanelSql(
   const vars = buildDryRunVars(config);
   for (let i = 0; i < panels.length; i++) {
     const p = panels[i] as Record<string, unknown>;
-    // Sections are layout-only — no SQL to dry-run.
+    // Sections are layout-only — no SQL to dry-run. heatmap, callout, and other
+    // query panels still validate normally below.
     if (p.chartType === "section") continue;
     const raw = typeof p.sql === "string" ? p.sql : "";
     if (!raw.trim()) continue;

--- a/templates/calendar/app/components/ThemeToggle.tsx
+++ b/templates/calendar/app/components/ThemeToggle.tsx
@@ -9,7 +9,8 @@ import {
 import { cn } from "@/lib/utils";
 
 export function ThemeToggle({ className }: { className?: string }) {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
 
   return (
     <Tooltip>
@@ -17,10 +18,10 @@ export function ThemeToggle({ className }: { className?: string }) {
         <Button
           variant="ghost"
           size="icon"
-          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+          onClick={() => setTheme(isDark ? "light" : "dark")}
           className={cn("text-muted-foreground", className)}
         >
-          {theme === "dark" ? (
+          {isDark ? (
             <IconSun className="h-4 w-4" />
           ) : (
             <IconMoon className="h-4 w-4" />

--- a/templates/calendar/app/entry.client.tsx
+++ b/templates/calendar/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/calendar/app/root.tsx
+++ b/templates/calendar/app/root.tsx
@@ -8,6 +8,7 @@ import {
 import { ThemeProvider } from "next-themes";
 import { useTheme } from "next-themes";
 import { useDbSync } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 import {
   ClientOnly,
   DefaultSpinner,
@@ -32,6 +33,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -41,6 +44,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#8B5CF6" />
@@ -83,13 +87,14 @@ function DbSyncSetup() {
 }
 
 function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <CommandMenu.Item
-      onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onSelect={() => setTheme(isDark ? "light" : "dark")}
       keywords={["theme", "dark", "light", "mode"]}
     >
-      {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
       Toggle theme
     </CommandMenu.Item>
   );

--- a/templates/calls/app/entry.client.tsx
+++ b/templates/calls/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/calls/app/root.tsx
+++ b/templates/calls/app/root.tsx
@@ -22,6 +22,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
 import { configureTracking } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
@@ -33,6 +34,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -42,6 +45,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#111111" />
         <meta name="mobile-web-app-capable" content="yes" />
@@ -94,13 +98,14 @@ function DbSyncSetup() {
 }
 
 function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <CommandMenu.Item
-      onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onSelect={() => setTheme(isDark ? "light" : "dark")}
       keywords={["theme", "dark", "light", "mode"]}
     >
-      {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
       Toggle theme
     </CommandMenu.Item>
   );

--- a/templates/clips/app/entry.client.tsx
+++ b/templates/clips/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/clips/app/root.tsx
+++ b/templates/clips/app/root.tsx
@@ -23,6 +23,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
 import { configureTracking } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
@@ -34,6 +35,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -43,6 +46,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#18181B" />
         <meta name="mobile-web-app-capable" content="yes" />
@@ -88,13 +92,14 @@ function DbSyncSetup() {
 }
 
 function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <CommandMenu.Item
-      onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onSelect={() => setTheme(isDark ? "light" : "dark")}
       keywords={["theme", "dark", "light", "mode"]}
     >
-      {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
       Toggle theme
     </CommandMenu.Item>
   );

--- a/templates/content/app/components/ThemeToggle.tsx
+++ b/templates/content/app/components/ThemeToggle.tsx
@@ -10,7 +10,8 @@ import {
 import { cn } from "@/lib/utils";
 
 export function ThemeToggle({ className }: { className?: string }) {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => setMounted(true), []);
@@ -21,17 +22,13 @@ export function ThemeToggle({ className }: { className?: string }) {
         <Button
           variant="ghost"
           size="icon"
-          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+          onClick={() => setTheme(isDark ? "light" : "dark")}
           className={cn(
             "text-sidebar-muted hover:text-sidebar-foreground",
             className,
           )}
         >
-          {mounted && theme === "dark" ? (
-            <IconSun size={14} />
-          ) : (
-            <IconMoon size={14} />
-          )}
+          {mounted && isDark ? <IconSun size={14} /> : <IconMoon size={14} />}
         </Button>
       </TooltipTrigger>
       <TooltipContent>Toggle theme</TooltipContent>

--- a/templates/content/app/entry.client.tsx
+++ b/templates/content/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/content/app/root.tsx
+++ b/templates/content/app/root.tsx
@@ -26,6 +26,7 @@ import { useNavigationState } from "./hooks/use-navigation-state";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
 import { configureTracking } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
@@ -37,6 +38,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript("dark", false);
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -46,6 +49,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#10B981" />
         <meta name="mobile-web-app-capable" content="yes" />
@@ -75,13 +79,14 @@ function AppSetup() {
 }
 
 function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <CommandMenu.Item
-      onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onSelect={() => setTheme(isDark ? "light" : "dark")}
       keywords={["theme", "dark", "light", "mode"]}
     >
-      {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
       Toggle theme
     </CommandMenu.Item>
   );

--- a/templates/design/app/entry.client.tsx
+++ b/templates/design/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/design/app/root.tsx
+++ b/templates/design/app/root.tsx
@@ -22,6 +22,7 @@ import { Layout as AppLayout } from "@/components/layout/Layout";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
 import { configureTracking } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
@@ -33,6 +34,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -42,6 +45,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#71717A" />
         <meta name="mobile-web-app-capable" content="yes" />
@@ -78,7 +82,8 @@ function DbSyncSetup() {
 
 function AppContent() {
   const [cmdkOpen, setCmdkOpen] = useState(false);
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
 
   return (
@@ -89,11 +94,11 @@ function AppContent() {
         </CommandMenu.Group>
         <CommandMenu.Group heading="Appearance">
           <CommandMenu.Item
-            onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+            onSelect={() => setTheme(isDark ? "light" : "dark")}
             keywords={["theme", "dark", "light", "mode"]}
           >
-            {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
-            Toggle {theme === "dark" ? "light" : "dark"} mode
+            {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
+            Toggle {isDark ? "light" : "dark"} mode
           </CommandMenu.Item>
         </CommandMenu.Group>
       </CommandMenu>

--- a/templates/dispatch/app/entry.client.tsx
+++ b/templates/dispatch/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/dispatch/app/root.tsx
+++ b/templates/dispatch/app/root.tsx
@@ -28,6 +28,7 @@ import type { LinksFunction } from "react-router";
 import { dispatchExtensions } from "./dispatch-extensions";
 import stylesheet from "./global.css?url";
 import { configureTracking } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
@@ -39,6 +40,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -48,6 +51,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#0f172a" />
         <meta name="mobile-web-app-capable" content="yes" />
@@ -140,13 +144,14 @@ function useThreadDeepLink() {
 }
 
 function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <CommandMenu.Item
-      onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onSelect={() => setTheme(isDark ? "light" : "dark")}
       keywords={["theme", "dark", "light", "mode"]}
     >
-      {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
       Toggle theme
     </CommandMenu.Item>
   );

--- a/templates/forms/app/components/ThemeToggle.tsx
+++ b/templates/forms/app/components/ThemeToggle.tsx
@@ -9,7 +9,8 @@ import {
 import { cn } from "@/lib/utils";
 
 export function ThemeToggle({ className }: { className?: string }) {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
 
   return (
     <Tooltip>
@@ -17,10 +18,10 @@ export function ThemeToggle({ className }: { className?: string }) {
         <Button
           variant="ghost"
           size="icon"
-          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+          onClick={() => setTheme(isDark ? "light" : "dark")}
           className={cn("text-muted-foreground", className)}
         >
-          {theme === "dark" ? (
+          {isDark ? (
             <IconSun className="h-4 w-4" />
           ) : (
             <IconMoon className="h-4 w-4" />

--- a/templates/forms/app/entry.client.tsx
+++ b/templates/forms/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/forms/app/root.tsx
+++ b/templates/forms/app/root.tsx
@@ -22,6 +22,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
 import { configureTracking } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
@@ -33,6 +34,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -42,6 +45,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#06B6D4" />
@@ -82,13 +86,14 @@ function NavigationStateSync() {
 }
 
 function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <CommandMenu.Item
-      onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onSelect={() => setTheme(isDark ? "light" : "dark")}
       keywords={["theme", "dark", "light", "mode"]}
     >
-      {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
       Toggle theme
     </CommandMenu.Item>
   );

--- a/templates/issues/app/components/ThemeToggle.tsx
+++ b/templates/issues/app/components/ThemeToggle.tsx
@@ -3,11 +3,12 @@ import { IconSun, IconMoon } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 
 export function ThemeToggle({ collapsed }: { collapsed?: boolean }) {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
 
   return (
     <button
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
       className={cn(
         "flex items-center gap-2.5 rounded-md px-2 py-1.5 text-[13px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground",
         collapsed && "justify-center px-0",

--- a/templates/issues/app/entry.client.tsx
+++ b/templates/issues/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/issues/app/root.tsx
+++ b/templates/issues/app/root.tsx
@@ -18,6 +18,7 @@ import {
   CommandMenu,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 import { IconSun, IconMoon } from "@tabler/icons-react";
 import { TAB_ID } from "@/lib/tab-id";
 import type { LinksFunction } from "react-router";
@@ -34,6 +35,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -43,6 +46,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <meta name="theme-color" content="#2563EB" />
         <meta name="mobile-web-app-capable" content="yes" />
@@ -132,13 +136,14 @@ function DbSyncSetup() {
 }
 
 function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <CommandMenu.Item
-      onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onSelect={() => setTheme(isDark ? "light" : "dark")}
       keywords={["theme", "dark", "light", "mode"]}
     >
-      {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
       Toggle theme
     </CommandMenu.Item>
   );

--- a/templates/macros/app/entry.client.tsx
+++ b/templates/macros/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/macros/app/root.tsx
+++ b/templates/macros/app/root.tsx
@@ -23,6 +23,7 @@ import { AppLayout } from "@/components/layout/AppLayout";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
 import { configureTracking } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
@@ -34,6 +35,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript("dark", true);
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -43,6 +46,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <meta name="theme-color" content="#0a0a0a" />
         <Meta />
@@ -82,13 +86,14 @@ function DbSyncSetup() {
 }
 
 function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <CommandMenu.Item
-      onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onSelect={() => setTheme(isDark ? "light" : "dark")}
       keywords={["theme", "dark", "light", "mode"]}
     >
-      {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
       Toggle theme
     </CommandMenu.Item>
   );

--- a/templates/mail/app/components/ThemeToggle.tsx
+++ b/templates/mail/app/components/ThemeToggle.tsx
@@ -10,7 +10,7 @@ import {
 import { cn } from "@/lib/utils";
 
 export function ThemeToggle({ className }: { className?: string }) {
-  const { theme, setTheme, resolvedTheme } = useTheme();
+  const { setTheme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => setMounted(true), []);

--- a/templates/mail/app/components/layout/CommandPalette.tsx
+++ b/templates/mail/app/components/layout/CommandPalette.tsx
@@ -79,7 +79,8 @@ export function CommandPalette({
   hasEmail,
 }: CommandPaletteProps) {
   const navigate = useNavigate();
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   const { data: settings } = useSettings();
   const updateSettings = useUpdateSettings();
   const imagePolicy = settings?.imagePolicy ?? "show";
@@ -222,15 +223,15 @@ export function CommandPalette({
 
       <CommandMenu.Group heading="Appearance">
         <CommandMenu.Item
-          onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+          onSelect={() => setTheme(isDark ? "light" : "dark")}
           keywords={["theme", "dark", "light", "mode"]}
         >
-          {theme === "dark" ? (
+          {isDark ? (
             <IconSun className="h-4 w-4" />
           ) : (
             <IconMoon className="h-4 w-4" />
           )}
-          Toggle {theme === "dark" ? "light" : "dark"} mode
+          Toggle {isDark ? "light" : "dark"} mode
         </CommandMenu.Item>
       </CommandMenu.Group>
     </CommandMenu>

--- a/templates/mail/app/entry.client.tsx
+++ b/templates/mail/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -11,6 +11,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { useDbSync } from "@agent-native/core";
 import { ClientOnly, DefaultSpinner, appPath } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 import { appApiPath } from "@/lib/api-path";
 import { TAB_ID } from "@/lib/tab-id";
 import type { LinksFunction } from "react-router";
@@ -27,6 +28,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -36,6 +39,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#3B82F6" />

--- a/templates/meeting-notes/app/entry.client.tsx
+++ b/templates/meeting-notes/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/meeting-notes/app/root.tsx
+++ b/templates/meeting-notes/app/root.tsx
@@ -15,6 +15,7 @@ import {
   appPath,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 import { IconSun, IconMoon } from "@tabler/icons-react";
 import { useTheme } from "next-themes";
 import { Toaster } from "sonner";
@@ -49,6 +50,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -58,6 +61,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <meta name="theme-color" content="#18181B" />
         <meta name="apple-mobile-web-app-title" content="Notes" />
         <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
@@ -97,13 +101,14 @@ function DbSyncSetup() {
 }
 
 function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <CommandMenu.Item
-      onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onSelect={() => setTheme(isDark ? "light" : "dark")}
       keywords={["theme", "dark", "light", "mode"]}
     >
-      {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
       Toggle theme
     </CommandMenu.Item>
   );

--- a/templates/recruiting/app/components/ThemeToggle.tsx
+++ b/templates/recruiting/app/components/ThemeToggle.tsx
@@ -2,14 +2,15 @@ import { useTheme } from "next-themes";
 import { IconSun, IconMoon } from "@tabler/icons-react";
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <button
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
       className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
       title="Toggle theme"
     >
-      {theme === "dark" ? (
+      {isDark ? (
         <IconSun className="h-4 w-4" />
       ) : (
         <IconMoon className="h-4 w-4" />

--- a/templates/recruiting/app/entry.client.tsx
+++ b/templates/recruiting/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/recruiting/app/root.tsx
+++ b/templates/recruiting/app/root.tsx
@@ -18,6 +18,7 @@ import {
   CommandMenu,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 import { IconSun, IconMoon } from "@tabler/icons-react";
 import { TAB_ID } from "@/lib/tab-id";
 import type { LinksFunction } from "react-router";
@@ -50,6 +51,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -59,6 +62,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#16A34A" />
@@ -136,13 +140,14 @@ function DbSyncSetup() {
 }
 
 function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <CommandMenu.Item
-      onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onSelect={() => setTheme(isDark ? "light" : "dark")}
       keywords={["theme", "dark", "light", "mode"]}
     >
-      {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
       Toggle theme
     </CommandMenu.Item>
   );

--- a/templates/scheduling/app/components/layout/ThemeToggle.tsx
+++ b/templates/scheduling/app/components/layout/ThemeToggle.tsx
@@ -3,8 +3,8 @@ import { Button } from "@/components/ui/button";
 import { IconSun, IconMoon } from "@tabler/icons-react";
 
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
-  const isDark = theme === "dark";
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <Button
       variant="ghost"

--- a/templates/scheduling/app/entry.client.tsx
+++ b/templates/scheduling/app/entry.client.tsx
@@ -4,11 +4,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 startTransition(() => {

--- a/templates/scheduling/app/root.tsx
+++ b/templates/scheduling/app/root.tsx
@@ -20,6 +20,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
 import { configureTracking } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
@@ -31,6 +32,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -40,6 +43,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <meta
           name="theme-color"
@@ -85,13 +89,14 @@ function DbSyncSetup() {
 }
 
 function ThemeToggleItem() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   return (
     <CommandMenu.Item
-      onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+      onSelect={() => setTheme(isDark ? "light" : "dark")}
       keywords={["theme", "dark", "light", "mode"]}
     >
-      {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
+      {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
       Toggle theme
     </CommandMenu.Item>
   );

--- a/templates/slides/app/components/ThemeToggle.tsx
+++ b/templates/slides/app/components/ThemeToggle.tsx
@@ -10,7 +10,7 @@ import {
 import { cn } from "@/lib/utils";
 
 export function ThemeToggle({ className }: { className?: string }) {
-  const { theme, setTheme, resolvedTheme } = useTheme();
+  const { setTheme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => setMounted(true), []);

--- a/templates/slides/app/entry.client.tsx
+++ b/templates/slides/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/slides/app/root.tsx
+++ b/templates/slides/app/root.tsx
@@ -30,6 +30,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
 import { configureTracking } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
@@ -89,6 +90,8 @@ function useExitSelectionOnOutsideClick() {
   }, []);
 }
 
+const THEME_INIT_SCRIPT = getThemeInitScript("dark", true);
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -98,6 +101,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#EC4899" />
@@ -125,7 +129,8 @@ function AppContent() {
   useNavigationState();
   const qc = useQueryClient();
   useDbSync({ queryClient: qc, queryKeys: ["action"] });
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   const [cmdkOpen, setCmdkOpen] = useState(false);
   useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
   const location = useLocation();
@@ -151,11 +156,11 @@ function AppContent() {
         </CommandMenu.Group>
         <CommandMenu.Group heading="Appearance">
           <CommandMenu.Item
-            onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+            onSelect={() => setTheme(isDark ? "light" : "dark")}
             keywords={["theme", "dark", "light", "mode"]}
           >
-            {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
-            Toggle {theme === "dark" ? "light" : "dark"} mode
+            {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
+            Toggle {isDark ? "light" : "dark"} mode
           </CommandMenu.Item>
         </CommandMenu.Group>
       </CommandMenu>

--- a/templates/starter/app/entry.client.tsx
+++ b/templates/starter/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/starter/app/root.tsx
+++ b/templates/starter/app/root.tsx
@@ -15,6 +15,7 @@ import {
   appPath,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 import { IconSun, IconMoon } from "@tabler/icons-react";
 import { useTheme } from "next-themes";
 import { Toaster } from "@/components/ui/sonner";
@@ -34,6 +35,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript();
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -43,6 +46,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#71717A" />
         <meta name="mobile-web-app-capable" content="yes" />
@@ -80,7 +84,8 @@ function DbSyncSetup() {
 
 function AppContent() {
   const [cmdkOpen, setCmdkOpen] = useState(false);
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
   return (
     <>
@@ -90,11 +95,11 @@ function AppContent() {
         </CommandMenu.Group>
         <CommandMenu.Group heading="Appearance">
           <CommandMenu.Item
-            onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+            onSelect={() => setTheme(isDark ? "light" : "dark")}
             keywords={["theme", "dark", "light", "mode"]}
           >
-            {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
-            Toggle {theme === "dark" ? "light" : "dark"} mode
+            {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
+            Toggle {isDark ? "light" : "dark"} mode
           </CommandMenu.Item>
         </CommandMenu.Group>
       </CommandMenu>

--- a/templates/starter/app/routes/_index.tsx
+++ b/templates/starter/app/routes/_index.tsx
@@ -42,7 +42,8 @@ export function HydrateFallback() {
 
 export default function IndexPage() {
   useSetPageTitle("Home");
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   const [startOpen, setStartOpen] = useState(false);
 
   function submit(text: string) {
@@ -142,7 +143,7 @@ export default function IndexPage() {
               </p>
             </a>
             <button
-              onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+              onClick={() => setTheme(isDark ? "light" : "dark")}
               className="rounded-lg border border-border/50 px-4 py-3 hover:bg-accent/50 text-left cursor-pointer"
             >
               <p className="text-[13px] font-medium text-foreground">Theme</p>

--- a/templates/videos/app/entry.client.tsx
+++ b/templates/videos/app/entry.client.tsx
@@ -3,11 +3,17 @@ import { HydratedRouter } from "react-router/dom";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 hydrateRoot(document, <HydratedRouter />);

--- a/templates/videos/app/root.tsx
+++ b/templates/videos/app/root.tsx
@@ -21,6 +21,7 @@ import { ThemeProvider, useTheme } from "next-themes";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
 import { configureTracking } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 configureTracking({
   getDefaultProps: (_name, properties) => ({
     ...properties,
@@ -32,6 +33,8 @@ export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
 
+const THEME_INIT_SCRIPT = getThemeInitScript("dark", true);
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -41,6 +44,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="manifest" href={appPath("/manifest.json")} />
         <meta name="theme-color" content="#EF4444" />
         <meta name="mobile-web-app-capable" content="yes" />
@@ -67,7 +71,8 @@ function AppContent() {
   useNavigationState();
   const qc = useQueryClient();
   useDbSync({ queryClient: qc, queryKeys: ["action"] });
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
   const [cmdkOpen, setCmdkOpen] = useState(false);
   useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
 
@@ -81,11 +86,11 @@ function AppContent() {
         </CommandMenu.Group>
         <CommandMenu.Group heading="Appearance">
           <CommandMenu.Item
-            onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+            onSelect={() => setTheme(isDark ? "light" : "dark")}
             keywords={["theme", "dark", "light", "mode"]}
           >
-            {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
-            Toggle {theme === "dark" ? "light" : "dark"} mode
+            {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
+            Toggle {isDark ? "light" : "dark"} mode
           </CommandMenu.Item>
         </CommandMenu.Group>
       </CommandMenu>

--- a/templates/voice/app/entry.client.tsx
+++ b/templates/voice/app/entry.client.tsx
@@ -4,11 +4,17 @@ import { hydrateRoot } from "react-dom/client";
 import { appBasePath } from "@agent-native/core/client";
 
 const basePath = appBasePath();
-if (basePath) {
-  const context = (
-    window as Window & { __reactRouterContext?: { basename?: string } }
-  ).__reactRouterContext;
-  if (context) context.basename = basePath;
+const pathname = window.location.pathname;
+const routerBasePath =
+  basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+    ? basePath
+    : "";
+
+const context = (
+  window as Window & { __reactRouterContext?: { basename?: string } }
+).__reactRouterContext;
+if (context) {
+  context.basename = routerBasePath;
 }
 
 startTransition(() => {

--- a/templates/voice/app/root.tsx
+++ b/templates/voice/app/root.tsx
@@ -10,6 +10,7 @@ import {
   appPath,
   useCommandMenuShortcut,
 } from "@agent-native/core/client";
+import { getThemeInitScript } from "@agent-native/core/client";
 import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { IconMoon, IconSun } from "@tabler/icons-react";
@@ -37,6 +38,8 @@ const toastOptions = {
   },
 };
 
+const THEME_INIT_SCRIPT = getThemeInitScript("dark", false);
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -46,6 +49,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
         />
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         <link rel="icon" type="image/svg+xml" href={appPath("/favicon.svg")} />
         <link rel="apple-touch-icon" href={appPath("/icon-180.svg")} />
         <Meta />
@@ -64,7 +68,8 @@ function AppShell() {
   useDbSync();
   const [cmdkOpen, setCmdkOpen] = useState(false);
   useCommandMenuShortcut(useCallback(() => setCmdkOpen(true), []));
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
 
   return (
     <TooltipProvider>
@@ -74,11 +79,11 @@ function AppShell() {
         </CommandMenu.Group>
         <CommandMenu.Group heading="Appearance">
           <CommandMenu.Item
-            onSelect={() => setTheme(theme === "dark" ? "light" : "dark")}
+            onSelect={() => setTheme(isDark ? "light" : "dark")}
             keywords={["theme", "dark", "light", "mode"]}
           >
-            {theme === "dark" ? <IconSun size={16} /> : <IconMoon size={16} />}
-            Toggle {theme === "dark" ? "light" : "dark"} mode
+            {isDark ? <IconSun size={16} /> : <IconMoon size={16} />}
+            Toggle {isDark ? "light" : "dark"} mode
           </CommandMenu.Item>
         </CommandMenu.Group>
       </CommandMenu>


### PR DESCRIPTION
## Summary
- Analytics: marketing-funnel dashboard v2 — tabs, heatmap, callout, WoW Δ, nurture; richer SQL panels; query-backed panel validation
- Templates: initialize template themes before hydration (avoids flash); only apply router basename under app base path
- Frame: show desktop app nudge in chat
- Core: add agent panel chat notice slot; avoid stale monorepo core prebundles
- CLI: tolerate changesets package tags when scaffolding (#506)

## Test plan
- [ ] Analytics: open marketing-funnel dashboard and verify tabs, heatmap, callout, WoW deltas, nurture sections render
- [ ] Templates: confirm no theme flash on initial load across mail/calendar/content/slides/etc.
- [ ] Frame: chat shows desktop app nudge
- [ ] Core agent panel: chat notice slot renders when set
- [ ] CI green