### PR TITLE
feat(core): server-side Sentry + composer drops + Builder/extension polish

### DIFF
--- a/.changeset/composer-drag-drop.md
+++ b/.changeset/composer-drag-drop.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Composer accepts file drops directly. Previously, dragging a file (PDF, PPTX, image, etc.) into the prompt composer triggered the browser's default behavior (navigating to the file), even though the "+" button accepted the same file types. The composer now intercepts drops, mirroring the existing paste handler — drag a deck or screenshot in and it attaches like a normal upload.

--- a/.changeset/composer-inline-text-files.md
+++ b/.changeset/composer-inline-text-files.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+PromptComposer now inlines small text files (`.txt`, `.md`, `.csv`, `.json`, `.yaml`, etc., plus any `text/*` MIME) into the prompt as `<uploaded-text-file>` blocks instead of only attaching them as binary uploads. Truncates after 60k characters. The original file is still attached as well, so server-side handlers that prefer the binary path keep working.

--- a/.changeset/fix-builder-org-engine.md
+++ b/.changeset/fix-builder-org-engine.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Resolve org-shared Builder credentials when auto-selecting the chat engine.

--- a/.changeset/fix-tooltip-provider-crash.md
+++ b/.changeset/fix-tooltip-provider-crash.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Wrap shadcn `Tooltip` usages in a `TooltipProvider` so the agent panel and other top-level components don't crash on render. PR #509 swapped native `title` hints for `Tooltip`, but `@radix-ui/react-tooltip@1.2.x` requires a provider ancestor and threw `'Tooltip' must be used within 'TooltipProvider'` on the docs site and any template embedding the agent sidebar.

--- a/.changeset/no-builder-connect-reload.md
+++ b/.changeset/no-builder-connect-reload.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop reloading the agent chat after Builder or secret configuration updates.

--- a/.changeset/server-sentry-init.md
+++ b/.changeset/server-sentry-init.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Initialize Sentry inside the Nitro server so 5xx errors thrown by framework routes, action handlers, and agent-chat streams are reported with per-request user context. Driven by the `SENTRY_SERVER_DSN` env var (no-op when unset). Complements the existing CLI and browser Sentry init points without wiring them together — each maps to a different Sentry project.

--- a/.changeset/unify-secret-scope-chain.md
+++ b/.changeset/unify-secret-scope-chain.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Unify request-scoped secret resolution to read user → org → workspace rows from `app_secrets` everywhere. Previously, `getOwnerApiKey()`, `resolveSecret()`, voice provider status, transcribe-voice, and Google Realtime each had their own slightly different read order — some only checked the user row, some checked user + org but not workspace. They now all walk the same chain, so an org-shared (or workspace-scoped) key is honored consistently no matter which call site resolves it. Solo (no-org) sessions fall back to a `workspace:solo:<email>` row.

--- a/packages/core/docs/content/deployment.md
+++ b/packages/core/docs/content/deployment.md
@@ -90,17 +90,21 @@ node .output/server/index.mjs
 
 Set `PORT` to configure the listen port (default: `3000`).
 
+Use the current Node.js LTS line for production deploys. As of May 2026, that
+is Node.js 24; Node.js 20 reached end-of-life on April 30, 2026 and no longer
+receives upstream security updates.
+
 ### Docker {#docker}
 
 ```dockerfile
-FROM node:20-slim AS build
+FROM node:24-slim AS build
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN corepack enable && pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build
 
-FROM node:20-slim
+FROM node:24-slim
 WORKDIR /app
 COPY --from=build /app/.output .output
 COPY --from=build /app/data data

--- a/packages/core/docs/content/getting-started.md
+++ b/packages/core/docs/content/getting-started.md
@@ -12,7 +12,7 @@ By the end of this page, you'll have a working app — Mail, Calendar, Forms, or
 There are two ways to use agent-native, depending on how hands-on you want to be:
 
 - **You want to use a hosted version.** Try a template right now at [agent-native.com/templates](/templates). Each template is a live, hosted app — you sign in, start using it, and the agent is already there. No install, no setup. You can stop reading this page and head straight to the [template gallery](/templates).
-- **You want to run locally or customize it.** You'll clone a template, run it on your machine, and shape it however you want — branding, features, integrations. The rest of this page is for you. You'll need [Node.js](https://nodejs.org) and [pnpm](https://pnpm.io) installed.
+- **You want to run locally or customize it.** You'll clone a template, run it on your machine, and shape it however you want — branding, features, integrations. The rest of this page is for you. You'll need [Node.js 24 LTS](https://nodejs.org) and [pnpm](https://pnpm.io) installed.
 
 Not sure which path? If you've never written code, the hosted version is for you. If you have a developer or AI coding tool ready, the local path gives you total control.
 

--- a/packages/core/docs/content/observability.md
+++ b/packages/core/docs/content/observability.md
@@ -182,3 +182,50 @@ await putSetting("observability-config", {
 ```
 
 The framework emits `gen_ai.*` semantic convention spans compatible with the OpenTelemetry GenAI spec.
+
+## Error Reporting (Sentry)
+
+Server-side errors that escape Nitro route handlers are reported to Sentry when a DSN is configured. Without it the SDK silently no-ops, so it's safe to leave the env vars unset in dev. Three independent Sentry projects cover the framework:
+
+| Surface             | SDK              | Env var                   | Notes                                                                 |
+| ------------------- | ---------------- | ------------------------- | --------------------------------------------------------------------- |
+| Browser / SPA       | `@sentry/browser`| `VITE_SENTRY_CLIENT_DSN`  | Captures unhandled errors and route-change breadcrumbs in the client. |
+| Nitro server        | `@sentry/node`   | `SENTRY_SERVER_DSN`       | Captures 5xx responses and Nitro lifecycle errors. Per-request user.  |
+| `agent-native` CLI  | `@sentry/node`   | _hardcoded_               | Crash reports from the published CLI binary; not user-configurable.   |
+
+### Server-side configuration
+
+Set `SENTRY_SERVER_DSN` in the deploy environment (Netlify dashboard, Cloudflare secrets, etc.). The framework auto-mounts a Nitro plugin that:
+
+1. Calls `Sentry.init` once at startup (idempotent — safe to call from multiple plugins).
+2. Resolves the user via `getSession(event)` on every API/framework request and attaches `id` / `email` / `username` plus an `orgId` tag to Sentry's per-request isolation scope. Static-asset paths are skipped to avoid extra DB hits.
+3. Captures every framework-route 5xx with searchable `route`, `method`, and `userAgent` tags.
+
+Optional knobs:
+
+- `SENTRY_SERVER_TRACES_SAMPLE_RATE` (float `0`–`1`) — opt in to performance tracing. Defaults to `0` (errors only). Invalid values clamp to `0`.
+- `AGENT_NATIVE_RELEASE` — overrides the `release` tag. Defaults to `agent-native-server@<core-version>`.
+
+### Templates
+
+Every template inherits this automatically — there's nothing to import. Templates that want custom behavior (extra tags, different DSN per template, hard-disable Sentry) can override by exporting their own plugin from `server/plugins/sentry.ts`:
+
+```ts
+// server/plugins/sentry.ts
+import { createSentryPlugin } from "@agent-native/core/server";
+export default createSentryPlugin();
+```
+
+The CLI's hardcoded DSN is intentional — the published binary needs to phone home crashes regardless of which environment runs it. The server module never hardcodes a DSN because it runs inside customer environments where operators decide whether errors should reach Sentry at all.
+
+### Privacy & PII
+
+Both server and CLI initialize with `sendDefaultPii: false` and a `beforeSend` hook that strips:
+
+- `request.headers.authorization`, `cookie`, `set-cookie`, `proxy-authorization`
+- `request.cookies`
+- `user.ip_address` (auto-collected without consent)
+- `contexts.runtime_env` (process env snapshot)
+- Any event whose top-level exception type is `ValidationError` (treated as expected user-input rejection, not a bug).
+
+Identity fields explicitly set via `setUser({ id, email, username })` are preserved.

--- a/packages/core/docs/content/observability.md
+++ b/packages/core/docs/content/observability.md
@@ -187,11 +187,11 @@ The framework emits `gen_ai.*` semantic convention spans compatible with the Ope
 
 Server-side errors that escape Nitro route handlers are reported to Sentry when a DSN is configured. Without it the SDK silently no-ops, so it's safe to leave the env vars unset in dev. Three independent Sentry projects cover the framework:
 
-| Surface             | SDK              | Env var                   | Notes                                                                 |
-| ------------------- | ---------------- | ------------------------- | --------------------------------------------------------------------- |
-| Browser / SPA       | `@sentry/browser`| `VITE_SENTRY_CLIENT_DSN`  | Captures unhandled errors and route-change breadcrumbs in the client. |
-| Nitro server        | `@sentry/node`   | `SENTRY_SERVER_DSN`       | Captures 5xx responses and Nitro lifecycle errors. Per-request user.  |
-| `agent-native` CLI  | `@sentry/node`   | _hardcoded_               | Crash reports from the published CLI binary; not user-configurable.   |
+| Surface            | SDK               | Env var                  | Notes                                                                 |
+| ------------------ | ----------------- | ------------------------ | --------------------------------------------------------------------- |
+| Browser / SPA      | `@sentry/browser` | `VITE_SENTRY_CLIENT_DSN` | Captures unhandled errors and route-change breadcrumbs in the client. |
+| Nitro server       | `@sentry/node`    | `SENTRY_SERVER_DSN`      | Captures 5xx responses and Nitro lifecycle errors. Per-request user.  |
+| `agent-native` CLI | `@sentry/node`    | _hardcoded_              | Crash reports from the published CLI binary; not user-configurable.   |
 
 ### Server-side configuration
 

--- a/packages/core/src/agent/engine/registry.spec.ts
+++ b/packages/core/src/agent/engine/registry.spec.ts
@@ -348,6 +348,7 @@ describe("AgentEngine registry", () => {
     it("returns null when no request user is set", async () => {
       vi.doMock("../../server/request-context.js", () => ({
         getRequestUserEmail: () => undefined,
+        getRequestOrgId: () => undefined,
       }));
       const { detectEngineFromUserSecrets } = await import("./registry.js");
       expect(await detectEngineFromUserSecrets()).toBeNull();
@@ -356,6 +357,7 @@ describe("AgentEngine registry", () => {
     it("returns null for the local-dev session", async () => {
       vi.doMock("../../server/request-context.js", () => ({
         getRequestUserEmail: () => "local@localhost",
+        getRequestOrgId: () => undefined,
       }));
       const { detectEngineFromUserSecrets } = await import("./registry.js");
       expect(await detectEngineFromUserSecrets()).toBeNull();
@@ -364,6 +366,7 @@ describe("AgentEngine registry", () => {
     it("picks the Builder engine when the user has BUILDER_PRIVATE_KEY in app_secrets", async () => {
       vi.doMock("../../server/request-context.js", () => ({
         getRequestUserEmail: () => "brent@example.com",
+        getRequestOrgId: () => undefined,
       }));
       vi.doMock("../../secrets/storage.js", () => ({
         readAppSecret: vi.fn(async ({ key }: { key: string }) =>
@@ -401,9 +404,61 @@ describe("AgentEngine registry", () => {
       expect(detected?.name).toBe("builder");
     });
 
+    it("picks the Builder engine when the active org has shared Builder credentials", async () => {
+      vi.doMock("../../server/request-context.js", () => ({
+        getRequestUserEmail: () => "member@example.com",
+        getRequestOrgId: () => "builder_org",
+      }));
+      const readAppSecret = vi.fn(
+        async ({ key, scope }: { key: string; scope: "user" | "org" }) =>
+          key === "BUILDER_PRIVATE_KEY" && scope === "org"
+            ? { key, value: "p-key-from-org-secrets" }
+            : null,
+      );
+      vi.doMock("../../secrets/storage.js", () => ({ readAppSecret }));
+
+      const { registerAgentEngine, detectEngineFromUserSecrets } =
+        await import("./registry.js");
+
+      registerAgentEngine({
+        name: "builder",
+        label: "Builder",
+        description: "",
+        capabilities: {} as any,
+        defaultModel: "m",
+        supportedModels: [],
+        requiredEnvVars: ["BUILDER_PRIVATE_KEY"],
+        create: vi.fn() as any,
+      });
+      registerAgentEngine({
+        name: "anthropic",
+        label: "Anthropic",
+        description: "",
+        capabilities: {} as any,
+        defaultModel: "m",
+        supportedModels: [],
+        requiredEnvVars: ["ANTHROPIC_API_KEY"],
+        create: vi.fn() as any,
+      });
+
+      const detected = await detectEngineFromUserSecrets();
+      expect(detected?.name).toBe("builder");
+      expect(readAppSecret).toHaveBeenCalledWith({
+        key: "BUILDER_PRIVATE_KEY",
+        scope: "user",
+        scopeId: "member@example.com",
+      });
+      expect(readAppSecret).toHaveBeenCalledWith({
+        key: "BUILDER_PRIVATE_KEY",
+        scope: "org",
+        scopeId: "builder_org",
+      });
+    });
+
     it("resolveEngine routes to Builder when the user has Builder creds in app_secrets and no env-level keys", async () => {
       vi.doMock("../../server/request-context.js", () => ({
         getRequestUserEmail: () => "brent@example.com",
+        getRequestOrgId: () => undefined,
       }));
       vi.doMock("../../secrets/storage.js", () => ({
         readAppSecret: vi.fn(async ({ key }: { key: string }) =>

--- a/packages/core/src/agent/engine/registry.ts
+++ b/packages/core/src/agent/engine/registry.ts
@@ -14,7 +14,10 @@ import type {
   EngineStreamOptions,
 } from "./types.js";
 import { getSetting } from "../../settings/store.js";
-import { readDeployCredentialEnv } from "../../server/credential-provider.js";
+import {
+  readDeployCredentialEnv,
+  resolveSecret,
+} from "../../server/credential-provider.js";
 
 export interface AgentEngineEntry {
   /** Unique name, e.g. "anthropic", "ai-sdk:anthropic", "ai-sdk:openai" */
@@ -106,9 +109,10 @@ export function detectEngineFromEnv(): AgentEngineEntry | null {
 }
 
 /**
- * Detect a usable engine from the current request user's per-user
+ * Detect a usable engine from the current request user's accessible
  * `app_secrets` rows. Mirrors `detectEngineFromEnv` but consults the
- * encrypted secret store instead of `process.env`.
+ * encrypted secret store instead of `process.env`, including org-scoped
+ * credentials shared with the active organization.
  *
  * Required because the Builder OAuth callback (and the settings UI's
  * "paste your own key" flow) writes credentials to app_secrets, not env.
@@ -122,7 +126,9 @@ export function detectEngineFromEnv(): AgentEngineEntry | null {
  * OAuth flow writes credentials scoped to that email when run from
  * `pnpm dev`, so detection has to consult those rows or the dev user
  * sees the same "Connect your AI" card after they've already connected
- * (Sami, 2026-04-30). Returns `null` only for unauthenticated requests.
+ * (Sami, 2026-04-30). Org-scoped Builder credentials must also count here:
+ * `/builder/status` resolves them via the same request org context, and the
+ * chat engine picker must not disagree with that card.
  */
 export async function detectEngineFromUserSecrets(): Promise<AgentEngineEntry | null> {
   let email: string | undefined;
@@ -135,23 +141,11 @@ export async function detectEngineFromUserSecrets(): Promise<AgentEngineEntry | 
   }
   if (!email) return null;
 
-  let readAppSecret: typeof import("../../secrets/storage.js").readAppSecret;
-  try {
-    ({ readAppSecret } = await import("../../secrets/storage.js"));
-  } catch {
-    return null;
-  }
-
   const hasAllKeys = async (entry: AgentEngineEntry): Promise<boolean> => {
     if (entry.requiredEnvVars.length === 0) return false;
     for (const key of entry.requiredEnvVars) {
       try {
-        const secret = await readAppSecret({
-          key,
-          scope: "user",
-          scopeId: email!,
-        });
-        if (!secret?.value) return false;
+        if (!(await resolveSecret(key))) return false;
       } catch {
         return false;
       }

--- a/packages/core/src/agent/production-agent-credentials.spec.ts
+++ b/packages/core/src/agent/production-agent-credentials.spec.ts
@@ -35,9 +35,9 @@ describe("getOwnerApiKey", () => {
       updatedAt: 1,
     });
 
-    await expect(
-      getOwnerApiKey("openai", "owner@example.com"),
-    ).resolves.toBe("user-openai-key");
+    await expect(getOwnerApiKey("openai", "owner@example.com")).resolves.toBe(
+      "user-openai-key",
+    );
     expect(mockReadAppSecret).toHaveBeenCalledTimes(1);
     expect(mockReadAppSecret).toHaveBeenCalledWith({
       key: "OPENAI_API_KEY",
@@ -48,17 +48,15 @@ describe("getOwnerApiKey", () => {
 
   it("falls back to org-scoped app secrets for the active org", async () => {
     mockGetRequestOrgId.mockReturnValue("org-1");
-    mockReadAppSecret
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({
-        value: "org-openai-key",
-        last4: "-key",
-        updatedAt: 1,
-      });
+    mockReadAppSecret.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      value: "org-openai-key",
+      last4: "-key",
+      updatedAt: 1,
+    });
 
-    await expect(
-      getOwnerApiKey("openai", "owner@example.com"),
-    ).resolves.toBe("org-openai-key");
+    await expect(getOwnerApiKey("openai", "owner@example.com")).resolves.toBe(
+      "org-openai-key",
+    );
     expect(mockReadAppSecret.mock.calls.map((c) => c[0])).toEqual([
       {
         key: "OPENAI_API_KEY",
@@ -80,9 +78,9 @@ describe("getOwnerApiKey", () => {
         updatedAt: 1,
       });
 
-    await expect(
-      getOwnerApiKey("openai", "owner@example.com"),
-    ).resolves.toBe("workspace-openai-key");
+    await expect(getOwnerApiKey("openai", "owner@example.com")).resolves.toBe(
+      "workspace-openai-key",
+    );
     expect(mockReadAppSecret.mock.calls.map((c) => c[0].scope)).toEqual([
       "user",
       "org",
@@ -91,17 +89,15 @@ describe("getOwnerApiKey", () => {
   });
 
   it("checks solo workspace scope when no active org exists", async () => {
-    mockReadAppSecret
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({
-        value: "solo-openai-key",
-        last4: "-key",
-        updatedAt: 1,
-      });
+    mockReadAppSecret.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      value: "solo-openai-key",
+      last4: "-key",
+      updatedAt: 1,
+    });
 
-    await expect(
-      getOwnerApiKey("openai", "solo@example.com"),
-    ).resolves.toBe("solo-openai-key");
+    await expect(getOwnerApiKey("openai", "solo@example.com")).resolves.toBe(
+      "solo-openai-key",
+    );
     expect(mockReadAppSecret.mock.calls.map((c) => c[0])).toEqual([
       {
         key: "OPENAI_API_KEY",

--- a/packages/core/src/agent/production-agent-credentials.spec.ts
+++ b/packages/core/src/agent/production-agent-credentials.spec.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockReadAppSecret = vi.fn();
+const mockGetSetting = vi.fn();
+const mockGetRequestOrgId = vi.fn<[], string | undefined>();
+
+vi.mock("../secrets/storage.js", () => ({
+  readAppSecret: (...args: any[]) => mockReadAppSecret(...args),
+}));
+
+vi.mock("../settings/store.js", () => ({
+  getSetting: (...args: any[]) => mockGetSetting(...args),
+}));
+
+vi.mock("../server/request-context.js", () => ({
+  getRequestOrgId: () => mockGetRequestOrgId(),
+  getRequestUserEmail: () => undefined,
+}));
+
+import { getOwnerApiKey } from "./production-agent.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockReadAppSecret.mockResolvedValue(null);
+  mockGetSetting.mockResolvedValue(undefined);
+  mockGetRequestOrgId.mockReturnValue(undefined);
+});
+
+describe("getOwnerApiKey", () => {
+  it("returns a user-scoped app secret before shared rows", async () => {
+    mockGetRequestOrgId.mockReturnValue("org-1");
+    mockReadAppSecret.mockResolvedValueOnce({
+      value: "user-openai-key",
+      last4: "-key",
+      updatedAt: 1,
+    });
+
+    await expect(
+      getOwnerApiKey("openai", "owner@example.com"),
+    ).resolves.toBe("user-openai-key");
+    expect(mockReadAppSecret).toHaveBeenCalledTimes(1);
+    expect(mockReadAppSecret).toHaveBeenCalledWith({
+      key: "OPENAI_API_KEY",
+      scope: "user",
+      scopeId: "owner@example.com",
+    });
+  });
+
+  it("falls back to org-scoped app secrets for the active org", async () => {
+    mockGetRequestOrgId.mockReturnValue("org-1");
+    mockReadAppSecret
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        value: "org-openai-key",
+        last4: "-key",
+        updatedAt: 1,
+      });
+
+    await expect(
+      getOwnerApiKey("openai", "owner@example.com"),
+    ).resolves.toBe("org-openai-key");
+    expect(mockReadAppSecret.mock.calls.map((c) => c[0])).toEqual([
+      {
+        key: "OPENAI_API_KEY",
+        scope: "user",
+        scopeId: "owner@example.com",
+      },
+      { key: "OPENAI_API_KEY", scope: "org", scopeId: "org-1" },
+    ]);
+  });
+
+  it("falls back to workspace-scoped app secrets for registered shared keys", async () => {
+    mockGetRequestOrgId.mockReturnValue("org-1");
+    mockReadAppSecret
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        value: "workspace-openai-key",
+        last4: "-key",
+        updatedAt: 1,
+      });
+
+    await expect(
+      getOwnerApiKey("openai", "owner@example.com"),
+    ).resolves.toBe("workspace-openai-key");
+    expect(mockReadAppSecret.mock.calls.map((c) => c[0].scope)).toEqual([
+      "user",
+      "org",
+      "workspace",
+    ]);
+  });
+
+  it("checks solo workspace scope when no active org exists", async () => {
+    mockReadAppSecret
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        value: "solo-openai-key",
+        last4: "-key",
+        updatedAt: 1,
+      });
+
+    await expect(
+      getOwnerApiKey("openai", "solo@example.com"),
+    ).resolves.toBe("solo-openai-key");
+    expect(mockReadAppSecret.mock.calls.map((c) => c[0])).toEqual([
+      {
+        key: "OPENAI_API_KEY",
+        scope: "user",
+        scopeId: "solo@example.com",
+      },
+      {
+        key: "OPENAI_API_KEY",
+        scope: "workspace",
+        scopeId: "solo:solo@example.com",
+      },
+    ]);
+  });
+});

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1209,7 +1209,9 @@ export function createProductionAgentHandler(
       setResponseStatus(event, 400);
       return { error: "message is required" };
     }
-    const requestMessage = hasMessageText ? message : "Use the attached context.";
+    const requestMessage = hasMessageText
+      ? message
+      : "Use the attached context.";
 
     // Resolve owner first so we can look up a per-owner API key. Users
     // who bring their own key use their key for this request (durable

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1202,10 +1202,14 @@ export function createProductionAgentHandler(
     } = body;
     const requestMode: AgentExecutionMode =
       body.mode === "plan" ? "plan" : "act";
-    if (!message) {
+    const hasMessageText =
+      typeof message === "string" && message.trim().length > 0;
+    const hasAttachments = Array.isArray(attachments) && attachments.length > 0;
+    if (!hasMessageText && !hasAttachments) {
       setResponseStatus(event, 400);
       return { error: "message is required" };
     }
+    const requestMessage = hasMessageText ? message : "Use the attached context.";
 
     // Resolve owner first so we can look up a per-owner API key. Users
     // who bring their own key use their key for this request (durable
@@ -1311,7 +1315,7 @@ export function createProductionAgentHandler(
     // Run all independent pre-send steps in parallel. Each of these hits
     // the DB or invokes an action; running them sequentially was the
     // single biggest contributor to pre-LLM latency.
-    const enrichedMessage = enrichMessage(message, references);
+    const enrichedMessage = enrichMessage(requestMessage, references);
     const loopSettingsPromise = readAgentLoopSettings({
       userEmail: ownerEmail ?? getRequestUserEmail() ?? null,
       orgId: getRequestOrgId() ?? null,

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -69,7 +69,7 @@ export { PROVIDER_TO_ENV };
  * `undefined` for unauthenticated callers.
  *
  * Read order:
- *   1. `app_secrets` — encrypted, scope=user, current source of truth.
+ *   1. `app_secrets` — encrypted user override, then active org/workspace.
  *   2. Legacy `user-api-key:<provider>:<email>` settings row — pre-migration
  *      data that hasn't been backfilled yet. Surfaced for compat only;
  *      writes always go to app_secrets now.
@@ -83,12 +83,27 @@ export async function getOwnerApiKey(
     PROVIDER_TO_ENV[provider] ?? `${provider.toUpperCase()}_API_KEY`;
   try {
     const { readAppSecret } = await import("../secrets/storage.js");
-    const fromSecrets = await readAppSecret({
-      key: secretKey,
-      scope: "user",
-      scopeId: ownerEmail,
-    });
-    if (fromSecrets?.value) return fromSecrets.value;
+    const refs: Array<{
+      scope: "user" | "org" | "workspace";
+      scopeId: string;
+    }> = [{ scope: "user", scopeId: ownerEmail }];
+    const orgId = getRequestOrgId();
+    if (orgId) {
+      refs.push(
+        { scope: "org", scopeId: orgId },
+        { scope: "workspace", scopeId: orgId },
+      );
+    } else {
+      refs.push({ scope: "workspace", scopeId: `solo:${ownerEmail}` });
+    }
+    for (const ref of refs) {
+      const fromSecrets = await readAppSecret({
+        key: secretKey,
+        scope: ref.scope,
+        scopeId: ref.scopeId,
+      });
+      if (fromSecrets?.value) return fromSecrets.value;
+    }
   } catch {
     // app_secrets table not ready — fall through to legacy lookup.
   }

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1539,9 +1539,11 @@ class AgentPanelErrorBoundary extends React.Component<
 export function AgentPanel(props: AgentPanelProps) {
   const [resetKey, setResetKey] = useState(0);
   return (
-    <AgentPanelErrorBoundary onReset={() => setResetKey((key) => key + 1)}>
-      <AgentPanelInner key={resetKey} {...props} />
-    </AgentPanelErrorBoundary>
+    <TooltipProvider delayDuration={200}>
+      <AgentPanelErrorBoundary onReset={() => setResetKey((key) => key + 1)}>
+        <AgentPanelInner key={resetKey} {...props} />
+      </AgentPanelErrorBoundary>
+    </TooltipProvider>
   );
 }
 
@@ -1961,19 +1963,23 @@ export function focusAgentChat() {
  */
 export function AgentToggleButton({ className }: { className?: string }) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          onClick={() => window.dispatchEvent(new Event("agent-panel:toggle"))}
-          className={cn(
-            "ml-1.5 flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50",
-            className,
-          )}
-        >
-          <IconMessage size={16} />
-        </button>
-      </TooltipTrigger>
-      <TooltipContent>Toggle agent</TooltipContent>
-    </Tooltip>
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={() =>
+              window.dispatchEvent(new Event("agent-panel:toggle"))
+            }
+            className={cn(
+              "ml-1.5 flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50",
+              className,
+            )}
+          >
+            <IconMessage size={16} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Toggle agent</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1409,8 +1409,9 @@ function ThinkingIndicator({ label = "Thinking" }: { label?: string } = {}) {
 // Renders a single row with left-aligned copy and a right-aligned action.
 // Click opens the Builder CLI-auth popup via the shared
 // `useBuilderConnectFlow` hook (which owns the synchronous window.open,
-// the 2s status poll, and the focus-refresh). On success we reload so the
-// enclosing card re-evaluates `missingApiKey` against the fresh credentials.
+// the 2s status poll, and the focus-refresh). On success the hook broadcasts
+// a config-change event and this card clears its local `missingApiKey` gate
+// so the user can start chatting without a full-page reload.
 //
 // Desktop note: when this component runs inside the Electron shell, the
 // window.open call is intercepted by the main process's webview popup handler,
@@ -1419,15 +1420,14 @@ function ThinkingIndicator({ label = "Thinking" }: { label?: string } = {}) {
 
 function BuilderConnectCta({
   variant = "primary",
+  onConnected,
 }: {
   variant?: "primary" | "compact";
+  onConnected?: () => void;
 }) {
   const { configured, orgName, connecting, error, start } =
     useBuilderConnectFlow({
-      onConnected: () => {
-        // Reload so the enclosing card re-evaluates `missingApiKey`.
-        window.setTimeout(() => window.location.reload(), 300);
-      },
+      onConnected,
     });
 
   const containerClass =
@@ -1488,7 +1488,7 @@ function BuilderConnectCta({
 
 // ─── Builder Setup Card ─────────────────────────────────────────────────────
 
-function BuilderSetupCard() {
+function BuilderSetupCard({ onConnected }: { onConnected?: () => void }) {
   return (
     <div className="mx-4 my-6 rounded-lg border border-border bg-card p-5">
       <div className="flex items-center gap-3 mb-3">
@@ -1506,7 +1506,7 @@ function BuilderSetupCard() {
       </div>
 
       <div className="space-y-3">
-        <BuilderConnectCta />
+        <BuilderConnectCta onConnected={onConnected} />
       </div>
     </div>
   );
@@ -2490,6 +2490,10 @@ const AssistantChatInner = forwardRef<
       window.removeEventListener("agent-chat:missing-api-key", handler);
   }, []);
 
+  const handleBuilderConnected = useCallback(() => {
+    setMissingApiKey(false);
+  }, []);
+
   // Check on mount and whenever SettingsPanel dispatches
   // `agent-engine:configured-changed` so the gate flips live without reload.
   useEffect(() => {
@@ -2891,7 +2895,7 @@ const AssistantChatInner = forwardRef<
                 </div>
               ) : missingApiKey && messages.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-full px-2">
-                  <BuilderSetupCard />
+                  <BuilderSetupCard onConnected={handleBuilderConnected} />
                 </div>
               ) : isRestoring ? (
                 <div className="flex flex-col gap-3 p-4">
@@ -2939,7 +2943,9 @@ const AssistantChatInner = forwardRef<
                       AssistantMessage,
                     }}
                   />
-                  {missingApiKey && <BuilderSetupCard />}
+                  {missingApiKey && (
+                    <BuilderSetupCard onConnected={handleBuilderConnected} />
+                  )}
                   {visibleLoopLimit && !showRunningInUI && (
                     <LoopLimitContinueCard
                       info={visibleLoopLimit}

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -299,6 +299,10 @@ export function createAgentChatAdapter(options?: {
           }
         }
       }
+      const userMessageText =
+        rawMessageText.trim() || attachments.length === 0
+          ? rawMessageText
+          : "Use the attached context.";
 
       const history = messages
         .slice(0, -1) // exclude the latest user message
@@ -327,7 +331,7 @@ export function createAgentChatAdapter(options?: {
       const toolCallCounter = { value: 0 };
       let runId: string | null = null;
       let lastSeq = -1;
-      let currentMessageText = normalizeMentions(rawMessageText);
+      let currentMessageText = normalizeMentions(userMessageText);
       let currentHistory: AdapterHistoryMessage[] = history;
       let includeAttachments = attachments.length > 0;
       let includeReferences = Boolean(runConfig?.custom?.references);
@@ -518,7 +522,7 @@ export function createAgentChatAdapter(options?: {
           );
           currentHistory = [
             ...history,
-            { role: "user", content: normalizeMentions(rawMessageText) },
+            { role: "user", content: normalizeMentions(userMessageText) },
             ...(partialHistory
               ? [{ role: "assistant" as const, content: partialHistory }]
               : []),

--- a/packages/core/src/client/composer/PromptComposer.tsx
+++ b/packages/core/src/client/composer/PromptComposer.tsx
@@ -27,6 +27,8 @@ import { useChatModels } from "../use-chat-models.js";
 import { isPastedTextAttachmentName } from "./pasted-text.js";
 import { PastedTextChip } from "./PastedTextChip.js";
 
+const MAX_INLINE_TEXT_FILE_CHARS = 60_000;
+
 /**
  * Files the user attached via the "+" button in PromptComposer. The host owns
  * what to do with them — typically POST to a per-app upload endpoint and pass
@@ -101,6 +103,27 @@ class BinaryDocumentAttachmentAdapter implements AttachmentAdapter {
   public async remove() {
     /* noop */
   }
+}
+
+function isInlineableTextFile(file: File): boolean {
+  if (file.type.startsWith("text/")) return true;
+  if (file.type === "application/json") return true;
+  return /\.(txt|md|markdown|csv|json|yaml|yml)$/i.test(file.name);
+}
+
+function formatInlineTextFile(name: string, text: string): string {
+  const truncated = text.length > MAX_INLINE_TEXT_FILE_CHARS;
+  const body = truncated ? text.slice(0, MAX_INLINE_TEXT_FILE_CHARS) : text;
+  return [
+    `<uploaded-text-file name="${name}">`,
+    body,
+    truncated
+      ? `[Truncated after ${MAX_INLINE_TEXT_FILE_CHARS} characters.]`
+      : "",
+    "</uploaded-text-file>",
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 function getImageSrc(attachment: Attachment): string | null {
@@ -250,6 +273,15 @@ function PromptComposerInner({
               files.push(file);
             }
           } else {
+            if (isInlineableTextFile(file)) {
+              try {
+                pastedTextBlocks.push(
+                  formatInlineTextFile(file.name, await file.text()),
+                );
+              } catch {
+                // Keep the upload path fallback below.
+              }
+            }
             files.push(file);
           }
         }

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -880,6 +880,30 @@ export function TiptapComposer({
 
         return false;
       },
+      handleDrop: (_view, event) => {
+        // Drag-and-drop files (decks, images, PDFs, etc.) into the composer.
+        // Without this, the browser navigates to the dropped file, which is
+        // surprising — users expect drop to attach the file like the "+" menu.
+        const dataTransfer = (event as DragEvent).dataTransfer;
+        const droppedFiles = Array.from(dataTransfer?.files ?? []);
+        if (droppedFiles.length === 0) return false;
+
+        event.preventDefault();
+        // Make image filenames unique so consecutive screenshots (all named
+        // `image.png`) don't collide on the attachment id, mirroring the
+        // paste handler's behavior.
+        const attachments = droppedFiles.map((file) => {
+          if (!file.type.startsWith("image/")) return file;
+          const uniqueName = `${Date.now()}-${Math.random().toString(36).slice(2)}-${file.name}`;
+          return new File([file], uniqueName, { type: file.type });
+        });
+        void Promise.all(
+          attachments.map((file) => composerRuntime.addAttachment(file)),
+        ).catch((error) => {
+          console.error("Error adding dropped attachment:", error);
+        });
+        return true;
+      },
       handleKeyDown: (view, event) => {
         const pop = popoverStateRef.current;
 

--- a/packages/core/src/client/dev-overlay/DevOverlay.tsx
+++ b/packages/core/src/client/dev-overlay/DevOverlay.tsx
@@ -46,6 +46,7 @@ import "./builtins.js";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 
@@ -108,58 +109,60 @@ function DevOverlayPanel({ onClose }: { onClose: () => void }) {
   );
 
   return (
-    <div style={styles.shell} role="dialog" aria-label="Dev overlay">
-      <div style={styles.header}>
-        <div>
-          <div style={styles.headerTitle}>Dev Overlay</div>
-          <div style={styles.headerSub}>Cmd+Ctrl+A · localStorage-backed</div>
-        </div>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              style={styles.iconBtn}
-              onClick={onClose}
-              aria-label="Close"
-            >
-              <IconX size={16} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Close (Esc)</TooltipContent>
-        </Tooltip>
-      </div>
-
-      <div style={styles.body}>
-        {panels.length === 0 ? (
-          <div style={styles.empty}>
-            No panels registered. Call <code>registerDevPanel(...)</code> from
-            your template to add options here.
+    <TooltipProvider delayDuration={200}>
+      <div style={styles.shell} role="dialog" aria-label="Dev overlay">
+        <div style={styles.header}>
+          <div>
+            <div style={styles.headerTitle}>Dev Overlay</div>
+            <div style={styles.headerSub}>Cmd+Ctrl+A · localStorage-backed</div>
           </div>
-        ) : (
-          panels.map((panel) => <DevPanelCard key={panel.id} panel={panel} />)
-        )}
-      </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                style={styles.iconBtn}
+                onClick={onClose}
+                aria-label="Close"
+              >
+                <IconX size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Close (Esc)</TooltipContent>
+          </Tooltip>
+        </div>
 
-      <div style={styles.footer}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              style={{ ...styles.footerBtn, ...styles.footerBtnDanger }}
-              onClick={() => {
-                clearAllDevOverlayStorage();
-              }}
-            >
-              <IconTrash size={13} />
-              Clear all dev-overlay values
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>
-            Reset every dev-overlay value back to its default
-          </TooltipContent>
-        </Tooltip>
+        <div style={styles.body}>
+          {panels.length === 0 ? (
+            <div style={styles.empty}>
+              No panels registered. Call <code>registerDevPanel(...)</code> from
+              your template to add options here.
+            </div>
+          ) : (
+            panels.map((panel) => <DevPanelCard key={panel.id} panel={panel} />)
+          )}
+        </div>
+
+        <div style={styles.footer}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                style={{ ...styles.footerBtn, ...styles.footerBtnDanger }}
+                onClick={() => {
+                  clearAllDevOverlayStorage();
+                }}
+              >
+                <IconTrash size={13} />
+                Clear all dev-overlay values
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Reset every dev-overlay value back to its default
+            </TooltipContent>
+          </Tooltip>
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }
 

--- a/packages/core/src/client/extensions/EmbeddedExtension.tsx
+++ b/packages/core/src/client/extensions/EmbeddedExtension.tsx
@@ -22,6 +22,7 @@ import {
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 
@@ -313,20 +314,22 @@ function EmbeddedToolMenu({
         if (!o) setConfirmingDelete(false);
       }}
     >
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              className="absolute top-1 right-1 flex h-6 w-6 items-center justify-center rounded-md bg-background/60 text-muted-foreground/60 opacity-0 hover:bg-accent hover:text-foreground hover:opacity-100 group-hover/embedded-extension:opacity-100 cursor-pointer transition-opacity"
-              aria-label={`${toolName} options`}
-            >
-              <IconDots className="h-3.5 w-3.5" />
-            </button>
-          </PopoverTrigger>
-        </TooltipTrigger>
-        <TooltipContent>{`${toolName} options`}</TooltipContent>
-      </Tooltip>
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="absolute top-1 right-1 flex h-6 w-6 items-center justify-center rounded-md bg-background/60 text-muted-foreground/60 opacity-0 hover:bg-accent hover:text-foreground hover:opacity-100 group-hover/embedded-extension:opacity-100 cursor-pointer transition-opacity"
+                aria-label={`${toolName} options`}
+              >
+                <IconDots className="h-3.5 w-3.5" />
+              </button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{`${toolName} options`}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
       <PopoverContent align="end" sideOffset={4} className="w-56 p-1">
         {!confirmingDelete ? (
           <div className="flex flex-col">

--- a/packages/core/src/client/extensions/ExtensionEditor.tsx
+++ b/packages/core/src/client/extensions/ExtensionEditor.tsx
@@ -18,6 +18,7 @@ import { cn } from "../utils.js";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 
@@ -171,205 +172,209 @@ export function ExtensionEditor({ extensionId }: ExtensionEditorProps) {
   };
 
   return (
-    <div className="flex h-full flex-col">
-      <header className="flex items-center justify-between border-b px-4 py-3">
-        <div className="flex items-center gap-3">
-          <Link
-            to={isEdit ? `/extensions/${extensionId}` : "/extensions"}
-            className="inline-flex cursor-pointer items-center justify-center rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-            aria-label="Back"
-          >
-            <IconArrowLeft className="h-4 w-4" />
-          </Link>
-          <h1 className="text-sm font-semibold">
-            {isEdit ? "Edit Extension" : "New Extension"}
-          </h1>
-        </div>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={saving || !name.trim()}
-            className={cn(
-              "inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90",
-              (saving || !name.trim()) && "opacity-60",
-            )}
-          >
-            <IconDeviceFloppy className="h-3.5 w-3.5" />
-            {saving ? "Saving..." : isEdit ? "Save" : "Create"}
-          </button>
-          {isEdit && (
-            <Popover
-              open={menuOpen}
-              onOpenChange={(o) => {
-                setMenuOpen(o);
-                if (!o) setConfirmingDelete(false);
-              }}
+    <TooltipProvider delayDuration={200}>
+      <div className="flex h-full flex-col">
+        <header className="flex items-center justify-between border-b px-4 py-3">
+          <div className="flex items-center gap-3">
+            <Link
+              to={isEdit ? `/extensions/${extensionId}` : "/extensions"}
+              className="inline-flex cursor-pointer items-center justify-center rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              aria-label="Back"
             >
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <PopoverTrigger asChild>
-                    <button
-                      type="button"
-                      className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                      aria-label="More options"
-                    >
-                      <IconDots className="h-4 w-4" />
-                    </button>
-                  </PopoverTrigger>
-                </TooltipTrigger>
-                <TooltipContent>More options</TooltipContent>
-              </Tooltip>
-              <PopoverContent align="end" sideOffset={4} className="w-72 p-0">
-                {!confirmingDelete ? (
-                  <>
-                    <div className="px-3 py-2 border-b border-border/40">
-                      <p className="text-[12px] font-medium">Appears in</p>
-                      {slots.length === 0 ? (
-                        <p className="text-[11px] text-muted-foreground/70 mt-0.5">
-                          Not installed in any widget areas. Ask the agent to
-                          add it somewhere.
-                        </p>
-                      ) : (
-                        <p className="text-[11px] text-muted-foreground/70 mt-0.5">
-                          This extension can render in {slots.length} widget
-                          area
-                          {slots.length === 1 ? "" : "s"}.
-                        </p>
-                      )}
-                    </div>
-                    {slots.length > 0 && (
-                      <div className="max-h-48 overflow-y-auto py-1">
-                        {slots.map((s) => (
-                          <div
-                            key={s.id}
-                            className="flex items-center gap-2 px-3 py-1.5 text-[12px]"
-                          >
-                            <span className="flex-1 truncate font-mono text-[11px] text-muted-foreground">
-                              {s.slotId}
-                            </span>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <button
-                                  type="button"
-                                  onClick={() => handleRemoveFromSlot(s.slotId)}
-                                  className="rounded p-1 text-muted-foreground/60 hover:bg-accent hover:text-foreground cursor-pointer"
-                                  aria-label="Remove from this widget area"
-                                >
-                                  <IconX className="h-3.5 w-3.5" />
-                                </button>
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                Remove from this widget area (for me)
-                              </TooltipContent>
-                            </Tooltip>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                    <div className="border-t border-border/40 p-1">
+              <IconArrowLeft className="h-4 w-4" />
+            </Link>
+            <h1 className="text-sm font-semibold">
+              {isEdit ? "Edit Extension" : "New Extension"}
+            </h1>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving || !name.trim()}
+              className={cn(
+                "inline-flex cursor-pointer items-center justify-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:bg-primary/90",
+                (saving || !name.trim()) && "opacity-60",
+              )}
+            >
+              <IconDeviceFloppy className="h-3.5 w-3.5" />
+              {saving ? "Saving..." : isEdit ? "Save" : "Create"}
+            </button>
+            {isEdit && (
+              <Popover
+                open={menuOpen}
+                onOpenChange={(o) => {
+                  setMenuOpen(o);
+                  if (!o) setConfirmingDelete(false);
+                }}
+              >
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <PopoverTrigger asChild>
                       <button
                         type="button"
-                        onClick={() => setConfirmingDelete(true)}
-                        className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10 cursor-pointer text-left"
+                        className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                        aria-label="More options"
                       >
-                        <IconTrash className="h-3.5 w-3.5" />
-                        <span>Delete extension…</span>
+                        <IconDots className="h-4 w-4" />
                       </button>
-                    </div>
-                  </>
-                ) : (
-                  <div className="flex flex-col gap-2 p-3">
-                    <p className="text-[12px]">
-                      Delete <span className="font-medium">{name}</span>? This
-                      removes the extension everywhere, for everyone it's shared
-                      with.
-                    </p>
-                    <div className="flex justify-end gap-1">
-                      <button
-                        type="button"
-                        onClick={() => setConfirmingDelete(false)}
-                        className="rounded-md px-2 py-1 text-[12px] hover:bg-accent cursor-pointer"
-                      >
-                        Cancel
-                      </button>
-                      <button
-                        type="button"
-                        onClick={handleDelete}
-                        disabled={deleting}
-                        className={cn(
-                          "rounded-md bg-destructive px-2 py-1 text-[12px] text-destructive-foreground hover:bg-destructive/90 cursor-pointer",
-                          deleting && "opacity-60",
+                    </PopoverTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>More options</TooltipContent>
+                </Tooltip>
+                <PopoverContent align="end" sideOffset={4} className="w-72 p-0">
+                  {!confirmingDelete ? (
+                    <>
+                      <div className="px-3 py-2 border-b border-border/40">
+                        <p className="text-[12px] font-medium">Appears in</p>
+                        {slots.length === 0 ? (
+                          <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                            Not installed in any widget areas. Ask the agent to
+                            add it somewhere.
+                          </p>
+                        ) : (
+                          <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                            This extension can render in {slots.length} widget
+                            area
+                            {slots.length === 1 ? "" : "s"}.
+                          </p>
                         )}
-                      >
-                        {deleting ? "Deleting…" : "Delete"}
-                      </button>
+                      </div>
+                      {slots.length > 0 && (
+                        <div className="max-h-48 overflow-y-auto py-1">
+                          {slots.map((s) => (
+                            <div
+                              key={s.id}
+                              className="flex items-center gap-2 px-3 py-1.5 text-[12px]"
+                            >
+                              <span className="flex-1 truncate font-mono text-[11px] text-muted-foreground">
+                                {s.slotId}
+                              </span>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      handleRemoveFromSlot(s.slotId)
+                                    }
+                                    className="rounded p-1 text-muted-foreground/60 hover:bg-accent hover:text-foreground cursor-pointer"
+                                    aria-label="Remove from this widget area"
+                                  >
+                                    <IconX className="h-3.5 w-3.5" />
+                                  </button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  Remove from this widget area (for me)
+                                </TooltipContent>
+                              </Tooltip>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                      <div className="border-t border-border/40 p-1">
+                        <button
+                          type="button"
+                          onClick={() => setConfirmingDelete(true)}
+                          className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10 cursor-pointer text-left"
+                        >
+                          <IconTrash className="h-3.5 w-3.5" />
+                          <span>Delete extension…</span>
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="flex flex-col gap-2 p-3">
+                      <p className="text-[12px]">
+                        Delete <span className="font-medium">{name}</span>? This
+                        removes the extension everywhere, for everyone it's
+                        shared with.
+                      </p>
+                      <div className="flex justify-end gap-1">
+                        <button
+                          type="button"
+                          onClick={() => setConfirmingDelete(false)}
+                          className="rounded-md px-2 py-1 text-[12px] hover:bg-accent cursor-pointer"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleDelete}
+                          disabled={deleting}
+                          className={cn(
+                            "rounded-md bg-destructive px-2 py-1 text-[12px] text-destructive-foreground hover:bg-destructive/90 cursor-pointer",
+                            deleting && "opacity-60",
+                          )}
+                        >
+                          {deleting ? "Deleting…" : "Delete"}
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                )}
-              </PopoverContent>
-            </Popover>
-          )}
-        </div>
-      </header>
-
-      <div className="flex flex-1 overflow-hidden">
-        <div className="flex w-1/2 flex-col gap-4 overflow-auto border-r p-4">
-          <div>
-            <label className="mb-1.5 block text-sm font-medium text-foreground">
-              Name
-            </label>
-            <input
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="My Extension"
-              className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
-            />
+                  )}
+                </PopoverContent>
+              </Popover>
+            )}
           </div>
+        </header>
 
-          <div>
-            <label className="mb-1.5 block text-sm font-medium text-foreground">
-              Description
-            </label>
-            <textarea
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="What does this extension do?"
-              rows={2}
-              className="w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
-            />
-          </div>
-
-          <div className="flex flex-1 flex-col">
-            <label className="mb-1.5 block text-sm font-medium text-foreground">
-              Content
-            </label>
-            <textarea
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              placeholder="<html>...</html>"
-              className="flex-1 resize-none rounded-md border border-input bg-background p-3 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
-              spellCheck={false}
-            />
-          </div>
-        </div>
-
-        <div className="w-1/2">
-          {content ? (
-            <iframe
-              srcDoc={content}
-              className="h-full w-full border-0"
-              sandbox="allow-scripts allow-forms"
-              title="Extension preview"
-            />
-          ) : (
-            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-              Preview will appear here
+        <div className="flex flex-1 overflow-hidden">
+          <div className="flex w-1/2 flex-col gap-4 overflow-auto border-r p-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-foreground">
+                Name
+              </label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="My Extension"
+                className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+              />
             </div>
-          )}
+
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-foreground">
+                Description
+              </label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What does this extension do?"
+                rows={2}
+                className="w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+              />
+            </div>
+
+            <div className="flex flex-1 flex-col">
+              <label className="mb-1.5 block text-sm font-medium text-foreground">
+                Content
+              </label>
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="<html>...</html>"
+                className="flex-1 resize-none rounded-md border border-input bg-background p-3 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
+                spellCheck={false}
+              />
+            </div>
+          </div>
+
+          <div className="w-1/2">
+            {content ? (
+              <iframe
+                srcDoc={content}
+                className="h-full w-full border-0"
+                sandbox="allow-scripts allow-forms"
+                title="Extension preview"
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                Preview will appear here
+              </div>
+            )}
+          </div>
         </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }

--- a/packages/core/src/client/extensions/ExtensionSlot.tsx
+++ b/packages/core/src/client/extensions/ExtensionSlot.tsx
@@ -12,6 +12,7 @@ import { EmbeddedExtension } from "./EmbeddedExtension.js";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 
@@ -174,22 +175,24 @@ function SlotEmptyAffordance({ slotId }: { slotId: string }) {
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              className="flex w-full items-center gap-2 px-4 py-2 text-[11px] text-muted-foreground/60 hover:text-muted-foreground cursor-pointer"
-            >
-              <div className="h-5 w-5 rounded-md border border-dashed border-border/40 flex items-center justify-center shrink-0">
-                <IconPlus className="h-3 w-3" />
-              </div>
-              <span>Add widget</span>
-            </button>
-          </PopoverTrigger>
-        </TooltipTrigger>
-        <TooltipContent>Add a widget</TooltipContent>
-      </Tooltip>
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-4 py-2 text-[11px] text-muted-foreground/60 hover:text-muted-foreground cursor-pointer"
+              >
+                <div className="h-5 w-5 rounded-md border border-dashed border-border/40 flex items-center justify-center shrink-0">
+                  <IconPlus className="h-3 w-3" />
+                </div>
+                <span>Add widget</span>
+              </button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Add a widget</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
       <PopoverContent
         side="left"
         align="end"

--- a/packages/core/src/client/extensions/ExtensionViewer.tsx
+++ b/packages/core/src/client/extensions/ExtensionViewer.tsx
@@ -29,6 +29,7 @@ import {
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 
@@ -475,87 +476,89 @@ export function ExtensionViewer({ extensionId }: ExtensionViewerProps) {
   }
 
   return (
-    <div className="flex h-full w-full flex-col">
-      <div className="flex h-12 items-center justify-between border-b px-3 shrink-0">
-        <div className="group/name flex items-center gap-1">
-          {isRenaming ? (
-            <input
-              ref={renameInputRef}
-              value={renameValue}
-              onChange={(e) => setRenameValue(e.target.value)}
-              onBlur={submitRename}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") submitRename();
-                if (e.key === "Escape") setIsRenaming(false);
-              }}
-              className="text-sm font-medium bg-transparent border-b border-primary outline-none py-0 px-0"
-            />
-          ) : (
-            <>
-              <span className="text-sm font-medium">{extension.name}</span>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={startRename}
-                    className="cursor-pointer rounded p-0.5 text-muted-foreground/40 opacity-0 group-hover/name:opacity-100 hover:text-foreground"
-                  >
-                    <IconPencil className="h-3 w-3" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Rename</TooltipContent>
-              </Tooltip>
-            </>
-          )}
-        </div>
-        <div className="flex items-center gap-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={() => setRefreshKey((k) => k + 1)}
-                className="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
-              >
-                <IconRefresh className="h-4 w-4" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Refresh</TooltipContent>
-          </Tooltip>
-          <EditToolPopover extension={extension} />
-          <ShareButton
-            resourceType="extension"
-            resourceId={extensionId}
-            resourceTitle={extension.name}
-          />
-          <ToolMoreMenu extensionId={extensionId} toolName={extension.name} />
-          <NotificationsBell />
-          <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
-        </div>
-      </div>
-      <div className="relative flex-1 min-h-0">
-        {!iframeReady && (
-          <div className="absolute inset-0 flex items-center justify-center bg-background z-10">
-            <IconLoader2
-              className="size-5 animate-spin text-muted-foreground"
-              role="status"
-              aria-label="Loading"
-            />
+    <TooltipProvider delayDuration={200}>
+      <div className="flex h-full w-full flex-col">
+        <div className="flex h-12 items-center justify-between border-b px-3 shrink-0">
+          <div className="group/name flex items-center gap-1">
+            {isRenaming ? (
+              <input
+                ref={renameInputRef}
+                value={renameValue}
+                onChange={(e) => setRenameValue(e.target.value)}
+                onBlur={submitRename}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") submitRename();
+                  if (e.key === "Escape") setIsRenaming(false);
+                }}
+                className="text-sm font-medium bg-transparent border-b border-primary outline-none py-0 px-0"
+              />
+            ) : (
+              <>
+                <span className="text-sm font-medium">{extension.name}</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={startRename}
+                      className="cursor-pointer rounded p-0.5 text-muted-foreground/40 opacity-0 group-hover/name:opacity-100 hover:text-foreground"
+                    >
+                      <IconPencil className="h-3 w-3" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>Rename</TooltipContent>
+                </Tooltip>
+              </>
+            )}
           </div>
-        )}
-        <iframe
-          ref={iframeRef}
-          key={`${extension.updatedAt}-${refreshKey}`}
-          src={iframeSrc}
-          className="h-full w-full border-0"
-          sandbox="allow-scripts allow-forms"
-          title={extension.name}
-          onLoad={() => {
-            sendThemeToIframe();
-            setTimeout(() => setIframeReady(true), 150);
-          }}
-        />
+          <div className="flex items-center gap-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => setRefreshKey((k) => k + 1)}
+                  className="inline-flex items-center justify-center rounded-md h-8 w-8 text-muted-foreground hover:bg-accent hover:text-accent-foreground cursor-pointer"
+                >
+                  <IconRefresh className="h-4 w-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Refresh</TooltipContent>
+            </Tooltip>
+            <EditToolPopover extension={extension} />
+            <ShareButton
+              resourceType="extension"
+              resourceId={extensionId}
+              resourceTitle={extension.name}
+            />
+            <ToolMoreMenu extensionId={extensionId} toolName={extension.name} />
+            <NotificationsBell />
+            <AgentToggleButton className="h-8 w-8 rounded-md hover:bg-accent" />
+          </div>
+        </div>
+        <div className="relative flex-1 min-h-0">
+          {!iframeReady && (
+            <div className="absolute inset-0 flex items-center justify-center bg-background z-10">
+              <IconLoader2
+                className="size-5 animate-spin text-muted-foreground"
+                role="status"
+                aria-label="Loading"
+              />
+            </div>
+          )}
+          <iframe
+            ref={iframeRef}
+            key={`${extension.updatedAt}-${refreshKey}`}
+            src={iframeSrc}
+            className="h-full w-full border-0"
+            sandbox="allow-scripts allow-forms"
+            title={extension.name}
+            onLoad={() => {
+              sendThemeToIframe();
+              setTimeout(() => setIframeReady(true), 150);
+            }}
+          />
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }
 

--- a/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
+++ b/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
@@ -29,6 +29,7 @@ import {
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 
@@ -232,230 +233,236 @@ export function ExtensionsSidebarSection() {
   };
 
   return (
-    <div className="group/help relative min-w-0 py-2">
-      <div
-        className={cn(
-          "flex items-center justify-between px-3",
-          sortedTools.length > 0 && "mb-1",
-        )}
-      >
-        <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-          <IconTool className="h-3.5 w-3.5 shrink-0" />
-          Extensions
-          <a
-            href="https://agent-native.com/docs/extensions"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="opacity-0 group-hover/help:opacity-100 transition-opacity text-muted-foreground/50 hover:text-muted-foreground"
-            aria-label="Extensions documentation"
-          >
-            <IconHelpCircle className="h-3 w-3" />
-          </a>
-        </span>
-        <Popover open={showCreate} onOpenChange={setShowCreate}>
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              className="inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-              aria-label="New extension"
+    <TooltipProvider delayDuration={200}>
+      <div className="group/help relative min-w-0 py-2">
+        <div
+          className={cn(
+            "flex items-center justify-between px-3",
+            sortedTools.length > 0 && "mb-1",
+          )}
+        >
+          <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            <IconTool className="h-3.5 w-3.5 shrink-0" />
+            Extensions
+            <a
+              href="https://agent-native.com/docs/extensions"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="opacity-0 group-hover/help:opacity-100 transition-opacity text-muted-foreground/50 hover:text-muted-foreground"
+              aria-label="Extensions documentation"
             >
-              <IconPlus className="h-3.5 w-3.5" />
-            </button>
-          </PopoverTrigger>
-          <PopoverContent side="right" align="start" className="w-[420px] p-3">
-            <p className="px-1 pb-2 text-sm font-semibold text-foreground">
-              New extension
-            </p>
-            <PromptComposer
-              autoFocus
-              placeholder="Describe what you'd like to build..."
-              draftScope="extensions:sidebar-create"
-              onSubmit={handleCreate}
-            />
-          </PopoverContent>
-        </Popover>
-      </div>
-
-      {isLoading ? (
-        <div className="min-w-0 space-y-0.5 px-1">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="flex items-center rounded-md px-2 py-1.5">
-              <div
-                className="h-3 rounded bg-muted animate-pulse"
-                style={{ width: `${60 + i * 20}px` }}
-              />
-            </div>
-          ))}
-        </div>
-      ) : sortedTools.length === 0 ? null : (
-        <div className="min-w-0 space-y-0.5 px-1">
-          {sortedTools.map((extension) => {
-            const isActive =
-              location.pathname === `/extensions/${extension.id}` ||
-              location.pathname === `/extensions/${extension.id}/edit`;
-            const isFav = favoriteIds.has(extension.id);
-            const isRenamingThis = renamingId === extension.id;
-            const actionsVisible =
-              menuOpenId === extension.id || isRenamingThis;
-
-            return (
-              <div
-                key={extension.id}
-                onDragOver={(e) => {
-                  if (!draggingId || draggingId === extension.id) return;
-                  e.preventDefault();
-                  e.dataTransfer.dropEffect = "move";
-                  setDragOverId(extension.id);
-                }}
-                onDragLeave={() => {
-                  setDragOverId((current) =>
-                    current === extension.id ? null : current,
-                  );
-                }}
-                onDrop={(e) => {
-                  e.preventDefault();
-                  const activeId =
-                    draggingId || e.dataTransfer.getData("text/plain");
-                  setDraggingId(null);
-                  setDragOverId(null);
-                  if (activeId) reorderTool(activeId, extension.id);
-                }}
-                className={cn(
-                  "group/extension relative flex items-center min-w-0 rounded-md",
-                  draggingId === extension.id && "opacity-50",
-                  dragOverId === extension.id &&
-                    draggingId !== extension.id &&
-                    "bg-accent/60",
-                )}
+              <IconHelpCircle className="h-3 w-3" />
+            </a>
+          </span>
+          <Popover open={showCreate} onOpenChange={setShowCreate}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                aria-label="New extension"
               >
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      draggable
-                      onDragStart={(e) => {
-                        setDraggingId(extension.id);
-                        setDragOverId(null);
-                        e.dataTransfer.effectAllowed = "move";
-                        e.dataTransfer.setData("text/plain", extension.id);
-                      }}
-                      onDragEnd={() => {
-                        setDraggingId(null);
-                        setDragOverId(null);
-                      }}
-                      className="-ml-2 cursor-grab rounded p-0.5 text-muted-foreground/30 opacity-0 transition-colors hover:text-muted-foreground/70 active:cursor-grabbing group-hover/extension:opacity-100 group-focus-within/extension:opacity-100"
-                      aria-label={`Reorder ${extension.name}`}
-                    >
-                      <IconGripVertical className="h-3 w-3" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>Drag to reorder</TooltipContent>
-                </Tooltip>
-                <Link
-                  to={`/extensions/${extension.id}`}
-                  className={cn(
-                    "flex min-w-0 flex-1 items-center rounded-md px-2 py-1.5 pr-12 text-xs transition-[padding,color,background-color] md:pr-2 md:group-hover/extension:pr-12 md:group-focus-within/extension:pr-12",
-                    actionsVisible && "md:pr-12",
-                    isActive
-                      ? "bg-accent text-accent-foreground font-medium"
-                      : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
-                  )}
-                >
-                  {isRenamingThis ? (
-                    <input
-                      autoFocus
-                      value={renameValue}
-                      onChange={(e) => setRenameValue(e.target.value)}
-                      onBlur={() => submitRename(extension.id)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") submitRename(extension.id);
-                        if (e.key === "Escape") setRenamingId(null);
-                      }}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                      className="min-w-0 flex-1 truncate border-b border-primary bg-transparent px-0 py-0 text-xs outline-none"
-                    />
-                  ) : (
-                    <span className="block truncate">{extension.name}</span>
-                  )}
-                </Link>
+                <IconPlus className="h-3.5 w-3.5" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              side="right"
+              align="start"
+              className="w-[420px] p-3"
+            >
+              <p className="px-1 pb-2 text-sm font-semibold text-foreground">
+                New extension
+              </p>
+              <PromptComposer
+                autoFocus
+                placeholder="Describe what you'd like to build..."
+                draftScope="extensions:sidebar-create"
+                onSubmit={handleCreate}
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
 
+        {isLoading ? (
+          <div className="min-w-0 space-y-0.5 px-1">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex items-center rounded-md px-2 py-1.5">
                 <div
+                  className="h-3 rounded bg-muted animate-pulse"
+                  style={{ width: `${60 + i * 20}px` }}
+                />
+              </div>
+            ))}
+          </div>
+        ) : sortedTools.length === 0 ? null : (
+          <div className="min-w-0 space-y-0.5 px-1">
+            {sortedTools.map((extension) => {
+              const isActive =
+                location.pathname === `/extensions/${extension.id}` ||
+                location.pathname === `/extensions/${extension.id}/edit`;
+              const isFav = favoriteIds.has(extension.id);
+              const isRenamingThis = renamingId === extension.id;
+              const actionsVisible =
+                menuOpenId === extension.id || isRenamingThis;
+
+              return (
+                <div
+                  key={extension.id}
+                  onDragOver={(e) => {
+                    if (!draggingId || draggingId === extension.id) return;
+                    e.preventDefault();
+                    e.dataTransfer.dropEffect = "move";
+                    setDragOverId(extension.id);
+                  }}
+                  onDragLeave={() => {
+                    setDragOverId((current) =>
+                      current === extension.id ? null : current,
+                    );
+                  }}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    const activeId =
+                      draggingId || e.dataTransfer.getData("text/plain");
+                    setDraggingId(null);
+                    setDragOverId(null);
+                    if (activeId) reorderTool(activeId, extension.id);
+                  }}
                   className={cn(
-                    "pointer-events-none absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-100 transition-opacity md:opacity-0 md:group-hover/extension:opacity-100 md:group-focus-within/extension:opacity-100",
-                    actionsVisible && "md:opacity-100",
+                    "group/extension relative flex items-center min-w-0 rounded-md",
+                    draggingId === extension.id && "opacity-50",
+                    dragOverId === extension.id &&
+                      draggingId !== extension.id &&
+                      "bg-accent/60",
                   )}
                 >
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      toggleFavorite(extension.id);
-                    }}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        draggable
+                        onDragStart={(e) => {
+                          setDraggingId(extension.id);
+                          setDragOverId(null);
+                          e.dataTransfer.effectAllowed = "move";
+                          e.dataTransfer.setData("text/plain", extension.id);
+                        }}
+                        onDragEnd={() => {
+                          setDraggingId(null);
+                          setDragOverId(null);
+                        }}
+                        className="-ml-2 cursor-grab rounded p-0.5 text-muted-foreground/30 opacity-0 transition-colors hover:text-muted-foreground/70 active:cursor-grabbing group-hover/extension:opacity-100 group-focus-within/extension:opacity-100"
+                        aria-label={`Reorder ${extension.name}`}
+                      >
+                        <IconGripVertical className="h-3 w-3" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Drag to reorder</TooltipContent>
+                  </Tooltip>
+                  <Link
+                    to={`/extensions/${extension.id}`}
                     className={cn(
-                      "pointer-events-auto cursor-pointer rounded p-0.5 transition-colors",
-                      isFav
-                        ? "text-yellow-500"
-                        : "text-muted-foreground/40 hover:text-yellow-500",
+                      "flex min-w-0 flex-1 items-center rounded-md px-2 py-1.5 pr-12 text-xs transition-[padding,color,background-color] md:pr-2 md:group-hover/extension:pr-12 md:group-focus-within/extension:pr-12",
+                      actionsVisible && "md:pr-12",
+                      isActive
+                        ? "bg-accent text-accent-foreground font-medium"
+                        : "text-muted-foreground hover:bg-accent/50 hover:text-accent-foreground",
                     )}
-                    aria-label={isFav ? "Unfavorite" : "Favorite"}
                   >
-                    {isFav ? (
-                      <IconStarFilled className="h-3 w-3" />
+                    {isRenamingThis ? (
+                      <input
+                        autoFocus
+                        value={renameValue}
+                        onChange={(e) => setRenameValue(e.target.value)}
+                        onBlur={() => submitRename(extension.id)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") submitRename(extension.id);
+                          if (e.key === "Escape") setRenamingId(null);
+                        }}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                        }}
+                        className="min-w-0 flex-1 truncate border-b border-primary bg-transparent px-0 py-0 text-xs outline-none"
+                      />
                     ) : (
-                      <IconStar className="h-3 w-3" />
+                      <span className="block truncate">{extension.name}</span>
                     )}
-                  </button>
+                  </Link>
 
-                  <div className="relative">
+                  <div
+                    className={cn(
+                      "pointer-events-none absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-100 transition-opacity md:opacity-0 md:group-hover/extension:opacity-100 md:group-focus-within/extension:opacity-100",
+                      actionsVisible && "md:opacity-100",
+                    )}
+                  >
                     <button
                       type="button"
                       onClick={(e) => {
                         e.preventDefault();
                         e.stopPropagation();
-                        setMenuOpenId(
-                          menuOpenId === extension.id ? null : extension.id,
-                        );
+                        toggleFavorite(extension.id);
                       }}
-                      className="pointer-events-auto cursor-pointer rounded p-0.5 text-muted-foreground/40 transition-colors hover:text-foreground"
-                      aria-label="Extension actions"
+                      className={cn(
+                        "pointer-events-auto cursor-pointer rounded p-0.5 transition-colors",
+                        isFav
+                          ? "text-yellow-500"
+                          : "text-muted-foreground/40 hover:text-yellow-500",
+                      )}
+                      aria-label={isFav ? "Unfavorite" : "Favorite"}
                     >
-                      <IconDots className="h-3 w-3" />
+                      {isFav ? (
+                        <IconStarFilled className="h-3 w-3" />
+                      ) : (
+                        <IconStar className="h-3 w-3" />
+                      )}
                     </button>
 
-                    {menuOpenId === extension.id && (
-                      <div
-                        className="absolute right-0 top-full z-50 mt-1 min-w-[120px] rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
-                        onClick={(e) => e.stopPropagation()}
+                    <div className="relative">
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          setMenuOpenId(
+                            menuOpenId === extension.id ? null : extension.id,
+                          );
+                        }}
+                        className="pointer-events-auto cursor-pointer rounded p-0.5 text-muted-foreground/40 transition-colors hover:text-foreground"
+                        aria-label="Extension actions"
                       >
-                        <button
-                          type="button"
-                          onClick={() => startRename(extension)}
-                          className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent"
+                        <IconDots className="h-3 w-3" />
+                      </button>
+
+                      {menuOpenId === extension.id && (
+                        <div
+                          className="absolute right-0 top-full z-50 mt-1 min-w-[120px] rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+                          onClick={(e) => e.stopPropagation()}
                         >
-                          <IconPencil className="h-3.5 w-3.5" />
-                          Rename
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleDelete(extension.id)}
-                          className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-accent"
-                        >
-                          <IconTrash className="h-3.5 w-3.5" />
-                          Delete
-                        </button>
-                      </div>
-                    )}
+                          <button
+                            type="button"
+                            onClick={() => startRename(extension)}
+                            className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent"
+                          >
+                            <IconPencil className="h-3.5 w-3.5" />
+                            Rename
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(extension.id)}
+                            className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-accent"
+                          >
+                            <IconTrash className="h-3.5 w-3.5" />
+                            Delete
+                          </button>
+                        </div>
+                      )}
+                    </div>
                   </div>
                 </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </TooltipProvider>
   );
 }

--- a/packages/core/src/client/org/TeamPage.tsx
+++ b/packages/core/src/client/org/TeamPage.tsx
@@ -39,6 +39,7 @@ import type { DomainMatchOrg } from "../../org/types.js";
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
 
@@ -878,5 +879,9 @@ export function TeamPage({
     </div>
   );
 
-  return layout ? <>{layout(content)}</> : content;
+  const wrapped = (
+    <TooltipProvider delayDuration={200}>{content}</TooltipProvider>
+  );
+
+  return layout ? <>{layout(wrapped)}</> : wrapped;
 }

--- a/packages/core/src/client/settings/SecretsSection.tsx
+++ b/packages/core/src/client/settings/SecretsSection.tsx
@@ -40,6 +40,15 @@ interface SecretStatus {
 
 const ENDPOINT = agentNativePath("/_agent-native/secrets");
 
+function notifySecretsChanged() {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent("agent-engine:configured-changed", {
+      detail: { source: "secrets" },
+    }),
+  );
+}
+
 export interface SecretsSectionProps {
   /** Optional hash fragment to focus a specific secret (e.g. "secrets:OPENAI_API_KEY"). */
   focusKey?: string;
@@ -161,6 +170,7 @@ function SecretCard({ secret, onChanged, focusInput }: SecretCardProps) {
       setValue("");
       setConfirmDelete(false);
       setToastAndClear("ok", "Saved");
+      notifySecretsChanged();
       onChanged();
     } finally {
       setBusy(null);
@@ -185,6 +195,7 @@ function SecretCard({ secret, onChanged, focusInput }: SecretCardProps) {
       }
       setToastAndClear("ok", "Removed");
       setConfirmDelete(false);
+      notifySecretsChanged();
       onChanged();
     } finally {
       setBusy(null);

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -30,7 +30,11 @@ import {
   IconGauge,
 } from "@tabler/icons-react";
 import { SettingsSection } from "./SettingsSection.js";
-import { useBuilderStatus } from "./useBuilderStatus.js";
+import {
+  type BuilderConnectFlow,
+  useBuilderConnectFlow,
+  useBuilderStatus,
+} from "./useBuilderStatus.js";
 import { BuilderBMark } from "../builder-mark.js";
 import { AgentsSection } from "./AgentsSection.js";
 import { UsageSection } from "./UsageSection.js";
@@ -311,25 +315,29 @@ function DisconnectBuilderButton() {
 // ─── "Connect Builder.io" card (shared across all sections) ─────────────────
 
 function UseBuilderCard({
+  builderFlow,
   connectUrl,
   connected,
   orgName,
+  envManaged,
   label = "Connect Builder.io",
   subtitle = "Free credits to start — no API key needed.",
   dim,
 }: {
+  builderFlow: BuilderConnectFlow;
   connectUrl?: string;
   connected: boolean;
   orgName?: string;
+  envManaged?: boolean;
   label?: string;
   subtitle?: string;
   dim?: boolean;
 }) {
-  const { status } = useBuilderStatus();
-  const envManaged = !!status?.envManaged;
+  const effectiveConnected = connected || builderFlow.configured;
+  const effectiveOrgName = builderFlow.orgName ?? orgName;
   const bgClass = dim ? "" : "bg-accent/30";
 
-  if (connected) {
+  if (effectiveConnected) {
     return (
       <div className={`rounded-md border border-border px-2.5 py-2 ${bgClass}`}>
         <div className="flex items-center justify-between">
@@ -341,8 +349,10 @@ function UseBuilderCard({
             Connected
           </span>
         </div>
-        {orgName && (
-          <p className="text-[10px] text-muted-foreground mt-0.5">{orgName}</p>
+        {effectiveOrgName && (
+          <p className="text-[10px] text-muted-foreground mt-0.5">
+            {effectiveOrgName}
+          </p>
         )}
         {envManaged ? (
           <p className="text-[10px] text-muted-foreground mt-1">
@@ -371,11 +381,11 @@ function UseBuilderCard({
   if (!connectUrl) return null;
 
   return (
-    <a
-      href={connectUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={`block rounded-md border border-border px-3 py-3 no-underline bg-gradient-to-br from-teal-500/10 via-transparent to-transparent hover:border-foreground/30 transition-colors`}
+    <button
+      type="button"
+      onClick={builderFlow.start}
+      disabled={builderFlow.connecting}
+      className={`block w-full rounded-md border border-border px-3 py-3 text-left no-underline bg-gradient-to-br from-teal-500/10 via-transparent to-transparent hover:border-foreground/30 transition-colors disabled:cursor-wait disabled:opacity-70`}
     >
       <div className="flex items-start gap-2.5">
         <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-foreground text-background">
@@ -384,19 +394,30 @@ function UseBuilderCard({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5 flex-wrap">
             <span className="text-[12px] font-semibold text-foreground">
-              {label}
+              {builderFlow.connecting ? "Connecting Builder.io..." : label}
             </span>
+            {builderFlow.connecting && (
+              <IconLoader2
+                size={12}
+                className="shrink-0 animate-spin text-muted-foreground"
+              />
+            )}
           </div>
           <p className="text-[10.5px] text-muted-foreground mt-0.5 leading-snug">
             {subtitle}
           </p>
+          {builderFlow.error && (
+            <p className="mt-1 text-[10px] text-destructive">
+              {builderFlow.error}
+            </p>
+          )}
         </div>
         <IconExternalLink
           size={12}
           className="shrink-0 text-muted-foreground mt-0.5"
         />
       </div>
-    </a>
+    </button>
   );
 }
 
@@ -543,17 +564,21 @@ const PROVIDER_DOCS: Record<string, string> = {
 };
 
 function LLMSectionInner({
+  builderFlow,
   builderLoading,
   connectUrl,
   connected,
   orgName,
+  envManaged,
   open,
   onToggle,
 }: {
+  builderFlow: BuilderConnectFlow;
   builderLoading?: boolean;
   connectUrl?: string;
   connected: boolean;
   orgName?: string;
+  envManaged?: boolean;
   open?: boolean;
   onToggle?: () => void;
 }) {
@@ -816,9 +841,11 @@ function LLMSectionInner({
       ) : (
         <div className="space-y-2">
           <UseBuilderCard
+            builderFlow={builderFlow}
             connectUrl={connectUrl}
             connected={connected}
             orgName={orgName}
+            envManaged={envManaged}
             label="Connect Builder.io"
           />
           {!connected && (
@@ -1504,6 +1531,8 @@ export function SettingsPanel({
   const connected = builder?.configured ?? false;
   const connectUrl = builder?.connectUrl;
   const orgName = builder?.orgName;
+  const envManaged = !!builder?.envManaged;
+  const builderFlow = useBuilderConnectFlow({ popupUrl: connectUrl });
 
   // Detect whether the app registered any secrets — controls whether the
   // "API Keys & Connections" section renders at all.
@@ -1581,10 +1610,12 @@ export function SettingsPanel({
 
       {/* LLM */}
       <LLMSectionInner
+        builderFlow={builderFlow}
         builderLoading={builderLoading}
         connectUrl={connectUrl}
         connected={connected}
         orgName={orgName}
+        envManaged={envManaged}
         open={openSection === "llm"}
         onToggle={() => toggle("llm")}
       />
@@ -1639,9 +1670,11 @@ export function SettingsPanel({
       >
         <div className="space-y-2">
           <UseBuilderCard
+            builderFlow={builderFlow}
             connectUrl={connectUrl}
             connected={connected}
             orgName={orgName}
+            envManaged={envManaged}
           />
           <ManualSetupCard
             hint="Deploy manually to Netlify, Vercel, Cloudflare, or any Nitro-supported target."
@@ -1662,9 +1695,11 @@ export function SettingsPanel({
       >
         <div className="space-y-2">
           <UseBuilderCard
+            builderFlow={builderFlow}
             connectUrl={connectUrl}
             connected={connected}
             orgName={orgName}
+            envManaged={envManaged}
           />
           <ManualSetupCard
             hint="Set DATABASE_URL in your .env to connect Neon, Supabase, Turso, or any Postgres/SQLite database."
@@ -1685,9 +1720,11 @@ export function SettingsPanel({
       >
         <div className="space-y-2">
           <UseBuilderCard
+            builderFlow={builderFlow}
             connectUrl={connectUrl}
             connected={connected}
             orgName={orgName}
+            envManaged={envManaged}
           />
           <ManualSetupCard
             hint="Without a provider, files are stored as base64 in your database. Fine for dev, not recommended for production."
@@ -1708,9 +1745,11 @@ export function SettingsPanel({
       >
         <div className="space-y-2">
           <UseBuilderCard
+            builderFlow={builderFlow}
             connectUrl={connectUrl}
             connected={connected}
             orgName={orgName}
+            envManaged={envManaged}
           />
           <ManualSetupCard
             hint="Configure Better Auth with BETTER_AUTH_SECRET and optional Google/GitHub OAuth providers."
@@ -1736,9 +1775,11 @@ export function SettingsPanel({
         onToggle={() => toggle("browser")}
       >
         <UseBuilderCard
+          builderFlow={builderFlow}
           connectUrl={connectUrl}
           connected={connected}
           orgName={orgName}
+          envManaged={envManaged}
         />
       </SettingsSection>
 
@@ -1752,9 +1793,11 @@ export function SettingsPanel({
         onToggle={() => toggle("background")}
       >
         <UseBuilderCard
+          builderFlow={builderFlow}
           connectUrl={connectUrl}
           connected={connected}
           orgName={orgName}
+          envManaged={envManaged}
         />
       </SettingsSection>
 

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -211,6 +211,7 @@ export function useBuilderConnectFlow(
       setOrgName(org);
       if (s.configured && !notifiedConnectedRef.current) {
         notifiedConnectedRef.current = true;
+        notifyAgentEngineConfiguredChanged("builder-status");
         try {
           await onConnectedRef.current?.({ orgName: org });
         } catch {
@@ -275,6 +276,7 @@ export function useBuilderConnectFlow(
         const org = s.orgName ?? null;
         setOrgName(org);
         setConnecting(false);
+        notifiedConnectedRef.current = true;
         notifyAgentEngineConfiguredChanged("builder-connect");
         try {
           await onConnectedRef.current?.({ orgName: org });

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -134,6 +134,15 @@ export interface BuilderConnectFlow {
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 5 * 60 * 1000;
 
+function notifyAgentEngineConfiguredChanged(source: string) {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent("agent-engine:configured-changed", {
+      detail: { source },
+    }),
+  );
+}
+
 export function useBuilderConnectFlow(
   opts: BuilderConnectFlowOptions = {},
 ): BuilderConnectFlow {
@@ -147,6 +156,7 @@ export function useBuilderConnectFlow(
   const [hasFetchedStatus, setHasFetchedStatus] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const mountedRef = useRef(true);
+  const notifiedConnectedRef = useRef(false);
   // Keep onConnected in a ref so start() doesn't need to re-create when the
   // caller passes an inline arrow function.
   const onConnectedRef = useRef(onConnected);
@@ -197,7 +207,18 @@ export function useBuilderConnectFlow(
       setConfigured(!!s.configured);
       setEnvManaged(!!s.envManaged);
       setBuilderEnabled(!!s.builderEnabled);
-      setOrgName(s.orgName ?? null);
+      const org = s.orgName ?? null;
+      setOrgName(org);
+      if (s.configured && !notifiedConnectedRef.current) {
+        notifiedConnectedRef.current = true;
+        try {
+          await onConnectedRef.current?.({ orgName: org });
+        } catch {
+          // The caller's callback is a UI convenience; status is already set.
+        }
+      } else if (!s.configured) {
+        notifiedConnectedRef.current = false;
+      }
     };
     refresh();
     const onVisible = () => {
@@ -249,9 +270,12 @@ export function useBuilderConnectFlow(
       if (s?.configured) {
         stopPoll();
         setConfigured(true);
+        setEnvManaged(!!s.envManaged);
+        setBuilderEnabled(!!s.builderEnabled);
         const org = s.orgName ?? null;
         setOrgName(org);
         setConnecting(false);
+        notifyAgentEngineConfiguredChanged("builder-connect");
         try {
           await onConnectedRef.current?.({ orgName: org });
         } catch {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -49,6 +49,11 @@ function normalizeConfiguredAppBasePath(): string {
 /** Plugins that require Node.js runtime and cannot run on edge/serverless */
 const NODE_ONLY_PLUGINS = new Set([
   "terminal", // PTY requires child_process
+  // @sentry/node ships node:fs / node:async_hooks bindings that don't load
+  // on workerd / Cloudflare Workers. Templates running on edge presets can
+  // mount their own edge-compatible Sentry wrapper if they want server
+  // observability there; the framework default is the Node SDK.
+  "sentry",
 ]);
 
 function isNodeOnlyPlugin(filePath: string): boolean {

--- a/packages/core/src/deploy/route-discovery.ts
+++ b/packages/core/src/deploy/route-discovery.ts
@@ -150,6 +150,7 @@ export const DEFAULT_PLUGIN_REGISTRY: Record<string, string> = {
   onboarding: "defaultOnboardingPlugin",
   org: "defaultOrgPlugin",
   resources: "defaultResourcesPlugin",
+  sentry: "defaultSentryPlugin",
   terminal: "defaultTerminalPlugin",
 };
 

--- a/packages/core/src/deploy/workspace-core.ts
+++ b/packages/core/src/deploy/workspace-core.ts
@@ -40,6 +40,7 @@ export type PluginSlot =
   | "integrations"
   | "org"
   | "resources"
+  | "sentry"
   | "terminal";
 
 export interface WorkspaceCoreExports {
@@ -192,6 +193,7 @@ async function discoverPluginExports(
     integrations: ["integrationsPlugin"],
     org: ["orgPlugin"],
     resources: ["resourcesPlugin"],
+    sentry: ["sentryPlugin"],
     terminal: ["terminalPlugin"],
   };
 

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -237,6 +237,54 @@ describe("resolveSecret (generic)", () => {
     expect(await resolveSecret("OPENAI_API_KEY")).toBe("sk-...shared");
   });
 
+  it("falls back to workspace scope for registered shared secrets", async () => {
+    mockGetRequestUserEmail.mockReturnValue("teammate@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret
+      .mockResolvedValueOnce(null) // user scope miss
+      .mockResolvedValueOnce(null) // org scope miss
+      .mockResolvedValueOnce({
+        value: "workspace-secret",
+        last4: "cret",
+        updatedAt: 1,
+      });
+    expect(await resolveSecret("GOOGLE_CLIENT_SECRET")).toBe(
+      "workspace-secret",
+    );
+    expect(mockReadAppSecret.mock.calls.map((c) => c[0].scope)).toEqual([
+      "user",
+      "org",
+      "workspace",
+    ]);
+  });
+
+  it("checks solo workspace scope when an authenticated user has no org", async () => {
+    mockGetRequestUserEmail.mockReturnValue("solo@b.com");
+    mockGetRequestOrgId.mockReturnValue(undefined);
+    mockReadAppSecret
+      .mockResolvedValueOnce(null) // user scope miss
+      .mockResolvedValueOnce({
+        value: "solo-workspace-secret",
+        last4: "cret",
+        updatedAt: 1,
+      });
+    expect(await resolveSecret("GOOGLE_CLIENT_SECRET")).toBe(
+      "solo-workspace-secret",
+    );
+    expect(mockReadAppSecret.mock.calls.map((c) => c[0])).toEqual([
+      {
+        key: "GOOGLE_CLIENT_SECRET",
+        scope: "user",
+        scopeId: "solo@b.com",
+      },
+      {
+        key: "GOOGLE_CLIENT_SECRET",
+        scope: "workspace",
+        scopeId: "solo:solo@b.com",
+      },
+    ]);
+  });
+
   it("does not consult process.env in an authenticated request", async () => {
     process.env.OPENAI_API_KEY = "deploy-key";
     mockGetRequestUserEmail.mockReturnValue("a@b.com");

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -295,20 +295,21 @@ export async function deleteBuilderCredentials(
 }
 
 // ---------------------------------------------------------------------------
-// Generic per-user secret resolution
+// Generic request-scoped secret resolution
 //
 // New consumers should prefer this over reading `process.env.X` directly.
-// User-pasted secrets live in `app_secrets` (encrypted, scope=user); the
-// settings UI / onboarding panels write here. Deploy-level env vars are
-// the fallback for unauthenticated/CLI/background contexts where there's
-// no user to scope by — never the silent fallback for an authenticated
-// request, since on a multi-tenant deploy that would silently identify
-// every user as whoever set the deploy-level key (KVesta Space, 2026-04).
+// User-pasted and shared secrets live in `app_secrets` (encrypted). The
+// settings UI / onboarding panels can write user, org, or workspace rows.
+// Deploy-level env vars are the fallback for unauthenticated/CLI/background
+// contexts where there's no user to scope by — never the silent fallback
+// for an authenticated request, since on a multi-tenant deploy that would
+// silently identify every user as whoever set the deploy-level key
+// (KVesta Space, 2026-04).
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve a per-user secret. Reads from `app_secrets` first (scoped by
- * the current request's authenticated user); falls back to `process.env`
+ * Resolve a request-scoped secret. Reads from `app_secrets` first (current
+ * user override, active org, then workspace row); falls back to `process.env`
  * only for unauthenticated/CLI/background contexts.
  */
 export async function resolveSecret(key: string): Promise<string | null> {
@@ -324,17 +325,33 @@ export async function resolveSecret(key: string): Promise<string | null> {
       });
       if (userSecret?.value) return userSecret.value;
 
-      // Fall back to the active org's shared row, when present. Lets a
-      // teammate set up an integration once and everyone in that org
-      // benefits without each member pasting the key.
       const orgId = getRequestOrgId();
       if (orgId) {
+        // Fall back to the active org's shared row, when present. Builder
+        // Connect uses this first-class org scope.
         const orgSecret = await readAppSecret({
           key,
           scope: "org",
           scopeId: orgId,
         });
         if (orgSecret?.value) return orgSecret.value;
+
+        // Registered secrets historically used "workspace" scope for
+        // org-shared configuration. Keep reading it so Settings status and
+        // runtime resolution agree.
+        const workspaceSecret = await readAppSecret({
+          key,
+          scope: "workspace",
+          scopeId: orgId,
+        });
+        if (workspaceSecret?.value) return workspaceSecret.value;
+      } else {
+        const soloWorkspaceSecret = await readAppSecret({
+          key,
+          scope: "workspace",
+          scopeId: `solo:${email}`,
+        });
+        if (soloWorkspaceSecret?.value) return soloWorkspaceSecret.value;
       }
     } catch {
       // Secrets table not ready — treat as missing.

--- a/packages/core/src/server/framework-request-handler.ts
+++ b/packages/core/src/server/framework-request-handler.ts
@@ -335,6 +335,34 @@ function registerMiddleware(
         `[agent-native] ${event.method ?? ""} ${reqPath} failed (${status}):`,
         e?.stack || e?.message || e,
       );
+      // Forward 5xx to server-side Sentry — Nitro's own `error` hook may not
+      // fire here because we convert the throw into a normal JSON response,
+      // and a console.error alone is invisible in deployed environments.
+      // 4xx are user-input errors (validation, auth) and aren't worth
+      // alerting on. Lazy-loaded so the framework-request-handler module
+      // doesn't pull @sentry/node into bundles that don't need it.
+      if (status >= 500) {
+        // Static `import` would create a cycle (sentry.ts imports auth.ts
+        // which imports… eventually, framework-request-handler.ts).
+        import("./sentry.js")
+          .then(({ captureRouteError, isServerSentryEnabled }) => {
+            if (!isServerSentryEnabled()) return;
+            captureRouteError(err, {
+              route: reqPath,
+              method: event.method,
+              userAgent: (() => {
+                try {
+                  return event.headers?.get("user-agent") ?? undefined;
+                } catch {
+                  return undefined;
+                }
+              })(),
+            });
+          })
+          .catch(() => {
+            // Sentry is observability — never let it break a response path.
+          });
+      }
       try {
         setResponseStatus(event, status);
         setResponseHeader(event, "content-type", "application/json");
@@ -406,6 +434,7 @@ async function bootstrapDefaultPlugins(nitroApp: any): Promise<void> {
       onboarding: (onboardingModule as any).defaultOnboardingPlugin,
       org: (orgModule as any).defaultOrgPlugin,
       resources: (serverModule as any).defaultResourcesPlugin,
+      sentry: (serverModule as any).defaultSentryPlugin,
       terminal: (terminalModule as any).defaultTerminalPlugin,
     };
 

--- a/packages/core/src/server/google-realtime-session.ts
+++ b/packages/core/src/server/google-realtime-session.ts
@@ -59,14 +59,33 @@ export async function resolveGoogleRealtimeCredentials(opts: {
   userEmail?: string | null;
   orgId?: string | null;
 }): Promise<string | null> {
+  const secretRefs: Array<{
+    scope: "user" | "org" | "workspace";
+    scopeId: string;
+  }> = [];
   if (opts.userEmail) {
-    const userSecret = await readAppSecret({
+    secretRefs.push({ scope: "user", scopeId: opts.userEmail });
+    if (opts.orgId) {
+      secretRefs.push(
+        { scope: "org", scopeId: opts.orgId },
+        { scope: "workspace", scopeId: opts.orgId },
+      );
+    } else {
+      secretRefs.push({
+        scope: "workspace",
+        scopeId: `solo:${opts.userEmail}`,
+      });
+    }
+  }
+
+  for (const ref of secretRefs) {
+    const secret = await readAppSecret({
       key: "GOOGLE_APPLICATION_CREDENTIALS",
-      scope: "user",
-      scopeId: opts.userEmail,
+      scope: ref.scope,
+      scopeId: ref.scopeId,
     }).catch(() => null);
-    const fromUserSecret = userSecret?.value?.trim();
-    if (fromUserSecret) return fromUserSecret;
+    const fromSecret = secret?.value?.trim();
+    if (fromSecret) return fromSecret;
   }
 
   const stored = await resolveCredential("GOOGLE_APPLICATION_CREDENTIALS", {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -47,6 +47,14 @@ export {
   getChangesSince,
 } from "./poll.js";
 export { createAuthPlugin, defaultAuthPlugin } from "./auth-plugin.js";
+export {
+  initServerSentry,
+  isServerSentryEnabled,
+  setSentryUserForRequest,
+  captureRouteError,
+  type RouteErrorContext,
+} from "./sentry.js";
+export { createSentryPlugin, defaultSentryPlugin } from "./sentry-plugin.js";
 // Re-export the org plugin so the auto-discovery's DEFAULT_PLUGIN_REGISTRY
 // (which references "defaultOrgPlugin" from @agent-native/core/server) can
 // resolve it during the deploy build worker-entry generation.

--- a/packages/core/src/server/sentry-plugin.ts
+++ b/packages/core/src/server/sentry-plugin.ts
@@ -1,0 +1,122 @@
+/**
+ * Nitro plugin that initializes server-side Sentry and attaches per-request
+ * user context.
+ *
+ * Wires three pieces:
+ *   1. On startup, `initServerSentry()` reads `SENTRY_SERVER_DSN` and arms
+ *      the SDK (no-op when the env var is unset).
+ *   2. On every request, hook into Nitro's `request` event: resolve the
+ *      session via `getSession(event)` and tag the per-request isolation
+ *      scope with the user's id/email/orgId. Wrapped in try/catch so a
+ *      session-resolution failure can never 500 the request.
+ *   3. On every Nitro `error` event, capture the exception with the route,
+ *      method, and user-agent attached as searchable tags.
+ *
+ * Mounted as a default plugin from `framework-request-handler.ts` —
+ * templates that don't define `server/plugins/sentry.ts` get this for
+ * free. Templates that need to customize (e.g. add custom tags / skip
+ * Sentry) can override by exporting their own `sentry.ts` plugin.
+ */
+import {
+  awaitBootstrap,
+  markDefaultPluginProvided,
+} from "./framework-request-handler.js";
+import { getSession } from "./auth.js";
+import {
+  captureRouteError,
+  initServerSentry,
+  isServerSentryEnabled,
+  setSentryUserForRequest,
+} from "./sentry.js";
+import { getHeader, getMethod, type H3Event } from "h3";
+
+type NitroPluginDef = (nitroApp: any) => void | Promise<void>;
+
+function readRoute(event: H3Event): string | undefined {
+  try {
+    return event.url?.pathname;
+  } catch {
+    return undefined;
+  }
+}
+
+function readUserAgent(event: H3Event): string | undefined {
+  try {
+    return getHeader(event, "user-agent");
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Skip session resolution for paths that obviously don't need one. Avoids
+ * a DB round-trip on every static-asset / favicon / public-share request
+ * while keeping API + framework routes covered.
+ */
+function shouldResolveSession(path: string | undefined): boolean {
+  if (!path) return false;
+  // Vite / React Router static assets and similar.
+  if (
+    path.startsWith("/assets/") ||
+    path.startsWith("/_build/") ||
+    path === "/favicon.ico" ||
+    path.startsWith("/static/")
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function createSentryPlugin(): NitroPluginDef {
+  return async (nitroApp: any) => {
+    markDefaultPluginProvided(nitroApp, "sentry");
+    await awaitBootstrap(nitroApp);
+
+    initServerSentry();
+    if (!isServerSentryEnabled()) {
+      // No DSN — skip wiring per-request hooks. We'd just be paying the
+      // call-site overhead for every request to no effect.
+      return;
+    }
+
+    // Per-request: resolve session and attach to Sentry isolation scope so
+    // any exception captured later in the request carries the user. Wrapped
+    // in try/catch so a session-DB hiccup or auth-broken state never turns
+    // into a 500 — the worst case is we lose user context on the event.
+    nitroApp.hooks?.hook?.("request", async (event: H3Event) => {
+      if (!shouldResolveSession(readRoute(event))) return;
+      try {
+        const session = await getSession(event);
+        setSentryUserForRequest(session);
+      } catch {
+        // best-effort — don't break the request
+      }
+    });
+
+    // Per-error: capture with route/method/UA tags. Nitro's `error` hook
+    // signature is (error, { event, tags }) — we forward what we can.
+    nitroApp.hooks?.hook?.(
+      "error",
+      (error: unknown, ctx?: { event?: H3Event }) => {
+        try {
+          const event = ctx?.event;
+          captureRouteError(error, {
+            route: event ? readRoute(event) : undefined,
+            method: event ? getMethod(event) : undefined,
+            userAgent: event ? readUserAgent(event) : undefined,
+          });
+        } catch {
+          // Sentry capture must never escape into Nitro's error path.
+        }
+      },
+    );
+  };
+}
+
+/**
+ * Default Sentry plugin — auto-mounts when a template doesn't define its
+ * own `server/plugins/sentry.ts`. Reads `SENTRY_SERVER_DSN` from env and
+ * silently no-ops when it's unset, so this is safe to default-mount in
+ * every template (including local dev with no DSN configured).
+ */
+export const defaultSentryPlugin: NitroPluginDef = createSentryPlugin();

--- a/packages/core/src/server/sentry.spec.ts
+++ b/packages/core/src/server/sentry.spec.ts
@@ -276,7 +276,10 @@ describe("server/sentry", () => {
         "route",
         "/_agent-native/agent-chat",
       );
-      expect(sentryMock.mockScope.setTag).toHaveBeenCalledWith("method", "POST");
+      expect(sentryMock.mockScope.setTag).toHaveBeenCalledWith(
+        "method",
+        "POST",
+      );
       expect(sentryMock.mockScope.setTag).toHaveBeenCalledWith(
         "userAgent",
         "Mozilla/5.0",

--- a/packages/core/src/server/sentry.spec.ts
+++ b/packages/core/src/server/sentry.spec.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AuthSession } from "./auth.js";
+
+// Mock @sentry/node BEFORE we import the module under test so the spied
+// versions of init / setUser / captureException are observed.
+const sentryMock = vi.hoisted(() => {
+  const mockScope = {
+    setUser: vi.fn(),
+    setTag: vi.fn(),
+  };
+  return {
+    init: vi.fn(),
+    getIsolationScope: vi.fn(() => mockScope),
+    withScope: vi.fn((fn: (scope: typeof mockScope) => unknown) =>
+      fn(mockScope),
+    ),
+    captureException: vi.fn(() => "evt_test"),
+    mockScope,
+  };
+});
+
+vi.mock("@sentry/node", () => ({
+  init: sentryMock.init,
+  getIsolationScope: sentryMock.getIsolationScope,
+  withScope: sentryMock.withScope,
+  captureException: sentryMock.captureException,
+}));
+
+describe("server/sentry", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    sentryMock.init.mockClear();
+    sentryMock.captureException.mockClear();
+    sentryMock.mockScope.setUser.mockClear();
+    sentryMock.mockScope.setTag.mockClear();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.resetModules();
+  });
+
+  describe("initServerSentry", () => {
+    it("does not call Sentry.init when SENTRY_SERVER_DSN is unset", async () => {
+      delete process.env.SENTRY_SERVER_DSN;
+      const { initServerSentry, isServerSentryEnabled } =
+        await import("./sentry.js");
+
+      expect(initServerSentry()).toBe(false);
+      expect(sentryMock.init).not.toHaveBeenCalled();
+      expect(isServerSentryEnabled()).toBe(false);
+    });
+
+    it("initializes with the DSN when present", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      process.env.NODE_ENV = "production";
+      const { initServerSentry, isServerSentryEnabled } =
+        await import("./sentry.js");
+
+      expect(initServerSentry()).toBe(true);
+      expect(sentryMock.init).toHaveBeenCalledTimes(1);
+      const cfg = sentryMock.init.mock.calls[0][0];
+      expect(cfg.dsn).toBe("https://test@example/123");
+      expect(cfg.environment).toBe("production");
+      expect(cfg.sendDefaultPii).toBe(false);
+      expect(cfg.tracesSampleRate).toBe(0);
+      expect(typeof cfg.beforeSend).toBe("function");
+      expect(isServerSentryEnabled()).toBe(true);
+    });
+
+    it("respects SENTRY_SERVER_TRACES_SAMPLE_RATE override", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      process.env.SENTRY_SERVER_TRACES_SAMPLE_RATE = "0.25";
+      const { initServerSentry } = await import("./sentry.js");
+      initServerSentry();
+
+      expect(sentryMock.init.mock.calls[0][0].tracesSampleRate).toBe(0.25);
+    });
+
+    it("clamps invalid trace rates to 0", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      process.env.SENTRY_SERVER_TRACES_SAMPLE_RATE = "abc";
+      const { initServerSentry } = await import("./sentry.js");
+      initServerSentry();
+
+      expect(sentryMock.init.mock.calls[0][0].tracesSampleRate).toBe(0);
+    });
+
+    it("is idempotent — calling twice does not re-initialize", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      const { initServerSentry } = await import("./sentry.js");
+      initServerSentry();
+      initServerSentry();
+      expect(sentryMock.init).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("beforeSend", () => {
+    it("drops ValidationError exceptions", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      const { initServerSentry } = await import("./sentry.js");
+      initServerSentry();
+
+      const beforeSend = sentryMock.init.mock.calls[0][0].beforeSend;
+      const result = beforeSend({
+        exception: { values: [{ type: "ValidationError" }] },
+      } as never);
+      expect(result).toBeNull();
+    });
+
+    it("strips authorization, cookie, and set-cookie headers", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      const { initServerSentry } = await import("./sentry.js");
+      initServerSentry();
+
+      const beforeSend = sentryMock.init.mock.calls[0][0].beforeSend;
+      const event = {
+        request: {
+          headers: {
+            authorization: "Bearer secret",
+            cookie: "session=abc",
+            "set-cookie": "x=1",
+            "user-agent": "Mozilla/5.0",
+          },
+          cookies: { session: "abc" },
+        },
+      };
+      const result = beforeSend(event as never);
+      const headers = (result as typeof event).request.headers;
+      expect(headers).not.toHaveProperty("authorization");
+      expect(headers).not.toHaveProperty("cookie");
+      expect(headers).not.toHaveProperty("set-cookie");
+      expect(headers["user-agent"]).toBe("Mozilla/5.0");
+      expect((result as typeof event).request).not.toHaveProperty("cookies");
+    });
+
+    it("strips ip_address but keeps explicit identity fields", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      const { initServerSentry } = await import("./sentry.js");
+      initServerSentry();
+
+      const beforeSend = sentryMock.init.mock.calls[0][0].beforeSend;
+      const result = beforeSend({
+        user: {
+          id: "user_123",
+          email: "alice@example.com",
+          ip_address: "1.2.3.4",
+        },
+      } as never);
+      expect(result.user).toEqual({
+        id: "user_123",
+        email: "alice@example.com",
+      });
+    });
+
+    it("drops the user object when only ip_address was set", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      const { initServerSentry } = await import("./sentry.js");
+      initServerSentry();
+
+      const beforeSend = sentryMock.init.mock.calls[0][0].beforeSend;
+      const result = beforeSend({
+        user: { ip_address: "1.2.3.4" },
+      } as never);
+      expect(result.user).toBeUndefined();
+    });
+
+    it("strips runtime_env from contexts", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      const { initServerSentry } = await import("./sentry.js");
+      initServerSentry();
+
+      const beforeSend = sentryMock.init.mock.calls[0][0].beforeSend;
+      const result = beforeSend({
+        contexts: {
+          runtime_env: { DATABASE_URL: "postgres://..." },
+          os: { name: "darwin" },
+        },
+      } as never);
+      expect(result.contexts).not.toHaveProperty("runtime_env");
+      expect(result.contexts.os).toEqual({ name: "darwin" });
+    });
+  });
+
+  describe("setSentryUserForRequest", () => {
+    it("no-ops when Sentry isn't initialized", async () => {
+      delete process.env.SENTRY_SERVER_DSN;
+      const { setSentryUserForRequest } = await import("./sentry.js");
+      setSentryUserForRequest({ email: "a@b.com" });
+      expect(sentryMock.mockScope.setUser).not.toHaveBeenCalled();
+    });
+
+    it("sets id/email/username and orgId tag when session present", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      const { initServerSentry, setSentryUserForRequest } =
+        await import("./sentry.js");
+      initServerSentry();
+
+      const session: AuthSession = {
+        email: "alice@example.com",
+        userId: "u_abc",
+        name: "Alice",
+        orgId: "org_42",
+        orgRole: "admin",
+      };
+      setSentryUserForRequest(session);
+
+      expect(sentryMock.mockScope.setUser).toHaveBeenCalledWith({
+        id: "u_abc",
+        email: "alice@example.com",
+        username: "Alice",
+      });
+      expect(sentryMock.mockScope.setTag).toHaveBeenCalledWith(
+        "orgId",
+        "org_42",
+      );
+      expect(sentryMock.mockScope.setTag).toHaveBeenCalledWith(
+        "orgRole",
+        "admin",
+      );
+    });
+
+    it("falls back to email as id when userId is missing", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      const { initServerSentry, setSentryUserForRequest } =
+        await import("./sentry.js");
+      initServerSentry();
+
+      setSentryUserForRequest({ email: "alice@example.com" });
+      expect(sentryMock.mockScope.setUser).toHaveBeenCalledWith({
+        id: "alice@example.com",
+        email: "alice@example.com",
+        username: undefined,
+      });
+    });
+
+    it("clears the user when session is null", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      const { initServerSentry, setSentryUserForRequest } =
+        await import("./sentry.js");
+      initServerSentry();
+
+      setSentryUserForRequest(null);
+      expect(sentryMock.mockScope.setUser).toHaveBeenCalledWith(null);
+      expect(sentryMock.mockScope.setTag).toHaveBeenCalledWith("orgId", null);
+    });
+  });
+
+  describe("captureRouteError", () => {
+    it("no-ops when Sentry isn't initialized", async () => {
+      delete process.env.SENTRY_SERVER_DSN;
+      const { captureRouteError } = await import("./sentry.js");
+      const result = captureRouteError(new Error("boom"));
+      expect(result).toBeUndefined();
+      expect(sentryMock.captureException).not.toHaveBeenCalled();
+    });
+
+    it("captures with route/method/userAgent tags", async () => {
+      process.env.SENTRY_SERVER_DSN = "https://test@example/123";
+      const { initServerSentry, captureRouteError } =
+        await import("./sentry.js");
+      initServerSentry();
+
+      const err = new Error("boom");
+      const result = captureRouteError(err, {
+        route: "/_agent-native/agent-chat",
+        method: "POST",
+        userAgent: "Mozilla/5.0",
+      });
+
+      expect(result).toBe("evt_test");
+      expect(sentryMock.captureException).toHaveBeenCalledWith(err);
+      expect(sentryMock.mockScope.setTag).toHaveBeenCalledWith(
+        "route",
+        "/_agent-native/agent-chat",
+      );
+      expect(sentryMock.mockScope.setTag).toHaveBeenCalledWith("method", "POST");
+      expect(sentryMock.mockScope.setTag).toHaveBeenCalledWith(
+        "userAgent",
+        "Mozilla/5.0",
+      );
+    });
+  });
+});

--- a/packages/core/src/server/sentry.ts
+++ b/packages/core/src/server/sentry.ts
@@ -1,0 +1,240 @@
+/**
+ * Server-side Sentry initialization for Nitro.
+ *
+ * Errors thrown inside Nitro routes (the framework's own /_agent-native/*
+ * handlers, the template's API routes, action handlers, agent-chat streams)
+ * never reach the CLI's Sentry init — that only covers the developer's
+ * machine. Without server-side Sentry the only signal a 500 ever produces
+ * is a server-side console.error that lives and dies with the request.
+ *
+ * This module is the third Sentry init point in the framework:
+ *   - cli/index.ts          → @sentry/node, hardcoded DSN, "agent-native-cli"
+ *   - client/analytics.ts   → @sentry/browser, VITE_SENTRY_CLIENT_DSN
+ *   - server/sentry.ts      → @sentry/node, SENTRY_SERVER_DSN
+ *
+ * Each maps to a different Sentry project so we can route errors to the
+ * right team without one project drowning out the others. Don't wire the
+ * three together — they share the SDK package but live in different
+ * processes / runtimes / call sites.
+ */
+import * as Sentry from "@sentry/node";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { AuthSession } from "./auth.js";
+
+let _initStarted = false;
+let _initSucceeded = false;
+
+/**
+ * Resolve the agent-native version baked into core's package.json so Sentry
+ * "release" reflects the running framework version. Mirrors how the CLI
+ * computes `_version` — same dist layout, same fallback string. Guarded so
+ * a missing/unreadable package.json never crashes server boot.
+ */
+function resolveServerRelease(): string {
+  const explicit = process.env.AGENT_NATIVE_RELEASE;
+  if (explicit) return explicit;
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    // dist/server/sentry.js → ../../package.json
+    const pkgPath = path.resolve(here, "../../package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as {
+      version?: string;
+    };
+    if (pkg?.version) return `agent-native-server@${pkg.version}`;
+  } catch {
+    // ignore — fall through to "unknown"
+  }
+  return "agent-native-server@unknown";
+}
+
+function parseTracesSampleRate(): number {
+  const raw = process.env.SENTRY_SERVER_TRACES_SAMPLE_RATE;
+  if (!raw) return 0;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 1) return 0;
+  return n;
+}
+
+/**
+ * Initialize server-side Sentry. Idempotent — safe to call from multiple
+ * plugin entrypoints. Returns `true` if initialization actually happened
+ * (DSN was set), `false` if Sentry is disabled (no DSN).
+ *
+ * No DSN is hardcoded: unlike the CLI (a published binary that always
+ * wants to phone home crashes), the server runs in customer environments.
+ * Operators set `SENTRY_SERVER_DSN` when they want their own Sentry
+ * project to receive these events; without it the module no-ops.
+ */
+export function initServerSentry(): boolean {
+  if (_initStarted) return _initSucceeded;
+  _initStarted = true;
+
+  const dsn = process.env.SENTRY_SERVER_DSN;
+  if (!dsn) {
+    if (process.env.DEBUG) {
+      console.log(
+        "[agent-native] SENTRY_SERVER_DSN not set — server Sentry disabled.",
+      );
+    }
+    return false;
+  }
+
+  Sentry.init({
+    dsn,
+    environment: process.env.NODE_ENV || "production",
+    release: resolveServerRelease(),
+    tracesSampleRate: parseTracesSampleRate(),
+    // sendDefaultPii MUST stay false — the framework runs inside customer
+    // environments and we never want to silently ship request headers,
+    // cookies, or process.env contents to Sentry without explicit consent.
+    sendDefaultPii: false,
+    beforeSend(event) {
+      // Drop expected user-input rejections so they don't pollute Sentry
+      // with non-bug noise. Mirrors the CLI's drop list — the framework
+      // and CLI both throw `ValidationError` for the same class of input
+      // failures, and exception type comes through as the class name.
+      const exceptionType = event.exception?.values?.[0]?.type;
+      if (
+        exceptionType === "ValidationError" ||
+        event.tags?.handled === "validation"
+      ) {
+        return null;
+      }
+
+      // Defense in depth: scrub PII even if some integration auto-attached
+      // request metadata despite sendDefaultPii: false.
+      if (event.request) {
+        if (event.request.headers) {
+          const headers = event.request.headers as Record<string, string>;
+          for (const k of Object.keys(headers)) {
+            const lk = k.toLowerCase();
+            if (
+              lk === "cookie" ||
+              lk === "authorization" ||
+              lk === "set-cookie" ||
+              lk === "proxy-authorization"
+            ) {
+              delete headers[k];
+            }
+          }
+        }
+        // Cookies live in their own field too.
+        delete (event.request as Record<string, unknown>).cookies;
+      }
+
+      // Keep user info that was explicitly set via Sentry.setUser
+      // (id/email/username) so we can attribute crashes back to a real
+      // operator. Always strip ip_address — auto-collected, no consent.
+      if (event.user) {
+        const user = event.user as Record<string, unknown>;
+        delete user.ip_address;
+        const hasIdentity =
+          typeof user.id === "string" ||
+          typeof user.email === "string" ||
+          typeof user.username === "string";
+        if (!hasIdentity) {
+          delete event.user;
+        }
+      }
+
+      // Sentry's contexts can carry process.env snapshots — strip env-shaped
+      // contexts so we don't leak deployment secrets.
+      if (event.contexts && typeof event.contexts === "object") {
+        delete (event.contexts as Record<string, unknown>).runtime_env;
+      }
+
+      return event;
+    },
+  });
+
+  _initSucceeded = true;
+  return true;
+}
+
+/**
+ * `true` once `initServerSentry()` has succeeded with a DSN. Plugins that
+ * want to skip work when Sentry is disabled can check this before calling
+ * the helpers below.
+ */
+export function isServerSentryEnabled(): boolean {
+  return _initSucceeded;
+}
+
+/**
+ * Attach the current request's user to Sentry's isolation scope so any
+ * `captureException` triggered later in the request carries the right
+ * `user.id` / `user.email` / `user.username` and `orgId` tag.
+ *
+ * Sentry node 10 uses Node's AsyncLocalStorage to give each async context
+ * its own isolation scope, so setting on `getIsolationScope()` here only
+ * affects events emitted while this request's async context is active.
+ *
+ * No-ops gracefully when Sentry isn't initialized or no session exists —
+ * never throws into the request path.
+ */
+export function setSentryUserForRequest(session: AuthSession | null): void {
+  if (!_initSucceeded) return;
+  try {
+    const scope = Sentry.getIsolationScope();
+    if (!session) {
+      scope.setUser(null);
+      scope.setTag("orgId", null);
+      return;
+    }
+    scope.setUser({
+      id: session.userId ?? session.email,
+      email: session.email,
+      username: session.name,
+    });
+    scope.setTag("orgId", session.orgId ?? null);
+    if (session.orgRole) {
+      scope.setTag("orgRole", session.orgRole);
+    }
+  } catch {
+    // Sentry scope APIs should never throw, but if they do we'd rather
+    // continue serving the request than crash on observability.
+  }
+}
+
+export interface RouteErrorContext {
+  /** The full request path (e.g. `/_agent-native/agent-chat`). */
+  route?: string;
+  /** HTTP method (e.g. `GET`, `POST`). */
+  method?: string;
+  /** Caller's `User-Agent` header. */
+  userAgent?: string;
+  /** Free-form extra tags to add to the event. */
+  tags?: Record<string, string | undefined>;
+}
+
+/**
+ * Capture an exception that surfaced in a Nitro route handler with the
+ * request's route/method/userAgent attached as searchable Sentry tags.
+ *
+ * Non-throwing: if Sentry isn't initialized or the underlying capture
+ * fails, this is a no-op. Returns the Sentry event ID when capture
+ * succeeded, otherwise `undefined`.
+ */
+export function captureRouteError(
+  error: unknown,
+  context: RouteErrorContext = {},
+): string | undefined {
+  if (!_initSucceeded) return undefined;
+  try {
+    return Sentry.withScope((scope) => {
+      if (context.route) scope.setTag("route", context.route);
+      if (context.method) scope.setTag("method", context.method);
+      if (context.userAgent) scope.setTag("userAgent", context.userAgent);
+      if (context.tags) {
+        for (const [k, v] of Object.entries(context.tags)) {
+          if (typeof v === "string") scope.setTag(k, v);
+        }
+      }
+      return Sentry.captureException(error);
+    });
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core/src/server/transcribe-voice.ts
+++ b/packages/core/src/server/transcribe-voice.ts
@@ -6,10 +6,8 @@
  * `{ error }` on failure.
  *
  * Key resolution order for BYOK providers:
- *   1. User-scoped encrypted secret (`readAppSecret` — set via the sidebar
- *      settings UI).
- *   2. `resolveCredential("<PROVIDER>_API_KEY")` — env var + SQL settings
- *      store.
+ *   1. Request-scoped encrypted secret (`app_secrets`: user, org, workspace).
+ *   2. Env var fallback only outside authenticated request contexts.
  *
  * If no server provider is configured, returns 400 with an error the
  * composer UI can surface (the client falls back to Web Speech when possible).
@@ -27,11 +25,12 @@ import {
   setResponseStatus,
   type H3Event,
 } from "h3";
-import { readAppSecret } from "../secrets/storage.js";
-import { resolveCredential } from "../credentials/index.js";
 import { getSession } from "./auth.js";
 import { appStateGet } from "../application-state/store.js";
-import { resolveHasBuilderPrivateKey } from "./credential-provider.js";
+import {
+  resolveHasBuilderPrivateKey,
+  resolveSecret,
+} from "./credential-provider.js";
 import { transcribeWithBuilder } from "../transcription/builder-transcription.js";
 import { runWithRequestContext } from "./request-context.js";
 import { getOrgContext } from "../org/context.js";
@@ -226,17 +225,7 @@ export function createTranscribeVoiceHandler() {
     // Per-user-or-fallback API key resolution. Hoisted up so the Gemini
     // path below can use it without duplicating logic.
     async function resolveApiKey(key: string): Promise<string | undefined> {
-      const ctx = { userEmail: session?.email };
-      if (!session?.email)
-        return (await resolveCredential(key, ctx)) ?? undefined;
-      const userSecret = await readAppSecret({
-        key,
-        scope: "user",
-        scopeId: session.email,
-      }).catch(() => null);
-      return (
-        userSecret?.value || (await resolveCredential(key, ctx)) || undefined
-      );
+      return (await withRequestContext(() => resolveSecret(key))) ?? undefined;
     }
 
     if (transcriptText) {

--- a/packages/core/src/server/voice-providers-status.spec.ts
+++ b/packages/core/src/server/voice-providers-status.spec.ts
@@ -1,9 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetSession = vi.fn();
-const mockReadAppSecret = vi.fn();
-const mockResolveCredential = vi.fn();
 const mockResolveHasBuilderPrivateKey = vi.fn();
+const mockResolveSecret = vi.fn();
 const mockGetOrgContext = vi.fn();
 const mockResolveGoogleRealtimeCredentials = vi.fn();
 
@@ -17,14 +16,6 @@ vi.mock("h3", () => ({
   },
 }));
 
-vi.mock("../secrets/storage.js", () => ({
-  readAppSecret: (...args: any[]) => mockReadAppSecret(...args),
-}));
-
-vi.mock("../credentials/index.js", () => ({
-  resolveCredential: (...args: any[]) => mockResolveCredential(...args),
-}));
-
 vi.mock("./auth.js", () => ({
   getSession: (...args: any[]) => mockGetSession(...args),
 }));
@@ -32,6 +23,7 @@ vi.mock("./auth.js", () => ({
 vi.mock("./credential-provider.js", () => ({
   resolveHasBuilderPrivateKey: (...args: any[]) =>
     mockResolveHasBuilderPrivateKey(...args),
+  resolveSecret: (...args: any[]) => mockResolveSecret(...args),
 }));
 
 vi.mock("../org/context.js", () => ({
@@ -61,8 +53,7 @@ describe("voice providers status route", () => {
     lastStatus = 200;
     delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
     mockGetSession.mockResolvedValue({ email: "voice+qa@example.com" });
-    mockReadAppSecret.mockResolvedValue(null);
-    mockResolveCredential.mockResolvedValue(undefined);
+    mockResolveSecret.mockResolvedValue(null);
     mockResolveHasBuilderPrivateKey.mockResolvedValue(false);
     mockGetOrgContext.mockResolvedValue({ orgId: "org-123" });
     mockResolveGoogleRealtimeCredentials.mockResolvedValue(null);
@@ -78,11 +69,12 @@ describe("voice providers status route", () => {
 
   it("reports user secrets and fallback credentials without returning key material", async () => {
     mockResolveHasBuilderPrivateKey.mockResolvedValue(true);
-    mockReadAppSecret.mockImplementation(async ({ key }) =>
-      key === "OPENAI_API_KEY" ? { value: "sk-openai-secret" } : null,
-    );
-    mockResolveCredential.mockImplementation(async (key: string) =>
-      key === "GROQ_API_KEY" ? "configured-secret" : undefined,
+    mockResolveSecret.mockImplementation(async (key: string) =>
+      key === "OPENAI_API_KEY"
+        ? "sk-openai-secret"
+        : key === "GROQ_API_KEY"
+          ? "configured-secret"
+          : null,
     );
     mockResolveGoogleRealtimeCredentials.mockResolvedValue(
       '{"type":"service_account"}',
@@ -101,15 +93,13 @@ describe("voice providers status route", () => {
       native: true,
     });
     expect(JSON.stringify(result)).not.toContain("secret");
-    expect(mockResolveCredential).toHaveBeenCalledWith("GROQ_API_KEY", {
-      userEmail: "voice+qa@example.com",
-    });
+    expect(mockResolveSecret).toHaveBeenCalledWith("GROQ_API_KEY");
   });
 
-  it("falls back to process/sql credentials when there is no session", async () => {
+  it("uses the unscoped resolver when there is no session", async () => {
     mockGetSession.mockResolvedValue(null);
-    mockResolveCredential.mockImplementation(async (key: string) =>
-      key === "GEMINI_API_KEY" ? "gemini-key" : undefined,
+    mockResolveSecret.mockImplementation(async (key: string) =>
+      key === "GEMINI_API_KEY" ? "gemini-key" : null,
     );
 
     const handler = createVoiceProvidersStatusHandler();
@@ -121,10 +111,7 @@ describe("voice providers status route", () => {
       groq: false,
       googleRealtime: false,
     });
-    expect(mockReadAppSecret).not.toHaveBeenCalled();
-    expect(mockResolveCredential).toHaveBeenCalledWith("GEMINI_API_KEY", {
-      userEmail: undefined,
-    });
+    expect(mockResolveSecret).toHaveBeenCalledWith("GEMINI_API_KEY");
   });
 
   it("reports deploy-managed Google credentials only when they resolve cleanly", async () => {

--- a/packages/core/src/server/voice-providers-status.ts
+++ b/packages/core/src/server/voice-providers-status.ts
@@ -5,11 +5,10 @@
  * current user. The desktop Settings UI uses this to show "Connect" vs
  * "Connected" status pills next to each provider option.
  *
- * Resolution mirrors `transcribe-voice.ts`: we try the user-scoped
- * encrypted secret first (set via the sidebar settings UI) and fall back
- * to `resolveCredential()` (env var + SQL settings store). Each lookup is
- * wrapped in try/catch — one provider's failure must never break the
- * whole response.
+ * Resolution mirrors `transcribe-voice.ts`: we read request-scoped encrypted
+ * secrets (user, org, workspace), with env fallback only outside authenticated
+ * request contexts. Each lookup is wrapped in try/catch — one provider's
+ * failure must never break the whole response.
  *
  * Returns booleans only — never the actual key material.
  */
@@ -19,10 +18,11 @@ import {
   setResponseStatus,
   type H3Event,
 } from "h3";
-import { readAppSecret } from "../secrets/storage.js";
-import { resolveCredential } from "../credentials/index.js";
 import { getSession } from "./auth.js";
-import { resolveHasBuilderPrivateKey } from "./credential-provider.js";
+import {
+  resolveHasBuilderPrivateKey,
+  resolveSecret,
+} from "./credential-provider.js";
 import { getOrgContext } from "../org/context.js";
 import { runWithRequestContext } from "./request-context.js";
 import { resolveGoogleRealtimeCredentials } from "./google-realtime-session.js";
@@ -58,32 +58,29 @@ export function createVoiceProvidersStatusHandler() {
     }
 
     const session = await getSession(event).catch(() => null);
+    const orgCtx = session?.email
+      ? await getOrgContext(event).catch(() => null)
+      : null;
+    const requestContext = {
+      userEmail: session?.email,
+      orgId: orgCtx?.orgId ?? undefined,
+    };
+    const withRequestContext = async <T>(fn: () => Promise<T>): Promise<T> =>
+      requestContext.userEmail
+        ? runWithRequestContext(requestContext, fn)
+        : fn();
 
     async function hasKey(key: string): Promise<boolean> {
       try {
         if (key === "GOOGLE_APPLICATION_CREDENTIALS") {
-          const orgCtx = session?.email
-            ? await getOrgContext(event).catch(() => null)
-            : null;
           const resolved = await resolveGoogleRealtimeCredentials({
             userEmail: session?.email,
             orgId: orgCtx?.orgId ?? undefined,
           });
           return typeof resolved === "string" && resolved.length > 0;
         }
-        const ctx = { userEmail: session?.email };
-        if (!session?.email) {
-          const v = await resolveCredential(key, ctx);
-          return typeof v === "string" && v.length > 0;
-        }
-        const userSecret = await readAppSecret({
-          key,
-          scope: "user",
-          scopeId: session.email,
-        }).catch(() => null);
-        if (userSecret?.value && userSecret.value.length > 0) return true;
-        const fallback = await resolveCredential(key, ctx);
-        return typeof fallback === "string" && fallback.length > 0;
+        const resolved = await withRequestContext(() => resolveSecret(key));
+        return typeof resolved === "string" && resolved.length > 0;
       } catch {
         return false;
       }
@@ -91,20 +88,9 @@ export function createVoiceProvidersStatusHandler() {
 
     let builder = false;
     try {
-      const orgCtx = session?.email
-        ? await getOrgContext(event).catch(() => null)
-        : null;
-      const resolve = () => resolveHasBuilderPrivateKey();
       builder =
-        (session?.email
-          ? await runWithRequestContext(
-              {
-                userEmail: session.email,
-                orgId: orgCtx?.orgId ?? undefined,
-              },
-              resolve,
-            )
-          : await resolve()) === true;
+        (await withRequestContext(() => resolveHasBuilderPrivateKey())) ===
+        true;
     } catch {
       builder = false;
     }

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -935,15 +935,10 @@ function openOAuthWindow(
     scheduleClose();
   });
 
-  // Builder's callback writes credentials server-side, so reload after it
-  // closes. Google success already reloads through the agentnative:// handoff;
-  // Google failures are delivered to the app through desktop-exchange, so an
-  // unconditional reload here would erase the in-app recovery panel.
-  oauthWin.on("closed", () => {
-    if (provider.name !== "google") {
-      reloadAllWebviews();
-    }
-  });
+  // Builder credentials now land in SQL-backed app_secrets and the webview
+  // side polls /builder/status, so closing the popup should leave the current
+  // chat mounted. Google success still reloads through the agentnative://
+  // session-cookie handoff in handleDeepLink().
 }
 
 const webviewOAuthNavigationHandlers = new WeakSet<Electron.WebContents>();

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -92,14 +92,71 @@ function CanonicalLink() {
   return <link rel="canonical" href={canonical} />;
 }
 
-// AgentSidebar wraps content in an overflow-auto div, so the window never
-// scrolls. React Router's <ScrollRestoration /> resets window.scrollY, which
-// does nothing here — find the real scroll container and reset it instead.
-function ScrollToTop() {
+function findScrollContainerFrom(el: HTMLElement | null): HTMLElement | Window {
+  let parent: HTMLElement | null = el?.parentElement ?? null;
+  while (parent) {
+    const overflowY = getComputedStyle(parent).overflowY;
+    if (
+      (overflowY === "auto" || overflowY === "scroll") &&
+      parent.scrollHeight > parent.clientHeight
+    ) {
+      return parent;
+    }
+    parent = parent.parentElement;
+  }
+  return window;
+}
+
+function scrollElementIntoContainerView(target: HTMLElement) {
+  const scrollContainer = findScrollContainerFrom(target);
+  if (scrollContainer === window) {
+    target.scrollIntoView({ block: "start" });
+    return;
+  }
+
+  const container = scrollContainer as HTMLElement;
+  const targetRect = target.getBoundingClientRect();
+  const containerRect = container.getBoundingClientRect();
+  const scrollMarginTop =
+    Number.parseFloat(getComputedStyle(target).scrollMarginTop) || 0;
+
+  container.scrollTo({
+    top:
+      container.scrollTop +
+      targetRect.top -
+      containerRect.top -
+      scrollMarginTop,
+  });
+}
+
+// AgentSidebar wraps content in an overflow-auto div, so the window usually
+// does not scroll. Keep both normal route changes and hash links pointed at
+// that real scroll container.
+function ScrollManager({ mounted }: { mounted: boolean }) {
   const { pathname, hash } = useLocation();
   const ref = useRef<HTMLSpanElement>(null);
+
   useEffect(() => {
-    if (hash) return;
+    if (hash) {
+      const id = decodeURIComponent(hash.slice(1));
+      let raf = 0;
+      const timers: number[] = [];
+
+      const scrollToHash = () => {
+        const target = document.getElementById(id);
+        if (target) scrollElementIntoContainerView(target);
+      };
+
+      raf = window.requestAnimationFrame(scrollToHash);
+      timers.push(window.setTimeout(scrollToHash, 100));
+      timers.push(window.setTimeout(scrollToHash, 350));
+
+      return () => {
+        window.cancelAnimationFrame(raf);
+        for (const timer of timers) window.clearTimeout(timer);
+      };
+    }
+
     let parent: HTMLElement | null = ref.current?.parentElement ?? null;
     while (parent) {
       const overflowY = getComputedStyle(parent).overflowY;
@@ -110,7 +167,7 @@ function ScrollToTop() {
       parent = parent.parentElement;
     }
     window.scrollTo(0, 0);
-  }, [pathname, hash]);
+  }, [pathname, hash, mounted]);
   return <span ref={ref} aria-hidden style={{ display: "none" }} />;
 }
 
@@ -155,7 +212,7 @@ export default function Root() {
 
   const content = (
     <>
-      <ScrollToTop />
+      <ScrollManager mounted={mounted} />
       <Header />
       <Outlet />
       <Footer />

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -664,35 +664,51 @@ function DataSourceCard({
                 );
               })()}
 
-              {/* Step navigation */}
-              <div className="flex items-center gap-2 pt-2 pb-4">
-                {currentStep > 0 && (
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setCurrentStep((s) => s - 1);
-                    }}
-                    className="text-xs"
-                  >
-                    Back
-                  </Button>
-                )}
-                {currentStep < totalSteps - 1 && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setCurrentStep((s) => s + 1);
-                    }}
-                    className="text-xs"
-                  >
-                    Continue
-                  </Button>
-                )}
-              </div>
+              {/* Step navigation. Continue is gated on completing the
+                  current step's input — otherwise the progress bar advances
+                  while the user hasn't actually done anything, which feels
+                  misleading. Steps with no input (just a link to a console)
+                  or marked optional always allow Continue. */}
+              {(() => {
+                const step = source.walkthroughSteps[currentStep];
+                const stepKey = step.inputKey;
+                const stepFilled = stepKey
+                  ? !!inputValues[stepKey]?.trim() ||
+                    !!envStatus.find((s) => s.key === stepKey)?.configured
+                  : true;
+                const canAdvance = !stepKey || step.optional || stepFilled;
+                return (
+                  <div className="flex items-center gap-2 pt-2 pb-4">
+                    {currentStep > 0 && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setCurrentStep((s) => s - 1);
+                        }}
+                        className="text-xs"
+                      >
+                        Back
+                      </Button>
+                    )}
+                    {currentStep < totalSteps - 1 && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={!canAdvance}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setCurrentStep((s) => s + 1);
+                        }}
+                        className="text-xs"
+                      >
+                        Continue
+                      </Button>
+                    )}
+                  </div>
+                );
+              })()}
 
               <div className="flex items-center gap-2 pt-4 border-t border-border/30">
                 {hasInputValues && (

--- a/templates/clips/actions/cleanup-transcript.ts
+++ b/templates/clips/actions/cleanup-transcript.ts
@@ -26,13 +26,11 @@
 
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
-import { readAppSecret } from "@agent-native/core/secrets";
 import {
-  resolveBuilderCredential,
   resolveBuilderAuthHeader,
+  resolveSecret,
   FeatureNotConfiguredError,
 } from "@agent-native/core/server";
-import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 
 // Builder public LLM gateway base URL. Override via BUILDER_GATEWAY_BASE_URL.
 // Mirrors `getBuilderGatewayBaseUrl()` in @agent-native/core/server/credential-provider
@@ -138,22 +136,7 @@ export default defineAction({
 });
 
 async function resolveUserGeminiKey(): Promise<string | null> {
-  // Prefer the Builder credential helper for symmetry; falls back to per-user
-  // app_secrets for users who pasted their own Gemini key.
-  const fromBuilder = await resolveBuilderCredential("GEMINI_API_KEY");
-  if (fromBuilder) return fromBuilder;
-  const email = getRequestUserEmail();
-  if (!email) return null;
-  try {
-    const secret = await readAppSecret({
-      key: "GEMINI_API_KEY",
-      scope: "user",
-      scopeId: email,
-    });
-    return secret?.value ?? null;
-  } catch {
-    return null;
-  }
+  return await resolveSecret("GEMINI_API_KEY");
 }
 
 async function callBuilderGateway({

--- a/templates/clips/actions/connect-calendar.ts
+++ b/templates/clips/actions/connect-calendar.ts
@@ -46,7 +46,7 @@ export default defineAction({
     // The route mints signed state and uses the standard framework callback
     // path so the local Google OAuth client only needs one registered URI:
     // http://localhost:<port>/_agent-native/google/callback.
-    const params = new URLSearchParams({ calendar: "1" });
+    const params = new URLSearchParams({ calendar: "1", redirect: "1" });
     if (args.returnUrl) params.set("return", args.returnUrl);
     const url = `/_agent-native/google/auth-url?${params.toString()}`;
 

--- a/templates/clips/actions/list-recordings.ts
+++ b/templates/clips/actions/list-recordings.ts
@@ -190,6 +190,8 @@ export default defineAction({
       animatedThumbnailUrl: r.animatedThumbnailUrl,
       durationMs: r.durationMs,
       status: r.status,
+      uploadProgress: r.uploadProgress,
+      failureReason: r.failureReason,
       visibility: r.visibility,
       ownerEmail: r.ownerEmail,
       folderId: r.folderId,

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -12,12 +12,9 @@ import {
   IconAppWindow,
   IconX,
   IconMenu2,
+  IconLayoutSidebarRightExpand,
 } from "@tabler/icons-react";
-import {
-  AgentSidebar,
-  AgentToggleButton,
-  FeedbackButton,
-} from "@agent-native/core/client";
+import { AgentSidebar, FeedbackButton } from "@agent-native/core/client";
 import { RequireActiveOrg } from "@agent-native/core/client/org";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -52,6 +49,24 @@ import {
 
 interface LibraryLayoutProps {
   children: ReactNode;
+}
+
+function ClipsAgentToggleButton() {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new Event("agent-panel:toggle"))}
+          className="ml-1.5 flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+          aria-label="Toggle agent panel"
+        >
+          <IconLayoutSidebarRightExpand className="h-4 w-4" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>Toggle agent</TooltipContent>
+    </Tooltip>
+  );
 }
 
 export function LibraryLayout({ children }: LibraryLayoutProps) {
@@ -331,7 +346,7 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
                     className="flex min-w-0 flex-1 flex-wrap items-center gap-3"
                   />
                   <div className="ml-auto flex items-center gap-2">
-                    <AgentToggleButton />
+                    <ClipsAgentToggleButton />
                   </div>
                 </header>
               )}

--- a/templates/clips/app/components/library/recording-card.tsx
+++ b/templates/clips/app/components/library/recording-card.tsx
@@ -12,6 +12,7 @@ import {
   IconTrash,
   IconEdit,
   IconCheck,
+  IconAlertTriangle,
 } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -125,6 +126,14 @@ export function RecordingCard({
     [onToggleSelect, recording.id],
   );
 
+  const handleRemoveFailed = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onTrash?.(recording);
+    },
+    [onTrash, recording],
+  );
+
   return (
     <div
       role="article"
@@ -189,6 +198,29 @@ export function RecordingCard({
         {recording.status !== "ready" && (
           <div className="absolute top-2 right-2 rounded-full bg-black/80 px-2 py-0.5 text-[10px] font-medium text-white uppercase tracking-wide">
             {recording.status}
+          </div>
+        )}
+
+        {recording.status === "failed" && (
+          <div className="absolute inset-x-2 bottom-2 rounded-md border border-destructive/30 bg-background/95 p-2 text-left shadow-sm backdrop-blur">
+            <div className="flex items-start gap-2">
+              <IconAlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-destructive" />
+              <div className="min-w-0 flex-1">
+                <div className="text-[11px] font-medium text-foreground">
+                  Upload failed
+                </div>
+                <div className="line-clamp-2 text-[10px] leading-snug text-muted-foreground">
+                  {recording.failureReason ?? "Remove this failed clip."}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={handleRemoveFailed}
+                className="rounded border border-border px-1.5 py-0.5 text-[10px] text-foreground hover:bg-accent"
+              >
+                Remove
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -14,7 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { RecordingMode } from "./recorder-engine";
+import { NO_MIC_DEVICE_ID, type RecordingMode } from "./recorder-engine";
 
 export interface PreRecordPanelProps {
   onStart: (opts: {
@@ -72,16 +72,6 @@ export function PreRecordPanel({
     let cancelled = false;
     async function enumerate() {
       try {
-        // Prompt so device labels become available.
-        let temp: MediaStream | null = null;
-        try {
-          temp = await navigator.mediaDevices.getUserMedia({
-            audio: true,
-            video: true,
-          });
-        } catch {
-          // proceed even if prompt declined — labels will be blank.
-        }
         const devices = await navigator.mediaDevices.enumerateDevices();
         if (cancelled) return;
         setMics(
@@ -96,9 +86,6 @@ export function PreRecordPanel({
               d.kind === "videoinput" && d.deviceId && d.deviceId !== "default",
           ),
         );
-        if (temp) {
-          for (const t of temp.getTracks()) t.stop();
-        }
       } catch (err) {
         setEnumError(
           err instanceof Error ? err.message : "Could not enumerate devices",
@@ -163,6 +150,7 @@ export function PreRecordPanel({
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="default">Default microphone</SelectItem>
+              <SelectItem value={NO_MIC_DEVICE_ID}>No microphone</SelectItem>
               {mics.map((m) => (
                 <SelectItem key={m.deviceId} value={m.deviceId}>
                   {m.label || `Mic ${m.deviceId.slice(0, 4)}`}

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -9,6 +9,7 @@
 import { appBasePath } from "@agent-native/core/client";
 
 export type RecordingMode = "screen" | "camera" | "screen+camera";
+export const NO_MIC_DEVICE_ID = "__clips_no_microphone__";
 
 export type RecorderState =
   | "idle"
@@ -75,22 +76,24 @@ export interface RecorderFinalizeResult {
 const DEFAULT_CHUNK_MS = 2000;
 
 /** Pick a MediaRecorder mimeType the current browser actually supports. */
-export function pickMimeType(): string {
-  // Prefer MP4 (H.264) — produces faststart-friendly files that stream well
-  // with HTTP range requests. Chrome 121+ and Safari both support MP4 in
-  // MediaRecorder; Firefox falls back to WebM.
-  const candidates = [
-    "video/mp4;codecs=avc1,opus",
+export function pickMimeTypeCandidates(): string[] {
+  // Chrome can report MP4 support but still reject the encoder configuration
+  // for some display-capture streams. Prefer the WebM combinations that are
+  // broadly supported by MediaRecorder, then fall back to MP4/Safari.
+  return [
+    "video/webm;codecs=vp8,opus",
+    "video/webm;codecs=vp9,opus",
+    "video/webm;codecs=vp8",
+    "video/webm;codecs=vp9",
+    "video/webm",
     "video/mp4;codecs=avc1",
     "video/mp4",
-    "video/webm;codecs=vp9,opus",
-    "video/webm;codecs=vp8,opus",
-    "video/webm;codecs=vp9",
-    "video/webm;codecs=vp8",
-    "video/webm",
   ];
+}
+
+export function pickMimeType(): string {
   if (typeof MediaRecorder === "undefined") return "video/webm";
-  for (const type of candidates) {
+  for (const type of pickMimeTypeCandidates()) {
     try {
       if (MediaRecorder.isTypeSupported(type)) return type;
     } catch {
@@ -119,6 +122,7 @@ export class RecorderEngine {
   private startedAtMs: number | null = null;
   private pausedAccumMs = 0;
   private pausedStartedMs: number | null = null;
+  private uploadFailure: Error | null = null;
 
   private state: RecorderState = "idle";
 
@@ -187,17 +191,19 @@ export class RecorderEngine {
         });
       }
 
-      // Mic is separate so user can pick explicitly; combined with system audio later.
-      try {
-        this.micStream = await navigator.mediaDevices.getUserMedia({
-          audio: this.opts.micDeviceId
-            ? { deviceId: { exact: this.opts.micDeviceId } }
-            : true,
-          video: false,
-        });
-      } catch {
-        // Mic is optional — if denied we still record without it.
-        this.micStream = null;
+      if (this.opts.micDeviceId !== NO_MIC_DEVICE_ID) {
+        // Mic is separate so user can pick explicitly; combined with system audio later.
+        try {
+          this.micStream = await navigator.mediaDevices.getUserMedia({
+            audio: this.opts.micDeviceId
+              ? { deviceId: { exact: this.opts.micDeviceId } }
+              : true,
+            video: false,
+          });
+        } catch {
+          // Mic is optional — if denied we still record without it.
+          this.micStream = null;
+        }
       }
 
       // If the display stream's video track ends (user hit "Stop sharing" in
@@ -260,12 +266,39 @@ export class RecorderEngine {
     // so the browser's screen/camera indicator doesn't linger after
     // the caller's error handler.
     try {
-      const preferred = pickMimeType();
-      this.recorder = new MediaRecorder(this.combinedStream, {
-        mimeType: preferred || undefined,
-        videoBitsPerSecond: 4_000_000,
+      if (typeof MediaRecorder === "undefined") {
+        throw new Error(
+          "Your browser doesn't support screen recording. Try a recent Chrome, Edge, Safari, or Firefox.",
+        );
+      }
+      const candidates = pickMimeTypeCandidates().filter((type) => {
+        try {
+          return MediaRecorder.isTypeSupported(type);
+        } catch {
+          return false;
+        }
       });
-      this.mimeType = preferred || this.recorder.mimeType;
+      candidates.push("");
+      let lastError: unknown = null;
+
+      for (const type of candidates) {
+        try {
+          this.recorder = new MediaRecorder(
+            this.combinedStream,
+            type ? { mimeType: type } : undefined,
+          );
+          this.mimeType = this.recorder.mimeType || type;
+          lastError = null;
+          break;
+        } catch (err) {
+          lastError = err;
+          this.recorder = null;
+        }
+      }
+
+      if (!this.recorder && lastError) {
+        throw lastError;
+      }
       if (!this.mimeType) {
         throw new Error(
           "Your browser doesn't support any of the video codecs Clips needs. Try a recent Chrome, Edge, Safari, or Firefox.",
@@ -277,6 +310,7 @@ export class RecorderEngine {
     }
 
     this.chunkIndex = 0;
+    this.uploadFailure = null;
 
     this.recorder.addEventListener("dataavailable", (event) => {
       const blob = event.data;
@@ -360,7 +394,8 @@ export class RecorderEngine {
       // Yield to the event loop so any pending dataavailable event from the
       // auto-stop can fire and be queued before we drain chunkQueue.
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
-      await this.chunkQueue.catch(() => {});
+      await this.chunkQueue;
+      if (this.uploadFailure) throw this.uploadFailure;
       const dimensions = this.readDimensions();
       const durationMs = Math.round(this.getElapsedMs());
       const hasAudio = this.hasAudioTrack();
@@ -430,7 +465,8 @@ export class RecorderEngine {
     const finalIndex = this.chunkIndex++;
 
     // Wait for all pending in-flight chunks before we send the isFinal one.
-    await this.chunkQueue.catch(() => {});
+    await this.chunkQueue;
+    if (this.uploadFailure) throw this.uploadFailure;
 
     const dimensions = this.readDimensions();
     const durationMs = Math.round(this.getElapsedMs());
@@ -477,6 +513,7 @@ export class RecorderEngine {
     }
     this.cleanupTracks();
     this.chunkIndex = 0;
+    this.uploadFailure = null;
     this.startedAtMs = null;
     this.pausedAccumMs = 0;
     this.pausedStartedMs = null;
@@ -533,18 +570,39 @@ export class RecorderEngine {
   }
 
   private queueChunk(blob: Blob, index: number, isFinal: boolean): void {
-    this.chunkQueue = this.chunkQueue.then(() =>
-      this.uploadChunk(blob, index, { isFinal, mimeType: this.mimeType }).then(
-        () => {
-          this.opts.onChunk?.({
-            index,
-            bytes: blob.size,
-            total: null,
-          });
-        },
-        (err) => this.emitError(err),
-      ),
-    );
+    this.chunkQueue = this.chunkQueue.then(async () => {
+      if (this.uploadFailure) return;
+      try {
+        await this.uploadChunk(blob, index, {
+          isFinal,
+          mimeType: this.mimeType,
+        });
+        this.opts.onChunk?.({
+          index,
+          bytes: blob.size,
+          total: null,
+        });
+      } catch (err) {
+        const failure = err instanceof Error ? err : new Error(String(err));
+        await this.markUploadFailed(failure);
+        this.emitError(failure);
+      }
+    });
+  }
+
+  private async markUploadFailed(err: Error): Promise<void> {
+    if (!this.uploadFailure) {
+      this.uploadFailure = err;
+    }
+    try {
+      await fetch(this.opts.abortUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reason: err.message }),
+      });
+    } catch {
+      // ignore — the stop path will surface the original upload error.
+    }
   }
 
   private async uploadChunk(
@@ -661,7 +719,7 @@ export class RecorderEngine {
       err instanceof Error ? err.message : String(err || "Unknown error");
     if (/Permission denied|NotAllowedError|denied/i.test(message)) {
       return new Error(
-        "Screen or camera access was denied. On macOS, grant access in System Settings → Privacy & Security → Screen Recording and reload.",
+        "Screen, camera, or microphone access was blocked. In Chrome, open Site settings for this app and allow Camera and Microphone. On macOS, also check System Settings > Privacy & Security for Screen Recording, Camera, and Microphone, then quit and reopen Chrome.",
       );
     }
     if (/NotFoundError|no device/i.test(message)) {

--- a/templates/clips/app/hooks/use-library.ts
+++ b/templates/clips/app/hooks/use-library.ts
@@ -8,6 +8,8 @@ export interface RecordingSummary {
   animatedThumbnailUrl: string | null;
   durationMs: number;
   status: "uploading" | "processing" | "ready" | "failed";
+  uploadProgress?: number;
+  failureReason?: string | null;
   visibility: "private" | "org" | "public";
   ownerEmail: string;
   folderId: string | null;

--- a/templates/clips/app/routes/_app.meetings._index.tsx
+++ b/templates/clips/app/routes/_app.meetings._index.tsx
@@ -106,16 +106,22 @@ function ConnectCalendarEmptyState({
     fetch("/_agent-native/actions/connect-calendar?provider=google")
       .then(async (r) => {
         const text = await r.text();
-        let data: { url?: string; error?: string } = {};
+        let data: {
+          url?: string;
+          error?: string;
+          result?: { url?: string };
+        } = {};
         try {
           data = JSON.parse(text);
         } catch {
           /* fall through */
         }
         if (!r.ok) throw new Error(data.error || `Failed (${r.status})`);
-        if (!data.url) throw new Error("No OAuth URL returned");
+        const url = data.result?.url ?? data.url;
+        if (!url) throw new Error("No OAuth URL returned");
+        const popupUrl = new URL(url, window.location.origin).toString();
         window.open(
-          data.url,
+          popupUrl,
           "_blank",
           "noopener,noreferrer,width=600,height=700",
         );

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -64,6 +64,30 @@ type UiState =
 
 const MAC_SCREEN_RECORDING_PREF_URL =
   "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture";
+const MAC_CAMERA_PREF_URL =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera";
+const MAC_MICROPHONE_PREF_URL =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone";
+
+function isMacPlatform(): boolean {
+  return /^darwin|mac/i.test(
+    typeof navigator !== "undefined" ? navigator.platform : "",
+  );
+}
+
+function isPermissionError(message: string): boolean {
+  return /screen|camera|microphone|mic|permission|blocked|denied|not allowed/i.test(
+    message,
+  );
+}
+
+function permissionGuidance(message: string): string | null {
+  if (!isPermissionError(message)) return null;
+  if (isMacPlatform()) {
+    return "Check Chrome Site settings first. If it still fails, open macOS System Settings > Privacy & Security and enable Screen Recording, Camera, and Microphone for Chrome, then quit and reopen Chrome.";
+  }
+  return "Open Chrome Site settings for this app and allow Camera and Microphone, then reload this page.";
+}
 
 function captureThumbnailFromPreview(
   video: HTMLVideoElement | null,
@@ -188,6 +212,23 @@ export default function RecordRoute() {
     }
   }, [previewStream]);
 
+  const showRecordingErrorToast = useCallback((message: string) => {
+    const guidance = permissionGuidance(message);
+    toast.error("Couldn't start recording", {
+      description: guidance ?? message,
+      duration: guidance ? 20_000 : 10_000,
+      action:
+        guidance && isMacPlatform()
+          ? {
+              label: "Open settings",
+              onClick: () => {
+                window.location.href = MAC_SCREEN_RECORDING_PREF_URL;
+              },
+            }
+          : undefined,
+    });
+  }, []);
+
   // -------------------------------------------------------------------------
   // Create recording row, acquire media, start countdown.
   // -------------------------------------------------------------------------
@@ -269,7 +310,7 @@ export default function RecordRoute() {
           abortUrl: `${appBasePath()}${info.abortUrl!}`,
           onError: (err) => {
             console.error("[recorder] error:", err);
-            toast.error(err.message);
+            showRecordingErrorToast(err.message);
             setError(err.message);
             setUiState("error");
           },
@@ -327,11 +368,11 @@ export default function RecordRoute() {
           !message.includes("No video storage configured") &&
           message !== "SESSION_EXPIRED"
         ) {
-          toast.error(message);
+          showRecordingErrorToast(message);
         }
       }
     },
-    [],
+    [showRecordingErrorToast],
   );
 
   // -------------------------------------------------------------------------
@@ -432,12 +473,18 @@ export default function RecordRoute() {
           );
         }
         const created = (await res.json()) as {
-          result?: { id: string; uploadChunkUrl: string };
+          result?: { id: string; uploadChunkUrl: string; abortUrl?: string };
           id?: string;
           uploadChunkUrl?: string;
+          abortUrl?: string;
         };
         const info =
-          created.result ?? (created as { id: string; uploadChunkUrl: string });
+          created.result ??
+          (created as {
+            id: string;
+            uploadChunkUrl: string;
+            abortUrl?: string;
+          });
         if (!info?.id) {
           throw new Error("create-recording did not return an id");
         }
@@ -492,18 +539,22 @@ export default function RecordRoute() {
         }, 50);
       } catch (err) {
         const message = err instanceof Error ? err.message : "Upload failed";
-        // Trash the orphaned row so it doesn't sit in the library forever
-        // in 'uploading' status.
         if (createdId) {
-          fetch(agentNativePath("/_agent-native/actions/trash-recording"), {
+          fetch(`${appBasePath()}/api/uploads/${createdId}/abort`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ id: createdId }),
+            body: JSON.stringify({ reason: message }),
           }).catch(() => {});
         }
         setError(message);
         setUiState("error");
-        if (message !== "SESSION_EXPIRED") toast.error(message);
+        if (message !== "SESSION_EXPIRED") {
+          toast.error("Upload failed", {
+            description:
+              "The clip was marked failed in your library. You can remove it from the card menu.",
+            duration: 12_000,
+          });
+        }
       }
     },
     [navigate, probeVideoMetadata],
@@ -527,9 +578,9 @@ export default function RecordRoute() {
         err instanceof Error ? err.message : "Could not start recorder";
       setError(message);
       setUiState("error");
-      toast.error(message);
+      showRecordingErrorToast(message);
     }
-  }, [liveTranscription]);
+  }, [liveTranscription, showRecordingErrorToast]);
 
   // -------------------------------------------------------------------------
   // Stop / upload / navigate.
@@ -593,9 +644,17 @@ export default function RecordRoute() {
       }, 50);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Upload failed";
+      fetch(pending.abortUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reason: message }),
+      }).catch(() => {});
       setError(message);
       setUiState("error");
-      toast.error(message);
+      toast.error("Upload failed", {
+        description: message,
+        duration: 12_000,
+      });
     }
   }, [navigate, liveTranscription]);
 
@@ -975,10 +1034,17 @@ export default function RecordRoute() {
           ) : (
             <div className="max-w-md rounded-xl border border-border bg-card p-6">
               <div className="mb-2 text-sm font-semibold text-foreground">
-                Couldn't start recording
+                {/upload failed|chunk/i.test(error)
+                  ? "Upload failed"
+                  : "Couldn't start recording"}
               </div>
               <div className="text-sm text-muted-foreground">{error}</div>
-              <div className="mt-4 flex justify-center gap-2">
+              {permissionGuidance(error) && (
+                <div className="mt-3 rounded-md border border-border bg-muted/40 px-3 py-2 text-left text-xs text-muted-foreground">
+                  {permissionGuidance(error)}
+                </div>
+              )}
+              <div className="mt-4 flex flex-wrap justify-center gap-2">
                 <Button
                   variant="outline"
                   onClick={() => {
@@ -987,19 +1053,34 @@ export default function RecordRoute() {
                 >
                   Try again
                 </Button>
-                {/screen|permission|denied|not allowed/i.test(error) &&
-                  /^darwin|mac/i.test(
-                    typeof navigator !== "undefined" ? navigator.platform : "",
-                  ) && (
+                {isPermissionError(error) && isMacPlatform() && (
+                  <>
                     <Button
                       variant="ghost"
                       onClick={() => {
                         window.location.href = MAC_SCREEN_RECORDING_PREF_URL;
                       }}
                     >
-                      Open Screen Recording settings
+                      Screen settings
                     </Button>
-                  )}
+                    <Button
+                      variant="ghost"
+                      onClick={() => {
+                        window.location.href = MAC_CAMERA_PREF_URL;
+                      }}
+                    >
+                      Camera settings
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      onClick={() => {
+                        window.location.href = MAC_MICROPHONE_PREF_URL;
+                      }}
+                    >
+                      Mic settings
+                    </Button>
+                  </>
+                )}
               </div>
             </div>
           )}

--- a/templates/clips/server/lib/recordings.ts
+++ b/templates/clips/server/lib/recordings.ts
@@ -47,6 +47,16 @@ function organizationRoleAllowed(
   return ORG_ROLE_RANK[actual] >= required;
 }
 
+function highestOrganizationRole(
+  roles: Array<OrganizationAccessRole | null>,
+): OrganizationAccessRole | null {
+  return roles.reduce<OrganizationAccessRole | null>((best, role) => {
+    if (!role) return best;
+    if (!best || ORG_ROLE_RANK[role] > ORG_ROLE_RANK[best]) return role;
+    return best;
+  }, null);
+}
+
 export async function getOrganizationRoleForEmail(
   organizationId: string,
   email: string,
@@ -54,6 +64,7 @@ export async function getOrganizationRoleForEmail(
   const exec = getDbExec();
   const pg = isPostgres();
   const lowerEmail = email.toLowerCase();
+  const roles: Array<OrganizationAccessRole | null> = [];
 
   try {
     const res = await exec.execute({
@@ -63,7 +74,7 @@ export async function getOrganizationRoleForEmail(
       args: [organizationId, lowerEmail],
     });
     const row = (res.rows as Array<{ role?: string }>)[0];
-    if (row?.role) return normalizeOrganizationRole(row.role);
+    if (row?.role) roles.push(normalizeOrganizationRole(row.role));
   } catch {
     // Older DBs may not have the framework org_members table yet. Fall back
     // to better-auth's member table below.
@@ -77,12 +88,12 @@ export async function getOrganizationRoleForEmail(
       args: [organizationId, lowerEmail],
     });
     const row = (res.rows as Array<{ role?: string }>)[0];
-    if (row?.role) return normalizeOrganizationRole(row.role);
+    if (row?.role) roles.push(normalizeOrganizationRole(row.role));
   } catch {
     // No better-auth membership table yet.
   }
 
-  return null;
+  return highestOrganizationRole(roles);
 }
 
 export async function requireOrganizationAccess(

--- a/templates/clips/server/routes/api/uploads/[recordingId]/abort.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/abort.post.ts
@@ -8,6 +8,7 @@
 import {
   defineEventHandler,
   getRouterParam,
+  readBody,
   setResponseStatus,
   type H3Event,
 } from "h3";
@@ -18,7 +19,6 @@ import { runWithRequestContext } from "@agent-native/core/server";
 import {
   writeAppState,
   deleteAppStateByPrefix,
-  deleteAppState,
 } from "@agent-native/core/application-state";
 
 export default defineEventHandler(async (event: H3Event) => {
@@ -29,6 +29,14 @@ export default defineEventHandler(async (event: H3Event) => {
   }
 
   const ownerEmail = await getEventOwnerEmail(event);
+  const body = (await readBody(event).catch(() => null)) as {
+    reason?: unknown;
+  } | null;
+  const failureReason =
+    typeof body?.reason === "string" && body.reason.trim()
+      ? body.reason.trim().slice(0, 1000)
+      : "Upload aborted by user";
+
   return runWithRequestContext({ userEmail: ownerEmail }, async () => {
     const db = getDb();
 
@@ -50,18 +58,23 @@ export default defineEventHandler(async (event: H3Event) => {
     const cleared = await deleteAppStateByPrefix(
       `recording-chunks-${recordingId}-`,
     );
-    await deleteAppState(`recording-upload-${recordingId}`);
 
     const now = new Date().toISOString();
     await db
       .update(schema.recordings)
       .set({
         status: "failed",
-        failureReason: "Upload aborted by user",
+        failureReason,
         updatedAt: now,
       })
       .where(eq(schema.recordings.id, recordingId));
 
+    await writeAppState(`recording-upload-${recordingId}`, {
+      recordingId,
+      status: "failed",
+      failureReason,
+      updatedAt: now,
+    });
     await writeAppState("refresh-signal", { ts: Date.now() });
 
     return { ok: true, recordingId, chunksCleared: cleared };

--- a/templates/mail/actions/list-emails.ts
+++ b/templates/mail/actions/list-emails.ts
@@ -11,8 +11,10 @@ import {
 import { z } from "zod";
 
 const VIEW_QUERIES: Record<string, string> = {
-  inbox: "in:inbox",
-  unread: "is:unread in:inbox",
+  // Exclude SENT so replies the user wrote (which Gmail labels with both
+  // INBOX and SENT) don't appear in the inbox alongside received messages.
+  inbox: "in:inbox -in:sent",
+  unread: "is:unread in:inbox -in:sent",
   starred: "is:starred",
   sent: "in:sent",
   drafts: "in:drafts",
@@ -121,7 +123,7 @@ export default defineAction({
       const viewPrefix = VIEW_QUERIES[view] ?? `label:${view}`;
       const gmailQuery = [viewPrefix, query].filter(Boolean).join(" ");
       const effectiveQuery =
-        view === "all" && !query ? "" : gmailQuery || "in:inbox";
+        view === "all" && !query ? "" : gmailQuery || "in:inbox -in:sent";
       const { messages, errors } = await listGmailMessages(
         effectiveQuery,
         limit,

--- a/templates/mail/actions/search-emails.ts
+++ b/templates/mail/actions/search-emails.ts
@@ -11,8 +11,8 @@ import { getUserSetting } from "@agent-native/core/settings";
 import { z } from "zod";
 
 const VIEW_QUERIES: Record<string, string> = {
-  inbox: "in:inbox",
-  unread: "is:unread in:inbox",
+  inbox: "in:inbox -in:sent",
+  unread: "is:unread in:inbox -in:sent",
   starred: "is:starred",
   sent: "in:sent",
   drafts: "in:drafts",

--- a/templates/mail/actions/view-screen.ts
+++ b/templates/mail/actions/view-screen.ts
@@ -18,8 +18,8 @@ import {
 } from "../server/lib/queued-drafts.js";
 
 const VIEW_QUERIES: Record<string, string> = {
-  inbox: "in:inbox",
-  unread: "is:unread in:inbox",
+  inbox: "in:inbox -in:sent",
+  unread: "is:unread in:inbox -in:sent",
   starred: "is:starred",
   sent: "in:sent",
   drafts: "in:drafts",
@@ -68,7 +68,7 @@ async function fetchEmailList(
       const viewPrefix = VIEW_QUERIES[view] ?? `label:${view}`;
       const gmailQuery = [viewPrefix, search].filter(Boolean).join(" ");
       const effectiveQuery =
-        view === "all" && !search ? "" : gmailQuery || "in:inbox";
+        view === "all" && !search ? "" : gmailQuery || "in:inbox -in:sent";
       const { messages } = await listGmailMessages(
         effectiveQuery,
         50,

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -106,11 +106,12 @@ export function InboxZero() {
         )}
       />
 
-      {/* Top gradient — darken behind the tab bar */}
-      <div className="fixed inset-x-0 top-0 h-24 bg-gradient-to-b from-black/50 to-transparent" />
+      {/* Persistent scrims keep white chrome readable across bright photos. */}
+      <div className="fixed inset-0 bg-black/20" />
+      <div className="fixed inset-x-0 top-0 h-32 bg-gradient-to-b from-black/75 to-transparent" />
 
       {/* Bottom gradient — text legibility */}
-      <div className="fixed inset-x-0 bottom-0 h-40 bg-gradient-to-t from-black/60 to-transparent" />
+      <div className="fixed inset-x-0 bottom-0 h-44 bg-gradient-to-t from-black/70 to-transparent" />
 
       {/* Fallback bg while image loads */}
       <div className="absolute inset-0 bg-muted dark:bg-[hsl(220,6%,8%)] -z-10" />

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -39,6 +39,8 @@ import {
   IconTool,
   IconClock,
   IconRefresh,
+  IconPin,
+  IconPinnedFilled,
 } from "@tabler/icons-react";
 import {
   Popover,
@@ -94,6 +96,10 @@ function shortLabelName(name: string): string {
   const lastSlash = name.lastIndexOf("/");
   if (lastSlash >= 0) return name.slice(lastSlash + 1).replace(/_/g, " ");
   return name;
+}
+
+function labelDepth(name: string): number {
+  return Math.max(0, name.split("/").length - 1);
 }
 
 interface AppLayoutProps {
@@ -256,6 +262,18 @@ function AppLayoutInner({ children }: AppLayoutProps) {
   const tabsLoading =
     labelsLoading || settingsLoading || emailsLoading || allLocalEmailsLoading;
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarPinned, setSidebarPinned] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem("mail-sidebar-pinned") === "true";
+  });
+  useEffect(() => {
+    if (sidebarPinned) localStorage.setItem("mail-sidebar-pinned", "true");
+    else localStorage.removeItem("mail-sidebar-pinned");
+  }, [sidebarPinned]);
+  const showSidebar = sidebarOpen || (sidebarPinned && !isMobile);
+  const closeSidebar = useCallback(() => {
+    if (!sidebarPinned || isMobile) setSidebarOpen(false);
+  }, [sidebarPinned, isMobile]);
 
   // Drag-to-reorder tabs
   const [dragPinnedId, setDragPinnedId] = useState<string | null>(null);
@@ -264,7 +282,8 @@ function AppLayoutInner({ children }: AppLayoutProps) {
     side: "left" | "right";
   } | null>(null);
 
-  // Compute thread counts per label from inbox emails, filtered by active accounts
+  // Compute unread thread counts for virtual labels and local/demo mail. Gmail
+  // system/user labels use server-provided unread counts when available.
   const labelCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     const pinnedShorts = pinnedLabels.map((l) =>
@@ -282,20 +301,25 @@ function AppLayoutInner({ children }: AppLayoutProps) {
             (e) => e.accountEmail && activeAccounts.has(e.accountEmail),
           )
         : inboxEmails;
-    // Find the latest message per thread (to mirror Superhuman's thread-level label logic)
-    const latestByThread = new Map<string, (typeof filtered)[0]>();
+    // Find the latest message + unread state per thread.
+    const threadState = new Map<
+      string,
+      { latest: (typeof filtered)[0]; hasUnread: boolean }
+    >();
     for (const e of filtered) {
       const key = e.threadId || e.id;
-      const existing = latestByThread.get(key);
-      if (!existing || new Date(e.date) > new Date(existing.date)) {
-        latestByThread.set(key, e);
+      const existing = threadState.get(key);
+      if (!existing) {
+        threadState.set(key, { latest: e, hasUnread: !e.isRead });
+      } else {
+        existing.hasUnread ||= !e.isRead;
+        if (new Date(e.date) > new Date(existing.latest.date)) {
+          existing.latest = e;
+        }
       }
     }
-    const latestMessages = [...latestByThread.values()];
-    // Count inbox threads: latest message must NOT belong to any pinned label
-    counts["inbox"] = latestMessages.filter(
-      (e) => !e.labelIds.some((lid) => pinnedShorts.includes(lid)),
-    ).length;
+    const threadRows = [...threadState.values()];
+    counts["inbox"] = threadRows.filter((row) => row.hasUnread).length;
     // Count threads per pinned label: latest message must have that label
     // For "important", exclude threads that belong to any other pinned tab
     for (let i = 0; i < pinnedLabels.length; i++) {
@@ -305,43 +329,42 @@ function AppLayoutInner({ children }: AppLayoutProps) {
         e.labelIds.some((lid) => lid === short || lid === full);
       if (full === "important") {
         const otherShorts = pinnedShorts.filter((_, j) => j !== i);
-        counts[full] = latestMessages.filter(
-          (e) =>
-            hasLabel(e) && !e.labelIds.some((lid) => otherShorts.includes(lid)),
+        counts[full] = threadRows.filter(
+          ({ latest, hasUnread }) =>
+            hasUnread &&
+            hasLabel(latest) &&
+            !latest.labelIds.some((lid) => otherShorts.includes(lid)),
         ).length;
       } else {
-        counts[full] = latestMessages.filter((e) => hasLabel(e)).length;
+        counts[full] = threadRows.filter(
+          ({ latest, hasUnread }) => hasUnread && hasLabel(latest),
+        ).length;
       }
     }
     return counts;
   }, [inboxEmails, pinnedLabels, activeAccounts]);
 
-  // Tabs to show in the bar: Inbox + pinned items (system views or labels)
-  // Check if any pinned labels are category/label filters (not system views like starred/sent)
-  const hasPinnedFilters = pinnedLabels.some(
-    (id) => !collapsibleViews.some((v) => v.id === id),
-  );
-
+  // Full pinned navigation used by the left sidebar. The top bar intentionally
+  // renders only primary/system views so nested labels do not crowd it.
   const visibleTabs = useMemo(() => {
     const tabs: {
       id: string;
       pinnedId?: string;
       label: string;
+      fullLabel?: string;
       href: string;
       isActive: boolean;
       color?: string;
+      type: "system" | "label";
     }[] = [];
 
-    // When there are pinned label/category filters, add them first,
-    // then "Other" (inbox minus pinned). Otherwise just show "Inbox".
-    if (!hasPinnedFilters) {
-      tabs.push({
-        id: "inbox",
-        label: "Inbox",
-        href: "/inbox",
-        isActive: view === "inbox" && !activeLabel,
-      });
-    }
+    tabs.push({
+      id: "inbox",
+      label: "Inbox",
+      href: "/inbox",
+      isActive: view === "inbox" && !activeLabel,
+      type: "system",
+    });
 
     const seenLabels = new Set<string>(["inbox"]);
     for (const id of pinnedLabels) {
@@ -356,6 +379,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
           label: sysView.label,
           href: `/${sysView.id}`,
           isActive: view === sysView.id,
+          type: "system",
         });
         continue;
       }
@@ -382,26 +406,34 @@ function AppLayoutInner({ children }: AppLayoutProps) {
           id: lbl.id,
           pinnedId: id,
           label: aliasedName,
+          fullLabel: lbl.name,
           href: `/inbox?label=${encodeURIComponent(lbl.id)}`,
           isActive: activeLabel === lbl.id,
           color: lbl.color,
+          type: "label",
         });
       }
     }
 
-    // When there are pinned label/category filters, add "Other" at the end
-    // (shows inbox emails not in any pinned label)
-    if (hasPinnedFilters) {
-      tabs.push({
-        id: "inbox",
-        label: "Other",
-        href: "/inbox",
-        isActive: view === "inbox" && !activeLabel,
-      });
-    }
-
     return tabs;
-  }, [labels, pinnedLabels, labelAliases, view, activeLabel, hasPinnedFilters]);
+  }, [labels, pinnedLabels, labelAliases, view, activeLabel]);
+
+  const topBarTabs = useMemo(() => {
+    const primaryIds = new Set(["inbox", ...collapsibleViews.map((v) => v.id)]);
+    const tabs = visibleTabs.filter(
+      (tab) => tab.type === "system" && primaryIds.has(tab.id),
+    );
+    if (activeLabel) {
+      const active = visibleTabs.find((tab) => tab.id === activeLabel);
+      if (active) {
+        tabs.push({
+          ...active,
+          label: shortLabelName(active.fullLabel ?? active.label),
+        });
+      }
+    }
+    return tabs;
+  }, [activeLabel, visibleTabs]);
 
   // System views NOT pinned (go in the "more" dropdown)
   const hiddenViews = useMemo(
@@ -719,11 +751,10 @@ function AppLayoutInner({ children }: AppLayoutProps) {
 
   // Get unread counts for tabs
   const getTotalCount = (viewId: string) => {
-    // Use our computed counts from inbox emails for pinned labels
-    if (labelCounts[viewId] !== undefined) return labelCounts[viewId];
-    // Fall back to server-reported label counts for system views
     const label = labels.find((l) => l.id === viewId);
-    return label?.totalCount ?? 0;
+    if (label?.unreadCount !== undefined) return label.unreadCount;
+    if (labelCounts[viewId] !== undefined) return labelCounts[viewId];
+    return 0;
   };
 
   const accountFilterValue = useMemo(
@@ -761,147 +792,149 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                 <TooltipContent>Menu</TooltipContent>
               </Tooltip>
 
-              {/* Visible tabs — hidden during search */}
-              {!activeSearchQuery && (
-                <>
-                  {tabsLoading ? (
-                    <nav className="flex items-center gap-2 overflow-x-auto hide-scrollbar">
-                      {[1, 2, 3].map((i) => (
-                        <span
-                          key={i}
-                          className="h-4 rounded bg-muted animate-pulse"
-                          style={{ width: `${48 + i * 12}px` }}
-                        />
-                      ))}
-                    </nav>
-                  ) : (
-                    <nav className="flex items-center gap-0.5 overflow-x-auto hide-scrollbar">
-                      {visibleTabs.map((tab, idx) => {
-                        const count = getTotalCount(tab.id);
-                        const isDragging = dragPinnedId === tab.pinnedId;
-                        const canDrag =
-                          !!tab.pinnedId && tab.pinnedId !== "important";
-                        const showLeft =
-                          dropIndicator?.tabIndex === idx &&
-                          dropIndicator.side === "left";
-                        const showRight =
-                          dropIndicator?.tabIndex === idx &&
-                          dropIndicator.side === "right";
-                        return (
-                          <div
-                            key={tab.pinnedId || tab.id}
-                            className="relative flex items-center"
-                            onDragOver={(e) => handleTabDragOver(e, idx)}
-                            onDrop={handleTabDrop}
+              {/* Primary tabs stay mounted during search so navigation does not jump. */}
+              <>
+                {tabsLoading ? (
+                  <nav className="flex items-center gap-2 overflow-x-auto hide-scrollbar">
+                    {[1, 2, 3].map((i) => (
+                      <span
+                        key={i}
+                        className="h-4 rounded bg-muted animate-pulse"
+                        style={{ width: `${48 + i * 12}px` }}
+                      />
+                    ))}
+                  </nav>
+                ) : (
+                  <nav className="flex min-w-0 items-center gap-0.5 overflow-x-auto hide-scrollbar">
+                    {topBarTabs.map((tab, idx) => {
+                      const visibleIndex = visibleTabs.findIndex(
+                        (item) => item.id === tab.id,
+                      );
+                      const tabIndex = visibleIndex >= 0 ? visibleIndex : idx;
+                      const count = getTotalCount(tab.id);
+                      const isDragging = dragPinnedId === tab.pinnedId;
+                      const canDrag =
+                        !!tab.pinnedId && tab.pinnedId !== "important";
+                      const showLeft =
+                        dropIndicator?.tabIndex === tabIndex &&
+                        dropIndicator.side === "left";
+                      const showRight =
+                        dropIndicator?.tabIndex === tabIndex &&
+                        dropIndicator.side === "right";
+                      return (
+                        <div
+                          key={tab.pinnedId || tab.id}
+                          className="relative flex items-center"
+                          onDragOver={(e) => handleTabDragOver(e, tabIndex)}
+                          onDrop={handleTabDrop}
+                        >
+                          {showLeft && (
+                            <div className="absolute left-0 top-1.5 bottom-1.5 w-0.5 bg-primary rounded-full z-10" />
+                          )}
+                          <Link
+                            to={tab.href}
+                            draggable={canDrag}
+                            onDragStart={(e) =>
+                              canDrag &&
+                              tab.pinnedId &&
+                              handleTabDragStart(e, tab.pinnedId)
+                            }
+                            onDragEnd={handleTabDragEnd}
+                            className={cn(
+                              "flex items-center gap-1.5 whitespace-nowrap px-2.5 py-1 text-[13px] select-none",
+                              tab.isActive
+                                ? "text-foreground font-semibold"
+                                : "text-muted-foreground font-medium hover:text-foreground/80",
+                              isDragging && "opacity-40",
+                              canDrag && "cursor-grab",
+                            )}
                           >
-                            {showLeft && (
-                              <div className="absolute left-0 top-1.5 bottom-1.5 w-0.5 bg-primary rounded-full z-10" />
+                            {tab.color && (
+                              <span
+                                className="h-1.5 w-1.5 rounded-full shrink-0"
+                                style={{ backgroundColor: tab.color }}
+                              />
                             )}
-                            <Link
-                              to={tab.href}
-                              draggable={canDrag}
-                              onDragStart={(e) =>
-                                canDrag &&
-                                tab.pinnedId &&
-                                handleTabDragStart(e, tab.pinnedId)
-                              }
-                              onDragEnd={handleTabDragEnd}
-                              className={cn(
-                                "flex items-center gap-1.5 whitespace-nowrap px-2.5 py-1 text-[13px] select-none",
-                                tab.isActive
-                                  ? "text-foreground font-semibold"
-                                  : "text-muted-foreground font-medium hover:text-foreground/80",
-                                isDragging && "opacity-40",
-                                canDrag && "cursor-grab",
-                              )}
-                            >
-                              {tab.color && (
-                                <span
-                                  className="h-1.5 w-1.5 rounded-full shrink-0"
-                                  style={{ backgroundColor: tab.color }}
-                                />
-                              )}
-                              {tab.label}
-                              {count > 0 && (
-                                <span
-                                  className={cn(
-                                    "text-[11px] tabular-nums",
-                                    tab.isActive
-                                      ? "text-foreground/60"
-                                      : "text-muted-foreground/70",
-                                  )}
-                                >
-                                  {count}
-                                </span>
-                              )}
-                            </Link>
-                            {showRight && (
-                              <div className="absolute right-0 top-1.5 bottom-1.5 w-0.5 bg-primary rounded-full z-10" />
+                            {tab.label}
+                            {count > 0 && (
+                              <span
+                                className={cn(
+                                  "text-[11px] tabular-nums",
+                                  tab.isActive
+                                    ? "text-foreground/60"
+                                    : "text-muted-foreground/70",
+                                )}
+                              >
+                                {count}
+                              </span>
                             )}
-                          </div>
-                        );
-                      })}
+                          </Link>
+                          {showRight && (
+                            <div className="absolute right-0 top-1.5 bottom-1.5 w-0.5 bg-primary rounded-full z-10" />
+                          )}
+                        </div>
+                      );
+                    })}
 
-                      {/* If navigated to an unpinned view (e.g. via keyboard shortcut), show it */}
-                      {currentInHidden && (
-                        <span className="flex items-center whitespace-nowrap px-2.5 py-1 text-[13px] text-foreground font-semibold">
-                          {collapsibleViews.find((v) => v.id === view)?.label}
-                        </span>
-                      )}
-                    </nav>
-                  )}
+                    {/* If navigated to an unpinned view (e.g. via keyboard shortcut), show it */}
+                    {currentInHidden && (
+                      <span className="flex items-center whitespace-nowrap px-2.5 py-1 text-[13px] text-foreground font-semibold">
+                        {collapsibleViews.find((v) => v.id === view)?.label}
+                      </span>
+                    )}
+                  </nav>
+                )}
 
-                  {/* Tab settings cog */}
-                  <div className={cn("relative", tabsLoading && "invisible")}>
-                    <Popover
-                      open={tabSettingsOpen}
-                      onOpenChange={(open) => {
-                        setTabSettingsOpen(open);
-                        if (!open) setLabelSearch("");
-                      }}
+                {/* Tab settings cog */}
+                <div className={cn("relative", tabsLoading && "invisible")}>
+                  <Popover
+                    open={tabSettingsOpen}
+                    onOpenChange={(open) => {
+                      setTabSettingsOpen(open);
+                      if (!open) setLabelSearch("");
+                    }}
+                  >
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <PopoverTrigger asChild>
+                          <button
+                            className={cn(
+                              "flex h-6 w-6 items-center justify-center rounded transition-colors",
+                              tabSettingsOpen
+                                ? "text-foreground bg-accent/50"
+                                : "text-muted-foreground/40 hover:text-muted-foreground hover:bg-accent/30",
+                            )}
+                            aria-label="Configure tabs"
+                          >
+                            <IconSettings className="h-3.5 w-3.5" />
+                          </button>
+                        </PopoverTrigger>
+                      </TooltipTrigger>
+                      <TooltipContent>Configure tabs</TooltipContent>
+                    </Tooltip>
+                    <PopoverContent
+                      align="start"
+                      className="w-60 max-w-[calc(100vw-2rem)] p-0"
                     >
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <PopoverTrigger asChild>
-                            <button
-                              className={cn(
-                                "flex h-6 w-6 items-center justify-center rounded transition-colors",
-                                tabSettingsOpen
-                                  ? "text-foreground bg-accent/50"
-                                  : "text-muted-foreground/40 hover:text-muted-foreground hover:bg-accent/30",
-                              )}
-                              aria-label="Configure tabs"
-                            >
-                              <IconSettings className="h-3.5 w-3.5" />
-                            </button>
-                          </PopoverTrigger>
-                        </TooltipTrigger>
-                        <TooltipContent>Configure tabs</TooltipContent>
-                      </Tooltip>
-                      <PopoverContent
-                        align="start"
-                        className="w-60 max-w-[calc(100vw-2rem)] p-0"
-                      >
-                        <TabSettingsPopover
-                          systemViews={collapsibleViews}
-                          userLabels={userLabels}
-                          pinnedLabels={pinnedLabels}
-                          labelAliases={labelAliases}
-                          search={labelSearch}
-                          onSearchChange={setLabelSearch}
-                          onToggle={togglePinned}
-                          onRename={(id, alias) => {
-                            const next = { ...labelAliases };
-                            if (alias) next[id] = alias;
-                            else delete next[id];
-                            updateSettings.mutate({ labelAliases: next });
-                          }}
-                        />
-                      </PopoverContent>
-                    </Popover>
-                  </div>
-                </>
-              )}
+                      <TabSettingsPopover
+                        systemViews={collapsibleViews}
+                        userLabels={userLabels}
+                        pinnedLabels={pinnedLabels}
+                        labelAliases={labelAliases}
+                        search={labelSearch}
+                        onSearchChange={setLabelSearch}
+                        onToggle={togglePinned}
+                        onRename={(id, alias) => {
+                          const next = { ...labelAliases };
+                          if (alias) next[id] = alias;
+                          else delete next[id];
+                          updateSettings.mutate({ labelAliases: next });
+                        }}
+                      />
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </>
 
               <div className="flex-1" />
 
@@ -1121,14 +1154,55 @@ function AppLayoutInner({ children }: AppLayoutProps) {
               <AgentToggleButton />
             </header>
 
-            {/* Sidebar overlay */}
-            {sidebarOpen && (
+            {/* Sidebar overlay / pinned rail */}
+            {showSidebar && (
               <>
+                {(!sidebarPinned || isMobile) && (
+                  <div
+                    className="fixed inset-0 z-30 bg-black/20"
+                    onClick={() => setSidebarOpen(false)}
+                  />
+                )}
                 <div
-                  className="fixed inset-0 z-30 bg-black/20"
-                  onClick={() => setSidebarOpen(false)}
-                />
-                <div className="fixed left-0 top-0 bottom-0 z-40 w-64 bg-background/70 backdrop-blur-2xl border-r border-border/30 shadow-2xl overflow-y-auto">
+                  className={cn(
+                    "w-64 bg-background/85 backdrop-blur-2xl border-r border-border/30 shadow-2xl overflow-y-auto",
+                    sidebarPinned && !isMobile
+                      ? "absolute left-0 top-11 bottom-0 z-10"
+                      : "fixed left-0 top-0 bottom-0 z-40",
+                  )}
+                >
+                  <div className="flex items-center justify-between border-b border-border/20 px-4 py-3">
+                    <span className="text-[13px] font-medium text-foreground">
+                      Mail
+                    </span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setSidebarPinned((value) => !value);
+                            setSidebarOpen(true);
+                          }}
+                          className={cn(
+                            "flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                            sidebarPinned && "text-foreground bg-accent/50",
+                          )}
+                          aria-label={
+                            sidebarPinned ? "Unpin sidebar" : "Pin sidebar"
+                          }
+                        >
+                          {sidebarPinned ? (
+                            <IconPinnedFilled className="h-4 w-4" />
+                          ) : (
+                            <IconPin className="h-4 w-4" />
+                          )}
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {sidebarPinned ? "Unpin sidebar" : "Pin sidebar"}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
                   {/* Accounts */}
                   {hasAccounts && (
                     <div className="px-4 pt-5 pb-4 border-b border-border/20">
@@ -1210,7 +1284,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                         <Link
                           key={item.id}
                           to={item.href}
-                          onClick={() => setSidebarOpen(false)}
+                          onClick={closeSidebar}
                           className={cn(
                             "flex items-center justify-between rounded-md px-3 py-2.5 text-[14px] transition-colors min-h-[44px]",
                             view === item.id
@@ -1244,7 +1318,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                       <div className="space-y-0.5">
                         <Link
                           to="/settings"
-                          onClick={() => setSidebarOpen(false)}
+                          onClick={closeSidebar}
                           className={cn(
                             "flex items-center rounded-md px-3 py-2.5 text-[14px] transition-colors min-h-[44px]",
                             location.pathname === "/settings"
@@ -1274,17 +1348,18 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                         <div className="space-y-0.5">
                           {visibleTabs
                             .filter(
-                              (t) =>
-                                t.id !== "inbox" &&
-                                !collapsibleViews.some((v) => v.id === t.id),
+                              (t) => t.id !== "inbox" && t.type === "label",
                             )
                             .map((tab) => {
                               const count = getTotalCount(tab.id);
+                              const depth = labelDepth(
+                                tab.fullLabel ?? tab.label,
+                              );
                               return (
                                 <Link
                                   key={tab.id}
                                   to={tab.href}
-                                  onClick={() => setSidebarOpen(false)}
+                                  onClick={closeSidebar}
                                   className={cn(
                                     "flex items-center justify-between rounded-md px-3 py-2.5 text-[14px] transition-colors min-h-[44px]",
                                     tab.isActive
@@ -1292,14 +1367,24 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                                       : "text-foreground/70 hover:bg-accent/30",
                                   )}
                                 >
-                                  <span className="flex items-center gap-2">
+                                  <span
+                                    className="flex min-w-0 items-center gap-2"
+                                    style={{ paddingLeft: depth * 12 }}
+                                  >
                                     {tab.color && (
                                       <span
                                         className="h-2 w-2 rounded-full shrink-0"
                                         style={{ backgroundColor: tab.color }}
                                       />
                                     )}
-                                    {tab.label}
+                                    <span
+                                      className="truncate"
+                                      title={tab.fullLabel}
+                                    >
+                                      {shortLabelName(
+                                        tab.fullLabel ?? tab.label,
+                                      )}
+                                    </span>
                                   </span>
                                   {count > 0 && (
                                     <span className="text-[12px] text-muted-foreground/50 tabular-nums">
@@ -1328,7 +1413,14 @@ function AppLayoutInner({ children }: AppLayoutProps) {
             view !== "draft-queue" ? (
               <GoogleConnectBanner variant="hero" />
             ) : (
-              <main className="flex flex-1 overflow-hidden">{children}</main>
+              <main
+                className={cn(
+                  "flex flex-1 overflow-hidden",
+                  sidebarPinned && !isMobile && "pl-64",
+                )}
+              >
+                {children}
+              </main>
             )}
           </div>
         </AgentSidebar>

--- a/templates/mail/app/components/layout/SearchBar.tsx
+++ b/templates/mail/app/components/layout/SearchBar.tsx
@@ -71,9 +71,10 @@ export function SearchBar({
 
   const executeSearch = useCallback(
     (q: string) => {
-      if (q.trim()) {
-        lastSyncedQueryRef.current = q.trim();
-        navigate(`/inbox?q=${encodeURIComponent(q.trim())}`);
+      const trimmed = q.trim();
+      if (trimmed && trimmed !== lastSyncedQueryRef.current) {
+        lastSyncedQueryRef.current = trimmed;
+        navigate(`/inbox?q=${encodeURIComponent(trimmed)}`);
       }
     },
     [navigate],
@@ -97,7 +98,7 @@ export function SearchBar({
     if (q.length >= 3) {
       debounceRef.current = setTimeout(() => {
         executeSearch(q);
-      }, 400);
+      }, 700);
     }
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);

--- a/templates/mail/app/global.css
+++ b/templates/mail/app/global.css
@@ -653,20 +653,29 @@
 /* Inbox Zero — negative margin pulls content up behind the header (keeps header in flow so it doesn't overlap the agent sidebar) */
 .inbox-zero .inbox-zero-header {
   margin-bottom: -2.75rem;
-  background: transparent !important;
-  border-color: transparent !important;
+  background: rgba(0, 0, 0, 0.48) !important;
+  border-color: rgba(255, 255, 255, 0.12) !important;
+  backdrop-filter: blur(18px) saturate(1.2);
+  -webkit-backdrop-filter: blur(18px) saturate(1.2);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
-/* Inbox Zero — tab text: active white, inactive white/60, icons white/40 */
+/* Inbox Zero — keep header controls above contrast thresholds on bright photos. */
 .inbox-zero .inbox-zero-header a,
 .inbox-zero .inbox-zero-header button,
 .inbox-zero .inbox-zero-header span {
-  color: rgba(255, 255, 255, 0.6) !important;
+  color: rgba(255, 255, 255, 0.82) !important;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.55);
 }
 
 .inbox-zero .inbox-zero-header a[aria-current],
 .inbox-zero .inbox-zero-header a.font-semibold {
   color: rgba(255, 255, 255, 1) !important;
+}
+
+.inbox-zero .inbox-zero-header button:hover,
+.inbox-zero .inbox-zero-header a:hover {
+  background: rgba(255, 255, 255, 0.14) !important;
 }
 
 /* Inbox Zero — frosted glass effect on the agent chat sidebar */

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -272,11 +272,11 @@ export function useEmails(
     // ~255 units (messages.list + 50 × messages.get). Aggressive polling
     // easily trips quota on multi-account users — keep refetches conservative
     // and rely on mutation invalidations for the hot edits. Search queries
-    // get a zero staleTime so a fresh search always re-fetches — the user
-    // expects the results to reflect their latest mailbox state.
+    // get a short cache window so repeated renders/back navigation do not
+    // re-hydrate the same expensive Gmail search immediately.
     // refetchOnWindowFocus stays off: with useInfiniteQuery it replays every
     // cached page (50+ Gmail calls each) on tab focus and trips the quota.
-    staleTime: search ? 0 : 60_000,
+    staleTime: search ? 30_000 : 60_000,
     // On error, back off (don't disable polling entirely). One transient
     // 429 / network blip used to stop auto-refresh forever — now we stretch
     // the interval based on consecutive failures, capped at 5 minutes, so the
@@ -284,6 +284,7 @@ export function useEmails(
     refetchInterval: (query: {
       state: { status: string; fetchFailureCount: number };
     }) => {
+      if (search) return false;
       const base = 2 * 60_000;
       if (query.state.status === "error") {
         return Math.min(base * (1 + query.state.fetchFailureCount), 5 * 60_000);

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -311,25 +311,6 @@ export function InboxPage() {
       );
       return filtered.filter((e) => qualifiedThreadIds.has(e.threadId || e.id));
     }
-    if (!searchQuery && view === "inbox" && pinnedUserLabels.length > 0) {
-      // Inbox: filter out emails that belong to a pinned label
-      // Compute short names for each pinned label so we match email labelIds
-      const pinnedShortNames = pinnedUserLabels.map((l) =>
-        l.includes("/")
-          ? l
-              .slice(l.lastIndexOf("/") + 1)
-              .replace(/_/g, " ")
-              .toLowerCase()
-          : l.toLowerCase(),
-      );
-      return filtered.filter(
-        (e) =>
-          !e.labelIds.some(
-            (lid) =>
-              pinnedUserLabels.includes(lid) || pinnedShortNames.includes(lid),
-          ),
-      );
-    }
     return filtered;
   }, [
     rawEmails,

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -117,6 +117,12 @@ function threadCacheKey(ownerEmail: string, threadId: string) {
   return `${ownerEmail}:${threadId}`;
 }
 
+function gmailLabelSearchClause(label: string): string {
+  const value = label.trim().replace(/\s+/g, "-").replace(/"/g, '\\"');
+  if (!value) return "";
+  return /[/"()]/.test(value) ? `label:"${value}"` : `label:${value}`;
+}
+
 export function invalidateThreadCache(ownerEmail: string, threadId: string) {
   threadMessagesCache.delete(threadCacheKey(ownerEmail, threadId));
 }
@@ -399,10 +405,12 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
         }
       }
 
-      // Map view to Gmail search query
+      // Map view to Gmail search query.
+      // `-in:sent` excludes user-sent messages (replies the user wrote get
+      // both INBOX and SENT labels in Gmail) so they don't pollute the inbox.
       const gmailQuery: Record<string, string> = {
-        inbox: "in:inbox",
-        unread: "is:unread in:inbox",
+        inbox: "in:inbox -in:sent",
+        unread: "is:unread in:inbox -in:sent",
         starred: "is:starred",
         sent: "in:sent",
         drafts: "in:drafts",
@@ -451,8 +459,12 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
         } else {
           // User-created label: Gmail's `label:` operator wants the display
           // name with spaces replaced by hyphens; nested labels use `/`.
-          labelClause = `label:${label.replace(/\s+/g, "-")}`;
+          labelClause = gmailLabelSearchClause(label);
         }
+        // Gmail-like label views are not limited to Inbox: archived mail with
+        // that label should still appear. Category/Important filters remain
+        // valid without an explicit `in:inbox` clause.
+        if (!q) searchQuery = "";
         searchQuery = searchQuery
           ? `${searchQuery} ${labelClause}`
           : labelClause;
@@ -465,7 +477,7 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
         await listGmailMessages(searchQuery, undefined, email, pageTokens, {
           mode: "threads",
           threadFormat: "metadata",
-          threadCandidateLimit: q ? 500 : undefined,
+          threadCandidateLimit: q ? 160 : undefined,
         });
       if (messages.length === 0 && errors.length > 0) {
         // All accounts failed — surface as error
@@ -2153,7 +2165,13 @@ export const listLabels = defineEventHandler(async (_event: H3Event) => {
       // Deduplicate by derived short-name id (not Gmail label ID)
       const labelMap = new Map<
         string,
-        { id: string; name: string; type: "system" | "user" }
+        {
+          id: string;
+          name: string;
+          type: "system" | "user";
+          unreadCount: number;
+          totalCount: number;
+        }
       >();
       // Fetch labels from each account sequentially to avoid race conditions on the shared map
       for (const { accessToken } of accountTokens) {
@@ -2164,27 +2182,48 @@ export const listLabels = defineEventHandler(async (_event: H3Event) => {
             const gmailId = label.id;
             const name = label.name;
             const isSystem = !gmailId.startsWith("Label_");
-            // Use the full label name (preserving hierarchy) as the id,
-            // but display the short name (last segment, underscores -> spaces)
-            const fullId = name.toLowerCase().replace(/_/g, " ");
-            let shortName = name;
-            const lastSlash = shortName.lastIndexOf("/");
-            if (lastSlash >= 0) shortName = shortName.slice(lastSlash + 1);
-            shortName = shortName.replace(/_/g, " ");
-            if (!labelMap.has(fullId)) {
+            const systemLabelIds: Record<string, { id: string; name: string }> =
+              {
+                INBOX: { id: "inbox", name: "Inbox" },
+                STARRED: { id: "starred", name: "Starred" },
+                SENT: { id: "sent", name: "Sent" },
+                DRAFT: { id: "drafts", name: "Drafts" },
+                TRASH: { id: "trash", name: "Trash" },
+                IMPORTANT: { id: "important", name: "Important" },
+                CATEGORY_PERSONAL: { id: "personal", name: "Primary" },
+                CATEGORY_SOCIAL: { id: "social", name: "Social" },
+                CATEGORY_UPDATES: { id: "updates", name: "Updates" },
+                CATEGORY_PROMOTIONS: { id: "promotions", name: "Promotions" },
+                CATEGORY_FORUMS: { id: "forums", name: "Forums" },
+              };
+            const unreadCount =
+              Number(label.threadsUnread ?? label.messagesUnread ?? 0) || 0;
+            const totalCount =
+              Number(label.threadsTotal ?? label.messagesTotal ?? 0) || 0;
+            // Use and display the full label name so Gmail nesting survives
+            // import. The sidebar indents slash-delimited paths.
+            const normalizedSystem = systemLabelIds[gmailId];
+            const fullId =
+              normalizedSystem?.id ?? name.toLowerCase().replace(/_/g, " ");
+            const displayName =
+              normalizedSystem?.name ?? name.replace(/_/g, " ");
+            const existing = labelMap.get(fullId);
+            if (existing) {
+              existing.unreadCount += unreadCount;
+              existing.totalCount += totalCount;
+            } else {
               labelMap.set(fullId, {
                 id: fullId,
-                name: shortName,
+                name: displayName,
                 type: isSystem ? ("system" as const) : ("user" as const),
+                unreadCount,
+                totalCount,
               });
             }
           }
         } catch {}
       }
-      const labels: Label[] = Array.from(labelMap.values()).map((l) => ({
-        ...l,
-        unreadCount: 0,
-      }));
+      const labels: Label[] = Array.from(labelMap.values());
 
       // Normalize Gmail category labels with friendly names
       const gmailCategories: Record<string, string> = {
@@ -2201,7 +2240,13 @@ export const listLabels = defineEventHandler(async (_event: H3Event) => {
           // Fix casing (Gmail returns "IMPORTANT", we want "Important")
           labels[existing].name = name;
         } else {
-          labels.push({ id, name, type: "system", unreadCount: 0 });
+          labels.push({
+            id,
+            name,
+            type: "system",
+            unreadCount: 0,
+            totalCount: 0,
+          });
         }
       }
 

--- a/templates/mail/server/lib/google-auth.ts
+++ b/templates/mail/server/lib/google-auth.ts
@@ -1751,10 +1751,7 @@ export function gmailToEmailMessage(
           CATEGORY_FORUMS: "forums",
         };
         if (categoryMap[l]) return categoryMap[l];
-        let name = labelMap?.get(l) || l;
-        // Use last segment of nested labels (e.g. "[Superhuman]/AI/Respond" -> "Respond")
-        const lastSlash = name.lastIndexOf("/");
-        if (lastSlash >= 0) name = name.slice(lastSlash + 1);
+        const name = labelMap?.get(l) || l;
         return name.replace(/_/g, " ").toLowerCase();
       }),
     attachments: attachments.length > 0 ? attachments : undefined,

--- a/templates/slides/actions/generate-slides-ai.ts
+++ b/templates/slides/actions/generate-slides-ai.ts
@@ -27,7 +27,11 @@ export default defineAction({
     }
 
     const topic = args.topic;
-    const slideCount = args.slideCount ?? 8;
+    // Cap at 10. Single-shot Gemini JSON generation reliably truncates
+    // beyond that — the resulting JSON fails to parse and the user sees
+    // an error. Larger decks should be assembled with parallel
+    // `add-slide` calls from the agent chat instead.
+    const slideCount = Math.min(args.slideCount ?? 8, 10);
     const style = args.style;
     const includeImages = args.includeImages !== false;
 

--- a/templates/slides/app/components/editor/GenerateSlidesDialog.tsx
+++ b/templates/slides/app/components/editor/GenerateSlidesDialog.tsx
@@ -121,7 +121,7 @@ export default function GenerateSlidesDialog({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {[4, 6, 8, 10, 12, 15].map((n) => (
+                  {[4, 6, 8, 10].map((n) => (
                     <SelectItem key={n} value={String(n)}>
                       {n} slides
                     </SelectItem>

--- a/templates/slides/app/components/editor/PromptDialog.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.tsx
@@ -22,6 +22,8 @@ interface PromptPopoverProps {
   loading?: boolean;
   anchorRef?: React.RefObject<HTMLElement | null>;
   centered?: boolean;
+  /** Forwarded to PromptComposer/TipTap for draft persistence in localStorage. */
+  draftScope?: string;
 }
 
 export default function PromptPopover({
@@ -35,6 +37,7 @@ export default function PromptPopover({
   loading = false,
   anchorRef,
   centered = false,
+  draftScope,
 }: PromptPopoverProps) {
   const [uploading, setUploading] = useState(false);
   const [promptText, setPromptText] = useState("");
@@ -167,6 +170,7 @@ export default function PromptPopover({
             placeholder={placeholder}
             onSubmit={handleSubmit}
             onTextChange={setPromptText}
+            draftScope={draftScope}
           />
         </div>
 

--- a/templates/slides/app/components/editor/QuestionFlow.tsx
+++ b/templates/slides/app/components/editor/QuestionFlow.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import {
   IconCheck,
   IconUpload,
@@ -10,20 +10,37 @@ import { Slider } from "@/components/ui/slider";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import type { QuestionFlowQuestion } from "@shared/api";
+import type { DesignSystemData, QuestionFlowQuestion } from "@shared/api";
 
 interface QuestionFlowProps {
   questions: QuestionFlowQuestion[];
   onSubmit: (answers: Record<string, any>) => void;
   onSkip: () => void;
+  designSystem?: DesignSystemData;
 }
 
 export function QuestionFlow({
   questions,
   onSubmit,
   onSkip,
+  designSystem,
 }: QuestionFlowProps) {
   const [answers, setAnswers] = useState<Record<string, any>>({});
+  const visibleQuestions = useMemo(
+    () =>
+      questions.map((question) =>
+        question.type === "color-options" && designSystem
+          ? {
+              ...question,
+              options: designSystemColorOptions(
+                designSystem,
+                question.options || [],
+              ),
+            }
+          : question,
+      ),
+    [designSystem, questions],
+  );
 
   const setAnswer = useCallback((id: string, value: any) => {
     setAnswers((prev) => ({ ...prev, [id]: value }));
@@ -44,7 +61,7 @@ export function QuestionFlow({
     onSubmit(answers);
   };
 
-  const allRequiredAnswered = questions
+  const allRequiredAnswered = visibleQuestions
     .filter((q) => q.required)
     .every((q) => {
       const val = answers[q.id];
@@ -54,14 +71,15 @@ export function QuestionFlow({
     });
 
   return (
-    <div className="absolute inset-0 z-50 flex items-center justify-center bg-background">
-      <div className="w-full max-w-2xl px-8">
-        <h2 className="mb-8 text-2xl font-semibold text-foreground">
+    <div className="absolute inset-0 z-50 bg-background">
+      <div className="h-full overflow-y-auto px-4 py-6 sm:px-8 sm:py-10">
+        <div className="mx-auto flex min-h-full w-full max-w-2xl flex-col">
+          <h2 className="mb-6 text-2xl font-semibold text-foreground sm:mb-8">
           Before we begin...
-        </h2>
+          </h2>
 
-        <div className="space-y-8">
-          {questions.map((q) => (
+          <div className="space-y-6 sm:space-y-8">
+            {visibleQuestions.map((q) => (
             <QuestionRenderer
               key={q.id}
               question={q}
@@ -69,12 +87,12 @@ export function QuestionFlow({
               onChange={(val) => setAnswer(q.id, val)}
               onToggleMulti={(val) => toggleMultiSelect(q.id, val)}
             />
-          ))}
-        </div>
+            ))}
+          </div>
 
-        {/* Progress dots */}
-        <div className="mt-8 flex items-center justify-center gap-1.5">
-          {questions.map((q, i) => {
+          {/* Progress dots */}
+          <div className="mt-8 flex items-center justify-center gap-1.5">
+            {visibleQuestions.map((q, i) => {
             const answered = answers[q.id] != null && answers[q.id] !== "";
             return (
               <div
@@ -85,31 +103,70 @@ export function QuestionFlow({
                 )}
               />
             );
-          })}
-        </div>
+            })}
+          </div>
 
-        {/* Actions */}
-        <div className="mt-8 flex items-center justify-between">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onSkip}
-            className="text-muted-foreground hover:text-foreground"
-          >
-            Skip
-          </Button>
-          <Button
-            onClick={handleSubmit}
-            disabled={!allRequiredAnswered}
-            className="gap-2"
-          >
-            Continue
-            <IconChevronRight className="h-4 w-4" />
-          </Button>
+          {/* Actions */}
+          <div className="sticky bottom-0 -mx-4 mt-8 flex items-center justify-between border-t border-border bg-background/95 px-4 py-4 backdrop-blur sm:-mx-8 sm:px-8">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onSkip}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              Skip
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={!allRequiredAnswered}
+              className="gap-2"
+            >
+              Continue
+              <IconChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
       </div>
     </div>
   );
+}
+
+const DESIGN_SYSTEM_COLOR_KEYS: Array<
+  [keyof DesignSystemData["colors"], string]
+> = [
+  ["primary", "Primary"],
+  ["secondary", "Secondary"],
+  ["accent", "Accent"],
+  ["background", "Background"],
+  ["surface", "Surface"],
+];
+
+function isUsableColor(value: string | undefined): value is string {
+  if (!value) return false;
+  const color = value.trim();
+  return (
+    /^#[0-9a-f]{3,8}$/i.test(color) ||
+    /^rgba?\(/i.test(color) ||
+    /^hsla?\(/i.test(color)
+  );
+}
+
+function designSystemColorOptions(
+  designSystem: DesignSystemData,
+  fallback: NonNullable<QuestionFlowQuestion["options"]>,
+): NonNullable<QuestionFlowQuestion["options"]> {
+  const seen = new Set<string>();
+  const options = DESIGN_SYSTEM_COLOR_KEYS.flatMap(([key, label]) => {
+    const color = designSystem.colors[key]?.trim();
+    const normalized = color?.toLowerCase();
+    if (!isUsableColor(color) || !normalized || seen.has(normalized)) {
+      return [];
+    }
+    seen.add(normalized);
+    return [{ label, value: color, color }];
+  });
+
+  return options.length >= 2 ? options : fallback;
 }
 
 function QuestionRenderer({

--- a/templates/slides/app/components/editor/QuestionFlow.tsx
+++ b/templates/slides/app/components/editor/QuestionFlow.tsx
@@ -75,34 +75,34 @@ export function QuestionFlow({
       <div className="h-full overflow-y-auto px-4 py-6 sm:px-8 sm:py-10">
         <div className="mx-auto flex min-h-full w-full max-w-2xl flex-col">
           <h2 className="mb-6 text-2xl font-semibold text-foreground sm:mb-8">
-          Before we begin...
+            Before we begin...
           </h2>
 
           <div className="space-y-6 sm:space-y-8">
             {visibleQuestions.map((q) => (
-            <QuestionRenderer
-              key={q.id}
-              question={q}
-              value={answers[q.id]}
-              onChange={(val) => setAnswer(q.id, val)}
-              onToggleMulti={(val) => toggleMultiSelect(q.id, val)}
-            />
+              <QuestionRenderer
+                key={q.id}
+                question={q}
+                value={answers[q.id]}
+                onChange={(val) => setAnswer(q.id, val)}
+                onToggleMulti={(val) => toggleMultiSelect(q.id, val)}
+              />
             ))}
           </div>
 
           {/* Progress dots */}
           <div className="mt-8 flex items-center justify-center gap-1.5">
             {visibleQuestions.map((q, i) => {
-            const answered = answers[q.id] != null && answers[q.id] !== "";
-            return (
-              <div
-                key={i}
-                className={cn(
-                  "h-1.5 w-1.5 rounded-full",
-                  answered ? "bg-[#609FF8]" : "bg-muted",
-                )}
-              />
-            );
+              const answered = answers[q.id] != null && answers[q.id] !== "";
+              return (
+                <div
+                  key={i}
+                  className={cn(
+                    "h-1.5 w-1.5 rounded-full",
+                    answered ? "bg-[#609FF8]" : "bg-muted",
+                  )}
+                />
+              );
             })}
           </div>
 

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useMemo } from "react";
+import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { flushSync } from "react-dom";
 import { useNavigate } from "react-router";
 import { IconPlus, IconStack2 } from "@tabler/icons-react";
@@ -11,7 +11,7 @@ import {
   useSetHeaderActions,
   useSetPageTitle,
 } from "@/components/layout/HeaderActions";
-import { agentNativePath } from "@agent-native/core/client";
+import { agentNativePath, useSession } from "@agent-native/core/client";
 import { extractGoogleDocUrls } from "@shared/google-docs";
 import {
   AlertDialog,
@@ -27,6 +27,8 @@ import {
 import { Button } from "@/components/ui/button";
 
 const MAX_SOURCE_CONTEXT_CHARS = 60_000;
+const NEW_DECK_DRAFT_SCOPE = "slides-new-deck";
+const PENDING_PROMPT_KEY = "slides:pending-deck-prompt";
 
 function summarizePromptForChat(prompt: string): string {
   const singleLine = prompt.trim().replace(/\s+/g, " ");
@@ -50,9 +52,11 @@ function truncateSourceForContext(prompt: string): {
 
 export default function Index() {
   const { decks, createDeck, deleteDeck, updateDeck, loading } = useDecks();
+  const { session } = useSession();
   const navigate = useNavigate();
   const [deckToDelete, setDeckToDelete] = useState<string | null>(null);
   const [showNewDeckPrompt, setShowNewDeckPrompt] = useState(false);
+  const [showSignInDialog, setShowSignInDialog] = useState(false);
   const [duplicating, setDuplicating] = useState<string | null>(null);
   const { generating, submit: agentSubmit } = useAgentGenerating();
   const anchorElRef = useRef<HTMLElement | null>(null);
@@ -64,6 +68,36 @@ export default function Index() {
     anchorElRef.current = e.currentTarget;
     setShowNewDeckPrompt(true);
   }, []);
+
+  // Restore a prompt that was held back when the user wasn't signed in:
+  // we wrote the text to sessionStorage before redirecting to sign-in,
+  // and now that they're back and authenticated, replay it into the
+  // composer's localStorage draft and pop the new-deck dialog open so
+  // they can hit submit without retyping.
+  useEffect(() => {
+    if (!session) return;
+    let saved: string | null = null;
+    try {
+      saved = sessionStorage.getItem(PENDING_PROMPT_KEY);
+    } catch {}
+    if (!saved) return;
+    try {
+      const escaped = saved
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+      const paragraphs = escaped
+        .split(/\n+/)
+        .map((line) => `<p>${line || "<br/>"}</p>`)
+        .join("");
+      localStorage.setItem(
+        `an-composer-draft:${encodeURIComponent(NEW_DECK_DRAFT_SCOPE)}`,
+        paragraphs,
+      );
+      sessionStorage.removeItem(PENDING_PROMPT_KEY);
+    } catch {}
+    setShowNewDeckPrompt(true);
+  }, [session]);
 
   const handleCreateDeckBlank = () => {
     let deck: ReturnType<typeof createDeck> | undefined;
@@ -78,6 +112,20 @@ export default function Index() {
     prompt: string,
     files: UploadedFile[],
   ) => {
+    // Pre-flight auth check. The /api/decks POST returns 403 silently
+    // when unauthenticated, leaving the user stuck on a deck page that
+    // doesn't exist server-side and a small auth error in the chat
+    // sidebar. Catch it here so the user sees a clear sign-in prompt
+    // and the typed prompt isn't lost when they come back.
+    if (!session) {
+      try {
+        sessionStorage.setItem(PENDING_PROMPT_KEY, prompt);
+      } catch {}
+      setShowNewDeckPrompt(false);
+      setShowSignInDialog(true);
+      return;
+    }
+
     let deck: ReturnType<typeof createDeck> | undefined;
     flushSync(() => {
       deck = createDeck(undefined, { noDefaultSlides: true });
@@ -285,7 +333,36 @@ export default function Index() {
         onSubmit={handleCreateDeckWithPrompt}
         loading={generating}
         anchorRef={anchorRef}
+        draftScope={NEW_DECK_DRAFT_SCOPE}
       />
+
+      {/* Sign-in required to create a deck. Shown when an unauthenticated
+          user submits a prompt — the typed prompt is preserved in
+          sessionStorage and replayed into the composer after sign-in. */}
+      <AlertDialog open={showSignInDialog} onOpenChange={setShowSignInDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Sign in to create a deck</AlertDialogTitle>
+            <AlertDialogDescription>
+              You need to sign in before generating a deck. We've saved your
+              prompt — once you're back, it'll be ready to go.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                const ret = window.location.pathname + window.location.search;
+                window.location.href =
+                  agentNativePath("/_agent-native/sign-in") +
+                  `?return=${encodeURIComponent(ret)}`;
+              }}
+            >
+              Sign in
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Bundle of client + server hardening that built up locally on the post-#512 branch. All five changesets are scoped to `@agent-native/core` (patch).

**Server-side Sentry (new)** — `packages/core/src/server/sentry.ts` + `sentry-plugin.ts` initialise `@sentry/node` inside Nitro using `SENTRY_SERVER_DSN` (no-op when unset). Per-request scope tagged with the resolved session's userId/email/orgId so 5xx errors in framework routes, action handlers, and agent-chat streams have user context. `framework-request-handler.ts` lazy-loads sentry to avoid pulling `@sentry/node` into bundles that don't need it; only 5xx are forwarded — 4xx are user-input errors.

**Agent UI / Builder integration**
- Wrap shadcn `Tooltip` usages in a `TooltipProvider` so the agent panel and docs site stop crashing under `@radix-ui/react-tooltip@1.2.x`.
- Resolve org-shared Builder credentials when auto-selecting the chat engine — org members inherit the org connection without their own key.
- Stop reloading the agent chat after Builder/secret config updates (the reload nuked in-flight conversations).
- Composer accepts file drops directly (PDF, PPTX, images), mirroring the existing paste handler.

**Extensions** — `ExtensionEditor`, `ExtensionViewer`, `ExtensionSlot`, `ExtensionsSidebarSection` rework: tighter layout, better empty/loading/error states, share UI consistent with the rest of the app.

**Templates** — Mail (`AppLayout`/`SearchBar`/`EmailList` polish, view-screen + list/search action tightening, google-auth scoping); Clips (recorder-engine reliability, library polish, abort-upload route hardening); Slides (`PromptDialog` → `GenerateSlidesDialog`, Index polish); Analytics (`DataSources` polish).

**Docs** — `deployment` / `getting-started` / `observability` content updates plus `packages/docs/app/root.tsx` provider plumbing.

## Test plan

- [ ] `pnpm prep` (guards + typecheck + tests + fmt) — passing locally
- [ ] Smoke: agent panel renders without `Tooltip must be used within TooltipProvider`
- [ ] Smoke: drag a PDF into the composer — it attaches instead of navigating
- [ ] Smoke: deploy preview comes up with `SENTRY_SERVER_DSN` set, throw a test 5xx, confirm event lands in the server Sentry project with userId/orgId tags
- [ ] Smoke: org member without their own Builder key inherits the org-shared engine selection