### PR TITLE
Org-scoped Builder credentials + private GitHub imports + reconnect hardening

### DIFF
--- a/.changeset/builder-credentials-org-scope.md
+++ b/.changeset/builder-credentials-org-scope.md
@@ -1,0 +1,13 @@
+---
+"@agent-native/core": minor
+---
+
+Builder credentials are now stored at org scope by default when an owner/admin connects, so a single OAuth flow powers AI chat for everyone in that org.
+
+- New `app_secrets` scope: `"org"` (alongside `"user"` and `"workspace"`).
+- `writeBuilderCredentials(email, creds, { orgId, role })` writes at `scope: "org"` when the connecting user is owner/admin of an active org. Plain members (or users in Personal mode) keep writing at `scope: "user"` so a teammate can never overwrite the org-shared connection. The Builder OAuth callback now passes `orgId`+`role` automatically — existing direct callers without options keep their previous user-scope behaviour.
+- `resolveBuilderCredential` and `resolveSecret` now check user scope first, then fall back to the active org's row. `${env.BUILDER_PRIVATE_KEY}` (deploy-managed mode) still wins over both, unchanged.
+- `deleteBuilderCredentials(email, { orgId, role })` mirrors the connect-side scope decision, so a Disconnect press undoes exactly what the same user's Connect press wrote — no orphaned org-shared rows for owners, no accidental org-wide tear-downs from a member's personal disconnect.
+- Helper `resolveCredentialWriteScope(email, orgId, role)` exposes the scope decision for any future credentials integration that wants the same default-to-org-when-admin behaviour.
+
+Migration: existing per-user Builder connections from before this change keep working for the connecter — but other org members won't auto-resolve to them. To promote a user-scope connection to org-shared, the owner/admin disconnects and reconnects once in the affected app.

--- a/.changeset/github-import-run-recovery.md
+++ b/.changeset/github-import-run-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Harden GitHub design-token imports with token-aware fetch helpers and keep persisted agent run diagnostics longer for reconnect investigation.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,201 +1,25 @@
 # Authentication
 
-Agent-native provides a zero-config authentication system that is invisible in development and automatic in production.
+> **Canonical docs:**
+>
+> - **User-facing:** [packages/core/docs/content/authentication.md](../packages/core/docs/content/authentication.md) — what ships on the docs site.
+> - **Framework agents:** [.agents/skills/authentication/SKILL.md](../.agents/skills/authentication/SKILL.md) — auth modes, sessions, organizations, BYOA.
+> - **Framework agents:** [.agents/skills/security/SKILL.md](../.agents/skills/security/SKILL.md) — data scoping, access helpers, custom routes.
+>
+> This file is a thin pointer; do not duplicate detail here. Older revisions of this file described an `ACCESS_TOKEN`-only model that no longer matches the framework. If you find a contradiction, update the canonical docs above and leave this file as-is.
 
-## How It Works
+## TL;DR
 
-```
-Development                    Production                     Custom Auth
-─────────────                  ──────────                     ───────────
-No auth middleware             Auth middleware auto-mounts     Plug in Auth.js, Clerk, etc.
-All requests pass through      Login page for visitors        Same getSession() contract
-getSession() → local@localhost One env var to enable           Templates don't change
-```
+Agent-native uses **Better Auth** by default — every visitor creates an account on first visit. Sessions feed `getSession(event)` server-side and `useSession()` client-side.
 
-### Development Mode
+Auth modes:
 
-In development (`NODE_ENV !== "production"`), auth is completely bypassed:
+| Mode                | When to use                                                             |
+| ------------------- | ----------------------------------------------------------------------- |
+| Better Auth         | Default. Email/password + Google / GitHub social + organizations.       |
+| `AUTH_MODE=local`   | Solo local dev. Forces `getSession()` → `{ email: "local@localhost" }`. |
+| `ACCESS_TOKEN(S)`   | Simple shared-token deploys. No per-user identity.                      |
+| `AUTH_DISABLED=1`   | Apps behind infrastructure auth (Cloudflare Access, VPN, etc.).         |
+| Custom `getSession` | BYOA — Auth.js, Clerk, Lucia, WorkOS, etc.                              |
 
-- No login page, no middleware, no cookies
-- `getSession()` always returns `{ email: "local@localhost" }`
-- `useSession()` hook returns the same dev stub
-- Zero friction, zero config
-
-### Production Mode
-
-When you deploy, set one environment variable and auth activates automatically:
-
-```bash
-ACCESS_TOKEN=your-secret-token
-```
-
-That's it. Every route is now protected. Unauthenticated visitors see a login page. The framework handles cookies, session management, and expiry.
-
-For small teams, use comma-separated tokens:
-
-```bash
-ACCESS_TOKENS=alice-token,bob-token,charlie-token
-```
-
-### Production Without Auth
-
-If your app is behind infrastructure-level auth (Cloudflare Access, VPN, etc.), explicitly disable framework auth:
-
-```bash
-AUTH_DISABLED=true
-```
-
-Without either `ACCESS_TOKEN` or `AUTH_DISABLED`, the server **refuses to start in production** to prevent accidental exposure.
-
-### QA Accounts
-
-Local development and tests skip signup email verification by default, so local
-QA accounts can be created without checking an inbox. Set
-`AUTH_SKIP_EMAIL_VERIFICATION=0` only when testing the verification flow itself.
-
-For QA or preview environments where testers need real accounts but should not
-wait for email verification links, set:
-
-```bash
-AUTH_SKIP_EMAIL_VERIFICATION=1
-```
-
-Email/password signup will skip verification and will not send the signup
-verification email. Use `+qa` email addresses for QA accounts so they remain
-easy to identify.
-
-## The Auth Contract
-
-All templates code against two interfaces — they never read cookies directly.
-
-### Server: `getSession(event)`
-
-```ts
-import { getSession } from "@agent-native/core/server";
-
-export default defineEventHandler(async (event) => {
-  const session = await getSession(event);
-  // session: { email, userId?, token? } or null
-});
-```
-
-### Client: `useSession()`
-
-```ts
-import { useSession } from "@agent-native/core";
-
-function MyComponent() {
-  const { session, isLoading } = useSession();
-  // session.email, session.userId, etc.
-}
-```
-
-### API Endpoint: `GET /_agent-native/auth/session`
-
-Returns the current session as JSON, or `{ error: "Not authenticated" }`.
-
-## How It's Wired
-
-Each template includes a Nitro plugin at `server/plugins/auth.ts`:
-
-```ts
-import { defineNitroPlugin, autoMountAuth } from "@agent-native/core";
-
-export default defineNitroPlugin((nitroApp: any) => {
-  autoMountAuth(nitroApp.h3App);
-});
-```
-
-This runs at server startup and configures auth based on the environment automatically.
-
-## Session Storage
-
-Sessions are stored in the `sessions` SQL table. Session data is:
-
-- Gitignored in all templates
-- Pruned on startup (expired sessions are removed)
-- Default session lifetime: 30 days
-
-## Bring Your Own Auth
-
-For apps that outgrow single-token auth (multi-user, OAuth, roles), the framework provides an upgrade path through the `AuthOptions.getSession` hook:
-
-```ts
-import { defineNitroPlugin, autoMountAuth } from "@agent-native/core";
-
-export default defineNitroPlugin((nitroApp: any) => {
-  autoMountAuth(nitroApp.h3App, {
-    getSession: async (event) => {
-      // Your custom auth logic here — Auth.js, Clerk, Lucia, etc.
-      // Return { email, userId?, token? } or null
-      const session = await myAuthLib.getSession(event);
-      return session ? { email: session.user.email } : null;
-    },
-  });
-});
-```
-
-The framework doesn't ship Auth.js, Clerk, or any specific auth library. Instead, the `getSession` contract makes any auth system pluggable without changing templates or application code.
-
-### Why Not Ship Auth.js in Core
-
-- No official Nitro/H3 adapter — maintaining a custom bridge would be a permanent burden
-- OAuth, account linking, and email verification are overkill for most agent-native apps
-- Alternatives (Clerk, Lucia, WorkOS) exist — the framework shouldn't pick winners
-- The auth contract makes any of them pluggable
-
-## Configuration Reference
-
-### Environment Variables
-
-| Variable                       | Description                                                                                                                 |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| `ACCESS_TOKEN`                 | Single access token for production auth                                                                                     |
-| `ACCESS_TOKENS`                | Comma-separated tokens for team access                                                                                      |
-| `AUTH_DISABLED`                | Set to `"true"` to skip auth in production                                                                                  |
-| `AUTH_SKIP_EMAIL_VERIFICATION` | Set to `1` in QA/preview environments to skip email verification for email/password signup; local dev/test skips by default |
-
-### `AuthOptions`
-
-```ts
-autoMountAuth(app, {
-  maxAge: 60 * 60 * 24 * 30, // Session lifetime in seconds (default: 30 days)
-  sessionsPath: "data/.sessions.json", // Path to session store (default)
-  getSession: async (event) => {}, // Custom auth (BYOA)
-});
-```
-
-### Routes
-
-| Route                                       | Method | Description                                                                      |
-| ------------------------------------------- | ------ | -------------------------------------------------------------------------------- |
-| `/_agent-native/auth/login`                 | POST   | Validate token, set session cookie                                               |
-| `/_agent-native/auth/logout`                | POST   | Clear session cookie                                                             |
-| `/_agent-native/auth/session`               | GET    | Get current session                                                              |
-| `/_agent-native/sign-in?return=<path>`      | GET    | Force-sign-in entrypoint. Anonymous → login page; signed-in → 302 to `return`    |
-| `/_agent-native/google/auth-url?return=<p>` | GET    | Build a Google OAuth URL. Optional `return` is preserved through the OAuth state |
-
-## Sign-In with Return URL
-
-Templates with **public pages** (share links, embeds, marketing pages) can route an anonymous viewer through sign-in and bring them back to the page they were on:
-
-```
-window.location.href =
-  "/_agent-native/sign-in?return=" +
-  encodeURIComponent(window.location.pathname + window.location.search);
-```
-
-Works across all flows:
-
-- **Token / email-password:** the framework's login page is served at the sign-in URL. After login, the page reloads, the framework sees the session, and 302s to `return`.
-- **Google OAuth:** `return` is threaded through the (HMAC-signed) OAuth state and applied as the redirect target on callback.
-- **Bookmarked private paths** (e.g. an unauthenticated user opens `/dashboard` directly): same-page reload after login already returns to the bookmarked URL — no plumbing needed in the template.
-
-`return` is validated as a same-origin path on every consumer (URL parser + origin check). Network-path references (`//evil.com/...`), absolute URLs, `data:` / `javascript:` schemes, and embedded control characters all fall back to `/`.
-
-## Security
-
-- **Cookies**: HttpOnly, Secure (production), SameSite=Lax
-- **Session tokens**: Cryptographically random (32 bytes)
-- **CSRF**: Baseline protection via SameSite=Lax
-- **Session file**: Gitignored, excluded from sync, pruned on startup
+See the canonical docs above for the full configuration reference, environment variables (`BETTER_AUTH_SECRET`, `GOOGLE_CLIENT_ID/SECRET`, `GITHUB_CLIENT_ID/SECRET`, `OAUTH_STATE_SECRET`, `A2A_SECRET`, …), the BYOA contract, organizations / orgs, the sign-in-with-return-URL flow, and access-control patterns (`ownableColumns`, `accessFilter`, `resolveAccess`, `assertAccess`).

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -18,7 +18,9 @@ vi.mock("./run-store.js", () => ({
 
 import {
   abortRun,
+  DEFAULT_COMPLETED_RUN_RETENTION_MS,
   DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS,
+  resolveCompletedRunRetentionMs,
   resolveRunSoftTimeoutMs,
   startRun,
   subscribeToRun,
@@ -31,6 +33,7 @@ import {
 } from "./run-store.js";
 
 const originalTimeoutEnv = process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
+const originalRetentionEnv = process.env.AGENT_RUN_RETENTION_MS;
 const originalNetlify = process.env.NETLIFY;
 const originalNetlifyLocal = process.env.NETLIFY_LOCAL;
 const originalCfPages = process.env.CF_PAGES;
@@ -42,6 +45,7 @@ const originalKService = process.env.K_SERVICE;
 
 function clearHostedEnvForTest() {
   delete process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
+  delete process.env.AGENT_RUN_RETENTION_MS;
   delete process.env.NETLIFY;
   delete process.env.NETLIFY_LOCAL;
   delete process.env.CF_PAGES;
@@ -56,6 +60,9 @@ function restoreHostedEnvAfterTest() {
   if (originalTimeoutEnv === undefined)
     delete process.env.AGENT_RUN_SOFT_TIMEOUT_MS;
   else process.env.AGENT_RUN_SOFT_TIMEOUT_MS = originalTimeoutEnv;
+  if (originalRetentionEnv === undefined)
+    delete process.env.AGENT_RUN_RETENTION_MS;
+  else process.env.AGENT_RUN_RETENTION_MS = originalRetentionEnv;
   if (originalNetlify === undefined) delete process.env.NETLIFY;
   else process.env.NETLIFY = originalNetlify;
   if (originalNetlifyLocal === undefined) delete process.env.NETLIFY_LOCAL;
@@ -161,6 +168,18 @@ describe("run manager soft timeout", () => {
     expect(resolveRunSoftTimeoutMs(undefined, { useHostedDefault: true })).toBe(
       0,
     );
+  });
+
+  it("keeps persisted run events for a day by default", () => {
+    expect(resolveCompletedRunRetentionMs()).toBe(
+      DEFAULT_COMPLETED_RUN_RETENTION_MS,
+    );
+  });
+
+  it("allows run event retention to be configured by environment", () => {
+    process.env.AGENT_RUN_RETENTION_MS = "60000";
+
+    expect(resolveCompletedRunRetentionMs()).toBe(60000);
   });
 
   it("retires explicitly aborted in-memory runs while preserving completion callbacks", async () => {
@@ -302,5 +321,55 @@ describe("run manager soft timeout", () => {
 
     expect(chunks.join("")).toContain('data: {"type":"done","seq":0}');
     expect(getRunEventsSince).toHaveBeenCalledWith("run-sql-aborted", 0);
+  });
+
+  it("synthesizes done for completed SQL runs missing terminal events", async () => {
+    vi.mocked(getRunById).mockResolvedValue({
+      id: "run-sql-completed",
+      threadId: "thread-sql-completed",
+      status: "completed",
+      startedAt: Date.now(),
+    });
+    vi.mocked(getRunEventsSince).mockResolvedValue([]);
+
+    const stream = subscribeToRun("run-sql-completed", 0);
+    expect(stream).not.toBeNull();
+    const reader = stream!.getReader();
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+
+    for (let i = 0; i < 5; i++) {
+      const next = await reader.read();
+      if (next.done) break;
+      chunks.push(decoder.decode(next.value));
+    }
+
+    expect(chunks.join("")).toContain('data: {"type":"done","seq":0}');
+  });
+
+  it("synthesizes an explicit error for errored SQL runs missing terminal events", async () => {
+    vi.mocked(getRunById).mockResolvedValue({
+      id: "run-sql-errored",
+      threadId: "thread-sql-errored",
+      status: "errored",
+      startedAt: Date.now(),
+    });
+    vi.mocked(getRunEventsSince).mockResolvedValue([]);
+
+    const stream = subscribeToRun("run-sql-errored", 0);
+    expect(stream).not.toBeNull();
+    const reader = stream!.getReader();
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+
+    for (let i = 0; i < 5; i++) {
+      const next = await reader.read();
+      if (next.done) break;
+      chunks.push(decoder.decode(next.value));
+    }
+
+    const output = chunks.join("");
+    expect(output).toContain('"type":"error"');
+    expect(output).toContain('"errorCode":"run_terminal_event_missing"');
   });
 });

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -34,6 +34,9 @@ const CLEANUP_DELAY_MS = 5 * 60 * 1000;
 /** Default run chunk budget for hosted/serverless deploys. */
 export const DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS = 55_000;
 
+/** Default SQL retention for completed/errored run event logs (24 hours). */
+export const DEFAULT_COMPLETED_RUN_RETENTION_MS = 24 * 60 * 60 * 1000;
+
 export interface StartRunOptions {
   /** Optional internal run chunk budget. When reached, the framework emits an
    * auto-continuation signal instead of a user-facing timeout. Leave unset for
@@ -77,6 +80,15 @@ export function resolveRunSoftTimeoutMs(
   return options?.useHostedDefault && isHostedRuntime()
     ? DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS
     : 0;
+}
+
+export function resolveCompletedRunRetentionMs(): number {
+  const envValue = process.env.AGENT_RUN_RETENTION_MS;
+  if (envValue !== undefined) {
+    const raw = Number(envValue);
+    if (Number.isFinite(raw) && raw >= 0) return raw;
+  }
+  return DEFAULT_COMPLETED_RUN_RETENTION_MS;
 }
 
 function isTerminalRunEvent(event: AgentChatEvent): boolean {
@@ -320,7 +332,7 @@ export function startRun(
           threadToRun.delete(threadId);
         }
       }, CLEANUP_DELAY_MS);
-      cleanupOldRuns(30 * 60 * 1000).catch(() => {});
+      cleanupOldRuns(resolveCompletedRunRetentionMs()).catch(() => {});
     });
 
   // On Cloudflare Workers, keep the isolate alive for this run
@@ -522,6 +534,36 @@ function subscribeFromSQL(
                   controller.enqueue(
                     encoder.encode(
                       `data: ${JSON.stringify({ type: "done", seq: lastSeq })}\n\n`,
+                    ),
+                  );
+                } catch {
+                  cancelled = true;
+                  return;
+                }
+              } else if (run?.status === "completed") {
+                try {
+                  controller.enqueue(
+                    encoder.encode(
+                      `data: ${JSON.stringify({ type: "done", seq: lastSeq })}\n\n`,
+                    ),
+                  );
+                } catch {
+                  cancelled = true;
+                  return;
+                }
+              } else if (run?.status === "errored") {
+                try {
+                  controller.enqueue(
+                    encoder.encode(
+                      `data: ${JSON.stringify({
+                        type: "error",
+                        error:
+                          "Agent run ended before its final error event was persisted.",
+                        errorCode: "run_terminal_event_missing",
+                        details:
+                          "The persisted run status is errored, but no terminal SSE event was available during reconnect.",
+                        seq: lastSeq,
+                      })}\n\n`,
                     ),
                   );
                 } catch {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2889,7 +2889,7 @@ const AssistantChatInner = forwardRef<
                     </button>
                   </div>
                 </div>
-              ) : missingApiKey ? (
+              ) : missingApiKey && messages.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-full px-2">
                   <BuilderSetupCard />
                 </div>
@@ -2939,6 +2939,7 @@ const AssistantChatInner = forwardRef<
                       AssistantMessage,
                     }}
                   />
+                  {missingApiKey && <BuilderSetupCard />}
                   {visibleLoopLimit && !showRunningInUI && (
                     <LoopLimitContinueCard
                       info={visibleLoopLimit}

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -336,6 +336,23 @@ export function createAgentChatAdapter(options?: {
       let totalTransientContinuationAttempts = 0;
       const continuationHistoryFragments: string[] = [];
       let visibleContinuationPrefix: ContentPart[] = [];
+      let lastAutoContinueReason: string | null = null;
+      const attemptedRunIds: string[] = [];
+
+      const connectionRecoveryDetails = (): string => {
+        return [
+          lastAutoContinueReason
+            ? `last_auto_continue_reason: ${lastAutoContinueReason}`
+            : "",
+          `stalled_transient_continuations: ${stalledTransientContinuationAttempts}`,
+          `total_transient_continuations: ${totalTransientContinuationAttempts}`,
+          attemptedRunIds.length > 0
+            ? `attempted_runs: ${attemptedRunIds.join(", ")}`
+            : "",
+        ]
+          .filter(Boolean)
+          .join("\n");
+      };
 
       try {
         const headers: Record<string, string> = {
@@ -429,6 +446,9 @@ export function createAgentChatAdapter(options?: {
               if (active?.active && active.runId) {
                 const activeRunId = String(active.runId);
                 runId = activeRunId;
+                if (!attemptedRunIds.includes(activeRunId)) {
+                  attemptedRunIds.push(activeRunId);
+                }
                 lastSeq = -1;
                 setActiveRun({ threadId, runId: activeRunId, lastSeq: -1 });
                 const reconnected = yield* reconnectCurrentRun();
@@ -464,6 +484,7 @@ export function createAgentChatAdapter(options?: {
         const prepareAutoContinuation = (
           signal: AgentAutoContinueSignal,
         ): { ok: boolean; resetVisibleContent: boolean } => {
+          lastAutoContinueReason = signal.reason;
           const isTransient = signal.reason !== "loop_limit";
           const visibleContent = visibleContentForContinuation();
           const currentPartialHistory =
@@ -571,6 +592,9 @@ export function createAgentChatAdapter(options?: {
                   if (body?.activeRunId) {
                     handledConflict = true;
                     runId = String(body.activeRunId);
+                    if (!attemptedRunIds.includes(runId)) {
+                      attemptedRunIds.push(runId);
+                    }
                     lastSeq = -1;
                     if (threadId) {
                       setActiveRun({ threadId, runId, lastSeq: -1 });
@@ -680,6 +704,9 @@ export function createAgentChatAdapter(options?: {
 
             // Track the run ID for reconnection
             runId = res.headers.get("X-Run-Id");
+            if (runId && !attemptedRunIds.includes(runId)) {
+              attemptedRunIds.push(runId);
+            }
             if (runId && threadId) {
               setActiveRun({ threadId, runId, lastSeq: -1 });
             }
@@ -724,6 +751,7 @@ export function createAgentChatAdapter(options?: {
                   "The agent connection kept failing after several automatic recovery attempts.";
                 const runError = {
                   message,
+                  details: connectionRecoveryDetails(),
                   errorCode: "connection_error",
                   recoverable: true,
                   ...(runId ? { runId } : {}),
@@ -816,6 +844,7 @@ export function createAgentChatAdapter(options?: {
                   "The agent connection kept failing after several automatic recovery attempts.";
                 const runError = {
                   message,
+                  details: connectionRecoveryDetails(),
                   errorCode: "connection_error",
                   recoverable: true,
                   ...(runId ? { runId } : {}),

--- a/packages/core/src/secrets/register.ts
+++ b/packages/core/src/secrets/register.ts
@@ -7,7 +7,7 @@
  * secrets are picked up without a restart.
  */
 
-export type SecretScope = "user" | "workspace";
+export type SecretScope = "user" | "workspace" | "org";
 export type SecretKind = "api-key" | "oauth";
 
 export interface ValidatorResult {
@@ -78,9 +78,13 @@ export function registerRequiredSecret(secret: RegisteredSecret): void {
   if (!secret || typeof secret.key !== "string" || !secret.key) {
     throw new Error("registerRequiredSecret: secret.key is required");
   }
-  if (secret.scope !== "user" && secret.scope !== "workspace") {
+  if (
+    secret.scope !== "user" &&
+    secret.scope !== "workspace" &&
+    secret.scope !== "org"
+  ) {
     throw new Error(
-      `registerRequiredSecret: secret.scope must be "user" or "workspace" (got "${secret.scope}")`,
+      `registerRequiredSecret: secret.scope must be "user", "workspace", or "org" (got "${secret.scope}")`,
     );
   }
   if (secret.kind !== "api-key" && secret.kind !== "oauth") {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -910,17 +910,31 @@ export function createCoreRoutesPlugin(
         try {
           const { writeBuilderCredentials } =
             await import("./credential-provider.js");
-          await writeBuilderCredentials(session.email, {
-            privateKey,
-            publicKey,
-            userId,
-            orgName,
-            orgKind,
-          });
+          // Resolve the user's active org / role so the credentials land
+          // at org scope when an owner/admin is connecting (everyone in
+          // the org auto-resolves them on next chat call). Members and
+          // users with no active org silently fall back to user scope.
+          // Failure to read org context is non-fatal — we just keep the
+          // legacy per-user behaviour for that connection.
+          let orgId: string | null = null;
+          let role: string | null = null;
+          try {
+            const { getOrgContext } = await import("../org/context.js");
+            const orgCtx = await getOrgContext(event);
+            orgId = orgCtx.orgId ?? null;
+            role = orgCtx.role ?? null;
+          } catch {
+            /* org module not present in this template — keep user scope */
+          }
+          await writeBuilderCredentials(
+            session.email,
+            { privateKey, publicKey, userId, orgName, orgKind },
+            { orgId, role },
+          );
         } catch (err) {
           writeError = (err as Error)?.message ?? String(err);
           console.error(
-            "[builder] Failed to persist per-user credentials:",
+            "[builder] Failed to persist Builder credentials:",
             writeError,
           );
         }
@@ -1006,9 +1020,25 @@ export function createCoreRoutesPlugin(
           };
         }
 
-        // Delete per-user Builder credentials from app_secrets.
+        // Mirror the connect-side scope decision so disconnect undoes
+        // exactly what connect wrote: owner/admin connections land at
+        // org scope and tear down at org scope; member or no-org
+        // connections stay user-scoped on both ends. Symmetric, so a
+        // single Disconnect press always reverses what the same user's
+        // Connect press did.
+        let orgId: string | null = null;
+        let role: string | null = null;
         try {
-          await deleteBuilderCredentials(session.email);
+          const { getOrgContext } = await import("../org/context.js");
+          const orgCtx = await getOrgContext(event);
+          orgId = orgCtx.orgId ?? null;
+          role = orgCtx.role ?? null;
+        } catch {
+          /* org module not present — keep user scope */
+        }
+
+        try {
+          await deleteBuilderCredentials(session.email, { orgId, role });
         } catch (err) {
           trackBuilderLifecycle("builder disconnect failed", session.email, {
             reason: "credential_delete_failed",

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockReadAppSecret = vi.fn();
+const mockWriteAppSecret = vi.fn();
+const mockDeleteAppSecret = vi.fn();
+const mockGetRequestUserEmail = vi.fn<[], string | undefined>();
+const mockGetRequestOrgId = vi.fn<[], string | undefined>();
+
+vi.mock("../secrets/storage.js", () => ({
+  readAppSecret: (...args: any[]) => mockReadAppSecret(...args),
+  writeAppSecret: (...args: any[]) => mockWriteAppSecret(...args),
+  deleteAppSecret: (...args: any[]) => mockDeleteAppSecret(...args),
+}));
+vi.mock("./request-context.js", () => ({
+  getRequestUserEmail: () => mockGetRequestUserEmail(),
+  getRequestOrgId: () => mockGetRequestOrgId(),
+}));
+
+import {
+  resolveCredentialWriteScope,
+  writeBuilderCredentials,
+  deleteBuilderCredentials,
+  resolveBuilderCredential,
+  resolveSecret,
+} from "./credential-provider.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.BUILDER_PRIVATE_KEY;
+  delete process.env.BUILDER_PUBLIC_KEY;
+  mockReadAppSecret.mockResolvedValue(null);
+  mockWriteAppSecret.mockResolvedValue("id");
+  mockDeleteAppSecret.mockResolvedValue(true);
+  mockGetRequestUserEmail.mockReturnValue(undefined);
+  mockGetRequestOrgId.mockReturnValue(undefined);
+});
+
+describe("resolveCredentialWriteScope", () => {
+  it("returns org scope for owner", () => {
+    expect(resolveCredentialWriteScope("a@b.com", "org_1", "owner")).toEqual({
+      scope: "org",
+      scopeId: "org_1",
+    });
+  });
+
+  it("returns org scope for admin", () => {
+    expect(resolveCredentialWriteScope("a@b.com", "org_1", "admin")).toEqual({
+      scope: "org",
+      scopeId: "org_1",
+    });
+  });
+
+  it("returns user scope for member", () => {
+    expect(resolveCredentialWriteScope("a@b.com", "org_1", "member")).toEqual({
+      scope: "user",
+      scopeId: "a@b.com",
+    });
+  });
+
+  it("returns user scope when no orgId, regardless of role", () => {
+    expect(resolveCredentialWriteScope("a@b.com", null, "owner")).toEqual({
+      scope: "user",
+      scopeId: "a@b.com",
+    });
+  });
+
+  it("returns user scope for unknown role", () => {
+    expect(resolveCredentialWriteScope("a@b.com", "org_1", null)).toEqual({
+      scope: "user",
+      scopeId: "a@b.com",
+    });
+  });
+});
+
+describe("writeBuilderCredentials", () => {
+  it("writes at user scope without options (legacy callers)", async () => {
+    const target = await writeBuilderCredentials("a@b.com", {
+      privateKey: "pk",
+      publicKey: "pub",
+    });
+    expect(target).toEqual({ scope: "user", scopeId: "a@b.com" });
+    const scopes = mockWriteAppSecret.mock.calls.map((c) => c[0].scope);
+    expect(scopes.every((s) => s === "user")).toBe(true);
+  });
+
+  it("writes at org scope for an owner of an active org", async () => {
+    const target = await writeBuilderCredentials(
+      "owner@b.com",
+      { privateKey: "pk", publicKey: "pub" },
+      { orgId: "builder_io", role: "owner" },
+    );
+    expect(target).toEqual({ scope: "org", scopeId: "builder_io" });
+    const calls = mockWriteAppSecret.mock.calls.map((c) => c[0]);
+    expect(calls.every((c) => c.scope === "org")).toBe(true);
+    expect(calls.every((c) => c.scopeId === "builder_io")).toBe(true);
+    const keys = calls.map((c) => c.key).sort();
+    expect(keys).toEqual(["BUILDER_PRIVATE_KEY", "BUILDER_PUBLIC_KEY"]);
+  });
+
+  it("writes at user scope for a plain member of an org", async () => {
+    const target = await writeBuilderCredentials(
+      "member@b.com",
+      { privateKey: "pk", publicKey: "pub" },
+      { orgId: "builder_io", role: "member" },
+    );
+    expect(target).toEqual({ scope: "user", scopeId: "member@b.com" });
+  });
+
+  it("includes optional fields (userId, orgName, orgKind)", async () => {
+    await writeBuilderCredentials(
+      "owner@b.com",
+      {
+        privateKey: "pk",
+        publicKey: "pub",
+        userId: "u1",
+        orgName: "Builder.io",
+        orgKind: "team",
+      },
+      { orgId: "builder_io", role: "owner" },
+    );
+    const keys = mockWriteAppSecret.mock.calls.map((c) => c[0].key).sort();
+    expect(keys).toEqual([
+      "BUILDER_ORG_KIND",
+      "BUILDER_ORG_NAME",
+      "BUILDER_PRIVATE_KEY",
+      "BUILDER_PUBLIC_KEY",
+      "BUILDER_USER_ID",
+    ]);
+  });
+});
+
+describe("deleteBuilderCredentials", () => {
+  it("deletes at user scope without options", async () => {
+    await deleteBuilderCredentials("a@b.com");
+    const scopes = mockDeleteAppSecret.mock.calls.map((c) => c[0].scope);
+    expect(scopes.every((s) => s === "user")).toBe(true);
+  });
+
+  it("deletes at org scope for an owner — undoes a connect that landed at org scope", async () => {
+    const target = await deleteBuilderCredentials("owner@b.com", {
+      orgId: "builder_io",
+      role: "owner",
+    });
+    expect(target).toEqual({ scope: "org", scopeId: "builder_io" });
+    expect(
+      mockDeleteAppSecret.mock.calls.every((c) => c[0].scope === "org"),
+    ).toBe(true);
+  });
+
+  it("deletes at user scope for a plain member — never nukes the org-shared row", async () => {
+    const target = await deleteBuilderCredentials("member@b.com", {
+      orgId: "builder_io",
+      role: "member",
+    });
+    expect(target).toEqual({ scope: "user", scopeId: "member@b.com" });
+  });
+});
+
+describe("resolveBuilderCredential", () => {
+  it("returns null without a request user", async () => {
+    mockGetRequestUserEmail.mockReturnValue(undefined);
+    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBeNull();
+    expect(mockReadAppSecret).not.toHaveBeenCalled();
+  });
+
+  it("returns env value when set (deploy-managed mode beats per-user/org)", async () => {
+    process.env.BUILDER_PRIVATE_KEY = "deploy-key";
+    mockGetRequestUserEmail.mockReturnValue("a@b.com");
+    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBe(
+      "deploy-key",
+    );
+    expect(mockReadAppSecret).not.toHaveBeenCalled();
+  });
+
+  it("falls back to org scope when no user-scope row exists", async () => {
+    mockGetRequestUserEmail.mockReturnValue("member@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret
+      .mockResolvedValueOnce(null) // user scope miss
+      .mockResolvedValueOnce({ value: "org-key", last4: "-key", updatedAt: 1 });
+    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBe(
+      "org-key",
+    );
+    const refs = mockReadAppSecret.mock.calls.map((c) => c[0]);
+    expect(refs[0]).toEqual({
+      key: "BUILDER_PRIVATE_KEY",
+      scope: "user",
+      scopeId: "member@b.com",
+    });
+    expect(refs[1]).toEqual({
+      key: "BUILDER_PRIVATE_KEY",
+      scope: "org",
+      scopeId: "builder_io",
+    });
+  });
+
+  it("user-scope override wins over org-scope row", async () => {
+    mockGetRequestUserEmail.mockReturnValue("dev@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret.mockResolvedValueOnce({
+      value: "personal-key",
+      last4: "-key",
+      updatedAt: 1,
+    });
+    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBe(
+      "personal-key",
+    );
+    expect(mockReadAppSecret).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when neither user nor org scope has the key", async () => {
+    mockGetRequestUserEmail.mockReturnValue("a@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret.mockResolvedValue(null);
+    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBeNull();
+  });
+
+  it("does not check org scope when caller has no active org", async () => {
+    mockGetRequestUserEmail.mockReturnValue("a@b.com");
+    mockGetRequestOrgId.mockReturnValue(undefined);
+    mockReadAppSecret.mockResolvedValue(null);
+    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBeNull();
+    expect(mockReadAppSecret).toHaveBeenCalledTimes(1);
+    expect(mockReadAppSecret.mock.calls[0][0].scope).toBe("user");
+  });
+});
+
+describe("resolveSecret (generic)", () => {
+  it("falls back to org scope for arbitrary keys (e.g. OPENAI_API_KEY)", async () => {
+    mockGetRequestUserEmail.mockReturnValue("teammate@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      value: "sk-...shared",
+      last4: "ared",
+      updatedAt: 1,
+    });
+    expect(await resolveSecret("OPENAI_API_KEY")).toBe("sk-...shared");
+  });
+
+  it("does not consult process.env in an authenticated request", async () => {
+    process.env.OPENAI_API_KEY = "deploy-key";
+    mockGetRequestUserEmail.mockReturnValue("a@b.com");
+    mockReadAppSecret.mockResolvedValue(null);
+    expect(await resolveSecret("OPENAI_API_KEY")).toBeNull();
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it("uses process.env outside an authenticated request (CLI / unauth)", async () => {
+    process.env.SOME_KEY = "v";
+    mockGetRequestUserEmail.mockReturnValue(undefined);
+    expect(await resolveSecret("SOME_KEY")).toBe("v");
+    delete process.env.SOME_KEY;
+  });
+});

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -18,7 +18,27 @@
  * (e.g. additional Builder-hosted services) without rewrites.
  */
 
-import { getRequestUserEmail } from "./request-context.js";
+import { getRequestUserEmail, getRequestOrgId } from "./request-context.js";
+
+/**
+ * Decide which `app_secrets` scope a Builder/credential write should use.
+ *
+ * Org scope ("everyone in this org sees these credentials") wins when the
+ * connecting user is an owner or admin of an active org — the write
+ * privileges shared infra. A plain member or a user without an active
+ * org falls through to per-user scope so a teammate can't silently
+ * overwrite the org-shared connection.
+ */
+export function resolveCredentialWriteScope(
+  email: string,
+  orgId: string | null | undefined,
+  role: string | null | undefined,
+): { scope: "user" | "org"; scopeId: string } {
+  if (orgId && (role === "owner" || role === "admin")) {
+    return { scope: "org", scopeId: orgId };
+  }
+  return { scope: "user", scopeId: email };
+}
 
 export class FeatureNotConfiguredError extends Error {
   readonly requiredCredential: string;
@@ -82,20 +102,37 @@ export async function resolveBuilderCredential(
   const envValue = readDeployCredentialEnv(key);
   if (envValue) return envValue;
 
-  // No env value: per-user OAuth fallback.
   const email = getRequestUserEmail();
-  if (email) {
-    try {
-      const { readAppSecret } = await import("../secrets/storage.js");
-      const secret = await readAppSecret({
+  if (!email) return null;
+
+  try {
+    const { readAppSecret } = await import("../secrets/storage.js");
+
+    // 1. Per-user override: a user can paste their own key in settings to
+    //    overrule the org-shared one (handy for a personal sandbox).
+    const userSecret = await readAppSecret({
+      key,
+      scope: "user",
+      scopeId: email,
+    });
+    if (userSecret) return userSecret.value;
+
+    // 2. Per-org shared credential: when one teammate connects Builder
+    //    as an owner/admin we write the OAuth result at org scope so
+    //    every member of that org gets the AI chat working without
+    //    re-running the connect flow. Resolution falls back here
+    //    silently — the caller never has to know which scope answered.
+    const orgId = getRequestOrgId();
+    if (orgId) {
+      const orgSecret = await readAppSecret({
         key,
-        scope: "user",
-        scopeId: email,
+        scope: "org",
+        scopeId: orgId,
       });
-      if (secret) return secret.value;
-    } catch {
-      // Secrets table not ready — treat as missing.
+      if (orgSecret) return orgSecret.value;
     }
+  } catch {
+    // Secrets table not ready — treat as missing.
   }
   return null;
 }
@@ -159,8 +196,27 @@ export async function resolveBuilderCredentials(): Promise<{
   return { privateKey, publicKey, userId, orgName, orgKind };
 }
 
+const BUILDER_CREDENTIAL_KEYS = [
+  "BUILDER_PRIVATE_KEY",
+  "BUILDER_PUBLIC_KEY",
+  "BUILDER_USER_ID",
+  "BUILDER_ORG_NAME",
+  "BUILDER_ORG_KIND",
+] as const;
+
 /**
- * Write Builder credentials for the current user to per-user app_secrets.
+ * Write Builder credentials to `app_secrets`.
+ *
+ * Scope decision (see `resolveCredentialWriteScope`): when the connecting
+ * user is owner/admin of an active org we write at `scope: "org"` so every
+ * member of that org auto-resolves the credentials via
+ * `resolveBuilderCredential`'s org fallback — no per-user re-connect
+ * needed. A plain member or a user with no active org writes at
+ * `scope: "user"` (the safe default that doesn't trample the org's shared
+ * connection).
+ *
+ * Returns the actual scope/scopeId used so the caller can show "Connected
+ * for Builder.io" vs "Connected (personal)" in the UI.
  */
 export async function writeBuilderCredentials(
   email: string,
@@ -171,8 +227,15 @@ export async function writeBuilderCredentials(
     orgName?: string | null;
     orgKind?: string | null;
   },
-): Promise<void> {
+  options?: { orgId?: string | null; role?: string | null },
+): Promise<{ scope: "user" | "org"; scopeId: string }> {
   const { writeAppSecret } = await import("../secrets/storage.js");
+  const target = resolveCredentialWriteScope(
+    email,
+    options?.orgId ?? null,
+    options?.role ?? null,
+  );
+
   const entries: Array<{ key: string; value: string }> = [
     { key: "BUILDER_PRIVATE_KEY", value: creds.privateKey },
     { key: "BUILDER_PUBLIC_KEY", value: creds.publicKey },
@@ -188,28 +251,47 @@ export async function writeBuilderCredentials(
   }
   await Promise.all(
     entries.map(({ key, value }) =>
-      writeAppSecret({ key, value, scope: "user", scopeId: email }),
+      writeAppSecret({
+        key,
+        value,
+        scope: target.scope,
+        scopeId: target.scopeId,
+      }),
     ),
   );
+  return target;
 }
 
 /**
- * Delete Builder credentials for the current user from app_secrets.
+ * Delete Builder credentials.
+ *
+ * Default behaviour: clears only this user's per-user override (so a
+ * member can disconnect their personal Builder identity without
+ * collapsing the org-wide connection for every teammate). To revoke the
+ * org's shared connection, pass `{ orgId, role }` for an owner/admin —
+ * matching the same authority gate `writeBuilderCredentials` uses on
+ * write. Plain members can never reach the org-scoped row.
  */
-export async function deleteBuilderCredentials(email: string): Promise<void> {
+export async function deleteBuilderCredentials(
+  email: string,
+  options?: { orgId?: string | null; role?: string | null },
+): Promise<{ scope: "user" | "org"; scopeId: string }> {
   const { deleteAppSecret } = await import("../secrets/storage.js");
-  const keys = [
-    "BUILDER_PRIVATE_KEY",
-    "BUILDER_PUBLIC_KEY",
-    "BUILDER_USER_ID",
-    "BUILDER_ORG_NAME",
-    "BUILDER_ORG_KIND",
-  ];
+  const target = resolveCredentialWriteScope(
+    email,
+    options?.orgId ?? null,
+    options?.role ?? null,
+  );
   await Promise.all(
-    keys.map((key) =>
-      deleteAppSecret({ key, scope: "user", scopeId: email }).catch(() => {}),
+    BUILDER_CREDENTIAL_KEYS.map((key) =>
+      deleteAppSecret({
+        key,
+        scope: target.scope,
+        scopeId: target.scopeId,
+      }).catch(() => {}),
     ),
   );
+  return target;
 }
 
 // ---------------------------------------------------------------------------
@@ -234,12 +316,26 @@ export async function resolveSecret(key: string): Promise<string | null> {
   if (email) {
     try {
       const { readAppSecret } = await import("../secrets/storage.js");
-      const secret = await readAppSecret({
+      // Per-user override first.
+      const userSecret = await readAppSecret({
         key,
         scope: "user",
         scopeId: email,
       });
-      if (secret?.value) return secret.value;
+      if (userSecret?.value) return userSecret.value;
+
+      // Fall back to the active org's shared row, when present. Lets a
+      // teammate set up an integration once and everyone in that org
+      // benefits without each member pasting the key.
+      const orgId = getRequestOrgId();
+      if (orgId) {
+        const orgSecret = await readAppSecret({
+          key,
+          scope: "org",
+          scopeId: orgId,
+        });
+        if (orgSecret?.value) return orgSecret.value;
+      }
     } catch {
       // Secrets table not ready — treat as missing.
     }

--- a/packages/core/src/server/design-token-utils.spec.ts
+++ b/packages/core/src/server/design-token-utils.spec.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchGitHubJsonResult,
+  fetchGitHubRaw,
+  parseOwnerRepo,
+} from "./design-token-utils.js";
+
+describe("design-token GitHub helpers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("parses common GitHub repository URL formats", () => {
+    expect(parseOwnerRepo("builderio/agent-native")).toEqual({
+      owner: "builderio",
+      repo: "agent-native",
+    });
+    expect(parseOwnerRepo("builderio/agent-native.git")).toEqual({
+      owner: "builderio",
+      repo: "agent-native",
+    });
+    expect(
+      parseOwnerRepo(
+        "https://github.com/builderio/agent-native/tree/main?tab=readme",
+      ),
+    ).toEqual({ owner: "builderio", repo: "agent-native" });
+    expect(parseOwnerRepo("git@github.com:builderio/agent-native.git")).toEqual(
+      {
+        owner: "builderio",
+        repo: "agent-native",
+      },
+    );
+    expect(
+      parseOwnerRepo("ssh://git@github.com/builderio/agent-native.git"),
+    ).toEqual({ owner: "builderio", repo: "agent-native" });
+  });
+
+  it("sends the GitHub token only when one is provided", async () => {
+    const fetchSpy = vi.fn(async () => {
+      return new Response(JSON.stringify([{ name: "package.json" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await fetchGitHubJsonResult("builderio", "agent-native", "", {
+      token: "github-secret",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer github-secret",
+      Accept: "application/vnd.github.v3+json",
+    });
+  });
+
+  it("returns classified GitHub JSON errors without throwing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ message: "Not Found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    await expect(
+      fetchGitHubJsonResult("builderio", "private-app", ""),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 404,
+      message: "Not Found",
+    });
+  });
+
+  it("uses the GitHub token when fetching raw file content", async () => {
+    const fetchSpy = vi.fn(async () => {
+      return new Response(":root { --brand: #123456; }", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      fetchGitHubRaw("builderio", "agent-native", "app.css", {
+        token: "github-secret",
+      }),
+    ).resolves.toContain("--brand");
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer github-secret",
+      Accept: "application/vnd.github.v3.raw",
+    });
+  });
+});

--- a/packages/core/src/server/design-token-utils.ts
+++ b/packages/core/src/server/design-token-utils.ts
@@ -131,6 +131,17 @@ export interface UrlExtractionResult {
   favicon?: string;
 }
 
+export interface GitHubFetchOptions {
+  token?: string | null;
+}
+
+export interface GitHubJsonResult<T = unknown> {
+  ok: boolean;
+  status: number;
+  data: T | null;
+  message?: string;
+}
+
 // ---------------------------------------------------------------------------
 // SSRF Guard
 // ---------------------------------------------------------------------------
@@ -174,20 +185,75 @@ export function parseOwnerRepo(raw: string): {
   owner: string;
   repo: string;
 } {
-  const shorthand = raw.match(/^([^/]+)\/([^/]+)$/);
+  const cleaned = raw
+    .trim()
+    .replace(/[?#].*$/, "")
+    .replace(/\/+$/, "");
+
+  const sshMatch = cleaned.match(
+    /^(?:ssh:\/\/)?git@github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?$/,
+  );
+  if (sshMatch) {
+    return { owner: sshMatch[1], repo: sshMatch[2] };
+  }
+
+  const shorthand = cleaned.match(/^([^/\s]+)\/([^/\s]+?)(?:\.git)?$/);
   if (shorthand) {
     return { owner: shorthand[1], repo: shorthand[2] };
   }
-  const urlMatch = raw.match(
-    /github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/.*)?$/,
+  const urlMatch = cleaned.match(
+    /github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?(?:\/.*)?$/,
   );
   if (urlMatch) {
     return { owner: urlMatch[1], repo: urlMatch[2] };
   }
   throw new Error(
     "Could not parse GitHub owner/repo from URL. " +
-      'Expected format: "https://github.com/org/repo" or "org/repo"',
+      'Expected format: "https://github.com/org/repo", "org/repo", or "git@github.com:org/repo.git"',
   );
+}
+
+/** Fetch a path from the GitHub Contents API as JSON. Returns null on error. */
+function githubHeaders(
+  accept: string,
+  options: GitHubFetchOptions = {},
+): Record<string, string> {
+  return {
+    Accept: accept,
+    "User-Agent": "AgentNative/1.0",
+    ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
+  };
+}
+
+/** Fetch a path from the GitHub Contents API as JSON with status details. */
+export async function fetchGitHubJsonResult<T = unknown>(
+  owner: string,
+  repo: string,
+  path: string,
+  options: GitHubFetchOptions = {},
+): Promise<GitHubJsonResult<T>> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
+  validateUrl(url);
+  const res = await fetch(url, {
+    headers: githubHeaders("application/vnd.github.v3+json", options),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT),
+  });
+  if (!res.ok) {
+    let message: string | undefined;
+    try {
+      const body = (await res.json()) as { message?: unknown };
+      if (typeof body.message === "string") message = body.message;
+    } catch {
+      try {
+        const text = await res.text();
+        if (text) message = text.slice(0, 200);
+      } catch {
+        // Keep the status-only result.
+      }
+    }
+    return { ok: false, status: res.status, data: null, message };
+  }
+  return { ok: true, status: res.status, data: (await res.json()) as T };
 }
 
 /** Fetch a path from the GitHub Contents API as JSON. Returns null on error. */
@@ -195,18 +261,10 @@ export async function fetchGitHubJson(
   owner: string,
   repo: string,
   path: string,
+  options: GitHubFetchOptions = {},
 ): Promise<unknown> {
-  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
-  validateUrl(url);
-  const res = await fetch(url, {
-    headers: {
-      Accept: "application/vnd.github.v3+json",
-      "User-Agent": "AgentNative/1.0",
-    },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT),
-  });
-  if (!res.ok) return null;
-  return res.json();
+  const result = await fetchGitHubJsonResult(owner, repo, path, options);
+  return result.ok ? result.data : null;
 }
 
 /** Fetch raw file content from the GitHub Contents API. Returns null on error or oversize. */
@@ -214,14 +272,12 @@ export async function fetchGitHubRaw(
   owner: string,
   repo: string,
   path: string,
+  options: GitHubFetchOptions = {},
 ): Promise<string | null> {
   const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
   validateUrl(url);
   const res = await fetch(url, {
-    headers: {
-      Accept: "application/vnd.github.v3.raw",
-      "User-Agent": "AgentNative/1.0",
-    },
+    headers: githubHeaders("application/vnd.github.v3.raw", options),
     signal: AbortSignal.timeout(FETCH_TIMEOUT),
   });
   if (!res.ok) return null;

--- a/packages/docs/app/components/TemplateCard.tsx
+++ b/packages/docs/app/components/TemplateCard.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { Link } from "react-router";
-import { IconBook2, IconTerminal2 } from "@tabler/icons-react";
 import { trackEvent } from "@agent-native/core/client";
 
 export { trackEvent };
@@ -301,9 +300,8 @@ function TemplateLaunchButton({ template }: { template: Template }) {
               });
             setShowCli(!showCli);
           }}
-          className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg border border-[var(--docs-border)] px-4 py-2 text-sm font-medium text-[var(--fg)] transition hover:border-[var(--fg-secondary)]"
+          className="inline-flex flex-1 items-center justify-center rounded-lg border border-[var(--docs-border)] px-4 py-2 text-sm font-medium text-[var(--fg)] transition hover:border-[var(--fg-secondary)]"
         >
-          <IconTerminal2 size={14} stroke={2} />
           Run Locally
         </button>
         <Link
@@ -315,9 +313,8 @@ function TemplateLaunchButton({ template }: { template: Template }) {
               location: "card",
             })
           }
-          className="inline-flex flex-1 items-center justify-center gap-2 rounded-lg border border-[var(--docs-border)] px-4 py-2 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
+          className="inline-flex flex-1 items-center justify-center rounded-lg border border-[var(--docs-border)] px-4 py-2 text-sm font-medium text-[var(--fg)] no-underline transition hover:border-[var(--fg-secondary)] hover:no-underline"
         >
-          <IconBook2 size={14} stroke={2} />
           View Docs
         </Link>
       </div>

--- a/packages/docs/vitest.config.ts
+++ b/packages/docs/vitest.config.ts
@@ -3,5 +3,11 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     passWithNoTests: true,
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/.output/**",
+      "**/.{idea,git,cache,output,temp}/**",
+    ],
   },
 });

--- a/scripts/qa-cli-smoke.ts
+++ b/scripts/qa-cli-smoke.ts
@@ -188,6 +188,14 @@ function assertWorkspaceApp(
   assert.equal(pkg.dependencies[workspaceCoreName], "workspace:*");
 }
 
+function assertDispatchPackageDependency(pkg: any, context: string): void {
+  assert.equal(
+    pkg.dependencies["@agent-native/dispatch"],
+    "latest",
+    `${context} must resolve @agent-native/dispatch from npm`,
+  );
+}
+
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "an-cli-smoke-"));
 
 try {
@@ -242,13 +250,7 @@ try {
   );
   assertNoWorkspaceProtocolDeps(dispatchPkg);
   assertScaffoldBasics(dispatchDir);
-  assert.equal(
-    fs.existsSync(
-      path.join(dispatchDir, "actions", "send-platform-message.ts"),
-    ),
-    true,
-    "dispatch standalone scaffold must include dispatch actions",
-  );
+  assertDispatchPackageDependency(dispatchPkg, "dispatch standalone scaffold");
 
   const workspaceOutput = runCli(
     ["create", "qa-workspace", "--template=starter,dispatch,calendar"],
@@ -288,6 +290,10 @@ try {
   assertWorkspaceApp(workspaceDir, "starter", workspaceCoreName);
   assertWorkspaceApp(workspaceDir, "dispatch", workspaceCoreName);
   assertWorkspaceApp(workspaceDir, "calendar", workspaceCoreName);
+  assertDispatchPackageDependency(
+    readJson(path.join(workspaceDir, "apps", "dispatch", "package.json")),
+    "dispatch workspace scaffold",
+  );
   assert.equal(
     fs.existsSync(path.join(workspaceDir, "scripts", "workspace-dev.ts")),
     false,

--- a/templates/analytics/.agents/skills/security/SKILL.md
+++ b/templates/analytics/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/calendar/.agents/skills/security/SKILL.md
+++ b/templates/calendar/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/calls/AGENTS.md
+++ b/templates/calls/AGENTS.md
@@ -428,12 +428,9 @@ All standard CRUD (list, get, create, update) goes through `/_agent-native/actio
 
 ## Authentication
 
-Auth is automatic and environment-driven:
+This template uses the framework's default auth — Better Auth, with email/password and optional Google / GitHub social providers. Use `getSession(event)` server-side and `useSession()` client-side; per-user scoping inside actions / handlers reads `getRequestUserEmail()` from `@agent-native/core/server/request-context`.
 
-- **Dev mode.** Auth is bypassed. `getSession()` returns `{ email: "local@localhost" }`.
-- **Production** (`ACCESS_TOKEN` set). Auth middleware auto-mounts. `AUTH_SECRET` signs the cookie.
-
-Use `getSession(event)` server-side and `useSession()` client-side. All per-user scoping uses `getRequestUserEmail()` from `@agent-native/core/server/request-context`.
+See the framework `authentication` skill for the full mode matrix (`AUTH_MODE=local`, `ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA) and the `security` skill for the access-control model (`ownableColumns`, `accessFilter`, `assertAccess`).
 
 ## Skills
 

--- a/templates/clips/.agents/skills/security/SKILL.md
+++ b/templates/clips/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -374,12 +374,9 @@ All standard CRUD (list, get, create, update) goes through `/_agent-native/actio
 
 ## Authentication
 
-Auth is automatic and environment-driven:
+This template uses the framework's default auth — Better Auth, with email/password and optional Google / GitHub social providers. Better Auth's organization plugin owns the team primitives (`organization` / `member` / `invitation` tables, see [Team & Recordings Data Model](#team--recordings-data-model)). Use `getSession(event)` server-side and `useSession()` client-side; per-user scoping inside actions / handlers reads `getRequestUserEmail()` from `@agent-native/core/server/request-context`.
 
-- **Dev mode.** Auth is bypassed. `getSession()` returns `{ email: "local@localhost" }`.
-- **Production** (`ACCESS_TOKEN` set). Auth middleware auto-mounts.
-
-Use `getSession(event)` server-side and `useSession()` client-side. All per-user scoping uses `getRequestUserEmail()` from `@agent-native/core/server/request-context`.
+See the `authentication` skill for the full mode matrix (`AUTH_MODE=local`, `ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA) and the `security` skill for the access-control model (`ownableColumns`, `accessFilter`, `assertAccess`).
 
 ## Meetings & Dictate
 

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -219,7 +219,7 @@ export default defineAction({
       if (!upload?.url) {
         throw new Error(
           upload === null
-            ? "No file upload provider configured. Connect Builder.io or S3-compatible storage in Settings."
+            ? "No file upload provider configured. Connect Builder.io here, or configure S3-compatible storage in Settings."
             : "File upload returned no URL. Check your storage provider configuration.",
         );
       }

--- a/templates/clips/app/components/recorder/storage-setup-card.tsx
+++ b/templates/clips/app/components/recorder/storage-setup-card.tsx
@@ -27,9 +27,15 @@ function BuilderBMark({ className }: { className?: string }) {
 
 export interface StorageSetupCardProps {
   onConfigured: () => void;
+  title?: string;
+  description?: string;
 }
 
-export function StorageSetupCard({ onConfigured }: StorageSetupCardProps) {
+export function StorageSetupCard({
+  onConfigured,
+  title = "Set up video storage",
+  description = "Connect a storage provider to start recording clips.",
+}: StorageSetupCardProps) {
   const [connecting, setConnecting] = useState(false);
   const [connected, setConnected] = useState(false);
   const [err, setErr] = useState<string | null>(null);
@@ -109,11 +115,9 @@ export function StorageSetupCard({ onConfigured }: StorageSetupCardProps) {
       <div>
         <div className="mb-1 flex items-center gap-2">
           <IconCloud className="h-5 w-5 text-muted-foreground" />
-          <h2 className="text-lg font-semibold">Set up video storage</h2>
+          <h2 className="text-lg font-semibold">{title}</h2>
         </div>
-        <p className="text-sm text-muted-foreground">
-          Connect a storage provider to start recording clips.
-        </p>
+        <p className="text-sm text-muted-foreground">{description}</p>
       </div>
 
       {/* Builder.io — primary option, one-click Connect flow. */}

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -41,6 +41,7 @@ import { ReactionsTray } from "@/components/player/reactions-tray";
 import { SettingsPanel } from "@/components/player/settings-panel";
 import { InsightsPanel } from "@/components/player/insights-panel";
 import { ShareRecordingPopover } from "@/components/player/share-dialog";
+import { StorageSetupCard } from "@/components/recorder/storage-setup-card";
 import { usePlayerShortcuts } from "@/hooks/use-player-shortcuts";
 import { useViewTracking } from "@/hooks/use-view-tracking";
 
@@ -272,6 +273,11 @@ export default function RecordingPage() {
       : stuckFailure
         ? `Processing hasn't completed after 30 seconds (status=${recording.status}). The clip may not have finished uploading — check the server logs for [chunk]/[finalize] messages.`
         : "Uploading and assembling your video — this usually takes just a few seconds.";
+    const storageSetupFailure =
+      isFailure &&
+      /file upload provider|storage provider|connect builder|s3-compatible/i.test(
+        failureReason,
+      );
     return (
       <div className="flex flex-col items-center justify-center h-screen w-full bg-background px-6">
         {!isFailure ? <Spinner className="h-8 w-8 mb-4" /> : null}
@@ -284,6 +290,18 @@ export default function RecordingPage() {
             <div
               className="h-full bg-foreground"
               style={{ width: `${Math.min(100, Math.max(0, progress))}%` }}
+            />
+          </div>
+        ) : null}
+        {storageSetupFailure ? (
+          <div className="mb-4 w-full">
+            <StorageSetupCard
+              title="Connect storage to finish saving"
+              description="Clips needs storage before it can save and share this recording."
+              onConfigured={() => {
+                setProcessingTimeout(false);
+                playerDataQ.refetch();
+              }}
             />
           </div>
         ) : null}

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -18,6 +18,7 @@ import { CommentsPanel } from "@/components/player/comments-panel";
 import { ReactionsTray } from "@/components/player/reactions-tray";
 import { AccessPasswordPrompt } from "@/components/player/access-password-prompt";
 import { SignInPromptDialog } from "@/components/player/sign-in-prompt-dialog";
+import { StorageSetupCard } from "@/components/recorder/storage-setup-card";
 import { usePlayerShortcuts } from "@/hooks/use-player-shortcuts";
 import { useViewTracking } from "@/hooks/use-view-tracking";
 import { Button } from "@/components/ui/button";
@@ -209,6 +210,11 @@ export default function ShareRoute() {
     const message = explicitFailure
       ? ((recording as any).failureReason ?? "The creator may need to retry.")
       : "Uploading and assembling the video. This page will update automatically.";
+    const storageSetupFailure =
+      explicitFailure &&
+      /file upload provider|storage provider|connect builder|s3-compatible/i.test(
+        message,
+      );
 
     return (
       <div className="flex flex-col items-center justify-center min-h-screen bg-background text-foreground px-6">
@@ -227,14 +233,25 @@ export default function ShareRoute() {
             />
           </div>
         ) : null}
-        <Button
-          onClick={() => dataQ.refetch()}
-          variant="outline"
-          size="sm"
-          className="border-foreground/20 bg-muted/50 hover:bg-accent text-foreground"
-        >
-          Check again
-        </Button>
+        {storageSetupFailure ? (
+          <div className="mb-4 w-full">
+            <StorageSetupCard
+              title="Connect storage to finish saving"
+              description="If this is your clip, connect Builder.io here and this page will check again."
+              onConfigured={() => dataQ.refetch()}
+            />
+          </div>
+        ) : null}
+        <div className="flex items-center gap-2">
+          <Button
+            onClick={() => dataQ.refetch()}
+            variant="outline"
+            size="sm"
+            className="border-foreground/20 bg-muted/50 hover:bg-accent text-foreground"
+          >
+            Check again
+          </Button>
+        </div>
       </div>
     );
   }

--- a/templates/content/.agents/skills/security/SKILL.md
+++ b/templates/content/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/design/.agents/skills/security/SKILL.md
+++ b/templates/design/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/design/AGENTS.md
+++ b/templates/design/AGENTS.md
@@ -338,7 +338,7 @@ If your cwd is the monorepo root instead (e.g., running from the Frame wrapper),
 | Action                  | Args                                                                 | Purpose                                                                       |
 | ----------------------- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | `import-from-url`       | `--url <websiteUrl>`                                                 | Analyze a website and extract design tokens, colors, fonts (static HTML only) |
-| `import-github`         | `--repoUrl <url-or-org/repo>`                                        | Extract tokens from a public GitHub repo (Tailwind, CSS, theme)               |
+| `import-github`         | `--repoUrl <url-or-org/repo>`                                        | Extract tokens from a GitHub repo (Tailwind, CSS, theme)                      |
 | `import-code`           | `--files '[{"filename":"...","content":"..."}]'`                     | Extract tokens from uploaded code files                                       |
 | `import-document`       | `--files '[{"filename":"...","fileType":"...","sizeBytes":...}]'`    | Process document metadata (DOCX, PPTX, PDF) for design cues                   |
 | `import-design-project` | `--designId <id> [--designSystemId <id>]`                            | Extract tokens from existing project or fork a design system                  |
@@ -346,6 +346,8 @@ If your cwd is the monorepo root instead (e.g., running from the Frame wrapper),
 | `analyze-brand-assets`  | `[--websiteUrl "..."] [--companyName "..."] [--designSystemId <id>]` | Gather brand data from multiple sources                                       |
 
 **Browser-powered URL import (recommended):** For website URLs, prefer browser automation over `import-from-url`. Most modern sites use JS-rendered styles (CSS-in-JS, Tailwind JIT, SPAs) that plain HTML fetch misses entirely. Call `activate-browser`, navigate to the URL with chrome-devtools tools, then use `evaluate_script` to extract `getComputedStyle()` values, CSS custom properties, rendered font families, and actual color palette. Take a screenshot for visual reference. Fall back to `import-from-url` only when Builder is not connected.
+
+**Private GitHub repositories:** `import-github` reads public repositories without setup and private repositories through the saved `GITHUB_TOKEN` secret. If GitHub denies access, tell the user to save a fine-grained personal access token in Settings > Secrets as `GITHUB_TOKEN`, limited to the target repository with Repository permissions > Contents: Read-only. Never ask the user to paste a PAT into chat or pass it as an action argument. If they do not want to connect GitHub, ask them to upload the relevant CSS, Tailwind config, theme, token, and package files instead.
 
 ### Export
 
@@ -1867,12 +1869,9 @@ As you build out this app, follow this checklist for each new feature:
 
 ### Authentication
 
-Auth is automatic and environment-driven:
+This template uses the framework's default auth — Better Auth, with email/password and optional Google / GitHub social providers. Use `getSession(event)` server-side and `useSession()` client-side.
 
-- **Dev mode**: Auth is bypassed. `getSession()` returns `{ email: "local@localhost" }`.
-- **Production** (`ACCESS_TOKEN` set): Auth middleware auto-mounts.
-
-Use `getSession(event)` server-side and `useSession()` client-side.
+See the `authentication` skill for the full mode matrix (`AUTH_MODE=local`, `ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA) and the `security` skill for the access-control model (`ownableColumns`, `accessFilter`, `assertAccess`).
 
 ### UI Components
 

--- a/templates/design/actions/import-github.test.ts
+++ b/templates/design/actions/import-github.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import importGithub from "./import-github";
+
+const originalGitHubToken = process.env.GITHUB_TOKEN;
+
+describe("import-github", () => {
+  afterEach(() => {
+    if (originalGitHubToken === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = originalGitHubToken;
+    vi.unstubAllGlobals();
+  });
+
+  it("uses a saved GITHUB_TOKEN for private repository imports", async () => {
+    process.env.GITHUB_TOKEN = "github-secret";
+    const fetchSpy = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/contents/")) {
+        return new Response(
+          JSON.stringify([
+            { name: "tailwind.config.ts", type: "file", size: 100 },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.endsWith("/contents/tailwind.config.ts")) {
+        return new Response(
+          'export default { theme: { colors: { brand: "#123456" } } }',
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ message: "Not Found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await importGithub.run({
+      repoUrl: "git@github.com:builderio/private-app.git",
+    });
+
+    expect(result.repoUrl).toBe("https://github.com/builderio/private-app");
+    expect(result.colors).toMatchObject({ brand: "#123456" });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.github.com/repos/builderio/private-app/contents/",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer github-secret",
+        }),
+      }),
+    );
+  });
+
+  it("explains how to configure private repository access", async () => {
+    delete process.env.GITHUB_TOKEN;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ message: "Not Found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    await expect(
+      importGithub.run({ repoUrl: "builderio/private-app" }),
+    ).rejects.toThrow(/GITHUB_TOKEN.*Contents: Read-only/);
+  });
+});

--- a/templates/design/actions/import-github.ts
+++ b/templates/design/actions/import-github.ts
@@ -1,9 +1,11 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
+import { resolveSecret } from "@agent-native/core/server";
 import {
   validateUrl,
   parseOwnerRepo,
   fetchGitHubJson,
+  fetchGitHubJsonResult,
   fetchGitHubRaw,
   parseTailwindConfig,
   parseCss,
@@ -15,11 +17,45 @@ import {
   COLOR_VAR_PATTERN,
 } from "@agent-native/core/server/design-token-utils";
 
+function githubAccessError(
+  owner: string,
+  repo: string,
+  status: number,
+  hasToken: boolean,
+  message?: string,
+): Error {
+  const repoLabel = `${owner}/${repo}`;
+  const suffix = message ? ` GitHub said: ${message}` : "";
+
+  if (!hasToken && (status === 401 || status === 403 || status === 404)) {
+    return new Error(
+      `Could not access ${repoLabel}. Public repositories work without setup; private repositories require a fine-grained GitHub personal access token saved as GITHUB_TOKEN in Settings > Secrets. Limit the token to this repository and grant Repository permissions > Contents: Read-only.${suffix}`,
+    );
+  }
+
+  if (hasToken && (status === 401 || status === 403 || status === 404)) {
+    return new Error(
+      `Could not access ${repoLabel} with the saved GITHUB_TOKEN. Check that the token is not expired, the repository is selected for the token, organization SSO/approval is complete, and Repository permissions > Contents is set to Read-only.${suffix}`,
+    );
+  }
+
+  if (status === 429) {
+    return new Error(
+      `GitHub rate-limited requests for ${repoLabel}. Save a GITHUB_TOKEN in Settings > Secrets or try again after the rate limit resets.${suffix}`,
+    );
+  }
+
+  return new Error(
+    `Could not list repository contents for ${repoLabel} (GitHub returned ${status || "an error"}).${suffix}`,
+  );
+}
+
 export default defineAction({
   description:
-    "Import design tokens from a public GitHub repository. " +
+    "Import design tokens from a GitHub repository. " +
     "Reads Tailwind configs, CSS files, theme/token files, and package.json " +
-    "to extract colors, fonts, spacing, and CSS custom properties.",
+    "to extract colors, fonts, spacing, and CSS custom properties. " +
+    "Private repositories require a saved GITHUB_TOKEN secret; never ask users to paste a token into chat.",
   schema: z.object({
     repoUrl: z
       .string()
@@ -31,6 +67,8 @@ export default defineAction({
   http: { method: "GET" },
   run: async ({ repoUrl }) => {
     const { owner, repo } = parseOwnerRepo(repoUrl.trim());
+    const githubToken = await resolveSecret("GITHUB_TOKEN");
+    const githubOptions = { token: githubToken };
 
     validateUrl(`https://api.github.com/repos/${owner}/${repo}`);
 
@@ -39,7 +77,7 @@ export default defineAction({
 
     async function collectFile(path: string): Promise<void> {
       if (fetchedCount >= MAX_FILES) return;
-      const content = await fetchGitHubRaw(owner, repo, path);
+      const content = await fetchGitHubRaw(owner, repo, path, githubOptions);
       if (content) {
         rawFiles[path] = content;
         fetchedCount++;
@@ -47,16 +85,22 @@ export default defineAction({
     }
 
     // 1. List repository root
-    const rootListing = (await fetchGitHubJson(owner, repo, "")) as Array<{
-      name: string;
-      type: string;
-      size?: number;
-    }> | null;
+    const rootResult = await fetchGitHubJsonResult<
+      Array<{
+        name: string;
+        type: string;
+        size?: number;
+      }>
+    >(owner, repo, "", githubOptions);
+    const rootListing = rootResult.data;
 
-    if (!rootListing || !Array.isArray(rootListing)) {
-      throw new Error(
-        `Could not list repository contents for ${owner}/${repo}. ` +
-          "Ensure the repository is public and the URL is correct.",
+    if (!rootResult.ok || !Array.isArray(rootListing)) {
+      throw githubAccessError(
+        owner,
+        repo,
+        rootResult.status,
+        !!githubToken,
+        rootResult.message,
       );
     }
 
@@ -86,6 +130,7 @@ export default defineAction({
               owner,
               repo,
               path,
+              githubOptions,
             )) as Array<{
               name: string;
               type: string;

--- a/templates/design/app/pages/DesignSystemSetup.tsx
+++ b/templates/design/app/pages/DesignSystemSetup.tsx
@@ -252,7 +252,7 @@ export default function DesignSystemSetup() {
 
     if (githubLinks.length > 0) {
       parts.push(
-        `\n## GitHub Repositories\nExtract design tokens from code. Call \`import-github\` for each:\n${githubLinks.map((l) => `- ${l.url}`).join("\n")}`,
+        `\n## GitHub Repositories\nExtract design tokens from code. Call \`import-github\` for each:\n${githubLinks.map((l) => `- ${l.url}`).join("\n")}\n\nIf a repository is private or GitHub denies access, tell me to save a fine-grained GitHub token as \`GITHUB_TOKEN\` in Settings > Secrets. The token should be limited to the repository with Repository permissions > Contents: Read-only. Do not ask me to paste a PAT into chat.`,
       );
     }
 
@@ -479,6 +479,16 @@ export default function DesignSystemSetup() {
                     Add
                   </Button>
                 </div>
+                <p className="mt-2 text-xs text-muted-foreground/80">
+                  Private repos need a fine-grained token saved as{" "}
+                  <a
+                    href="/settings#secrets:GITHUB_TOKEN"
+                    className="font-medium text-foreground/80 underline-offset-2 hover:underline"
+                  >
+                    GITHUB_TOKEN
+                  </a>{" "}
+                  with Contents read access.
+                </p>
                 {githubLinks.length > 0 && (
                   <div className="mt-2 space-y-1">
                     {githubLinks.map((link) => (

--- a/templates/design/server/plugins/agent-chat.ts
+++ b/templates/design/server/plugins/agent-chat.ts
@@ -3,6 +3,7 @@ import {
   loadActionsFromStaticRegistry,
 } from "@agent-native/core/server";
 import actionsRegistry from "../../.generated/actions-registry.js";
+import "../register-secrets.js";
 
 export default createAgentChatPlugin({
   appId: "design",

--- a/templates/design/server/register-secrets.ts
+++ b/templates/design/server/register-secrets.ts
@@ -1,0 +1,45 @@
+import { registerRequiredSecret } from "@agent-native/core/secrets";
+
+// Optional: enables design-system import from private GitHub repositories.
+// The import-github action reads this server-side via resolveSecret(); tokens
+// should never be pasted into chat or passed as action parameters.
+registerRequiredSecret({
+  key: "GITHUB_TOKEN",
+  label: "GitHub token",
+  description:
+    "Optional. Enables design-token import from private GitHub repositories. Use a fine-grained token limited to the target repository with Contents read access.",
+  docsUrl:
+    "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens",
+  scope: "user",
+  kind: "api-key",
+  required: false,
+  validator: async (value) => {
+    if (!value) return true;
+    try {
+      const res = await fetch("https://api.github.com/user", {
+        headers: {
+          Accept: "application/vnd.github.v3+json",
+          Authorization: `Bearer ${value}`,
+          "User-Agent": "AgentNative/1.0",
+        },
+      });
+      if (res.ok) return true;
+      if (res.status === 401) {
+        return { ok: false, error: "GitHub rejected this token (401)." };
+      }
+      if (res.status === 403) {
+        return {
+          ok: false,
+          error:
+            "GitHub rejected this token (403). Check SSO or organization approval.",
+        };
+      }
+      return { ok: false, error: `GitHub returned ${res.status}.` };
+    } catch (err: any) {
+      return {
+        ok: false,
+        error: `Could not reach GitHub: ${err?.message ?? err}`,
+      };
+    }
+  },
+});

--- a/templates/dispatch/.agents/skills/security/SKILL.md
+++ b/templates/dispatch/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/forms/.agents/skills/security/SKILL.md
+++ b/templates/forms/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/issues/.agents/skills/security/SKILL.md
+++ b/templates/issues/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/macros/.agents/skills/security/SKILL.md
+++ b/templates/macros/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/mail/.agents/skills/security/SKILL.md
+++ b/templates/mail/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/meeting-notes/AGENTS.md
+++ b/templates/meeting-notes/AGENTS.md
@@ -220,12 +220,9 @@ Templates control the output structure. Built-in templates include things like "
 
 ## Authentication
 
-Auth is automatic and environment-driven:
+This template uses the framework's default auth — Better Auth, with email/password and optional Google / GitHub social providers. Use `getSession(event)` server-side and `useSession()` client-side.
 
-- **Dev mode.** Auth is bypassed. `getSession()` returns `{ email: "local@localhost" }`.
-- **Production** (`ACCESS_TOKEN` set). Auth middleware auto-mounts.
-
-Use `getSession(event)` server-side and `useSession()` client-side.
+See the `authentication` skill for the full mode matrix (`AUTH_MODE=local`, `ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA) and the `security` skill for the access-control model. List/get actions in this template filter via `accessFilter(schema.meetings, schema.meetingShares)`.
 
 ## UI Components
 

--- a/templates/recruiting/.agents/skills/security/SKILL.md
+++ b/templates/recruiting/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/slides/.agents/skills/security/SKILL.md
+++ b/templates/slides/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/starter/.agents/skills/security/SKILL.md
+++ b/templates/starter/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/starter/AGENTS.md
+++ b/templates/starter/AGENTS.md
@@ -84,12 +84,9 @@ As you build out this app, follow this checklist for each new feature:
 
 ### Authentication
 
-Auth is automatic and environment-driven:
+This template uses the framework's default auth — Better Auth, with email/password and optional Google / GitHub social providers. New users create an account on first visit. Use `getSession(event)` server-side and `useSession()` client-side.
 
-- **Dev mode**: Auth is bypassed. `getSession()` returns `{ email: "local@localhost" }`.
-- **Production** (`ACCESS_TOKEN` set): Auth middleware auto-mounts.
-
-Use `getSession(event)` server-side and `useSession()` client-side.
+See the `authentication` skill for the full mode matrix (`AUTH_MODE=local` for solo dev, `ACCESS_TOKEN` for shared-token deploys, `AUTH_DISABLED` for infrastructure auth, BYOA for custom providers) and the `security` skill for per-user / per-org data scoping.
 
 ### UI Components
 

--- a/templates/videos/.agents/skills/security/SKILL.md
+++ b/templates/videos/.agents/skills/security/SKILL.md
@@ -8,101 +8,145 @@ description: >-
 
 # Security & Data Scoping
 
-## How Data Isolation Works
+The framework gives you two layers of isolation. Use both — they cover
+different surfaces and read the same identity.
 
-In production, the framework enforces data isolation at the SQL level. Agents and users can only see and modify data they own. This is automatic — you don't write WHERE clauses yourself.
+| Layer                                            | Where it runs                                                            | What it protects                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------- |
+| `accessFilter` / `resolveAccess` / `assertAccess` | Drizzle helpers used inside actions and `/api/` handlers                 | List, read, and write of **ownable resources** |
+| `owner_email` / `org_id` view scoping            | The agent's `db-query` / `db-exec` raw-SQL CLI (`pnpm action db-query`)  | Ad-hoc SQL the agent runs from the terminal     |
 
-### Per-User Scoping (`owner_email`)
+Identity comes from the auth session via
+`runWithRequestContext({ userEmail, orgId }, fn)`; raw-SQL agent scripts
+read it from `AGENT_USER_EMAIL` / `AGENT_ORG_ID`, which the framework
+sets automatically when actions and CLI scripts execute.
 
-Every table with user-specific data **must** have an `owner_email` text column.
+## Auth (Better Auth by default)
+
+The framework uses **Better Auth** for authentication. New users create an
+account on first visit; sessions feed `getSession(event)` server-side and
+`useSession()` client-side. The full mode matrix (`AUTH_MODE=local`,
+`ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA via custom `getSession`) lives in
+the `authentication` skill — read it before changing how visitors sign in.
+
+**Key environment variables** (see `authentication` skill for the full list):
+
+- `BETTER_AUTH_SECRET` — signing key, auto-generated in dev if not set
+- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
+- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
+- `AUTH_MODE=local` — explicit local-only escape hatch
+- `ACCESS_TOKEN` / `ACCESS_TOKENS` — simple shared-token auth (no per-user identity)
+- `AUTH_DISABLED=true` — skip auth (apps behind infrastructure auth like Cloudflare Access)
+
+## Make a resource ownable
+
+For anything a user creates (notes, projects, dashboards, …), use
+`ownableColumns()` + `createSharesTable()`. This is the canonical shape —
+the framework's share dialog, list filtering, and the CI guard
+(`scripts/guard-no-unscoped-queries.mjs`) all key off it. See the
+`sharing` skill for the full registration pattern.
 
 ```ts
-import { table, text, integer } from "@agent-native/core/db/schema";
+import {
+  table,
+  text,
+  ownableColumns,
+  createSharesTable,
+} from "@agent-native/core/db/schema";
 
 export const notes = table("notes", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),
-  content: text("content"),
-  owner_email: text("owner_email").notNull(), // REQUIRED for user data
+  body: text("body"),
+  ...ownableColumns(), // adds owner_email, org_id, visibility
 });
+
+export const noteShares = createSharesTable("note_shares");
 ```
 
-**What happens automatically:**
-- `db-query` creates temporary views with `WHERE owner_email = <current user>`
-- `db-exec` INSERT statements get `owner_email` auto-injected
-- `db-exec` UPDATE/DELETE statements are scoped to the current user's rows
-- The current user comes from `AGENT_USER_EMAIL` (set from the auth session)
+`ownableColumns()` adds three columns: `owner_email` (creator), `org_id`
+(the owner's active org at creation time), and `visibility`
+(`'private' | 'org' | 'public'`, default `'private'`).
 
-### Per-Org Scoping (`org_id`)
+## Use the access helpers in every server-side query
 
-For multi-user apps where teams share data, add an `org_id` column:
+Auto-mounted action routes (`/_agent-native/actions/...`) get a request
+context wired automatically. Hand-written `/api/*` Nitro routes do **not** —
+you must wrap your work in `runWithRequestContext` after reading the
+session yourself.
 
 ```ts
-export const projects = table("projects", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  owner_email: text("owner_email").notNull(), // who created it
-  org_id: text("org_id").notNull(),           // which org it belongs to
-});
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import {
+  accessFilter,
+  resolveAccess,
+  assertAccess,
+} from "@agent-native/core/sharing";
+
+// List
+db.select()
+  .from(schema.notes)
+  .where(accessFilter(schema.notes, schema.noteShares));
+
+// Read by id (returns null when no access — return 404 to avoid existence leak)
+const access = await resolveAccess("note", id);
+
+// Write / delete (throws ForbiddenError if the role isn't met)
+await assertAccess("note", id, "editor");
 ```
 
-When both columns are present, queries are scoped by **both**: `WHERE owner_email = ? AND org_id = ?`.
+The CI guard fails the build if any file in `templates/*/server/`,
+`templates/*/actions/`, or `packages/*/src/` queries an ownable table
+without one of these helpers. Last-resort opt-out is the marker comment
+`// guard:allow-unscoped — <reason>`; only use it for the sharing
+primitives themselves and share-token-public viewer endpoints.
 
-The `org_id` comes from `AGENT_ORG_ID` which is automatically set from the user's active organization in Better Auth.
+## Auto-scoping for `db-query` / `db-exec`
 
-### Validation
+When the agent runs `pnpm action db-query --sql "SELECT ..."`, the
+framework creates temporary views that shadow real tables with
+`WHERE owner_email = <current user> [AND org_id = <current org>]`.
+INSERT statements auto-fill `owner_email` / `org_id`; UPDATE / DELETE
+statements are scoped the same way. This is the agent's escape hatch
+for ad-hoc SQL — application code should still go through the helpers
+above.
 
-Run `pnpm action db-check-scoping` to verify all tables have proper ownership columns. Use `--require-org` for multi-org apps.
-
-## Auth Model
-
-### Better Auth (Default)
-
-The framework uses Better Auth for authentication. It's always on by default — users create an account on first visit.
-
-**Environment variables:**
-- `BETTER_AUTH_SECRET` — signing key (auto-generated if not set)
-- `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` — enable Google OAuth
-- `GITHUB_CLIENT_ID` + `GITHUB_CLIENT_SECRET` — enable GitHub OAuth
-- `AUTH_MODE=local` — disable auth for solo local dev (escape hatch)
-
-### Organizations
-
-Better Auth's organization plugin is built-in. Every app supports:
-- Creating organizations
-- Inviting members (owner/admin/member roles)
-- Switching active organization
-- Per-org data scoping via `org_id`
-
-The active organization ID flows from `session.orgId` → `AGENT_ORG_ID` → SQL scoping automatically.
-
-### ACCESS_TOKEN (Legacy)
-
-For simple deployments, set `ACCESS_TOKEN` or `ACCESS_TOKENS` (comma-separated) as environment variables. This provides a shared token for all users — no per-user identity.
+Auto-scoping uses the same column convention `ownableColumns()` produces,
+so following the pattern above means raw-SQL scoping just works.
+Run `pnpm action db-check-scoping` to verify (use `--require-org` for
+multi-org apps).
 
 ## A2A Security
 
-### Cross-App Identity
+When apps call each other via A2A, set the same `A2A_SECRET` on every
+app that needs to trust each other. Outbound calls are signed JWTs with
+`sub: "<email>"`; inbound calls verify the signature and set
+`AGENT_USER_EMAIL` from the verified `sub` claim — the access helpers
+above then keep the call scoped to that user.
 
-When apps call each other via A2A, they need to verify identity. Set the same `A2A_SECRET` on all apps that need to trust each other:
-
-```bash
-# On both apps
-A2A_SECRET=your-shared-secret-at-least-32-chars
-```
-
-**How it works:**
-1. App A signs a JWT with `A2A_SECRET` containing `sub: "steve@builder.io"`
-2. App B receives the call, verifies the JWT signature
-3. App B sets `AGENT_USER_EMAIL` from the verified `sub` claim
-4. Data scoping applies — App B only shows steve's data
-
-Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev, not production).
+Without `A2A_SECRET`, A2A calls are unauthenticated (fine for local dev,
+not production).
 
 ## Rules for Agents
 
-1. **Every new table with user data must have `owner_email`.** No exceptions.
-2. **Never bypass scoping** — don't raw-query tables without going through `db-query`/`db-exec`.
-3. **Don't expose user data in application state** — application state is per-session, not per-user. Use SQL tables with `owner_email` for persistent user data.
-4. **Don't hardcode emails** — use `AGENT_USER_EMAIL` environment variable.
-5. **Test with multiple users** — create two accounts and verify data isolation.
+1. Every new user-data table uses `ownableColumns()` (which provides
+   `owner_email`, `org_id`, and `visibility`).
+2. Every list / read-many query goes through `accessFilter`.
+3. Every read-by-id goes through `resolveAccess`.
+4. Every write / delete-by-id goes through `assertAccess`.
+5. Hand-written `/api/*` handlers that touch ownable data wrap their
+   work in `runWithRequestContext({ userEmail, orgId }, fn)` after
+   reading the session via `getSession(event)`.
+6. Don't put per-user data in `application_state` — it's session-scoped,
+   not user-scoped. Use SQL tables with `ownableColumns()`.
+7. Don't hardcode `local@localhost` as a fallback — the
+   `guard-no-localhost-fallback` CI guard rejects it. Throw / 401 when
+   there's no session instead.
+8. Test isolation with two real accounts before shipping.
+
+## Related Skills
+
+- `sharing` — full pattern for ownable resources, share rows, and the share dialog
+- `authentication` — auth modes, sessions, organizations, BYOA
+- `storing-data` — SQL patterns and the agent's db tools
+- `actions` — `defineAction` (auto-protected by the auth guard)

--- a/templates/voice/AGENTS.md
+++ b/templates/voice/AGENTS.md
@@ -215,12 +215,9 @@ All AI formatting (applying style presets, expanding snippets, polishing text) g
 
 ## Authentication
 
-Auth is automatic and environment-driven:
+This template uses the framework's default auth — Better Auth, with email/password and optional Google / GitHub social providers. Use `getSession(event)` server-side and `useSession()` client-side.
 
-- **Dev mode.** Auth is bypassed. `getSession()` returns `{ email: "local@localhost" }`.
-- **Production** (`ACCESS_TOKEN` set). Auth middleware auto-mounts.
-
-Use `getSession(event)` server-side and `useSession()` client-side.
+See the `authentication` skill for the full mode matrix (`AUTH_MODE=local`, `ACCESS_TOKEN`, `AUTH_DISABLED`, BYOA) and the `security` skill for the access-control model (`ownableColumns`, `accessFilter`, `assertAccess`).
 
 ## Development
 


### PR DESCRIPTION
## Summary

Bundled changes from the `codex/org-scoped-credentials` branch — multiple concurrent agents.

- **Org-scoped Builder credentials.** When an owner/admin connects Builder, credentials now write at `scope: "org"` so the whole org auto-resolves them on next chat call — no per-user re-connect. Plain members and users without an active org keep writing at `scope: "user"` (safe default that doesn't trample the org-shared connection). Symmetric on disconnect: a member's Disconnect press never tears down the org's shared row. New `resolveCredentialWriteScope(email, orgId, role)` helper exposes the decision.
- **Private GitHub design-token imports.** `import-github` now reads a saved `GITHUB_TOKEN` secret server-side via `resolveSecret()` — never asks the user to paste a PAT into chat. New `fetchGitHubJsonResult` returns status + message details so the action can distinguish "needs token" vs "token rejected" vs "rate-limited" vs "wrong URL". `parseOwnerRepo` now handles SSH (`git@github.com:org/repo.git`) and `.git` suffixes. Templates/design registers the secret as optional with a fine-grained-token validator.
- **Agent run reconnect hardening.** Run-event retention bumped from 30 min to 24 h (configurable via `AGENT_RUN_RETENTION_MS`) so reconnect investigations have history. SSE reconnect now synthesizes a terminal `done`/`error` event when the persisted run status is `completed`/`errored` but no terminal event made it into the event log. Adapter records the last auto-continue reason and attempted run IDs, attaches them as `details` on the eventual connection-error so debugging stalled streams gets concrete signal. `BuilderSetupCard` now also appears mid-conversation when the API key is missing.
- **Clips storage recovery.** When a recording fails because no upload provider is configured, the recording detail and share routes render the `StorageSetupCard` inline so the user can connect Builder.io / S3 right there.
- **Auth docs canonicalization.** `docs/auth.md` becomes a thin pointer to the canonical user-facing docs and the framework `authentication` / `security` skills. Every template's `AGENTS.md` and security `SKILL.md` updated to reflect the Better Auth default + the access-helper model.
- **CLI smoke fix.** Asserts dispatch resolves from npm in scaffolds (matches the published-package layout we ship today, replacing the older "scaffold copies actions inline" check).
- **Local prep fix.** Docs vitest was picking up Nitro-bundled `.spec.mjs` files from `.output/` after a build; excluded that path so `pnpm prep` works after `agent-native build`.

Two changesets included:
- `@agent-native/core` minor — Builder credential org scope.
- `@agent-native/core` patch — GitHub import + run reconnect.

## Test plan

- [ ] CI green: lint / typecheck / test / scaffold E2E / guards
- [ ] New tests pass: `credential-provider.spec.ts`, `design-token-utils.spec.ts`, `import-github.test.ts`, run-manager retention + reconnect synthesis tests
- [ ] No CLAUDE.md / guard violations (changeset present, ownable-query guards, no-env-credentials, no-unscoped-credentials, no-localhost-fallback, template-list)
- [ ] Manual sanity: connect Builder as org admin → other org member sees AI chat working without reconnect; private GitHub import without `GITHUB_TOKEN` returns the new explanatory error