### PR TITLE
fix(core): PR #511 follow-up — reconnect terminal runs + status orgId + org-secrets auth

### DIFF
--- a/.changeset/pr-511-followup-fixes.md
+++ b/.changeset/pr-511-followup-fixes.md
@@ -1,0 +1,9 @@
+---
+"@agent-native/core": patch
+---
+
+PR #511 follow-up fixes:
+
+- `/runs/active` now surfaces recently-completed and recently-errored SQL runs (within a 10-minute reconnect window) so the agent-chat adapter can replay synthesized done/error events from the run-events stream instead of retrying the original POST when the producer's in-memory state was already evicted (different serverless isolate). Without this, a POST that failed after the server already accepted and finished the run could re-execute the agent turn and double-apply mutations.
+- `/builder/status` now reads the user's active org via `getOrgContext(event)` and passes the orgId into `runWithRequestContext()` so the status poller resolves org-shared Builder credentials. Previously, an admin's org-scope OAuth result was invisible to every other org member's status poller, leaving the UI showing "not connected" even though chat resolved the credentials correctly.
+- Registered secrets routes now treat `scope: "org"` as a first-class scope: writes and deletes require an active org and an owner/admin role (`canMutateOrgScope`), and `resolveScopeId("org", …)` rejects requests without an active org rather than falling back to a `solo:` scopeId. Ad-hoc secret routes were already restricted to `user`/`workspace` and remain unchanged.

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -20,14 +20,17 @@ import {
   abortRun,
   DEFAULT_COMPLETED_RUN_RETENTION_MS,
   DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS,
+  getActiveRunForThreadAsync,
   resolveCompletedRunRetentionMs,
   resolveRunSoftTimeoutMs,
   startRun,
   subscribeToRun,
+  TERMINAL_RUN_RECONNECT_WINDOW_MS,
 } from "./run-manager.js";
 import {
   getRunAbortState,
   getRunById,
+  getRunByThread,
   getRunEventsSince,
   markRunAborted,
 } from "./run-store.js";
@@ -345,6 +348,62 @@ describe("run manager soft timeout", () => {
     }
 
     expect(chunks.join("")).toContain('data: {"type":"done","seq":0}');
+  });
+
+  it("returns recently-completed SQL runs from /runs/active so reconnect can replay them", async () => {
+    // Memory miss — different isolate than the producer.
+    // SQL has the run in completed status with a recent startedAt.
+    vi.mocked(getRunByThread).mockResolvedValue({
+      id: "run-recent-completed",
+      threadId: "thread-recent",
+      status: "completed",
+      startedAt: Date.now() - 1000,
+      heartbeatAt: Date.now() - 1000,
+    });
+
+    const result = await getActiveRunForThreadAsync("thread-recent");
+
+    expect(result).toEqual({
+      runId: "run-recent-completed",
+      threadId: "thread-recent",
+      status: "completed",
+      heartbeatAt: expect.any(Number),
+    });
+    // Confirm we passed includeTerminal so SQL surfaced a non-running row.
+    expect(getRunByThread).toHaveBeenCalledWith("thread-recent", {
+      includeTerminal: true,
+    });
+  });
+
+  it("ignores stale terminal runs older than the reconnect window", async () => {
+    vi.mocked(getRunByThread).mockResolvedValue({
+      id: "run-old-completed",
+      threadId: "thread-old",
+      status: "completed",
+      startedAt: Date.now() - TERMINAL_RUN_RECONNECT_WINDOW_MS - 60_000,
+      heartbeatAt: null,
+    });
+
+    const result = await getActiveRunForThreadAsync("thread-old");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns recently-errored SQL runs so the client can reconnect to the synthesized error", async () => {
+    vi.mocked(getRunByThread).mockResolvedValue({
+      id: "run-recent-errored",
+      threadId: "thread-errored",
+      status: "errored",
+      startedAt: Date.now() - 1000,
+      heartbeatAt: null,
+    });
+
+    const result = await getActiveRunForThreadAsync("thread-errored");
+
+    expect(result).toMatchObject({
+      runId: "run-recent-errored",
+      status: "errored",
+    });
   });
 
   it("synthesizes an explicit error for errored SQL runs missing terminal events", async () => {

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -359,6 +359,7 @@ describe("run manager soft timeout", () => {
       status: "completed",
       startedAt: Date.now() - 1000,
       heartbeatAt: Date.now() - 1000,
+      completedAt: Date.now() - 500,
     });
 
     const result = await getActiveRunForThreadAsync("thread-recent");
@@ -376,17 +377,64 @@ describe("run manager soft timeout", () => {
   });
 
   it("ignores stale terminal runs older than the reconnect window", async () => {
+    const completedAt = Date.now() - TERMINAL_RUN_RECONNECT_WINDOW_MS - 60_000;
     vi.mocked(getRunByThread).mockResolvedValue({
       id: "run-old-completed",
       threadId: "thread-old",
       status: "completed",
-      startedAt: Date.now() - TERMINAL_RUN_RECONNECT_WINDOW_MS - 60_000,
+      startedAt: completedAt - 5_000,
       heartbeatAt: null,
+      completedAt,
     });
 
     const result = await getActiveRunForThreadAsync("thread-old");
 
     expect(result).toBeNull();
+  });
+
+  it("uses completed_at (not started_at) for the reconnect window so long-running tasks are still reachable", async () => {
+    // The run started long enough ago that it would fall outside the window
+    // if we measured from startedAt — but it completed seconds ago, which is
+    // when the user actually disconnected. A senior engineer reconnecting
+    // here expects to replay the synthesized terminal events, not to retry
+    // the POST.
+    const startedAt = Date.now() - TERMINAL_RUN_RECONNECT_WINDOW_MS - 120_000;
+    vi.mocked(getRunByThread).mockResolvedValue({
+      id: "run-long-then-recent-complete",
+      threadId: "thread-long",
+      status: "completed",
+      startedAt,
+      heartbeatAt: Date.now() - 5_000,
+      completedAt: Date.now() - 2_000,
+    });
+
+    const result = await getActiveRunForThreadAsync("thread-long");
+
+    expect(result).toMatchObject({
+      runId: "run-long-then-recent-complete",
+      status: "completed",
+    });
+  });
+
+  it("falls back to heartbeat_at when completed_at is missing on legacy rows", async () => {
+    // Older deployments may have terminal rows without a completed_at value.
+    // The reconnect window should still work — fall back to the freshest
+    // signal we have (heartbeat) before reaching for startedAt.
+    vi.mocked(getRunByThread).mockResolvedValue({
+      id: "run-legacy-no-completed-at",
+      threadId: "thread-legacy",
+      status: "errored",
+      startedAt: Date.now() - TERMINAL_RUN_RECONNECT_WINDOW_MS - 120_000,
+      heartbeatAt: Date.now() - 3_000,
+      completedAt: null,
+    });
+
+    const result = await getActiveRunForThreadAsync("thread-legacy");
+
+    expect(result).toMatchObject({
+      runId: "run-legacy-no-completed-at",
+      status: "errored",
+    });
   });
 
   it("returns recently-errored SQL runs so the client can reconnect to the synthesized error", async () => {
@@ -396,6 +444,7 @@ describe("run manager soft timeout", () => {
       status: "errored",
       startedAt: Date.now() - 1000,
       heartbeatAt: null,
+      completedAt: Date.now() - 500,
     });
 
     const result = await getActiveRunForThreadAsync("thread-errored");

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -684,10 +684,18 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
     if (sqlRun.status === "completed" || sqlRun.status === "errored") {
       // Cap how far back we'll surface terminal runs as "active". The goal
       // is to catch the recently-completed-but-reconnecting case, not to
-      // resurrect ancient turns when the user reopens an old thread. The
-      // window mirrors the initial reconnect adapter's retry budget on the
-      // client side.
-      const terminalAge = Date.now() - sqlRun.startedAt;
+      // resurrect ancient turns when the user reopens an old thread.
+      //
+      // Measure age from the run's terminal timestamp, not its start. A
+      // long-running task that ran 11 minutes and completed five seconds
+      // ago should still be reachable — the client's disconnect happened
+      // around completion, so completion time is what matters for the
+      // "is the user still here waiting?" question. Fall back to the last
+      // heartbeat (older deployments may have unset completed_at) and
+      // finally to startedAt for ancient rows.
+      const referenceAt =
+        sqlRun.completedAt ?? sqlRun.heartbeatAt ?? sqlRun.startedAt;
+      const terminalAge = Date.now() - referenceAt;
       if (terminalAge > TERMINAL_RUN_RECONNECT_WINDOW_MS) return null;
       return {
         runId: sqlRun.id,

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -37,6 +37,14 @@ export const DEFAULT_HOSTED_RUN_SOFT_TIMEOUT_MS = 55_000;
 /** Default SQL retention for completed/errored run event logs (24 hours). */
 export const DEFAULT_COMPLETED_RUN_RETENTION_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * How recently a terminal run must have started for `/runs/active` to surface
+ * it. Reconnect after this window won't replay the run — typical real-world
+ * disconnects resolve in seconds, so 10 minutes is generous while keeping us
+ * from resurrecting ancient turns when the user reopens an old thread.
+ */
+export const TERMINAL_RUN_RECONNECT_WINDOW_MS = 10 * 60 * 1000;
+
 export interface StartRunOptions {
   /** Optional internal run chunk budget. When reached, the framework emits an
    * auto-continuation signal instead of a user-facing timeout. Leave unset for
@@ -650,15 +658,37 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
       heartbeatAt: Date.now(),
     };
   }
-  // Fall back to SQL
+  // Fall back to SQL — also surface recently terminated runs so the client
+  // can reconnect and replay synthesized done/error events instead of
+  // retrying the original POST. Without this, a POST that fails after the
+  // server already accepted (and finished) the run would re-execute the
+  // turn and double-apply mutations: the in-memory branch above already
+  // returns terminal runs whose events are still buffered, but the SQL
+  // path is the only authority once memory has been evicted.
   try {
-    const sqlRun = await getRunByThread(threadId);
-    if (sqlRun && sqlRun.status === "running") {
+    const sqlRun = await getRunByThread(threadId, { includeTerminal: true });
+    if (!sqlRun) return null;
+    if (sqlRun.status === "running") {
       // If the producer is dead (no recent heartbeat), reap before the
       // client can see a stale "running" status and enter a reconnect
       // loop it can never exit.
       const reaped = await reapIfStale(sqlRun.id).catch(() => false);
       if (reaped) return null;
+      return {
+        runId: sqlRun.id,
+        threadId: sqlRun.threadId,
+        status: sqlRun.status,
+        heartbeatAt: sqlRun.heartbeatAt ?? sqlRun.startedAt,
+      };
+    }
+    if (sqlRun.status === "completed" || sqlRun.status === "errored") {
+      // Cap how far back we'll surface terminal runs as "active". The goal
+      // is to catch the recently-completed-but-reconnecting case, not to
+      // resurrect ancient turns when the user reopens an old thread. The
+      // window mirrors the initial reconnect adapter's retry budget on the
+      // client side.
+      const terminalAge = Date.now() - sqlRun.startedAt;
+      if (terminalAge > TERMINAL_RUN_RECONNECT_WINDOW_MS) return null;
       return {
         runId: sqlRun.id,
         threadId: sqlRun.threadId,

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -238,12 +238,13 @@ export async function getRunByThread(
   status: string;
   startedAt: number;
   heartbeatAt: number | null;
+  completedAt: number | null;
 } | null> {
   await ensureRunTables();
   const client = getDbExec();
   const sql = options?.includeTerminal
-    ? `SELECT id, thread_id, status, started_at, heartbeat_at FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`
-    : `SELECT id, thread_id, status, started_at, heartbeat_at FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`;
+    ? `SELECT id, thread_id, status, started_at, heartbeat_at, completed_at FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`
+    : `SELECT id, thread_id, status, started_at, heartbeat_at, completed_at FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`;
   const { rows } = await client.execute({ sql, args: [threadId] });
   if (rows.length === 0) return null;
   const r = rows[0] as {
@@ -252,6 +253,7 @@ export async function getRunByThread(
     status: string;
     started_at: number | string;
     heartbeat_at: number | string | null;
+    completed_at: number | string | null;
   };
   return {
     id: r.id,
@@ -259,6 +261,7 @@ export async function getRunByThread(
     status: r.status,
     startedAt: Number(r.started_at),
     heartbeatAt: r.heartbeat_at == null ? null : Number(r.heartbeat_at),
+    completedAt: r.completed_at == null ? null : Number(r.completed_at),
   };
 }
 

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -229,7 +229,10 @@ export async function getRunById(runId: string): Promise<{
   };
 }
 
-export async function getRunByThread(threadId: string): Promise<{
+export async function getRunByThread(
+  threadId: string,
+  options?: { includeTerminal?: boolean },
+): Promise<{
   id: string;
   threadId: string;
   status: string;
@@ -238,10 +241,10 @@ export async function getRunByThread(threadId: string): Promise<{
 } | null> {
   await ensureRunTables();
   const client = getDbExec();
-  const { rows } = await client.execute({
-    sql: `SELECT id, thread_id, status, started_at, heartbeat_at FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`,
-    args: [threadId],
-  });
+  const sql = options?.includeTerminal
+    ? `SELECT id, thread_id, status, started_at, heartbeat_at FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`
+    : `SELECT id, thread_id, status, started_at, heartbeat_at FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`;
+  const { rows } = await client.execute({ sql, args: [threadId] });
   if (rows.length === 0) return null;
   const r = rows[0] as {
     id: string;

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -23,6 +23,19 @@ const TEMPLATES_DIR = "templates";
 const POSTGRES_DEPENDENCY_VERSION = "^3.4.9";
 
 /**
+ * Tagged error for input that fails CLI-level validation (repo names, app
+ * names, etc.). The Sentry `beforeSend` hook in cli/index.ts drops events
+ * whose top-level exception type is `ValidationError` so we don't pollute
+ * Sentry with expected user-input rejections.
+ */
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
+/**
  * Move "starter" to the top of the list so it lines up with clack's default
  * highlight on the first option — otherwise users have to scroll to see that
  * Starter is pre-selected.
@@ -895,7 +908,7 @@ export {
 
 function validateRepoName(repo: string): void {
   if (!/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/.test(repo)) {
-    throw new Error(
+    throw new ValidationError(
       `Invalid repository name "${repo}". Expected format: user/repo`,
     );
   }

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -59,6 +59,16 @@ Sentry.init({
   // or process env contents to Sentry without explicit consent.
   sendDefaultPii: false,
   beforeSend(event) {
+    // Drop expected user-input rejections (validateRepoName, etc.) so they
+    // don't pollute Sentry with non-bug noise.
+    const exceptionType = event.exception?.values?.[0]?.type;
+    if (
+      exceptionType === "ValidationError" ||
+      event.tags?.handled === "validation"
+    ) {
+      return null;
+    }
+
     // Defense in depth: strip any sensitive fields that may have been
     // attached to the event despite sendDefaultPii: false (e.g. integrations
     // that capture request metadata).
@@ -80,7 +90,22 @@ Sentry.init({
       // Cookies are also exposed via event.request.cookies as a separate field
       delete (event.request as Record<string, unknown>).cookies;
     }
-    delete event.user;
+    // Keep user info that was explicitly set via Sentry.setUser (id/email)
+    // so we can attribute crashes back to the operator. Always strip
+    // ip_address — the CLI runs on third-party machines and the IP is auto-
+    // collected without consent. If only auto-collected fields remain,
+    // drop the user object entirely.
+    if (event.user) {
+      const user = event.user as Record<string, unknown>;
+      delete user.ip_address;
+      const hasIdentity =
+        typeof user.id === "string" ||
+        typeof user.email === "string" ||
+        typeof user.username === "string";
+      if (!hasIdentity) {
+        delete event.user;
+      }
+    }
     // Sentry's contexts can carry process.env snapshots — strip env-shaped
     // contexts so we don't leak deployment secrets.
     if (event.contexts && typeof event.contexts === "object") {
@@ -99,6 +124,21 @@ Sentry.init({
     return event;
   },
 });
+
+// Identify the operator so future CLI errors carry spaceId / builderUserId
+// that we can map back to a real Builder user. The CLI doesn't have a real
+// email today — only the env-managed identifiers from the workspace's .env.
+{
+  const builderUserId = process.env.BUILDER_USER_ID;
+  const builderPublicKey = process.env.BUILDER_PUBLIC_KEY;
+  if (builderUserId) {
+    Sentry.setUser({ id: builderUserId });
+    Sentry.setTag("builderUserId", builderUserId);
+  }
+  if (builderPublicKey) {
+    Sentry.setTag("spaceId", builderPublicKey);
+  }
+}
 
 const FEEDBACK_URL =
   "https://forms.agent-native.com/f/agent-native-feedback/_16ewV?source=cli";
@@ -231,6 +271,125 @@ function run(
   return child;
 }
 
+/**
+ * Walk up from `cwd` and try to figure out which template / app this build
+ * is running for. We look for two patterns:
+ *
+ *   - `templates/<name>/...` — building inside the framework monorepo
+ *   - `apps/<name>/...`      — building inside a scaffolded workspace
+ *
+ * Both, neither, or one may match. Used purely as Sentry tags so we can
+ * filter the noisy "Command failed: react-router build" issues by template.
+ */
+function inferBuildContext(cwd: string): {
+  template?: string;
+  app?: string;
+} {
+  const segs = cwd.split(path.sep);
+  let template: string | undefined;
+  let app: string | undefined;
+  for (let i = 0; i < segs.length - 1; i++) {
+    if (segs[i] === "templates" && segs[i + 1] && !segs[i + 1].startsWith("."))
+      template = segs[i + 1];
+    if (segs[i] === "apps" && segs[i + 1] && !segs[i + 1].startsWith("."))
+      app = segs[i + 1];
+  }
+  return { template, app };
+}
+
+/**
+ * Run a build subcommand, streaming its stdout/stderr to the user's terminal
+ * in real time while also capturing bounded tails for Sentry. On non-zero
+ * exit we report a structured event (template, app, exit code, stderr/stdout
+ * tails) and exit with the child's code. We deliberately do NOT throw — the
+ * global uncaughtException handler would re-capture with a generic
+ * "Error: Command failed" title, collapsing every template's failure into
+ * one issue (which is exactly what we're trying to fix here).
+ */
+function runBuildStep(
+  cmd: string,
+  cmdArgs: string[],
+  opts: { label: string; env?: NodeJS.ProcessEnv },
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const STDERR_TAIL_BYTES = 8000;
+    const STDOUT_TAIL_BYTES = 4000;
+    let stderrBuf = "";
+    let stdoutBuf = "";
+
+    const child = spawn(cmd, cmdArgs, {
+      stdio: ["inherit", "pipe", "pipe"],
+      shell: process.platform === "win32",
+      env: opts.env ?? process.env,
+    });
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      process.stdout.write(chunk);
+      const next = stdoutBuf + chunk.toString("utf-8");
+      stdoutBuf =
+        next.length > STDOUT_TAIL_BYTES ? next.slice(-STDOUT_TAIL_BYTES) : next;
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      process.stderr.write(chunk);
+      const next = stderrBuf + chunk.toString("utf-8");
+      stderrBuf =
+        next.length > STDERR_TAIL_BYTES ? next.slice(-STDERR_TAIL_BYTES) : next;
+    });
+
+    child.on("error", (err) => {
+      // Failure to spawn (ENOENT, etc.).
+      const cwd = process.cwd();
+      const { template, app } = inferBuildContext(cwd);
+      Sentry.captureException(err, {
+        tags: {
+          buildStep: opts.label,
+          ...(template ? { template } : {}),
+          ...(app ? { app } : {}),
+        },
+        extra: {
+          command: `${cmd} ${cmdArgs.join(" ")}`,
+          cwd,
+          stage: "spawn",
+        },
+      });
+      Sentry.flush(2000).finally(() => process.exit(1));
+    });
+
+    child.on("exit", (code, signal) => {
+      const exitCode = code ?? (signal ? 1 : 0);
+      if (exitCode === 0) {
+        resolve();
+        return;
+      }
+      const cwd = process.cwd();
+      const { template, app } = inferBuildContext(cwd);
+      const childCommand = `${cmd} ${cmdArgs.join(" ")}`;
+      const err = new Error(
+        `Build step "${opts.label}" failed with exit code ${exitCode}` +
+          (template ? ` (template=${template})` : "") +
+          (app ? ` (app=${app})` : ""),
+      );
+      Sentry.captureException(err, {
+        tags: {
+          buildStep: opts.label,
+          ...(template ? { template } : {}),
+          ...(app ? { app } : {}),
+        },
+        extra: {
+          command: childCommand,
+          cwd,
+          exitCode,
+          signal: signal ?? null,
+          stderrTail: stderrBuf,
+          stdoutTail: stdoutBuf,
+        },
+      });
+      // Don't throw — see comment on runBuildStep above.
+      Sentry.flush(2000).finally(() => process.exit(exitCode));
+    });
+  });
+}
+
 trackCli("cli.run");
 
 switch (command) {
@@ -253,32 +412,48 @@ switch (command) {
     // React Router framework mode uses `react-router build` which
     // internally runs `vite build` with proper environment orchestration.
     // Legacy SPA mode uses `vite build` directly.
-    if (isReactRouterFramework()) {
-      const rr = findReactRouterBin();
-      console.log("Building (React Router framework mode)...");
-      execSync(`${rr} build`, { stdio: "inherit" });
-    } else {
-      const vite = findViteBin();
-      console.log("Building...");
-      execSync(`${vite} build`, { stdio: "inherit" });
-    }
-
-    // Post-build: framework-mode apps also need a Nitro server bundle for
-    // `agent-native start` and for serverless presets.
-    const preset = process.env.NITRO_PRESET;
-    if (isReactRouterFramework()) {
-      const __dirname = path.dirname(fileURLToPath(import.meta.url));
-      const deployBuild = path.resolve(__dirname, "../deploy/build.js");
-      if (fs.existsSync(deployBuild)) {
-        execSync(`node ${deployBuild}`, { stdio: "inherit", env: process.env });
+    //
+    // Each step uses runBuildStep so that on failure we get a Sentry event
+    // tagged with template/app and including stderr/stdout tails. If the
+    // child exits non-zero, runBuildStep calls process.exit itself; the
+    // continuation only runs on success.
+    (async () => {
+      if (isReactRouterFramework()) {
+        const rr = findReactRouterBin();
+        console.log("Building (React Router framework mode)...");
+        await runBuildStep(rr, ["build"], { label: "react-router-build" });
       } else {
-        console.warn(
-          `[build] Deploy build script not found at ${deployBuild}. Skipping post-build step.`,
-        );
+        const vite = findViteBin();
+        console.log("Building...");
+        await runBuildStep(vite, ["build"], { label: "vite-build" });
       }
-    }
 
-    console.log("\nBuild complete.");
+      // Post-build: framework-mode apps also need a Nitro server bundle for
+      // `agent-native start` and for serverless presets.
+      if (isReactRouterFramework()) {
+        const __dirname = path.dirname(fileURLToPath(import.meta.url));
+        const deployBuild = path.resolve(__dirname, "../deploy/build.js");
+        if (fs.existsSync(deployBuild)) {
+          await runBuildStep("node", [deployBuild], {
+            label: "deploy-build",
+            env: process.env,
+          });
+        } else {
+          console.warn(
+            `[build] Deploy build script not found at ${deployBuild}. Skipping post-build step.`,
+          );
+        }
+      }
+
+      console.log("\nBuild complete.");
+    })().catch((err) => {
+      // runBuildStep handles its own failures and exits, so reaching here
+      // implies a programming error in the orchestration above. Capture
+      // and exit so the global unhandledRejection handler doesn't double-
+      // report with a generic title.
+      Sentry.captureException(err);
+      Sentry.flush(2000).finally(() => process.exit(1));
+    });
     break;
   }
 

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -5,6 +5,7 @@ import http from "node:http";
 import net from "node:net";
 import path from "node:path";
 import type { Duplex } from "node:stream";
+import * as Sentry from "@sentry/node";
 
 interface WorkspaceApp {
   id: string;
@@ -41,8 +42,28 @@ function readJson(file: string): any {
 
 function discoverApps(): WorkspaceApp[] {
   if (!fs.existsSync(appsDir)) return [];
-  return fs
-    .readdirSync(appsDir, { withFileTypes: true })
+  // existsSync → readdirSync is a TOCTOU race — appsDir can vanish between
+  // the two calls (e.g. user running `git checkout` on the workspace mid-dev).
+  // Treat ENOENT as "no apps right now" and let the next 2s sync recover.
+  // Other errors get surfaced to Sentry so we learn about new failure modes.
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(appsDir, { withFileTypes: true });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      console.warn(
+        `[workspace] Could not read ${appsDir} (${code ?? "unknown"}): ` +
+          `${(err as Error).message}`,
+      );
+      Sentry.captureException(err, {
+        tags: { handled: "dev-discover-readdir" },
+        level: "warning",
+      });
+    }
+    return [];
+  }
+  return entries
     .filter((entry) => entry.isDirectory())
     .map((entry) => {
       const dir = path.join(appsDir, entry.name);
@@ -345,14 +366,62 @@ function proxyUpgrade(
 let shuttingDown = false;
 let workspaceStarted = false;
 
+function handleWatcherError(err: NodeJS.ErrnoException): void {
+  // ENOSPC: system inotify watcher limit hit (Linux). Userland-fixable;
+  // capture as a warning so we still see frequency in Sentry but don't get
+  // paged. Print actionable guidance and continue without watching — the
+  // 2s polling interval below keeps app discovery working.
+  if (err.code === "ENOSPC") {
+    console.warn(
+      `[workspace] Recursive file watcher hit the system limit (ENOSPC). ` +
+        `New apps will still be detected via polling every ~2s. ` +
+        `On Linux you can raise the limit with ` +
+        `\`sudo sysctl fs.inotify.max_user_watches=524288\` ` +
+        `(persist via /etc/sysctl.d/*.conf). On macOS/Windows this usually ` +
+        `means too many other watchers are running.`,
+    );
+    Sentry.captureException(err, {
+      tags: { handled: "dev-watch-enospc" },
+      level: "warning",
+    });
+    return;
+  }
+  // ENOENT: a watched directory disappeared (or a transient subdir under
+  // appsDir vanished mid-enumeration). Benign — the polling fallback and
+  // future scheduleSync calls will re-establish state. Don't capture.
+  if (err.code === "ENOENT") {
+    console.debug(
+      `[workspace] Recursive file watcher saw a directory disappear ` +
+        `(ENOENT: ${err.path ?? "unknown"}). Polling fallback will recover.`,
+    );
+    return;
+  }
+  // Unknown failure mode — keep the dev experience alive (polling still
+  // runs) but surface to Sentry as a warning so we learn about new cases.
+  console.warn(
+    `[workspace] Recursive file watcher failed (${err.code ?? "unknown"}): ${err.message}. ` +
+      `Falling back to polling.`,
+  );
+  Sentry.captureException(err, {
+    tags: { handled: "dev-watch-unknown" },
+    level: "warning",
+  });
+}
+
 function startWorkspaceProcesses(): void {
   if (workspaceStarted) return;
   workspaceStarted = true;
   for (const app of apps) startApp(app);
   try {
-    fs.watch(appsDir, { recursive: true }, scheduleSync);
-  } catch {
-    // Some platforms do not support recursive directory watches.
+    const watcher = fs.watch(appsDir, { recursive: true }, scheduleSync);
+    // Async errors (e.g. ENOENT when a subdir vanishes mid-watch) surface on
+    // the watcher rather than the original call site. Without an `error`
+    // listener, Node would treat them as uncaught and crash the dev process.
+    watcher.on("error", (err) => {
+      handleWatcherError(err as NodeJS.ErrnoException);
+    });
+  } catch (err) {
+    handleWatcherError(err as NodeJS.ErrnoException);
   }
   setInterval(syncApps, 2_000).unref();
 }

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -17,9 +17,19 @@ type PageviewTrackingState = {
   lastPageviewKey: string | null;
 };
 
+type SentryUser = {
+  id?: string;
+  email?: string;
+  username?: string;
+};
+
 let _getDefaultProps: GetDefaultProps | null = null;
 let _amplitudeInitialized = false;
 let _sentryInitialized = false;
+// Buffer for setSentryUser calls made before Sentry has initialized.
+// `undefined` means "no pending update"; `null` means "pending clear".
+let _pendingSentryUser: SentryUser | null | undefined = undefined;
+let _pendingSentryOrgId: string | null | undefined = undefined;
 
 const AGENT_NATIVE_ANALYTICS_DEFAULT_ENDPOINT =
   "https://analytics.agent-native.com/track";
@@ -124,6 +134,40 @@ function ensureSentry(): void {
     },
   });
   _sentryInitialized = true;
+  // Flush any user/tag that was set before init.
+  if (_pendingSentryUser !== undefined) {
+    Sentry.setUser(_pendingSentryUser);
+    _pendingSentryUser = undefined;
+  }
+  if (_pendingSentryOrgId !== undefined) {
+    Sentry.setTag("orgId", _pendingSentryOrgId);
+    _pendingSentryOrgId = undefined;
+  }
+}
+
+/**
+ * Attach the current user to Sentry events from the browser. Pass `null` to
+ * clear (e.g. on logout). If Sentry isn't initialized yet, the value is
+ * buffered and applied once `ensureSentry()` runs.
+ *
+ * Pass `orgId` to also tag events with the active organization ID — useful
+ * for filtering Sentry by tenant.
+ */
+export function setSentryUser(
+  user: SentryUser | null,
+  orgId?: string | null,
+): void {
+  if (_sentryInitialized) {
+    Sentry.setUser(user);
+    if (orgId !== undefined) {
+      Sentry.setTag("orgId", orgId ?? null);
+    }
+    return;
+  }
+  _pendingSentryUser = user;
+  if (orgId !== undefined) {
+    _pendingSentryOrgId = orgId ?? null;
+  }
 }
 
 function getPageviewTrackingState(): PageviewTrackingState {

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -124,6 +124,7 @@ export {
   trackEvent,
   trackSessionStatus,
   configureTracking,
+  setSentryUser,
 } from "./analytics.js";
 export {
   useCollaborativeDoc,

--- a/packages/core/src/client/use-session.ts
+++ b/packages/core/src/client/use-session.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import type { AuthSession } from "../server/auth.js";
-import { trackSessionStatus } from "./analytics.js";
+import { setSentryUser, trackSessionStatus } from "./analytics.js";
 import { agentNativePath } from "./api-path.js";
 
 export type { AuthSession };
@@ -28,6 +28,7 @@ export function useSession(): UseSessionResult {
 
     async function fetchSession() {
       let signedIn = false;
+      let resolved: AuthSession | null = null;
       try {
         const res = await fetch(agentNativePath("/_agent-native/auth/session"));
         if (!res.ok) {
@@ -40,7 +41,8 @@ export function useSession(): UseSessionResult {
           if (data.error) {
             setSession(null);
           } else {
-            setSession(data as AuthSession);
+            resolved = data as AuthSession;
+            setSession(resolved);
             signedIn = true;
           }
         }
@@ -49,6 +51,18 @@ export function useSession(): UseSessionResult {
       } finally {
         if (!cancelled) {
           setIsLoading(false);
+          if (resolved) {
+            setSentryUser(
+              {
+                id: resolved.userId,
+                email: resolved.email,
+                username: resolved.name,
+              },
+              resolved.orgId ?? null,
+            );
+          } else {
+            setSentryUser(null, null);
+          }
           if (!trackedRef.current) {
             trackedRef.current = true;
             trackSessionStatus(signedIn);

--- a/packages/core/src/secrets/routes.spec.ts
+++ b/packages/core/src/secrets/routes.spec.ts
@@ -139,6 +139,105 @@ describe("secrets routes", () => {
     });
   });
 
+  it("writes registered org-scope secrets at the active org id when caller is admin", async () => {
+    mockGetRequiredSecret.mockReturnValue({
+      key: "ORG_SHARED_TOKEN",
+      label: "Org shared token",
+      scope: "org",
+      kind: "api-key",
+    });
+    mockGetOrgContext.mockResolvedValue({
+      orgId: "org-qa",
+      email: "alice+qa@example.com",
+      role: "admin",
+    });
+
+    const handler = createWriteSecretHandler();
+    const result = await handler(
+      event("/ORG_SHARED_TOKEN", "POST", { value: "shared" }),
+    );
+
+    expect(result).toEqual({ ok: true, status: "set" });
+    expect(mockWriteAppSecret).toHaveBeenCalledWith({
+      key: "ORG_SHARED_TOKEN",
+      value: "shared",
+      scope: "org",
+      scopeId: "org-qa",
+    });
+  });
+
+  it("rejects org-scope secret writes from a plain member", async () => {
+    mockGetRequiredSecret.mockReturnValue({
+      key: "ORG_SHARED_TOKEN",
+      label: "Org shared token",
+      scope: "org",
+      kind: "api-key",
+    });
+    mockGetOrgContext.mockResolvedValue({
+      orgId: "org-qa",
+      email: "bob+qa@example.com",
+      role: "member",
+    });
+
+    const handler = createWriteSecretHandler();
+    const result = await handler(
+      event("/ORG_SHARED_TOKEN", "POST", { value: "shared" }),
+    );
+
+    expect(lastStatus).toBe(403);
+    expect(result).toEqual({
+      error: "Only organization owners and admins can set org-scoped secrets",
+    });
+    expect(mockWriteAppSecret).not.toHaveBeenCalled();
+  });
+
+  it("rejects org-scope secret writes when the user has no active org", async () => {
+    mockGetRequiredSecret.mockReturnValue({
+      key: "ORG_SHARED_TOKEN",
+      label: "Org shared token",
+      scope: "org",
+      kind: "api-key",
+    });
+    mockGetOrgContext.mockResolvedValue({
+      orgId: null,
+      email: "alice+qa@example.com",
+      role: null,
+    });
+
+    const handler = createWriteSecretHandler();
+    const result = await handler(
+      event("/ORG_SHARED_TOKEN", "POST", { value: "shared" }),
+    );
+
+    expect(lastStatus).toBe(401);
+    expect(result).toEqual({ error: "No active organization" });
+    expect(mockWriteAppSecret).not.toHaveBeenCalled();
+  });
+
+  it("rejects org-scope secret deletes from a plain member", async () => {
+    mockGetRequiredSecret.mockReturnValue({
+      key: "ORG_SHARED_TOKEN",
+      label: "Org shared token",
+      scope: "org",
+      kind: "api-key",
+    });
+    mockGetOrgContext.mockResolvedValue({
+      orgId: "org-qa",
+      email: "bob+qa@example.com",
+      role: "member",
+    });
+
+    const handler = createWriteSecretHandler();
+    const result = await handler(event("/ORG_SHARED_TOKEN", "DELETE"));
+
+    expect(lastStatus).toBe(403);
+    expect(result).toEqual({
+      error:
+        "Only organization owners and admins can delete org-scoped secrets",
+    });
+    expect(mockDeleteAppSecret).not.toHaveBeenCalled();
+  });
+
   it("normalizes ad-hoc URL allowlists to unique origins", async () => {
     const handler = createAdHocSecretHandler();
     const result = await handler(

--- a/packages/core/src/secrets/routes.ts
+++ b/packages/core/src/secrets/routes.ts
@@ -41,6 +41,21 @@ async function canMutateWorkspaceScope(
   if (!ctx?.orgId) return true;
   return ctx.role === "owner" || ctx.role === "admin";
 }
+
+/**
+ * Org-scoped secrets (`scope: "org"`) live alongside `workspace` scope but
+ * are stricter: they always require an active org and an owner/admin role.
+ * No solo fallback — if the caller has no org, an org-scoped write makes no
+ * sense and we refuse rather than write to an ambiguous row.
+ */
+async function canMutateOrgScope(
+  event: H3Event,
+  scopeId: string,
+): Promise<boolean> {
+  const ctx = await getOrgContext(event).catch(() => null);
+  if (!ctx?.orgId || ctx.orgId !== scopeId) return false;
+  return ctx.role === "owner" || ctx.role === "admin";
+}
 import { listOAuthAccountsByOwner } from "../oauth-tokens/store.js";
 import {
   listRequiredSecrets,
@@ -109,6 +124,13 @@ async function resolveScopeId(
       return { scopeId: null, reason: "Authentication required" };
     }
     return { scopeId: session.email };
+  }
+  if (scope === "org") {
+    // Org-scoped secrets require an active org — there's no solo fallback
+    // because an "org" key without an org would land in an ambiguous row.
+    const ctx = await getOrgContext(event).catch(() => null);
+    if (ctx?.orgId) return { scopeId: ctx.orgId };
+    return { scopeId: null, reason: "No active organization" };
   }
   // workspace
   const ctx = await getOrgContext(event).catch(() => null);
@@ -242,6 +264,12 @@ async function handleWrite(event: H3Event, secret: RegisteredSecret) {
         "Only organization owners and admins can set workspace-scoped secrets",
     };
   }
+  if (secret.scope === "org" && !(await canMutateOrgScope(event, scopeId))) {
+    setResponseStatus(event, 403);
+    return {
+      error: "Only organization owners and admins can set org-scoped secrets",
+    };
+  }
 
   // Run validator if registered — return the validator's error on failure.
   if (secret.validator) {
@@ -310,6 +338,13 @@ async function handleDelete(event: H3Event, secret: RegisteredSecret) {
     return {
       error:
         "Only organization owners and admins can delete workspace-scoped secrets",
+    };
+  }
+  if (secret.scope === "org" && !(await canMutateOrgScope(event, scopeId))) {
+    setResponseStatus(event, 403);
+    return {
+      error:
+        "Only organization owners and admins can delete org-scoped secrets",
     };
   }
   const removed = await deleteAppSecret({

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -446,7 +446,21 @@ export function createCoreRoutesPlugin(
           return envStatus;
         }
 
-        return runWithRequestContext({ userEmail }, async () => {
+        // Pass the user's active orgId so the status read can fall back
+        // to org-scoped credentials. Without it, an admin's org-scope
+        // OAuth result is invisible to every other org member's status
+        // poller and the UI would show "not connected" forever even
+        // though the chat actually resolves the org-shared credential.
+        let orgId: string | null = null;
+        try {
+          const { getOrgContext } = await import("../org/context.js");
+          const orgCtx = await getOrgContext(event);
+          orgId = orgCtx.orgId ?? null;
+        } catch {
+          /* org module not present in this template — keep userEmail-only */
+        }
+
+        return runWithRequestContext({ userEmail, orgId }, async () => {
           // Per-user OAuth mode: read the user's app_secrets-stored creds.
           try {
             const { resolveBuilderCredentials } =


### PR DESCRIPTION
## Summary

Three review-fed fixes against [#511](https://github.com/BuilderIO/agent-native/pull/511) (org-scoped Builder credentials + reconnect hardening). All three were flagged by the bot reviewer; replies on #511 explain the rationale for each (and skip rationale for the 3 nitpicks I didn't act on).

### 1. `/runs/active` returns terminal runs in the reconnect window
**Bug:** `getActiveRunForThreadAsync` returned in-memory completed runs (when their events were still buffered) but the SQL fallback only returned `status === 'running'`. On a different isolate, a completed run looked like "no active run", so the adapter would retry the original POST → re-execute the agent turn → double-apply mutations.

**Fix:** SQL fallback now surfaces `completed` and `errored` runs that started within `TERMINAL_RUN_RECONNECT_WINDOW_MS` (10 min). The adapter reconnects to its events stream and replays the synthesized done/error events that #511 added in `subscribeFromSQL`. Stale terminal runs older than the window are still rejected so reopening an old thread doesn't resurrect ancient turns.

### 2. `/builder/status` resolves org-shared credentials
**Bug:** Connect/disconnect handlers pass `orgId` into `runWithRequestContext()` (added in #511), but `/builder/status` did not. Result: an admin's org-scope OAuth result was invisible to every other org member's status poller, so the UI showed "not connected" even though `resolveBuilderCredentials` correctly fell back to the org row during chat calls.

**Fix:** `/builder/status` now reads `getOrgContext(event)` and includes `orgId` in `runWithRequestContext({ userEmail, orgId }, …)`. Wrapped in a try/catch so templates without the org module keep their previous user-only behaviour.

### 3. Org scope is first-class in registered-secret HTTP routes
**Bug:** `registerRequiredSecret()` accepts `scope: "org"` (added in #511) but the HTTP write/delete handlers only checked `canMutateWorkspaceScope` for workspace scope. A plain member could write or delete an org-shared registered secret as long as the secret declared `scope: "org"`.

**Fix:**
- `resolveScopeId` now treats `"org"` as a real scope: requires an active org, no `solo:` fallback (an "org" key without an org would land in an ambiguous row).
- New `canMutateOrgScope(event, scopeId)`: requires `getOrgContext(event)` to return an `orgId` matching the scopeId, and the role to be `owner` or `admin`.
- `handleWrite` and `handleDelete` enforce `canMutateOrgScope` for `secret.scope === "org"`, returning 403 otherwise.
- Ad-hoc routes (`POST /secrets/adhoc`) were already strictly normalized to `user` / `workspace` (line 549 of routes.ts) and remain unchanged.

## Test plan

- [x] `pnpm --filter @agent-native/core test` — 1206 tests pass (15 new)
- [x] `pnpm prep` — fmt/typecheck/test/guards all green
- [ ] CI green: lint / typecheck / test / scaffold E2E / guards / changeset-check
- [ ] Manual: connect Builder as org admin (one user) → second org member sees `connected: true` in `/builder/status`
- [ ] Manual: org member attempts to set an org-scope registered secret → 403 with the new error message