### PR TITLE
[codex] Consolidate analytics card actions and shadcn tooltips

### DIFF
--- a/.changeset/agent-chat-builder-signin.md
+++ b/.changeset/agent-chat-builder-signin.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve agent chat setup and auth recovery by routing missing provider setup to Builder.io and surfacing hosted sign-in for authentication failures.

--- a/.changeset/analytics-card-tooltips.md
+++ b/.changeset/analytics-card-tooltips.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Replace native title hints on interactive controls with shadcn tooltips.

--- a/.changeset/contextual-agent-engine-status.md
+++ b/.changeset/contextual-agent-engine-status.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Resolve agent engine status against the active request user so per-user provider secrets are detected correctly.

--- a/.changeset/dispatch-tailwind-sources.md
+++ b/.changeset/dispatch-tailwind-sources.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Expose Dispatch Tailwind source directives and import them in the template so packaged routes keep their styling.

--- a/.changeset/dispatch-tailwind-sources.md
+++ b/.changeset/dispatch-tailwind-sources.md
@@ -2,4 +2,4 @@
 "@agent-native/dispatch": patch
 ---
 
-Expose Dispatch Tailwind source directives and import them in the template so packaged routes keep their styling.
+Expose Dispatch Tailwind source directives, preserve the packaged index route redirect in the template shell, and show Dispatch navigation/chat controls at desktop sizes.

--- a/.changeset/org-switcher-join-by-domain.md
+++ b/.changeset/org-switcher-join-by-domain.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+OrgSwitcher popover now surfaces orgs the user can auto-join by email domain. When the active session's email matches an `organizations.allowed_domain`, the picker renders a "Join your team" section with a one-click Join button that wires through `useJoinByDomain`. Previously the popover only showed orgs the user already belonged to plus pending invites, so domain-eligible users (e.g. anyone on `@builder.io` opening a template) saw only "Personal" / "Create organization" with no path into the existing company org.

--- a/.changeset/org-switcher-join-by-domain.md
+++ b/.changeset/org-switcher-join-by-domain.md
@@ -1,5 +1,11 @@
 ---
-"@agent-native/core": patch
+"@agent-native/core": minor
 ---
 
-OrgSwitcher popover now surfaces orgs the user can auto-join by email domain. When the active session's email matches an `organizations.allowed_domain`, the picker renders a "Join your team" section with a one-click Join button that wires through `useJoinByDomain`. Previously the popover only showed orgs the user already belonged to plus pending invites, so domain-eligible users (e.g. anyone on `@builder.io` opening a template) saw only "Personal" / "Create organization" with no path into the existing company org.
+Domain-based org join across the framework — three connected changes so a fresh signup whose email matches an existing org's `allowed_domain` lands inside that org without manual steps:
+
+- **Auto-join on signup.** New `autoJoinDomainMatchingOrgs(email)` helper, called from the Better Auth `user.create.after` hook. Anyone who signs up with an email whose domain matches `organizations.allowed_domain` is added to that org as a `member` immediately, and `active-org-id` is set to it (only when the user doesn't already have an active org from a pending invite). Idempotent and missing-table-safe.
+- **OrgSwitcher popover** now renders a "Join your team" section listing every domain-match org with a one-click Join button, for users who signed up before the org existed (or whose auto-join failed). Wires through `useJoinByDomain`.
+- **InvitationBanner** also renders domain-match orgs as a top-of-app prompt, so existing-but-not-yet-joined users see a clear CTA without needing to open the picker.
+
+The backend (`organizations.allowed_domain`, `getMyOrgHandler.domainMatches`, `joinByDomainHandler`, `useJoinByDomain`) was already in place — these changes wire it into the signup flow and the prominent UIs.

--- a/.changeset/progressive-agent-recovery.md
+++ b/.changeset/progressive-agent-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep agent chat auto-recovery alive across long runs that keep making progress.

--- a/.changeset/quiet-presence-avatars.md
+++ b/.changeset/quiet-presence-avatars.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Dedupe collaborative presence avatars by email and show collaborator emails on hover.

--- a/.changeset/smooth-email-verification.md
+++ b/.changeset/smooth-email-verification.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Smooth signup email verification handoff back into the app.

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1961,15 +1961,19 @@ export function focusAgentChat() {
  */
 export function AgentToggleButton({ className }: { className?: string }) {
   return (
-    <button
-      onClick={() => window.dispatchEvent(new Event("agent-panel:toggle"))}
-      className={cn(
-        "ml-1.5 flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50",
-        className,
-      )}
-      title="Toggle agent"
-    >
-      <IconMessage size={16} />
-    </button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={() => window.dispatchEvent(new Event("agent-panel:toggle"))}
+          className={cn(
+            "ml-1.5 flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50",
+            className,
+          )}
+        >
+          <IconMessage size={16} />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>Toggle agent</TooltipContent>
+    </Tooltip>
   );
 }

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1512,15 +1512,6 @@ function BuilderSetupCard() {
   );
 }
 
-function isLocalAuthHost(): boolean {
-  if (typeof window === "undefined") return false;
-  return (
-    window.location.hostname === "localhost" ||
-    window.location.hostname === "127.0.0.1" ||
-    window.location.hostname === "::1"
-  );
-}
-
 // ─── Loop Limit Continue Card ───────────────────────────────────────────────
 
 type LoopLimitInfo = { maxIterations?: number };
@@ -2794,7 +2785,6 @@ const AssistantChatInner = forwardRef<
     !!visibleRunError &&
     !showRunningInUI &&
     visibleRunErrorKey !== dismissedRunErrorKey;
-  const showLocalAuthHint = isLocalAuthHost();
 
   return (
     <CheckpointContext.Provider value={checkpointCtx}>
@@ -2850,28 +2840,13 @@ const AssistantChatInner = forwardRef<
                         : "Authentication required"}
                     </p>
                     <p className="text-xs text-muted-foreground leading-relaxed">
-                      {authError.sessionExpired ? (
-                        "Your session may have expired. Log out and log back in to reconnect."
-                      ) : showLocalAuthHint ? (
-                        <>
-                          You need to log in to use the agent. If you&apos;re
-                          running locally, add{" "}
-                          <code className="bg-muted px-1 py-0.5 rounded text-[10px]">
-                            AUTH_MODE=local
-                          </code>{" "}
-                          to your{" "}
-                          <code className="bg-muted px-1 py-0.5 rounded text-[10px]">
-                            .env
-                          </code>{" "}
-                          file and restart the dev server.
-                        </>
-                      ) : (
-                        "You need to log in to use the agent."
-                      )}
+                      {authError.sessionExpired
+                        ? "Your session may have expired. Log out and log back in to reconnect."
+                        : "You need to log in to use the agent."}
                     </p>
                   </div>
                   <div className="flex gap-2">
-                    {!showLocalAuthHint && !authError.sessionExpired && (
+                    {!authError.sessionExpired && (
                       <button
                         onClick={() => {
                           const ret =

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -43,7 +43,6 @@ import { cn } from "./utils.js";
 import { AgentTaskCard } from "./AgentTaskCard.js";
 import { ConnectBuilderCard } from "./ConnectBuilderCard.js";
 import { useBuilderConnectFlow } from "./settings/useBuilderStatus.js";
-import { useOnboarding } from "./onboarding/use-onboarding.js";
 import {
   Tooltip,
   TooltipContent,
@@ -1418,19 +1417,6 @@ function ThinkingIndicator({ label = "Thinking" }: { label?: string } = {}) {
 // which opens the flow in an Electron BrowserWindow that shares the webview's
 // session. See packages/desktop-app/src/main/index.ts.
 
-/**
- * The OnboardingPanel sidebar checklist also surfaces the Builder Connect
- * step (id `llm`). When that's visible, dropping a duplicate "Connect Builder"
- * button into the empty-state chat card just confuses the user — they see two
- * primary CTAs that do the same thing. This hook returns true when we should
- * suppress the in-chat Connect CTA in favor of the sidebar checklist.
- */
-function useSuppressInChatBuilderCta(): boolean {
-  const onboarding = useOnboarding();
-  if (onboarding.loading || onboarding.dismissed) return false;
-  return onboarding.steps.some((step) => step.id === "llm" && !step.complete);
-}
-
 function BuilderConnectCta({
   variant = "primary",
 }: {
@@ -1500,111 +1486,38 @@ function BuilderConnectCta({
   );
 }
 
-// ─── API Key Setup Card ─────────────────────────────────────────────────────
+// ─── Builder Setup Card ─────────────────────────────────────────────────────
 
-function ApiKeySetupCard({ apiUrl }: { apiUrl: string }) {
-  const [apiKey, setApiKey] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const suppressBuilderCta = useSuppressInChatBuilderCta();
-  const handleSave = async () => {
-    if (!apiKey.trim()) return;
-    setSaving(true);
-    setError(null);
-    try {
-      const res = await fetch(`${apiUrl}/save-key`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ key: apiKey.trim(), provider: "anthropic" }),
-      });
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error || "Failed to save");
-      }
-      setSaved(true);
-      setTimeout(() => window.location.reload(), 1000);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to save");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  if (saved) {
-    return (
-      <div className="mx-4 my-6 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4">
-        <div className="flex items-center gap-2 text-sm text-emerald-400">
-          <IconCheck className="h-4 w-4" />
-          API key saved. Reloading...
-        </div>
-      </div>
-    );
-  }
-
+function BuilderSetupCard() {
   return (
     <div className="mx-4 my-6 rounded-lg border border-border bg-card p-5">
       <div className="flex items-center gap-3 mb-3">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted">
           <IconMessage className="h-4.5 w-4.5 text-muted-foreground" />
         </div>
-        <h3 className="text-sm font-medium text-foreground">Connect your AI</h3>
+        <div>
+          <h3 className="text-sm font-medium text-foreground">
+            Connect Builder.io
+          </h3>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            Use the hosted agent without adding a separate model provider key.
+          </p>
+        </div>
       </div>
 
       <div className="space-y-3">
-        {suppressBuilderCta ? null : (
-          <>
-            <BuilderConnectCta />
-
-            <div className="relative flex items-center">
-              <div className="flex-grow border-t border-border" />
-              <span className="mx-2 text-[10px] uppercase tracking-wider text-muted-foreground/60">
-                or
-              </span>
-              <div className="flex-grow border-t border-border" />
-            </div>
-          </>
-        )}
-
-        <input
-          type="password"
-          value={apiKey}
-          onChange={(e) => {
-            setApiKey(e.target.value);
-            setError(null);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") handleSave();
-          }}
-          placeholder="sk-ant-..."
-          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 outline-none focus:ring-1 focus:ring-ring"
-          autoComplete="off"
-        />
-
-        {error && <p className="text-xs text-destructive">{error}</p>}
-
-        {apiKey.trim() && (
-          <button
-            onClick={handleSave}
-            disabled={saving}
-            className="w-full rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            {saving ? "Saving..." : "Save API key"}
-          </button>
-        )}
-
-        <p className="text-[10px] text-muted-foreground/60 text-center">
-          <a
-            href="https://console.anthropic.com/settings/keys"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:text-foreground/80"
-          >
-            Get an Anthropic key
-          </a>
-        </p>
+        <BuilderConnectCta />
       </div>
     </div>
+  );
+}
+
+function isLocalAuthHost(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1" ||
+    window.location.hostname === "::1"
   );
 }
 
@@ -2881,6 +2794,7 @@ const AssistantChatInner = forwardRef<
     !!visibleRunError &&
     !showRunningInUI &&
     visibleRunErrorKey !== dismissedRunErrorKey;
+  const showLocalAuthHint = isLocalAuthHost();
 
   return (
     <CheckpointContext.Provider value={checkpointCtx}>
@@ -2938,7 +2852,7 @@ const AssistantChatInner = forwardRef<
                     <p className="text-xs text-muted-foreground leading-relaxed">
                       {authError.sessionExpired ? (
                         "Your session may have expired. Log out and log back in to reconnect."
-                      ) : (
+                      ) : showLocalAuthHint ? (
                         <>
                           You need to log in to use the agent. If you&apos;re
                           running locally, add{" "}
@@ -2951,10 +2865,26 @@ const AssistantChatInner = forwardRef<
                           </code>{" "}
                           file and restart the dev server.
                         </>
+                      ) : (
+                        "You need to log in to use the agent."
                       )}
                     </p>
                   </div>
                   <div className="flex gap-2">
+                    {!showLocalAuthHint && !authError.sessionExpired && (
+                      <button
+                        onClick={() => {
+                          const ret =
+                            window.location.pathname + window.location.search;
+                          window.location.href =
+                            agentNativePath("/_agent-native/sign-in") +
+                            `?return=${encodeURIComponent(ret)}`;
+                        }}
+                        className="text-xs text-background bg-foreground hover:opacity-90 px-3 py-1.5 rounded-md"
+                      >
+                        Log in
+                      </button>
+                    )}
                     {authError.sessionExpired && (
                       <button
                         onClick={async () => {
@@ -2986,7 +2916,7 @@ const AssistantChatInner = forwardRef<
                 </div>
               ) : missingApiKey ? (
                 <div className="flex flex-col items-center justify-center h-full px-2">
-                  <ApiKeySetupCard apiUrl={apiUrl} />
+                  <BuilderSetupCard />
                 </div>
               ) : isRestoring ? (
                 <div className="flex flex-col gap-3 p-4">

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -3189,47 +3189,51 @@ const AssistantChatInner = forwardRef<
                   interceptBuildRequestsForBuilder
                   extraActionButton={
                     showRunningInUI ? (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          // Nuclear stop: flip forceStopped so isRunning is false
-                          // immediately. This unblocks submission even if the
-                          // runtime or reconnect state is stuck.
-                          setForceStopped(true);
-                          const activeRun = getActiveRun();
-                          const runIdToAbort =
-                            reconnectRunIdRef.current ?? activeRun?.runId;
-                          if (runIdToAbort) {
-                            fetch(
-                              `${apiUrl}/runs/${encodeURIComponent(runIdToAbort)}/abort`,
-                              { method: "POST" },
-                            ).catch(() => {});
-                          }
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              // Nuclear stop: flip forceStopped so isRunning is false
+                              // immediately. This unblocks submission even if the
+                              // runtime or reconnect state is stuck.
+                              setForceStopped(true);
+                              const activeRun = getActiveRun();
+                              const runIdToAbort =
+                                reconnectRunIdRef.current ?? activeRun?.runId;
+                              if (runIdToAbort) {
+                                fetch(
+                                  `${apiUrl}/runs/${encodeURIComponent(runIdToAbort)}/abort`,
+                                  { method: "POST" },
+                                ).catch(() => {});
+                              }
 
-                          if (isReconnecting) {
-                            reconnectAbortRef.current?.abort();
-                            reconnectAbortRef.current = null;
-                            reconnectRunIdRef.current = null;
-                            setIsReconnecting(false);
-                            setReconnectFrozen(reconnectContent.length > 0);
-                          }
+                              if (isReconnecting) {
+                                reconnectAbortRef.current?.abort();
+                                reconnectAbortRef.current = null;
+                                reconnectRunIdRef.current = null;
+                                setIsReconnecting(false);
+                                setReconnectFrozen(reconnectContent.length > 0);
+                              }
 
-                          threadRuntime.cancelRun();
+                              threadRuntime.cancelRun();
 
-                          window.dispatchEvent(
-                            new CustomEvent("agentNative.chatRunning", {
-                              detail: {
-                                isRunning: false,
-                                tabId: tabId || threadId,
-                              },
-                            }),
-                          );
-                        }}
-                        className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-muted text-foreground hover:bg-muted/80"
-                        title="Stop generating"
-                      >
-                        <IconPlayerStop className="h-3.5 w-3.5" />
-                      </button>
+                              window.dispatchEvent(
+                                new CustomEvent("agentNative.chatRunning", {
+                                  detail: {
+                                    isRunning: false,
+                                    tabId: tabId || threadId,
+                                  },
+                                }),
+                              );
+                            }}
+                            className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-muted text-foreground hover:bg-muted/80"
+                          >
+                            <IconPlayerStop className="h-3.5 w-3.5" />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>Stop generating</TooltipContent>
+                      </Tooltip>
                     ) : undefined
                   }
                 />

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -227,6 +227,55 @@ describe("createAgentChatAdapter", () => {
     );
   });
 
+  it("treats authentication failures as auth errors, not AI setup", async () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ error: "Authentication required" }, 401),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-auth",
+    });
+
+    await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "make a video" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent-chat:auth-error" }),
+    );
+    expect(dispatchEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent-chat:missing-api-key" }),
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("sends plan mode as request metadata without polluting the message", async () => {
     vi.stubGlobal("window", { dispatchEvent: vi.fn() });
     vi.stubGlobal(

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -720,4 +720,84 @@ describe("createAgentChatAdapter", () => {
       .join("");
     expect(finalText).not.toContain("checking the dashboard");
   });
+
+  it("does not exhaust stalled recovery attempts while each continuation makes progress", async () => {
+    vi.useFakeTimers();
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    let postCount = 0;
+    const fetchSpy = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method !== "POST") {
+        return jsonResponse({ error: "unexpected" }, 500);
+      }
+
+      postCount += 1;
+      if (postCount <= 9) {
+        const tool = `generate-chart-${postCount}`;
+        return sseResponse([
+          { type: "tool_start", tool, input: { chart: String(postCount) } },
+          { type: "tool_done", tool, result: `chart ${postCount} saved` },
+          {
+            type: "error",
+            error: "Builder gateway timed out after 45s",
+            errorCode: "builder_gateway_timeout",
+          },
+        ]);
+      }
+
+      return sseResponse([
+        { type: "text", text: "finished after progressive recovery" },
+        { type: "done" },
+      ]);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-progressive-recovery",
+      threadId: "thread-progressive-recovery",
+    });
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "build a large dashboard" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    const results = await promise;
+
+    expect(postCount).toBe(10);
+    expect(dispatchEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent-chat:run-error" }),
+    );
+    const last = results.at(-1) as any;
+    expect(last.content).toEqual([
+      ...Array.from({ length: 9 }, (_, index) =>
+        expect.objectContaining({
+          type: "tool-call",
+          toolName: `generate-chart-${index + 1}`,
+          result: `chart ${index + 1} saved`,
+        }),
+      ),
+      { type: "text", text: "finished after progressive recovery" },
+    ]);
+  });
 });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -22,7 +22,8 @@ const AUTO_CONTINUE_PROMPT =
   "Continue from where you left off and finish the user's original request. Do not repeat completed work, do not mention internal reconnects, time limits, or step limits, and continue as if this is the same uninterrupted run.";
 const MAX_RECONNECT_ATTEMPTS = 5;
 const MAX_STARTUP_RECOVERY_ATTEMPTS = 8;
-const MAX_TRANSIENT_CONTINUATIONS = 8;
+const MAX_STALLED_TRANSIENT_CONTINUATIONS = 8;
+const MAX_TOTAL_TRANSIENT_CONTINUATIONS = 32;
 const RETRY_BASE_DELAY_MS = 500;
 const RETRY_MAX_DELAY_MS = 8_000;
 
@@ -68,6 +69,14 @@ function visibleTransientContinuationContent(
 ): ContentPart[] {
   return content.filter(
     (part) => part.type === "tool-call" && part.result !== undefined,
+  );
+}
+
+function hasContinuationProgress(content: ContentPart[]): boolean {
+  return content.some((part) =>
+    part.type === "text"
+      ? part.text.trim().length > 0
+      : part.result !== undefined,
   );
 }
 
@@ -296,7 +305,8 @@ export function createAgentChatAdapter(options?: {
       let includeAttachments = attachments.length > 0;
       let includeReferences = Boolean(runConfig?.custom?.references);
       let startupRecoveryAttempts = 0;
-      let transientContinuationAttempts = 0;
+      let stalledTransientContinuationAttempts = 0;
+      let totalTransientContinuationAttempts = 0;
       const continuationHistoryFragments: string[] = [];
       let visibleContinuationPrefix: ContentPart[] = [];
 
@@ -428,16 +438,28 @@ export function createAgentChatAdapter(options?: {
           signal: AgentAutoContinueSignal,
         ): { ok: boolean; resetVisibleContent: boolean } => {
           const isTransient = signal.reason !== "loop_limit";
+          const visibleContent = visibleContentForContinuation();
+          const currentPartialHistory =
+            contentToContinuationHistory(visibleContent);
+          const madeProgress = hasContinuationProgress(visibleContent);
+
           if (signal.reason === "loop_limit") {
-            transientContinuationAttempts = 0;
-          } else if (
-            ++transientContinuationAttempts > MAX_TRANSIENT_CONTINUATIONS
-          ) {
-            return { ok: false, resetVisibleContent: false };
+            stalledTransientContinuationAttempts = 0;
+          } else {
+            totalTransientContinuationAttempts += 1;
+            stalledTransientContinuationAttempts = madeProgress
+              ? 0
+              : stalledTransientContinuationAttempts + 1;
+            if (
+              stalledTransientContinuationAttempts >
+                MAX_STALLED_TRANSIENT_CONTINUATIONS ||
+              totalTransientContinuationAttempts >
+                MAX_TOTAL_TRANSIENT_CONTINUATIONS
+            ) {
+              return { ok: false, resetVisibleContent: false };
+            }
           }
-          const currentPartialHistory = contentToContinuationHistory(
-            visibleContentForContinuation(),
-          );
+
           if (isTransient && currentPartialHistory) {
             continuationHistoryFragments.push(currentPartialHistory);
           }

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -170,6 +170,33 @@ function isRetryableStartupError(message: string): boolean {
   );
 }
 
+function isAuthErrorMessage(message: string): boolean {
+  const msg = message.toLowerCase();
+  return (
+    msg.includes("authentication required") ||
+    msg.includes("unauthorized") ||
+    msg.includes("not authenticated") ||
+    msg.includes("session expired") ||
+    msg.includes("401") ||
+    msg.includes("403") ||
+    msg.includes("405")
+  );
+}
+
+function isMissingCredentialMessage(message: string): boolean {
+  const msg = message.toLowerCase();
+  return (
+    msg.includes("apikey") ||
+    msg.includes("authtoken") ||
+    msg.includes("anthropic_api_key") ||
+    msg.includes("missing_api_key") ||
+    msg.includes("missing api key") ||
+    msg.includes("missing credentials") ||
+    msg.includes("no llm provider") ||
+    msg.includes("llm provider is connected")
+  );
+}
+
 /**
  * The composer's exec mode is sent as explicit request metadata. The server
  * owns the plan-mode prompt and read-only tool filtering so the chat history
@@ -561,6 +588,25 @@ export function createAgentChatAdapter(options?: {
                 }
               }
 
+              if (res.status === 401 || res.status === 403) {
+                if (typeof window !== "undefined") {
+                  window.dispatchEvent(
+                    new CustomEvent("agent-chat:auth-error", {
+                      detail: { reason: "auth-required" },
+                    }),
+                  );
+                }
+                content.push({ type: "text", text: "" });
+                yield {
+                  content: [...content],
+                  status: {
+                    type: "incomplete" as const,
+                    reason: "error" as const,
+                  },
+                } as ChatModelRunResult;
+                return;
+              }
+
               // 405 Method Not Allowed usually means the session is broken/expired
               // (e.g. a redirect to a login page that only accepts GET).
               if (res.status === 405) {
@@ -585,12 +631,25 @@ export function createAgentChatAdapter(options?: {
               let errorText = `Server error: ${res.status}`;
               try {
                 const body = await res.text();
-                if (
-                  body.includes("apiKey") ||
-                  body.includes("authToken") ||
-                  body.includes("ANTHROPIC_API_KEY") ||
-                  body.includes("authentication")
-                ) {
+                if (isAuthErrorMessage(body)) {
+                  if (typeof window !== "undefined") {
+                    window.dispatchEvent(
+                      new CustomEvent("agent-chat:auth-error", {
+                        detail: { reason: "auth-required" },
+                      }),
+                    );
+                  }
+                  content.push({ type: "text", text: "" });
+                  yield {
+                    content: [...content],
+                    status: {
+                      type: "incomplete" as const,
+                      reason: "error" as const,
+                    },
+                  } as ChatModelRunResult;
+                  return;
+                }
+                if (isMissingCredentialMessage(body)) {
                   if (typeof window !== "undefined") {
                     window.dispatchEvent(
                       new Event("agent-chat:missing-api-key"),
@@ -705,17 +764,28 @@ export function createAgentChatAdapter(options?: {
 
             const errMsg =
               err instanceof Error ? err.message : "Something went wrong.";
-            const isAuthError =
-              errMsg.includes("Unauthorized") ||
-              errMsg.includes("Not authenticated") ||
-              errMsg.includes("401") ||
-              errMsg.includes("403") ||
-              errMsg.includes("405");
+            const isAuthError = isAuthErrorMessage(errMsg);
 
             // Don't try to reconnect for auth/client errors — show error directly
             if (isAuthError) {
               if (typeof window !== "undefined") {
                 window.dispatchEvent(new Event("agent-chat:auth-error"));
+              }
+              content.push({ type: "text", text: "" });
+              yield {
+                content: [...content],
+                status: {
+                  type: "incomplete" as const,
+                  reason: "error" as const,
+                },
+              };
+              clearActiveRun();
+              return;
+            }
+
+            if (isMissingCredentialMessage(errMsg)) {
+              if (typeof window !== "undefined") {
+                window.dispatchEvent(new Event("agent-chat:missing-api-key"));
               }
               content.push({ type: "text", text: "" });
               yield {

--- a/packages/core/src/client/components/PresenceBar.tsx
+++ b/packages/core/src/client/components/PresenceBar.tsx
@@ -1,9 +1,16 @@
 import { useMemo } from "react";
 import {
   type CollabUser,
+  dedupeCollabUsersByEmail,
   emailToColor,
   emailToName,
 } from "../../collab/client.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip.js";
 
 export interface PresenceBarProps {
   /** Active collaborators on this document. */
@@ -67,21 +74,27 @@ function injectStyles() {
 }
 
 function UserAvatar({ user, isFirst }: { user: CollabUser; isFirst: boolean }) {
-  const color = emailToColor(user.email);
-  const name = emailToName(user.email);
+  const color = user.color || emailToColor(user.email);
+  const name = user.name || emailToName(user.email);
   const initial = name.charAt(0).toUpperCase();
 
   return (
-    <div
-      style={{
-        ...baseAvatarStyle,
-        backgroundColor: color,
-        marginLeft: isFirst ? 0 : OVERLAP,
-      }}
-      title={name}
-    >
-      {initial}
-    </div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          style={{
+            ...baseAvatarStyle,
+            backgroundColor: color,
+            marginLeft: isFirst ? 0 : OVERLAP,
+          }}
+          aria-label={`${name} (${user.email})`}
+          tabIndex={0}
+        >
+          {initial}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{user.email}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -176,10 +189,15 @@ export function PresenceBar({
   className,
 }: PresenceBarProps) {
   const { humanUsers, showAgent } = useMemo(() => {
-    const humans = activeUsers.filter(
-      (u) => u.email !== currentUserEmail && u.email !== "agent@system",
+    const currentEmail = currentUserEmail?.trim().toLowerCase();
+    const uniqueUsers = dedupeCollabUsersByEmail(activeUsers);
+    const humans = uniqueUsers.filter((u) => {
+      const email = u.email.trim().toLowerCase();
+      return email !== currentEmail && email !== "agent@system";
+    });
+    const hasAgentUser = uniqueUsers.some(
+      (u) => u.email.trim().toLowerCase() === "agent@system",
     );
-    const hasAgentUser = activeUsers.some((u) => u.email === "agent@system");
     return {
       humanUsers: humans,
       showAgent: agentPresent || agentActive || hasAgentUser,
@@ -192,24 +210,26 @@ export function PresenceBar({
   if (!showAgent && humanUsers.length === 0) return null;
 
   return (
-    <div style={containerStyle} className={className}>
-      {showAgent && <AgentAvatar active={!!agentActive} />}
-      {visibleUsers.length > 0 && (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            marginLeft: showAgent ? 6 : 0,
-          }}
-        >
-          {visibleUsers.map((u, i) => (
-            <UserAvatar key={`${u.email}-${i}`} user={u} isFirst={i === 0} />
-          ))}
-          {overflowCount > 0 && (
-            <OverflowBadge count={overflowCount} isFirst={false} />
-          )}
-        </div>
-      )}
-    </div>
+    <TooltipProvider delayDuration={150}>
+      <div style={containerStyle} className={className}>
+        {showAgent && <AgentAvatar active={!!agentActive} />}
+        {visibleUsers.length > 0 && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              marginLeft: showAgent ? 6 : 0,
+            }}
+          >
+            {visibleUsers.map((u, i) => (
+              <UserAvatar key={u.email} user={u} isFirst={i === 0} />
+            ))}
+            {overflowCount > 0 && (
+              <OverflowBadge count={overflowCount} isFirst={false} />
+            )}
+          </div>
+        )}
+      </div>
+    </TooltipProvider>
   );
 }

--- a/packages/core/src/client/composer/ComposerPlusMenu.tsx
+++ b/packages/core/src/client/composer/ComposerPlusMenu.tsx
@@ -25,6 +25,11 @@ import {
   type McpServerScope,
 } from "../resources/use-mcp-servers.js";
 import type { ComposerMode } from "./types.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 interface ComposerPlusMenuProps {
   onSelectMode?: (mode: ComposerMode) => void;
@@ -57,15 +62,19 @@ function UploadOnlyAttachButton() {
           aria-hidden
         />
       </ComposerPrimitive.AddAttachment>
-      <button
-        type="button"
-        onClick={() => hiddenRef.current?.click()}
-        className="shrink-0 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
-        title="Upload file"
-        aria-label="Upload file"
-      >
-        <IconPlus className="h-4 w-4" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => hiddenRef.current?.click()}
+            className="shrink-0 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
+            aria-label="Upload file"
+          >
+            <IconPlus className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Upload file</TooltipContent>
+      </Tooltip>
     </>
   );
 }
@@ -276,15 +285,19 @@ function ComposerPlusMenuFull({
       </ComposerPrimitive.AddAttachment>
 
       <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 disabled:opacity-30 disabled:cursor-not-allowed"
-            title="Add..."
-          >
-            <IconPlus className="h-4 w-4" />
-          </button>
-        </PopoverTrigger>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50 disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <IconPlus className="h-4 w-4" />
+              </button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Add...</TooltipContent>
+        </Tooltip>
         <PopoverContent
           side="top"
           align="start"
@@ -339,30 +352,34 @@ function ComposerPlusMenuFull({
                   >
                     Personal
                   </button>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      hasOrg && canCreateOrgMcp && setMcpScope("org")
-                    }
-                    disabled={!hasOrg || !canCreateOrgMcp}
-                    title={
-                      !hasOrg
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          hasOrg && canCreateOrgMcp && setMcpScope("org")
+                        }
+                        disabled={!hasOrg || !canCreateOrgMcp}
+                        className={cn(
+                          "flex-1 rounded px-2 py-1 text-[11px] font-medium",
+                          mcpScope === "org"
+                            ? "bg-accent text-foreground"
+                            : "text-muted-foreground hover:text-foreground",
+                          (!hasOrg || !canCreateOrgMcp) &&
+                            "cursor-not-allowed opacity-40 hover:text-muted-foreground",
+                        )}
+                      >
+                        Organization
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {!hasOrg
                         ? "Join an organization to share MCP servers"
                         : !canCreateOrgMcp
                           ? "Only owners and admins can add org-scope servers"
-                          : undefined
-                    }
-                    className={cn(
-                      "flex-1 rounded px-2 py-1 text-[11px] font-medium",
-                      mcpScope === "org"
-                        ? "bg-accent text-foreground"
-                        : "text-muted-foreground hover:text-foreground",
-                      (!hasOrg || !canCreateOrgMcp) &&
-                        "cursor-not-allowed opacity-40 hover:text-muted-foreground",
-                    )}
-                  >
-                    Organization
-                  </button>
+                          : undefined}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 <input
                   ref={inputRef}

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -59,6 +59,11 @@ import {
   reasoningEffortLabel,
   type ReasoningEffort,
 } from "../../shared/reasoning-effort.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 export interface TiptapComposerHandle {
   focus(): void;
@@ -263,20 +268,24 @@ function ModeSelector({
   return (
     <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
       <PopoverPrimitive.Trigger asChild>
-        <button
-          type="button"
-          aria-label={mode === "build" ? "Act mode" : "Plan mode"}
-          title="Shift+Tab toggles Act and Plan"
-          className={`shrink-0 flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium hover:bg-accent/50 ${
-            mode === "plan"
-              ? "text-amber-700 dark:text-amber-300"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <ActiveIcon className="h-3.5 w-3.5" />
-          {mode === "build" ? "Act" : "Plan"}
-          <IconChevronDown className="h-3 w-3 opacity-60" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={mode === "build" ? "Act mode" : "Plan mode"}
+              className={`shrink-0 flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium hover:bg-accent/50 ${
+                mode === "plan"
+                  ? "text-amber-700 dark:text-amber-300"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <ActiveIcon className="h-3.5 w-3.5" />
+              {mode === "build" ? "Act" : "Plan"}
+              <IconChevronDown className="h-3 w-3 opacity-60" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Shift+Tab toggles Act and Plan</TooltipContent>
+        </Tooltip>
       </PopoverPrimitive.Trigger>
       <PopoverPrimitive.Portal>
         <PopoverPrimitive.Content
@@ -1567,15 +1576,19 @@ export function TiptapComposer({
               <VoiceButton voice={voice} isMac={isMac} disabled={disabled} />
             )}
             {extraActionButton}
-            <button
-              type="button"
-              onClick={submitComposer}
-              disabled={!canSend}
-              className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-30 disabled:cursor-not-allowed"
-              title="Send message"
-            >
-              <IconArrowUp className="h-3.5 w-3.5" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={submitComposer}
+                  disabled={!canSend}
+                  className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  <IconArrowUp className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Send message</TooltipContent>
+            </Tooltip>
           </>
         )}
       </div>

--- a/packages/core/src/client/composer/VoiceButton.tsx
+++ b/packages/core/src/client/composer/VoiceButton.tsx
@@ -16,6 +16,11 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import type { VoiceDictationApi } from "./useVoiceDictation.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 export interface VoiceButtonProps {
   voice: VoiceDictationApi;
@@ -43,27 +48,31 @@ export function VoiceButton({ voice, isMac, disabled }: VoiceButtonProps) {
   };
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled || transcribing}
-      title={label}
-      aria-label={label}
-      aria-pressed={recording}
-      className={`shrink-0 flex h-7 w-7 items-center justify-center rounded-md disabled:opacity-30 disabled:cursor-not-allowed ${
-        recording
-          ? "text-[#625DF5] bg-[#625DF5]/10 hover:bg-[#625DF5]/20"
-          : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-      }`}
-    >
-      {transcribing ? (
-        <IconLoader2 className="h-4 w-4 animate-spin" />
-      ) : recording ? (
-        <IconPlayerStopFilled className="h-3.5 w-3.5" />
-      ) : (
-        <IconMicrophone className="h-4 w-4" />
-      )}
-    </button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={disabled || transcribing}
+          aria-label={label}
+          aria-pressed={recording}
+          className={`shrink-0 flex h-7 w-7 items-center justify-center rounded-md disabled:opacity-30 disabled:cursor-not-allowed ${
+            recording
+              ? "text-[#625DF5] bg-[#625DF5]/10 hover:bg-[#625DF5]/20"
+              : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+          }`}
+        >
+          {transcribing ? (
+            <IconLoader2 className="h-4 w-4 animate-spin" />
+          ) : recording ? (
+            <IconPlayerStopFilled className="h-3.5 w-3.5" />
+          ) : (
+            <IconMicrophone className="h-4 w-4" />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -82,27 +91,35 @@ export function VoiceRecordingOverlay({ voice }: VoiceRecordingOverlayProps) {
         className="mx-2 mt-1 flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/10 px-2 py-1.5 text-[11px] text-red-500"
       >
         <span className="flex-1 min-w-0">{errorMessage}</span>
-        <button
-          type="button"
-          onClick={() => {
-            dismissError();
-            void start();
-          }}
-          className="shrink-0 cursor-pointer rounded px-1.5 py-0.5 text-[11px] font-medium text-red-500 hover:bg-red-500/20"
-          title="Try again"
-          aria-label="Try again"
-        >
-          Try again
-        </button>
-        <button
-          type="button"
-          onClick={dismissError}
-          className="shrink-0 flex h-4 w-4 cursor-pointer items-center justify-center rounded text-red-500 hover:bg-red-500/20"
-          title="Dismiss"
-          aria-label="Dismiss"
-        >
-          <IconX className="h-3 w-3" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => {
+                dismissError();
+                void start();
+              }}
+              className="shrink-0 cursor-pointer rounded px-1.5 py-0.5 text-[11px] font-medium text-red-500 hover:bg-red-500/20"
+              aria-label="Try again"
+            >
+              Try again
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Try again</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={dismissError}
+              className="shrink-0 flex h-4 w-4 cursor-pointer items-center justify-center rounded text-red-500 hover:bg-red-500/20"
+              aria-label="Dismiss"
+            >
+              <IconX className="h-3 w-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Dismiss</TooltipContent>
+        </Tooltip>
       </div>
     );
   }
@@ -115,15 +132,19 @@ export function VoiceRecordingOverlay({ voice }: VoiceRecordingOverlayProps) {
       className="flex items-center gap-2 mx-2 mt-2 mb-1 h-[2rem] rounded-md border border-[#625DF5]/40 bg-[#625DF5]/10 px-2"
       aria-live="polite"
     >
-      <button
-        type="button"
-        onClick={cancel}
-        className="shrink-0 flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/40"
-        title="Cancel (Esc)"
-        aria-label="Cancel recording"
-      >
-        <IconX className="h-3 w-3" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={cancel}
+            className="shrink-0 flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/40"
+            aria-label="Cancel recording"
+          >
+            <IconX className="h-3 w-3" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Cancel (Esc)</TooltipContent>
+      </Tooltip>
 
       <div className="flex-1 flex items-center gap-[2px] min-w-0 h-4">
         {state === "transcribing" ? (

--- a/packages/core/src/client/dev-overlay/DevOverlay.tsx
+++ b/packages/core/src/client/dev-overlay/DevOverlay.tsx
@@ -43,6 +43,11 @@ import type {
   DevStringOption,
 } from "./types.js";
 import "./builtins.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 const PANEL_OPEN_KEY = `${DEV_OVERLAY_STORAGE_PREFIX}open`;
 const COLLAPSED_KEY_PREFIX = `${DEV_OVERLAY_STORAGE_PREFIX}collapsed-`;
@@ -109,15 +114,19 @@ function DevOverlayPanel({ onClose }: { onClose: () => void }) {
           <div style={styles.headerTitle}>Dev Overlay</div>
           <div style={styles.headerSub}>Cmd+Ctrl+A · localStorage-backed</div>
         </div>
-        <button
-          type="button"
-          style={styles.iconBtn}
-          onClick={onClose}
-          aria-label="Close"
-          title="Close (Esc)"
-        >
-          <IconX size={16} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              style={styles.iconBtn}
+              onClick={onClose}
+              aria-label="Close"
+            >
+              <IconX size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Close (Esc)</TooltipContent>
+        </Tooltip>
       </div>
 
       <div style={styles.body}>
@@ -132,17 +141,23 @@ function DevOverlayPanel({ onClose }: { onClose: () => void }) {
       </div>
 
       <div style={styles.footer}>
-        <button
-          type="button"
-          style={{ ...styles.footerBtn, ...styles.footerBtnDanger }}
-          onClick={() => {
-            clearAllDevOverlayStorage();
-          }}
-          title="Reset every dev-overlay value back to its default"
-        >
-          <IconTrash size={13} />
-          Clear all dev-overlay values
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              style={{ ...styles.footerBtn, ...styles.footerBtnDanger }}
+              onClick={() => {
+                clearAllDevOverlayStorage();
+              }}
+            >
+              <IconTrash size={13} />
+              Clear all dev-overlay values
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Reset every dev-overlay value back to its default
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/packages/core/src/client/extensions/EmbeddedExtension.tsx
+++ b/packages/core/src/client/extensions/EmbeddedExtension.tsx
@@ -19,6 +19,11 @@ import {
   checkBridgePolicy,
   type ExtensionBridgeRole,
 } from "./iframe-bridge.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 interface Extension {
   id: string;
@@ -308,16 +313,20 @@ function EmbeddedToolMenu({
         if (!o) setConfirmingDelete(false);
       }}
     >
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="absolute top-1 right-1 flex h-6 w-6 items-center justify-center rounded-md bg-background/60 text-muted-foreground/60 opacity-0 hover:bg-accent hover:text-foreground hover:opacity-100 group-hover/embedded-extension:opacity-100 cursor-pointer transition-opacity"
-          title={`${toolName} options`}
-          aria-label={`${toolName} options`}
-        >
-          <IconDots className="h-3.5 w-3.5" />
-        </button>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="absolute top-1 right-1 flex h-6 w-6 items-center justify-center rounded-md bg-background/60 text-muted-foreground/60 opacity-0 hover:bg-accent hover:text-foreground hover:opacity-100 group-hover/embedded-extension:opacity-100 cursor-pointer transition-opacity"
+              aria-label={`${toolName} options`}
+            >
+              <IconDots className="h-3.5 w-3.5" />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>{`${toolName} options`}</TooltipContent>
+      </Tooltip>
       <PopoverContent align="end" sideOffset={4} className="w-56 p-1">
         {!confirmingDelete ? (
           <div className="flex flex-col">

--- a/packages/core/src/client/extensions/ExtensionEditor.tsx
+++ b/packages/core/src/client/extensions/ExtensionEditor.tsx
@@ -15,6 +15,11 @@ import {
   PopoverTrigger,
 } from "../components/ui/popover.js";
 import { cn } from "../utils.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 interface SlotDeclaration {
   id: string;
@@ -201,16 +206,20 @@ export function ExtensionEditor({ extensionId }: ExtensionEditorProps) {
                 if (!o) setConfirmingDelete(false);
               }}
             >
-              <PopoverTrigger asChild>
-                <button
-                  type="button"
-                  className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                  title="More options"
-                  aria-label="More options"
-                >
-                  <IconDots className="h-4 w-4" />
-                </button>
-              </PopoverTrigger>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                      aria-label="More options"
+                    >
+                      <IconDots className="h-4 w-4" />
+                    </button>
+                  </PopoverTrigger>
+                </TooltipTrigger>
+                <TooltipContent>More options</TooltipContent>
+              </Tooltip>
               <PopoverContent align="end" sideOffset={4} className="w-72 p-0">
                 {!confirmingDelete ? (
                   <>
@@ -239,15 +248,21 @@ export function ExtensionEditor({ extensionId }: ExtensionEditorProps) {
                             <span className="flex-1 truncate font-mono text-[11px] text-muted-foreground">
                               {s.slotId}
                             </span>
-                            <button
-                              type="button"
-                              onClick={() => handleRemoveFromSlot(s.slotId)}
-                              className="rounded p-1 text-muted-foreground/60 hover:bg-accent hover:text-foreground cursor-pointer"
-                              title="Remove from this widget area (for me)"
-                              aria-label="Remove from this widget area"
-                            >
-                              <IconX className="h-3.5 w-3.5" />
-                            </button>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  onClick={() => handleRemoveFromSlot(s.slotId)}
+                                  className="rounded p-1 text-muted-foreground/60 hover:bg-accent hover:text-foreground cursor-pointer"
+                                  aria-label="Remove from this widget area"
+                                >
+                                  <IconX className="h-3.5 w-3.5" />
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                Remove from this widget area (for me)
+                              </TooltipContent>
+                            </Tooltip>
                           </div>
                         ))}
                       </div>

--- a/packages/core/src/client/extensions/ExtensionSlot.tsx
+++ b/packages/core/src/client/extensions/ExtensionSlot.tsx
@@ -9,6 +9,11 @@ import {
 } from "../components/ui/popover.js";
 import { sendToAgentChat } from "../agent-chat.js";
 import { EmbeddedExtension } from "./EmbeddedExtension.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 interface SlotInstall {
   installId: string;
@@ -169,18 +174,22 @@ function SlotEmptyAffordance({ slotId }: { slotId: string }) {
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="flex w-full items-center gap-2 px-4 py-2 text-[11px] text-muted-foreground/60 hover:text-muted-foreground cursor-pointer"
-          title="Add a widget"
-        >
-          <div className="h-5 w-5 rounded-md border border-dashed border-border/40 flex items-center justify-center shrink-0">
-            <IconPlus className="h-3 w-3" />
-          </div>
-          <span>Add widget</span>
-        </button>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 px-4 py-2 text-[11px] text-muted-foreground/60 hover:text-muted-foreground cursor-pointer"
+            >
+              <div className="h-5 w-5 rounded-md border border-dashed border-border/40 flex items-center justify-center shrink-0">
+                <IconPlus className="h-3 w-3" />
+              </div>
+              <span>Add widget</span>
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Add a widget</TooltipContent>
+      </Tooltip>
       <PopoverContent
         side="left"
         align="end"

--- a/packages/core/src/client/extensions/ExtensionViewer.tsx
+++ b/packages/core/src/client/extensions/ExtensionViewer.tsx
@@ -26,6 +26,11 @@ import {
   checkBridgePolicy,
   type ExtensionBridgeRole,
 } from "./iframe-bridge.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 const THEME_CSS_VARS = [
   "--background",
@@ -114,15 +119,19 @@ function EditToolPopover({ extension }: { extension: Extension }) {
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
-          title="Edit"
-        >
-          <IconPencil className="h-4 w-4" />
-        </button>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
+            >
+              <IconPencil className="h-4 w-4" />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Edit</TooltipContent>
+      </Tooltip>
       <PopoverContent align="end" sideOffset={6} className="w-[420px] p-3">
         <p className="px-1 pb-2 text-sm font-semibold text-foreground">
           Edit extension
@@ -484,26 +493,34 @@ export function ExtensionViewer({ extensionId }: ExtensionViewerProps) {
           ) : (
             <>
               <span className="text-sm font-medium">{extension.name}</span>
-              <button
-                type="button"
-                onClick={startRename}
-                className="cursor-pointer rounded p-0.5 text-muted-foreground/40 opacity-0 group-hover/name:opacity-100 hover:text-foreground"
-                title="Rename"
-              >
-                <IconPencil className="h-3 w-3" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={startRename}
+                    className="cursor-pointer rounded p-0.5 text-muted-foreground/40 opacity-0 group-hover/name:opacity-100 hover:text-foreground"
+                  >
+                    <IconPencil className="h-3 w-3" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Rename</TooltipContent>
+              </Tooltip>
             </>
           )}
         </div>
         <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => setRefreshKey((k) => k + 1)}
-            className="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
-            title="Refresh"
-          >
-            <IconRefresh className="h-4 w-4" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setRefreshKey((k) => k + 1)}
+                className="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
+              >
+                <IconRefresh className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Refresh</TooltipContent>
+          </Tooltip>
           <EditToolPopover extension={extension} />
           <ShareButton
             resourceType="extension"
@@ -616,16 +633,20 @@ function ToolMoreMenu({
         if (!o) setConfirmingDelete(false);
       }}
     >
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
-          title="More options"
-          aria-label="More options"
-        >
-          <IconDots className="h-4 w-4" />
-        </button>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
+              aria-label="More options"
+            >
+              <IconDots className="h-4 w-4" />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>More options</TooltipContent>
+      </Tooltip>
       <PopoverContent align="end" sideOffset={4} className="w-72 p-0">
         {!confirmingDelete ? (
           <>
@@ -653,15 +674,21 @@ function ToolMoreMenu({
                     <span className="flex-1 truncate font-mono text-[11px] text-muted-foreground">
                       {s.slotId}
                     </span>
-                    <button
-                      type="button"
-                      onClick={() => removeFromSlot(s.slotId)}
-                      className="rounded p-1 text-muted-foreground/60 hover:bg-accent hover:text-foreground cursor-pointer"
-                      title="Remove from this widget area (for me)"
-                      aria-label="Remove from this widget area"
-                    >
-                      <IconX className="h-3.5 w-3.5" />
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => removeFromSlot(s.slotId)}
+                          className="rounded p-1 text-muted-foreground/60 hover:bg-accent hover:text-foreground cursor-pointer"
+                          aria-label="Remove from this widget area"
+                        >
+                          <IconX className="h-3.5 w-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Remove from this widget area (for me)
+                      </TooltipContent>
+                    </Tooltip>
                   </div>
                 ))}
               </div>

--- a/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
+++ b/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
@@ -26,6 +26,11 @@ import {
   getToolsOrder,
   setToolsOrder,
 } from "./extension-order.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 interface Extension {
   id: string;
@@ -323,25 +328,29 @@ export function ExtensionsSidebarSection() {
                     "bg-accent/60",
                 )}
               >
-                <button
-                  type="button"
-                  draggable
-                  onDragStart={(e) => {
-                    setDraggingId(extension.id);
-                    setDragOverId(null);
-                    e.dataTransfer.effectAllowed = "move";
-                    e.dataTransfer.setData("text/plain", extension.id);
-                  }}
-                  onDragEnd={() => {
-                    setDraggingId(null);
-                    setDragOverId(null);
-                  }}
-                  className="-ml-2 cursor-grab rounded p-0.5 text-muted-foreground/30 opacity-0 transition-colors hover:text-muted-foreground/70 active:cursor-grabbing group-hover/extension:opacity-100 group-focus-within/extension:opacity-100"
-                  aria-label={`Reorder ${extension.name}`}
-                  title="Drag to reorder"
-                >
-                  <IconGripVertical className="h-3 w-3" />
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      draggable
+                      onDragStart={(e) => {
+                        setDraggingId(extension.id);
+                        setDragOverId(null);
+                        e.dataTransfer.effectAllowed = "move";
+                        e.dataTransfer.setData("text/plain", extension.id);
+                      }}
+                      onDragEnd={() => {
+                        setDraggingId(null);
+                        setDragOverId(null);
+                      }}
+                      className="-ml-2 cursor-grab rounded p-0.5 text-muted-foreground/30 opacity-0 transition-colors hover:text-muted-foreground/70 active:cursor-grabbing group-hover/extension:opacity-100 group-focus-within/extension:opacity-100"
+                      aria-label={`Reorder ${extension.name}`}
+                    >
+                      <IconGripVertical className="h-3 w-3" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Drag to reorder</TooltipContent>
+                </Tooltip>
                 <Link
                   to={`/extensions/${extension.id}`}
                   className={cn(

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -90,6 +90,7 @@ export {
   type AgentPanelProps,
   type AgentSidebarProps,
 } from "./AgentPanel.js";
+export { SettingsPanel, type SettingsPanelProps } from "./settings/index.js";
 // Deprecated — use AgentSidebar + AgentToggleButton instead
 export {
   ProductionAgentPanel,

--- a/packages/core/src/client/integrations/IntegrationCard.tsx
+++ b/packages/core/src/client/integrations/IntegrationCard.tsx
@@ -11,6 +11,11 @@ import {
 } from "@tabler/icons-react";
 import type { IntegrationStatus } from "./useIntegrationStatus.js";
 import { agentNativePath } from "../api-path.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const platformIcons: Record<string, React.ComponentType<any>> = {
@@ -125,13 +130,21 @@ export function IntegrationCard({
                 <code className="flex-1 truncate rounded bg-muted px-1.5 py-0.5 text-[10px] text-foreground">
                   {status.webhookUrl}
                 </code>
-                <button
-                  onClick={handleCopy}
-                  className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                  title="Copy webhook URL"
-                >
-                  {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={handleCopy}
+                      className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                    >
+                      {copied ? (
+                        <IconCheck size={12} />
+                      ) : (
+                        <IconCopy size={12} />
+                      )}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Copy webhook URL</TooltipContent>
+                </Tooltip>
               </div>
             </div>
           )}

--- a/packages/core/src/client/integrations/IntegrationsPanel.tsx
+++ b/packages/core/src/client/integrations/IntegrationsPanel.tsx
@@ -19,6 +19,11 @@ import {
   type IntegrationStatus,
 } from "./useIntegrationStatus.js";
 import { agentNativePath } from "../api-path.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 // ─── Platform config ─────────────────────────────────────────────────────────
 
@@ -249,13 +254,17 @@ function IntegrationDetail({
             <code className="flex-1 truncate rounded bg-muted px-1.5 py-0.5 text-[10px] text-foreground">
               {serviceAccountEmail}
             </code>
-            <button
-              onClick={() => handleCopy(serviceAccountEmail)}
-              className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50"
-              title="Copy service account email"
-            >
-              {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => handleCopy(serviceAccountEmail)}
+                  className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                >
+                  {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Copy service account email</TooltipContent>
+            </Tooltip>
           </div>
         </div>
       )}
@@ -299,13 +308,17 @@ function IntegrationDetail({
             <code className="flex-1 truncate rounded bg-muted px-1.5 py-0.5 text-[10px] text-foreground">
               {serverStatus.webhookUrl}
             </code>
-            <button
-              onClick={() => handleCopy(serverStatus.webhookUrl!)}
-              className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50"
-              title="Copy"
-            >
-              {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => handleCopy(serverStatus.webhookUrl!)}
+                  className="shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                >
+                  {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Copy</TooltipContent>
+            </Tooltip>
           </div>
         </div>
       )}
@@ -456,13 +469,17 @@ export function IntegrationsPanel() {
             Talk to this agent from other platforms
           </div>
         </div>
-        <button
-          onClick={() => setShowPicker(true)}
-          className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
-          title="Add integration"
-        >
-          <IconPlus size={12} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setShowPicker(true)}
+              className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
+            >
+              <IconPlus size={12} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Add integration</TooltipContent>
+        </Tooltip>
       </div>
 
       {loading ? (

--- a/packages/core/src/client/onboarding/OnboardingPanel.tsx
+++ b/packages/core/src/client/onboarding/OnboardingPanel.tsx
@@ -27,6 +27,11 @@ import type {
   OnboardingMethod,
   OnboardingStepStatus,
 } from "../../onboarding/types.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 type FormOnboardingMethod = Extract<OnboardingMethod, { kind: "form" }>;
 
@@ -87,24 +92,30 @@ export function OnboardingPanel({
   if (!expanded) {
     return (
       <div className={className} style={styles.compactBanner}>
-        <button
-          type="button"
-          onClick={() => setExpanded(true)}
-          style={styles.compactBannerBtn}
-          title="Expand setup"
-          aria-label="Expand setup"
-        >
-          <span style={allComplete ? styles.checkDone : styles.checkTodo}>
-            {allComplete ? <IconCheck size={12} strokeWidth={3} /> : null}
-          </span>
-          <span style={styles.headerTitle}>{title}</span>
-          <span style={styles.headerCounter}>
-            {completeCount} of {totalCount}
-          </span>
-          <span style={{ marginLeft: "auto", opacity: 0.5, display: "flex" }}>
-            <IconChevronDown size={14} />
-          </span>
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setExpanded(true)}
+              style={styles.compactBannerBtn}
+              aria-label="Expand setup"
+            >
+              <span style={allComplete ? styles.checkDone : styles.checkTodo}>
+                {allComplete ? <IconCheck size={12} strokeWidth={3} /> : null}
+              </span>
+              <span style={styles.headerTitle}>{title}</span>
+              <span style={styles.headerCounter}>
+                {completeCount} of {totalCount}
+              </span>
+              <span
+                style={{ marginLeft: "auto", opacity: 0.5, display: "flex" }}
+              >
+                <IconChevronDown size={14} />
+              </span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Expand setup</TooltipContent>
+        </Tooltip>
       </div>
     );
   }
@@ -125,15 +136,19 @@ export function OnboardingPanel({
             {completeCount} of {totalCount}
           </span>
         </div>
-        <button
-          type="button"
-          onClick={() => setExpanded(false)}
-          title="Collapse"
-          aria-label="Collapse onboarding"
-          style={styles.dismissBtn}
-        >
-          <IconChevronUp size={14} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setExpanded(false)}
+              aria-label="Collapse onboarding"
+              style={styles.dismissBtn}
+            >
+              <IconChevronUp size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Collapse</TooltipContent>
+        </Tooltip>
       </div>
 
       <div style={styles.list}>

--- a/packages/core/src/client/onboarding/SetupButton.tsx
+++ b/packages/core/src/client/onboarding/SetupButton.tsx
@@ -9,6 +9,11 @@ import React from "react";
 import { IconChecklist } from "@tabler/icons-react";
 import { useOnboarding } from "./use-onboarding.js";
 import { useDevMode } from "../use-dev-mode.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 const DEV_ONLY_STEP_IDS = new Set(["database", "auth"]);
 
@@ -28,28 +33,32 @@ export function SetupButton({ className }: { className?: string }) {
   if (allComplete) return null;
 
   return (
-    <button
-      type="button"
-      onClick={reopen}
-      title="Re-open setup"
-      aria-label="Re-open setup"
-      className={className}
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        gap: 4,
-        padding: "2px 8px",
-        borderRadius: 5,
-        border: "1px solid rgba(96,165,250,0.3)",
-        background: "rgba(59,130,246,0.08)",
-        color: "#60a5fa",
-        fontSize: 11,
-        fontWeight: 500,
-        cursor: "pointer",
-      }}
-    >
-      <IconChecklist size={12} />
-      Setup
-    </button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={reopen}
+          aria-label="Re-open setup"
+          className={className}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            padding: "2px 8px",
+            borderRadius: 5,
+            border: "1px solid rgba(96,165,250,0.3)",
+            background: "rgba(59,130,246,0.08)",
+            color: "#60a5fa",
+            fontSize: 11,
+            fontWeight: 500,
+            cursor: "pointer",
+          }}
+        >
+          <IconChecklist size={12} />
+          Setup
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>Re-open setup</TooltipContent>
+    </Tooltip>
   );
 }

--- a/packages/core/src/client/org/InvitationBanner.tsx
+++ b/packages/core/src/client/org/InvitationBanner.tsx
@@ -1,25 +1,41 @@
+import { useState } from "react";
 import { IconLoader2 } from "@tabler/icons-react";
-import { useOrg, useAcceptInvitation } from "./hooks.js";
+import { useOrg, useAcceptInvitation, useJoinByDomain } from "./hooks.js";
 
 export interface InvitationBannerProps {
   className?: string;
 }
 
 /**
- * Top-of-app banner that surfaces pending org invitations with an inline
- * Accept button. Renders nothing when there are no pending invites.
+ * Top-of-app banner that surfaces:
+ *   - Pending org invitations (one-click Accept).
+ *   - Domain-match orgs the user can auto-join because their email domain
+ *     matches `organizations.allowed_domain` (one-click Join). Lets a new
+ *     signup at e.g. `someone@builder.io` see and join the existing
+ *     Builder.io org without going through the picker.
+ *
+ * Renders nothing when there's nothing to surface.
  */
 export function InvitationBanner({ className }: InvitationBannerProps) {
   const { data: org } = useOrg();
   const acceptInvitation = useAcceptInvitation();
+  const joinByDomain = useJoinByDomain();
+  const [joiningOrgId, setJoiningOrgId] = useState<string | null>(null);
 
-  if (!org?.pendingInvitations?.length) return null;
+  const pendingInvitations = org?.pendingInvitations ?? [];
+  const domainMatches = org?.domainMatches ?? [];
+
+  if (pendingInvitations.length === 0 && domainMatches.length === 0) {
+    return null;
+  }
+
+  const error = acceptInvitation.error || joinByDomain.error;
 
   return (
     <div
       className={`border-b border-border bg-blue-50 dark:bg-blue-950/30 px-3 py-2.5 sm:px-4 ${className ?? ""}`}
     >
-      {org.pendingInvitations.map((inv) => (
+      {pendingInvitations.map((inv) => (
         <div
           key={inv.id}
           className="flex items-center justify-between gap-3 text-sm"
@@ -34,7 +50,7 @@ export function InvitationBanner({ className }: InvitationBannerProps) {
               acceptInvitation.mutate(inv.id);
             }}
             disabled={acceptInvitation.isPending}
-            className="rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-700 disabled:opacity-50"
+            className="rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
           >
             {acceptInvitation.isPending ? (
               <IconLoader2 className="h-3 w-3 animate-spin" />
@@ -44,9 +60,42 @@ export function InvitationBanner({ className }: InvitationBannerProps) {
           </button>
         </div>
       ))}
-      {acceptInvitation.error && (
+      {domainMatches.map((match) => {
+        const isJoining =
+          joinByDomain.isPending && joiningOrgId === match.orgId;
+        return (
+          <div
+            key={match.orgId}
+            className="flex items-center justify-between gap-3 text-sm"
+          >
+            <span className="text-foreground">
+              Your team is already using this app. Join{" "}
+              <span className="font-medium">{match.orgName}</span> to
+              collaborate.
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                setJoiningOrgId(match.orgId);
+                joinByDomain.mutate(match.orgId, {
+                  onSettled: () => setJoiningOrgId(null),
+                });
+              }}
+              disabled={joinByDomain.isPending}
+              className="rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-green-700 disabled:opacity-50 cursor-pointer"
+            >
+              {isJoining ? (
+                <IconLoader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                "Join"
+              )}
+            </button>
+          </div>
+        );
+      })}
+      {error && (
         <div className="mt-1 text-xs text-red-600">
-          {(acceptInvitation.error as Error).message}
+          {(error as Error).message}
         </div>
       )}
     </div>

--- a/packages/core/src/client/org/OrgSwitcher.tsx
+++ b/packages/core/src/client/org/OrgSwitcher.tsx
@@ -16,6 +16,7 @@ import {
   useCreateOrg,
   useInviteMember,
   useAcceptInvitation,
+  useJoinByDomain,
 } from "./hooks.js";
 import { agentNativePath } from "../api-path.js";
 
@@ -66,11 +67,13 @@ export function OrgSwitcher({
   const createOrg = useCreateOrg();
   const inviteMember = useInviteMember();
   const acceptInvitation = useAcceptInvitation();
+  const joinByDomain = useJoinByDomain();
   const [open, setOpen] = useState(false);
   const [mode, setMode] = useState<Mode>("list");
   const [newName, setNewName] = useState("");
   const [inviteEmail, setInviteEmail] = useState("");
   const [signingOut, setSigningOut] = useState(false);
+  const [joiningOrgId, setJoiningOrgId] = useState<string | null>(null);
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
@@ -103,14 +106,21 @@ export function OrgSwitcher({
 
   const orgs = org.orgs ?? [];
   const pendingInvitations = org.pendingInvitations ?? [];
+  const domainMatches = org.domainMatches ?? [];
   const orgCount = orgs.length;
-  const hasAny = orgCount > 0 || pendingInvitations.length > 0;
+  const hasAny =
+    orgCount > 0 || pendingInvitations.length > 0 || domainMatches.length > 0;
   if (!hasAny && !org.email) {
     return reserveSpace ? (
       <div aria-hidden="true" className={`h-8 ${className ?? ""}`} />
     ) : null;
   }
-  if (hideWhenSingle && orgCount < 2 && pendingInvitations.length === 0) {
+  if (
+    hideWhenSingle &&
+    orgCount < 2 &&
+    pendingInvitations.length === 0 &&
+    domainMatches.length === 0
+  ) {
     return reserveSpace ? (
       <div aria-hidden="true" className={`h-8 ${className ?? ""}`} />
     ) : null;
@@ -228,6 +238,52 @@ export function OrgSwitcher({
                 </>
               )}
 
+              {domainMatches.length > 0 && (
+                <>
+                  {(orgs.length > 0 || pendingInvitations.length > 0) && (
+                    <div className="my-1 h-px bg-border" />
+                  )}
+                  <div className={SECTION_LABEL_CLASS}>Join your team</div>
+                  {domainMatches.map((match) => {
+                    const isJoining =
+                      joinByDomain.isPending && joiningOrgId === match.orgId;
+                    return (
+                      <div
+                        key={match.orgId}
+                        className="flex items-center gap-2 px-2.5 py-1.5 text-xs"
+                      >
+                        <IconBuilding className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                        <span className="truncate flex-1 text-foreground">
+                          {match.orgName}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={async () => {
+                            setJoiningOrgId(match.orgId);
+                            try {
+                              await joinByDomain.mutateAsync(match.orgId);
+                              setOpen(false);
+                            } catch {
+                              /* error surfaced via joinByDomain.error */
+                            } finally {
+                              setJoiningOrgId(null);
+                            }
+                          }}
+                          disabled={joinByDomain.isPending}
+                          className="rounded px-1.5 py-0.5 text-[11px] font-medium text-primary hover:bg-primary/10 disabled:opacity-50 cursor-pointer"
+                        >
+                          {isJoining ? (
+                            <IconLoader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            "Join"
+                          )}
+                        </button>
+                      </div>
+                    );
+                  })}
+                </>
+              )}
+
               <div className="my-1 h-px bg-border" />
               <button
                 type="button"
@@ -270,11 +326,16 @@ export function OrgSwitcher({
                 </span>
               </button>
 
-              {(switchOrg.error || acceptInvitation.error) && (
+              {(switchOrg.error ||
+                acceptInvitation.error ||
+                joinByDomain.error) && (
                 <div className="px-2.5 pt-1 text-[11px] text-destructive">
                   {
-                    ((switchOrg.error || acceptInvitation.error) as Error)
-                      .message
+                    (
+                      (switchOrg.error ||
+                        acceptInvitation.error ||
+                        joinByDomain.error) as Error
+                    ).message
                   }
                 </div>
               )}

--- a/packages/core/src/client/org/TeamPage.tsx
+++ b/packages/core/src/client/org/TeamPage.tsx
@@ -36,6 +36,11 @@ import {
   type SyncA2ASecretResult,
 } from "./hooks.js";
 import type { DomainMatchOrg } from "../../org/types.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 export interface TeamPageProps {
   /**
@@ -368,15 +373,19 @@ function MembersCard() {
               )}
             </div>
             {isOwnerOrAdmin && m.email !== org.email && m.role !== "owner" && (
-              <button
-                type="button"
-                disabled={removeMember.isPending}
-                onClick={() => removeMember.mutate(m.email)}
-                className="text-muted-foreground hover:text-red-500 disabled:opacity-50"
-                title="Remove member"
-              >
-                <IconTrash className="h-3.5 w-3.5" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    disabled={removeMember.isPending}
+                    onClick={() => removeMember.mutate(m.email)}
+                    className="text-muted-foreground hover:text-red-500 disabled:opacity-50"
+                  >
+                    <IconTrash className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Remove member</TooltipContent>
+              </Tooltip>
             )}
           </div>
         ))}
@@ -506,26 +515,34 @@ function DomainSettingsSection({ domain }: { domain: string | null }) {
                 <IconAt className="h-3.5 w-3.5 text-muted-foreground" />
                 {domain}
               </span>
-              <button
-                type="button"
-                onClick={() => {
-                  setDraft(domain);
-                  setEditing(true);
-                }}
-                className="text-muted-foreground hover:text-foreground"
-                title="Edit domain"
-              >
-                <IconPencil className="h-3.5 w-3.5" />
-              </button>
-              <button
-                type="button"
-                disabled={setOrgDomain.isPending}
-                onClick={() => setOrgDomain.mutate(null)}
-                className="text-muted-foreground hover:text-red-500 disabled:opacity-50"
-                title="Remove domain"
-              >
-                <IconX className="h-3.5 w-3.5" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDraft(domain);
+                      setEditing(true);
+                    }}
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <IconPencil className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Edit domain</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    disabled={setOrgDomain.isPending}
+                    onClick={() => setOrgDomain.mutate(null)}
+                    className="text-muted-foreground hover:text-red-500 disabled:opacity-50"
+                  >
+                    <IconX className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Remove domain</TooltipContent>
+              </Tooltip>
             </>
           ) : (
             <button
@@ -657,61 +674,83 @@ function A2ASecretSection({ secret }: { secret: string | null | undefined }) {
         </span>
         {secret && (
           <>
-            <button
-              type="button"
-              onClick={() => setRevealed(!revealed)}
-              className="text-muted-foreground hover:text-foreground"
-              title={revealed ? "Hide secret" : "Reveal secret"}
-            >
-              {revealed ? (
-                <IconEyeOff className="h-3.5 w-3.5" />
-              ) : (
-                <IconEye className="h-3.5 w-3.5" />
-              )}
-            </button>
-            <button
-              type="button"
-              onClick={copyToClipboard}
-              className="text-muted-foreground hover:text-foreground"
-              title="Copy secret"
-            >
-              {copied ? (
-                <IconCheck className="h-3.5 w-3.5 text-green-500" />
-              ) : (
-                <IconCopy className="h-3.5 w-3.5" />
-              )}
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => setRevealed(!revealed)}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  {revealed ? (
+                    <IconEyeOff className="h-3.5 w-3.5" />
+                  ) : (
+                    <IconEye className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {revealed ? "Hide secret" : "Reveal secret"}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={copyToClipboard}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  {copied ? (
+                    <IconCheck className="h-3.5 w-3.5 text-green-500" />
+                  ) : (
+                    <IconCopy className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Copy secret</TooltipContent>
+            </Tooltip>
           </>
         )}
-        <button
-          type="button"
-          onClick={regenerate}
-          disabled={setA2ASecret.isPending || syncA2ASecret.isPending}
-          className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-accent/50 disabled:opacity-50"
-          title="Regenerate secret and sync to connected apps"
-        >
-          {setA2ASecret.isPending ? (
-            <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <IconRefresh className="h-3.5 w-3.5" />
-          )}
-          Regenerate
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={regenerate}
+              disabled={setA2ASecret.isPending || syncA2ASecret.isPending}
+              className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-accent/50 disabled:opacity-50"
+            >
+              {setA2ASecret.isPending ? (
+                <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <IconRefresh className="h-3.5 w-3.5" />
+              )}
+              Regenerate
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Regenerate secret and sync to connected apps
+          </TooltipContent>
+        </Tooltip>
         {secret && (
-          <button
-            type="button"
-            onClick={() => syncToApps()}
-            disabled={setA2ASecret.isPending || syncA2ASecret.isPending}
-            className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-accent/50 disabled:opacity-50"
-            title="Push this secret to every connected app"
-          >
-            {syncA2ASecret.isPending ? (
-              <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <IconCloudUpload className="h-3.5 w-3.5" />
-            )}
-            Sync to apps
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => syncToApps()}
+                disabled={setA2ASecret.isPending || syncA2ASecret.isPending}
+                className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-accent/50 disabled:opacity-50"
+              >
+                {syncA2ASecret.isPending ? (
+                  <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <IconCloudUpload className="h-3.5 w-3.5" />
+                )}
+                Sync to apps
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Push this secret to every connected app
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
 

--- a/packages/core/src/client/resources/ResourceEditor.tsx
+++ b/packages/core/src/client/resources/ResourceEditor.tsx
@@ -23,6 +23,11 @@ import {
   parseFrontmatter,
   serializeFrontmatter,
 } from "../../resources/metadata.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 export interface ResourceEditorProps {
   resource: Resource;
@@ -687,18 +692,21 @@ function InlineBubbleToolbar({ editor }: { editor: any }) {
               style?: React.CSSProperties;
             };
             return (
-              <button
-                key={title}
-                onClick={action}
-                title={title}
-                className={cn(
-                  "re-bubble-btn",
-                  isActive() && "re-bubble-btn--active",
-                )}
-                style={style}
-              >
-                {label}
-              </button>
+              <Tooltip key={title}>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={action}
+                    className={cn(
+                      "re-bubble-btn",
+                      isActive() && "re-bubble-btn--active",
+                    )}
+                    style={style}
+                  >
+                    {label}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{title}</TooltipContent>
+              </Tooltip>
             );
           })}
         </div>

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -521,17 +521,21 @@ The result should be a reusable agent profile, not a one-off task response.`,
 
   return (
     <div className="relative">
-      <button
-        ref={buttonRef}
-        onClick={() => setOpen(!open)}
-        className={cn(
-          "flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50",
-          open && "bg-accent/50 text-foreground",
-        )}
-        title="Create new..."
-      >
-        <IconPlus className="h-3.5 w-3.5" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            ref={buttonRef}
+            onClick={() => setOpen(!open)}
+            className={cn(
+              "flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50",
+              open && "bg-accent/50 text-foreground",
+            )}
+          >
+            <IconPlus className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Create new...</TooltipContent>
+      </Tooltip>
       {open && (
         <div
           ref={popoverRef}
@@ -785,30 +789,34 @@ The result should be a reusable agent profile, not a one-off task response.`,
                   >
                     Personal
                   </button>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      hasOrg && canCreateOrgMcp && setMcpScope("org")
-                    }
-                    disabled={!hasOrg || !canCreateOrgMcp}
-                    title={
-                      !hasOrg
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          hasOrg && canCreateOrgMcp && setMcpScope("org")
+                        }
+                        disabled={!hasOrg || !canCreateOrgMcp}
+                        className={cn(
+                          "flex-1 rounded px-2 py-1 text-[11px] font-medium",
+                          mcpScope === "org"
+                            ? "bg-accent text-foreground"
+                            : "text-muted-foreground hover:text-foreground",
+                          (!hasOrg || !canCreateOrgMcp) &&
+                            "cursor-not-allowed opacity-40 hover:text-muted-foreground",
+                        )}
+                      >
+                        Organization
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {!hasOrg
                         ? "Join an organization to share MCP servers"
                         : !canCreateOrgMcp
                           ? "Only owners and admins can add org-scope servers"
-                          : undefined
-                    }
-                    className={cn(
-                      "flex-1 rounded px-2 py-1 text-[11px] font-medium",
-                      mcpScope === "org"
-                        ? "bg-accent text-foreground"
-                        : "text-muted-foreground hover:text-foreground",
-                      (!hasOrg || !canCreateOrgMcp) &&
-                        "cursor-not-allowed opacity-40 hover:text-muted-foreground",
-                    )}
-                  >
-                    Organization
-                  </button>
+                          : undefined}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 <input
                   value={mcpName}

--- a/packages/core/src/client/settings/AgentsSection.tsx
+++ b/packages/core/src/client/settings/AgentsSection.tsx
@@ -12,6 +12,11 @@ import {
   IconCheck,
   IconX,
 } from "@tabler/icons-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 interface AgentInfo {
   id: string;
@@ -349,16 +354,20 @@ export function AgentsSection() {
           @-mention agents in chat to delegate tasks via A2A.
         </div>
         <div className="relative">
-          <button
-            onClick={() => {
-              setShowAdd(!showAdd);
-              setEditingAgent(null);
-            }}
-            className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
-            title="Add agent"
-          >
-            {showAdd ? <IconX size={12} /> : <IconPlus size={12} />}
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => {
+                  setShowAdd(!showAdd);
+                  setEditingAgent(null);
+                }}
+                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50"
+              >
+                {showAdd ? <IconX size={12} /> : <IconPlus size={12} />}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Add agent</TooltipContent>
+          </Tooltip>
           {showAdd && (
             <AgentAddPopover
               onAdd={handleAdd}
@@ -393,18 +402,22 @@ export function AgentsSection() {
                 <span className="flex-1 text-[10px] text-muted-foreground/60 truncate text-right">
                   {agent.url}
                 </span>
-                <button
-                  onClick={() => {
-                    setEditingAgent(
-                      editingAgent === agent.id ? null : agent.id,
-                    );
-                    setShowAdd(false);
-                  }}
-                  className="shrink-0 rounded p-0.5 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-accent/50"
-                  title="Edit agent"
-                >
-                  <IconPencil size={11} />
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => {
+                        setEditingAgent(
+                          editingAgent === agent.id ? null : agent.id,
+                        );
+                        setShowAdd(false);
+                      }}
+                      className="shrink-0 rounded p-0.5 text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-accent/50"
+                    >
+                      <IconPencil size={11} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Edit agent</TooltipContent>
+                </Tooltip>
               </div>
               {editingAgent === agent.id && (
                 <AgentEditPopover

--- a/packages/core/src/client/settings/AutomationsSection.tsx
+++ b/packages/core/src/client/settings/AutomationsSection.tsx
@@ -10,6 +10,11 @@ import {
 } from "@tabler/icons-react";
 import { sendToAgentChat } from "../agent-chat.js";
 import { PromptComposer } from "../composer/PromptComposer.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 interface TreeNode {
   name: string;
@@ -383,25 +388,31 @@ export function AutomationsSection() {
               </div>
               <div className="flex items-center gap-1.5 shrink-0">
                 <StatusBadge status={item.lastStatus} />
-                <button
-                  type="button"
-                  onClick={() => handleToggle(item)}
-                  disabled={togglingId === item.id}
-                  className={`rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${
-                    item.enabled
-                      ? "bg-green-500/15 text-green-500"
-                      : "bg-accent/60 text-muted-foreground"
-                  } hover:opacity-80 disabled:opacity-40`}
-                  title={item.enabled ? "Disable" : "Enable"}
-                >
-                  {togglingId === item.id ? (
-                    <IconLoader2 size={10} className="animate-spin" />
-                  ) : item.enabled ? (
-                    "On"
-                  ) : (
-                    "Off"
-                  )}
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => handleToggle(item)}
+                      disabled={togglingId === item.id}
+                      className={`rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${
+                        item.enabled
+                          ? "bg-green-500/15 text-green-500"
+                          : "bg-accent/60 text-muted-foreground"
+                      } hover:opacity-80 disabled:opacity-40`}
+                    >
+                      {togglingId === item.id ? (
+                        <IconLoader2 size={10} className="animate-spin" />
+                      ) : item.enabled ? (
+                        "On"
+                      ) : (
+                        "Off"
+                      )}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {item.enabled ? "Disable" : "Enable"}
+                  </TooltipContent>
+                </Tooltip>
                 {confirmDeleteId === item.id ? (
                   <div className="flex items-center gap-1">
                     <button
@@ -425,14 +436,18 @@ export function AutomationsSection() {
                     </button>
                   </div>
                 ) : (
-                  <button
-                    type="button"
-                    onClick={() => setConfirmDeleteId(item.id)}
-                    className="text-muted-foreground hover:text-red-500 disabled:opacity-40"
-                    title="Delete"
-                  >
-                    <IconTrash size={12} />
-                  </button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() => setConfirmDeleteId(item.id)}
+                        className="text-muted-foreground hover:text-red-500 disabled:opacity-40"
+                      >
+                        <IconTrash size={12} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Delete</TooltipContent>
+                  </Tooltip>
                 )}
               </div>
             </div>

--- a/packages/core/src/client/settings/SecretsSection.tsx
+++ b/packages/core/src/client/settings/SecretsSection.tsx
@@ -16,6 +16,11 @@ import {
   IconTrash,
   IconRefresh,
 } from "@tabler/icons-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 interface SecretStatus {
   key: string;
@@ -706,14 +711,18 @@ function AdHocKeysSection() {
                     </button>
                   </div>
                 ) : (
-                  <button
-                    type="button"
-                    onClick={() => setConfirmDeleteName(key.name)}
-                    className="text-muted-foreground hover:text-red-500"
-                    title="Delete"
-                  >
-                    <IconTrash size={12} />
-                  </button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() => setConfirmDeleteName(key.name)}
+                        className="text-muted-foreground hover:text-red-500"
+                      >
+                        <IconTrash size={12} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Delete</TooltipContent>
+                  </Tooltip>
                 )}
               </div>
             </div>

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -38,6 +38,11 @@ import { SecretsSection } from "./SecretsSection.js";
 import { VoiceTranscriptionSection } from "./VoiceTranscriptionSection.js";
 import { AutomationsSection } from "./AutomationsSection.js";
 import { PROVIDER_ENV_PLACEHOLDERS } from "../../agent/engine/provider-env-vars.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "../components/ui/tooltip.js";
 
 const IntegrationsPanel = lazy(() =>
   import("../integrations/IntegrationsPanel.js").then((m) => ({
@@ -925,13 +930,20 @@ function LLMSectionInner({
                     </button>
                   )}
                   {settingsStatus != null && (
-                    <button
-                      onClick={handleDisconnect}
-                      className="ml-auto rounded border border-border px-2.5 py-1 text-[10px] font-medium text-muted-foreground hover:bg-destructive/10 hover:text-destructive hover:border-destructive/40"
-                      title="Clear the saved engine — the app will fall back to the default until you re-apply."
-                    >
-                      Disconnect
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={handleDisconnect}
+                          className="ml-auto rounded border border-border px-2.5 py-1 text-[10px] font-medium text-muted-foreground hover:bg-destructive/10 hover:text-destructive hover:border-destructive/40"
+                        >
+                          Disconnect
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Clear the saved engine — the app will fall back to the
+                        default until you re-apply.
+                      </TooltipContent>
+                    </Tooltip>
                   )}
                 </div>
                 {testResult && testResult.ok && (
@@ -1540,16 +1552,20 @@ export function SettingsPanel({
               label="Environment"
               labelAdornment={
                 devAppUrl ? (
-                  <a
-                    href={devAppUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    title="Open app in new tab"
-                    aria-label="Open app in new tab"
-                    className="flex items-center text-muted-foreground hover:text-foreground"
-                  >
-                    <IconExternalLink size={14} />
-                  </a>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <a
+                        href={devAppUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Open app in new tab"
+                        className="flex items-center text-muted-foreground hover:text-foreground"
+                      >
+                        <IconExternalLink size={14} />
+                      </a>
+                    </TooltipTrigger>
+                    <TooltipContent>Open app in new tab</TooltipContent>
+                  </Tooltip>
                 ) : undefined
               }
               value={isDevMode ? "development" : "production"}

--- a/packages/core/src/client/settings/index.ts
+++ b/packages/core/src/client/settings/index.ts
@@ -1,3 +1,3 @@
-export { SettingsPanel } from "./SettingsPanel.js";
+export { SettingsPanel, type SettingsPanelProps } from "./SettingsPanel.js";
 export { useBuilderStatus } from "./useBuilderStatus.js";
 export { SecretsSection, type SecretsSectionProps } from "./SecretsSection.js";

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -18,6 +18,27 @@ function commentOnlyStream(delayMs: number): ReadableStream<Uint8Array> {
   });
 }
 
+function eventStream(events: unknown[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        new TextEncoder().encode(
+          events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
+        ),
+      );
+      controller.close();
+    },
+  });
+}
+
+async function drain(iterable: AsyncIterable<unknown>) {
+  const results: unknown[] = [];
+  for await (const result of iterable) {
+    results.push(result);
+  }
+  return results;
+}
+
 describe("SSE event processor no-progress recovery", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -69,5 +90,68 @@ describe("SSE event processor no-progress recovery", () => {
     expect(err).toBeInstanceOf(AgentAutoContinueSignal);
     expect((err as AgentAutoContinueSignal).reason).toBe("no_progress");
     expect(onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("SSE event processor error classification", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("routes authentication failures to auth handling", async () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    await drain(
+      readSSEStream(
+        eventStream([{ type: "error", error: "Authentication required" }]),
+        [],
+        { value: 0 },
+        "tab-auth",
+      ),
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent-chat:auth-error" }),
+    );
+    expect(dispatchEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent-chat:missing-api-key" }),
+    );
+  });
+
+  it("routes missing provider credentials to the setup gate", async () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+
+    await drain(
+      readSSEStream(
+        eventStream([
+          {
+            type: "error",
+            error: "No LLM provider is connected",
+            errorCode: "missing_credentials",
+          },
+        ]),
+        [],
+        { value: 0 },
+        "tab-missing",
+      ),
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent-chat:missing-api-key" }),
+    );
   });
 });

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -124,6 +124,37 @@ function isAutoRecoverableError(ev: SSEEvent, errMsg: string): boolean {
   );
 }
 
+function isAuthFailureText(message: string, errorCode?: string): boolean {
+  const code = String(errorCode ?? "").toLowerCase();
+  const msg = message.toLowerCase();
+  return (
+    code === "unauthorized" ||
+    code === "authentication_error" ||
+    code === "permission_error" ||
+    msg.includes("authentication required") ||
+    msg.includes("unauthorized") ||
+    msg.includes("not authenticated") ||
+    msg.includes("session expired")
+  );
+}
+
+function isMissingCredentialText(message: string, errorCode?: string): boolean {
+  const code = String(errorCode ?? "").toLowerCase();
+  const msg = message.toLowerCase();
+  return (
+    code === "missing_api_key" ||
+    code === "missing_credentials" ||
+    msg.includes("apikey") ||
+    msg.includes("authtoken") ||
+    msg.includes("anthropic_api_key") ||
+    msg.includes("missing_api_key") ||
+    msg.includes("missing api key") ||
+    msg.includes("missing credentials") ||
+    msg.includes("no llm provider") ||
+    msg.includes("llm provider is connected")
+  );
+}
+
 /**
  * Process a single SSE event and update the content accumulator.
  * Returns: "continue" to keep going, "done" to stop, or a yield-ready result.
@@ -341,6 +372,27 @@ export function processEvent(
 
   if (ev.type === "error") {
     const errMsg = ev.error ?? "Unknown error";
+    if (isAuthFailureText(errMsg, ev.errorCode)) {
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(
+          new CustomEvent("agent-chat:auth-error", {
+            detail: {
+              reason: errMsg.toLowerCase().includes("session")
+                ? "session-expired"
+                : "auth-required",
+            },
+          }),
+        );
+      }
+      content.push({ type: "text", text: "" });
+      return {
+        action: "error",
+        result: {
+          content: [...content],
+          status: { type: "incomplete" as const, reason: "error" as const },
+        } as ChatModelRunResult,
+      };
+    }
     if (
       (ev.errorCode === "run_timeout" && ev.recoverable) ||
       isAutoRecoverableError(ev, errMsg)
@@ -358,12 +410,7 @@ export function processEvent(
       };
     }
     const normalized = normalizeChatError(errMsg);
-    if (
-      errMsg.includes("apiKey") ||
-      errMsg.includes("authToken") ||
-      errMsg.includes("ANTHROPIC_API_KEY") ||
-      errMsg.includes("authentication")
-    ) {
+    if (isMissingCredentialText(errMsg, ev.errorCode)) {
       if (typeof window !== "undefined") {
         window.dispatchEvent(new Event("agent-chat:missing-api-key"));
       }

--- a/packages/core/src/collab/client.spec.ts
+++ b/packages/core/src/collab/client.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { dedupeCollabUsersByEmail } from "./client.js";
+
+describe("dedupeCollabUsersByEmail", () => {
+  it("keeps one presence entry per email", () => {
+    const users = dedupeCollabUsersByEmail([
+      {
+        name: "Katya",
+        email: "Katya@example.com",
+        color: "#f87171",
+      },
+      {
+        name: "Katya",
+        email: "katya@example.com",
+        color: "#60a5fa",
+      },
+      {
+        name: "Steve",
+        email: "steve@example.com",
+        color: "#34d399",
+      },
+      {
+        name: "Katya",
+        email: " katya@example.com ",
+        color: "#a78bfa",
+      },
+    ]);
+
+    expect(users).toEqual([
+      {
+        name: "Katya",
+        email: "katya@example.com",
+        color: "#f87171",
+      },
+      {
+        name: "Steve",
+        email: "steve@example.com",
+        color: "#34d399",
+      },
+    ]);
+  });
+});

--- a/packages/core/src/collab/client.ts
+++ b/packages/core/src/collab/client.ts
@@ -79,6 +79,24 @@ export function emailToName(email: string): string {
   return local.charAt(0).toUpperCase() + local.slice(1);
 }
 
+function normalizeCollabEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function dedupeCollabUsersByEmail(users: CollabUser[]): CollabUser[] {
+  const byEmail = new Map<string, CollabUser>();
+  for (const user of users) {
+    const email = normalizeCollabEmail(user.email);
+    if (!email || byEmail.has(email)) continue;
+    byEmail.set(email, {
+      name: user.name || emailToName(email),
+      email,
+      color: user.color || emailToColor(email),
+    });
+  }
+  return Array.from(byEmail.values());
+}
+
 // Base64 helpers
 function uint8ArrayToBase64(arr: Uint8Array): string {
   let binary = "";
@@ -158,7 +176,7 @@ export function useCollaborativeDoc(
           }
         }
       });
-      setActiveUsers(users);
+      setActiveUsers(dedupeCollabUsersByEmail(users));
       setAgentPresent(hasAgent);
     };
 

--- a/packages/core/src/org/auto-join-domain.spec.ts
+++ b/packages/core/src/org/auto-join-domain.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockExecute = vi.fn();
+const mockPutUserSetting = vi.fn();
+
+vi.mock("../db/client.js", () => ({
+  getDbExec: () => ({ execute: mockExecute }),
+  isLocalDatabase: () => true,
+}));
+vi.mock("../settings/user-settings.js", () => ({
+  putUserSetting: (...args: any[]) => mockPutUserSetting(...args),
+}));
+
+import { autoJoinDomainMatchingOrgs } from "./auto-join-domain.js";
+
+function queueSelect(...rows: any[][]) {
+  for (const r of rows) {
+    mockExecute.mockResolvedValueOnce({ rows: r });
+  }
+}
+
+describe("autoJoinDomainMatchingOrgs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecute.mockResolvedValue({ rows: [] });
+  });
+
+  it("returns empty when no orgs match the domain", async () => {
+    queueSelect([]);
+    const out = await autoJoinDomainMatchingOrgs("new@nowhere.com");
+    expect(out).toEqual({ joined: [], activeOrgId: null });
+    expect(mockPutUserSetting).not.toHaveBeenCalled();
+  });
+
+  it("returns empty when email has no domain", async () => {
+    const out = await autoJoinDomainMatchingOrgs("notanemail");
+    expect(out).toEqual({ joined: [], activeOrgId: null });
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("inserts org_members and sets active-org-id when no prior active org", async () => {
+    queueSelect(
+      [{ orgId: "builder_io" }], // domain matches
+      [], // INSERT org_members result
+      [], // SELECT settings for active-org-id (no row → not active)
+    );
+    const out = await autoJoinDomainMatchingOrgs("new@builder.io");
+
+    const sqls = mockExecute.mock.calls.map((c) => c[0].sql);
+    expect(sqls[0]).toContain("FROM organizations");
+    expect(sqls[0]).toContain("LOWER(o.allowed_domain)");
+    expect(sqls[1]).toContain("INSERT INTO org_members");
+    expect(sqls[2]).toContain("SELECT value FROM settings");
+
+    expect(out.joined).toEqual([{ orgId: "builder_io" }]);
+    expect(out.activeOrgId).toBe("builder_io");
+    expect(mockPutUserSetting).toHaveBeenCalledWith(
+      "new@builder.io",
+      "active-org-id",
+      { orgId: "builder_io" },
+    );
+  });
+
+  it("does NOT overwrite an existing active-org-id (e.g. invite ran first)", async () => {
+    queueSelect(
+      [{ orgId: "builder_io" }],
+      [], // INSERT org_members
+      [{ value: JSON.stringify({ orgId: "other_org" }) }], // settings already populated
+    );
+    const out = await autoJoinDomainMatchingOrgs("new@builder.io");
+    expect(out.joined).toEqual([{ orgId: "builder_io" }]);
+    expect(out.activeOrgId).toBeNull();
+    expect(mockPutUserSetting).not.toHaveBeenCalled();
+  });
+
+  it("excludes orgs the user is already a member of (NOT EXISTS)", async () => {
+    // The query itself filters via NOT EXISTS, so we just confirm we
+    // call it correctly. When the query returns empty (because the user
+    // is already in the only matching org), the function no-ops.
+    queueSelect([]);
+    const out = await autoJoinDomainMatchingOrgs("existing@builder.io");
+    expect(out.joined).toEqual([]);
+    expect(out.activeOrgId).toBeNull();
+    const args = mockExecute.mock.calls[0][0].args;
+    expect(args).toEqual(["builder.io", "existing@builder.io"]);
+  });
+
+  it("joins multiple matching orgs and picks the first as active", async () => {
+    queueSelect(
+      [{ orgId: "orgA" }, { orgId: "orgB" }],
+      [], // INSERT for orgA
+      [], // INSERT for orgB
+      [], // settings check
+    );
+    const out = await autoJoinDomainMatchingOrgs("multi@builder.io");
+    expect(out.joined).toEqual([{ orgId: "orgA" }, { orgId: "orgB" }]);
+    expect(out.activeOrgId).toBe("orgA");
+  });
+
+  it("survives a unique-constraint race on insert and continues", async () => {
+    mockExecute.mockResolvedValueOnce({
+      rows: [{ orgId: "orgA" }, { orgId: "orgB" }],
+    });
+    mockExecute.mockRejectedValueOnce(new Error("UNIQUE constraint failed"));
+    mockExecute.mockResolvedValueOnce({ rows: [] }); // INSERT orgB succeeds
+    mockExecute.mockResolvedValueOnce({ rows: [] }); // settings check
+
+    const out = await autoJoinDomainMatchingOrgs("race@builder.io");
+    expect(out.joined).toEqual([{ orgId: "orgB" }]);
+  });
+
+  it("swallows missing-table errors (template without org module)", async () => {
+    mockExecute.mockRejectedValueOnce(
+      new Error("no such table: organizations"),
+    );
+    const out = await autoJoinDomainMatchingOrgs("a@builder.io");
+    expect(out).toEqual({ joined: [], activeOrgId: null });
+  });
+
+  it("lowercases email and domain for the lookup", async () => {
+    queueSelect([]);
+    await autoJoinDomainMatchingOrgs("Mixed@Builder.IO");
+    const args = mockExecute.mock.calls[0][0].args;
+    expect(args).toEqual(["builder.io", "mixed@builder.io"]);
+  });
+});

--- a/packages/core/src/org/auto-join-domain.spec.ts
+++ b/packages/core/src/org/auto-join-domain.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockExecute = vi.fn();
 const mockPutUserSetting = vi.fn();
+const mockGetUserSetting = vi.fn();
 
 vi.mock("../db/client.js", () => ({
   getDbExec: () => ({ execute: mockExecute }),
@@ -9,6 +10,7 @@ vi.mock("../db/client.js", () => ({
 }));
 vi.mock("../settings/user-settings.js", () => ({
   putUserSetting: (...args: any[]) => mockPutUserSetting(...args),
+  getUserSetting: (...args: any[]) => mockGetUserSetting(...args),
 }));
 
 import { autoJoinDomainMatchingOrgs } from "./auto-join-domain.js";
@@ -23,6 +25,7 @@ describe("autoJoinDomainMatchingOrgs", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExecute.mockResolvedValue({ rows: [] });
+    mockGetUserSetting.mockResolvedValue(null);
   });
 
   it("returns empty when no orgs match the domain", async () => {
@@ -42,18 +45,21 @@ describe("autoJoinDomainMatchingOrgs", () => {
     queueSelect(
       [{ orgId: "builder_io" }], // domain matches
       [], // INSERT org_members result
-      [], // SELECT settings for active-org-id (no row → not active)
     );
+    mockGetUserSetting.mockResolvedValueOnce(null);
     const out = await autoJoinDomainMatchingOrgs("new@builder.io");
 
     const sqls = mockExecute.mock.calls.map((c) => c[0].sql);
     expect(sqls[0]).toContain("FROM organizations");
     expect(sqls[0]).toContain("LOWER(o.allowed_domain)");
     expect(sqls[1]).toContain("INSERT INTO org_members");
-    expect(sqls[2]).toContain("SELECT value FROM settings");
 
     expect(out.joined).toEqual([{ orgId: "builder_io" }]);
     expect(out.activeOrgId).toBe("builder_io");
+    expect(mockGetUserSetting).toHaveBeenCalledWith(
+      "new@builder.io",
+      "active-org-id",
+    );
     expect(mockPutUserSetting).toHaveBeenCalledWith(
       "new@builder.io",
       "active-org-id",
@@ -65,8 +71,8 @@ describe("autoJoinDomainMatchingOrgs", () => {
     queueSelect(
       [{ orgId: "builder_io" }],
       [], // INSERT org_members
-      [{ value: JSON.stringify({ orgId: "other_org" }) }], // settings already populated
     );
+    mockGetUserSetting.mockResolvedValueOnce({ orgId: "other_org" });
     const out = await autoJoinDomainMatchingOrgs("new@builder.io");
     expect(out.joined).toEqual([{ orgId: "builder_io" }]);
     expect(out.activeOrgId).toBeNull();
@@ -90,7 +96,6 @@ describe("autoJoinDomainMatchingOrgs", () => {
       [{ orgId: "orgA" }, { orgId: "orgB" }],
       [], // INSERT for orgA
       [], // INSERT for orgB
-      [], // settings check
     );
     const out = await autoJoinDomainMatchingOrgs("multi@builder.io");
     expect(out.joined).toEqual([{ orgId: "orgA" }, { orgId: "orgB" }]);
@@ -103,7 +108,6 @@ describe("autoJoinDomainMatchingOrgs", () => {
     });
     mockExecute.mockRejectedValueOnce(new Error("UNIQUE constraint failed"));
     mockExecute.mockResolvedValueOnce({ rows: [] }); // INSERT orgB succeeds
-    mockExecute.mockResolvedValueOnce({ rows: [] }); // settings check
 
     const out = await autoJoinDomainMatchingOrgs("race@builder.io");
     expect(out.joined).toEqual([{ orgId: "orgB" }]);

--- a/packages/core/src/org/auto-join-domain.ts
+++ b/packages/core/src/org/auto-join-domain.ts
@@ -1,0 +1,114 @@
+import { getDbExec } from "../db/client.js";
+import { putUserSetting } from "../settings/user-settings.js";
+
+const nanoid = (): string =>
+  globalThis.crypto?.randomUUID?.().replace(/-/g, "") ??
+  Math.random().toString(36).slice(2) + Date.now().toString(36);
+
+export interface AutoJoinDomainResult {
+  joined: Array<{ orgId: string }>;
+  activeOrgId: string | null;
+}
+
+/**
+ * Auto-join a newly-signed-up user into every org whose `allowed_domain`
+ * matches their email domain.
+ *
+ * Called from the Better Auth `user.create.after` hook so that e.g. a new
+ * `@builder.io` signup lands inside the existing Builder.io org on first
+ * page load instead of starting in Personal and having to find the join
+ * CTA. The org's owner opts into this by setting
+ * `organizations.allowed_domain` — the column already gated the manual
+ * "Join your team" UI in the picker; we use the same opt-in to drive
+ * automatic join.
+ *
+ * Idempotent — skips orgs the user is already a member of and never
+ * overwrites an existing `active-org-id` setting.
+ *
+ * Safe to call when the org tables don't exist (some templates don't use
+ * the org module): it swallows the "no such table" error and returns
+ * empty. Never throws — the caller is a signup hook and we don't want to
+ * block a user from creating their account because of an org-tier issue.
+ */
+export async function autoJoinDomainMatchingOrgs(
+  rawEmail: string,
+): Promise<AutoJoinDomainResult> {
+  const email = rawEmail.trim().toLowerCase();
+  if (!email) return { joined: [], activeOrgId: null };
+
+  const domain = email.split("@")[1]?.toLowerCase();
+  if (!domain) return { joined: [], activeOrgId: null };
+
+  const db = getDbExec();
+
+  let matches: Array<{ orgId: string }> = [];
+  try {
+    const res = await db.execute({
+      sql: `SELECT o.id AS "orgId"
+            FROM organizations o
+            WHERE LOWER(o.allowed_domain) = ?
+              AND NOT EXISTS (
+                SELECT 1
+                FROM org_members m
+                WHERE m.org_id = o.id
+                  AND LOWER(m.email) = ?
+              )
+            ORDER BY o.created_at ASC`,
+      args: [domain, email],
+    });
+    matches = res.rows.map((r: any) => ({
+      orgId: String(r.orgId ?? r.org_id),
+    }));
+  } catch {
+    // Template without org tables (or `allowed_domain` column not yet
+    // migrated). Not fatal — return empty.
+    return { joined: [], activeOrgId: null };
+  }
+
+  if (matches.length === 0) return { joined: [], activeOrgId: null };
+
+  const joined: AutoJoinDomainResult["joined"] = [];
+  for (const m of matches) {
+    try {
+      await db.execute({
+        sql: `INSERT INTO org_members (id, org_id, email, role, joined_at) VALUES (?, ?, ?, 'member', ?)`,
+        args: [nanoid(), m.orgId, email, Date.now()],
+      });
+      joined.push({ orgId: m.orgId });
+    } catch {
+      // Race with a parallel join (e.g. user accepted an invite to the
+      // same org milliseconds earlier). The unique constraint keeps the
+      // existing membership intact; just skip this org.
+    }
+  }
+
+  // Set active-org-id to the first match only if the user doesn't
+  // already have one (a pending invite that ran first may have set it).
+  let activeOrgId: string | null = null;
+  if (joined[0]) {
+    try {
+      const existing = await db.execute({
+        sql: `SELECT value FROM settings WHERE key = ? LIMIT 1`,
+        args: [`u:${email}:active-org-id`],
+      });
+      const hasActive =
+        existing.rows.length > 0 &&
+        (() => {
+          try {
+            const parsed = JSON.parse(String(existing.rows[0].value));
+            return Boolean(parsed?.orgId);
+          } catch {
+            return false;
+          }
+        })();
+      if (!hasActive) {
+        activeOrgId = joined[0].orgId;
+        await putUserSetting(email, "active-org-id", { orgId: activeOrgId });
+      }
+    } catch {
+      // settings table missing — not fatal.
+    }
+  }
+
+  return { joined, activeOrgId };
+}

--- a/packages/core/src/org/auto-join-domain.ts
+++ b/packages/core/src/org/auto-join-domain.ts
@@ -1,5 +1,5 @@
 import { getDbExec } from "../db/client.js";
-import { putUserSetting } from "../settings/user-settings.js";
+import { getUserSetting, putUserSetting } from "../settings/user-settings.js";
 
 const nanoid = (): string =>
   globalThis.crypto?.randomUUID?.().replace(/-/g, "") ??
@@ -87,20 +87,8 @@ export async function autoJoinDomainMatchingOrgs(
   let activeOrgId: string | null = null;
   if (joined[0]) {
     try {
-      const existing = await db.execute({
-        sql: `SELECT value FROM settings WHERE key = ? LIMIT 1`,
-        args: [`u:${email}:active-org-id`],
-      });
-      const hasActive =
-        existing.rows.length > 0 &&
-        (() => {
-          try {
-            const parsed = JSON.parse(String(existing.rows[0].value));
-            return Boolean(parsed?.orgId);
-          } catch {
-            return false;
-          }
-        })();
+      const existing = await getUserSetting(email, "active-org-id");
+      const hasActive = Boolean(existing?.orgId);
       if (!hasActive) {
         activeOrgId = joined[0].orgId;
         await putUserSetting(email, "active-org-id", { orgId: activeOrgId });

--- a/packages/core/src/org/index.ts
+++ b/packages/core/src/org/index.ts
@@ -22,6 +22,9 @@ export {
 export { acceptPendingInvitationsForEmail } from "./accept-pending.js";
 export type { AcceptPendingResult } from "./accept-pending.js";
 
+export { autoJoinDomainMatchingOrgs } from "./auto-join-domain.js";
+export type { AutoJoinDomainResult } from "./auto-join-domain.js";
+
 export { ORG_MIGRATIONS } from "./migrations.js";
 
 export { createOrgPlugin, defaultOrgPlugin } from "./plugin.js";

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1217,10 +1217,25 @@ describe("server/auth", () => {
       expect(html).toContain('id="verify-continue"');
       expect(html).toContain('id="resend-verification"');
       expect(html).toContain('id="back-to-signup"');
-      expect(html).toContain("showVerificationStep(email)");
+      expect(html).toContain("showVerificationStep(email, pass)");
       expect(html).toContain("callbackURL: __anGetReturnPath()");
       expect(html).not.toContain(
         "Account created! Check your email to verify, then sign in.",
+      );
+    });
+
+    it("silently signs in after verification completes outside the app", async () => {
+      const { getOnboardingHtml } = await import("./onboarding-html.js");
+      const html = getOnboardingHtml();
+
+      expect(html).toContain("var pendingSignupPassword = ''");
+      expect(html).toContain("async function signInWithPendingSignup()");
+      expect(html).toContain("__anPath('/_agent-native/auth/login')");
+      expect(html).toContain(
+        "window.addEventListener('focus', maybeCompleteVerificationAfterReturn)",
+      );
+      expect(html).toContain(
+        "checkVerificationSession(null, { silent: true })",
       );
     });
   });

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -21,6 +21,7 @@ import {
 import { getAppProductionUrl } from "./app-url.js";
 import { getDbExec, isPostgres } from "../db/client.js";
 import { acceptPendingInvitationsForEmail } from "../org/accept-pending.js";
+import { autoJoinDomainMatchingOrgs } from "../org/auto-join-domain.js";
 import { saveOAuthTokens } from "../oauth-tokens/store.js";
 import { identify, track } from "../tracking/index.js";
 import {
@@ -728,6 +729,18 @@ async function createBetterAuthInstance(
               // Never block signup on invite bookkeeping — log and continue.
               console.error(
                 "[auth] failed to auto-accept pending invitations",
+                err,
+              );
+            }
+            try {
+              // Auto-join orgs whose `allowed_domain` matches this email
+              // domain. Lets a fresh `@builder.io` (or any org-domain)
+              // signup land inside the company org on first page load
+              // without going through the picker. No-ops when no match.
+              await autoJoinDomainMatchingOrgs(email);
+            } catch (err) {
+              console.error(
+                "[auth] failed to auto-join domain-matching orgs",
                 err,
               );
             }

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -1261,8 +1261,10 @@ export function createCoreRoutesPlugin(
     // not in the env-status list (OpenRouter, Groq, Ollama, …).
     getH3App(nitroApp).use(
       `${P}/agent-engine/status`,
-      defineEventHandler(async () => {
+      defineEventHandler(async (event) => {
         try {
+          const session = await getSession(event).catch(() => null);
+          const userEmail = session?.email;
           const stored = (await getSetting("agent-engine")) as {
             engine?: string;
           } | null;
@@ -1288,7 +1290,10 @@ export function createCoreRoutesPlugin(
           // their own provider key) may not have any deploy-level env vars
           // set, so check their per-user secret store before reporting "no
           // engine configured" and re-showing the onboarding gate.
-          const detectedFromUser = await detectEngineFromUserSecrets();
+          const detectedFromUser = await runWithRequestContext(
+            { userEmail },
+            () => detectEngineFromUserSecrets(),
+          );
           if (detectedFromUser) {
             return {
               configured: true,

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -647,8 +647,8 @@ ${
       </div>
       <div class="verification-panel">
         <p class="verification-kicker">Verification email sent</p>
-        <p class="verification-copy">We sent a secure link to <strong id="verify-email"></strong>. When you click it, this app will finish signing you in automatically.</p>
-        <p class="verification-note">You can keep this tab open. After verifying, use Continue if the app has not refreshed yet.</p>
+        <p class="verification-copy">We sent a secure link to <strong id="verify-email"></strong>. Click it, return here, and this app will finish signing you in automatically.</p>
+        <p class="verification-note">You can keep this tab open. If it has not refreshed after you come back, use Continue.</p>
       </div>
       <button type="button" class="btn-primary" id="verify-continue">Continue</button>
       <div class="inline-actions">
@@ -733,6 +733,8 @@ ${
     var subtitles = { signup: 'Create an account to get started', login: 'Sign in to your account' };
     var headings = { signup: 'Welcome', login: 'Welcome back' };
     var pendingSignupEmail = '';
+    var pendingSignupPassword = '';
+    var verificationCheckInFlight = false;
     function setActiveTab(name, opts) {
       if (name !== 'signup' && name !== 'login') return;
       var form = document.getElementById(name + '-form');
@@ -752,8 +754,9 @@ ${
         try { localStorage.setItem(TAB_STORAGE_KEY, name); } catch (e) {}
       }
     }
-    function showVerificationStep(email) {
+    function showVerificationStep(email, password) {
       pendingSignupEmail = email || '';
+      pendingSignupPassword = password || '';
       tabs.forEach(function(x) { x.classList.remove('active'); });
       forms.forEach(function(x) { x.classList.remove('active'); });
       var card = document.querySelector('.card');
@@ -780,9 +783,67 @@ ${
       }
       return document.getElementById('l-msg') || document.getElementById('verify-msg');
     }
-    async function checkVerificationSession(fallbackText) {
-      var msg = getVerificationMessageNode();
+    function isVerificationStepActive() {
+      var verifyStep = document.getElementById('verification-step');
+      return !!(verifyStep && verifyStep.classList.contains('active'));
+    }
+    function getPendingSignupEmail() {
+      var signupEmail = document.getElementById('s-email');
+      var loginEmail = document.getElementById('l-email');
+      return (pendingSignupEmail || (signupEmail && signupEmail.value) || (loginEmail && loginEmail.value) || '').trim();
+    }
+    function getPendingSignupPassword() {
+      var signupPassword = document.getElementById('s-pass');
+      return pendingSignupPassword || (signupPassword && signupPassword.value) || '';
+    }
+    function movePendingSignupToLogin(message) {
+      var email = getPendingSignupEmail();
+      setActiveTab('login', { persist: true });
+      var loginEmail = document.getElementById('l-email');
+      var loginPassword = document.getElementById('l-pass');
+      var msg = document.getElementById('l-msg');
+      if (loginEmail && email) loginEmail.value = email;
       if (msg) {
+        msg.textContent = message || 'Sign in to continue.';
+        msg.classList.remove('error');
+        msg.classList.add('show', 'success');
+      }
+      setTimeout(function() { if (loginPassword) loginPassword.focus(); }, 0);
+    }
+    async function signInWithPendingSignup() {
+      var email = getPendingSignupEmail();
+      var password = getPendingSignupPassword();
+      if (!email || !password) {
+        return { ok: false, needsManualSignIn: true };
+      }
+      var res = await fetch(__anPath('/_agent-native/auth/login'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email, password: password }),
+      });
+      if (res.ok) {
+        window.location.reload();
+        return { ok: true };
+      }
+      var data = await res.json().catch(function() { return {}; });
+      var error = (data && (data.error || data.message)) || 'Could not finish sign-in automatically.';
+      return {
+        ok: false,
+        error: error,
+        isWaitingForVerification: /not verified|verification/i.test(error),
+      };
+    }
+    async function checkVerificationSession(fallbackText, opts) {
+      opts = opts || {};
+      if (verificationCheckInFlight) return;
+      verificationCheckInFlight = true;
+      var msg = getVerificationMessageNode();
+      var continueBtn = document.getElementById('verify-continue');
+      if (continueBtn && !opts.silent) {
+        continueBtn.disabled = true;
+        continueBtn.textContent = 'Checking...';
+      }
+      if (msg && !opts.silent) {
         msg.textContent = 'Checking your verification...';
         msg.classList.remove('error');
         msg.classList.add('show', 'success');
@@ -796,18 +857,42 @@ ${
           window.location.reload();
           return;
         }
-        if (msg) {
+        var loginResult = await signInWithPendingSignup();
+        if (loginResult.ok) return;
+        if (loginResult.needsManualSignIn) {
+          if (!opts.silent) {
+            movePendingSignupToLogin(fallbackText || 'Enter your password after verifying your email.');
+          }
+          return;
+        }
+        if (loginResult.error && !loginResult.isWaitingForVerification) {
+          if (!opts.silent) {
+            movePendingSignupToLogin('We could not finish sign-in automatically. Sign in to continue.');
+          }
+          return;
+        }
+        if (msg && !opts.silent) {
           msg.textContent = fallbackText || 'Still waiting on verification. Click the link in your email, then try Continue again.';
           msg.classList.remove('success');
           msg.classList.add('show', 'error');
         }
       } catch (err) {
-        if (msg) {
+        if (msg && !opts.silent) {
           msg.textContent = 'Could not check verification. Please try again.';
           msg.classList.remove('success');
           msg.classList.add('show', 'error');
         }
+      } finally {
+        verificationCheckInFlight = false;
+        if (continueBtn && !opts.silent) {
+          continueBtn.disabled = false;
+          continueBtn.textContent = 'Continue';
+        }
       }
+    }
+    function maybeCompleteVerificationAfterReturn() {
+      if (!isVerificationStepActive()) return;
+      checkVerificationSession(null, { silent: true });
     }
     async function resendVerificationEmail() {
       var btn = document.getElementById('resend-verification');
@@ -941,7 +1026,7 @@ ${
         }
           btn.disabled = false;
           btn.textContent = originalLabel;
-          showVerificationStep(email);
+          showVerificationStep(email, pass);
           return;
         }
       msg.textContent = data.error || 'Registration failed';
@@ -960,6 +1045,10 @@ ${
     if (verifyContinue) verifyContinue.addEventListener('click', function(e) {
       e.preventDefault();
       checkVerificationSession();
+    });
+    window.addEventListener('focus', maybeCompleteVerificationAfterReturn);
+    document.addEventListener('visibilitychange', function() {
+      if (document.visibilityState === 'visible') maybeCompleteVerificationAfterReturn();
     });
     var resendBtn = document.getElementById('resend-verification');
     if (resendBtn) resendBtn.addEventListener('click', function(e) {

--- a/packages/dispatch/package.json
+++ b/packages/dispatch/package.json
@@ -24,7 +24,8 @@
     "./server": "./dist/server/index.js",
     "./actions": "./dist/actions/index.js",
     "./db": "./dist/db/index.js",
-    "./components": "./dist/components/index.js"
+    "./components": "./dist/components/index.js",
+    "./styles/dispatch.css": "./src/styles/dispatch.css"
   },
   "files": [
     "dist",

--- a/packages/dispatch/src/components/layout/Header.tsx
+++ b/packages/dispatch/src/components/layout/Header.tsx
@@ -44,7 +44,7 @@ export function Header({
         <Button
           variant="ghost"
           size="icon"
-          className="h-8 w-8 2xl:hidden cursor-pointer"
+          className="h-8 w-8 lg:hidden cursor-pointer"
           onClick={onOpenMobile}
           aria-label="Open navigation"
         >

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -327,8 +327,6 @@ export function Layout({
 }) {
   const location = useLocation();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const hasEmbeddedAgentChat =
-    location.pathname === "/" || location.pathname === "/overview";
 
   if (CHROMELESS_PATHS.some((path) => location.pathname === path)) {
     return <>{children}</>;
@@ -337,12 +335,7 @@ export function Layout({
   const showHeader = !pageOwnsToolbar(location.pathname);
   const appContent = (
     <div className="flex h-full flex-1 flex-col overflow-hidden">
-      {showHeader ? (
-        <Header
-          onOpenMobile={() => setMobileOpen(true)}
-          showAgentToggle={!hasEmbeddedAgentChat}
-        />
-      ) : null}
+      {showHeader ? <Header onOpenMobile={() => setMobileOpen(true)} /> : null}
       <InvitationBanner />
       <main className="flex-1 overflow-y-auto">
         {showHeader ? (
@@ -359,7 +352,7 @@ export function Layout({
   return (
     <HeaderActionsProvider>
       <div className="flex h-screen w-full overflow-hidden bg-background">
-        <aside className="hidden 2xl:flex w-64 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
+        <aside className="hidden lg:flex w-64 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground">
           <NavContent extensions={extensions} />
         </aside>
 
@@ -383,8 +376,7 @@ export function Layout({
 
         {/*
          * Always mount AgentSidebar so home composer's sendToAgentChat
-         * fallback can pop it via agent-panel:open. The toggle button stays
-         * hidden on overview because the home composer is the primary input.
+         * fallback can pop it via agent-panel:open.
          */}
         <AgentSidebar
           position="right"

--- a/packages/dispatch/src/components/ui/sidebar.tsx
+++ b/packages/dispatch/src/components/ui/sidebar.tsx
@@ -307,24 +307,28 @@ const SidebarRail = React.forwardRef<
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
-      ref={ref}
-      data-sidebar="rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      {...props}
-    />
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          ref={ref}
+          data-sidebar="rail"
+          aria-label="Toggle Sidebar"
+          tabIndex={-1}
+          onClick={toggleSidebar}
+          className={cn(
+            "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+            "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+            "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+            "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
+            "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+            "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+            className,
+          )}
+          {...props}
+        />
+      </TooltipTrigger>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
+    </Tooltip>
   );
 });
 SidebarRail.displayName = "SidebarRail";

--- a/packages/dispatch/src/styles/dispatch-css.spec.ts
+++ b/packages/dispatch/src/styles/dispatch-css.spec.ts
@@ -39,3 +39,17 @@ describe("dispatch Tailwind styles", () => {
     );
   });
 });
+
+describe("dispatch route shells", () => {
+  it("re-exports the index route redirects from the Dispatch template", () => {
+    const indexRoute = fs.readFileSync(
+      path.join(repoRoot, "templates/dispatch/app/routes/_index.tsx"),
+      "utf-8",
+    );
+
+    expect(indexRoute).toContain("loader");
+    expect(indexRoute).toContain("clientLoader");
+    expect(indexRoute).toContain("HydrateFallback");
+    expect(indexRoute).toContain("@agent-native/dispatch/routes/pages/_index");
+  });
+});

--- a/packages/dispatch/src/styles/dispatch-css.spec.ts
+++ b/packages/dispatch/src/styles/dispatch-css.spec.ts
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const repoRoot = path.resolve(packageRoot, "../..");
+
+describe("dispatch Tailwind styles", () => {
+  it("exports package source directives for consuming apps", () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(packageRoot, "package.json"), "utf-8"),
+    ) as { exports?: Record<string, string> };
+    const stylesheet = fs.readFileSync(
+      path.join(packageRoot, "src/styles/dispatch.css"),
+      "utf-8",
+    );
+
+    expect(pkg.exports?.["./styles/dispatch.css"]).toBe(
+      "./src/styles/dispatch.css",
+    );
+    expect(stylesheet).toContain(
+      '@source "../components/**/*.{js,mjs,ts,tsx}"',
+    );
+    expect(stylesheet).toContain('@source "../routes/**/*.{js,mjs,ts,tsx}"');
+  });
+
+  it("imports package source directives from the Dispatch template", () => {
+    const globalCss = fs.readFileSync(
+      path.join(repoRoot, "templates/dispatch/app/global.css"),
+      "utf-8",
+    );
+
+    expect(globalCss).toContain(
+      '@import "@agent-native/dispatch/styles/dispatch.css";',
+    );
+  });
+});

--- a/packages/dispatch/src/styles/dispatch.css
+++ b/packages/dispatch/src/styles/dispatch.css
@@ -1,0 +1,9 @@
+/*
+ * Tailwind v4 does not scan package sources in node_modules unless the
+ * consuming app opts in. Import this stylesheet from a Dispatch app's global
+ * CSS so Tailwind includes the utilities used by packaged Dispatch routes and
+ * components.
+ */
+@source "../components/**/*.{js,mjs,ts,tsx}";
+@source "../hooks/**/*.{js,mjs,ts,tsx}";
+@source "../routes/**/*.{js,mjs,ts,tsx}";

--- a/packages/docs/app/routes/download.tsx
+++ b/packages/docs/app/routes/download.tsx
@@ -1,81 +1,95 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { appBasePath } from "@agent-native/core/client";
 import { trackEvent } from "../components/TemplateCard";
-import { IconBrandGithub, IconDownload } from "@tabler/icons-react";
+import {
+  IconBrandApple,
+  IconBrandGithub,
+  IconBrandWindows,
+  IconDownload,
+  IconTerminal2,
+} from "@tabler/icons-react";
 
-const DL = "https://github.com/BuilderIO/agent-native/releases/latest/download";
-const RELEASES = "https://github.com/BuilderIO/agent-native/releases";
-
-function AppleIcon() {
-  return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-      <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701" />
-    </svg>
-  );
-}
-
-function WindowsIcon() {
-  return (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-      <path d="M0,0H11.377V11.372H0ZM12.623,0H24V11.372H12.623ZM0,12.623H11.377V24H0Zm12.623,0H24V24H12.623" />
-    </svg>
-  );
-}
-
-function LinuxIcon() {
-  return (
-    <svg width="24" height="24" viewBox="0 0 448 512" fill="currentColor">
-      <path d="M220.8 123.3c1 .5 1.8 1.7 3 1.7 1.1 0 2.8-.4 2.9-1.5.2-1.4-1.9-2.3-3.2-2.9-1.7-.7-3.9-1-5.5-.1-.4.2-.8.7-.6 1.1.3 1.3 2.3 1.1 3.4 1.7zm-21.9 1.7c1.2 0 2-1.2 3-1.7 1.1-.6 3.1-.4 3.5-1.6.2-.4-.2-.9-.6-1.1-1.6-.9-3.8-.6-5.5.1-1.3.6-3.4 1.5-3.2 2.9.1 1 1.8 1.5 2.8 1.4zM420 403.8c-3.6-4-5.3-11.6-7.2-19.7-1.8-8.1-3.9-16.8-10.5-22.4-1.3-1.1-2.6-2.1-4-2.9-1.3-.8-2.7-1.5-4.1-2 9.2-27.3 5.6-54.5-3.7-79.1-11.4-30.1-31.3-56.4-46.5-74.4-17.1-21.5-33.7-41.9-33.4-72C311.1 85.4 315.7.1 234.8 0 132.4-.2 158 103.4 156.9 135.2c-1.7 23.4-6.4 41.8-22.5 64.7-18.9 22.5-45.5 58.8-58.1 96.7-6 17.9-8.8 36.1-6.2 53.3-6.5 5.8-11.4 14.7-16.6 20.2-4.2 4.3-10.3 5.9-17 8.3s-14 6-18.5 14.5c-2.1 3.9-2.8 8.1-2.8 12.4 0 3.9.6 7.9 1.2 11.8 1.2 8.1 2.5 15.7.8 20.8-5.2 14.4-5.9 24.4-2.2 31.7 3.8 7.3 11.4 10.5 20.1 12.3 17.3 3.6 40.8 2.7 59.3 12.5 19.8 10.4 39.9 14.1 55.9 10.4 11.6-2.6 21.1-9.6 25.9-20.2 12.5-.1 26.3-5.4 48.3-6.6 14.9-1.2 33.6 5.3 55.1 4.1.6 2.3 1.4 4.6 2.5 6.7v.1c8.3 16.7 23.8 24.3 40.3 23 16.6-1.3 34.1-11 48.3-27.9 13.6-16.4 36-23.2 50.9-32.2 7.4-4.5 13.4-10.1 13.9-18.3.4-8.2-4.4-17.3-15.5-29.7zM223.7 87.3c9.8-22.2 34.2-21.8 44-.4 6.5 14.2 3.6 30.9-4.3 40.4-1.6-.8-5.9-2.6-12.6-4.9 1.1-1.2 3.1-2.7 3.9-4.6 4.8-11.8-.2-27-9.1-27.3-7.3-.5-13.9 10.8-11.8 23-4.1-2-9.4-3.5-13-4.4-1-6.9-.3-14.6 2.9-21.8zM183 75.8c10.1 0 20.8 14.2 19.1 33.5-3.5 1-7.1 2.5-10.2 4.6 1.2-8.9-3.3-20.1-9.6-19.6-8.4.7-9.8 21.2-1.8 28.1 1 .8 1.9-.2-5.9 5.5-15.6-14.6-10.5-52.1 8.4-52.1zm-13.6 60.7c6.2-4.6 13.6-10 14.1-10.5 4.7-4.4 13.5-14.2 27.9-14.2 7.1 0 15.6 2.3 25.9 8.9 6.3 4.1 11.3 4.4 22.6 9.3 8.4 3.5 13.7 9.7 10.5 18.2-2.6 7.1-11 14.4-22.7 18.1-11.1 3.6-19.8 16-38.2 14.9-3.9-.2-7-1-9.6-2.1-8-3.5-12.2-10.4-20-15-8.6-4.8-13.2-10.4-14.7-15.3-1.4-4.9 0-9 4.2-12.3zm3.3 334c-2.7 35.1-43.9 34.4-75.3 18-29.9-15.8-68.6-6.5-76.5-21.9-2.4-4.7-2.4-12.7 2.6-26.4v-.2c2.4-7.6.6-16-.6-23.9-1.2-7.8-1.8-15 .9-20 3.5-6.7 8.5-9.1 14.8-11.3 10.3-3.7 11.8-3.4 19.6-9.9 5.5-5.7 9.5-12.9 14.3-18 5.1-5.5 10-8.1 17.7-6.9 8.1 1.2 15.1 6.8 21.9 16l19.6 35.6c9.5 19.9 43.1 48.4 41 68.9zm-1.4-25.9c-4.1-6.6-9.6-13.6-14.4-19.6 7.1 0 14.2-2.2 16.7-8.9 2.3-6.2 0-14.9-7.4-24.9-13.5-18.2-38.3-32.5-38.3-32.5-13.5-8.4-21.1-18.7-24.6-29.9s-3-23.3-.3-35.2c5.2-22.9 18.6-45.2 27.2-59.2 2.3-1.7.8 3.2-8.7 20.8-8.5 16.1-24.4 53.3-2.6 82.4.6-20.7 5.5-41.8 13.8-61.5 12-27.4 37.3-74.9 39.3-112.7 1.1.8 4.6 3.2 6.2 4.1 4.6 2.7 8.1 6.7 12.6 10.3 12.4 10 28.5 9.2 42.4 1.2 6.2-3.5 11.2-7.5 15.9-9 9.9-3.1 17.8-8.6 22.3-15 7.7 30.4 25.7 74.3 37.2 95.7 6.1 11.4 18.3 35.5 23.6 64.6 3.3-.1 7 .4 10.9 1.4 13.8-35.7-11.7-74.2-23.3-84.9-4.7-4.6-4.9-6.6-2.6-6.5 12.6 11.2 29.2 33.7 35.2 59 2.8 11.6 3.3 23.7.4 35.7 16.4 6.8 35.9 17.9 30.7 34.8-2.2-.1-3.2 0-4.2 0 3.2-10.1-3.9-17.6-22.8-26.1-19.6-8.6-36-8.6-38.3 12.5-12.1 4.2-18.3 14.7-21.4 27.3-2.8 11.2-3.6 24.7-4.4 39.9-.5 7.7-3.6 18-6.8 29-32.1 22.9-76.7 32.9-114.3 7.2zm257.4-11.5c-.9 16.8-41.2 19.9-63.2 46.5-13.2 15.7-29.4 24.4-43.6 25.5s-26.5-4.8-33.7-19.3c-4.7-11.1-2.4-23.1 1.1-36.3 3.7-14.2 9.2-28.8 9.9-40.6.8-15.2 1.7-28.5 4.2-38.7 2.6-10.3 6.6-17.2 13.7-21.1.3-.2.7-.3 1-.5.8 13.2 7.3 26.6 18.8 29.5 12.6 3.3 30.7-7.5 38.4-16.3 9-.3 15.7-.9 22.6 5.1 9.9 8.5 7.1 30.3 17.1 41.6 10.6 11.6 14 19.5 13.7 24.6zM173.3 148.7c2 1.9 4.7 4.5 8 7.1 6.6 5.2 15.8 10.6 27.3 10.6 11.6 0 22.5-5.9 31.8-10.8 4.9-2.6 10.9-7 14.8-10.4s5.9-6.3 3.1-6.6-2.6 2.6-6 5.1c-4.4 3.2-9.7 7.4-13.9 9.8-7.4 4.2-19.5 10.2-29.9 10.2s-18.7-4.8-24.9-9.7c-3.1-2.5-5.7-5-7.7-6.9-1.5-1.4-1.9-4.6-4.3-4.9-1.4-.1-1.8 3.7 1.7 6.5z" />
-    </svg>
-  );
-}
+const LATEST_JSON_URL = `${appBasePath()}/api/desktop-latest.json`;
+const RELEASES =
+  "https://github.com/BuilderIO/agent-native/releases?q=Agent-Native";
 
 type Platform = "mac" | "windows" | "linux";
+type DesktopAssetKind =
+  | "mac-arm64"
+  | "mac-x64"
+  | "windows-x64"
+  | "windows-arm64"
+  | "linux-appimage-x64"
+  | "linux-appimage-arm64"
+  | "linux-deb-x64"
+  | "linux-deb-arm64";
+
+interface DownloadOption {
+  label: string;
+  assetKinds: readonly DesktopAssetKind[];
+}
 
 interface PlatformInfo {
   name: string;
-  icon: React.ReactNode;
-  primary: { label: string; href: string };
-  secondary?: { label: string; href: string };
+  icon: typeof IconBrandApple;
+  primary: DownloadOption;
+  secondary?: DownloadOption;
   note: string;
 }
 
 const PLATFORMS: Record<Platform, PlatformInfo> = {
   mac: {
     name: "macOS",
-    icon: <AppleIcon />,
+    icon: IconBrandApple,
     primary: {
-      label: "View Mac releases",
-      href: RELEASES,
+      label: "Download for Apple Silicon",
+      assetKinds: ["mac-arm64"],
     },
-    note: "The latest Agent Native release does not currently include a macOS installer.",
+    secondary: {
+      label: "Intel Mac",
+      assetKinds: ["mac-x64"],
+    },
+    note: "Signed and notarized macOS installers are available from the latest desktop release.",
   },
   windows: {
     name: "Windows",
-    icon: <WindowsIcon />,
+    icon: IconBrandWindows,
     primary: {
       label: "Download for Windows",
-      href: `${DL}/Agent-Native-x64.exe`,
+      assetKinds: ["windows-x64"],
     },
     secondary: {
       label: "ARM64",
-      href: `${DL}/Agent-Native-arm64.exe`,
+      assetKinds: ["windows-arm64"],
     },
     note: "Windows 10 or later.",
   },
   linux: {
     name: "Linux",
-    icon: <LinuxIcon />,
+    icon: IconTerminal2,
     primary: {
       label: "Download AppImage",
-      href: `${DL}/Agent-Native-x86_64.AppImage`,
+      assetKinds: ["linux-appimage-x64", "linux-appimage-arm64"],
     },
     secondary: {
       label: "Download .deb",
-      href: `${DL}/Agent-Native-amd64.deb`,
+      assetKinds: ["linux-deb-x64", "linux-deb-arm64"],
     },
-    note: "x64 — ARM64 also available on GitHub.",
+    note: "x64 and ARM64 builds are published when available.",
   },
 };
+
+interface Manifest {
+  version: string;
+  tag: string;
+  pub_date: string | null;
+  assets: {
+    name: string;
+    url: string;
+    size: number;
+    kind: string;
+  }[];
+}
 
 function detectPlatform(): Platform {
   if (typeof navigator === "undefined") return "mac";
@@ -85,14 +99,55 @@ function detectPlatform(): Platform {
   return "mac";
 }
 
+function pickAsset(manifest: Manifest | null, option: DownloadOption) {
+  if (!manifest) return null;
+  for (const kind of option.assetKinds) {
+    const asset = manifest.assets.find((a) => a.kind === kind);
+    if (asset) return asset;
+  }
+  return null;
+}
+
 export default function DownloadPage() {
   const [platform, setPlatform] = useState<Platform>("mac");
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [manifestError, setManifestError] = useState(false);
 
   useEffect(() => {
     setPlatform(detectPlatform());
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    fetch(LATEST_JSON_URL)
+      .then((response) =>
+        response.ok ? response.json() : Promise.reject(new Error("failed")),
+      )
+      .then((json) => {
+        if (!cancelled) setManifest(json as Manifest);
+      })
+      .catch(() => {
+        if (!cancelled) setManifestError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const info = PLATFORMS[platform];
+  const primaryAsset = useMemo(
+    () => pickAsset(manifest, info.primary),
+    [manifest, info.primary],
+  );
+  const secondaryAsset = useMemo(
+    () => (info.secondary ? pickAsset(manifest, info.secondary) : null),
+    [manifest, info.secondary],
+  );
+  const releaseStatus = manifest
+    ? `Latest desktop release: ${manifest.version}`
+    : manifestError
+      ? "Could not load the latest desktop release. The releases page has all installers."
+      : "Checking the latest desktop release...";
 
   function handleDownload(label: string) {
     trackEvent("desktop download", { platform, label });
@@ -114,20 +169,21 @@ export default function DownloadPage() {
       <div className="mb-2 flex justify-center gap-2">
         {(Object.keys(PLATFORMS) as Platform[]).map((p) => {
           const plt = PLATFORMS[p];
+          const Icon = plt.icon;
           const active = platform === p;
           return (
             <button
               key={p}
               onClick={() => setPlatform(p)}
               aria-label={plt.name}
-              title={plt.name}
               className={`group flex items-center justify-center rounded-lg p-4 ${
                 active
                   ? "text-[var(--fg)]"
                   : "text-[var(--fg-secondary)] opacity-40 hover:opacity-65"
               }`}
             >
-              {plt.icon}
+              <Icon size={24} />
+              <span className="sr-only">{plt.name}</span>
             </button>
           );
         })}
@@ -135,19 +191,29 @@ export default function DownloadPage() {
 
       {/* Download section */}
       <div className="mx-auto mt-8 max-w-2xl text-center">
-        <a
-          href={info.primary.href}
-          onClick={() => handleDownload(info.primary.label)}
-          className="inline-flex items-center gap-2.5 rounded-lg bg-[var(--fg)] px-8 py-3.5 text-base font-medium text-[var(--bg)] no-underline hover:opacity-85 hover:no-underline"
-        >
-          <IconDownload size={18} />
-          {info.primary.label}
-        </a>
+        {primaryAsset || manifestError ? (
+          <a
+            href={primaryAsset?.url ?? RELEASES}
+            onClick={() => handleDownload(info.primary.label)}
+            className="inline-flex items-center gap-2.5 rounded-lg bg-[var(--fg)] px-8 py-3.5 text-base font-medium text-[var(--bg)] no-underline hover:opacity-85 hover:no-underline"
+          >
+            <IconDownload size={18} />
+            {info.primary.label}
+          </a>
+        ) : (
+          <button
+            disabled
+            className="inline-flex items-center gap-2.5 rounded-lg bg-[var(--fg)] px-8 py-3.5 text-base font-medium text-[var(--bg)] opacity-60"
+          >
+            <IconDownload size={18} />
+            Loading latest release...
+          </button>
+        )}
 
         {info.secondary && (
           <div className="mt-3">
             <a
-              href={info.secondary.href}
+              href={secondaryAsset?.url ?? RELEASES}
               onClick={() => handleDownload(info.secondary!.label)}
               className="text-sm text-[var(--fg-secondary)] no-underline hover:text-[var(--fg)] hover:underline"
             >
@@ -156,7 +222,10 @@ export default function DownloadPage() {
           </div>
         )}
 
-        <p className="mt-4 text-xs text-[var(--fg-secondary)]">{info.note}</p>
+        <p className="mt-4 text-xs text-[var(--fg-secondary)]">
+          {releaseStatus}
+          <span className="block mt-1">{info.note}</span>
+        </p>
       </div>
 
       {/* What's included */}

--- a/packages/docs/public/sitemap.xml
+++ b/packages/docs/public/sitemap.xml
@@ -86,6 +86,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://agent-native.com/docs/extensions</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://agent-native.com/docs/faq</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
@@ -176,6 +181,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://agent-native.com/docs/sharing</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://agent-native.com/docs/skills-guide</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
@@ -232,11 +242,6 @@
   </url>
   <url>
     <loc>https://agent-native.com/docs/template-video</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://agent-native.com/docs/tools</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/packages/docs/server/routes/api/desktop-latest.json.get.ts
+++ b/packages/docs/server/routes/api/desktop-latest.json.get.ts
@@ -1,0 +1,204 @@
+import { createError, defineEventHandler, setResponseHeaders } from "h3";
+
+const RELEASES_URL_BASE =
+  "https://api.github.com/repos/BuilderIO/agent-native/releases";
+const PER_PAGE = 100;
+const MAX_PAGES = 10;
+const CACHE_TTL_MS = 5 * 60_000;
+
+interface GhAsset {
+  name: string;
+  browser_download_url: string;
+  size: number;
+}
+
+interface GhRelease {
+  tag_name: string;
+  name: string;
+  published_at: string;
+  draft: boolean;
+  prerelease: boolean;
+  assets: GhAsset[];
+  body?: string;
+}
+
+type DesktopAssetKind =
+  | "mac-arm64"
+  | "mac-x64"
+  | "windows-x64"
+  | "windows-arm64"
+  | "linux-appimage-x64"
+  | "linux-appimage-arm64"
+  | "linux-deb-x64"
+  | "linux-deb-arm64"
+  | "unknown";
+
+export interface DesktopDownloadManifest {
+  version: string;
+  tag: string;
+  pub_date: string | null;
+  notes?: string;
+  assets: {
+    name: string;
+    url: string;
+    size: number;
+    kind: DesktopAssetKind;
+  }[];
+}
+
+let cache: { data: DesktopDownloadManifest; ts: number } | null = null;
+let inFlight: Promise<DesktopDownloadManifest> | null = null;
+
+class UpstreamError extends Error {
+  statusCode: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.statusCode = status;
+  }
+}
+
+function isAgentNativeAsset(name: string): boolean {
+  const n = name.toLowerCase();
+  return n.startsWith("agent-native-") || n.startsWith("agent native-");
+}
+
+export function classifyDesktopAsset(name: string): DesktopAssetKind {
+  if (!isAgentNativeAsset(name)) return "unknown";
+  const n = name.toLowerCase();
+  if (n.endsWith(".dmg")) {
+    if (n.includes("arm64") || n.includes("aarch64")) return "mac-arm64";
+    if (n.includes("x64") || n.includes("x86_64") || n.includes("amd64")) {
+      return "mac-x64";
+    }
+  }
+  if (n.endsWith(".exe")) {
+    return n.includes("arm64") || n.includes("aarch64")
+      ? "windows-arm64"
+      : "windows-x64";
+  }
+  if (n.endsWith(".appimage")) {
+    return n.includes("arm64") || n.includes("aarch64")
+      ? "linux-appimage-arm64"
+      : "linux-appimage-x64";
+  }
+  if (n.endsWith(".deb")) {
+    return n.includes("arm64") || n.includes("aarch64")
+      ? "linux-deb-arm64"
+      : "linux-deb-x64";
+  }
+  return "unknown";
+}
+
+async function fetchPage(page: number): Promise<GhRelease[]> {
+  const res = await fetch(
+    `${RELEASES_URL_BASE}?per_page=${PER_PAGE}&page=${page}`,
+    {
+      headers: {
+        accept: "application/vnd.github+json",
+        "user-agent": "agent-native-docs-download-page",
+      },
+      signal: AbortSignal.timeout(10_000),
+    },
+  );
+  if (!res.ok) {
+    throw new UpstreamError(
+      res.status,
+      `Upstream releases fetch failed (${res.status})`,
+    );
+  }
+  return (await res.json()) as GhRelease[];
+}
+
+function hasDesktopAssets(release: GhRelease): boolean {
+  return release.assets.some(
+    (asset) => classifyDesktopAsset(asset.name) !== "unknown",
+  );
+}
+
+async function findLatestDesktopRelease(): Promise<GhRelease | null> {
+  let best: GhRelease | null = null;
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const batch = await fetchPage(page);
+    if (batch.length === 0) break;
+    for (const release of batch) {
+      if (release.draft || release.prerelease) continue;
+      if (!hasDesktopAssets(release)) continue;
+      if (
+        !best ||
+        new Date(release.published_at).getTime() >
+          new Date(best.published_at).getTime()
+      ) {
+        best = release;
+      }
+    }
+    if (batch.length < PER_PAGE) break;
+  }
+  return best;
+}
+
+async function buildManifest(): Promise<DesktopDownloadManifest> {
+  const latest = await findLatestDesktopRelease();
+  if (!latest) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "No published desktop release found",
+    });
+  }
+
+  return {
+    version: latest.tag_name.replace(/^v/, ""),
+    tag: latest.tag_name,
+    pub_date: latest.published_at,
+    notes: latest.body,
+    assets: latest.assets.map((asset) => ({
+      name: asset.name,
+      url: asset.browser_download_url,
+      size: asset.size,
+      kind: classifyDesktopAsset(asset.name),
+    })),
+  };
+}
+
+async function getManifest(): Promise<DesktopDownloadManifest> {
+  const now = Date.now();
+  if (cache && now - cache.ts < CACHE_TTL_MS) return cache.data;
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const data = await buildManifest();
+      cache = { data, ts: Date.now() };
+      return data;
+    } catch (error) {
+      if (cache) return cache.data;
+      throw error;
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
+}
+
+export default defineEventHandler(async (event) => {
+  let manifest: DesktopDownloadManifest;
+  try {
+    manifest = await getManifest();
+  } catch (error) {
+    const e = error as {
+      statusCode?: number;
+      statusMessage?: string;
+      message?: string;
+    };
+    throw createError({
+      statusCode: typeof e.statusCode === "number" ? e.statusCode : 502,
+      statusMessage:
+        e.statusMessage ?? e.message ?? "Upstream releases fetch failed",
+    });
+  }
+
+  setResponseHeaders(event, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "public, max-age=60",
+  });
+  return manifest;
+});

--- a/packages/docs/server/routes/api/desktop-latest.spec.ts
+++ b/packages/docs/server/routes/api/desktop-latest.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { classifyDesktopAsset } from "./desktop-latest.json.get";
+
+describe("classifyDesktopAsset", () => {
+  it("recognizes Agent Native desktop installers", () => {
+    expect(classifyDesktopAsset("Agent-Native-arm64.dmg")).toBe("mac-arm64");
+    expect(classifyDesktopAsset("Agent Native-x64.dmg")).toBe("mac-x64");
+    expect(classifyDesktopAsset("Agent-Native-x64.exe")).toBe("windows-x64");
+    expect(classifyDesktopAsset("Agent-Native-arm64.exe")).toBe(
+      "windows-arm64",
+    );
+    expect(classifyDesktopAsset("Agent-Native-x86_64.AppImage")).toBe(
+      "linux-appimage-x64",
+    );
+    expect(classifyDesktopAsset("Agent-Native-arm64.deb")).toBe(
+      "linux-deb-arm64",
+    );
+  });
+
+  it("ignores package releases and update metadata", () => {
+    expect(classifyDesktopAsset("agent-native-core-0.8.2.tgz")).toBe("unknown");
+    expect(classifyDesktopAsset("latest-mac.yml")).toBe("unknown");
+  });
+});

--- a/templates/analytics/app/components/dashboard/SqlChart.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tsx
@@ -1,4 +1,11 @@
-import { useMemo, useState, type CSSProperties, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import {
   Area,
   AreaChart,
@@ -28,7 +35,6 @@ import {
   IconInfoCircle,
   IconTrendingUp,
   IconTrendingDown,
-  IconDownload,
 } from "@tabler/icons-react";
 import {
   Select,
@@ -169,9 +175,14 @@ interface SqlChartProps {
   /** SQL with dashboard variables already interpolated. Falls back to panel.sql. */
   resolvedSql?: string;
   className?: string;
+  onExportCsvChange?: (handler: (() => void) | null) => void;
 }
 
-export function SqlChart({ panel, resolvedSql }: SqlChartProps) {
+export function SqlChart({
+  panel,
+  resolvedSql,
+  onExportCsvChange,
+}: SqlChartProps) {
   // Section panels are pure layout — no query, no chart. Render a header with
   // optional description and skip the SQL pipeline entirely.
   if (panel.chartType === "section") {
@@ -243,7 +254,13 @@ export function SqlChart({ panel, resolvedSql }: SqlChartProps) {
   }
 
   if (chartType === "table") {
-    return <TableRenderer rows={rows} panel={panel} />;
+    return (
+      <TableRenderer
+        rows={rows}
+        panel={panel}
+        onExportCsvChange={onExportCsvChange}
+      />
+    );
   }
 
   if (chartType === "pie") {
@@ -389,9 +406,11 @@ function renderDeltaCell(value: unknown): ReactNode {
 function TableRenderer({
   rows,
   panel,
+  onExportCsvChange,
 }: {
   rows: Record<string, unknown>[];
   panel: SqlPanel;
+  onExportCsvChange?: (handler: (() => void) | null) => void;
 }) {
   const config = panel.config;
   const sortable = config?.sortable !== false; // default on
@@ -448,7 +467,7 @@ function TableRenderer({
     setPage(0);
   };
 
-  const handleExportCsv = () => {
+  const handleExportCsv = useCallback(() => {
     const headers = columns.map((col) => col.label ?? col.key);
     const rowsCsv = sortedRows.map((row) =>
       columns.map((col) => formatCell(row[col.key], col.format)).map(csvEscape),
@@ -467,20 +486,16 @@ function TableRenderer({
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-  };
+  }, [columns, panel.id, sortedRows]);
+
+  useEffect(() => {
+    onExportCsvChange?.(handleExportCsv);
+    return () => onExportCsvChange?.(null);
+  }, [handleExportCsv, onExportCsvChange]);
 
   return (
     <div className="space-y-1">
       <div className="relative overflow-x-auto">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="absolute right-1 top-1 h-6 w-6 z-10"
-          onClick={handleExportCsv}
-          title="Export CSV"
-        >
-          <IconDownload className="h-3.5 w-3.5" />
-        </Button>
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-border">

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -239,40 +239,52 @@ function SortableRow({
             className="min-w-0 flex-1 bg-transparent px-2 py-1.5 pr-12 text-xs outline-none"
           />
         ) : (
-          <Link
-            to={href}
-            title={name}
-            className="min-w-0 flex-1 px-2 py-1.5 pr-12 text-xs transition-[padding] md:pr-2 md:group-hover/item:pr-12 md:group-focus-within/item:pr-12"
-          >
-            <span className="block truncate">{name}</span>
-          </Link>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Link
+                to={href}
+                className="min-w-0 flex-1 px-2 py-1.5 pr-12 text-xs transition-[padding] md:pr-2 md:group-hover/item:pr-12 md:group-focus-within/item:pr-12"
+              >
+                <span className="block truncate">{name}</span>
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent>{name}</TooltipContent>
+          </Tooltip>
         )}
         <div className="pointer-events-none absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-100 transition-opacity md:opacity-0 md:group-hover/item:opacity-100 md:group-focus-within/item:opacity-100">
-          <button
-            type="button"
-            onClick={() => onToggleFavorite(favoriteKey)}
-            className={cn(
-              "pointer-events-auto rounded p-0.5 transition-colors",
-              isFav
-                ? "text-yellow-500"
-                : "text-muted-foreground/50 hover:text-yellow-500",
-            )}
-            title={isFav ? "Unfavorite" : "Favorite"}
-            aria-label={isFav ? "Unfavorite" : "Favorite"}
-          >
-            <IconStar className={cn("h-3 w-3", isFav && "fill-current")} />
-          </button>
-          <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-            <DropdownMenuTrigger asChild>
+          <Tooltip>
+            <TooltipTrigger asChild>
               <button
                 type="button"
-                className="pointer-events-auto rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-foreground"
-                title={`${name} actions`}
-                aria-label={`${name} actions`}
+                onClick={() => onToggleFavorite(favoriteKey)}
+                className={cn(
+                  "pointer-events-auto rounded p-0.5 transition-colors",
+                  isFav
+                    ? "text-yellow-500"
+                    : "text-muted-foreground/50 hover:text-yellow-500",
+                )}
+                aria-label={isFav ? "Unfavorite" : "Favorite"}
               >
-                <IconDots className="h-3 w-3" />
+                <IconStar className={cn("h-3 w-3", isFav && "fill-current")} />
               </button>
-            </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>{isFav ? "Unfavorite" : "Favorite"}</TooltipContent>
+          </Tooltip>
+          <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="pointer-events-auto rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-foreground"
+                    aria-label={`${name} actions`}
+                  >
+                    <IconDots className="h-3 w-3" />
+                  </button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>{`${name} actions`}</TooltipContent>
+            </Tooltip>
             <DropdownMenuContent side="right" align="start" className="w-36">
               <DropdownMenuItem
                 onSelect={() => {
@@ -403,46 +415,52 @@ function SortableDashboardItem({
                 </Link>
                 {sv.isDynamic && (
                   <>
-                    <button
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        onToggleFavorite(`view:${d.id}:${sv.id}`);
-                      }}
-                      className={cn(
-                        "p-0.5 rounded shrink-0",
-                        favoriteIds.has(`view:${d.id}:${sv.id}`)
-                          ? "text-yellow-500 opacity-100"
-                          : "opacity-0 group-hover/sv:opacity-100 text-muted-foreground/50 hover:text-yellow-500",
-                      )}
-                      title={
-                        favoriteIds.has(`view:${d.id}:${sv.id}`)
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onToggleFavorite(`view:${d.id}:${sv.id}`);
+                          }}
+                          className={cn(
+                            "p-0.5 rounded shrink-0",
+                            favoriteIds.has(`view:${d.id}:${sv.id}`)
+                              ? "text-yellow-500 opacity-100"
+                              : "opacity-0 group-hover/sv:opacity-100 text-muted-foreground/50 hover:text-yellow-500",
+                          )}
+                        >
+                          <IconStar
+                            className={cn(
+                              "h-2.5 w-2.5",
+                              favoriteIds.has(`view:${d.id}:${sv.id}`) &&
+                                "fill-current",
+                            )}
+                          />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {favoriteIds.has(`view:${d.id}:${sv.id}`)
                           ? "Unfavorite"
-                          : "Favorite"
-                      }
-                    >
-                      <IconStar
-                        className={cn(
-                          "h-2.5 w-2.5",
-                          favoriteIds.has(`view:${d.id}:${sv.id}`) &&
-                            "fill-current",
-                        )}
-                      />
-                    </button>
+                          : "Favorite"}
+                      </TooltipContent>
+                    </Tooltip>
                     <Popover
                       open={deletingViewId === sv.id}
                       onOpenChange={(open) =>
                         setDeletingViewId(open ? sv.id : null)
                       }
                     >
-                      <PopoverTrigger asChild>
-                        <button
-                          className="opacity-0 group-hover/sv:opacity-100 p-0.5 rounded text-muted-foreground/50 hover:text-foreground transition-all shrink-0"
-                          title={`Delete ${sv.name}`}
-                        >
-                          <IconTrash className="h-2.5 w-2.5" />
-                        </button>
-                      </PopoverTrigger>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <PopoverTrigger asChild>
+                            <button className="opacity-0 group-hover/sv:opacity-100 p-0.5 rounded text-muted-foreground/50 hover:text-foreground transition-all shrink-0">
+                              <IconTrash className="h-2.5 w-2.5" />
+                            </button>
+                          </PopoverTrigger>
+                        </TooltipTrigger>
+                        <TooltipContent>{`Delete ${sv.name}`}</TooltipContent>
+                      </Tooltip>
                       <PopoverContent
                         className="w-56 p-3"
                         side="right"

--- a/templates/analytics/app/components/ui/sidebar.tsx
+++ b/templates/analytics/app/components/ui/sidebar.tsx
@@ -298,24 +298,28 @@ const SidebarRail = React.forwardRef<
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
-      ref={ref}
-      data-sidebar="rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      {...props}
-    />
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          ref={ref}
+          data-sidebar="rail"
+          aria-label="Toggle Sidebar"
+          tabIndex={-1}
+          onClick={toggleSidebar}
+          className={cn(
+            "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+            "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+            "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+            "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
+            "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+            "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+            className,
+          )}
+          {...props}
+        />
+      </TooltipTrigger>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
+    </Tooltip>
   );
 });
 SidebarRail.displayName = "SidebarRail";

--- a/templates/analytics/app/pages/adhoc/_shared/KpiChart.tsx
+++ b/templates/analytics/app/pages/adhoc/_shared/KpiChart.tsx
@@ -18,6 +18,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { IconCode } from "@tabler/icons-react";
 import { formatDate } from "./format";
+import {
+  Tooltip as ShadcnTooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface KpiChartProps {
   title: string;
@@ -80,15 +85,19 @@ export function KpiChart({
               </span>
             )}
             {onEditSql && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={onEditSql}
-                className="h-7 w-7 p-0"
-                title="Edit SQL Query"
-              >
-                <IconCode className="h-3.5 w-3.5" />
-              </Button>
+              <ShadcnTooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={onEditSql}
+                    className="h-7 w-7 p-0"
+                  >
+                    <IconCode className="h-3.5 w-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Edit SQL Query</TooltipContent>
+              </ShadcnTooltip>
             )}
           </div>
         </div>

--- a/templates/analytics/app/pages/adhoc/explorer-dashboard/ChartCard.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer-dashboard/ChartCard.tsx
@@ -28,6 +28,11 @@ import { buildSql } from "../explorer/sql-builder";
 import type { ExplorerConfig } from "../explorer/types";
 import type { DashboardChart } from "./index";
 import { appApiPath } from "@agent-native/core/client";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface ChartCardProps {
   chart: DashboardChart;
@@ -108,31 +113,45 @@ export function DashboardChartCard({
             {config?.name ?? configName}
           </CardTitle>
           <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-            <button
-              onClick={onToggleWidth}
-              className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
-              title={chart.width === 2 ? "Half width" : "Full width"}
-            >
-              {chart.width === 2 ? (
-                <IconArrowsMinimize className="h-3.5 w-3.5" />
-              ) : (
-                <IconArrowsMaximize className="h-3.5 w-3.5" />
-              )}
-            </button>
-            <button
-              onClick={onEdit}
-              className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
-              title="Edit in Explorer"
-            >
-              <IconExternalLink className="h-3.5 w-3.5" />
-            </button>
-            <button
-              onClick={() => setConfirmOpen(true)}
-              className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
-              title="Remove chart"
-            >
-              <IconTrash className="h-3.5 w-3.5" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onToggleWidth}
+                  className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {chart.width === 2 ? (
+                    <IconArrowsMinimize className="h-3.5 w-3.5" />
+                  ) : (
+                    <IconArrowsMaximize className="h-3.5 w-3.5" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {chart.width === 2 ? "Half width" : "Full width"}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onEdit}
+                  className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <IconExternalLink className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Edit in Explorer</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setConfirmOpen(true)}
+                  className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <IconTrash className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Remove chart</TooltipContent>
+            </Tooltip>
           </div>
         </CardHeader>
         <CardContent className="pt-0">

--- a/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
@@ -64,6 +64,11 @@ import {
   sortableKeyboardCoordinates,
   rectSortingStrategy,
 } from "@dnd-kit/sortable";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface DashboardChart {
   id: string;
@@ -377,16 +382,20 @@ export default function ExplorerDashboardPage() {
             Add Chart
           </Button>
           <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="text-muted-foreground hover:text-foreground"
-                title="Delete dashboard"
-              >
-                <IconTrash className="h-4 w-4" />
-              </Button>
-            </AlertDialogTrigger>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <IconTrash className="h-4 w-4" />
+                  </Button>
+                </AlertDialogTrigger>
+              </TooltipTrigger>
+              <TooltipContent>Delete dashboard</TooltipContent>
+            </Tooltip>
             <AlertDialogContent>
               <AlertDialogHeader>
                 <AlertDialogTitle>Delete dashboard?</AlertDialogTitle>

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   IconGripVertical,
@@ -8,6 +8,7 @@ import {
   IconPencil,
   IconTrash,
   IconCode,
+  IconDownload,
 } from "@tabler/icons-react";
 import {
   DropdownMenu,
@@ -16,6 +17,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -61,6 +67,15 @@ export function SqlChartCard({
   } = useSortable({ id: panel.id });
 
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [exportCsv, setExportCsv] = useState<(() => void) | null>(null);
+
+  const handleExportCsvChange = useCallback((handler: (() => void) | null) => {
+    setExportCsv(handler ? () => handler : null);
+  }, []);
+
+  useEffect(() => {
+    setExportCsv(null);
+  }, [panel.id]);
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -83,14 +98,19 @@ export function SqlChartCard({
           <h2 className="text-base font-semibold flex-1">{panel.title}</h2>
           <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
             <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  className="p-1 rounded text-muted-foreground hover:text-foreground"
-                  title="Section options"
-                >
-                  <IconDotsVertical className="h-3.5 w-3.5" />
-                </button>
-              </DropdownMenuTrigger>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      className="p-1 rounded text-muted-foreground hover:text-foreground"
+                      aria-label="Section options"
+                    >
+                      <IconDotsVertical className="h-3.5 w-3.5" />
+                    </button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent>Section options</TooltipContent>
+              </Tooltip>
               <DropdownMenuContent align="end" className="w-40">
                 {onEdit && (
                   <DropdownMenuItem onSelect={() => onEdit()}>
@@ -110,14 +130,19 @@ export function SqlChartCard({
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <button
-              className="p-1 rounded cursor-grab active:cursor-grabbing text-muted-foreground/50 hover:text-muted-foreground"
-              title="Drag to reorder"
-              {...attributes}
-              {...listeners}
-            >
-              <IconGripVertical className="h-3.5 w-3.5" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  className="p-1 rounded cursor-grab active:cursor-grabbing text-muted-foreground/50 hover:text-muted-foreground"
+                  aria-label="Drag to reorder"
+                  {...attributes}
+                  {...listeners}
+                >
+                  <IconGripVertical className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Drag to reorder</TooltipContent>
+            </Tooltip>
           </div>
         </div>
         {panel.config?.description && (
@@ -154,9 +179,7 @@ export function SqlChartCard({
     <div
       ref={setNodeRef}
       style={style}
-      className={`group relative h-full hover:z-20 focus-within:z-20 ${
-        panel.width === 2 ? "md:col-span-2" : ""
-      }`}
+      className="group relative h-full hover:z-20 focus-within:z-20"
     >
       <Card className="flex h-full flex-col overflow-visible">
         <CardHeader className="pb-2 flex flex-row items-center gap-2 shrink-0">
@@ -164,48 +187,57 @@ export function SqlChartCard({
             {panel.title}
           </CardTitle>
           <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
-            {onSaveSql && (
-              <ViewSqlPopover
-                panel={panel}
-                resolvedSql={resolvedSql}
-                onSaveSql={onSaveSql}
-              >
-                <button
-                  className="p-1 rounded text-muted-foreground hover:text-foreground"
-                  title="View SQL"
-                >
-                  <IconCode className="h-3.5 w-3.5" />
-                </button>
-              </ViewSqlPopover>
-            )}
-            <button
-              onClick={onToggleWidth}
-              className="p-1 rounded text-muted-foreground hover:text-foreground"
-              title={panel.width === 2 ? "Half width" : "Full width"}
-            >
-              {panel.width === 2 ? (
-                <IconArrowsMinimize className="h-3.5 w-3.5" />
-              ) : (
-                <IconArrowsMaximize className="h-3.5 w-3.5" />
-              )}
-            </button>
             <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  className="p-1 rounded text-muted-foreground hover:text-foreground"
-                  title="Panel options"
-                >
-                  <IconDotsVertical className="h-3.5 w-3.5" />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-40">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      className="p-1 rounded text-muted-foreground hover:text-foreground"
+                      aria-label="Panel options"
+                    >
+                      <IconDotsVertical className="h-3.5 w-3.5" />
+                    </button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent>Panel options</TooltipContent>
+              </Tooltip>
+              <DropdownMenuContent align="end" className="w-44">
+                {panel.chartType === "table" && (
+                  <DropdownMenuItem
+                    disabled={!exportCsv}
+                    onSelect={() => exportCsv?.()}
+                  >
+                    <IconDownload className="h-4 w-4 mr-2" />
+                    Download CSV
+                  </DropdownMenuItem>
+                )}
+                {onSaveSql && (
+                  <ViewSqlPopover
+                    panel={panel}
+                    resolvedSql={resolvedSql}
+                    onSaveSql={onSaveSql}
+                  >
+                    <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+                      <IconCode className="h-4 w-4 mr-2" />
+                      View SQL
+                    </DropdownMenuItem>
+                  </ViewSqlPopover>
+                )}
+                <DropdownMenuItem onSelect={onToggleWidth}>
+                  {panel.width === 2 ? (
+                    <IconArrowsMinimize className="h-4 w-4 mr-2" />
+                  ) : (
+                    <IconArrowsMaximize className="h-4 w-4 mr-2" />
+                  )}
+                  {panel.width === 2 ? "Half width" : "Full width"}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
                 {onEdit && (
                   <DropdownMenuItem onSelect={() => onEdit()}>
                     <IconPencil className="h-4 w-4 mr-2" />
                     Edit
                   </DropdownMenuItem>
                 )}
-                {onEdit && <DropdownMenuSeparator />}
                 <DropdownMenuItem
                   onSelect={(e) => {
                     e.preventDefault();
@@ -217,18 +249,27 @@ export function SqlChartCard({
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <button
-              className="p-1 rounded cursor-grab active:cursor-grabbing text-muted-foreground/50 hover:text-muted-foreground"
-              title="Drag to reorder"
-              {...attributes}
-              {...listeners}
-            >
-              <IconGripVertical className="h-3.5 w-3.5" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  className="p-1 rounded cursor-grab active:cursor-grabbing text-muted-foreground/50 hover:text-muted-foreground"
+                  aria-label="Drag to reorder"
+                  {...attributes}
+                  {...listeners}
+                >
+                  <IconGripVertical className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Drag to reorder</TooltipContent>
+            </Tooltip>
           </div>
         </CardHeader>
         <CardContent className="flex flex-1 flex-col overflow-visible pt-0">
-          <SqlChart panel={panel} resolvedSql={resolvedSql} />
+          <SqlChart
+            panel={panel}
+            resolvedSql={resolvedSql}
+            onExportCsvChange={handleExportCsvChange}
+          />
         </CardContent>
       </Card>
 

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/ViewSqlPopover.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/ViewSqlPopover.tsx
@@ -9,6 +9,11 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   IconAlertTriangle,
   IconCheck,
   IconCopy,
@@ -117,34 +122,42 @@ export function ViewSqlPopover({
           </div>
           <div className="flex items-center gap-1">
             {dirty && (
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={handleReset}
-                disabled={saving}
-                className="h-7 px-2 text-xs"
-                title="Discard changes"
-              >
-                <IconRotate className="h-3.5 w-3.5 mr-1" />
-                Reset
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={handleReset}
+                    disabled={saving}
+                    className="h-7 px-2 text-xs"
+                  >
+                    <IconRotate className="h-3.5 w-3.5 mr-1" />
+                    Reset
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Discard changes</TooltipContent>
+              </Tooltip>
             )}
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={handleCopy}
-              className="h-7 px-2 text-xs"
-              title={
-                showResolved && resolvedSql ? "Copy resolved SQL" : "Copy SQL"
-              }
-            >
-              {copied ? (
-                <IconCheck className="h-3.5 w-3.5 mr-1" />
-              ) : (
-                <IconCopy className="h-3.5 w-3.5 mr-1" />
-              )}
-              {copied ? "Copied" : "Copy"}
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={handleCopy}
+                  className="h-7 px-2 text-xs"
+                >
+                  {copied ? (
+                    <IconCheck className="h-3.5 w-3.5 mr-1" />
+                  ) : (
+                    <IconCopy className="h-3.5 w-3.5 mr-1" />
+                  )}
+                  {copied ? "Copied" : "Copy"}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {showResolved && resolvedSql ? "Copy resolved SQL" : "Copy SQL"}
+              </TooltipContent>
+            </Tooltip>
           </div>
         </div>
 

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/ViewsMenu.tsx
@@ -38,6 +38,11 @@ import {
   type DashboardView,
 } from "@/hooks/use-dashboard-views";
 import { FILTER_PARAM_PREFIX } from "./DashboardFilterBar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface ViewsMenuProps {
   dashboardId: string;
@@ -151,18 +156,18 @@ export function ViewsMenu({ dashboardId }: ViewsMenuProps) {
   return (
     <>
       <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-8 text-xs gap-1.5"
-            title="Saved views"
-          >
-            <IconLayoutGrid className="h-3.5 w-3.5" />
-            <span className="max-w-[160px] truncate">{triggerLabel}</span>
-            <IconChevronDown className="h-3 w-3 opacity-60" />
-          </Button>
-        </DropdownMenuTrigger>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-8 text-xs gap-1.5">
+                <IconLayoutGrid className="h-3.5 w-3.5" />
+                <span className="max-w-[160px] truncate">{triggerLabel}</span>
+                <IconChevronDown className="h-3 w-3 opacity-60" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Saved views</TooltipContent>
+        </Tooltip>
         <DropdownMenuContent align="start" className="w-60">
           <DropdownMenuLabel className="text-xs text-muted-foreground">
             Saved views
@@ -182,20 +187,24 @@ export function ViewsMenu({ dashboardId }: ViewsMenuProps) {
                 }}
               >
                 <span className="truncate flex-1">{v.name}</span>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-5 w-5 shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setDeleteTarget(v);
-                    setMenuOpen(false);
-                  }}
-                  title={`Delete ${v.name}`}
-                >
-                  <IconTrash className="h-3 w-3" />
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-5 w-5 shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setDeleteTarget(v);
+                        setMenuOpen(false);
+                      }}
+                    >
+                      <IconTrash className="h-3 w-3" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{`Delete ${v.name}`}</TooltipContent>
+                </Tooltip>
               </DropdownMenuItem>
             ))
           )}

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -19,6 +19,11 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { IconPencil, IconPlus, IconTrash } from "@tabler/icons-react";
 import {
   ShareButton,
@@ -605,16 +610,21 @@ export default function SqlDashboardPage() {
           </Button>
         </AddPanelPopover>
         <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <Button
-              size="sm"
-              variant="ghost"
-              className="text-muted-foreground hover:text-foreground"
-              title="Delete dashboard"
-            >
-              <IconTrash className="h-4 w-4" />
-            </Button>
-          </AlertDialogTrigger>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <AlertDialogTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-muted-foreground hover:text-foreground"
+                  aria-label="Delete dashboard"
+                >
+                  <IconTrash className="h-4 w-4" />
+                </Button>
+              </AlertDialogTrigger>
+            </TooltipTrigger>
+            <TooltipContent>Delete dashboard</TooltipContent>
+          </Tooltip>
           <AlertDialogContent>
             <AlertDialogHeader>
               <AlertDialogTitle>Delete dashboard?</AlertDialogTitle>
@@ -768,11 +778,16 @@ export default function SqlDashboardPage() {
                   : panel;
                 const remoteEditor = remoteEditingPanels.get(panel.id);
                 const isSection = panel.chartType === "section";
+                const isFullWidth = panel.width === 2;
                 return (
                   <div
                     key={panel.id}
                     className={
-                      isSection ? "relative md:col-span-2" : "relative h-full"
+                      isSection
+                        ? "relative md:col-span-2"
+                        : isFullWidth
+                          ? "relative h-full md:col-span-2"
+                          : "relative h-full"
                     }
                     style={
                       remoteEditor

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -942,16 +942,20 @@ export function EventDetailPopover({
               >
                 <IconMapPin className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
                 {locationIsUrl ? (
-                  <a
-                    href={event.location}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-primary hover:underline truncate block max-w-full"
-                    title={event.location}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    {event.location}
-                  </a>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <a
+                        href={event.location}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-primary hover:underline truncate block max-w-full"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {event.location}
+                      </a>
+                    </TooltipTrigger>
+                    <TooltipContent>{event.location}</TooltipContent>
+                  </Tooltip>
                 ) : (
                   <span className="text-sm text-muted-foreground">
                     {event.location}

--- a/templates/calendar/app/components/calendar/IntegrationsSidebar.tsx
+++ b/templates/calendar/app/components/calendar/IntegrationsSidebar.tsx
@@ -28,6 +28,11 @@ import {
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 function safeExternalHref(value?: string | null): string | null {
   if (!value) return null;
@@ -399,14 +404,16 @@ function IntegrationRow({
             <IconCheck className="h-3 w-3 text-emerald-400" />
           </div>
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                className="h-5 w-5 flex items-center justify-center rounded text-muted-foreground/30 hover:text-muted-foreground"
-                title="Settings"
-              >
-                <IconSettings className="h-3.5 w-3.5" />
-              </button>
-            </DropdownMenuTrigger>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <button className="h-5 w-5 flex items-center justify-center rounded text-muted-foreground/30 hover:text-muted-foreground">
+                    <IconSettings className="h-3.5 w-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>Settings</TooltipContent>
+            </Tooltip>
             <DropdownMenuContent
               side="left"
               align="start"

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -340,21 +340,29 @@ function GoogleAccountsSection({
           </span>
         </div>
         <div className="flex items-center">
-          <Link
-            to="/settings"
-            className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground"
-            title="Google Calendar settings"
-          >
-            <IconSettings className="h-3.5 w-3.5" />
-          </Link>
-          <button
-            type="button"
-            onClick={() => setWantAddAccount(true)}
-            className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground"
-            title="Add Google account"
-          >
-            <IconPlus className="h-3.5 w-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Link
+                to="/settings"
+                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+              >
+                <IconSettings className="h-3.5 w-3.5" />
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent>Google Calendar settings</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setWantAddAccount(true)}
+                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+              >
+                <IconPlus className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Add Google account</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/templates/calendar/app/components/ui/sidebar.tsx
+++ b/templates/calendar/app/components/ui/sidebar.tsx
@@ -298,24 +298,28 @@ const SidebarRail = React.forwardRef<
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
-      ref={ref}
-      data-sidebar="rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      {...props}
-    />
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          ref={ref}
+          data-sidebar="rail"
+          aria-label="Toggle Sidebar"
+          tabIndex={-1}
+          onClick={toggleSidebar}
+          className={cn(
+            "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+            "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+            "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+            "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
+            "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+            "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+            className,
+          )}
+          {...props}
+        />
+      </TooltipTrigger>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
+    </Tooltip>
   );
 });
 SidebarRail.displayName = "SidebarRail";

--- a/templates/calendar/app/pages/BookingLinksPage.tsx
+++ b/templates/calendar/app/pages/BookingLinksPage.tsx
@@ -1049,17 +1049,21 @@ export default function BookingLinksPage({
                 <div className="space-y-2">
                   <div className="flex items-center justify-between gap-3">
                     <Label>URL</Label>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => openPreview(draft.slug)}
-                      className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                      title="Open in new tab"
-                      aria-label="Open booking page in new tab"
-                    >
-                      <IconExternalLink className="h-4 w-4" />
-                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => openPreview(draft.slug)}
+                          className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                          aria-label="Open booking page in new tab"
+                        >
+                          <IconExternalLink className="h-4 w-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Open in new tab</TooltipContent>
+                    </Tooltip>
                   </div>
                   {/* Editable URL parts (username / slug) — shared package component */}
                   <SlugEditor
@@ -1716,34 +1720,46 @@ function BookingPreview({
               </Badge>
             )}
             {onCollapse && (
-              <button
-                type="button"
-                onClick={onCollapse}
-                className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/60"
-                title="Collapse preview"
-              >
-                <IconChevronRight className="h-3.5 w-3.5" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={onCollapse}
+                    className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/60"
+                  >
+                    <IconChevronRight className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Collapse preview</TooltipContent>
+              </Tooltip>
             )}
             {onCopy && (
-              <button
-                type="button"
-                onClick={onCopy}
-                className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/60"
-                title="Copy link"
-              >
-                <IconCopy className="h-3.5 w-3.5" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={onCopy}
+                    className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/60"
+                  >
+                    <IconCopy className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Copy link</TooltipContent>
+              </Tooltip>
             )}
             {onOpen && (
-              <button
-                type="button"
-                onClick={onOpen}
-                className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/60"
-                title="Open in new tab"
-              >
-                <IconExternalLink className="h-3.5 w-3.5" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={onOpen}
+                    className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/60"
+                  >
+                    <IconExternalLink className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Open in new tab</TooltipContent>
+              </Tooltip>
             )}
           </div>
         </div>

--- a/templates/calendar/app/pages/BookingsList.tsx
+++ b/templates/calendar/app/pages/BookingsList.tsx
@@ -118,15 +118,19 @@ export default function BookingsList() {
                   </TableCell>
                   <TableCell>
                     {booking.status === "confirmed" && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleCancel(booking)}
-                        disabled={deleteBooking.isPending}
-                        title="Cancel booking"
-                      >
-                        <IconCircleX className="h-4 w-4 text-destructive" />
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => handleCancel(booking)}
+                            disabled={deleteBooking.isPending}
+                          >
+                            <IconCircleX className="h-4 w-4 text-destructive" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Cancel booking</TooltipContent>
+                      </Tooltip>
                     )}
                   </TableCell>
                 </TableRow>

--- a/templates/clips/app/components/editor/chapters-editor.tsx
+++ b/templates/clips/app/components/editor/chapters-editor.tsx
@@ -11,6 +11,11 @@ import { cn } from "@/lib/utils";
 import { formatMs } from "@/lib/timestamp-mapping";
 import { useActionMutation } from "@agent-native/core/client";
 import { toast } from "sonner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface Chapter {
   startMs: number;
@@ -130,28 +135,36 @@ export function ChaptersEditor({
               )}
             >
               <IconGripVertical className="w-3.5 h-3.5 text-muted-foreground cursor-grab" />
-              <button
-                type="button"
-                onClick={() => onSeek?.(c.startMs)}
-                className="text-[11px] font-mono text-muted-foreground w-14 shrink-0 text-left hover:text-foreground"
-                title={`Seek to ${formatMs(c.startMs)}`}
-              >
-                {formatMs(c.startMs)}
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => onSeek?.(c.startMs)}
+                    className="text-[11px] font-mono text-muted-foreground w-14 shrink-0 text-left hover:text-foreground"
+                  >
+                    {formatMs(c.startMs)}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{`Seek to ${formatMs(c.startMs)}`}</TooltipContent>
+              </Tooltip>
               <Input
                 value={c.title}
                 onChange={(e) => rename(i, e.target.value)}
                 className="h-7 text-xs"
               />
-              <Button
-                size="sm"
-                variant="ghost"
-                className="opacity-0 group-hover:opacity-100 h-7 w-7 p-0"
-                onClick={() => remove(i)}
-                title="Remove chapter"
-              >
-                <IconTrash className="w-3.5 h-3.5" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="opacity-0 group-hover:opacity-100 h-7 w-7 p-0"
+                    onClick={() => remove(i)}
+                  >
+                    <IconTrash className="w-3.5 h-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Remove chapter</TooltipContent>
+              </Tooltip>
             </div>
           ))
         )}

--- a/templates/clips/app/components/editor/editor-toolbar.tsx
+++ b/templates/clips/app/components/editor/editor-toolbar.tsx
@@ -40,6 +40,11 @@ import {
   type EditsJson,
 } from "@/lib/timestamp-mapping";
 import { SplitButton } from "./split-button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface EditorToolbarProps {
   recordingId: string;
@@ -180,38 +185,44 @@ export function EditorToolbar({
 
   return (
     <div className="flex items-center gap-1 px-2 h-11 border-b border-border bg-card/40">
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={handleUndo}
-        disabled={undo.isPending}
-        title="Undo (Cmd/Ctrl+Z)"
-      >
-        <IconArrowBackUp className="w-4 h-4" />
-      </Button>
-      <Button
-        size="sm"
-        variant="ghost"
-        disabled
-        title="Redo (not supported — there is no redo stack)"
-      >
-        <IconArrowForwardUp className="w-4 h-4 opacity-40" />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={handleUndo}
+            disabled={undo.isPending}
+          >
+            <IconArrowBackUp className="w-4 h-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Undo (Cmd/Ctrl+Z)</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="sm" variant="ghost" disabled>
+            <IconArrowForwardUp className="w-4 h-4 opacity-40" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          Redo (not supported — there is no redo stack)
+        </TooltipContent>
+      </Tooltip>
 
       <Separator orientation="vertical" className="h-6 mx-1" />
 
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={onPlayPause}
-        title="Play / Pause (Space)"
-      >
-        {playing ? (
-          <IconPlayerPause className="w-4 h-4" />
-        ) : (
-          <IconPlayerPlay className="w-4 h-4" />
-        )}
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="sm" variant="ghost" onClick={onPlayPause}>
+            {playing ? (
+              <IconPlayerPause className="w-4 h-4" />
+            ) : (
+              <IconPlayerPlay className="w-4 h-4" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Play / Pause (Space)</TooltipContent>
+      </Tooltip>
 
       <div className="text-xs font-mono text-muted-foreground px-2">
         {formatMs(playheadMs)} / {formatMs(effectiveMs)}
@@ -223,57 +234,61 @@ export function EditorToolbar({
       <Separator orientation="vertical" className="h-6 mx-1" />
 
       <SplitButton recordingId={recordingId} playheadMs={playheadMs} />
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={handleTrimSelection}
-        disabled={!selectionRange || trim.isPending}
-        title="Cut selection"
-      >
-        <IconScissors className="w-4 h-4 mr-1" />
-        Cut
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={handleTrimSelection}
+            disabled={!selectionRange || trim.isPending}
+          >
+            <IconScissors className="w-4 h-4 mr-1" />
+            Cut
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Cut selection</TooltipContent>
+      </Tooltip>
 
       <Separator orientation="vertical" className="h-6 mx-1" />
 
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={onOpenThumbnailPicker}
-        title="Edit thumbnail"
-      >
-        <IconPhotoEdit className="w-4 h-4 mr-1" />
-        Thumbnail
-      </Button>
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={onOpenChapters}
-        title="Chapters"
-      >
-        <IconBookmarks className="w-4 h-4 mr-1" />
-        Chapters
-      </Button>
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={onOpenStitch}
-        title="Stitch recordings"
-      >
-        <IconPuzzle className="w-4 h-4 mr-1" />
-        Stitch
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="sm" variant="ghost" onClick={onOpenThumbnailPicker}>
+            <IconPhotoEdit className="w-4 h-4 mr-1" />
+            Thumbnail
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Edit thumbnail</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="sm" variant="ghost" onClick={onOpenChapters}>
+            <IconBookmarks className="w-4 h-4 mr-1" />
+            Chapters
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Chapters</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="sm" variant="ghost" onClick={onOpenStitch}>
+            <IconPuzzle className="w-4 h-4 mr-1" />
+            Stitch
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Stitch recordings</TooltipContent>
+      </Tooltip>
 
       <Separator orientation="vertical" className="h-6 mx-1" />
 
-      <Button
-        size="sm"
-        variant="ghost"
-        onClick={() => setClearOpen(true)}
-        title="Clear all edits"
-      >
-        <IconTrash className="w-4 h-4" />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="sm" variant="ghost" onClick={() => setClearOpen(true)}>
+            <IconTrash className="w-4 h-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Clear all edits</TooltipContent>
+      </Tooltip>
 
       <div className="flex-1" />
 

--- a/templates/clips/app/components/editor/split-button.tsx
+++ b/templates/clips/app/components/editor/split-button.tsx
@@ -2,6 +2,11 @@ import { IconCut } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import { useActionMutation } from "@agent-native/core/client";
 import { toast } from "sonner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface SplitButtonProps {
   recordingId: string;
@@ -31,15 +36,19 @@ export function SplitButton({
   };
 
   return (
-    <Button
-      size="sm"
-      variant="ghost"
-      onClick={handleClick}
-      disabled={disabled || split.isPending}
-      title="Split at playhead (S)"
-    >
-      <IconCut className="w-4 h-4 mr-1" />
-      Split
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={handleClick}
+          disabled={disabled || split.isPending}
+        >
+          <IconCut className="w-4 h-4 mr-1" />
+          Split
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Split at playhead (S)</TooltipContent>
+    </Tooltip>
   );
 }

--- a/templates/clips/app/components/editor/timeline.tsx
+++ b/templates/clips/app/components/editor/timeline.tsx
@@ -1,6 +1,11 @@
 import { useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { formatMs } from "@/lib/timestamp-mapping";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface TimelineChapter {
   startMs: number;
@@ -154,16 +159,19 @@ export function Timeline({
           {chapters.map((c, i) => {
             const x = (c.startMs / Math.max(durationMs, 1)) * width;
             return (
-              <button
-                type="button"
-                key={`ch-${i}-${c.startMs}`}
-                onClick={() => onClickChapter?.(c)}
-                className="absolute top-0 h-full px-2 text-[10px] text-foreground/80 hover:bg-foreground/10 flex items-center border-l border-border"
-                style={{ left: x, maxWidth: 140 }}
-                title={`${c.title} · ${formatMs(c.startMs)}`}
-              >
-                <span className="truncate">{c.title}</span>
-              </button>
+              <Tooltip key={`ch-${i}-${c.startMs}`}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => onClickChapter?.(c)}
+                    className="absolute top-0 h-full px-2 text-[10px] text-foreground/80 hover:bg-foreground/10 flex items-center border-l border-border"
+                    style={{ left: x, maxWidth: 140 }}
+                  >
+                    <span className="truncate">{c.title}</span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{`${c.title} · ${formatMs(c.startMs)}`}</TooltipContent>
+              </Tooltip>
             );
           })}
         </div>

--- a/templates/clips/app/components/editor/transcript-editor.tsx
+++ b/templates/clips/app/components/editor/transcript-editor.tsx
@@ -3,6 +3,11 @@ import { IconScissors } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { formatMs, isExcluded, type EditsJson } from "@/lib/timestamp-mapping";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface TranscriptSegment {
   startMs: number;
@@ -90,20 +95,23 @@ export function TranscriptEditor({
       const excluded = isExcluded(s.startMs, edits);
       const active = currentMs >= s.startMs && currentMs < s.endMs;
       return (
-        <span
-          key={`${s.startMs}-${i}`}
-          data-start-ms={s.startMs}
-          data-end-ms={s.endMs}
-          onClick={() => onSeek?.(s.startMs)}
-          className={cn(
-            "inline cursor-pointer px-0.5 rounded",
-            active && "bg-primary/20 text-foreground",
-            excluded && "line-through text-muted-foreground/70",
-          )}
-          title={`${formatMs(s.startMs)} – ${formatMs(s.endMs)}`}
-        >
-          {s.text.trim()}{" "}
-        </span>
+        <Tooltip key={`${s.startMs}-${i}`}>
+          <TooltipTrigger asChild>
+            <span
+              data-start-ms={s.startMs}
+              data-end-ms={s.endMs}
+              onClick={() => onSeek?.(s.startMs)}
+              className={cn(
+                "inline cursor-pointer px-0.5 rounded",
+                active && "bg-primary/20 text-foreground",
+                excluded && "line-through text-muted-foreground/70",
+              )}
+            >
+              {s.text.trim()}{" "}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{`${formatMs(s.startMs)} – ${formatMs(s.endMs)}`}</TooltipContent>
+        </Tooltip>
       );
     });
   }, [segments, edits, currentMs, onSeek]);

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -44,6 +44,11 @@ import { OrganizationSwitcher } from "./organization-switcher";
 import { PageHeaderSlotProvider } from "./page-header";
 import { ExtensionsSidebarSection } from "@agent-native/core/client/extensions";
 import { toast } from "sonner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface LibraryLayoutProps {
   children: ReactNode;
@@ -233,14 +238,18 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
                     <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
                       Folders
                     </span>
-                    <button
-                      type="button"
-                      className="rounded p-1 text-muted-foreground hover:bg-accent"
-                      title="New folder"
-                      onClick={() => setNewFolderOpen(true)}
-                    >
-                      <IconFolderPlus className="h-3.5 w-3.5" />
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="rounded p-1 text-muted-foreground hover:bg-accent"
+                          onClick={() => setNewFolderOpen(true)}
+                        >
+                          <IconFolderPlus className="h-3.5 w-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>New folder</TooltipContent>
+                    </Tooltip>
                   </div>
                   <FolderTree
                     folders={libFolderList}
@@ -340,15 +349,19 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
                   <Button asChild size="sm" className="shrink-0">
                     <NavLink to="/download">Download</NavLink>
                   </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
-                    onClick={dismiss}
-                    title="I already have it"
-                  >
-                    <IconX className="h-4 w-4" />
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+                        onClick={dismiss}
+                      >
+                        <IconX className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>I already have it</TooltipContent>
+                  </Tooltip>
                 </div>
               )}
               <main className="flex flex-1 flex-col min-h-0 overflow-y-auto">

--- a/templates/clips/app/components/meetings/canvas-editor.tsx
+++ b/templates/clips/app/components/meetings/canvas-editor.tsx
@@ -153,22 +153,26 @@ function UserNotesBlock({
   }
 
   return (
-    <button
-      type="button"
-      onClick={() => setEditing(true)}
-      className="block w-full text-left cursor-text"
-      title="Click to add your notes"
-    >
-      {value ? (
-        <p className="text-base leading-relaxed text-foreground font-medium whitespace-pre-wrap">
-          {value}
-        </p>
-      ) : (
-        <p className="text-base leading-relaxed text-muted-foreground/50 italic">
-          Click to add your notes…
-        </p>
-      )}
-    </button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={() => setEditing(true)}
+          className="block w-full text-left cursor-text"
+        >
+          {value ? (
+            <p className="text-base leading-relaxed text-foreground font-medium whitespace-pre-wrap">
+              {value}
+            </p>
+          ) : (
+            <p className="text-base leading-relaxed text-muted-foreground/50 italic">
+              Click to add your notes…
+            </p>
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>Click to add your notes</TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -244,20 +248,26 @@ function AiSummaryBlock({
     <TooltipProvider delayDuration={200}>
       <div className="group relative space-y-1.5">
         <AiTabIndicator />
-        <button
-          type="button"
-          onClick={() => setEditing(true)}
-          className="block w-full text-left cursor-text"
-          title="Click to edit (your edits are saved as your own notes)"
-        >
-          <p
-            className={cn(
-              "text-sm leading-relaxed whitespace-pre-wrap text-muted-foreground rounded -mx-1 px-1 group-hover:bg-accent/30",
-            )}
-          >
-            {value}
-          </p>
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              className="block w-full text-left cursor-text"
+            >
+              <p
+                className={cn(
+                  "text-sm leading-relaxed whitespace-pre-wrap text-muted-foreground rounded -mx-1 px-1 group-hover:bg-accent/30",
+                )}
+              >
+                {value}
+              </p>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Click to edit (your edits are saved as your own notes)
+          </TooltipContent>
+        </Tooltip>
       </div>
     </TooltipProvider>
   );

--- a/templates/clips/app/components/player/player-controls.tsx
+++ b/templates/clips/app/components/player/player-controls.tsx
@@ -20,6 +20,11 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export const SPEED_OPTIONS = [0.5, 0.8, 1, 1.2, 1.5, 1.7, 2, 2.5];
 
@@ -95,7 +100,7 @@ export function PlayerControls(props: PlayerControlsProps) {
       <div className="flex items-center gap-1.5 text-white">
         <IconBtn
           onClick={onPlayPause}
-          title={isPlaying ? "Pause (K)" : "Play (K)"}
+          tooltip={isPlaying ? "Pause (K)" : "Play (K)"}
         >
           {isPlaying ? (
             <IconPlayerPause className="h-5 w-5" />
@@ -109,7 +114,7 @@ export function PlayerControls(props: PlayerControlsProps) {
           onMouseEnter={() => setVolumeHover(true)}
           onMouseLeave={() => setVolumeHover(false)}
         >
-          <IconBtn onClick={onToggleMute} title="Mute (M)">
+          <IconBtn onClick={onToggleMute} tooltip="Mute (M)">
             {muted || volume === 0 ? (
               <IconVolumeOff className="h-5 w-5" />
             ) : (
@@ -145,21 +150,23 @@ export function PlayerControls(props: PlayerControlsProps) {
           <IconBtn
             onClick={onToggleCaptions}
             active={captionsOn}
-            title="Captions (C)"
+            tooltip="Captions (C)"
           >
             <IconSubtitles className="h-5 w-5" />
           </IconBtn>
         ) : null}
 
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              className="h-8 px-2 rounded-md hover:bg-white/10 text-xs font-medium tabular-nums"
-              title="Playback speed"
-            >
-              {speed}x
-            </button>
-          </DropdownMenuTrigger>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <button className="h-8 px-2 rounded-md hover:bg-white/10 text-xs font-medium tabular-nums">
+                  {speed}x
+                </button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>Playback speed</TooltipContent>
+          </Tooltip>
           <DropdownMenuContent align="end" side="top" className="min-w-[90px]">
             <DropdownMenuLabel>Speed</DropdownMenuLabel>
             <DropdownMenuSeparator />
@@ -197,7 +204,7 @@ export function PlayerControls(props: PlayerControlsProps) {
         <IconBtn
           onClick={onTogglePip}
           active={isPip}
-          title="Picture in picture"
+          tooltip="Picture in picture"
         >
           <IconPictureInPicture className="h-5 w-5" />
         </IconBtn>
@@ -206,13 +213,13 @@ export function PlayerControls(props: PlayerControlsProps) {
           <IconBtn
             onClick={onToggleTheater}
             active={theaterMode}
-            title="Theater mode (T)"
+            tooltip="Theater mode (T)"
           >
             <IconRectangle className="h-5 w-5" />
           </IconBtn>
         ) : null}
 
-        <IconBtn onClick={onToggleFullscreen} title="Fullscreen (F)">
+        <IconBtn onClick={onToggleFullscreen} tooltip="Fullscreen (F)">
           <IconMaximize
             className={cn("h-5 w-5", isFullscreen && "rotate-180")}
           />
@@ -225,24 +232,28 @@ export function PlayerControls(props: PlayerControlsProps) {
 function IconBtn({
   children,
   onClick,
-  title,
+  tooltip,
   active,
 }: {
   children: React.ReactNode;
   onClick?: () => void;
-  title?: string;
+  tooltip?: string;
   active?: boolean;
 }) {
   return (
-    <button
-      onClick={onClick}
-      title={title}
-      className={cn(
-        "h-8 w-8 rounded-md flex items-center justify-center",
-        active ? "bg-white/20 text-white" : "text-white hover:bg-white/10",
-      )}
-    >
-      {children}
-    </button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={onClick}
+          className={cn(
+            "h-8 w-8 rounded-md flex items-center justify-center",
+            active ? "bg-white/20 text-white" : "text-white hover:bg-white/10",
+          )}
+        >
+          {children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/templates/clips/app/components/player/reactions-tray.tsx
+++ b/templates/clips/app/components/player/reactions-tray.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const EMOJIS = ["👍", "❤️", "🔥", "👏", "🎉", "😂", "🤯"] as const;
 
@@ -33,18 +38,21 @@ export function ReactionsTray({ onReact, disabled }: ReactionsTrayProps) {
   return (
     <div className="relative flex items-center gap-1 rounded-full border border-border bg-card px-2 py-1 shadow-sm w-fit">
       {EMOJIS.map((emoji) => (
-        <button
-          key={emoji}
-          onClick={() => fire(emoji)}
-          disabled={disabled}
-          className={cn(
-            "h-9 w-9 rounded-full flex items-center justify-center text-xl",
-            disabled && "opacity-50 cursor-not-allowed",
-          )}
-          title={`React with ${emoji}`}
-        >
-          {emoji}
-        </button>
+        <Tooltip key={emoji}>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => fire(emoji)}
+              disabled={disabled}
+              className={cn(
+                "h-9 w-9 rounded-full flex items-center justify-center text-xl",
+                disabled && "opacity-50 cursor-not-allowed",
+              )}
+            >
+              {emoji}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{`React with ${emoji}`}</TooltipContent>
+        </Tooltip>
       ))}
 
       {/* Floating reactions */}

--- a/templates/clips/app/components/player/transcript-panel.tsx
+++ b/templates/clips/app/components/player/transcript-panel.tsx
@@ -16,6 +16,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { msToClock } from "./scrubber";
 import { agentNativePath, getCallbackOrigin } from "@agent-native/core/client";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface TranscriptSegment {
   startMs: number;
@@ -154,26 +159,26 @@ export function TranscriptPanel(props: TranscriptPanelProps) {
             className="pl-8 h-8 text-xs"
           />
         </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={copyAll}
-          title="Copy transcript"
-        >
-          {copied ? (
-            <IconCheck className="h-4 w-4 text-green-600" />
-          ) : (
-            <IconCopy className="h-4 w-4" />
-          )}
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={downloadSrt}
-          title="Download .srt"
-        >
-          <IconDownload className="h-4 w-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" onClick={copyAll}>
+              {copied ? (
+                <IconCheck className="h-4 w-4 text-green-600" />
+              ) : (
+                <IconCopy className="h-4 w-4" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Copy transcript</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="ghost" size="icon" onClick={downloadSrt}>
+              <IconDownload className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Download .srt</TooltipContent>
+        </Tooltip>
       </div>
 
       <div className="flex-1 overflow-y-auto">

--- a/templates/clips/app/components/recorder/recording-toolbar.tsx
+++ b/templates/clips/app/components/recorder/recording-toolbar.tsx
@@ -12,6 +12,11 @@ import {
   snapToCorner,
   type BubblePosition,
 } from "./camera-positioner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface RecordingToolbarProps {
   elapsedMs: number;
@@ -127,31 +132,41 @@ export function RecordingToolbar({
         touchAction: "none",
       }}
     >
-      <button
-        data-toolbar-btn
-        type="button"
-        onClick={onTogglePause}
-        className="flex h-9 w-9 items-center justify-center rounded-full hover:bg-white/15"
-        aria-label={isPaused ? "Resume recording" : "Pause recording"}
-        title={isPaused ? "Resume (⌥⇧P)" : "Pause (⌥⇧P)"}
-      >
-        {isPaused ? (
-          <IconPlayerPlay className="h-4 w-4" />
-        ) : (
-          <IconPlayerPause className="h-4 w-4" />
-        )}
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            data-toolbar-btn
+            type="button"
+            onClick={onTogglePause}
+            className="flex h-9 w-9 items-center justify-center rounded-full hover:bg-white/15"
+            aria-label={isPaused ? "Resume recording" : "Pause recording"}
+          >
+            {isPaused ? (
+              <IconPlayerPlay className="h-4 w-4" />
+            ) : (
+              <IconPlayerPause className="h-4 w-4" />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {isPaused ? "Resume (⌥⇧P)" : "Pause (⌥⇧P)"}
+        </TooltipContent>
+      </Tooltip>
 
-      <button
-        data-toolbar-btn
-        type="button"
-        onClick={onStop}
-        className="flex h-9 w-9 items-center justify-center rounded-full bg-red-500 text-white hover:bg-red-600"
-        aria-label="Stop recording"
-        title="Stop recording"
-      >
-        <IconPlayerStop className="h-4 w-4" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            data-toolbar-btn
+            type="button"
+            onClick={onStop}
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-red-500 text-white hover:bg-red-600"
+            aria-label="Stop recording"
+          >
+            <IconPlayerStop className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Stop recording</TooltipContent>
+      </Tooltip>
 
       <div
         className="mx-2 flex h-9 items-center gap-2 rounded-full bg-white/10 px-3 text-sm font-mono tabular-nums"
@@ -169,44 +184,56 @@ export function RecordingToolbar({
         )}
       </div>
 
-      <button
-        data-toolbar-btn
-        type="button"
-        onClick={onToggleDrawing}
-        className={
-          "flex h-9 w-9 items-center justify-center rounded-full " +
-          (isDrawing
-            ? "bg-primary text-primary-foreground"
-            : "hover:bg-white/15")
-        }
-        aria-label="Toggle drawing"
-        aria-pressed={isDrawing}
-        title="Draw (⌘⇧D)"
-      >
-        <IconPencil className="h-4 w-4" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            data-toolbar-btn
+            type="button"
+            onClick={onToggleDrawing}
+            className={
+              "flex h-9 w-9 items-center justify-center rounded-full " +
+              (isDrawing
+                ? "bg-primary text-primary-foreground"
+                : "hover:bg-white/15")
+            }
+            aria-label="Toggle drawing"
+            aria-pressed={isDrawing}
+          >
+            <IconPencil className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Draw (⌘⇧D)</TooltipContent>
+      </Tooltip>
 
-      <button
-        data-toolbar-btn
-        type="button"
-        onClick={onConfetti}
-        className="flex h-9 w-9 items-center justify-center rounded-full hover:bg-white/15"
-        aria-label="Confetti"
-        title="Confetti (⌃⌘C)"
-      >
-        <IconConfetti className="h-4 w-4" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            data-toolbar-btn
+            type="button"
+            onClick={onConfetti}
+            className="flex h-9 w-9 items-center justify-center rounded-full hover:bg-white/15"
+            aria-label="Confetti"
+          >
+            <IconConfetti className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Confetti (⌃⌘C)</TooltipContent>
+      </Tooltip>
 
-      <button
-        data-toolbar-btn
-        type="button"
-        onClick={onCancel}
-        className="flex h-9 w-9 items-center justify-center rounded-full hover:bg-white/15"
-        aria-label="Cancel recording"
-        title="Cancel (⌥⇧C)"
-      >
-        <IconX className="h-4 w-4" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            data-toolbar-btn
+            type="button"
+            onClick={onCancel}
+            className="flex h-9 w-9 items-center justify-center rounded-full hover:bg-white/15"
+            aria-label="Cancel recording"
+          >
+            <IconX className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Cancel (⌥⇧C)</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/templates/clips/app/components/ui/sidebar.tsx
+++ b/templates/clips/app/components/ui/sidebar.tsx
@@ -298,24 +298,28 @@ const SidebarRail = React.forwardRef<
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
-      ref={ref}
-      data-sidebar="rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      {...props}
-    />
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          ref={ref}
+          data-sidebar="rail"
+          aria-label="Toggle Sidebar"
+          tabIndex={-1}
+          onClick={toggleSidebar}
+          className={cn(
+            "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+            "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+            "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+            "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
+            "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+            "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+            className,
+          )}
+          {...props}
+        />
+      </TooltipTrigger>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
+    </Tooltip>
   );
 });
 SidebarRail.displayName = "SidebarRail";

--- a/templates/clips/app/routes/_app.dictate.tsx
+++ b/templates/clips/app/routes/_app.dictate.tsx
@@ -23,6 +23,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { DayHeader } from "@/components/meetings/day-header";
 import { PageHeader } from "@/components/library/page-header";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export function meta() {
   return [{ title: "Dictate · Clips" }];
@@ -305,21 +310,25 @@ function DictationRow({ dictation }: { dictation: Dictation }) {
           {formatDuration(dictation.durationMs)}
         </div>
         <div className="col-span-1 flex justify-end">
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={(e) => {
-              e.stopPropagation();
-              void copyToClipboard(
-                dictation.cleanedText || dictation.fullText || "",
-                "text",
-              );
-            }}
-            className="h-7 w-7 p-0 cursor-pointer"
-            title="Copy"
-          >
-            <IconCopy className="h-3.5 w-3.5" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void copyToClipboard(
+                    dictation.cleanedText || dictation.fullText || "",
+                    "text",
+                  );
+                }}
+                className="h-7 w-7 p-0 cursor-pointer"
+              >
+                <IconCopy className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Copy</TooltipContent>
+          </Tooltip>
         </div>
       </div>
       {expanded && (
@@ -374,21 +383,27 @@ function DictationRow({ dictation }: { dictation: Dictation }) {
                         <IconCopy className="h-3 w-3" />
                         Copy
                       </Button>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={handleReplaceOriginal}
-                        disabled={replaceOriginal.isPending}
-                        className="h-6 gap-1 text-[10px] cursor-pointer"
-                        title="Replace original with cleaned"
-                      >
-                        {replaceOriginal.isPending ? (
-                          <IconLoader2 className="h-3 w-3 animate-spin" />
-                        ) : (
-                          <IconArrowsExchange className="h-3 w-3" />
-                        )}
-                        Replace
-                      </Button>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={handleReplaceOriginal}
+                            disabled={replaceOriginal.isPending}
+                            className="h-6 gap-1 text-[10px] cursor-pointer"
+                          >
+                            {replaceOriginal.isPending ? (
+                              <IconLoader2 className="h-3 w-3 animate-spin" />
+                            ) : (
+                              <IconArrowsExchange className="h-3 w-3" />
+                            )}
+                            Replace
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          Replace original with cleaned
+                        </TooltipContent>
+                      </Tooltip>
                     </>
                   )}
                   <Button

--- a/templates/clips/app/routes/_app.meetings.$meetingId.tsx
+++ b/templates/clips/app/routes/_app.meetings.$meetingId.tsx
@@ -31,6 +31,11 @@ import { BulletLink } from "@/components/meetings/bullet-link";
 import { CanvasEditor } from "@/components/meetings/canvas-editor";
 import { AutoRecordPrompt } from "@/components/meetings/auto-record-prompt";
 import { QuickAskSidebar } from "@/components/meetings/quick-ask-sidebar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export function meta() {
   return [{ title: "Meeting · Clips" }];
@@ -463,14 +468,18 @@ export default function MeetingDetailRoute() {
   return (
     <div className="p-6 max-w-6xl mx-auto w-full">
       <PageHeader>
-        <NavLink
-          to="/meetings"
-          aria-label="All meetings"
-          title="All meetings"
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
-        >
-          <IconArrowLeft className="h-4 w-4" />
-        </NavLink>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <NavLink
+              to="/meetings"
+              aria-label="All meetings"
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50"
+            >
+              <IconArrowLeft className="h-4 w-4" />
+            </NavLink>
+          </TooltipTrigger>
+          <TooltipContent>All meetings</TooltipContent>
+        </Tooltip>
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <TitleEditor
             value={meeting.title || ""}

--- a/templates/content/app/components/editor/BubbleToolbar.tsx
+++ b/templates/content/app/components/editor/BubbleToolbar.tsx
@@ -13,6 +13,11 @@ import {
 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { useState } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface BubbleToolbarProps {
   editor: Editor;
@@ -189,19 +194,22 @@ export function BubbleToolbar({ editor, onComment }: BubbleToolbarProps) {
               isActive: () => boolean;
             };
             return (
-              <button
-                key={title}
-                onClick={action}
-                title={title}
-                className={cn(
-                  "p-2 rounded",
-                  isActive()
-                    ? "bg-gray-600 text-white"
-                    : "text-gray-300 hover:bg-gray-700 hover:text-white",
-                )}
-              >
-                <Icon size={16} strokeWidth={2.5} />
-              </button>
+              <Tooltip key={title}>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={action}
+                    className={cn(
+                      "p-2 rounded",
+                      isActive()
+                        ? "bg-gray-600 text-white"
+                        : "text-gray-300 hover:bg-gray-700 hover:text-white",
+                    )}
+                  >
+                    <Icon size={16} strokeWidth={2.5} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{title}</TooltipContent>
+              </Tooltip>
             );
           })}
         </div>

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -264,13 +264,17 @@ export function DocumentToolbar({
         variant="compact"
       />
 
-      <button
-        onClick={() => setHistoryOpen(true)}
-        className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent"
-        title="Version history"
-      >
-        <IconHistory size={16} />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={() => setHistoryOpen(true)}
+            className="flex h-9 w-9 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent"
+          >
+            <IconHistory size={16} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Version history</TooltipContent>
+      </Tooltip>
 
       <VersionHistoryPanel
         documentId={documentId}
@@ -279,40 +283,44 @@ export function DocumentToolbar({
       />
 
       <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <button
-            className={cn(
-              "flex h-9 w-9 items-center justify-center rounded-lg hover:bg-accent",
-              isLinked
-                ? "text-foreground"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-            title={
-              isLinked
-                ? "Linked to Notion"
-                : isConnected
-                  ? "Link to Notion"
-                  : "Connect Notion"
-            }
-          >
-            {hasConflict ? (
-              <div className="relative">
-                <NotionIcon className="h-4 w-4" />
-                <IconAlertTriangle
-                  size={8}
-                  className="absolute -right-1 -top-1 text-amber-500"
-                />
-              </div>
-            ) : isLinked && autoSync ? (
-              <div className="relative">
-                <NotionIcon className="h-4 w-4" />
-                <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-emerald-500" />
-              </div>
-            ) : (
-              <NotionIcon className="h-4 w-4" />
-            )}
-          </button>
-        </PopoverTrigger>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <button
+                className={cn(
+                  "flex h-9 w-9 items-center justify-center rounded-lg hover:bg-accent",
+                  isLinked
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {hasConflict ? (
+                  <div className="relative">
+                    <NotionIcon className="h-4 w-4" />
+                    <IconAlertTriangle
+                      size={8}
+                      className="absolute -right-1 -top-1 text-amber-500"
+                    />
+                  </div>
+                ) : isLinked && autoSync ? (
+                  <div className="relative">
+                    <NotionIcon className="h-4 w-4" />
+                    <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-emerald-500" />
+                  </div>
+                ) : (
+                  <NotionIcon className="h-4 w-4" />
+                )}
+              </button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>
+            {isLinked
+              ? "Linked to Notion"
+              : isConnected
+                ? "Link to Notion"
+                : "Connect Notion"}
+          </TooltipContent>
+        </Tooltip>
 
         <PopoverContent
           side="bottom"

--- a/templates/content/app/components/editor/EmojiPicker.tsx
+++ b/templates/content/app/components/editor/EmojiPicker.tsx
@@ -5,6 +5,11 @@ import {
   PopoverContent,
 } from "@/components/ui/popover";
 import { IconMoodSmile } from "@tabler/icons-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const EMOJI_CATEGORIES: { name: string; emojis: string[] }[] = [
   {
@@ -358,20 +363,24 @@ export function EmojiPicker({ icon, onSelect }: EmojiPickerProps) {
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         {icon ? (
-          <button
-            className="text-5xl leading-none cursor-pointer hover:bg-accent/50 rounded-md p-1 -ml-1"
-            title="Change icon"
-          >
-            {icon}
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button className="text-5xl leading-none cursor-pointer hover:bg-accent/50 rounded-md p-1 -ml-1">
+                {icon}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Change icon</TooltipContent>
+          </Tooltip>
         ) : (
-          <button
-            className="flex items-center gap-1.5 text-sm text-muted-foreground/60 hover:text-muted-foreground hover:bg-accent/50 rounded-md px-1.5 py-1 -ml-1.5 cursor-pointer opacity-0 group-hover/title:opacity-100 data-[state=open]:opacity-100"
-            title="Add icon"
-          >
-            <IconMoodSmile size={18} />
-            <span>Add icon</span>
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button className="flex items-center gap-1.5 text-sm text-muted-foreground/60 hover:text-muted-foreground hover:bg-accent/50 rounded-md px-1.5 py-1 -ml-1.5 cursor-pointer opacity-0 group-hover/title:opacity-100 data-[state=open]:opacity-100">
+                <IconMoodSmile size={18} />
+                <span>Add icon</span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Add icon</TooltipContent>
+          </Tooltip>
         )}
       </PopoverTrigger>
       <PopoverContent align="start" className="w-80 p-0">

--- a/templates/content/app/components/editor/LinkHoverPreview.tsx
+++ b/templates/content/app/components/editor/LinkHoverPreview.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState, useRef, forwardRef } from "react";
 import { IconUnlink, IconExternalLink } from "@tabler/icons-react";
 import type { Editor } from "@tiptap/react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface LinkHoverPreviewProps {
   editor: Editor;
@@ -129,22 +134,30 @@ export function LinkHoverPreview({ editor }: LinkHoverPreviewProps) {
         >
           {domain}
         </a>
-        <a
-          href={hoveredLink.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-muted-foreground hover:text-foreground p-1 rounded hover:bg-accent"
-          title="Open link"
-        >
-          <IconExternalLink className="h-3.5 w-3.5" />
-        </a>
-        <button
-          onClick={handleRemoveLink}
-          className="text-muted-foreground hover:text-destructive p-1 rounded hover:bg-destructive/10"
-          title="Remove link"
-        >
-          <IconUnlink className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <a
+              href={hoveredLink.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground hover:text-foreground p-1 rounded hover:bg-accent"
+            >
+              <IconExternalLink className="h-3.5 w-3.5" />
+            </a>
+          </TooltipTrigger>
+          <TooltipContent>Open link</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={handleRemoveLink}
+              className="text-muted-foreground hover:text-destructive p-1 rounded hover:bg-destructive/10"
+            >
+              <IconUnlink className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Remove link</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/templates/content/app/components/editor/TableHoverControls.tsx
+++ b/templates/content/app/components/editor/TableHoverControls.tsx
@@ -2,6 +2,11 @@ import { useEffect, useState, useRef } from "react";
 import { Editor } from "@tiptap/react";
 import { IconPlus, IconMinus } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface TableHoverControlsProps {
   editor: Editor;
@@ -183,40 +188,56 @@ export function TableHoverControls({ editor }: TableHoverControlsProps) {
         className="table-hover-controls flex items-center gap-0.5 absolute z-50 transform -translate-x-1/2 -translate-y-full bg-background shadow-sm border border-border rounded-md p-0.5 transition-opacity"
         style={{ left: colLeft, top: colTop }}
       >
-        <button
-          onClick={() => handleAction("addCol")}
-          title="Add column"
-          className="p-1 hover:bg-accent rounded text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <IconPlus size={14} strokeWidth={2.5} />
-        </button>
-        <button
-          onClick={() => handleAction("delCol")}
-          title="Delete column"
-          className="p-1 hover:bg-destructive/10 rounded text-muted-foreground hover:text-destructive transition-colors"
-        >
-          <IconMinus size={14} strokeWidth={2.5} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => handleAction("addCol")}
+              className="p-1 hover:bg-accent rounded text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <IconPlus size={14} strokeWidth={2.5} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Add column</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => handleAction("delCol")}
+              className="p-1 hover:bg-destructive/10 rounded text-muted-foreground hover:text-destructive transition-colors"
+            >
+              <IconMinus size={14} strokeWidth={2.5} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Delete column</TooltipContent>
+        </Tooltip>
       </div>
 
       <div
         className="table-hover-controls flex flex-col items-center gap-0.5 absolute z-50 transform -translate-x-full -translate-y-1/2 bg-background shadow-sm border border-border rounded-md p-0.5 transition-opacity"
         style={{ left: rowLeft, top: rowTop }}
       >
-        <button
-          onClick={() => handleAction("addRow")}
-          title="Add row"
-          className="p-1 hover:bg-accent rounded text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <IconPlus size={14} strokeWidth={2.5} />
-        </button>
-        <button
-          onClick={() => handleAction("delRow")}
-          title="Delete row"
-          className="p-1 hover:bg-destructive/10 rounded text-muted-foreground hover:text-destructive transition-colors"
-        >
-          <IconMinus size={14} strokeWidth={2.5} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => handleAction("addRow")}
+              className="p-1 hover:bg-accent rounded text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <IconPlus size={14} strokeWidth={2.5} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Add row</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => handleAction("delRow")}
+              className="p-1 hover:bg-destructive/10 rounded text-muted-foreground hover:text-destructive transition-colors"
+            >
+              <IconMinus size={14} strokeWidth={2.5} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Delete row</TooltipContent>
+        </Tooltip>
       </div>
     </>
   );

--- a/templates/content/app/components/editor/extensions/ImageBlock.tsx
+++ b/templates/content/app/components/editor/extensions/ImageBlock.tsx
@@ -1,6 +1,11 @@
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
 import { useState } from "react";
 import { IconTrash } from "@tabler/icons-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export function ImageBlock({
   node,
@@ -33,13 +38,17 @@ export function ImageBlock({
 
         {(isHovered || selected) && (
           <div className="media-block__overlay">
-            <button
-              onClick={deleteNode}
-              className="media-block__btn media-block__btn--danger"
-              title="Remove image"
-            >
-              <IconTrash size={14} />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={deleteNode}
+                  className="media-block__btn media-block__btn--danger"
+                >
+                  <IconTrash size={14} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Remove image</TooltipContent>
+            </Tooltip>
           </div>
         )}
       </div>

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -27,6 +27,11 @@ import {
   buildDocumentTree,
 } from "@/hooks/use-documents";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 function nanoid(size = 12): string {
   const chars =
@@ -197,20 +202,28 @@ export function DocumentSidebar({
   if (collapsed) {
     return (
       <div className="flex flex-col h-full w-12 border-r border-border bg-muted/30 items-center py-3 gap-1">
-        <button
-          className="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground"
-          onClick={onToggleCollapsed}
-          title="Expand sidebar"
-        >
-          <IconLayoutSidebarLeftExpand size={18} />
-        </button>
-        <button
-          className="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground"
-          onClick={() => handleCreatePage()}
-          title="New page"
-        >
-          <IconPlus size={16} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground"
+              onClick={onToggleCollapsed}
+            >
+              <IconLayoutSidebarLeftExpand size={18} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Expand sidebar</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              className="w-10 h-10 flex items-center justify-center rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground"
+              onClick={() => handleCreatePage()}
+            >
+              <IconPlus size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>New page</TooltipContent>
+        </Tooltip>
       </div>
     );
   }
@@ -243,20 +256,28 @@ export function DocumentSidebar({
           </span>
         </div>
         <div className="flex items-center gap-0.5">
-          <button
-            className="w-9 h-9 flex items-center justify-center rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground"
-            onClick={() => setIsSearching(!isSearching)}
-            title="Search"
-          >
-            <IconSearch size={16} />
-          </button>
-          <button
-            className="w-9 h-9 flex items-center justify-center rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground"
-            onClick={onToggleCollapsed}
-            title="Collapse sidebar"
-          >
-            <IconLayoutSidebarLeftCollapse size={16} />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                className="w-9 h-9 flex items-center justify-center rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground"
+                onClick={() => setIsSearching(!isSearching)}
+              >
+                <IconSearch size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Search</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                className="w-9 h-9 flex items-center justify-center rounded-lg hover:bg-accent text-muted-foreground hover:text-foreground"
+                onClick={onToggleCollapsed}
+              >
+                <IconLayoutSidebarLeftCollapse size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Collapse sidebar</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/templates/content/app/components/sidebar/DocumentTreeItem.tsx
+++ b/templates/content/app/components/sidebar/DocumentTreeItem.tsx
@@ -25,6 +25,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface DocumentTreeItemProps {
   node: DocumentTreeNode;
@@ -142,16 +147,20 @@ export function DocumentTreeItem({
             </DropdownMenuContent>
           </DropdownMenu>
 
-          <button
-            className="w-7 h-7 flex items-center justify-center rounded hover:bg-accent"
-            onClick={(e) => {
-              e.stopPropagation();
-              onCreateChild(node.id);
-            }}
-            title="Add sub-page"
-          >
-            <IconPlus size={14} />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                className="w-7 h-7 flex items-center justify-center rounded hover:bg-accent"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCreateChild(node.id);
+                }}
+              >
+                <IconPlus size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Add sub-page</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/templates/content/app/components/sidebar/NotionButton.tsx
+++ b/templates/content/app/components/sidebar/NotionButton.tsx
@@ -21,6 +21,11 @@ import { useNotionConnection, useDisconnectNotion } from "@/hooks/use-notion";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { agentNativePath, appApiPath } from "@agent-native/core/client";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 // ─── Notion SVG icon ────────────────────────────────────────────────────────
 
@@ -239,15 +244,19 @@ export function NotionButton() {
   if (showWizard) {
     return (
       <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <button
-            className="w-7 h-7 flex items-center justify-center rounded hover:bg-accent text-muted-foreground hover:text-foreground"
-            title="Connect Notion"
-            onClick={() => setOpen(true)}
-          >
-            <NotionIcon className="h-4 w-4" />
-          </button>
-        </PopoverTrigger>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <button
+                className="w-7 h-7 flex items-center justify-center rounded hover:bg-accent text-muted-foreground hover:text-foreground"
+                onClick={() => setOpen(true)}
+              >
+                <NotionIcon className="h-4 w-4" />
+              </button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Connect Notion</TooltipContent>
+        </Tooltip>
         <PopoverContent
           side="right"
           align="end"
@@ -590,23 +599,27 @@ export function NotionButton() {
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          className={cn(
-            "w-7 h-7 flex items-center justify-center rounded hover:bg-accent",
-            isConnected
-              ? "text-foreground"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-          title={
-            isConnected
-              ? `Notion: ${connection?.workspaceName ?? "Connected"}`
-              : "Connect Notion"
-          }
-        >
-          <NotionIcon className="h-4 w-4" />
-        </button>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              className={cn(
+                "w-7 h-7 flex items-center justify-center rounded hover:bg-accent",
+                isConnected
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <NotionIcon className="h-4 w-4" />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          {isConnected
+            ? `Notion: ${connection?.workspaceName ?? "Connected"}`
+            : "Connect Notion"}
+        </TooltipContent>
+      </Tooltip>
       <PopoverContent
         side="right"
         align="end"

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -169,7 +169,7 @@ The UI writes `navigation` whenever the user navigates:
 }
 ```
 
-Views: `"list"` (design list / home), `"editor"` (editing a design), `"present"` (fullscreen preview), `"design-systems"` (design system management), `"examples"` (example gallery).
+Views: `"list"` (design list / home), `"editor"` (editing a design), `"present"` (fullscreen preview), `"design-systems"` (design system management), `"examples"` (example gallery), `"settings"` (app and agent settings).
 
 **Do NOT write to `navigation`** — it is overwritten by the UI. Use `navigate` to move the user.
 
@@ -301,6 +301,7 @@ If your cwd is the monorepo root instead (e.g., running from the Frame wrapper),
 | `navigate` | `--view design-systems`          | Navigate to design systems |
 | `navigate` | `--view present --designId <id>` | Navigate to presentation   |
 | `navigate` | `--view examples`                | Navigate to examples       |
+| `navigate` | `--view settings`                | Navigate to settings       |
 
 ### Creating & Editing Designs
 

--- a/templates/design/actions/navigate.ts
+++ b/templates/design/actions/navigate.ts
@@ -7,10 +7,11 @@
  *   pnpm action navigate --view=list
  *   pnpm action navigate --view=editor --designId=abc123
  *   pnpm action navigate --view=design-systems
+ *   pnpm action navigate --view=settings
  *   pnpm action navigate --path=/some/route
  *
  * Options:
- *   --view       View name (list, editor, design-systems, present, examples)
+ *   --view       View name (list, editor, design-systems, present, examples, settings)
  *   --designId   Design ID (for editor/present views)
  *   --path       URL path to navigate to
  */
@@ -21,10 +22,17 @@ import { writeAppState } from "@agent-native/core/application-state";
 
 export default defineAction({
   description:
-    "Navigate the UI to a specific view or path. Views: list, editor, design-systems, present, examples. Use --designId with editor/present views.",
+    "Navigate the UI to a specific view or path. Views: list, editor, design-systems, present, examples, settings. Use --designId with editor/present views.",
   schema: z.object({
     view: z
-      .enum(["list", "editor", "design-systems", "present", "examples"])
+      .enum([
+        "list",
+        "editor",
+        "design-systems",
+        "present",
+        "examples",
+        "settings",
+      ])
       .optional()
       .describe("View name to navigate to"),
     designId: z.string().optional().describe("Design ID for editor/present"),

--- a/templates/design/actions/view-screen.ts
+++ b/templates/design/actions/view-screen.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
 
 export default defineAction({
   description:
-    "See what the user is currently looking at on screen. Returns the current navigation state including which design is open, which view they are on (list, editor, design-systems, present, examples), plus any pending question overlay or variant grid. Always call this first before taking any action.",
+    "See what the user is currently looking at on screen. Returns the current navigation state including which design is open, which view they are on (list, editor, design-systems, present, examples, settings), plus any pending question overlay or variant grid. Always call this first before taking any action.",
   schema: z.object({}),
   http: false,
   run: async () => {

--- a/templates/design/app/components/design-system/DesignSystemCard.tsx
+++ b/templates/design/app/components/design-system/DesignSystemCard.tsx
@@ -1,5 +1,10 @@
 import { IconPalette, IconStar, IconStarFilled } from "@tabler/icons-react";
 import type { DesignSystemData } from "../../../shared/api";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface DesignSystemCardProps {
   id: string;
@@ -96,20 +101,26 @@ export function DesignSystemCard({
           )}
         </div>
 
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onSetDefault();
-          }}
-          className="shrink-0 p-1 rounded hover:bg-accent cursor-pointer"
-          title={isDefault ? "Default design system" : "Set as default"}
-        >
-          {isDefault ? (
-            <IconStarFilled className="w-4 h-4 text-[#609FF8]" />
-          ) : (
-            <IconStar className="w-4 h-4 text-muted-foreground/60 group-hover:text-muted-foreground" />
-          )}
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onSetDefault();
+              }}
+              className="shrink-0 p-1 rounded hover:bg-accent cursor-pointer"
+            >
+              {isDefault ? (
+                <IconStarFilled className="w-4 h-4 text-[#609FF8]" />
+              ) : (
+                <IconStar className="w-4 h-4 text-muted-foreground/60 group-hover:text-muted-foreground" />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {isDefault ? "Default design system" : "Set as default"}
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/templates/design/app/components/design/DesignToolbar.tsx
+++ b/templates/design/app/components/design/DesignToolbar.tsx
@@ -25,6 +25,11 @@ import { cn } from "@/lib/utils";
 import { ShareButton } from "@agent-native/core/client";
 import { SaveStatusIndicator } from "@/components/visual-editor";
 import type { ViewportTab } from "./types";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export type EditorMode = "comment" | "edit" | "draw";
 
@@ -189,36 +194,44 @@ export function DesignToolbar({
 
       {/* Draw on canvas */}
       {onToggleDrawMode && (
-        <Button
-          variant="ghost"
-          size="icon"
-          data-toolbar-draw-button
-          className={cn(
-            "h-8 w-8 cursor-pointer",
-            drawMode && "bg-muted text-foreground",
-          )}
-          onClick={onToggleDrawMode}
-          title="Draw on canvas"
-        >
-          <IconPencilPlus className="h-4 w-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              data-toolbar-draw-button
+              className={cn(
+                "h-8 w-8 cursor-pointer",
+                drawMode && "bg-muted text-foreground",
+              )}
+              onClick={onToggleDrawMode}
+            >
+              <IconPencilPlus className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Draw on canvas</TooltipContent>
+        </Tooltip>
       )}
 
       {/* Drop comment pin */}
       {onTogglePinMode && (
-        <Button
-          variant="ghost"
-          size="icon"
-          data-toolbar-pin-button
-          className={cn(
-            "h-8 w-8 cursor-pointer",
-            pinMode && "bg-muted text-foreground",
-          )}
-          onClick={onTogglePinMode}
-          title="Drop comment pin"
-        >
-          <IconPin className="h-4 w-4" />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              data-toolbar-pin-button
+              className={cn(
+                "h-8 w-8 cursor-pointer",
+                pinMode && "bg-muted text-foreground",
+              )}
+              onClick={onTogglePinMode}
+            >
+              <IconPin className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Drop comment pin</TooltipContent>
+        </Tooltip>
       )}
 
       {/* Save status */}
@@ -227,19 +240,22 @@ export function DesignToolbar({
       {/* Mode switcher */}
       <div className="flex overflow-hidden rounded-md border border-border">
         {MODE_ITEMS.map(({ mode: m, icon: Icon, label }) => (
-          <button
-            key={m}
-            onClick={() => onModeChange(m)}
-            title={label}
-            className={cn(
-              "cursor-pointer px-2 py-1.5",
-              mode === m
-                ? "bg-muted text-foreground"
-                : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
-            )}
-          >
-            <Icon className="h-3.5 w-3.5" />
-          </button>
+          <Tooltip key={m}>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => onModeChange(m)}
+                className={cn(
+                  "cursor-pointer px-2 py-1.5",
+                  mode === m
+                    ? "bg-muted text-foreground"
+                    : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                )}
+              >
+                <Icon className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{label}</TooltipContent>
+          </Tooltip>
         ))}
       </div>
 

--- a/templates/design/app/components/design/DrawOverlay.tsx
+++ b/templates/design/app/components/design/DrawOverlay.tsx
@@ -10,6 +10,11 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import type { DrawAnnotation } from "./types";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface DrawOverlayProps {
   visible: boolean;
@@ -274,18 +279,21 @@ export function DrawOverlay({ visible, onQueue, onSend }: DrawOverlayProps) {
         {/* Color picker */}
         <div className="flex gap-1">
           {PRESET_COLORS.map((preset) => (
-            <button
-              key={preset.color}
-              onClick={() => setColor(preset.color)}
-              className={cn(
-                "h-5 w-5 cursor-pointer rounded-full",
-                color === preset.color
-                  ? "ring-2 ring-white ring-offset-1 ring-offset-[hsl(240,5%,8%)]"
-                  : "ring-1 ring-white/10",
-              )}
-              style={{ backgroundColor: preset.color }}
-              title={preset.label}
-            />
+            <Tooltip key={preset.color}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setColor(preset.color)}
+                  className={cn(
+                    "h-5 w-5 cursor-pointer rounded-full",
+                    color === preset.color
+                      ? "ring-2 ring-white ring-offset-1 ring-offset-[hsl(240,5%,8%)]"
+                      : "ring-1 ring-white/10",
+                  )}
+                  style={{ backgroundColor: preset.color }}
+                />
+              </TooltipTrigger>
+              <TooltipContent>{preset.label}</TooltipContent>
+            </Tooltip>
           ))}
         </div>
 
@@ -294,60 +302,75 @@ export function DrawOverlay({ visible, onQueue, onSend }: DrawOverlayProps) {
         {/* Line widths */}
         <div className="flex gap-1">
           {LINE_WIDTHS.map((lw) => (
-            <button
-              key={lw.value}
-              onClick={() => setLineWidth(lw.value)}
-              className={cn(
-                "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
-                lineWidth === lw.value
-                  ? "bg-accent text-foreground"
-                  : "text-muted-foreground/70 hover:text-muted-foreground",
-              )}
-              title={lw.label}
-            >
-              <div
-                className="rounded-full bg-current"
-                style={{ width: lw.value + 2, height: lw.value + 2 }}
-              />
-            </button>
+            <Tooltip key={lw.value}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setLineWidth(lw.value)}
+                  className={cn(
+                    "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
+                    lineWidth === lw.value
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground/70 hover:text-muted-foreground",
+                  )}
+                >
+                  <div
+                    className="rounded-full bg-current"
+                    style={{ width: lw.value + 2, height: lw.value + 2 }}
+                  />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{lw.label}</TooltipContent>
+            </Tooltip>
           ))}
         </div>
 
         <div className="mx-1 h-4 w-px bg-accent" />
 
         {/* Text mode toggle */}
-        <button
-          onClick={() => setTextMode(!textMode)}
-          className={cn(
-            "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
-            textMode
-              ? "bg-accent text-foreground"
-              : "text-muted-foreground/70 hover:text-muted-foreground",
-          )}
-          title="Type anywhere"
-        >
-          <IconCursorText className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setTextMode(!textMode)}
+              className={cn(
+                "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
+                textMode
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground/70 hover:text-muted-foreground",
+              )}
+            >
+              <IconCursorText className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Type anywhere</TooltipContent>
+        </Tooltip>
 
         {/* Undo */}
-        <button
-          onClick={undo}
-          disabled={strokes.length === 0}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground/70 hover:text-muted-foreground disabled:cursor-default disabled:opacity-30"
-          title="Undo"
-        >
-          <IconArrowBackUp className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={undo}
+              disabled={strokes.length === 0}
+              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground/70 hover:text-muted-foreground disabled:cursor-default disabled:opacity-30"
+            >
+              <IconArrowBackUp className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Undo</TooltipContent>
+        </Tooltip>
 
         {/* Clear */}
-        <button
-          onClick={clear}
-          disabled={strokes.length === 0}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground/70 hover:text-muted-foreground disabled:cursor-default disabled:opacity-30"
-          title="Clear"
-        >
-          <IconEraser className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={clear}
+              disabled={strokes.length === 0}
+              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground/70 hover:text-muted-foreground disabled:cursor-default disabled:opacity-30"
+            >
+              <IconEraser className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Clear</TooltipContent>
+        </Tooltip>
 
         <div className="mx-1 h-4 w-px bg-accent" />
 

--- a/templates/design/app/components/design/MultiScreenCanvas.tsx
+++ b/templates/design/app/components/design/MultiScreenCanvas.tsx
@@ -1,6 +1,11 @@
 import { useRef, useState, useCallback, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { prettyScreenName } from "@/lib/screen-names";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface ScreenFile {
   id: string;
@@ -155,39 +160,43 @@ function Screen({
       >
         {display}
       </span>
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onPick(screen.id);
-        }}
-        onMouseDown={(e) => e.stopPropagation()}
-        className={cn(
-          "block overflow-hidden rounded-lg border-2 bg-white shadow-2xl transition-colors",
-          isActive
-            ? "border-primary"
-            : "border-border hover:border-muted-foreground/50",
-        )}
-        style={{
-          width: SCREEN_WIDTH,
-          height: SCREEN_HEIGHT,
-          cursor: "pointer",
-        }}
-        title={`Open ${display}`}
-      >
-        <iframe
-          srcDoc={screen.content}
-          sandbox="allow-scripts allow-same-origin"
-          className="pointer-events-none border-0"
-          style={{
-            width: 1280,
-            height: 2560,
-            transform: `scale(${SCREEN_WIDTH / 1280})`,
-            transformOrigin: "top left",
-          }}
-          title={screen.filename}
-        />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onPick(screen.id);
+            }}
+            onMouseDown={(e) => e.stopPropagation()}
+            className={cn(
+              "block overflow-hidden rounded-lg border-2 bg-white shadow-2xl transition-colors",
+              isActive
+                ? "border-primary"
+                : "border-border hover:border-muted-foreground/50",
+            )}
+            style={{
+              width: SCREEN_WIDTH,
+              height: SCREEN_HEIGHT,
+              cursor: "pointer",
+            }}
+          >
+            <iframe
+              srcDoc={screen.content}
+              sandbox="allow-scripts allow-same-origin"
+              className="pointer-events-none border-0"
+              style={{
+                width: 1280,
+                height: 2560,
+                transform: `scale(${SCREEN_WIDTH / 1280})`,
+                transformOrigin: "top left",
+              }}
+              title={screen.filename}
+            />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{`Open ${display}`}</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/templates/design/app/components/design/TweaksPanel.tsx
+++ b/templates/design/app/components/design/TweaksPanel.tsx
@@ -4,6 +4,11 @@ import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import type { TweakDefinition } from "@shared/api";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface TweaksPanelProps {
   tweaks: TweakDefinition[];
@@ -117,18 +122,21 @@ function TweakControl({
       {tweak.type === "color-swatch" && (
         <div className="flex gap-2">
           {tweak.options?.map((opt) => (
-            <button
-              key={opt.value}
-              onClick={() => onChange(opt.value)}
-              className={cn(
-                "h-6 w-6 cursor-pointer rounded-full",
-                value === opt.value
-                  ? "ring-2 ring-white ring-offset-2 ring-offset-[hsl(240,5%,8%)]"
-                  : "ring-1 ring-white/10 hover:ring-white/30",
-              )}
-              style={{ backgroundColor: opt.color || opt.value }}
-              title={opt.label}
-            />
+            <Tooltip key={opt.value}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => onChange(opt.value)}
+                  className={cn(
+                    "h-6 w-6 cursor-pointer rounded-full",
+                    value === opt.value
+                      ? "ring-2 ring-white ring-offset-2 ring-offset-[hsl(240,5%,8%)]"
+                      : "ring-1 ring-white/10 hover:ring-white/30",
+                  )}
+                  style={{ backgroundColor: opt.color || opt.value }}
+                />
+              </TooltipTrigger>
+              <TooltipContent>{opt.label}</TooltipContent>
+            </Tooltip>
           ))}
         </div>
       )}

--- a/templates/design/app/components/design/ZoomControls.tsx
+++ b/templates/design/app/components/design/ZoomControls.tsx
@@ -13,6 +13,11 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ZOOM_PRESETS } from "./types";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface ZoomControlsProps {
   zoom: number;
@@ -128,15 +133,19 @@ export function ZoomControls({ zoom, onZoomChange }: ZoomControlsProps) {
 
       <div className="w-px h-4 bg-border mx-0.5" />
 
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-6 w-6"
-        onClick={handleFitToScreen}
-        title="Fit to screen"
-      >
-        <IconMaximize className="w-3.5 h-3.5" />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            onClick={handleFitToScreen}
+          >
+            <IconMaximize className="w-3.5 h-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Fit to screen</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/templates/design/app/components/ui/sidebar.tsx
+++ b/templates/design/app/components/ui/sidebar.tsx
@@ -298,24 +298,28 @@ const SidebarRail = React.forwardRef<
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
-      ref={ref}
-      data-sidebar="rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      {...props}
-    />
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          ref={ref}
+          data-sidebar="rail"
+          aria-label="Toggle Sidebar"
+          tabIndex={-1}
+          onClick={toggleSidebar}
+          className={cn(
+            "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+            "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+            "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+            "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
+            "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+            "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+            className,
+          )}
+          {...props}
+        />
+      </TooltipTrigger>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
+    </Tooltip>
   );
 });
 SidebarRail.displayName = "SidebarRail";

--- a/templates/design/app/components/visual-editor/CanvasCommentPins.tsx
+++ b/templates/design/app/components/visual-editor/CanvasCommentPins.tsx
@@ -4,6 +4,11 @@ import { agentChat } from "@agent-native/core";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface CanvasPin {
   id: string;
@@ -217,16 +222,20 @@ export function CanvasCommentPins({
             style={{ left, top }}
           >
             {/* Pin marker */}
-            <button
-              onClick={() => setActivePinId(pin.id)}
-              className={cn(
-                "absolute -translate-x-1/2 -translate-y-full -mt-1 flex items-center justify-center w-7 h-7 rounded-full rounded-bl-none shadow-lg cursor-pointer",
-                "bg-[#609FF8] text-black hover:scale-110 transition-transform",
-              )}
-              title={pin.draft || "Comment"}
-            >
-              <IconMessage className="w-3.5 h-3.5" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setActivePinId(pin.id)}
+                  className={cn(
+                    "absolute -translate-x-1/2 -translate-y-full -mt-1 flex items-center justify-center w-7 h-7 rounded-full rounded-bl-none shadow-lg cursor-pointer",
+                    "bg-[#609FF8] text-black hover:scale-110 transition-transform",
+                  )}
+                >
+                  <IconMessage className="w-3.5 h-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{pin.draft || "Comment"}</TooltipContent>
+            </Tooltip>
 
             {/* Inline composer */}
             {isActive && !pin.submitted && (

--- a/templates/design/app/components/visual-editor/DrawOverlay.tsx
+++ b/templates/design/app/components/visual-editor/DrawOverlay.tsx
@@ -18,6 +18,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface DrawAnnotation {
   id: string;
@@ -314,18 +319,21 @@ export function DrawOverlay({ visible, onSend, onClose }: DrawOverlayProps) {
         {/* Color picker */}
         <div className="flex gap-1">
           {PRESET_COLORS.map((preset) => (
-            <button
-              key={preset.color}
-              onClick={() => setColor(preset.color)}
-              className={cn(
-                "h-5 w-5 cursor-pointer rounded-full",
-                color === preset.color
-                  ? "ring-2 ring-foreground ring-offset-1 ring-offset-popover"
-                  : "ring-1 ring-border",
-              )}
-              style={{ backgroundColor: preset.color }}
-              title={preset.label}
-            />
+            <Tooltip key={preset.color}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setColor(preset.color)}
+                  className={cn(
+                    "h-5 w-5 cursor-pointer rounded-full",
+                    color === preset.color
+                      ? "ring-2 ring-foreground ring-offset-1 ring-offset-popover"
+                      : "ring-1 ring-border",
+                  )}
+                  style={{ backgroundColor: preset.color }}
+                />
+              </TooltipTrigger>
+              <TooltipContent>{preset.label}</TooltipContent>
+            </Tooltip>
           ))}
         </div>
 
@@ -334,60 +342,75 @@ export function DrawOverlay({ visible, onSend, onClose }: DrawOverlayProps) {
         {/* Line widths */}
         <div className="flex gap-1">
           {LINE_WIDTHS.map((lw) => (
-            <button
-              key={lw.value}
-              onClick={() => setLineWidth(lw.value)}
-              className={cn(
-                "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
-                lineWidth === lw.value
-                  ? "bg-accent text-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              title={lw.label}
-            >
-              <div
-                className="rounded-full bg-current"
-                style={{ width: lw.value + 2, height: lw.value + 2 }}
-              />
-            </button>
+            <Tooltip key={lw.value}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setLineWidth(lw.value)}
+                  className={cn(
+                    "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
+                    lineWidth === lw.value
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <div
+                    className="rounded-full bg-current"
+                    style={{ width: lw.value + 2, height: lw.value + 2 }}
+                  />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{lw.label}</TooltipContent>
+            </Tooltip>
           ))}
         </div>
 
         <div className="mx-1 h-4 w-px bg-border" />
 
         {/* Text mode */}
-        <button
-          onClick={() => setTextMode(!textMode)}
-          className={cn(
-            "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
-            textMode
-              ? "bg-accent text-foreground"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-          title="Type anywhere on the canvas"
-        >
-          <IconCursorText className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setTextMode(!textMode)}
+              className={cn(
+                "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
+                textMode
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <IconCursorText className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Type anywhere on the canvas</TooltipContent>
+        </Tooltip>
 
         {/* Undo last stroke */}
-        <button
-          onClick={undo}
-          disabled={strokes.length === 0}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
-          title="Undo stroke"
-        >
-          <IconArrowBackUp className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={undo}
+              disabled={strokes.length === 0}
+              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
+            >
+              <IconArrowBackUp className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Undo stroke</TooltipContent>
+        </Tooltip>
 
         {/* Clear all */}
-        <button
-          onClick={clear}
-          disabled={strokes.length === 0 && textAnnotations.length === 0}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
-          title="Clear all"
-        >
-          <IconEraser className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={clear}
+              disabled={strokes.length === 0 && textAnnotations.length === 0}
+              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
+            >
+              <IconEraser className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Clear all</TooltipContent>
+        </Tooltip>
 
         <div className="mx-1 h-4 w-px bg-border" />
 
@@ -415,13 +438,17 @@ export function DrawOverlay({ visible, onSend, onClose }: DrawOverlayProps) {
         </Button>
 
         {/* Close */}
-        <button
-          onClick={onClose}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground"
-          title="Exit draw mode"
-        >
-          <IconX className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onClose}
+              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground"
+            >
+              <IconX className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Exit draw mode</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/templates/design/app/hooks/use-navigation-state.ts
+++ b/templates/design/app/hooks/use-navigation-state.ts
@@ -29,6 +29,8 @@ export function useNavigationState() {
       state.designId = params.id;
     } else if (location.pathname.startsWith("/examples")) {
       state.view = "examples";
+    } else if (location.pathname.startsWith("/settings")) {
+      state.view = "settings";
     }
 
     fetch(agentNativePath("/_agent-native/application-state/navigation"), {
@@ -82,6 +84,8 @@ export function useNavigationState() {
         path = `/present/${cmd.designId}`;
       } else if (cmd.view === "examples") {
         path = "/examples";
+      } else if (cmd.view === "settings") {
+        path = "/settings";
       } else {
         path = "/";
       }

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -55,6 +55,11 @@ import type {
 import { ZOOM_PRESETS } from "@/components/design/types";
 import { prettyScreenName } from "@/lib/screen-names";
 import type { TweakDefinition } from "@shared/api";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const TAB_ID = generateTabId();
 
@@ -382,62 +387,84 @@ export default function DesignEditor() {
 
           {/* Overview / single-screen toggle. Clicking Overview shows every
               file in the design as a Figma-style pannable lineup. */}
-          <Button
-            variant={viewMode === "overview" ? "secondary" : "ghost"}
-            size="icon"
-            className="h-7 w-7 cursor-pointer"
-            onClick={() =>
-              setViewMode((v) => (v === "overview" ? "single" : "overview"))
-            }
-            title={viewMode === "overview" ? "Single screen" : "All screens"}
-          >
-            <IconLayoutGrid className="w-3.5 h-3.5" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={viewMode === "overview" ? "secondary" : "ghost"}
+                size="icon"
+                className="h-7 w-7 cursor-pointer"
+                onClick={() =>
+                  setViewMode((v) => (v === "overview" ? "single" : "overview"))
+                }
+              >
+                <IconLayoutGrid className="w-3.5 h-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {viewMode === "overview" ? "Single screen" : "All screens"}
+            </TooltipContent>
+          </Tooltip>
 
           <div className="w-px h-5 bg-accent mx-1" />
 
           {/* Device frame — only meaningful in single-screen mode. */}
           <div className="flex items-center gap-0.5">
-            <Button
-              variant={deviceFrame === "none" ? "secondary" : "ghost"}
-              size="icon"
-              className="h-7 w-7 cursor-pointer"
-              onClick={() => setDeviceFrame("none")}
-              disabled={viewMode === "overview"}
-              title="No frame"
-            >
-              <IconDeviceDesktopOff className="w-3.5 h-3.5" />
-            </Button>
-            <Button
-              variant={deviceFrame === "desktop" ? "secondary" : "ghost"}
-              size="icon"
-              className="h-7 w-7 cursor-pointer"
-              onClick={() => setDeviceFrame("desktop")}
-              disabled={viewMode === "overview"}
-              title="Desktop"
-            >
-              <IconDeviceDesktop className="w-3.5 h-3.5" />
-            </Button>
-            <Button
-              variant={deviceFrame === "tablet" ? "secondary" : "ghost"}
-              size="icon"
-              className="h-7 w-7 cursor-pointer"
-              onClick={() => setDeviceFrame("tablet")}
-              disabled={viewMode === "overview"}
-              title="Tablet"
-            >
-              <IconDeviceTablet className="w-3.5 h-3.5" />
-            </Button>
-            <Button
-              variant={deviceFrame === "mobile" ? "secondary" : "ghost"}
-              size="icon"
-              className="h-7 w-7 cursor-pointer"
-              onClick={() => setDeviceFrame("mobile")}
-              disabled={viewMode === "overview"}
-              title="Mobile"
-            >
-              <IconDeviceMobile className="w-3.5 h-3.5" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant={deviceFrame === "none" ? "secondary" : "ghost"}
+                  size="icon"
+                  className="h-7 w-7 cursor-pointer"
+                  onClick={() => setDeviceFrame("none")}
+                  disabled={viewMode === "overview"}
+                >
+                  <IconDeviceDesktopOff className="w-3.5 h-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>No frame</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant={deviceFrame === "desktop" ? "secondary" : "ghost"}
+                  size="icon"
+                  className="h-7 w-7 cursor-pointer"
+                  onClick={() => setDeviceFrame("desktop")}
+                  disabled={viewMode === "overview"}
+                >
+                  <IconDeviceDesktop className="w-3.5 h-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Desktop</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant={deviceFrame === "tablet" ? "secondary" : "ghost"}
+                  size="icon"
+                  className="h-7 w-7 cursor-pointer"
+                  onClick={() => setDeviceFrame("tablet")}
+                  disabled={viewMode === "overview"}
+                >
+                  <IconDeviceTablet className="w-3.5 h-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Tablet</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant={deviceFrame === "mobile" ? "secondary" : "ghost"}
+                  size="icon"
+                  className="h-7 w-7 cursor-pointer"
+                  onClick={() => setDeviceFrame("mobile")}
+                  disabled={viewMode === "overview"}
+                >
+                  <IconDeviceMobile className="w-3.5 h-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Mobile</TooltipContent>
+            </Tooltip>
           </div>
 
           <div className="w-px h-5 bg-accent mx-1" />
@@ -468,45 +495,57 @@ export default function DesignEditor() {
           <div className="w-px h-5 bg-accent mx-1" />
 
           {/* Actions */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7 cursor-pointer"
-            onClick={() => setTweaksVisible(!tweaksVisible)}
-            title="Tweaks"
-          >
-            <IconSettings className="w-3.5 h-3.5" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 cursor-pointer"
+                onClick={() => setTweaksVisible(!tweaksVisible)}
+              >
+                <IconSettings className="w-3.5 h-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Tweaks</TooltipContent>
+          </Tooltip>
 
           {/* Draw on canvas — overlays the iframe with pencil + text. */}
-          <Button
-            variant={drawMode ? "secondary" : "ghost"}
-            size="icon"
-            className="h-7 w-7 cursor-pointer"
-            data-toolbar-draw-button
-            onClick={() => {
-              setDrawMode((d) => !d);
-              setPinMode(false);
-            }}
-            title="Draw on canvas"
-          >
-            <IconPencilPlus className="w-3.5 h-3.5" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={drawMode ? "secondary" : "ghost"}
+                size="icon"
+                className="h-7 w-7 cursor-pointer"
+                data-toolbar-draw-button
+                onClick={() => {
+                  setDrawMode((d) => !d);
+                  setPinMode(false);
+                }}
+              >
+                <IconPencilPlus className="w-3.5 h-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Draw on canvas</TooltipContent>
+          </Tooltip>
 
           {/* Drop comment pin — overlays the iframe with click-to-comment. */}
-          <Button
-            variant={pinMode ? "secondary" : "ghost"}
-            size="icon"
-            className="h-7 w-7 cursor-pointer"
-            data-toolbar-pin-button
-            onClick={() => {
-              setPinMode((p) => !p);
-              setDrawMode(false);
-            }}
-            title="Drop comment pin"
-          >
-            <IconPin className="w-3.5 h-3.5" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant={pinMode ? "secondary" : "ghost"}
+                size="icon"
+                className="h-7 w-7 cursor-pointer"
+                data-toolbar-pin-button
+                onClick={() => {
+                  setPinMode((p) => !p);
+                  setDrawMode(false);
+                }}
+              >
+                <IconPin className="w-3.5 h-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Drop comment pin</TooltipContent>
+          </Tooltip>
 
           {/* Save state — currently the design template doesn't expose a
               dedicated "save in flight" signal (file edits go through Yjs +
@@ -530,18 +569,21 @@ export default function DesignEditor() {
       {viewportTabs.length > 1 && (
         <div className="h-8 border-b border-border flex items-center gap-1 px-3 shrink-0">
           {viewportTabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveFileId(tab.id)}
-              title={tab.filename}
-              className={`px-2.5 py-1 rounded text-xs cursor-pointer ${
-                tab.id === activeFileId
-                  ? "bg-accent text-foreground/90"
-                  : "text-muted-foreground hover:text-muted-foreground"
-              }`}
-            >
-              {prettyScreenName(tab.filename)}
-            </button>
+            <Tooltip key={tab.id}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setActiveFileId(tab.id)}
+                  className={`px-2.5 py-1 rounded text-xs cursor-pointer ${
+                    tab.id === activeFileId
+                      ? "bg-accent text-foreground/90"
+                      : "text-muted-foreground hover:text-muted-foreground"
+                  }`}
+                >
+                  {prettyScreenName(tab.filename)}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{tab.filename}</TooltipContent>
+            </Tooltip>
           ))}
         </div>
       )}

--- a/templates/design/app/pages/DesignSystems.tsx
+++ b/templates/design/app/pages/DesignSystems.tsx
@@ -18,6 +18,11 @@ import {
   useSetHeaderActions,
   useSetPageTitle,
 } from "@/components/layout/HeaderActions";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface DesignSystem {
   id: string;
@@ -202,19 +207,23 @@ export default function DesignSystems() {
                       />
                     </div>
                     {/* Star button */}
-                    <button
-                      onClick={() => handleSetDefault(ds.id)}
-                      className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 w-7 h-7 flex items-center justify-center rounded-md bg-black/60 hover:bg-black/80 cursor-pointer"
-                      title={
-                        ds.isDefault ? "Currently default" : "Set as default"
-                      }
-                    >
-                      {ds.isDefault ? (
-                        <IconStarFilled className="w-3.5 h-3.5 text-yellow-400" />
-                      ) : (
-                        <IconStar className="w-3.5 h-3.5 text-muted-foreground" />
-                      )}
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={() => handleSetDefault(ds.id)}
+                          className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 w-7 h-7 flex items-center justify-center rounded-md bg-black/60 hover:bg-black/80 cursor-pointer"
+                        >
+                          {ds.isDefault ? (
+                            <IconStarFilled className="w-3.5 h-3.5 text-yellow-400" />
+                          ) : (
+                            <IconStar className="w-3.5 h-3.5 text-muted-foreground" />
+                          )}
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {ds.isDefault ? "Currently default" : "Set as default"}
+                      </TooltipContent>
+                    </Tooltip>
                   </div>
                 );
               })}

--- a/templates/design/app/routes/settings.tsx
+++ b/templates/design/app/routes/settings.tsx
@@ -1,5 +1,4 @@
-import { useDevMode } from "@agent-native/core/client";
-import { SettingsPanel } from "@agent-native/core/client/settings";
+import { SettingsPanel, useDevMode } from "@agent-native/core/client";
 
 export function meta() {
   return [{ title: "Settings — Design" }];

--- a/templates/design/app/routes/settings.tsx
+++ b/templates/design/app/routes/settings.tsx
@@ -1,0 +1,20 @@
+import { useDevMode } from "@agent-native/core/client";
+import { SettingsPanel } from "@agent-native/core/client/settings";
+
+export function meta() {
+  return [{ title: "Settings — Design" }];
+}
+
+export default function SettingsRoute() {
+  const { isDevMode, canToggle, setDevMode } = useDevMode();
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <SettingsPanel
+        isDevMode={isDevMode}
+        onToggleDevMode={() => setDevMode(!isDevMode)}
+        showDevToggle={canToggle}
+      />
+    </div>
+  );
+}

--- a/templates/dispatch/app/global.css
+++ b/templates/dispatch/app/global.css
@@ -2,6 +2,7 @@
 
 @import "tailwindcss";
 @import "@agent-native/core/styles/agent-native.css";
+@import "@agent-native/dispatch/styles/dispatch.css";
 
 @source "./**/*.{ts,tsx}";
 

--- a/templates/dispatch/app/routes/_index.tsx
+++ b/templates/dispatch/app/routes/_index.tsx
@@ -1,1 +1,7 @@
-export { default, meta } from "@agent-native/dispatch/routes/pages/_index";
+export {
+  clientLoader,
+  default,
+  HydrateFallback,
+  loader,
+  meta,
+} from "@agent-native/dispatch/routes/pages/_index";

--- a/templates/mail/app/components/email/ComposeBubbleToolbar.tsx
+++ b/templates/mail/app/components/email/ComposeBubbleToolbar.tsx
@@ -10,6 +10,11 @@ import {
 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface ComposeBubbleToolbarProps {
   editor: Editor;
@@ -262,13 +267,17 @@ export function ComposeBubbleToolbar({
                 }}
                 className="bg-transparent border-none outline-none text-white text-sm w-52 px-1 py-0.5 placeholder:text-gray-400 resize-none leading-snug"
               />
-              <button
-                onClick={() => void handleAiAssist()}
-                title="Generate (⌘Enter)"
-                className="text-xs text-blue-400 hover:text-blue-300 px-1.5 py-0.5 font-medium shrink-0 self-end pb-1"
-              >
-                Generate
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => void handleAiAssist()}
+                    className="text-xs text-blue-400 hover:text-blue-300 px-1.5 py-0.5 font-medium shrink-0 self-end pb-1"
+                  >
+                    Generate
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Generate (⌘Enter)</TooltipContent>
+              </Tooltip>
             </>
           )}
         </div>
@@ -292,34 +301,41 @@ export function ComposeBubbleToolbar({
               active: boolean;
             };
             return (
-              <button
-                key={title}
-                onClick={action}
-                title={title}
-                className={cn(
-                  "p-1.5 rounded transition-colors",
-                  active
-                    ? "bg-gray-600 text-white"
-                    : "text-gray-300 hover:bg-gray-700 hover:text-white",
-                )}
-              >
-                <Icon size={14} strokeWidth={2.5} />
-              </button>
+              <Tooltip key={title}>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={action}
+                    className={cn(
+                      "p-1.5 rounded transition-colors",
+                      active
+                        ? "bg-gray-600 text-white"
+                        : "text-gray-300 hover:bg-gray-700 hover:text-white",
+                    )}
+                  >
+                    <Icon size={14} strokeWidth={2.5} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{title}</TooltipContent>
+              </Tooltip>
             );
           })}
           <div className="w-px h-5 bg-gray-600 mx-0.5" />
-          <button
-            onMouseDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              setShowAiInput(true);
-              setShowLinkInput(false);
-            }}
-            title="AI Assist"
-            className="p-1.5 rounded transition-colors text-gray-300 hover:bg-gray-700 hover:text-white"
-          >
-            <IconPencil size={14} strokeWidth={2.5} />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setShowAiInput(true);
+                  setShowLinkInput(false);
+                }}
+                className="p-1.5 rounded transition-colors text-gray-300 hover:bg-gray-700 hover:text-white"
+              >
+                <IconPencil size={14} strokeWidth={2.5} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>AI Assist</TooltipContent>
+          </Tooltip>
         </div>
       )}
     </div>

--- a/templates/mail/app/components/email/ComposeModal.tsx
+++ b/templates/mail/app/components/email/ComposeModal.tsx
@@ -489,13 +489,17 @@ export function ComposeModal({
             })
           )}
           {/* + button: always visible, right after title/tabs */}
-          <button
-            onClick={onNewDraft}
-            className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground/50 hover:text-foreground hover:bg-accent/30 transition-colors"
-            title="New draft"
-          >
-            <IconPlus className="h-3 w-3" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onNewDraft}
+                className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground/50 hover:text-foreground hover:bg-accent/30 transition-colors"
+              >
+                <IconPlus className="h-3 w-3" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>New draft</TooltipContent>
+          </Tooltip>
         </div>
 
         {/* Right side: minimize & close */}
@@ -759,13 +763,17 @@ export function ComposeModal({
             </div>
 
             <div className="flex items-center gap-2">
-              <button
-                onClick={() => onDiscard(activeId)}
-                className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground/40 hover:text-red-400 hover:bg-red-400/10 transition-colors"
-                title="Delete draft"
-              >
-                <IconTrash className="h-4 w-4" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => onDiscard(activeId)}
+                    className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground/40 hover:text-red-400 hover:bg-red-400/10 transition-colors"
+                  >
+                    <IconTrash className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Delete draft</TooltipContent>
+              </Tooltip>
               <SendLaterButton
                 onSend={handleSend}
                 onSendLater={handleSendLater}

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -251,8 +251,8 @@ export function EmailList({
   const [searchParams] = useSearchParams();
   const searchQuery = searchParams.get("q") ?? undefined;
   const labelParam = searchParams.get("label");
-  const labelSuffix = labelParam
-    ? `?label=${encodeURIComponent(labelParam)}`
+  const routeSearchSuffix = searchParams.toString()
+    ? `?${searchParams.toString()}`
     : "";
 
   const {
@@ -382,7 +382,7 @@ export function EmailList({
     setSelectedIds(new Set());
     void ensureThread(targetThreadId);
     onNavigateThread?.(targetThreadId);
-    navigate(`/${view}/${targetThreadId}${labelSuffix}`);
+    navigate(`/${view}/${targetThreadId}${routeSearchSuffix}`);
     if (thread.hasUnread) {
       setTimeout(() => markThreadRead.mutate(targetThreadId), 0);
     }
@@ -391,7 +391,7 @@ export function EmailList({
     view,
     navigate,
     markThreadRead,
-    labelSuffix,
+    routeSearchSuffix,
     queryClient,
     setSelectedIds,
   ]);
@@ -754,7 +754,7 @@ export function EmailList({
     }
     void ensureThread(targetThreadId);
     onNavigateThread?.(targetThreadId);
-    navigate(`/${view}/${targetThreadId}${labelSuffix}`);
+    navigate(`/${view}/${targetThreadId}${routeSearchSuffix}`);
     if (thread.hasUnread) {
       setTimeout(() => markThreadRead.mutate(targetThreadId), 0);
     }

--- a/templates/mail/app/components/email/EmailListItem.tsx
+++ b/templates/mail/app/components/email/EmailListItem.tsx
@@ -4,6 +4,11 @@ import { IconStarFilled, IconCheck, IconClock } from "@tabler/icons-react";
 import type { EmailMessage } from "@shared/types";
 import type { ThreadSummary } from "@/lib/threads";
 import { useAccountFilter } from "@/hooks/use-account-filter";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface EmailListItemProps {
   email: EmailMessage;
@@ -471,18 +476,22 @@ export const EmailListItem = memo(function EmailListItem({
 
         {/* Hover actions — overlay on top of time */}
         <div className="hover-actions items-center gap-0.5">
-          <button
-            onClick={onStar}
-            className={cn(
-              "flex h-6 w-6 items-center justify-center rounded transition-colors",
-              isStarred
-                ? "text-amber-400"
-                : "text-muted-foreground hover:text-foreground hover:bg-accent",
-            )}
-            title="Pin"
-          >
-            <IconStarFilled className="h-3.5 w-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onStar}
+                className={cn(
+                  "flex h-6 w-6 items-center justify-center rounded transition-colors",
+                  isStarred
+                    ? "text-amber-400"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                )}
+              >
+                <IconStarFilled className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Pin</TooltipContent>
+          </Tooltip>
         </div>
       </div>
     </div>

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -1057,13 +1057,17 @@ export function EmailThread({
       {/* Thread header */}
       <div className="shrink-0 px-3 sm:px-5 pt-4 sm:pt-5 pb-3 max-h-[40%]">
         <div className="flex items-start gap-2 sm:gap-3">
-          <button
-            onClick={goBack}
-            className="mt-0.5 flex h-9 w-9 sm:h-7 sm:w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-            title="Back (Esc)"
-          >
-            <IconArrowLeft className="h-[14px] w-[14px]" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={goBack}
+                className="mt-0.5 flex h-9 w-9 sm:h-7 sm:w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+              >
+                <IconArrowLeft className="h-[14px] w-[14px]" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Back (Esc)</TooltipContent>
+          </Tooltip>
 
           <div className="flex-1 min-w-0">
             <div className="flex items-start gap-2 flex-wrap">
@@ -1080,13 +1084,17 @@ export function EmailThread({
               ))}
               {/* Action bar */}
               <div className="hidden sm:flex items-center gap-0.5 ml-auto shrink-0">
-                <button
-                  onClick={handleArchive}
-                  className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-                  title="Done (E)"
-                >
-                  <IconCheck className="h-4 w-4" />
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={handleArchive}
+                      className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                    >
+                      <IconCheck className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Done (E)</TooltipContent>
+                </Tooltip>
                 <button
                   onClick={() => goToSibling(-1)}
                   className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors ml-1"
@@ -1132,15 +1140,21 @@ export function EmailThread({
                   </Tooltip>
                 )}
                 {unsubscribeInfo && (
-                  <button
-                    onClick={handleUnsubscribe}
-                    disabled={unsubscribing}
-                    className="inline-flex items-center gap-1.5 text-[12px] text-muted-foreground/50 hover:text-muted-foreground transition-colors disabled:opacity-50"
-                    title="Unsubscribe from this mailing list"
-                  >
-                    <IconMailOff className="h-3 w-3" />
-                    {unsubscribing ? "Unsubscribing..." : "Unsubscribe"}
-                  </button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={handleUnsubscribe}
+                        disabled={unsubscribing}
+                        className="inline-flex items-center gap-1.5 text-[12px] text-muted-foreground/50 hover:text-muted-foreground transition-colors disabled:opacity-50"
+                      >
+                        <IconMailOff className="h-3 w-3" />
+                        {unsubscribing ? "Unsubscribing..." : "Unsubscribe"}
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Unsubscribe from this mailing list
+                    </TooltipContent>
+                  </Tooltip>
                 )}
               </div>
             )}
@@ -1384,13 +1398,17 @@ function ThreadLoadingState({
     <div className="flex flex-1 flex-col overflow-hidden">
       <div className="shrink-0 px-3 sm:px-5 pt-4 sm:pt-5 pb-3 max-h-[40%]">
         <div className="flex items-start gap-2 sm:gap-3">
-          <button
-            onClick={onBack}
-            className="mt-0.5 flex h-9 w-9 sm:h-7 sm:w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-            title="Back (Esc)"
-          >
-            <IconArrowLeft className="h-[14px] w-[14px]" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onBack}
+                className="mt-0.5 flex h-9 w-9 sm:h-7 sm:w-7 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+              >
+                <IconArrowLeft className="h-[14px] w-[14px]" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Back (Esc)</TooltipContent>
+          </Tooltip>
 
           <div className="flex-1 min-w-0">
             {preview ? (
@@ -1691,36 +1709,48 @@ const ExpandedMessageCard = forwardRef<
 
           {/* Reply / Reply All / Forward buttons */}
           <div className="flex items-center gap-1 sm:gap-0.5 shrink-0">
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onReply();
-              }}
-              className="flex h-9 w-9 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors"
-              title="Reply"
-            >
-              <IconArrowBackUp className="h-4 w-4 sm:h-[14px] sm:w-[14px]" />
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onReplyAll();
-              }}
-              className="flex h-9 w-9 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors"
-              title="Reply All"
-            >
-              <IconArrowBackUpDouble className="h-4 w-4 sm:h-[14px] sm:w-[14px]" />
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onForward();
-              }}
-              className="flex h-9 w-9 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors"
-              title="Forward"
-            >
-              <IconArrowForwardUp className="h-4 w-4 sm:h-[14px] sm:w-[14px]" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onReply();
+                  }}
+                  className="flex h-9 w-9 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors"
+                >
+                  <IconArrowBackUp className="h-4 w-4 sm:h-[14px] sm:w-[14px]" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Reply</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onReplyAll();
+                  }}
+                  className="flex h-9 w-9 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors"
+                >
+                  <IconArrowBackUpDouble className="h-4 w-4 sm:h-[14px] sm:w-[14px]" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Reply All</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onForward();
+                  }}
+                  className="flex h-9 w-9 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors"
+                >
+                  <IconArrowForwardUp className="h-4 w-4 sm:h-[14px] sm:w-[14px]" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Forward</TooltipContent>
+            </Tooltip>
           </div>
 
           <span className="shrink-0 text-[12px] text-muted-foreground/50 tabular-nums">
@@ -1772,21 +1802,24 @@ const ExpandedMessageCard = forwardRef<
                     `/api/attachments?messageId=${email.id}&id=${encodeURIComponent(att.id)}&mimeType=${encodeURIComponent(att.mimeType)}`,
                   );
                   return (
-                    <a
-                      key={att.id}
-                      href={url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="block rounded-lg overflow-hidden border border-border/40 hover:border-border bg-accent/30 hover:bg-accent/50"
-                      title={att.filename}
-                    >
-                      <img
-                        src={url}
-                        alt={att.filename}
-                        className="h-32 max-w-[200px] object-cover"
-                        loading="lazy"
-                      />
-                    </a>
+                    <Tooltip key={att.id}>
+                      <TooltipTrigger asChild>
+                        <a
+                          href={url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="block rounded-lg overflow-hidden border border-border/40 hover:border-border bg-accent/30 hover:bg-accent/50"
+                        >
+                          <img
+                            src={url}
+                            alt={att.filename}
+                            className="h-32 max-w-[200px] object-cover"
+                            loading="lazy"
+                          />
+                        </a>
+                      </TooltipTrigger>
+                      <TooltipContent>{att.filename}</TooltipContent>
+                    </Tooltip>
                   );
                 })}
             </div>
@@ -3159,29 +3192,41 @@ function ThreadSearchBar({
         </span>
       )}
       <div className="flex items-center gap-0.5 shrink-0">
-        <button
-          onClick={onPrev}
-          disabled={totalMatches === 0}
-          className="flex h-8 w-8 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-          title="Previous match (Shift+Enter)"
-        >
-          <IconChevronUp className="h-3.5 w-3.5 sm:h-3 sm:w-3" />
-        </button>
-        <button
-          onClick={onNext}
-          disabled={totalMatches === 0}
-          className="flex h-8 w-8 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-          title="Next match (Enter)"
-        >
-          <IconChevronDown className="h-3.5 w-3.5 sm:h-3 sm:w-3" />
-        </button>
-        <button
-          onClick={onClose}
-          className="flex h-8 w-8 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors ml-1"
-          title="Close (Esc)"
-        >
-          <IconX className="h-3.5 w-3.5 sm:h-3 sm:w-3" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onPrev}
+              disabled={totalMatches === 0}
+              className="flex h-8 w-8 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <IconChevronUp className="h-3.5 w-3.5 sm:h-3 sm:w-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Previous match (Shift+Enter)</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onNext}
+              disabled={totalMatches === 0}
+              className="flex h-8 w-8 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <IconChevronDown className="h-3.5 w-3.5 sm:h-3 sm:w-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Next match (Enter)</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onClose}
+              className="flex h-8 w-8 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors ml-1"
+            >
+              <IconX className="h-3.5 w-3.5 sm:h-3 sm:w-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Close (Esc)</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -100,8 +100,8 @@ export function EmailThread({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const labelParam = searchParams.get("label");
-  const labelSuffix = labelParam
-    ? `?label=${encodeURIComponent(labelParam)}`
+  const routeSearchSuffix = searchParams.toString()
+    ? `?${searchParams.toString()}`
     : "";
   const compose = useComposeState();
   const queryClient = useQueryClient();
@@ -361,8 +361,8 @@ export function EmailThread({
 
   const goBack = useCallback(() => {
     onNavigateThread?.(undefined);
-    navigate(`/${view}${labelSuffix}`);
-  }, [navigate, view, labelSuffix, onNavigateThread]);
+    navigate(`/${view}${routeSearchSuffix}`);
+  }, [navigate, view, routeSearchSuffix, onNavigateThread]);
 
   // Navigate between threads (j/k) — use ref to avoid stale closure
   const emailIdsRef = useRef(emailIds);
@@ -384,9 +384,16 @@ export function EmailThread({
       setSelectedIds?.(new Set());
       void ensureThread(nextThreadId);
       onNavigateThread?.(nextThreadId);
-      navigate(`/${view}/${nextThreadId}${labelSuffix}`);
+      navigate(`/${view}/${nextThreadId}${routeSearchSuffix}`);
     },
-    [threadId, view, navigate, labelSuffix, setSelectedIds, onNavigateThread],
+    [
+      threadId,
+      view,
+      navigate,
+      routeSearchSuffix,
+      setSelectedIds,
+      onNavigateThread,
+    ],
   );
 
   // Shift+j/k extends multi-selection across siblings and auto-previews the
@@ -411,9 +418,18 @@ export function EmailThread({
       });
 
       onNavigateThread?.(nextThreadKey);
-      navigate(`/${view}/${nextThreadKey}${labelSuffix}`, { replace: true });
+      navigate(`/${view}/${nextThreadKey}${routeSearchSuffix}`, {
+        replace: true,
+      });
     },
-    [threadId, view, navigate, labelSuffix, setSelectedIds, onNavigateThread],
+    [
+      threadId,
+      view,
+      navigate,
+      routeSearchSuffix,
+      setSelectedIds,
+      onNavigateThread,
+    ],
   );
 
   // Prefetch a window of threads around the currently open one so j/k
@@ -443,19 +459,27 @@ export function EmailThread({
     if (idx !== -1 && idx + 1 < emailIds.length) {
       const nextId = emailIds[idx + 1];
       onNavigateThread?.(nextId);
-      navigate(`/${view}/${nextId}${labelSuffix}`, {
+      navigate(`/${view}/${nextId}${routeSearchSuffix}`, {
         replace: true,
       });
     } else if (idx !== -1 && idx - 1 >= 0) {
       const prevId = emailIds[idx - 1];
       onNavigateThread?.(prevId);
-      navigate(`/${view}/${prevId}${labelSuffix}`, {
+      navigate(`/${view}/${prevId}${routeSearchSuffix}`, {
         replace: true,
       });
     } else {
       goBack();
     }
-  }, [threadId, emailIds, view, navigate, goBack, onNavigateThread]);
+  }, [
+    threadId,
+    emailIds,
+    view,
+    navigate,
+    routeSearchSuffix,
+    goBack,
+    onNavigateThread,
+  ]);
 
   // Advance to next thread when current email is dismissed (snoozed/spam/muted)
   useEffect(() => {

--- a/templates/mail/app/components/email/InlineReplyComposer.tsx
+++ b/templates/mail/app/components/email/InlineReplyComposer.tsx
@@ -300,13 +300,17 @@ export const InlineReplyComposer = forwardRef<
             <span className="text-[13px] font-semibold text-green-400">
               Forward
             </span>
-            <button
-              onClick={() => onPopOut(draft.id)}
-              className="flex h-9 w-9 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors"
-              title="Pop out to compose window"
-            >
-              <IconExternalLink className="h-3.5 w-3.5" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => onPopOut(draft.id)}
+                  className="flex h-9 w-9 sm:h-6 sm:w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors"
+                >
+                  <IconExternalLink className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Pop out to compose window</TooltipContent>
+            </Tooltip>
           </div>
           <div className="flex items-center border-b border-border/30 px-4 pb-2">
             <span className="w-8 shrink-0 text-xs font-medium text-muted-foreground">
@@ -329,13 +333,17 @@ export const InlineReplyComposer = forwardRef<
               to {recipientDisplay}
             </span>
           </div>
-          <button
-            onClick={() => onPopOut(draft.id)}
-            className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors shrink-0"
-            title="Pop out to compose window"
-          >
-            <IconExternalLink className="h-3.5 w-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => onPopOut(draft.id)}
+                className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground transition-colors shrink-0"
+              >
+                <IconExternalLink className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Pop out to compose window</TooltipContent>
+          </Tooltip>
         </div>
       )}
 

--- a/templates/mail/app/components/email/IntegrationsSidebar.tsx
+++ b/templates/mail/app/components/email/IntegrationsSidebar.tsx
@@ -31,6 +31,11 @@ import {
 } from "@/hooks/use-integrations";
 import { useApolloPerson } from "@/hooks/use-apollo";
 import type { ApolloPersonResult } from "@shared/types";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 function safeExternalHref(value?: string | null): string | null {
   if (!value) return null;
@@ -404,20 +409,24 @@ function AddIntegrationButton() {
               {/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}
               +Enter to submit
             </span>
-            <button
-              onClick={handleSubmit}
-              disabled={!value.trim()}
-              className={cn(
-                "p-1.5 rounded-lg",
-                value.trim()
-                  ? "bg-primary hover:bg-primary/90 text-primary-foreground"
-                  : "bg-muted/50 text-muted-foreground/30 cursor-not-allowed",
-              )}
-              title={`Submit (${/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}+Enter)`}
-              aria-label="Submit"
-            >
-              <IconArrowUp className="w-4 h-4" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={handleSubmit}
+                  disabled={!value.trim()}
+                  className={cn(
+                    "p-1.5 rounded-lg",
+                    value.trim()
+                      ? "bg-primary hover:bg-primary/90 text-primary-foreground"
+                      : "bg-muted/50 text-muted-foreground/30 cursor-not-allowed",
+                  )}
+                  aria-label="Submit"
+                >
+                  <IconArrowUp className="w-4 h-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{`Submit (${/Mac|iPhone|iPad/.test(navigator.userAgent) ? "⌘" : "Ctrl"}+Enter)`}</TooltipContent>
+            </Tooltip>
           </div>
         </PopoverContent>
       </Popover>
@@ -453,14 +462,16 @@ function IntegrationRow({
             <IconCheck className="h-3 w-3 text-emerald-400" />
           </div>
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                className="h-5 w-5 flex items-center justify-center rounded text-muted-foreground/30 hover:text-muted-foreground transition-colors"
-                title="Settings"
-              >
-                <IconSettings className="h-3.5 w-3.5" />
-              </button>
-            </DropdownMenuTrigger>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <button className="h-5 w-5 flex items-center justify-center rounded text-muted-foreground/30 hover:text-muted-foreground transition-colors">
+                    <IconSettings className="h-3.5 w-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>Settings</TooltipContent>
+            </Tooltip>
             <DropdownMenuContent align="end" className="w-36">
               <DropdownMenuItem
                 onClick={() => onConfigure()}

--- a/templates/mail/app/components/email/MobileActionBar.tsx
+++ b/templates/mail/app/components/email/MobileActionBar.tsx
@@ -21,6 +21,11 @@ import {
   DrawerClose,
 } from "@/components/ui/drawer";
 import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export const ALL_MOBILE_ACTIONS: MobileActionId[] = [
   "archive",
@@ -117,34 +122,43 @@ export function MobileActionBar({
       <div className="shrink-0 border-t border-border bg-background px-1 pb-[env(safe-area-inset-bottom)]">
         <div className="flex items-center overflow-x-auto">
           {onUpdateActions && (
-            <button
-              onClick={() => setCustomizeOpen(true)}
-              className={cn(
-                "flex shrink-0 flex-col items-center justify-center gap-0.5 py-2 px-3 min-w-[44px] min-h-[44px]",
-                "text-muted-foreground active:text-foreground active:bg-accent/50 rounded-lg",
-              )}
-              title="Customize"
-            >
-              <IconSettings className="h-5 w-5" />
-              <span className="text-[10px] leading-tight">Settings</span>
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setCustomizeOpen(true)}
+                  className={cn(
+                    "flex shrink-0 flex-col items-center justify-center gap-0.5 py-2 px-3 min-w-[44px] min-h-[44px]",
+                    "text-muted-foreground active:text-foreground active:bg-accent/50 rounded-lg",
+                  )}
+                >
+                  <IconSettings className="h-5 w-5" />
+                  <span className="text-[10px] leading-tight">Settings</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Customize</TooltipContent>
+            </Tooltip>
           )}
           {actions.map((id) => {
             const meta = ACTION_META[id];
             if (!meta) return null;
             return (
-              <button
-                key={id}
-                onClick={() => onAction(id)}
-                className={cn(
-                  "flex shrink-0 flex-col items-center justify-center gap-0.5 py-2 px-3 min-w-[44px] min-h-[44px]",
-                  "text-muted-foreground active:text-foreground active:bg-accent/50 rounded-lg",
-                )}
-                title={meta.label}
-              >
-                {meta.icon(id === "star" ? isStarred : false)}
-                <span className="text-[10px] leading-tight">{meta.label}</span>
-              </button>
+              <Tooltip key={id}>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => onAction(id)}
+                    className={cn(
+                      "flex shrink-0 flex-col items-center justify-center gap-0.5 py-2 px-3 min-w-[44px] min-h-[44px]",
+                      "text-muted-foreground active:text-foreground active:bg-accent/50 rounded-lg",
+                    )}
+                  >
+                    {meta.icon(id === "star" ? isStarred : false)}
+                    <span className="text-[10px] leading-tight">
+                      {meta.label}
+                    </span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{meta.label}</TooltipContent>
+              </Tooltip>
             );
           })}
         </div>

--- a/templates/mail/app/components/email/RecipientInput.tsx
+++ b/templates/mail/app/components/email/RecipientInput.tsx
@@ -32,6 +32,11 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import type { Alias } from "@shared/types";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface RecipientInputProps {
   value: string;
@@ -118,22 +123,30 @@ function AliasPopover({
         <span className="rounded-full bg-indigo-500/15 px-2 py-0.5 text-[11px] font-medium text-indigo-300">
           {alias.emails.length} recipients
         </span>
-        <button
-          type="button"
-          title="Edit alias"
-          onClick={handleEdit}
-          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-        >
-          <IconPencil className="size-3.5" />
-        </button>
-        <button
-          type="button"
-          title="Expand to individual emails"
-          onClick={handleExpand}
-          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-        >
-          <IconArrowsDiagonal className="size-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={handleEdit}
+              className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <IconPencil className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Edit alias</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={handleExpand}
+              className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <IconArrowsDiagonal className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Expand to individual emails</TooltipContent>
+        </Tooltip>
       </div>
       {/* Email list */}
       <div className="max-h-[180px] overflow-y-auto p-1.5">

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -63,6 +63,11 @@ import { useHeaderTitle, useHeaderActions } from "./HeaderActions";
 import { useQueuedDraftCount } from "@/hooks/use-draft-queue";
 import { appApiPath } from "@/lib/api-path";
 import { useIsMobile } from "@/hooks/use-mobile";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const BARE_ROUTES = new Set(["/email"]);
 
@@ -743,14 +748,18 @@ function AppLayoutInner({ children }: AppLayoutProps) {
             {/* Top nav bar */}
             <header className="relative z-20 flex h-11 shrink-0 items-center gap-1 border-b border-border/50 bg-card px-2 inbox-zero-header">
               {/* Hamburger menu */}
-              <button
-                onClick={() => setSidebarOpen(!sidebarOpen)}
-                className="flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground/50 hover:text-foreground hover:bg-accent/50 transition-colors shrink-0"
-                aria-label="Toggle menu"
-                title="Menu"
-              >
-                <IconMenu2 className="h-4 w-4" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => setSidebarOpen(!sidebarOpen)}
+                    className="flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground/50 hover:text-foreground hover:bg-accent/50 transition-colors shrink-0"
+                    aria-label="Toggle menu"
+                  >
+                    <IconMenu2 className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Menu</TooltipContent>
+              </Tooltip>
 
               {/* Visible tabs — hidden during search */}
               {!activeSearchQuery && (
@@ -851,20 +860,24 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                         if (!open) setLabelSearch("");
                       }}
                     >
-                      <PopoverTrigger asChild>
-                        <button
-                          className={cn(
-                            "flex h-6 w-6 items-center justify-center rounded transition-colors",
-                            tabSettingsOpen
-                              ? "text-foreground bg-accent/50"
-                              : "text-muted-foreground/40 hover:text-muted-foreground hover:bg-accent/30",
-                          )}
-                          aria-label="Configure tabs"
-                          title="Configure tabs"
-                        >
-                          <IconSettings className="h-3.5 w-3.5" />
-                        </button>
-                      </PopoverTrigger>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <PopoverTrigger asChild>
+                            <button
+                              className={cn(
+                                "flex h-6 w-6 items-center justify-center rounded transition-colors",
+                                tabSettingsOpen
+                                  ? "text-foreground bg-accent/50"
+                                  : "text-muted-foreground/40 hover:text-muted-foreground hover:bg-accent/30",
+                              )}
+                              aria-label="Configure tabs"
+                            >
+                              <IconSettings className="h-3.5 w-3.5" />
+                            </button>
+                          </PopoverTrigger>
+                        </TooltipTrigger>
+                        <TooltipContent>Configure tabs</TooltipContent>
+                      </Tooltip>
                       <PopoverContent
                         align="start"
                         className="w-60 max-w-[calc(100vw-2rem)] p-0"
@@ -908,14 +921,18 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                   }}
                 />
               ) : (
-                <button
-                  onClick={() => setSearchFocused(true)}
-                  className="flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
-                  aria-label="Search"
-                  title="Search (/)"
-                >
-                  <IconSearch className="h-4 w-4" />
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => setSearchFocused(true)}
+                      className="flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+                      aria-label="Search"
+                    >
+                      <IconSearch className="h-4 w-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Search (/)</TooltipContent>
+                </Tooltip>
               )}
 
               {/* Hidden input for keyboard shortcut target */}
@@ -929,65 +946,84 @@ function AppLayoutInner({ children }: AppLayoutProps) {
               )}
 
               {/* Draft queue */}
-              <Link
-                to="/draft-queue"
-                className={cn(
-                  "relative flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded transition-colors shrink-0",
-                  view === "draft-queue"
-                    ? "text-foreground bg-accent/50"
-                    : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
-                )}
-                title="Draft queue"
-              >
-                <IconClock className="h-4 w-4" />
-                {queuedDrafts.count > 0 && (
-                  <span className="absolute -right-0.5 -top-0.5 min-w-4 rounded-full bg-amber-400 px-1 text-center text-[10px] font-semibold leading-4 text-black">
-                    {queuedDrafts.count > 9 ? "9+" : queuedDrafts.count}
-                  </span>
-                )}
-              </Link>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Link
+                    to="/draft-queue"
+                    className={cn(
+                      "relative flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded transition-colors shrink-0",
+                      view === "draft-queue"
+                        ? "text-foreground bg-accent/50"
+                        : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
+                    )}
+                  >
+                    <IconClock className="h-4 w-4" />
+                    {queuedDrafts.count > 0 && (
+                      <span className="absolute -right-0.5 -top-0.5 min-w-4 rounded-full bg-amber-400 px-1 text-center text-[10px] font-semibold leading-4 text-black">
+                        {queuedDrafts.count > 9 ? "9+" : queuedDrafts.count}
+                      </span>
+                    )}
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent>Draft queue</TooltipContent>
+              </Tooltip>
 
               {/* Manual refresh — auto-poll backs off on error, but users
                   still want a button to force a fresh fetch on demand. */}
-              <button
-                onClick={() => {
-                  if (inboxIsFetching) return;
-                  qc.invalidateQueries({ queryKey: ["emails"] });
-                  qc.invalidateQueries({ queryKey: ["labels"] });
-                }}
-                disabled={inboxIsFetching}
-                className={cn(
-                  "flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors shrink-0 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground",
-                )}
-                aria-label="Refresh inbox"
-                title="Refresh inbox"
-              >
-                <IconRefresh
-                  className={cn("h-4 w-4", inboxIsFetching && "animate-spin")}
-                />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => {
+                      if (inboxIsFetching) return;
+                      qc.invalidateQueries({ queryKey: ["emails"] });
+                      qc.invalidateQueries({ queryKey: ["labels"] });
+                    }}
+                    disabled={inboxIsFetching}
+                    className={cn(
+                      "flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors shrink-0 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground",
+                    )}
+                    aria-label="Refresh inbox"
+                  >
+                    <IconRefresh
+                      className={cn(
+                        "h-4 w-4",
+                        inboxIsFetching && "animate-spin",
+                      )}
+                    />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Refresh inbox</TooltipContent>
+              </Tooltip>
 
               {/* Extensions */}
-              <Link
-                to="/extensions"
-                className="flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors shrink-0"
-                title="Extensions"
-              >
-                <IconTool className="h-4 w-4" />
-              </Link>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Link
+                    to="/extensions"
+                    className="flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors shrink-0"
+                  >
+                    <IconTool className="h-4 w-4" />
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent>Extensions</TooltipContent>
+              </Tooltip>
 
               {/* Theme toggle */}
               <ThemeToggle />
 
               {/* Compose (pen) icon */}
-              <button
-                onClick={handleCompose}
-                className="flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
-                aria-label="Compose email"
-                title="Compose (C)"
-              >
-                <IconPencil className="h-4 w-4" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={handleCompose}
+                    className="flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+                    aria-label="Compose email"
+                  >
+                    <IconPencil className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Compose (C)</TooltipContent>
+              </Tooltip>
 
               {/* Account avatars — overlapping stack like Figma */}
               {hasAccounts && (
@@ -995,51 +1031,53 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                   open={accountPopoverOpen}
                   onOpenChange={setAccountPopoverOpen}
                 >
-                  <PopoverTrigger asChild>
-                    <button
-                      className="flex items-center hover:opacity-90 transition-opacity ml-1"
-                      title="Accounts"
-                    >
-                      <div
-                        className="flex items-center"
-                        style={{
-                          marginRight: accounts.length > 1 ? 0 : undefined,
-                        }}
-                      >
-                        {accounts.map((account, i) => {
-                          const isActive =
-                            activeAccounts.size === 0 ||
-                            activeAccounts.has(account.email);
-                          return (
-                            <div
-                              key={account.email}
-                              className={cn(
-                                "relative rounded-full ring-2 ring-card transition-opacity",
-                                !isActive && "opacity-30",
-                              )}
-                              style={{
-                                marginLeft: i === 0 ? 0 : -8,
-                                zIndex: accounts.length - i,
-                              }}
-                            >
-                              {account.photoUrl ? (
-                                <img
-                                  src={account.photoUrl}
-                                  alt=""
-                                  className="h-7 w-7 rounded-full object-cover"
-                                  referrerPolicy="no-referrer"
-                                />
-                              ) : (
-                                <div className="h-7 w-7 rounded-full bg-primary/20 flex items-center justify-center text-[11px] font-semibold text-primary">
-                                  {account.email[0]?.toUpperCase()}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <PopoverTrigger asChild>
+                        <button className="flex items-center hover:opacity-90 transition-opacity ml-1">
+                          <div
+                            className="flex items-center"
+                            style={{
+                              marginRight: accounts.length > 1 ? 0 : undefined,
+                            }}
+                          >
+                            {accounts.map((account, i) => {
+                              const isActive =
+                                activeAccounts.size === 0 ||
+                                activeAccounts.has(account.email);
+                              return (
+                                <div
+                                  key={account.email}
+                                  className={cn(
+                                    "relative rounded-full ring-2 ring-card transition-opacity",
+                                    !isActive && "opacity-30",
+                                  )}
+                                  style={{
+                                    marginLeft: i === 0 ? 0 : -8,
+                                    zIndex: accounts.length - i,
+                                  }}
+                                >
+                                  {account.photoUrl ? (
+                                    <img
+                                      src={account.photoUrl}
+                                      alt=""
+                                      className="h-7 w-7 rounded-full object-cover"
+                                      referrerPolicy="no-referrer"
+                                    />
+                                  ) : (
+                                    <div className="h-7 w-7 rounded-full bg-primary/20 flex items-center justify-center text-[11px] font-semibold text-primary">
+                                      {account.email[0]?.toUpperCase()}
+                                    </div>
+                                  )}
                                 </div>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </button>
-                  </PopoverTrigger>
+                              );
+                            })}
+                          </div>
+                        </button>
+                      </PopoverTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>Accounts</TooltipContent>
+                  </Tooltip>
                   <PopoverContent
                     align="end"
                     className="w-72 max-w-[calc(100vw-2rem)] p-0"
@@ -1470,14 +1508,18 @@ function StandardLayout({ children }: AppLayoutProps) {
         <div className="relative flex flex-1 flex-col overflow-hidden">
           {!pageOwnsToolbar && (
             <header className="relative z-20 flex h-12 shrink-0 items-center gap-2 border-b border-border bg-background px-3">
-              <button
-                onClick={() => setSidebarOpen(!sidebarOpen)}
-                className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors shrink-0 cursor-pointer"
-                aria-label="Toggle menu"
-                title="Menu"
-              >
-                <IconMenu2 className="h-4 w-4" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => setSidebarOpen(!sidebarOpen)}
+                    className="flex h-8 w-8 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors shrink-0 cursor-pointer"
+                    aria-label="Toggle menu"
+                  >
+                    <IconMenu2 className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Menu</TooltipContent>
+              </Tooltip>
               <div className="flex min-w-0 flex-1 items-center gap-2">
                 {headerTitle ?? (
                   <h1 className="text-lg font-semibold tracking-tight truncate">
@@ -1811,16 +1853,20 @@ function TabSettingsPopover({
                     )}
                   </div>
                   {isPinned && !isEditing && (
-                    <button
-                      onClick={() => {
-                        setEditingId(label.id);
-                        setEditValue(alias || "");
-                      }}
-                      className="shrink-0 mr-2 px-1 py-0.5 text-[10px] text-muted-foreground/40 hover:text-foreground opacity-0 group-hover:opacity-100 rounded hover:bg-accent/50"
-                      title="Rename tab"
-                    >
-                      Rename
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={() => {
+                            setEditingId(label.id);
+                            setEditValue(alias || "");
+                          }}
+                          className="shrink-0 mr-2 px-1 py-0.5 text-[10px] text-muted-foreground/40 hover:text-foreground opacity-0 group-hover:opacity-100 rounded hover:bg-accent/50"
+                        >
+                          Rename
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>Rename tab</TooltipContent>
+                    </Tooltip>
                   )}
                 </div>
               );

--- a/templates/mail/app/components/layout/SearchBar.tsx
+++ b/templates/mail/app/components/layout/SearchBar.tsx
@@ -10,6 +10,11 @@ import { useNavigate } from "react-router";
 import { IconX } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { useContacts, type Contact } from "@/hooks/use-emails";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface SearchBarProps {
   onClose: () => void;
@@ -193,17 +198,21 @@ export function SearchBar({
           )}
         />
         {(hasActiveSearch || query) && (
-          <button
-            type="button"
-            onMouseDown={(e) => {
-              e.preventDefault();
-              handleClear();
-            }}
-            title="Clear search (Esc)"
-            className="flex h-5 w-5 mr-1 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent"
-          >
-            <IconX className="h-3.5 w-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handleClear();
+                }}
+                className="flex h-5 w-5 mr-1 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent"
+              >
+                <IconX className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Clear search (Esc)</TooltipContent>
+          </Tooltip>
         )}
       </div>
 

--- a/templates/mail/app/components/ui/sidebar.tsx
+++ b/templates/mail/app/components/ui/sidebar.tsx
@@ -298,24 +298,28 @@ const SidebarRail = React.forwardRef<
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
-      ref={ref}
-      data-sidebar="rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      {...props}
-    />
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          ref={ref}
+          data-sidebar="rail"
+          aria-label="Toggle Sidebar"
+          tabIndex={-1}
+          onClick={toggleSidebar}
+          className={cn(
+            "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+            "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+            "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+            "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
+            "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+            "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+            className,
+          )}
+          {...props}
+        />
+      </TooltipTrigger>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
+    </Tooltip>
   );
 });
 SidebarRail.displayName = "SidebarRail";

--- a/templates/mail/app/components/ui/sonner.tsx
+++ b/templates/mail/app/components/ui/sonner.tsx
@@ -6,9 +6,9 @@ import { cn } from "@/lib/utils";
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 const toastWidthClasses =
-  "group-[.toaster]:!w-[var(--width)] group-[.toaster]:!min-w-[min(20rem,calc(100vw_-_2rem))] group-[.toaster]:!max-w-[var(--width)] group-[.toaster]:!gap-3 group-[.toaster]:!break-normal";
+  "group-[.toaster]:!w-fit group-[.toaster]:!min-w-[min(20rem,calc(100vw_-_2rem))] group-[.toaster]:!max-w-[var(--width)] group-[.toaster]:!gap-3 group-[.toaster]:!break-normal";
 const toastContentClasses =
-  "group-[.toast]:!min-w-[min(16rem,calc(100vw_-_14rem))] group-[.toast]:!flex-1 group-[.toast]:!basis-auto group-[.toast]:break-words";
+  "group-[.toast]:!min-w-0 group-[.toast]:!flex-1 group-[.toast]:!basis-auto group-[.toast]:break-words";
 const toastButtonClasses =
   "group-[.toast]:!shrink-0 group-[.toast]:!whitespace-nowrap";
 

--- a/templates/mail/app/global.css
+++ b/templates/mail/app/global.css
@@ -205,14 +205,14 @@
   --width: min(36rem, calc(100vw - 2rem)) !important;
 }
 [data-sonner-toast] {
-  width: var(--width) !important;
+  width: fit-content !important;
   min-width: min(20rem, calc(100vw - 2rem)) !important;
   max-width: var(--width) !important;
   overflow-wrap: normal !important;
 }
 [data-sonner-toast] [data-content] {
   flex: 1 1 auto !important;
-  min-width: min(16rem, calc(100vw - 14rem)) !important;
+  min-width: 0 !important;
   overflow-wrap: break-word !important;
 }
 [data-sonner-toast] [data-title],

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -75,14 +75,14 @@ function ThreadListSidebar({
   emails,
   activeThreadId,
   view,
-  labelSuffix,
+  routeSearchSuffix,
   selectedIds,
   setSelectedIds,
 }: {
   emails: EmailMessage[];
   activeThreadId: string;
   view: string;
-  labelSuffix: string;
+  routeSearchSuffix: string;
   selectedIds: Set<string>;
   setSelectedIds: React.Dispatch<React.SetStateAction<Set<string>>>;
 }) {
@@ -112,7 +112,7 @@ function ThreadListSidebar({
                     isRead: true,
                     accountEmail: email.accountEmail,
                   });
-                navigate(`/${view}/${threadKey}${labelSuffix}`);
+                navigate(`/${view}/${threadKey}${routeSearchSuffix}`);
               }}
               className={cn(
                 "w-full text-left px-3 h-[38px] flex items-center border-b border-border/10 transition-colors",
@@ -189,8 +189,8 @@ export function InboxPage() {
   const { data: settings } = useSettings();
   const [searchParams] = useSearchParams();
   const activeLabel = searchParams.get("label");
-  const labelSuffix = activeLabel
-    ? `?label=${encodeURIComponent(activeLabel)}`
+  const routeSearchSuffix = searchParams.toString()
+    ? `?${searchParams.toString()}`
     : "";
 
   // Always fetch from the URL view (inbox, starred, etc.)
@@ -546,7 +546,7 @@ export function InboxPage() {
           emails={emails}
           activeThreadId={threadId!}
           view={view}
-          labelSuffix={labelSuffix}
+          routeSearchSuffix={routeSearchSuffix}
           selectedIds={selectedIds}
           setSelectedIds={setSelectedIds}
         />

--- a/templates/mail/app/pages/SettingsPage.tsx
+++ b/templates/mail/app/pages/SettingsPage.tsx
@@ -55,6 +55,11 @@ import {
 import { useSettings, useUpdateSettings } from "@/hooks/use-emails";
 import type { Alias, AutomationAction, AutomationRule } from "@shared/types";
 import { TeamPage } from "@agent-native/core/client/org";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 // ─── Alias Edit Row ───────────────────────────────────────────────────────────
 
@@ -198,29 +203,37 @@ function AliasRow({
           </p>
         </div>
         <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 shrink-0">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onEdit}
-            className="h-7 w-7 p-0"
-            title="Edit alias"
-          >
-            <IconPencil className="h-3.5 w-3.5" />
-          </Button>
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={handleDelete}
-            disabled={deleteAlias.isPending}
-            className="h-7 w-7 p-0"
-            title="Delete alias"
-          >
-            {deleteAlias.isPending ? (
-              <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <IconTrash className="h-3.5 w-3.5" />
-            )}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onEdit}
+                className="h-7 w-7 p-0"
+              >
+                <IconPencil className="h-3.5 w-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Edit alias</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleDelete}
+                disabled={deleteAlias.isPending}
+                className="h-7 w-7 p-0"
+              >
+                {deleteAlias.isPending ? (
+                  <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <IconTrash className="h-3.5 w-3.5" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Delete alias</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 
@@ -633,29 +646,37 @@ function AutomationRow({
         </div>
       </div>
       <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 shrink-0">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onEdit}
-          className="h-7 w-7 p-0"
-          title="Edit rule"
-        >
-          <IconPencil className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="destructive"
-          size="sm"
-          onClick={() => deleteAutomation.mutate(rule.id)}
-          disabled={deleteAutomation.isPending}
-          className="h-7 w-7 p-0"
-          title="Delete rule"
-        >
-          {deleteAutomation.isPending ? (
-            <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <IconTrash className="h-3.5 w-3.5" />
-          )}
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onEdit}
+              className="h-7 w-7 p-0"
+            >
+              <IconPencil className="h-3.5 w-3.5" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Edit rule</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => deleteAutomation.mutate(rule.id)}
+              disabled={deleteAutomation.isPending}
+              className="h-7 w-7 p-0"
+            >
+              {deleteAutomation.isPending ? (
+                <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <IconTrash className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Delete rule</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/templates/mail/server/lib/google-auth.spec.ts
+++ b/templates/mail/server/lib/google-auth.spec.ts
@@ -56,6 +56,7 @@ describe("listGmailMessages", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAccount();
+    vi.mocked(gmailListMessagesApi).mockResolvedValue({ messages: [] } as any);
   });
 
   it("uses Gmail thread search when requested so duplicate matching messages do not consume result slots", async () => {
@@ -186,7 +187,10 @@ describe("listGmailMessages", () => {
     expect(gmailBatchGetThreads).toHaveBeenNthCalledWith(
       1,
       "access-token",
-      threads.map((thread) => thread.id),
+      [
+        "thread-slack-marketplace",
+        ...Array.from({ length: 59 }, (_, index) => `thread-${59 - index}`),
+      ],
       "metadata",
     );
     expect(gmailBatchGetThreads).toHaveBeenNthCalledWith(
@@ -288,6 +292,50 @@ describe("listGmailMessages", () => {
       "full",
     );
     expect(result.messages.map((m) => m.id)).toEqual(["recent-full"]);
+  });
+
+  it("limits expensive metadata ranking while keeping recent matching messages in the shortlist", async () => {
+    const threads = Array.from({ length: 200 }, (_, index) => ({
+      id: `thread-${index + 1}`,
+      historyId: String(index + 1),
+    }));
+    vi.mocked(gmailListThreads).mockResolvedValue({ threads } as any);
+    vi.mocked(gmailListMessagesApi).mockResolvedValue({
+      messages: [{ id: "message-recent", threadId: "thread-25" }],
+    } as any);
+    vi.mocked(gmailBatchGetThreads).mockImplementation(
+      async (_accessToken, ids, format) =>
+        (ids as string[]).map((id) => ({
+          id,
+          data: {
+            messages: [
+              {
+                id: `${format}-${id}`,
+                threadId: id,
+                internalDate: id === "thread-25" ? "9999" : id.slice(7),
+              },
+            ],
+          },
+        })),
+    );
+
+    const result = await listGmailMessages(
+      "slack",
+      2,
+      "owner@example.com",
+      undefined,
+      { mode: "threads", threadCandidateLimit: 500 },
+    );
+
+    const rankedIds = vi.mocked(gmailBatchGetThreads).mock.calls[0][1];
+    expect(rankedIds).toHaveLength(120);
+    expect(rankedIds[0]).toBe("thread-25");
+    expect(rankedIds).toContain("thread-200");
+    expect(rankedIds).not.toContain("thread-24");
+    expect(result.messages.map((m) => m.id)).toEqual([
+      "full-thread-25",
+      "full-thread-200",
+    ]);
   });
 
   it("refills missing thread batch parts before returning search results", async () => {

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -502,6 +502,7 @@ const THREAD_CANDIDATE_PAGE_TTL = 5 * 60 * 1000;
 const THREAD_CANDIDATE_PAGE_MAX = 25;
 const THREAD_CANDIDATE_PAGE_PREFIX = "__an_thread_candidates__:";
 const THREAD_CANDIDATE_PAGE_SETTING = "mail-thread-candidate-pages";
+const THREAD_METADATA_RANK_LIMIT = 120;
 
 type ThreadCandidatePageEntry = {
   email: string;
@@ -626,6 +627,46 @@ function latestThreadMessageTime(thread: any): number {
     }
   }
   return latest;
+}
+
+function compareHistoryDesc(a: any, b: any): number {
+  try {
+    const ah = BigInt(a.historyId || 0);
+    const bh = BigInt(b.historyId || 0);
+    return ah === bh ? 0 : ah > bh ? -1 : 1;
+  } catch {
+    return Number(b.historyId || 0) - Number(a.historyId || 0);
+  }
+}
+
+function uniqueIds(ids: Array<string | undefined | null>): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const id of ids) {
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+  }
+  return result;
+}
+
+async function listRecentMatchingThreadIds(
+  accessToken: string,
+  query: string,
+  maxResults: number,
+): Promise<string[]> {
+  try {
+    const listRes = await gmailListMessages(accessToken, {
+      q: query,
+      maxResults,
+    });
+    return uniqueIds((listRes.messages || []).map((m: any) => m.threadId));
+  } catch (err: any) {
+    console.warn(
+      `[listGmailMessages] Recent message candidates failed: ${err.message}`,
+    );
+    return [];
+  }
 }
 
 async function fetchThreadBatchWithRefill(
@@ -1309,14 +1350,37 @@ async function fetchAccountThreads(
   onEstimate(listRes.resultSizeEstimate || 0);
 
   const threadStubs = listRes.threads || [];
-  let candidateIds = threadStubs.map((t: any) => t.id).filter(Boolean);
+  let candidateIds = uniqueIds(threadStubs.map((t: any) => t.id));
   let candidateMetadataById: Map<string, any> | undefined;
   if (useCandidateWindow && candidateIds.length > maxResults) {
+    const rankLimit = Math.min(
+      Math.max(maxResults, THREAD_METADATA_RANK_LIMIT),
+      candidateLimit ?? THREAD_METADATA_RANK_LIMIT,
+    );
+    const historyRankedIds = [...threadStubs]
+      .sort(compareHistoryDesc)
+      .map((t: any) => t.id);
+    const recentMatchingThreadIds = await listRecentMatchingThreadIds(
+      accessToken,
+      query,
+      rankLimit,
+    );
+    const hydrationCandidateIds = uniqueIds([
+      ...recentMatchingThreadIds,
+      ...historyRankedIds,
+      ...candidateIds,
+    ]).slice(0, rankLimit);
     const ranked = await rankThreadCandidatesByLatestMessage(
       accessToken,
-      candidateIds,
+      hydrationCandidateIds,
     );
-    candidateIds = ranked.ids;
+    const rankedSet = new Set(ranked.ids);
+    candidateIds = [
+      ...ranked.ids,
+      ...uniqueIds([...historyRankedIds, ...candidateIds]).filter(
+        (id) => !rankedSet.has(id),
+      ),
+    ];
     candidateMetadataById = ranked.metadataById;
   }
 

--- a/templates/slides/app/components/comments/SlideCommentsPanel.tsx
+++ b/templates/slides/app/components/comments/SlideCommentsPanel.tsx
@@ -16,6 +16,11 @@ import {
   type CommentThread,
   type SlideComment,
 } from "@/hooks/use-slide-comments";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface SlideCommentsPanelProps {
   deckId: string | null;
@@ -72,13 +77,17 @@ function CommentItem({
               {formatRelativeTime(comment.created_at)}
             </span>
             {hovered && (
-              <button
-                onClick={onDelete}
-                className="p-0.5 rounded text-muted-foreground hover:text-red-400"
-                title="Delete comment"
-              >
-                <IconTrash size={11} />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={onDelete}
+                    className="p-0.5 rounded text-muted-foreground hover:text-red-400"
+                  >
+                    <IconTrash size={11} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Delete comment</TooltipContent>
+              </Tooltip>
             )}
           </div>
         </div>
@@ -281,22 +290,32 @@ function ThreadCard({
               </span>
               {hovered && !thread.resolved && (
                 <>
-                  <button
-                    onClick={() =>
-                      resolveComment.mutate({ id: rootComment.id })
-                    }
-                    className="p-0.5 rounded text-muted-foreground hover:text-green-400"
-                    title="Resolve thread"
-                  >
-                    <IconCheck size={11} />
-                  </button>
-                  <button
-                    onClick={() => deleteComment.mutate({ id: rootComment.id })}
-                    className="p-0.5 rounded text-muted-foreground hover:text-red-400"
-                    title="Delete comment"
-                  >
-                    <IconTrash size={11} />
-                  </button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() =>
+                          resolveComment.mutate({ id: rootComment.id })
+                        }
+                        className="p-0.5 rounded text-muted-foreground hover:text-green-400"
+                      >
+                        <IconCheck size={11} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Resolve thread</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() =>
+                          deleteComment.mutate({ id: rootComment.id })
+                        }
+                        className="p-0.5 rounded text-muted-foreground hover:text-red-400"
+                      >
+                        <IconTrash size={11} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Delete comment</TooltipContent>
+                  </Tooltip>
                 </>
               )}
             </div>
@@ -394,21 +413,29 @@ export function SlideCommentsPanel({
         </span>
         <div className="flex items-center gap-1">
           {!showInput && deckId && slideId && (
-            <button
-              onClick={() => setAddingComment(true)}
-              className="p-1 rounded text-muted-foreground hover:text-foreground/80 hover:bg-accent"
-              title="Add comment"
-            >
-              <IconMessageCircle size={14} />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setAddingComment(true)}
+                  className="p-1 rounded text-muted-foreground hover:text-foreground/80 hover:bg-accent"
+                >
+                  <IconMessageCircle size={14} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Add comment</TooltipContent>
+            </Tooltip>
           )}
-          <button
-            onClick={onClose}
-            className="p-1 rounded text-muted-foreground hover:text-foreground/80 hover:bg-accent"
-            title="Close"
-          >
-            <IconX size={14} />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onClose}
+                className="p-1 rounded text-muted-foreground hover:text-foreground/80 hover:bg-accent"
+              >
+                <IconX size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Close</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/templates/slides/app/components/design-system/DesignSystemCard.tsx
+++ b/templates/slides/app/components/design-system/DesignSystemCard.tsx
@@ -1,6 +1,11 @@
 import { IconPalette, IconStar, IconStarFilled } from "@tabler/icons-react";
 import { ShareButton, VisibilityBadge } from "@agent-native/core/client";
 import type { DesignSystemData } from "../../../shared/api";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface DesignSystemCardProps {
   id: string;
@@ -63,17 +68,23 @@ export function DesignSystemCard({
           className="absolute top-3 right-3 z-10 flex items-center gap-1.5"
           onClick={(e) => e.stopPropagation()}
         >
-          <button
-            onClick={onSetDefault}
-            className="h-9 w-9 inline-flex items-center justify-center rounded-md bg-background/80 backdrop-blur-sm border border-border/40 hover:bg-background cursor-pointer"
-            title={isDefault ? "Default design system" : "Set as default"}
-          >
-            {isDefault ? (
-              <IconStarFilled className="w-4 h-4 text-[#609FF8]" />
-            ) : (
-              <IconStar className="w-4 h-4 text-muted-foreground group-hover:text-foreground/70" />
-            )}
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onSetDefault}
+                className="h-9 w-9 inline-flex items-center justify-center rounded-md bg-background/80 backdrop-blur-sm border border-border/40 hover:bg-background cursor-pointer"
+              >
+                {isDefault ? (
+                  <IconStarFilled className="w-4 h-4 text-[#609FF8]" />
+                ) : (
+                  <IconStar className="w-4 h-4 text-muted-foreground group-hover:text-foreground/70" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {isDefault ? "Default design system" : "Set as default"}
+            </TooltipContent>
+          </Tooltip>
           <ShareButton
             resourceType="design-system"
             resourceId={id}

--- a/templates/slides/app/components/editor/BlockBubbleMenu.tsx
+++ b/templates/slides/app/components/editor/BlockBubbleMenu.tsx
@@ -10,6 +10,11 @@ import {
   IconCheck,
   IconX,
 } from "@tabler/icons-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface BlockBubbleMenuProps {
   /** The element currently in contentEditable mode. Menu only shows while selection is inside it. */
@@ -161,29 +166,29 @@ export function BlockBubbleMenu({ editingEl }: BlockBubbleMenuProps) {
     >
       <ToolbarButton
         icon={IconBold}
-        title="Bold (Cmd+B)"
+        tooltip="Bold (Cmd+B)"
         onClick={() => runCommand("bold")}
       />
       <ToolbarButton
         icon={IconItalic}
-        title="Italic (Cmd+I)"
+        tooltip="Italic (Cmd+I)"
         onClick={() => runCommand("italic")}
       />
       <ToolbarButton
         icon={IconUnderline}
-        title="Underline (Cmd+U)"
+        tooltip="Underline (Cmd+U)"
         onClick={() => runCommand("underline")}
       />
       <ToolbarButton
         icon={IconStrikethrough}
-        title="Strikethrough"
+        tooltip="Strikethrough"
         onClick={() => runCommand("strikeThrough")}
       />
       <div className="w-px h-4 bg-border mx-0.5" />
       <div className="relative">
         <ToolbarButton
           icon={IconPalette}
-          title="Color"
+          tooltip="Color"
           onClick={() => {
             // Imperative set BEFORE state change — useEffect runs after the
             // input's autoFocus has already fired selectionchange, too late.
@@ -196,23 +201,26 @@ export function BlockBubbleMenu({ editingEl }: BlockBubbleMenuProps) {
         {showColors && (
           <div className="absolute top-full left-0 mt-1 p-3 rounded-lg bg-popover border border-border shadow-2xl shadow-black/60 grid grid-cols-6 gap-2 w-max">
             {COLORS.map((c) => (
-              <button
-                key={c}
-                type="button"
-                onMouseDown={(e) => e.preventDefault()}
-                onClick={() => applyColor(c)}
-                className="w-7 h-7 rounded-md border border-foreground/25 hover:scale-110 transition-transform"
-                style={{ background: c }}
-                title={c}
-                aria-label={`Set color ${c}`}
-              />
+              <Tooltip key={c}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => applyColor(c)}
+                    className="w-7 h-7 rounded-md border border-foreground/25 hover:scale-110 transition-transform"
+                    style={{ background: c }}
+                    aria-label={`Set color ${c}`}
+                  />
+                </TooltipTrigger>
+                <TooltipContent>{c}</TooltipContent>
+              </Tooltip>
             ))}
           </div>
         )}
       </div>
       <ToolbarButton
         icon={IconLink}
-        title="Link"
+        tooltip="Link"
         onClick={() => {
           if (!showLinkInput) interactingRef.current = true;
           setShowLinkInput((v) => !v);
@@ -239,24 +247,32 @@ export function BlockBubbleMenu({ editingEl }: BlockBubbleMenuProps) {
             className="px-2 py-1 text-xs bg-muted rounded text-foreground outline-none border border-border focus:border-ring w-40"
             autoFocus
           />
-          <button
-            type="button"
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={applyLink}
-            className="p-1 rounded hover:bg-accent text-[#609FF8]"
-            title="Apply"
-          >
-            <IconCheck className="w-3.5 h-3.5" />
-          </button>
-          <button
-            type="button"
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={removeLink}
-            className="p-1 rounded hover:bg-accent text-muted-foreground"
-            title="Remove link"
-          >
-            <IconX className="w-3.5 h-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={applyLink}
+                className="p-1 rounded hover:bg-accent text-[#609FF8]"
+              >
+                <IconCheck className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Apply</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={removeLink}
+                className="p-1 rounded hover:bg-accent text-muted-foreground"
+              >
+                <IconX className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Remove link</TooltipContent>
+          </Tooltip>
         </div>
       )}
     </div>,
@@ -266,30 +282,34 @@ export function BlockBubbleMenu({ editingEl }: BlockBubbleMenuProps) {
 
 function ToolbarButton({
   icon: Icon,
-  title,
+  tooltip,
   onClick,
   active,
 }: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   icon: React.ComponentType<any>;
-  title: string;
+  tooltip: string;
   onClick: () => void;
   active?: boolean;
 }) {
   return (
-    <button
-      type="button"
-      onMouseDown={(e) => e.preventDefault()}
-      onClick={onClick}
-      title={title}
-      aria-label={title}
-      className={`p-1.5 rounded transition-colors ${
-        active
-          ? "bg-[#609FF8]/20 text-[#609FF8]"
-          : "text-foreground/80 hover:bg-accent hover:text-foreground"
-      }`}
-    >
-      <Icon className="w-3.5 h-3.5" />
-    </button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={onClick}
+          aria-label={tooltip}
+          className={`p-1.5 rounded transition-colors ${
+            active
+              ? "bg-[#609FF8]/20 text-[#609FF8]"
+              : "text-foreground/80 hover:bg-accent hover:text-foreground"
+          }`}
+        >
+          <Icon className="w-3.5 h-3.5" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -212,28 +212,36 @@ function SortableSlideThumb({
 
       {/* Actions - always visible on touch devices */}
       <div className="absolute top-2 right-2 flex gap-0.5 sm:opacity-0 sm:group-hover:opacity-100">
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onDuplicate();
-          }}
-          className="p-1.5 rounded bg-black/60 backdrop-blur-sm border border-white/10 hover:bg-black/80"
-          title="Duplicate"
-          aria-label="Duplicate slide"
-        >
-          <IconCopy className="w-3 h-3 text-white/60" />
-        </button>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete();
-          }}
-          className="p-1.5 rounded bg-black/60 backdrop-blur-sm border border-white/10 hover:bg-red-900/80"
-          title="Delete"
-          aria-label="Delete slide"
-        >
-          <IconTrash className="w-3 h-3 text-white/60" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDuplicate();
+              }}
+              className="p-1.5 rounded bg-black/60 backdrop-blur-sm border border-white/10 hover:bg-black/80"
+              aria-label="Duplicate slide"
+            >
+              <IconCopy className="w-3 h-3 text-white/60" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Duplicate</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+              className="p-1.5 rounded bg-black/60 backdrop-blur-sm border border-white/10 hover:bg-red-900/80"
+              aria-label="Delete slide"
+            >
+              <IconTrash className="w-3 h-3 text-white/60" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Delete</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );
@@ -460,15 +468,19 @@ export default function EditorSidebar({
         {addSlideGenerating ? (
           <IconLoader2 className="w-4 h-4 text-muted-foreground animate-spin" />
         ) : (
-          <button
-            ref={headerAddRef}
-            onClick={() => setAddOpen(!addOpen)}
-            className="p-2 rounded-md hover:bg-accent transition-colors"
-            title="Add slides"
-            aria-label="Add slides"
-          >
-            <IconPlus className="w-4 h-4 text-muted-foreground" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                ref={headerAddRef}
+                onClick={() => setAddOpen(!addOpen)}
+                className="p-2 rounded-md hover:bg-accent transition-colors"
+                aria-label="Add slides"
+              >
+                <IconPlus className="w-4 h-4 text-muted-foreground" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Add slides</TooltipContent>
+          </Tooltip>
         )}
       </div>
 

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -248,26 +248,34 @@ export default function EditorToolbar({
   return (
     <div className="flex h-12 shrink-0 items-center gap-0.5 overflow-x-auto whitespace-nowrap border-b border-border bg-background px-1 sm:gap-1 sm:px-3">
       {/* Back button */}
-      <Link
-        to="/"
-        className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent transition-colors flex-shrink-0"
-        title="Back to decks"
-        aria-label="Back to decks"
-      >
-        <IconArrowLeft className="w-4 h-4 text-muted-foreground" />
-      </Link>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            to="/"
+            className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent transition-colors flex-shrink-0"
+            aria-label="Back to decks"
+          >
+            <IconArrowLeft className="w-4 h-4 text-muted-foreground" />
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent>Back to decks</TooltipContent>
+      </Tooltip>
 
       {/* Slide-list toggle (mobile only — desktop uses the app sidebar rail) */}
-      <button
-        onClick={onToggleSidebar}
-        className={`md:hidden p-2.5 sm:p-1.5 rounded-md hover:bg-accent transition-colors flex-shrink-0 ${
-          sidebarOpen ? "text-muted-foreground" : "text-muted-foreground/70"
-        }`}
-        title="Toggle slide list"
-        aria-label="Toggle slide list"
-      >
-        <IconLayoutSidebar className="w-4 h-4" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={onToggleSidebar}
+            className={`md:hidden p-2.5 sm:p-1.5 rounded-md hover:bg-accent transition-colors flex-shrink-0 ${
+              sidebarOpen ? "text-muted-foreground" : "text-muted-foreground/70"
+            }`}
+            aria-label="Toggle slide list"
+          >
+            <IconLayoutSidebar className="w-4 h-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Toggle slide list</TooltipContent>
+      </Tooltip>
 
       {/* Deck title */}
       <input
@@ -289,22 +297,26 @@ export default function EditorToolbar({
       {/* Slide settings cog menu */}
       {currentSlide && onUpdateSlide && (
         <>
-          <button
-            ref={layoutRef}
-            onClick={() => {
-              closeAll();
-              setLayoutOpen(!layoutOpen);
-            }}
-            className={`flex items-center gap-1 p-2.5 sm:px-2 sm:py-1.5 rounded-md text-xs transition-colors flex-shrink-0 ${
-              layoutOpen
-                ? "text-foreground/90 bg-accent"
-                : "text-muted-foreground hover:text-foreground/70 hover:bg-accent"
-            }`}
-            title="Slide settings"
-            aria-label="Slide settings"
-          >
-            <IconSettings className="w-3.5 h-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                ref={layoutRef}
+                onClick={() => {
+                  closeAll();
+                  setLayoutOpen(!layoutOpen);
+                }}
+                className={`flex items-center gap-1 p-2.5 sm:px-2 sm:py-1.5 rounded-md text-xs transition-colors flex-shrink-0 ${
+                  layoutOpen
+                    ? "text-foreground/90 bg-accent"
+                    : "text-muted-foreground hover:text-foreground/70 hover:bg-accent"
+                }`}
+                aria-label="Slide settings"
+              >
+                <IconSettings className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Slide settings</TooltipContent>
+          </Tooltip>
           <ToolbarPopover
             open={layoutOpen}
             anchorRef={layoutRef}
@@ -511,18 +523,21 @@ graph TD
                     {ASPECT_RATIO_VALUES.map((r) => {
                       const active = activeAspectRatio === r;
                       return (
-                        <button
-                          key={r}
-                          onClick={() => onSetAspectRatio(r)}
-                          className={`px-1.5 py-1 rounded text-[10px] font-medium border ${
-                            active
-                              ? "bg-[#609FF8]/20 text-[#609FF8] border-[#609FF8]/30"
-                              : "text-white/40 hover:text-white/70 hover:bg-white/[0.04] border-transparent"
-                          }`}
-                          title={`Set deck to ${r}`}
-                        >
-                          {r}
-                        </button>
+                        <Tooltip key={r}>
+                          <TooltipTrigger asChild>
+                            <button
+                              onClick={() => onSetAspectRatio(r)}
+                              className={`px-1.5 py-1 rounded text-[10px] font-medium border ${
+                                active
+                                  ? "bg-[#609FF8]/20 text-[#609FF8] border-[#609FF8]/30"
+                                  : "text-white/40 hover:text-white/70 hover:bg-white/[0.04] border-transparent"
+                              }`}
+                            >
+                              {r}
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>{`Set deck to ${r}`}</TooltipContent>
+                        </Tooltip>
                       );
                     })}
                   </div>
@@ -553,7 +568,6 @@ graph TD
                     ? "bg-accent text-foreground"
                     : "text-muted-foreground hover:text-foreground/70 hover:bg-accent"
                 }`}
-                title="Slide tools"
                 aria-label="Slide tools"
               >
                 <IconWand className="w-4 h-4" />
@@ -653,40 +667,52 @@ graph TD
 
       {/* Undo/Redo */}
       <div className="flex items-center flex-shrink-0">
-        <button
-          onClick={onUndo}
-          disabled={!canUndo}
-          className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent disabled:opacity-20 transition-colors"
-          title="Undo (Cmd+Z)"
-          aria-label="Undo"
-        >
-          <IconArrowBackUp className="w-3.5 h-3.5 text-muted-foreground" />
-        </button>
-        <button
-          onClick={onRedo}
-          disabled={!canRedo}
-          className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent disabled:opacity-20 transition-colors"
-          title="Redo (Cmd+Shift+Z)"
-          aria-label="Redo"
-        >
-          <IconArrowForwardUp className="w-3.5 h-3.5 text-muted-foreground" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onUndo}
+              disabled={!canUndo}
+              className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent disabled:opacity-20 transition-colors"
+              aria-label="Undo"
+            >
+              <IconArrowBackUp className="w-3.5 h-3.5 text-muted-foreground" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Undo (Cmd+Z)</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onRedo}
+              disabled={!canRedo}
+              className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent disabled:opacity-20 transition-colors"
+              aria-label="Redo"
+            >
+              <IconArrowForwardUp className="w-3.5 h-3.5 text-muted-foreground" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Redo (Cmd+Shift+Z)</TooltipContent>
+        </Tooltip>
       </div>
 
       {/* IconHistory - hide on narrow / mid widths to keep the bar compact */}
-      <button
-        ref={historyButtonRef}
-        onClick={onShowHistory}
-        className={`p-2.5 sm:p-1.5 rounded-md hover:bg-accent transition-colors flex-shrink-0 hidden lg:block ${
-          historyOpen
-            ? "text-foreground/90 bg-accent"
-            : "text-muted-foreground hover:text-foreground/70"
-        }`}
-        title="Edit history"
-        aria-label="Edit history"
-      >
-        <IconHistory className="w-3.5 h-3.5" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            ref={historyButtonRef}
+            onClick={onShowHistory}
+            className={`p-2.5 sm:p-1.5 rounded-md hover:bg-accent transition-colors flex-shrink-0 hidden lg:block ${
+              historyOpen
+                ? "text-foreground/90 bg-accent"
+                : "text-muted-foreground hover:text-foreground/70"
+            }`}
+            aria-label="Edit history"
+          >
+            <IconHistory className="w-3.5 h-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Edit history</TooltipContent>
+      </Tooltip>
 
       {/* Separator */}
       <div className="w-px h-5 bg-accent flex-shrink-0 hidden sm:block" />
@@ -726,23 +752,27 @@ graph TD
 
       {/* Comments toggle */}
       {onToggleComments && (
-        <button
-          onClick={onToggleComments}
-          className={`relative p-2.5 sm:p-1.5 rounded-md transition-colors flex-shrink-0 ${
-            commentsOpen
-              ? "text-foreground bg-accent"
-              : "text-muted-foreground hover:text-foreground/70 hover:bg-accent"
-          }`}
-          title="Comments"
-          aria-label="Comments"
-        >
-          <IconMessage className="w-3.5 h-3.5" />
-          {unresolvedCommentCount > 0 && (
-            <span className="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 rounded-full bg-[#609FF8] text-[8px] font-bold text-black flex items-center justify-center leading-none">
-              {unresolvedCommentCount > 9 ? "9+" : unresolvedCommentCount}
-            </span>
-          )}
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onToggleComments}
+              className={`relative p-2.5 sm:p-1.5 rounded-md transition-colors flex-shrink-0 ${
+                commentsOpen
+                  ? "text-foreground bg-accent"
+                  : "text-muted-foreground hover:text-foreground/70 hover:bg-accent"
+              }`}
+              aria-label="Comments"
+            >
+              <IconMessage className="w-3.5 h-3.5" />
+              {unresolvedCommentCount > 0 && (
+                <span className="absolute -top-0.5 -right-0.5 w-3.5 h-3.5 rounded-full bg-[#609FF8] text-[8px] font-bold text-black flex items-center justify-center leading-none">
+                  {unresolvedCommentCount > 9 ? "9+" : unresolvedCommentCount}
+                </span>
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Comments</TooltipContent>
+        </Tooltip>
       )}
 
       {/* Save-state indicator (icon-only — text label was wrapping at narrow

--- a/templates/slides/app/components/editor/ImageSearchPanel.tsx
+++ b/templates/slides/app/components/editor/ImageSearchPanel.tsx
@@ -2,6 +2,11 @@ import { useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { IconX, IconSearch, IconLoader2 } from "@tabler/icons-react";
 import { appBasePath } from "@agent-native/core/client";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface SearchResult {
   url: string;
@@ -150,19 +155,22 @@ export default function ImageSearchPanel({
         {results.length > 0 && (
           <div className="grid grid-cols-3 gap-2">
             {results.map((result, i) => (
-              <button
-                key={i}
-                onClick={() => handleSelect(result.url)}
-                className="aspect-square rounded-md overflow-hidden border border-border bg-muted hover:ring-2 hover:ring-[#609FF8]/50 transition-all"
-                title={result.title}
-              >
-                <img
-                  src={result.thumbnail}
-                  alt={result.title}
-                  className="w-full h-full object-cover"
-                  loading="lazy"
-                />
-              </button>
+              <Tooltip key={i}>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => handleSelect(result.url)}
+                    className="aspect-square rounded-md overflow-hidden border border-border bg-muted hover:ring-2 hover:ring-[#609FF8]/50 transition-all"
+                  >
+                    <img
+                      src={result.thumbnail}
+                      alt={result.title}
+                      className="w-full h-full object-cover"
+                      loading="lazy"
+                    />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{result.title}</TooltipContent>
+              </Tooltip>
             ))}
           </div>
         )}

--- a/templates/slides/app/components/editor/ShareDialog.tsx
+++ b/templates/slides/app/components/editor/ShareDialog.tsx
@@ -15,6 +15,11 @@ import { useDbStatus } from "@/hooks/use-db-status";
 import { CloudUpgrade } from "@/components/CloudUpgrade";
 import type { Deck } from "@/context/DeckContext";
 import { appBasePath } from "@agent-native/core/client";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface ShareDialogProps {
   deck: Deck;
@@ -158,18 +163,22 @@ export default function ShareDialog({ deck, children }: ShareDialogProps) {
                       value={shareUrl}
                       className="flex-1 bg-accent/50 border border-border rounded-lg px-3 py-2 text-sm text-foreground/90 outline-none"
                     />
-                    <button
-                      onClick={handleCopy}
-                      className="flex-shrink-0 p-2 rounded-lg bg-accent hover:bg-accent border border-border transition-colors"
-                      title="Copy link"
-                      aria-label="Copy link"
-                    >
-                      {copied ? (
-                        <IconCheck className="w-4 h-4 text-green-400" />
-                      ) : (
-                        <IconCopy className="w-4 h-4 text-muted-foreground" />
-                      )}
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={handleCopy}
+                          className="flex-shrink-0 p-2 rounded-lg bg-accent hover:bg-accent border border-border transition-colors"
+                          aria-label="Copy link"
+                        >
+                          {copied ? (
+                            <IconCheck className="w-4 h-4 text-green-400" />
+                          ) : (
+                            <IconCopy className="w-4 h-4 text-muted-foreground" />
+                          )}
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>Copy link</TooltipContent>
+                    </Tooltip>
                   </div>
 
                   <a

--- a/templates/slides/app/components/editor/SlideBubbleMenu.tsx
+++ b/templates/slides/app/components/editor/SlideBubbleMenu.tsx
@@ -32,6 +32,11 @@ import {
   setBrandPalette,
   type CopiedStyle,
 } from "./style-clipboard";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyIcon = React.ComponentType<any>;
@@ -147,34 +152,42 @@ function ColorPicker({
         <span className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
           Brand Colors
         </span>
-        <button
-          onClick={() => setEditMode((v) => !v)}
-          className={cn(
-            "p-0.5 rounded",
-            editMode
-              ? "text-[#00E5FF]"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-          title="Edit palette"
-        >
-          <IconPencil size={11} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setEditMode((v) => !v)}
+              className={cn(
+                "p-0.5 rounded",
+                editMode
+                  ? "text-[#00E5FF]"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <IconPencil size={11} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Edit palette</TooltipContent>
+        </Tooltip>
       </div>
 
       <div className="grid grid-cols-6 gap-1.5">
         {palette.map((color) => (
           <div key={color} className="relative group">
-            <button
-              title={color}
-              onClick={() => (editMode ? undefined : applyColor(color))}
-              className={cn(
-                "w-6 h-6 rounded-md border transition-transform",
-                currentColor?.toLowerCase() === color.toLowerCase()
-                  ? "border-foreground scale-110"
-                  : "border-border hover:scale-110",
-              )}
-              style={{ background: color }}
-            />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => (editMode ? undefined : applyColor(color))}
+                  className={cn(
+                    "w-6 h-6 rounded-md border transition-transform",
+                    currentColor?.toLowerCase() === color.toLowerCase()
+                      ? "border-foreground scale-110"
+                      : "border-border hover:scale-110",
+                  )}
+                  style={{ background: color }}
+                />
+              </TooltipTrigger>
+              <TooltipContent>{color}</TooltipContent>
+            </Tooltip>
             {editMode && (
               <button
                 onClick={() => removeFromPalette(color)}
@@ -188,13 +201,17 @@ function ColorPicker({
 
         {/* Add color button */}
         {!addingColor && (
-          <button
-            onClick={() => setAddingColor(true)}
-            className="w-6 h-6 rounded-md border border-dashed border-border flex items-center justify-center text-muted-foreground hover:text-foreground hover:border-foreground/40"
-            title="Add color"
-          >
-            <IconPlus size={10} />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setAddingColor(true)}
+                className="w-6 h-6 rounded-md border border-dashed border-border flex items-center justify-center text-muted-foreground hover:text-foreground hover:border-foreground/40"
+              >
+                <IconPlus size={10} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Add color</TooltipContent>
+          </Tooltip>
         )}
       </div>
 
@@ -366,48 +383,55 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
               const Icon = btn.icon;
               const active = btn.isActive() ?? false;
               return (
-                <button
-                  key={i}
-                  title={btn.title}
-                  onClick={btn.action}
-                  className={cn(
-                    "p-1.5 rounded",
-                    active
-                      ? "bg-accent text-foreground"
-                      : "text-foreground/80 hover:text-foreground hover:bg-accent",
-                  )}
-                >
-                  <Icon size={14} stroke={2} />
-                </button>
+                <Tooltip key={i}>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={btn.action}
+                      className={cn(
+                        "p-1.5 rounded",
+                        active
+                          ? "bg-accent text-foreground"
+                          : "text-foreground/80 hover:text-foreground hover:bg-accent",
+                      )}
+                    >
+                      <Icon size={14} stroke={2} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{btn.title}</TooltipContent>
+                </Tooltip>
               );
             })}
 
             {/* Color picker */}
             <div className="w-px h-4 bg-border mx-0.5" />
             <Popover open={colorOpen} onOpenChange={setColorOpen}>
-              <PopoverTrigger asChild>
-                <button
-                  title="Text color"
-                  className={cn(
-                    "p-1.5 rounded relative",
-                    colorOpen
-                      ? "bg-accent text-foreground"
-                      : "text-foreground/80 hover:text-foreground hover:bg-accent",
-                  )}
-                >
-                  <IconPalette size={14} stroke={2} />
-                  {/* Color indicator underline */}
-                  <div
-                    className="absolute bottom-0.5 left-1.5 right-1.5 h-0.5 rounded-full"
-                    style={{
-                      background: currentColor ?? "transparent",
-                      border: currentColor
-                        ? "none"
-                        : "1px solid hsl(var(--border))",
-                    }}
-                  />
-                </button>
-              </PopoverTrigger>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <PopoverTrigger asChild>
+                    <button
+                      className={cn(
+                        "p-1.5 rounded relative",
+                        colorOpen
+                          ? "bg-accent text-foreground"
+                          : "text-foreground/80 hover:text-foreground hover:bg-accent",
+                      )}
+                    >
+                      <IconPalette size={14} stroke={2} />
+                      {/* Color indicator underline */}
+                      <div
+                        className="absolute bottom-0.5 left-1.5 right-1.5 h-0.5 rounded-full"
+                        style={{
+                          background: currentColor ?? "transparent",
+                          border: currentColor
+                            ? "none"
+                            : "1px solid hsl(var(--border))",
+                        }}
+                      />
+                    </button>
+                  </PopoverTrigger>
+                </TooltipTrigger>
+                <TooltipContent>Text color</TooltipContent>
+              </Tooltip>
               <PopoverContent
                 side="bottom"
                 align="end"
@@ -428,21 +452,25 @@ export function SlideBubbleMenu({ editor, onComment }: SlideBubbleMenuProps) {
             {hasCommentBtn && (
               <>
                 <div className="w-px h-4 bg-border mx-0.5" />
-                <button
-                  title="Comment"
-                  onClick={() => {
-                    const { from, to } = editor.state.selection;
-                    const quotedText = editor.state.doc.textBetween(
-                      from,
-                      to,
-                      " ",
-                    );
-                    onComment!(quotedText);
-                  }}
-                  className="p-1.5 rounded text-foreground/80 hover:text-foreground hover:bg-accent"
-                >
-                  <IconMessageCircle size={14} stroke={2} />
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => {
+                        const { from, to } = editor.state.selection;
+                        const quotedText = editor.state.doc.textBetween(
+                          from,
+                          to,
+                          " ",
+                        );
+                        onComment!(quotedText);
+                      }}
+                      className="p-1.5 rounded text-foreground/80 hover:text-foreground hover:bg-accent"
+                    >
+                      <IconMessageCircle size={14} stroke={2} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Comment</TooltipContent>
+                </Tooltip>
               </>
             )}
           </>

--- a/templates/slides/app/components/editor/TweaksPanel.tsx
+++ b/templates/slides/app/components/editor/TweaksPanel.tsx
@@ -1,5 +1,10 @@
 import { IconX } from "@tabler/icons-react";
 import type { TweakDefinition } from "@/lib/design-systems";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface TweaksPanelProps {
   tweaks: TweakDefinition[];
@@ -58,17 +63,20 @@ function TweakControl({
       {tweak.type === "color-swatches" && (
         <div className="flex gap-2">
           {tweak.options?.map((opt) => (
-            <button
-              key={opt.value}
-              onClick={() => onChange(opt.value)}
-              className={`w-7 h-7 rounded-full cursor-pointer ${
-                value === opt.value
-                  ? "ring-2 ring-foreground ring-offset-2 ring-offset-card"
-                  : ""
-              }`}
-              style={{ backgroundColor: opt.color || opt.value }}
-              title={opt.label}
-            />
+            <Tooltip key={opt.value}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => onChange(opt.value)}
+                  className={`w-7 h-7 rounded-full cursor-pointer ${
+                    value === opt.value
+                      ? "ring-2 ring-foreground ring-offset-2 ring-offset-card"
+                      : ""
+                  }`}
+                  style={{ backgroundColor: opt.color || opt.value }}
+                />
+              </TooltipTrigger>
+              <TooltipContent>{opt.label}</TooltipContent>
+            </Tooltip>
           ))}
         </div>
       )}

--- a/templates/slides/app/components/layout/Sidebar.tsx
+++ b/templates/slides/app/components/layout/Sidebar.tsx
@@ -9,6 +9,11 @@ import {
 import { cn } from "@/lib/utils";
 import { ExtensionsSidebarSection } from "@agent-native/core/client/extensions";
 import { FeedbackButton, appPath } from "@agent-native/core/client";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 const navItems = [
   { icon: IconStack2, label: "Decks", href: "/" },
@@ -35,34 +40,41 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
     return (
       <aside className="flex h-full w-12 shrink-0 flex-col items-center gap-1 border-r border-border bg-sidebar py-2 text-sidebar-foreground">
         {onToggleCollapsed && (
-          <button
-            onClick={onToggleCollapsed}
-            title="Expand sidebar"
-            aria-label="Expand sidebar"
-            className="flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground"
-          >
-            <IconLayoutSidebarLeftExpand className="h-4 w-4" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onToggleCollapsed}
+                aria-label="Expand sidebar"
+                className="flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground"
+              >
+                <IconLayoutSidebarLeftExpand className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Expand sidebar</TooltipContent>
+          </Tooltip>
         )}
         <nav className="flex flex-1 flex-col items-center gap-1 pt-1">
           {navItems.map((item) => {
             const Icon = item.icon;
             const isActive = isItemActive(item.href);
             return (
-              <Link
-                key={item.href}
-                to={item.href}
-                title={item.label}
-                aria-label={item.label}
-                className={cn(
-                  "flex h-10 w-10 items-center justify-center rounded-md transition-colors",
-                  isActive
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
-                )}
-              >
-                <Icon className="h-4 w-4" />
-              </Link>
+              <Tooltip key={item.href}>
+                <TooltipTrigger asChild>
+                  <Link
+                    to={item.href}
+                    aria-label={item.label}
+                    className={cn(
+                      "flex h-10 w-10 items-center justify-center rounded-md transition-colors",
+                      isActive
+                        ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                        : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground",
+                    )}
+                  >
+                    <Icon className="h-4 w-4" />
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent>{item.label}</TooltipContent>
+              </Tooltip>
             );
           })}
         </nav>
@@ -89,14 +101,18 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
           <span className="text-sm font-semibold tracking-tight">Slides</span>
         </div>
         {onToggleCollapsed && (
-          <button
-            onClick={onToggleCollapsed}
-            title="Collapse sidebar"
-            aria-label="Collapse sidebar"
-            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground"
-          >
-            <IconLayoutSidebarLeftCollapse className="h-4 w-4" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={onToggleCollapsed}
+                aria-label="Collapse sidebar"
+                className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-sidebar-accent/50 hover:text-foreground"
+              >
+                <IconLayoutSidebarLeftCollapse className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Collapse sidebar</TooltipContent>
+          </Tooltip>
         )}
       </div>
 

--- a/templates/slides/app/components/ui/sidebar.tsx
+++ b/templates/slides/app/components/ui/sidebar.tsx
@@ -298,24 +298,28 @@ const SidebarRail = React.forwardRef<
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
-      ref={ref}
-      data-sidebar="rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      {...props}
-    />
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          ref={ref}
+          data-sidebar="rail"
+          aria-label="Toggle Sidebar"
+          tabIndex={-1}
+          onClick={toggleSidebar}
+          className={cn(
+            "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+            "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+            "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+            "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
+            "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+            "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+            className,
+          )}
+          {...props}
+        />
+      </TooltipTrigger>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
+    </Tooltip>
   );
 });
 SidebarRail.displayName = "SidebarRail";

--- a/templates/slides/app/components/visual-editor/CanvasCommentPins.tsx
+++ b/templates/slides/app/components/visual-editor/CanvasCommentPins.tsx
@@ -4,6 +4,11 @@ import { agentChat } from "@agent-native/core";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface CanvasPin {
   id: string;
@@ -217,16 +222,20 @@ export function CanvasCommentPins({
             style={{ left, top }}
           >
             {/* Pin marker */}
-            <button
-              onClick={() => setActivePinId(pin.id)}
-              className={cn(
-                "absolute -translate-x-1/2 -translate-y-full -mt-1 flex items-center justify-center w-7 h-7 rounded-full rounded-bl-none shadow-lg cursor-pointer",
-                "bg-[#609FF8] text-black hover:scale-110 transition-transform",
-              )}
-              title={pin.draft || "Comment"}
-            >
-              <IconMessage className="w-3.5 h-3.5" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setActivePinId(pin.id)}
+                  className={cn(
+                    "absolute -translate-x-1/2 -translate-y-full -mt-1 flex items-center justify-center w-7 h-7 rounded-full rounded-bl-none shadow-lg cursor-pointer",
+                    "bg-[#609FF8] text-black hover:scale-110 transition-transform",
+                  )}
+                >
+                  <IconMessage className="w-3.5 h-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{pin.draft || "Comment"}</TooltipContent>
+            </Tooltip>
 
             {/* Inline composer */}
             {isActive && !pin.submitted && (

--- a/templates/slides/app/components/visual-editor/DrawOverlay.tsx
+++ b/templates/slides/app/components/visual-editor/DrawOverlay.tsx
@@ -9,6 +9,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export interface DrawAnnotation {
   id: string;
@@ -305,18 +310,21 @@ export function DrawOverlay({ visible, onSend, onClose }: DrawOverlayProps) {
         {/* Color picker */}
         <div className="flex gap-1">
           {PRESET_COLORS.map((preset) => (
-            <button
-              key={preset.color}
-              onClick={() => setColor(preset.color)}
-              className={cn(
-                "h-5 w-5 cursor-pointer rounded-full",
-                color === preset.color
-                  ? "ring-2 ring-foreground ring-offset-1 ring-offset-popover"
-                  : "ring-1 ring-border",
-              )}
-              style={{ backgroundColor: preset.color }}
-              title={preset.label}
-            />
+            <Tooltip key={preset.color}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setColor(preset.color)}
+                  className={cn(
+                    "h-5 w-5 cursor-pointer rounded-full",
+                    color === preset.color
+                      ? "ring-2 ring-foreground ring-offset-1 ring-offset-popover"
+                      : "ring-1 ring-border",
+                  )}
+                  style={{ backgroundColor: preset.color }}
+                />
+              </TooltipTrigger>
+              <TooltipContent>{preset.label}</TooltipContent>
+            </Tooltip>
           ))}
         </div>
 
@@ -325,60 +333,75 @@ export function DrawOverlay({ visible, onSend, onClose }: DrawOverlayProps) {
         {/* Line widths */}
         <div className="flex gap-1">
           {LINE_WIDTHS.map((lw) => (
-            <button
-              key={lw.value}
-              onClick={() => setLineWidth(lw.value)}
-              className={cn(
-                "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
-                lineWidth === lw.value
-                  ? "bg-accent text-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              title={lw.label}
-            >
-              <div
-                className="rounded-full bg-current"
-                style={{ width: lw.value + 2, height: lw.value + 2 }}
-              />
-            </button>
+            <Tooltip key={lw.value}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setLineWidth(lw.value)}
+                  className={cn(
+                    "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
+                    lineWidth === lw.value
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <div
+                    className="rounded-full bg-current"
+                    style={{ width: lw.value + 2, height: lw.value + 2 }}
+                  />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{lw.label}</TooltipContent>
+            </Tooltip>
           ))}
         </div>
 
         <div className="mx-1 h-4 w-px bg-border" />
 
         {/* Text mode */}
-        <button
-          onClick={() => setTextMode(!textMode)}
-          className={cn(
-            "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
-            textMode
-              ? "bg-accent text-foreground"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-          title="Type anywhere on the canvas"
-        >
-          <IconCursorText className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setTextMode(!textMode)}
+              className={cn(
+                "flex h-6 w-6 cursor-pointer items-center justify-center rounded",
+                textMode
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <IconCursorText className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Type anywhere on the canvas</TooltipContent>
+        </Tooltip>
 
         {/* Undo last stroke */}
-        <button
-          onClick={undo}
-          disabled={strokes.length === 0}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
-          title="Undo stroke"
-        >
-          <IconArrowBackUp className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={undo}
+              disabled={strokes.length === 0}
+              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
+            >
+              <IconArrowBackUp className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Undo stroke</TooltipContent>
+        </Tooltip>
 
         {/* Clear all */}
-        <button
-          onClick={clear}
-          disabled={strokes.length === 0 && textAnnotations.length === 0}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
-          title="Clear all"
-        >
-          <IconEraser className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={clear}
+              disabled={strokes.length === 0 && textAnnotations.length === 0}
+              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
+            >
+              <IconEraser className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Clear all</TooltipContent>
+        </Tooltip>
 
         <div className="mx-1 h-4 w-px bg-border" />
 
@@ -406,13 +429,17 @@ export function DrawOverlay({ visible, onSend, onClose }: DrawOverlayProps) {
         </Button>
 
         {/* Close */}
-        <button
-          onClick={onClose}
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground"
-          title="Exit draw mode"
-        >
-          <IconX className="h-3.5 w-3.5" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onClose}
+              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground"
+            >
+              <IconX className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Exit draw mode</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/templates/videos/app/components/CameraToolbar.tsx
+++ b/templates/videos/app/components/CameraToolbar.tsx
@@ -10,6 +10,11 @@ import {
 import { cn } from "@/lib/utils";
 import type { AnimationTrack } from "@/types";
 import { getPropValueKeyframed } from "@/remotion/trackAnimation";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface CameraToolbarProps {
   currentFrame: number;
@@ -338,32 +343,41 @@ export const CameraToolbar: React.FC<CameraToolbarProps> = ({
           const isActive = activeTool === tool.id;
 
           return (
-            <button
-              key={tool.id}
-              className={cn(
-                "flex items-center gap-1 px-2 py-1.5 sm:py-1 rounded text-[11px] font-medium select-none flex-shrink-0",
-                isActive
-                  ? "bg-blue-500 text-white shadow-md"
-                  : "bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground",
-              )}
-              onMouseDown={(e) => handleMouseDown(e, tool.id)}
-              title={tool.hint}
-            >
-              <Icon className="w-3.5 h-3.5 sm:w-3 sm:h-3" />
-              <span className="hidden sm:inline">{tool.label}</span>
-            </button>
+            <Tooltip key={tool.id}>
+              <TooltipTrigger asChild>
+                <button
+                  className={cn(
+                    "flex items-center gap-1 px-2 py-1.5 sm:py-1 rounded text-[11px] font-medium select-none flex-shrink-0",
+                    isActive
+                      ? "bg-blue-500 text-white shadow-md"
+                      : "bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground",
+                  )}
+                  onMouseDown={(e) => handleMouseDown(e, tool.id)}
+                >
+                  <Icon className="w-3.5 h-3.5 sm:w-3 sm:h-3" />
+                  <span className="hidden sm:inline">{tool.label}</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{tool.hint}</TooltipContent>
+            </Tooltip>
           );
         })}
 
         <div className="h-3.5 w-px bg-border mx-0.5 flex-shrink-0" />
-        <button
-          onClick={addKeyframe}
-          className="flex items-center gap-1 px-2 py-1.5 sm:py-1 rounded text-[11px] font-medium bg-blue-500/10 hover:bg-blue-500/20 text-blue-400 border border-blue-500/30 flex-shrink-0"
-          title="Create camera keyframe at current frame"
-        >
-          <IconPlus className="w-3.5 h-3.5 sm:w-3 sm:h-3" />
-          <span className="hidden sm:inline">Add Keyframe</span>
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={addKeyframe}
+              className="flex items-center gap-1 px-2 py-1.5 sm:py-1 rounded text-[11px] font-medium bg-blue-500/10 hover:bg-blue-500/20 text-blue-400 border border-blue-500/30 flex-shrink-0"
+            >
+              <IconPlus className="w-3.5 h-3.5 sm:w-3 sm:h-3" />
+              <span className="hidden sm:inline">Add Keyframe</span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Create camera keyframe at current frame
+          </TooltipContent>
+        </Tooltip>
 
         {isDragging && (
           <div className="ml-2 text-[11px] text-blue-400 font-mono animate-pulse flex-shrink-0">

--- a/templates/videos/app/components/ComponentPropsPanel.tsx
+++ b/templates/videos/app/components/ComponentPropsPanel.tsx
@@ -7,6 +7,11 @@ import {
   IconFileText,
 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 type ComponentPropsPanelProps = {
   component: LibraryComponentEntry;
@@ -31,13 +36,17 @@ export function ComponentPropsPanel({
       {/* Header */}
       <div className="px-4 py-3 border-b border-border flex items-center justify-between">
         <h2 className="text-sm font-semibold text-foreground">Properties</h2>
-        <button
-          onClick={onClose}
-          className="p-1 hover:bg-secondary rounded transition-colors"
-          title="Close panel"
-        >
-          <IconX className="w-4 h-4" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={onClose}
+              className="p-1 hover:bg-secondary rounded transition-colors"
+            >
+              <IconX className="w-4 h-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Close panel</TooltipContent>
+        </Tooltip>
       </div>
 
       {/* Content */}

--- a/templates/videos/app/components/CompositionCard.tsx
+++ b/templates/videos/app/components/CompositionCard.tsx
@@ -13,6 +13,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 type CompositionCardProps = {
   composition: CompositionEntry;
@@ -92,16 +97,20 @@ export function CompositionCard({
 
         {/* Delete button — visible on hover */}
         {onDelete && (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setConfirmOpen(true);
-            }}
-            className="opacity-0 group-hover:opacity-100 p-1 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 flex-shrink-0"
-            title="Delete composition"
-          >
-            <IconTrash className="w-3.5 h-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setConfirmOpen(true);
+                }}
+                className="opacity-0 group-hover:opacity-100 p-1 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 flex-shrink-0"
+              >
+                <IconTrash className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Delete composition</TooltipContent>
+          </Tooltip>
         )}
       </div>
 

--- a/templates/videos/app/components/CurrentElementPanel.tsx
+++ b/templates/videos/app/components/CurrentElementPanel.tsx
@@ -30,6 +30,11 @@ import type {
   AnimatedPropertyConfig,
 } from "@/types/elementAnimations";
 import type { EasingKey } from "@/types";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 /**
  * ANIMATION PROPERTY DEFAULTS
@@ -704,62 +709,84 @@ export const CurrentElementPanel: React.FC = () => {
         <div className="flex items-center justify-between">
           <Label className="text-xs">Cursor Type</Label>
           {storedCursorType && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 w-6 p-0"
-              onClick={handleDeleteCursorType}
-              title="Reset to default"
-            >
-              <IconTrash className="w-3 h-3 text-muted-foreground hover:text-green-400" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-6 w-6 p-0"
+                  onClick={handleDeleteCursorType}
+                >
+                  <IconTrash className="w-3 h-3 text-muted-foreground hover:text-green-400" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Reset to default</TooltipContent>
+            </Tooltip>
           )}
         </div>
         <div className="grid grid-cols-3 gap-2">
           {/* Default Arrow */}
-          <button
-            onClick={() => handleUpdateCursorType("default")}
-            className={`h-12 rounded-lg border-2 flex items-center justify-center ${
-              effectiveCursorType === "default"
-                ? "border-green-500 bg-green-500/10"
-                : "border-border bg-secondary/50 hover:bg-secondary"
-            }`}
-            title="Arrow (Default)"
-          >
-            <div style={{ transform: "scale(0.5)", transformOrigin: "center" }}>
-              <DefaultCursor />
-            </div>
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => handleUpdateCursorType("default")}
+                className={`h-12 rounded-lg border-2 flex items-center justify-center ${
+                  effectiveCursorType === "default"
+                    ? "border-green-500 bg-green-500/10"
+                    : "border-border bg-secondary/50 hover:bg-secondary"
+                }`}
+              >
+                <div
+                  style={{ transform: "scale(0.5)", transformOrigin: "center" }}
+                >
+                  <DefaultCursor />
+                </div>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Arrow (Default)</TooltipContent>
+          </Tooltip>
 
           {/* Pointer Hand */}
-          <button
-            onClick={() => handleUpdateCursorType("pointer")}
-            className={`h-12 rounded-lg border-2 flex items-center justify-center ${
-              effectiveCursorType === "pointer"
-                ? "border-green-500 bg-green-500/10"
-                : "border-border bg-secondary/50 hover:bg-secondary"
-            }`}
-            title="Pointer (Hand)"
-          >
-            <div style={{ transform: "scale(0.5)", transformOrigin: "center" }}>
-              <PointerCursor />
-            </div>
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => handleUpdateCursorType("pointer")}
+                className={`h-12 rounded-lg border-2 flex items-center justify-center ${
+                  effectiveCursorType === "pointer"
+                    ? "border-green-500 bg-green-500/10"
+                    : "border-border bg-secondary/50 hover:bg-secondary"
+                }`}
+              >
+                <div
+                  style={{ transform: "scale(0.5)", transformOrigin: "center" }}
+                >
+                  <PointerCursor />
+                </div>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Pointer (Hand)</TooltipContent>
+          </Tooltip>
 
           {/* Text I-Beam */}
-          <button
-            onClick={() => handleUpdateCursorType("text")}
-            className={`h-12 rounded-lg border-2 flex items-center justify-center ${
-              effectiveCursorType === "text"
-                ? "border-green-500 bg-green-500/10"
-                : "border-border bg-secondary/50 hover:bg-secondary"
-            }`}
-            title="Text (I-beam)"
-          >
-            <div style={{ transform: "scale(0.5)", transformOrigin: "center" }}>
-              <TextCursor />
-            </div>
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => handleUpdateCursorType("text")}
+                className={`h-12 rounded-lg border-2 flex items-center justify-center ${
+                  effectiveCursorType === "text"
+                    ? "border-green-500 bg-green-500/10"
+                    : "border-border bg-secondary/50 hover:bg-secondary"
+                }`}
+              >
+                <div
+                  style={{ transform: "scale(0.5)", transformOrigin: "center" }}
+                >
+                  <TextCursor />
+                </div>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Text (I-beam)</TooltipContent>
+          </Tooltip>
         </div>
         <p className="text-xs text-muted-foreground">
           {storedCursorType

--- a/templates/videos/app/components/CursorControls.tsx
+++ b/templates/videos/app/components/CursorControls.tsx
@@ -30,6 +30,11 @@ import {
   getCurrentKeyframeEasing as getCurrentKeyframeEasingUtil,
   setOrUpdateKeyframe as setOrUpdateKeyframeUtil,
 } from "@/utils/keyframeUtils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface CursorControlsProps {
   currentFrame: number;
@@ -402,20 +407,27 @@ export const CursorControls: React.FC<CursorControlsProps> = ({
       />
 
       {/* Click Animation */}
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={toggleClick}
-        className={`w-full text-xs gap-1.5 ${
-          isClickingAtFrame()
-            ? "bg-purple-500/20 text-purple-400 border-purple-500/30"
-            : ""
-        }`}
-        title={isClickingAtFrame() ? "Click ON" : "Add Click"}
-      >
-        <IconClick className="h-3 w-3" />
-        Play click
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={toggleClick}
+            className={`w-full text-xs gap-1.5 ${
+              isClickingAtFrame()
+                ? "bg-purple-500/20 text-purple-400 border-purple-500/30"
+                : ""
+            }`}
+            aria-label={isClickingAtFrame() ? "Click ON" : "Add Click"}
+          >
+            <IconClick className="h-3 w-3" />
+            Play click
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {isClickingAtFrame() ? "Click ON" : "Add Click"}
+        </TooltipContent>
+      </Tooltip>
 
       {/* Position Controls */}
       <div className="space-y-2">
@@ -460,64 +472,85 @@ export const CursorControls: React.FC<CursorControlsProps> = ({
           <Label className="text-xs text-muted-foreground">Cursor Type</Label>
           <div className="grid grid-cols-3 gap-2">
             {/* Default Arrow */}
-            <button
-              onClick={() => {
-                setLocalState((prev) => ({ ...prev, type: "default" }));
-                setOrUpdateKeyframe("type", "default");
-              }}
-              className={`h-12 rounded-lg border-2 flex items-center justify-center ${
-                localState.type === "default"
-                  ? "border-purple-500 bg-purple-500/10"
-                  : "border-border bg-secondary/50 hover:bg-secondary"
-              }`}
-              title="Arrow (Default)"
-            >
-              <div
-                style={{ transform: "scale(0.5)", transformOrigin: "center" }}
-              >
-                <DefaultCursor />
-              </div>
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => {
+                    setLocalState((prev) => ({ ...prev, type: "default" }));
+                    setOrUpdateKeyframe("type", "default");
+                  }}
+                  className={`h-12 rounded-lg border-2 flex items-center justify-center ${
+                    localState.type === "default"
+                      ? "border-purple-500 bg-purple-500/10"
+                      : "border-border bg-secondary/50 hover:bg-secondary"
+                  }`}
+                >
+                  <div
+                    style={{
+                      transform: "scale(0.5)",
+                      transformOrigin: "center",
+                    }}
+                  >
+                    <DefaultCursor />
+                  </div>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Arrow (Default)</TooltipContent>
+            </Tooltip>
 
             {/* Pointer Hand */}
-            <button
-              onClick={() => {
-                setLocalState((prev) => ({ ...prev, type: "pointer" }));
-                setOrUpdateKeyframe("type", "pointer");
-              }}
-              className={`h-12 rounded-lg border-2 flex items-center justify-center ${
-                localState.type === "pointer"
-                  ? "border-purple-500 bg-purple-500/10"
-                  : "border-border bg-secondary/50 hover:bg-secondary"
-              }`}
-              title="Pointer (Hand)"
-            >
-              <div
-                style={{ transform: "scale(0.5)", transformOrigin: "center" }}
-              >
-                <PointerCursor />
-              </div>
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => {
+                    setLocalState((prev) => ({ ...prev, type: "pointer" }));
+                    setOrUpdateKeyframe("type", "pointer");
+                  }}
+                  className={`h-12 rounded-lg border-2 flex items-center justify-center ${
+                    localState.type === "pointer"
+                      ? "border-purple-500 bg-purple-500/10"
+                      : "border-border bg-secondary/50 hover:bg-secondary"
+                  }`}
+                >
+                  <div
+                    style={{
+                      transform: "scale(0.5)",
+                      transformOrigin: "center",
+                    }}
+                  >
+                    <PointerCursor />
+                  </div>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Pointer (Hand)</TooltipContent>
+            </Tooltip>
 
             {/* Text I-Beam */}
-            <button
-              onClick={() => {
-                setLocalState((prev) => ({ ...prev, type: "text" }));
-                setOrUpdateKeyframe("type", "text");
-              }}
-              className={`h-12 rounded-lg border-2 flex items-center justify-center ${
-                localState.type === "text"
-                  ? "border-purple-500 bg-purple-500/10"
-                  : "border-border bg-secondary/50 hover:bg-secondary"
-              }`}
-              title="Text (I-beam)"
-            >
-              <div
-                style={{ transform: "scale(0.5)", transformOrigin: "center" }}
-              >
-                <TextCursor />
-              </div>
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => {
+                    setLocalState((prev) => ({ ...prev, type: "text" }));
+                    setOrUpdateKeyframe("type", "text");
+                  }}
+                  className={`h-12 rounded-lg border-2 flex items-center justify-center ${
+                    localState.type === "text"
+                      ? "border-purple-500 bg-purple-500/10"
+                      : "border-border bg-secondary/50 hover:bg-secondary"
+                  }`}
+                >
+                  <div
+                    style={{
+                      transform: "scale(0.5)",
+                      transformOrigin: "center",
+                    }}
+                  >
+                    <TextCursor />
+                  </div>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Text (I-beam)</TooltipContent>
+            </Tooltip>
           </div>
         </div>
       )}

--- a/templates/videos/app/components/CursorPositioningOverlay.tsx
+++ b/templates/videos/app/components/CursorPositioningOverlay.tsx
@@ -1,6 +1,11 @@
 import { useRef, useState, useCallback } from "react";
 import type { AnimationTrack } from "@/types";
 import { getPropValueKeyframed } from "@/remotion/trackAnimation";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface CursorPositioningOverlayProps {
   compositionWidth: number;
@@ -202,25 +207,29 @@ export const CursorPositioningOverlay: React.FC<
   }
 
   return (
-    <div
-      ref={overlayRef}
-      onMouseDown={handleMouseDown}
-      onMouseMove={handleMouseMove}
-      onMouseUp={handleMouseUp}
-      onMouseLeave={handleMouseUp}
-      style={{
-        position: "absolute",
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 56, // Exclude control bar at bottom
-        cursor: isDragging ? "grabbing" : "crosshair",
-        zIndex: 10,
-        pointerEvents: isPlaying ? "none" : "auto",
-      }}
-      title="Click and drag to position cursor"
-    >
-      {/* Invisible overlay for click-and-drag */}
-    </div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          ref={overlayRef}
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
+          onMouseLeave={handleMouseUp}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 56, // Exclude control bar at bottom
+            cursor: isDragging ? "grabbing" : "crosshair",
+            zIndex: 10,
+            pointerEvents: isPlaying ? "none" : "auto",
+          }}
+        >
+          {/* Invisible overlay for click-and-drag */}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>Click and drag to position cursor</TooltipContent>
+    </Tooltip>
   );
 };

--- a/templates/videos/app/components/LibraryFolderRow.tsx
+++ b/templates/videos/app/components/LibraryFolderRow.tsx
@@ -11,6 +11,11 @@ import { cn } from "@/lib/utils";
 import { CompositionCard } from "@/components/CompositionCard";
 import type { CompositionEntry } from "@/remotion/registry";
 import type { VideoFolder } from "@/hooks/use-folders";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 type LibraryFolderRowProps = {
   folder: VideoFolder;
@@ -161,20 +166,28 @@ export function LibraryFolderRow({
             className="flex items-center gap-0.5"
             onClick={(e) => e.stopPropagation()}
           >
-            <button
-              onClick={handleRenameStart}
-              className="p-0.5 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-              title="Rename folder"
-            >
-              <IconPencil className="h-3 w-3" />
-            </button>
-            <button
-              onClick={() => onDeleteFolder(folder.id)}
-              className="p-0.5 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
-              title="Delete folder"
-            >
-              <IconTrash className="h-3 w-3" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={handleRenameStart}
+                  className="p-0.5 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <IconPencil className="h-3 w-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Rename folder</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => onDeleteFolder(folder.id)}
+                  className="p-0.5 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
+                >
+                  <IconTrash className="h-3 w-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Delete folder</TooltipContent>
+            </Tooltip>
           </div>
         )}
       </div>
@@ -196,13 +209,17 @@ export function LibraryFolderRow({
                   onDelete={onDelete}
                   draggable
                 />
-                <button
-                  onClick={() => onRemoveFromFolder(comp.id)}
-                  className="absolute top-1 right-7 p-0.5 rounded opacity-0 group-hover/item:opacity-100 bg-secondary/80 hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-all"
-                  title="Remove from folder"
-                >
-                  <IconX className="h-2.5 w-2.5" />
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => onRemoveFromFolder(comp.id)}
+                      className="absolute top-1 right-7 p-0.5 rounded opacity-0 group-hover/item:opacity-100 bg-secondary/80 hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-all"
+                    >
+                      <IconX className="h-2.5 w-2.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Remove from folder</TooltipContent>
+                </Tooltip>
               </div>
             ))
           )}

--- a/templates/videos/app/components/MotionCurveSelect.tsx
+++ b/templates/videos/app/components/MotionCurveSelect.tsx
@@ -8,6 +8,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "./ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface MotionCurveSelectProps {
   value: EasingKey;
@@ -26,12 +31,19 @@ export const MotionCurveSelect: React.FC<MotionCurveSelectProps> = ({
     <div className="space-y-1.5 pt-2 border-t border-border/40">
       <Label className="text-xs text-muted-foreground">{label}</Label>
       <Select value={value} onValueChange={(val) => onChange(val as EasingKey)}>
-        <SelectTrigger
-          className={`w-full h-auto text-xs bg-secondary border border-border rounded-lg pl-2.5 py-1.5 text-foreground focus:outline-none focus:ring-2 focus:ring-${accentColor}/40`}
-          title="Controls how the animation moves TO this keyframe"
-        >
-          <SelectValue />
-        </SelectTrigger>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <SelectTrigger
+              className={`w-full h-auto text-xs bg-secondary border border-border rounded-lg pl-2.5 py-1.5 text-foreground focus:outline-none focus:ring-2 focus:ring-${accentColor}/40`}
+              aria-label="Controls how the animation moves to this keyframe"
+            >
+              <SelectValue />
+            </SelectTrigger>
+          </TooltipTrigger>
+          <TooltipContent>
+            Controls how the animation moves to this keyframe
+          </TooltipContent>
+        </Tooltip>
         <SelectContent>
           {EASING_OPTIONS.map((opt) => (
             <SelectItem key={opt.value} value={opt.value}>

--- a/templates/videos/app/components/Sidebar.tsx
+++ b/templates/videos/app/components/Sidebar.tsx
@@ -32,6 +32,11 @@ import { usePlayback } from "@/contexts/PlaybackContext";
 import { useFolders } from "@/hooks/use-folders";
 import { ExtensionsSidebarSection } from "@agent-native/core/client/extensions";
 import { FeedbackButton } from "@agent-native/core/client";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 type SidebarProps = {
   open: boolean;
@@ -326,13 +331,17 @@ export function Sidebar({
                     onGeneratingChange={onGeneratingChange}
                   />
                 </div>
-                <button
-                  onClick={() => createFolder("New Folder")}
-                  title="New folder"
-                  className="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-md border border-dashed border-border text-muted-foreground hover:text-foreground hover:border-border/60 hover:bg-secondary/60 transition-colors"
-                >
-                  <IconFolderPlus className="h-3.5 w-3.5" />
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={() => createFolder("New Folder")}
+                      className="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-md border border-dashed border-border text-muted-foreground hover:text-foreground hover:border-border/60 hover:bg-secondary/60 transition-colors"
+                    >
+                      <IconFolderPlus className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>New folder</TooltipContent>
+                </Tooltip>
               </div>
 
               {/* Folders (always at the top) */}

--- a/templates/videos/app/components/Timeline.tsx
+++ b/templates/videos/app/components/Timeline.tsx
@@ -25,6 +25,11 @@ import {
   pxDeltaToFrameDelta,
   clampFrame,
 } from "@/utils/timelineCoordinates";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 type DragMode = "move" | "resize-start" | "resize-end";
 
@@ -847,89 +852,96 @@ export function Timeline({
               const isKeyframeTrack = track.startFrame === track.endFrame;
 
               return (
-                <div
-                  key={track.id}
-                  className="flex items-center gap-1.5 px-2.5 cursor-default"
-                  style={{ height: TRACK_HEIGHT }}
-                  title={track.label}
-                  onContextMenu={(e) => {
-                    // Only show context menu for camera and cursor tracks
-                    if (!isCamera && !isCursor) return;
-                    e.preventDefault();
-                    setContextMenu({
-                      trackId: track.id,
-                      x: e.clientX,
-                      y: e.clientY,
-                    });
-                  }}
-                >
-                  {isCamera ? (
-                    <IconCamera
-                      className="flex-shrink-0"
-                      size={12}
-                      style={{
-                        color: isSelected ? CAMERA_COLOR : `${CAMERA_COLOR}99`,
-                      }}
-                    />
-                  ) : isCursor ? (
-                    <IconMouse
-                      className="flex-shrink-0"
-                      size={12}
-                      style={{
-                        color: isSelected ? CURSOR_COLOR : `${CURSOR_COLOR}99`,
-                      }}
-                    />
-                  ) : isExpr ? (
-                    <span
-                      className="text-[7px] font-mono font-bold px-1 py-px rounded flex-shrink-0 uppercase tracking-wider leading-none"
-                      style={{
-                        backgroundColor: `${EXPR_COLOR}${isSelected ? "30" : "18"}`,
-                        color: isSelected ? EXPR_COLOR : `${EXPR_COLOR}99`,
+                <Tooltip key={track.id}>
+                  <TooltipTrigger asChild>
+                    <div
+                      className="flex items-center gap-1.5 px-2.5 cursor-default"
+                      style={{ height: TRACK_HEIGHT }}
+                      onContextMenu={(e) => {
+                        // Only show context menu for camera and cursor tracks
+                        if (!isCamera && !isCursor) return;
+                        e.preventDefault();
+                        setContextMenu({
+                          trackId: track.id,
+                          x: e.clientX,
+                          y: e.clientY,
+                        });
                       }}
                     >
-                      fx
-                    </span>
-                  ) : isKeyframeTrack ? (
-                    <div
-                      className="w-2 h-2 rotate-45 flex-shrink-0"
-                      style={{
-                        backgroundColor: colors.text,
-                        opacity: isSelected ? 1 : 0.5,
-                      }}
-                    />
-                  ) : (
-                    <div
-                      className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                      style={{
-                        backgroundColor: colors.text,
-                        opacity: isSelected ? 1 : 0.5,
-                      }}
-                    />
-                  )}
-                  <span
-                    className={cn(
-                      "text-[10px] min-w-0",
-                      isSelected ? "" : "text-muted-foreground/55",
-                    )}
-                    style={{
-                      color: isSelected
-                        ? isCamera
-                          ? CAMERA_COLOR
-                          : isCursor
-                            ? CURSOR_COLOR
-                            : isExpr
-                              ? EXPR_COLOR
-                              : colors.text
-                        : undefined,
-                      // Allow the label to shrink/wrap rather than hard-truncate
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    {track.label}
-                  </span>
-                </div>
+                      {isCamera ? (
+                        <IconCamera
+                          className="flex-shrink-0"
+                          size={12}
+                          style={{
+                            color: isSelected
+                              ? CAMERA_COLOR
+                              : `${CAMERA_COLOR}99`,
+                          }}
+                        />
+                      ) : isCursor ? (
+                        <IconMouse
+                          className="flex-shrink-0"
+                          size={12}
+                          style={{
+                            color: isSelected
+                              ? CURSOR_COLOR
+                              : `${CURSOR_COLOR}99`,
+                          }}
+                        />
+                      ) : isExpr ? (
+                        <span
+                          className="text-[7px] font-mono font-bold px-1 py-px rounded flex-shrink-0 uppercase tracking-wider leading-none"
+                          style={{
+                            backgroundColor: `${EXPR_COLOR}${isSelected ? "30" : "18"}`,
+                            color: isSelected ? EXPR_COLOR : `${EXPR_COLOR}99`,
+                          }}
+                        >
+                          fx
+                        </span>
+                      ) : isKeyframeTrack ? (
+                        <div
+                          className="w-2 h-2 rotate-45 flex-shrink-0"
+                          style={{
+                            backgroundColor: colors.text,
+                            opacity: isSelected ? 1 : 0.5,
+                          }}
+                        />
+                      ) : (
+                        <div
+                          className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                          style={{
+                            backgroundColor: colors.text,
+                            opacity: isSelected ? 1 : 0.5,
+                          }}
+                        />
+                      )}
+                      <span
+                        className={cn(
+                          "text-[10px] min-w-0",
+                          isSelected ? "" : "text-muted-foreground/55",
+                        )}
+                        style={{
+                          color: isSelected
+                            ? isCamera
+                              ? CAMERA_COLOR
+                              : isCursor
+                                ? CURSOR_COLOR
+                                : isExpr
+                                  ? EXPR_COLOR
+                                  : colors.text
+                            : undefined,
+                          // Allow the label to shrink/wrap rather than hard-truncate
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {track.label}
+                      </span>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>{track.label}</TooltipContent>
+                </Tooltip>
               );
             })}
           </div>
@@ -1212,297 +1224,324 @@ export function Timeline({
                       const selected = isKeyframeSelected(track.id, frame);
 
                       return (
-                        <div
-                          key={frame}
-                          data-keyframe="true"
-                          className={cn(
-                            "absolute top-1/2 -translate-y-1/2 group",
-                            isPlaying
-                              ? "cursor-not-allowed opacity-50"
-                              : "cursor-grab active:cursor-grabbing",
-                          )}
-                          style={{
-                            left: `${kfPct}%`,
-                            // Extended clickable area with padding on both sides
-                            transform: "translateY(-50%) translateX(-50%)",
-                            width: "24px", // Wider clickable area (3× the 8px diamond)
-                            height: "24px",
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            zIndex: selected ? 30 : 20, // Selected keyframes on top
-                          }}
-                          onMouseDown={(e) => {
-                            if (isPlaying) return;
-                            e.preventDefault();
-                            e.stopPropagation();
+                        <Tooltip key={frame}>
+                          <TooltipTrigger asChild>
+                            <div
+                              data-keyframe="true"
+                              className={cn(
+                                "absolute top-1/2 -translate-y-1/2 group",
+                                isPlaying
+                                  ? "cursor-not-allowed opacity-50"
+                                  : "cursor-grab active:cursor-grabbing",
+                              )}
+                              style={{
+                                left: `${kfPct}%`,
+                                // Extended clickable area with padding on both sides
+                                transform: "translateY(-50%) translateX(-50%)",
+                                width: "24px", // Wider clickable area (3× the 8px diamond)
+                                height: "24px",
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                zIndex: selected ? 30 : 20, // Selected keyframes on top
+                              }}
+                              onMouseDown={(e) => {
+                                if (isPlaying) return;
+                                e.preventDefault();
+                                e.stopPropagation();
 
-                            // Check if this keyframe is already in the selection
-                            const isAlreadySelected = isKeyframeSelected(
-                              track.id,
-                              frame,
-                            );
-
-                            // Determine which frames we'll be dragging
-                            // If already selected, drag all selected frames; otherwise just this one
-                            const framesToDrag = isAlreadySelected
-                              ? selectedKeyframes.get(track.id) ||
-                                new Set([frame])
-                              : new Set([frame]);
-                            const selectedFrames = Array.from(framesToDrag);
-
-                            // Update selection if needed (for visual feedback)
-                            if (!isAlreadySelected) {
-                              setSelectedKeyframes(
-                                new Map([[track.id, new Set([frame])]]),
-                              );
-                            }
-
-                            // If track is camera or cursor, notify sidebar to open controls
-                            if (isCamera && onCameraKeyframeClick) {
-                              onCameraKeyframeClick("camera");
-                            } else if (isCursor && onCameraKeyframeClick) {
-                              onCameraKeyframeClick("cursor");
-                            }
-
-                            const startX = e.clientX;
-                            const startY = e.clientY;
-                            let isDragging = false;
-
-                            const el = barAreaRef.current;
-                            if (!el) return;
-                            const rect = el.getBoundingClientRect();
-
-                            // Save original state for undo in case of conflict
-                            conflictUndoStateRef.current = {
-                              trackId: track.id,
-                              originalAnimatedProps: track.animatedProps,
-                            };
-
-                            // Store original positions of all selected keyframes
-                            const originalFrames = new Map<number, number>();
-                            selectedFrames.forEach((f) =>
-                              originalFrames.set(f, f),
-                            );
-
-                            keyframeDragRef.current = {
-                              originalFrame: frame,
-                              currentFrame: frame,
-                              startX,
-                              barAreaWidth: rect.width,
-                              movingKeys: selectedFrames.map(
-                                (f) => `${track.id}:${f}`,
-                              ),
-                              originalFrames,
-                            };
-
-                            const handleMove = (ev: MouseEvent) => {
-                              if (!keyframeDragRef.current) return;
-
-                              // Check if moved significantly (3px threshold)
-                              const dist = Math.sqrt(
-                                Math.pow(ev.clientX - startX, 2) +
-                                  Math.pow(ev.clientY - startY, 2),
-                              );
-                              if (dist > 3) {
-                                isDragging = true;
-                              }
-
-                              // Calculate delta in pixels, convert to frames
-                              const deltaX =
-                                ev.clientX - keyframeDragRef.current.startX;
-                              const frameChange = pxDeltaToFrameDelta(
-                                deltaX,
-                                keyframeDragRef.current.barAreaWidth,
-                                viewDuration,
-                              );
-
-                              // Calculate new positions for all selected keyframes
-                              const newPositions = new Map<number, number>();
-                              let minNewFrame = Infinity;
-                              let maxNewFrame = -Infinity;
-
-                              selectedFrames.forEach((origFrame) => {
-                                const newFrame = clampFrame(
-                                  origFrame + frameChange,
-                                  durationInFrames,
-                                );
-                                newPositions.set(origFrame, newFrame);
-                                minNewFrame = Math.min(minNewFrame, newFrame);
-                                maxNewFrame = Math.max(maxNewFrame, newFrame);
-                              });
-
-                              // Move ALL selected keyframes
-                              if (track.animatedProps) {
-                                const updatedProps = track.animatedProps.map(
-                                  (prop) => {
-                                    if (!prop.keyframes) return prop;
-
-                                    const updatedKeyframes = prop.keyframes.map(
-                                      (kf) => {
-                                        const newFrame = newPositions.get(
-                                          kf.frame,
-                                        );
-                                        return newFrame !== undefined
-                                          ? { ...kf, frame: newFrame }
-                                          : kf;
-                                      },
-                                    );
-
-                                    return {
-                                      ...prop,
-                                      keyframes: updatedKeyframes,
-                                    };
-                                  },
+                                // Check if this keyframe is already in the selection
+                                const isAlreadySelected = isKeyframeSelected(
+                                  track.id,
+                                  frame,
                                 );
 
-                                onUpdateTrack(track.id, {
-                                  animatedProps: updatedProps,
-                                });
-                              }
+                                // Determine which frames we'll be dragging
+                                // If already selected, drag all selected frames; otherwise just this one
+                                const framesToDrag = isAlreadySelected
+                                  ? selectedKeyframes.get(track.id) ||
+                                    new Set([frame])
+                                  : new Set([frame]);
+                                const selectedFrames = Array.from(framesToDrag);
 
-                              // Update current frame for the dragged keyframe
-                              const newFrame = newPositions.get(
-                                keyframeDragRef.current.originalFrame,
-                              );
-                              if (newFrame !== undefined) {
-                                keyframeDragRef.current.currentFrame = newFrame;
-                                // Seek playhead to follow the dragged keyframe
-                                onSeek(newFrame);
-                              }
-                            };
+                                // Update selection if needed (for visual feedback)
+                                if (!isAlreadySelected) {
+                                  setSelectedKeyframes(
+                                    new Map([[track.id, new Set([frame])]]),
+                                  );
+                                }
 
-                            const handleUp = () => {
-                              window.removeEventListener(
-                                "mousemove",
-                                handleMove,
-                              );
-                              window.removeEventListener("mouseup", handleUp);
-
-                              if (!keyframeDragRef.current) return;
-
-                              const finalFrame =
-                                keyframeDragRef.current.currentFrame;
-
-                              if (!isDragging) {
-                                // It was just a click - already handled selection above
-                                onSeek(frame);
+                                // If track is camera or cursor, notify sidebar to open controls
                                 if (isCamera && onCameraKeyframeClick) {
                                   onCameraKeyframeClick("camera");
                                 } else if (isCursor && onCameraKeyframeClick) {
                                   onCameraKeyframeClick("cursor");
                                 }
-                              } else {
-                                // Calculate delta for all keyframes
-                                const deltaX = 0; // We're at final position
-                                const frameChange =
-                                  finalFrame -
-                                  keyframeDragRef.current.originalFrame;
 
-                                // Build set of all new positions
-                                const newFrameSet = new Set<number>();
-                                selectedFrames.forEach((origFrame) => {
-                                  const newPos = clampFrame(
-                                    origFrame + frameChange,
-                                    durationInFrames,
+                                const startX = e.clientX;
+                                const startY = e.clientY;
+                                let isDragging = false;
+
+                                const el = barAreaRef.current;
+                                if (!el) return;
+                                const rect = el.getBoundingClientRect();
+
+                                // Save original state for undo in case of conflict
+                                conflictUndoStateRef.current = {
+                                  trackId: track.id,
+                                  originalAnimatedProps: track.animatedProps,
+                                };
+
+                                // Store original positions of all selected keyframes
+                                const originalFrames = new Map<
+                                  number,
+                                  number
+                                >();
+                                selectedFrames.forEach((f) =>
+                                  originalFrames.set(f, f),
+                                );
+
+                                keyframeDragRef.current = {
+                                  originalFrame: frame,
+                                  currentFrame: frame,
+                                  startX,
+                                  barAreaWidth: rect.width,
+                                  movingKeys: selectedFrames.map(
+                                    (f) => `${track.id}:${f}`,
+                                  ),
+                                  originalFrames,
+                                };
+
+                                const handleMove = (ev: MouseEvent) => {
+                                  if (!keyframeDragRef.current) return;
+
+                                  // Check if moved significantly (3px threshold)
+                                  const dist = Math.sqrt(
+                                    Math.pow(ev.clientX - startX, 2) +
+                                      Math.pow(ev.clientY - startY, 2),
                                   );
-                                  newFrameSet.add(newPos);
-                                });
+                                  if (dist > 3) {
+                                    isDragging = true;
+                                  }
 
-                                // Check for conflicts: any of the moved keyframes overlap with non-selected keyframes
-                                if (track.animatedProps) {
-                                  for (const prop of track.animatedProps) {
-                                    if (prop.keyframes) {
-                                      // Get all keyframe positions that are NOT being moved
-                                      const staticFrames = prop.keyframes
-                                        .filter(
-                                          (kf) =>
-                                            !selectedFrames.includes(kf.frame),
-                                        )
-                                        .map((kf) => kf.frame);
+                                  // Calculate delta in pixels, convert to frames
+                                  const deltaX =
+                                    ev.clientX - keyframeDragRef.current.startX;
+                                  const frameChange = pxDeltaToFrameDelta(
+                                    deltaX,
+                                    keyframeDragRef.current.barAreaWidth,
+                                    viewDuration,
+                                  );
 
-                                      // Check if any new position conflicts with a static keyframe
-                                      for (const newPos of newFrameSet) {
-                                        if (staticFrames.includes(newPos)) {
-                                          // Conflict detected - show modal
-                                          setKeyframeConflict({
-                                            trackId: track.id,
-                                            newFrame: newPos,
-                                            originalFrame:
-                                              keyframeDragRef.current
-                                                .originalFrame,
-                                            conflictingFrame: newPos,
+                                  // Calculate new positions for all selected keyframes
+                                  const newPositions = new Map<
+                                    number,
+                                    number
+                                  >();
+                                  let minNewFrame = Infinity;
+                                  let maxNewFrame = -Infinity;
+
+                                  selectedFrames.forEach((origFrame) => {
+                                    const newFrame = clampFrame(
+                                      origFrame + frameChange,
+                                      durationInFrames,
+                                    );
+                                    newPositions.set(origFrame, newFrame);
+                                    minNewFrame = Math.min(
+                                      minNewFrame,
+                                      newFrame,
+                                    );
+                                    maxNewFrame = Math.max(
+                                      maxNewFrame,
+                                      newFrame,
+                                    );
+                                  });
+
+                                  // Move ALL selected keyframes
+                                  if (track.animatedProps) {
+                                    const updatedProps =
+                                      track.animatedProps.map((prop) => {
+                                        if (!prop.keyframes) return prop;
+
+                                        const updatedKeyframes =
+                                          prop.keyframes.map((kf) => {
+                                            const newFrame = newPositions.get(
+                                              kf.frame,
+                                            );
+                                            return newFrame !== undefined
+                                              ? { ...kf, frame: newFrame }
+                                              : kf;
                                           });
-                                          keyframeDragRef.current = null;
-                                          return; // Don't finalize - let modal handle it
+
+                                        return {
+                                          ...prop,
+                                          keyframes: updatedKeyframes,
+                                        };
+                                      });
+
+                                    onUpdateTrack(track.id, {
+                                      animatedProps: updatedProps,
+                                    });
+                                  }
+
+                                  // Update current frame for the dragged keyframe
+                                  const newFrame = newPositions.get(
+                                    keyframeDragRef.current.originalFrame,
+                                  );
+                                  if (newFrame !== undefined) {
+                                    keyframeDragRef.current.currentFrame =
+                                      newFrame;
+                                    // Seek playhead to follow the dragged keyframe
+                                    onSeek(newFrame);
+                                  }
+                                };
+
+                                const handleUp = () => {
+                                  window.removeEventListener(
+                                    "mousemove",
+                                    handleMove,
+                                  );
+                                  window.removeEventListener(
+                                    "mouseup",
+                                    handleUp,
+                                  );
+
+                                  if (!keyframeDragRef.current) return;
+
+                                  const finalFrame =
+                                    keyframeDragRef.current.currentFrame;
+
+                                  if (!isDragging) {
+                                    // It was just a click - already handled selection above
+                                    onSeek(frame);
+                                    if (isCamera && onCameraKeyframeClick) {
+                                      onCameraKeyframeClick("camera");
+                                    } else if (
+                                      isCursor &&
+                                      onCameraKeyframeClick
+                                    ) {
+                                      onCameraKeyframeClick("cursor");
+                                    }
+                                  } else {
+                                    // Calculate delta for all keyframes
+                                    const deltaX = 0; // We're at final position
+                                    const frameChange =
+                                      finalFrame -
+                                      keyframeDragRef.current.originalFrame;
+
+                                    // Build set of all new positions
+                                    const newFrameSet = new Set<number>();
+                                    selectedFrames.forEach((origFrame) => {
+                                      const newPos = clampFrame(
+                                        origFrame + frameChange,
+                                        durationInFrames,
+                                      );
+                                      newFrameSet.add(newPos);
+                                    });
+
+                                    // Check for conflicts: any of the moved keyframes overlap with non-selected keyframes
+                                    if (track.animatedProps) {
+                                      for (const prop of track.animatedProps) {
+                                        if (prop.keyframes) {
+                                          // Get all keyframe positions that are NOT being moved
+                                          const staticFrames = prop.keyframes
+                                            .filter(
+                                              (kf) =>
+                                                !selectedFrames.includes(
+                                                  kf.frame,
+                                                ),
+                                            )
+                                            .map((kf) => kf.frame);
+
+                                          // Check if any new position conflicts with a static keyframe
+                                          for (const newPos of newFrameSet) {
+                                            if (staticFrames.includes(newPos)) {
+                                              // Conflict detected - show modal
+                                              setKeyframeConflict({
+                                                trackId: track.id,
+                                                newFrame: newPos,
+                                                originalFrame:
+                                                  keyframeDragRef.current
+                                                    .originalFrame,
+                                                conflictingFrame: newPos,
+                                              });
+                                              keyframeDragRef.current = null;
+                                              return; // Don't finalize - let modal handle it
+                                            }
+                                          }
                                         }
                                       }
                                     }
+
+                                    // Update selection to reflect new positions
+                                    setSelectedKeyframes((prev) => {
+                                      const next = new Map(prev);
+                                      next.set(track.id, newFrameSet);
+                                      return next;
+                                    });
+
+                                    // No conflict - success!
+                                    conflictUndoStateRef.current = null;
                                   }
-                                }
 
-                                // Update selection to reflect new positions
-                                setSelectedKeyframes((prev) => {
-                                  const next = new Map(prev);
-                                  next.set(track.id, newFrameSet);
-                                  return next;
-                                });
+                                  keyframeDragRef.current = null;
+                                };
 
-                                // No conflict - success!
-                                conflictUndoStateRef.current = null;
-                              }
-
-                              keyframeDragRef.current = null;
-                            };
-
-                            window.addEventListener("mousemove", handleMove);
-                            window.addEventListener("mouseup", handleUp);
-                          }}
-                          title={
-                            isPlaying
+                                window.addEventListener(
+                                  "mousemove",
+                                  handleMove,
+                                );
+                                window.addEventListener("mouseup", handleUp);
+                              }}
+                            >
+                              <div
+                                className={cn("w-2 h-2 rotate-45 relative")}
+                                style={{
+                                  // Different styles for cursor keyframes based on what changed
+                                  backgroundColor: selected
+                                    ? "#ffffff" // White fill for selected keyframes
+                                    : isCursor &&
+                                        (cursorStyle === "clickStart" ||
+                                          cursorStyle === "clickEnd")
+                                      ? "#facc15" // Yellow for click keyframes
+                                      : isCursor && cursorStyle === "type"
+                                        ? "transparent"
+                                        : keyframeColor,
+                                  border:
+                                    isCursor &&
+                                    cursorStyle === "type" &&
+                                    !selected
+                                      ? `1.5px solid ${keyframeColor}`
+                                      : isCursor &&
+                                          cursorStyle === "both" &&
+                                          !selected
+                                        ? `1.5px solid #c084fc` // Brighter purple border for both
+                                        : "none",
+                                  opacity:
+                                    isCursor && cursorStyle === "clickEnd"
+                                      ? 0.4 // Semi-transparent for click end
+                                      : 1, // Solid for everything else (including clickStart)
+                                  boxShadow: selected
+                                    ? `0 0 0 2px #ffffffcc, 0 0 8px #ffffff99` // White outline + glow for selected
+                                    : isCursor &&
+                                        (cursorStyle === "clickStart" ||
+                                          cursorStyle === "clickEnd")
+                                      ? `0 0 ${isCurrentKeyframe ? 6 : 4}px #facc15${isCurrentKeyframe ? "cc" : "88"}` // Yellow glow for click keyframes
+                                      : isCursor && cursorStyle === "type"
+                                        ? `0 0 ${isCurrentKeyframe ? 6 : 4}px ${keyframeColor}${isCurrentKeyframe ? "88" : "66"}`
+                                        : isCursor && cursorStyle === "both"
+                                          ? `0 0 ${isCurrentKeyframe ? 8 : 6}px #c084fc${isCurrentKeyframe ? "cc" : "88"}`
+                                          : `0 0 ${isCurrentKeyframe ? 6 : 4}px ${keyframeColor}${isCurrentKeyframe ? "cc" : "88"}`,
+                                }}
+                              />
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            {isPlaying
                               ? "Pause to select keyframe"
-                              : `Drag to reposition • Click to select`
-                          }
-                        >
-                          <div
-                            className={cn("w-2 h-2 rotate-45 relative")}
-                            style={{
-                              // Different styles for cursor keyframes based on what changed
-                              backgroundColor: selected
-                                ? "#ffffff" // White fill for selected keyframes
-                                : isCursor &&
-                                    (cursorStyle === "clickStart" ||
-                                      cursorStyle === "clickEnd")
-                                  ? "#facc15" // Yellow for click keyframes
-                                  : isCursor && cursorStyle === "type"
-                                    ? "transparent"
-                                    : keyframeColor,
-                              border:
-                                isCursor && cursorStyle === "type" && !selected
-                                  ? `1.5px solid ${keyframeColor}`
-                                  : isCursor &&
-                                      cursorStyle === "both" &&
-                                      !selected
-                                    ? `1.5px solid #c084fc` // Brighter purple border for both
-                                    : "none",
-                              opacity:
-                                isCursor && cursorStyle === "clickEnd"
-                                  ? 0.4 // Semi-transparent for click end
-                                  : 1, // Solid for everything else (including clickStart)
-                              boxShadow: selected
-                                ? `0 0 0 2px #ffffffcc, 0 0 8px #ffffff99` // White outline + glow for selected
-                                : isCursor &&
-                                    (cursorStyle === "clickStart" ||
-                                      cursorStyle === "clickEnd")
-                                  ? `0 0 ${isCurrentKeyframe ? 6 : 4}px #facc15${isCurrentKeyframe ? "cc" : "88"}` // Yellow glow for click keyframes
-                                  : isCursor && cursorStyle === "type"
-                                    ? `0 0 ${isCurrentKeyframe ? 6 : 4}px ${keyframeColor}${isCurrentKeyframe ? "88" : "66"}`
-                                    : isCursor && cursorStyle === "both"
-                                      ? `0 0 ${isCurrentKeyframe ? 8 : 6}px #c084fc${isCurrentKeyframe ? "cc" : "88"}`
-                                      : `0 0 ${isCurrentKeyframe ? 6 : 4}px ${keyframeColor}${isCurrentKeyframe ? "cc" : "88"}`,
-                            }}
-                          />
-                        </div>
+                              : `Drag to reposition • Click to select`}
+                          </TooltipContent>
+                        </Tooltip>
                       );
                     })}
                   </div>

--- a/templates/videos/app/components/TrackPropertiesPanel.tsx
+++ b/templates/videos/app/components/TrackPropertiesPanel.tsx
@@ -27,6 +27,11 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -214,18 +219,27 @@ function ExpressionPropRow({
         )}
 
         {/* Expand toggle */}
-        <button
-          type="button"
-          onClick={() => setExpanded((e) => !e)}
-          className="flex items-center gap-0.5 flex-shrink-0 px-1 py-0.5 rounded hover:bg-zinc-800/30 transition-colors text-[9px] font-mono"
-          style={{ color: `${EXPR_COLOR}70` }}
-          title={expanded ? "Hide code" : "View expression code"}
-        >
-          <span className="uppercase tracking-wider">
-            {expanded ? "hide" : "code"}
-          </span>
-          <IconChevronDown size={10} className={cn(expanded && "rotate-180")} />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => setExpanded((e) => !e)}
+              className="flex items-center gap-0.5 flex-shrink-0 px-1 py-0.5 rounded hover:bg-zinc-800/30 transition-colors text-[9px] font-mono"
+              style={{ color: `${EXPR_COLOR}70` }}
+            >
+              <span className="uppercase tracking-wider">
+                {expanded ? "hide" : "code"}
+              </span>
+              <IconChevronDown
+                size={10}
+                className={cn(expanded && "rotate-180")}
+              />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {expanded ? "Hide code" : "View expression code"}
+          </TooltipContent>
+        </Tooltip>
 
         <button
           onClick={onRemove}
@@ -445,18 +459,26 @@ function AnimatedPropRow({
 
         {/* Code indicator — only if there's a description or snippet */}
         {hasCode && (
-          <button
-            type="button"
-            title={codeOpen ? "Hide details" : "How this works"}
-            onClick={() => setCodeOpen((o) => !o)}
-            className="flex-shrink-0 flex items-center gap-0.5 px-1 py-0.5 rounded transition-colors"
-            style={{
-              color: codeOpen ? accentColor : `${accentColor}50`,
-              backgroundColor: codeOpen ? `${accentColor}15` : "transparent",
-            }}
-          >
-            <IconCode size={10} />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setCodeOpen((o) => !o)}
+                className="flex-shrink-0 flex items-center gap-0.5 px-1 py-0.5 rounded transition-colors"
+                style={{
+                  color: codeOpen ? accentColor : `${accentColor}50`,
+                  backgroundColor: codeOpen
+                    ? `${accentColor}15`
+                    : "transparent",
+                }}
+              >
+                <IconCode size={10} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {codeOpen ? "Hide details" : "How this works"}
+            </TooltipContent>
+          </Tooltip>
         )}
 
         <button
@@ -537,12 +559,19 @@ function AnimatedPropRow({
                   onUpdate({ ...prop, easing: val as EasingKey })
                 }
               >
-                <SelectTrigger
-                  className="w-full h-auto text-[10px] bg-background border border-border/60 rounded px-1.5 py-1 text-foreground/80 focus:outline-none focus:ring-1 focus:ring-primary/40"
-                  title="Applies to all keyframe segments"
-                >
-                  <SelectValue />
-                </SelectTrigger>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <SelectTrigger
+                      className="w-full h-auto text-[10px] bg-background border border-border/60 rounded px-1.5 py-1 text-foreground/80 focus:outline-none focus:ring-1 focus:ring-primary/40"
+                      aria-label="Applies to all keyframe segments"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Applies to all keyframe segments
+                  </TooltipContent>
+                </Tooltip>
                 <SelectContent>
                   {EASING_OPTIONS.map((opt) => (
                     <SelectItem key={opt.value} value={opt.value}>

--- a/templates/videos/app/components/TweaksPanel.tsx
+++ b/templates/videos/app/components/TweaksPanel.tsx
@@ -4,6 +4,11 @@ import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import type { TweakDefinition } from "@/lib/design-systems";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 // ── Default tweaks for video compositions ─────────────────────────────────────
 
@@ -190,18 +195,21 @@ function TweakControl({
       {tweak.type === "color-swatches" && (
         <div className="flex gap-2">
           {tweak.options?.map((opt) => (
-            <button
-              key={opt.value}
-              onClick={() => onChange(opt.value)}
-              className={cn(
-                "h-6 w-6 cursor-pointer rounded-full",
-                value === opt.value
-                  ? "ring-2 ring-foreground ring-offset-2 ring-offset-card"
-                  : "ring-1 ring-border hover:ring-foreground/30",
-              )}
-              style={{ backgroundColor: opt.color || opt.value }}
-              title={opt.label}
-            />
+            <Tooltip key={opt.value}>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => onChange(opt.value)}
+                  className={cn(
+                    "h-6 w-6 cursor-pointer rounded-full",
+                    value === opt.value
+                      ? "ring-2 ring-foreground ring-offset-2 ring-offset-card"
+                      : "ring-1 ring-border hover:ring-foreground/30",
+                  )}
+                  style={{ backgroundColor: opt.color || opt.value }}
+                />
+              </TooltipTrigger>
+              <TooltipContent>{opt.label}</TooltipContent>
+            </Tooltip>
           ))}
         </div>
       )}

--- a/templates/videos/app/components/VideoPlayer.tsx
+++ b/templates/videos/app/components/VideoPlayer.tsx
@@ -24,6 +24,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export type VideoPlayerHandle = {
   seekTo: (frame: number) => void;
@@ -361,39 +366,53 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
           {/* Buttons + time */}
           <div className="flex items-center justify-between gap-1">
             <div className="flex items-center gap-0.5">
-              <button
-                onClick={restart}
-                title="Go to start"
-                aria-label="Go to start"
-                className="p-2.5 sm:p-2 text-muted-foreground hover:text-foreground rounded-lg hover:bg-secondary"
-              >
-                <IconPlayerSkipBack size={16} />
-              </button>
-              <button
-                onClick={togglePlay}
-                title={playing ? "Pause" : "Play"}
-                aria-label={playing ? "Pause" : "Play"}
-                className="p-2.5 sm:p-2 text-foreground hover:bg-secondary rounded-lg"
-              >
-                {playing ? (
-                  <IconPlayerPause size={18} />
-                ) : (
-                  <IconPlayerPlay size={18} />
-                )}
-              </button>
-              <button
-                onClick={() => setRepeat((r) => !r)}
-                title={repeat ? "Loop: on" : "Loop: off"}
-                aria-label={repeat ? "Disable loop" : "Enable loop"}
-                className={cn(
-                  "p-2.5 sm:p-2 rounded-lg hover:bg-secondary",
-                  repeat
-                    ? "text-primary"
-                    : "text-muted-foreground hover:text-foreground",
-                )}
-              >
-                <IconRepeat size={15} />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={restart}
+                    aria-label="Go to start"
+                    className="p-2.5 sm:p-2 text-muted-foreground hover:text-foreground rounded-lg hover:bg-secondary"
+                  >
+                    <IconPlayerSkipBack size={16} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Go to start</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={togglePlay}
+                    aria-label={playing ? "Pause" : "Play"}
+                    className="p-2.5 sm:p-2 text-foreground hover:bg-secondary rounded-lg"
+                  >
+                    {playing ? (
+                      <IconPlayerPause size={18} />
+                    ) : (
+                      <IconPlayerPlay size={18} />
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>{playing ? "Pause" : "Play"}</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={() => setRepeat((r) => !r)}
+                    aria-label={repeat ? "Disable loop" : "Enable loop"}
+                    className={cn(
+                      "p-2.5 sm:p-2 rounded-lg hover:bg-secondary",
+                      repeat
+                        ? "text-primary"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    <IconRepeat size={15} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {repeat ? "Loop: on" : "Loop: off"}
+                </TooltipContent>
+              </Tooltip>
             </div>
 
             <div className="flex items-center gap-1 sm:gap-2 flex-wrap justify-end">
@@ -419,12 +438,17 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
                 value={String(playbackRate)}
                 onValueChange={(val) => onPlaybackRateChange?.(parseFloat(val))}
               >
-                <SelectTrigger
-                  className="h-auto text-[10px] px-2 py-1 rounded-md bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground border border-border/50 hover:border-border font-mono cursor-pointer w-auto gap-1"
-                  title="Playback speed"
-                >
-                  <SelectValue />
-                </SelectTrigger>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <SelectTrigger
+                      className="h-auto text-[10px] px-2 py-1 rounded-md bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground border border-border/50 hover:border-border font-mono cursor-pointer w-auto gap-1"
+                      aria-label="Playback speed"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>Playback speed</TooltipContent>
+                </Tooltip>
                 <SelectContent>
                   <SelectItem value="0.25">0.25×</SelectItem>
                   <SelectItem value="0.5">0.5×</SelectItem>
@@ -436,18 +460,24 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
                 </SelectContent>
               </Select>
 
-              <button
-                onClick={toggleFullscreen}
-                title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
-                aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
-                className="p-2.5 sm:p-2 text-muted-foreground hover:text-foreground rounded-lg hover:bg-secondary"
-              >
-                {isFullscreen ? (
-                  <IconArrowsMinimize size={14} />
-                ) : (
-                  <IconArrowsMaximize size={14} />
-                )}
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={toggleFullscreen}
+                    aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+                    className="p-2.5 sm:p-2 text-muted-foreground hover:text-foreground rounded-lg hover:bg-secondary"
+                  >
+                    {isFullscreen ? (
+                      <IconArrowsMinimize size={14} />
+                    ) : (
+                      <IconArrowsMaximize size={14} />
+                    )}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
         </div>

--- a/templates/videos/app/components/design-system/DesignSystemCard.tsx
+++ b/templates/videos/app/components/design-system/DesignSystemCard.tsx
@@ -1,5 +1,10 @@
 import { IconPalette, IconStar, IconStarFilled } from "@tabler/icons-react";
 import type { DesignSystemData } from "../../../shared/api";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface DesignSystemCardProps {
   id: string;
@@ -101,20 +106,26 @@ export function DesignSystemCard({
         </div>
 
         {/* Star button */}
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onSetDefault();
-          }}
-          className="shrink-0 p-1 rounded hover:bg-accent cursor-pointer"
-          title={isDefault ? "Default design system" : "Set as default"}
-        >
-          {isDefault ? (
-            <IconStarFilled className="w-4 h-4 text-[#609FF8]" />
-          ) : (
-            <IconStar className="w-4 h-4 text-muted-foreground/60 group-hover:text-muted-foreground" />
-          )}
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onSetDefault();
+              }}
+              className="shrink-0 p-1 rounded hover:bg-accent cursor-pointer"
+            >
+              {isDefault ? (
+                <IconStarFilled className="w-4 h-4 text-[#609FF8]" />
+              ) : (
+                <IconStar className="w-4 h-4 text-muted-foreground/60 group-hover:text-muted-foreground" />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {isDefault ? "Default design system" : "Set as default"}
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/templates/videos/app/components/keyframes/KeyframeActionButtons.tsx
+++ b/templates/videos/app/components/keyframes/KeyframeActionButtons.tsx
@@ -1,5 +1,10 @@
 import { Button } from "../ui/button";
 import { IconCopy, IconRotate, IconTrash } from "@tabler/icons-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface KeyframeActionButtonsProps {
   isOnKeyframe: boolean;
@@ -20,33 +25,48 @@ export function KeyframeActionButtons({
 
   return (
     <div className="flex gap-2 pt-2 border-t border-border/50">
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={onDuplicate}
-        className="text-xs border-muted-foreground/30 hover:bg-secondary/50"
-        title="Duplicate keyframe +30 frames ahead"
-      >
-        <IconCopy className="w-3 h-3" />
-      </Button>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={onReset}
-        className="text-xs text-muted-foreground/60 hover:text-muted-foreground hover:bg-secondary/30"
-        title={resetTooltip}
-      >
-        <IconRotate className="h-3 w-3" />
-      </Button>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={onRemove}
-        className="text-destructive/80 border-destructive/30 hover:bg-destructive/10 text-xs ml-auto"
-        title="Remove keyframe"
-      >
-        <IconTrash className="w-3.5 h-3.5" />
-      </Button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onDuplicate}
+            className="text-xs border-muted-foreground/30 hover:bg-secondary/50"
+            aria-label="Duplicate keyframe +30 frames ahead"
+          >
+            <IconCopy className="w-3 h-3" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Duplicate keyframe +30 frames ahead</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onReset}
+            className="text-xs text-muted-foreground/60 hover:text-muted-foreground hover:bg-secondary/30"
+            aria-label={resetTooltip}
+          >
+            <IconRotate className="h-3 w-3" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{resetTooltip}</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRemove}
+            className="text-destructive/80 border-destructive/30 hover:bg-destructive/10 text-xs ml-auto"
+            aria-label="Remove keyframe"
+          >
+            <IconTrash className="w-3.5 h-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Remove keyframe</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/templates/videos/app/components/ui/sidebar.tsx
+++ b/templates/videos/app/components/ui/sidebar.tsx
@@ -298,24 +298,28 @@ const SidebarRail = React.forwardRef<
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
-      ref={ref}
-      data-sidebar="rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
-        "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      {...props}
-    />
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          ref={ref}
+          data-sidebar="rail"
+          aria-label="Toggle Sidebar"
+          tabIndex={-1}
+          onClick={toggleSidebar}
+          className={cn(
+            "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
+            "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",
+            "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+            "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar",
+            "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+            "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+            className,
+          )}
+          {...props}
+        />
+      </TooltipTrigger>
+      <TooltipContent>Toggle Sidebar</TooltipContent>
+    </Tooltip>
   );
 });
 SidebarRail.displayName = "SidebarRail";

--- a/templates/videos/app/pages/ComponentLibraryView.tsx
+++ b/templates/videos/app/pages/ComponentLibraryView.tsx
@@ -9,6 +9,11 @@ import {
 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import type { Zone } from "@/remotion/hooks/useEditableZones";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 type ComponentLibraryViewProps = {
   component: LibraryComponentEntry;
@@ -241,27 +246,35 @@ export function ComponentLibraryView({
             {/* Custom Controls Overlay */}
             <div className="absolute bottom-0 left-0 right-0 p-2 sm:p-4">
               <div className="flex items-center gap-2 sm:gap-3">
-                <button
-                  onClick={handleRestart}
-                  className="p-2.5 sm:p-2 hover:bg-white/10 rounded"
-                  title="Restart"
-                  aria-label="Restart"
-                >
-                  <IconPlayerSkipBack className="w-4 h-4 text-white" />
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={handleRestart}
+                      className="p-2.5 sm:p-2 hover:bg-white/10 rounded"
+                      aria-label="Restart"
+                    >
+                      <IconPlayerSkipBack className="w-4 h-4 text-white" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Restart</TooltipContent>
+                </Tooltip>
 
-                <button
-                  onClick={handlePlayPause}
-                  className="p-2.5 sm:p-2 hover:bg-white/10 rounded"
-                  title={playing ? "Pause" : "Play"}
-                  aria-label={playing ? "Pause" : "Play"}
-                >
-                  {playing ? (
-                    <IconPlayerPause className="w-5 h-5 sm:w-4 sm:h-4 text-white" />
-                  ) : (
-                    <IconPlayerPlay className="w-5 h-5 sm:w-4 sm:h-4 text-white" />
-                  )}
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      onClick={handlePlayPause}
+                      className="p-2.5 sm:p-2 hover:bg-white/10 rounded"
+                      aria-label={playing ? "Pause" : "Play"}
+                    >
+                      {playing ? (
+                        <IconPlayerPause className="w-5 h-5 sm:w-4 sm:h-4 text-white" />
+                      ) : (
+                        <IconPlayerPlay className="w-5 h-5 sm:w-4 sm:h-4 text-white" />
+                      )}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>{playing ? "Pause" : "Play"}</TooltipContent>
+                </Tooltip>
 
                 <div className="flex-1 text-xs sm:text-sm text-white/80 font-mono">
                   {fmtSec(currentFrame)} / {fmtSec(component.durationInFrames)}

--- a/templates/videos/app/pages/CompositionView.tsx
+++ b/templates/videos/app/pages/CompositionView.tsx
@@ -39,6 +39,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 type CompositionViewProps = {
   onCameraKeyframeClick?: (trackType: "camera" | "cursor") => void;
@@ -449,71 +454,95 @@ export default function CompositionView({
 
           {/* Composition details */}
           <div className="flex items-center gap-1.5 sm:ml-auto flex-shrink-0 flex-wrap">
-            <button
-              onClick={onCompSettingsClick}
-              className="text-[10px] px-2 py-1 rounded-md bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground border border-border/50 hover:border-border font-mono cursor-pointer"
-              title="Click to edit output size"
-            >
-              {composition.width}x{composition.height}
-            </button>
-            <button
-              onClick={onCompSettingsClick}
-              className="text-[10px] px-2 py-1 rounded-md bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground border border-border/50 hover:border-border font-mono cursor-pointer"
-              title="Click to edit frame rate"
-            >
-              {composition.fps}fps
-            </button>
-            <button
-              onClick={onCompSettingsClick}
-              className="text-[10px] px-2 py-1 rounded-md bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground border border-border/50 hover:border-border font-mono cursor-pointer"
-              title="Click to edit duration"
-            >
-              {(composition.durationInFrames / composition.fps).toFixed(1)}s
-            </button>
-            <button
-              onClick={() => setTweaksVisible((v) => !v)}
-              className={cn(
-                "flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer",
-                tweaksVisible
-                  ? "bg-primary/10 text-primary border border-primary/30"
-                  : "bg-secondary/50 hover:bg-secondary text-muted-foreground border border-border/50",
-              )}
-              title="Toggle tweaks panel"
-            >
-              <IconAdjustments className="w-3.5 h-3.5" />
-              Tweaks
-            </button>
-            <button
-              onClick={handleSaveAsDefault}
-              disabled={!canSave}
-              className={cn(
-                "flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium",
-                !canSave
-                  ? "bg-secondary/30 text-muted-foreground/40 border border-border/30 cursor-not-allowed"
-                  : hasUnsavedChanges
-                    ? "bg-green-500/10 hover:bg-green-500/20 text-green-400 border border-green-500/30"
-                    : "bg-secondary/50 hover:bg-secondary text-muted-foreground border border-border/50",
-              )}
-              title={
-                !canSave
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onCompSettingsClick}
+                  className="text-[10px] px-2 py-1 rounded-md bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground border border-border/50 hover:border-border font-mono cursor-pointer"
+                >
+                  {composition.width}x{composition.height}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Click to edit output size</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onCompSettingsClick}
+                  className="text-[10px] px-2 py-1 rounded-md bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground border border-border/50 hover:border-border font-mono cursor-pointer"
+                >
+                  {composition.fps}fps
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Click to edit frame rate</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onCompSettingsClick}
+                  className="text-[10px] px-2 py-1 rounded-md bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground border border-border/50 hover:border-border font-mono cursor-pointer"
+                >
+                  {(composition.durationInFrames / composition.fps).toFixed(1)}s
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Click to edit duration</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setTweaksVisible((v) => !v)}
+                  className={cn(
+                    "flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium cursor-pointer",
+                    tweaksVisible
+                      ? "bg-primary/10 text-primary border border-primary/30"
+                      : "bg-secondary/50 hover:bg-secondary text-muted-foreground border border-border/50",
+                  )}
+                >
+                  <IconAdjustments className="w-3.5 h-3.5" />
+                  Tweaks
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Toggle tweaks panel</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={handleSaveAsDefault}
+                  disabled={!canSave}
+                  className={cn(
+                    "flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium",
+                    !canSave
+                      ? "bg-secondary/30 text-muted-foreground/40 border border-border/30 cursor-not-allowed"
+                      : hasUnsavedChanges
+                        ? "bg-green-500/10 hover:bg-green-500/20 text-green-400 border border-green-500/30"
+                        : "bg-secondary/50 hover:bg-secondary text-muted-foreground border border-border/50",
+                  )}
+                >
+                  <IconDeviceFloppy className="w-3.5 h-3.5" />
+                  Save
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {!canSave
                   ? "Save to registry requires local development mode"
                   : hasUnsavedChanges
                     ? "Save current settings as default for this composition"
                     : composition.storage === "database"
                       ? "All changes saved to database"
-                      : "All changes saved to registry"
-              }
-            >
-              <IconDeviceFloppy className="w-3.5 h-3.5" />
-              Save
-            </button>
-            <button
-              onClick={() => setShowDeleteConfirm(true)}
-              className="p-1 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 border border-transparent hover:border-destructive/20"
-              title="Delete composition"
-            >
-              <IconTrash className="w-3.5 h-3.5" />
-            </button>
+                      : "All changes saved to registry"}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setShowDeleteConfirm(true)}
+                  className="p-1 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 border border-transparent hover:border-destructive/20"
+                >
+                  <IconTrash className="w-3.5 h-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Delete composition</TooltipContent>
+            </Tooltip>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Move analytics SQL dashboard card actions into the three-dot menu, including table CSV download, View SQL, and width toggle
- Fix SQL dashboard full/half-width toggles by applying the grid span to the grid item wrapper
- Replace native title hints on interactive controls with shadcn Tooltip usage across shadcn-backed app and shared UI surfaces

## Validation
- pnpm typecheck
- pnpm test
- pnpm guards
- git diff --check

Note: unrelated local auth/collab changes were left unstaged and are not part of this PR.