### PR TITLE
feat(clips): auto-compress large recordings before upload

### DIFF
--- a/templates/clips/actions/delete-recording-permanent.ts
+++ b/templates/clips/actions/delete-recording-permanent.ts
@@ -67,6 +67,7 @@ export default defineAction({
     // Clean up any lingering application state for this recording.
     await deleteAppStateByPrefix(`recording-chunks-${args.id}-`);
     await deleteAppState(`recording-upload-${args.id}`);
+    await deleteAppState(`recording-compression-${args.id}`);
     await deleteAppState(`recording-blob-${args.id}`);
     await deleteAppState(`agent-task-recording-${args.id}`);
 

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -127,6 +127,32 @@ export default defineAction({
         ? "mp4"
         : "webm";
 
+      // The recorder stashes compression metadata at
+      // `recording-upload-{id}.compression` when its browser-side
+      // ffmpeg.wasm pass ran to bring the assembled blob under Builder.io's
+      // 100 MB upload cap. Surface it into the Sentry payload on any
+      // upload failure so we can tell at a glance whether the user hit
+      // the limit on the original blob or on the compressed one.
+      const compressionMeta: {
+        originalBytes?: number;
+        compressedBytes?: number;
+        ratio?: number;
+        elapsedMs?: number;
+        outputMimeType?: string;
+      } | null =
+        uploadState &&
+        typeof uploadState === "object" &&
+        uploadState.compression &&
+        typeof uploadState.compression === "object"
+          ? (uploadState.compression as {
+              originalBytes?: number;
+              compressedBytes?: number;
+              ratio?: number;
+              elapsedMs?: number;
+              outputMimeType?: string;
+            })
+          : null;
+
       // Flip to 'processing' while we assemble.
       await db
         .update(schema.recordings)
@@ -209,12 +235,39 @@ export default defineAction({
         }
       }
 
-      const upload = await uploadFile({
-        data: uploadData,
-        filename: `${id}.${videoFormat}`,
-        mimeType,
-        ownerEmail,
-      });
+      let upload: Awaited<ReturnType<typeof uploadFile>>;
+      try {
+        upload = await uploadFile({
+          data: uploadData,
+          filename: `${id}.${videoFormat}`,
+          mimeType,
+          ownerEmail,
+        });
+      } catch (err) {
+        // Log structured context so a "Builder.io upload failed (500)" can be
+        // diagnosed without round-tripping with the user. Especially important
+        // alongside the new browser-side compression — we want to know whether
+        // the user hit Builder.io's 100 MB cap on the original recording or
+        // on the compressed result.
+        // (The PR adding `captureRouteError` here lives in a sibling branch;
+        // when it merges, this console.error is replaced with the Sentry
+        // capture call — see PR description.)
+        console.error("[finalize] upload failed", {
+          recordingId: id,
+          dataBytes: uploadData.byteLength,
+          mimeType,
+          videoFormat,
+          ownerEmail,
+          originalBytes: compressionMeta?.originalBytes ?? assembled.byteLength,
+          compressedBytes: compressionMeta?.compressedBytes,
+          compressionRatio: compressionMeta?.ratio,
+          compressionElapsedMs: compressionMeta?.elapsedMs,
+          compressionOutputMimeType: compressionMeta?.outputMimeType,
+          compressionRan: !!compressionMeta,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
 
       if (!upload?.url) {
         throw new Error(

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -128,11 +128,16 @@ export default defineAction({
         : "webm";
 
       // The recorder stashes compression metadata at
-      // `recording-upload-{id}.compression` when its browser-side
-      // ffmpeg.wasm pass ran to bring the assembled blob under Builder.io's
-      // 100 MB upload cap. Surface it into the Sentry payload on any
-      // upload failure so we can tell at a glance whether the user hit
-      // the limit on the original blob or on the compressed one.
+      // `recording-compression-{id}` when its browser-side ffmpeg.wasm
+      // pass ran to bring the assembled blob under Builder.io's 100 MB
+      // upload cap. Stored under its own sub-key (rather than nested
+      // inside `recording-upload-{id}`) because the recorder client
+      // overwrites the upload key on every chunk POST — co-locating the
+      // compression context would mean it gets clobbered before this
+      // action runs. Surface it into the Sentry payload on any upload
+      // failure so we can tell at a glance whether the user hit the limit
+      // on the original blob or on the compressed one.
+      const compressionRaw = await readAppState(`recording-compression-${id}`);
       const compressionMeta: {
         originalBytes?: number;
         compressedBytes?: number;
@@ -140,11 +145,8 @@ export default defineAction({
         elapsedMs?: number;
         outputMimeType?: string;
       } | null =
-        uploadState &&
-        typeof uploadState === "object" &&
-        uploadState.compression &&
-        typeof uploadState.compression === "object"
-          ? (uploadState.compression as {
+        compressionRaw && typeof compressionRaw === "object"
+          ? (compressionRaw as {
               originalBytes?: number;
               compressedBytes?: number;
               ratio?: number;
@@ -419,6 +421,17 @@ export default defineAction({
           id,
           purged,
           attempted: chunkKeysToPurge.length,
+        });
+      }
+      // Drop the compression sub-key written by reset-chunks. Best effort;
+      // it's small (<200 bytes) so a leaked one is harmless, but tidying
+      // up keeps `application_state` clean across many recordings.
+      try {
+        await deleteAppState(`recording-compression-${id}`);
+      } catch (err) {
+        console.warn("[finalize] compression key delete failed", {
+          id,
+          err: err instanceof Error ? err.message : String(err),
         });
       }
     }

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -7,6 +7,13 @@
  * and `onError`.
  */
 import { appBasePath } from "@agent-native/core/client";
+import {
+  COMPRESS_THRESHOLD_BYTES,
+  MAX_UPLOAD_BYTES,
+  compressBlobIfTooLarge,
+  formatMb,
+  type CompressionResult,
+} from "@/lib/compress";
 
 export type RecordingMode = "screen" | "camera" | "screen+camera";
 export const NO_MIC_DEVICE_ID = "__clips_no_microphone__";
@@ -18,6 +25,7 @@ export type RecorderState =
   | "recording"
   | "paused"
   | "stopping"
+  | "compressing"
   | "uploading"
   | "complete"
   | "error";
@@ -55,6 +63,16 @@ export interface RecorderEngineOptions {
    * transcription flush, navigation) before the MediaRecorder is finalized.
    */
   onDisplayTrackEnded?: () => void;
+  /**
+   * Fired with progress updates while ffmpeg.wasm is re-encoding a too-large
+   * recording. Stage transitions from `loading-ffmpeg` → `preparing` →
+   * `encoding` (with 0..1 progress) → `finalizing`. The engine itself
+   * transitions through the `compressing` state for the duration.
+   */
+  onCompressionProgress?: (info: {
+    stage: "loading-ffmpeg" | "preparing" | "encoding" | "finalizing";
+    progress: number | null;
+  }) => void;
 }
 
 export interface RecorderStartResult {
@@ -123,6 +141,19 @@ export class RecorderEngine {
   private pausedAccumMs = 0;
   private pausedStartedMs: number | null = null;
   private uploadFailure: Error | null = null;
+  /**
+   * Local mirror of every chunk we sent to the server, in record order.
+   * We hold these to enable the post-stop "compress and re-upload" path
+   * for clips larger than COMPRESS_THRESHOLD_BYTES — without this buffer
+   * we'd have to ask the server for the chunks back, which neither the
+   * `/api/uploads/:id/chunk` endpoint nor `application_state` support.
+   *
+   * Memory cost: one Blob per 2s slice. A 10-min 1080p screen capture is
+   * ~600 MB worst case (heavy motion); typical screen capture is much
+   * smaller. The browser handles ~1 GB blob arrays without trouble.
+   */
+  private localChunks: Blob[] = [];
+  private totalRecordedBytes = 0;
 
   private state: RecorderState = "idle";
 
@@ -311,10 +342,17 @@ export class RecorderEngine {
 
     this.chunkIndex = 0;
     this.uploadFailure = null;
+    this.localChunks = [];
+    this.totalRecordedBytes = 0;
 
     this.recorder.addEventListener("dataavailable", (event) => {
       const blob = event.data;
       if (!blob || blob.size === 0) return;
+      // Mirror to local buffer BEFORE upload — if compression turns out to
+      // be needed (decided post-stop based on totalRecordedBytes), we need
+      // every chunk on the client side to assemble + re-encode.
+      this.localChunks.push(blob);
+      this.totalRecordedBytes += blob.size;
       const index = this.chunkIndex++;
       this.queueChunk(blob, index, /* isFinal */ false);
     });
@@ -400,26 +438,43 @@ export class RecorderEngine {
       const durationMs = Math.round(this.getElapsedMs());
       const hasAudio = this.hasAudioTrack();
       const hasCamera = !!this.cameraStream;
-      this.transition("uploading", { progress: 100 });
+
+      // Auto-stop path: there's no extra final blob we missed. Branch on
+      // size and either finalize via the streamed chunks (small clip) or
+      // discard them and re-upload a compressed assembly (large clip).
       let result: Record<string, unknown> | undefined;
       try {
-        result = await this.uploadChunk(
-          new Blob([], { type: this.mimeType }),
-          this.chunkIndex++,
-          {
-            isFinal: true,
-            total: this.chunkIndex,
-            mimeType: this.mimeType,
+        if (this.totalRecordedBytes > COMPRESS_THRESHOLD_BYTES) {
+          result = await this.compressAndReupload({
             durationMs,
-            width: dimensions.width,
-            height: dimensions.height,
+            dimensions,
             hasAudio,
             hasCamera,
-          },
-        );
+          });
+        } else {
+          this.transition("uploading", { progress: 100 });
+          result = await this.uploadChunk(
+            new Blob([], { type: this.mimeType }),
+            this.chunkIndex++,
+            {
+              isFinal: true,
+              total: this.chunkIndex,
+              mimeType: this.mimeType,
+              durationMs,
+              width: dimensions.width,
+              height: dimensions.height,
+              hasAudio,
+              hasCamera,
+            },
+          );
+        }
       } finally {
         // Always release hardware resources, even if the final upload failed.
         this.cleanupTracks();
+        // Drop the in-memory chunks now that they're either uploaded or no
+        // longer recoverable from this engine (a finalize failure surfaces
+        // through the thrown error path, not by retrying the chunks).
+        this.localChunks = [];
       }
       this.transition("complete");
       return {
@@ -462,6 +517,13 @@ export class RecorderEngine {
     }
 
     const finalBlob = await stopPromise;
+    if (finalBlob.size > 0) {
+      // Mirror the final dataavailable into the local buffer so the
+      // compression path (if any) sees the complete recording. The
+      // streaming path also pushed every prior `dataavailable` here.
+      this.localChunks.push(finalBlob);
+      this.totalRecordedBytes += finalBlob.size;
+    }
     const finalIndex = this.chunkIndex++;
 
     // Wait for all pending in-flight chunks before we send the isFinal one.
@@ -470,21 +532,38 @@ export class RecorderEngine {
 
     const dimensions = this.readDimensions();
     const durationMs = Math.round(this.getElapsedMs());
+    const hasAudio = this.hasAudioTrack();
+    const hasCamera = !!this.cameraStream;
 
-    this.transition("uploading", { progress: 100 });
-
-    const result = await this.uploadChunk(finalBlob, finalIndex, {
-      isFinal: true,
-      total: this.chunkIndex,
-      mimeType: this.mimeType,
-      durationMs,
-      width: dimensions.width,
-      height: dimensions.height,
-      hasAudio: this.hasAudioTrack(),
-      hasCamera: !!this.cameraStream,
-    });
-
-    this.cleanupTracks();
+    let result: Record<string, unknown> | undefined;
+    try {
+      if (this.totalRecordedBytes > COMPRESS_THRESHOLD_BYTES) {
+        // Discard everything that streamed up during recording — it's
+        // about to be replaced by the compressed assembly below — and
+        // re-upload from index 0.
+        result = await this.compressAndReupload({
+          durationMs,
+          dimensions,
+          hasAudio,
+          hasCamera,
+        });
+      } else {
+        this.transition("uploading", { progress: 100 });
+        result = await this.uploadChunk(finalBlob, finalIndex, {
+          isFinal: true,
+          total: this.chunkIndex,
+          mimeType: this.mimeType,
+          durationMs,
+          width: dimensions.width,
+          height: dimensions.height,
+          hasAudio,
+          hasCamera,
+        });
+      }
+    } finally {
+      this.cleanupTracks();
+      this.localChunks = [];
+    }
     this.transition("complete");
 
     return {
@@ -492,9 +571,169 @@ export class RecorderEngine {
       durationMs,
       width: dimensions.width,
       height: dimensions.height,
-      hasAudio: this.hasAudioTrack(),
-      hasCamera: !!this.cameraStream,
+      hasAudio,
+      hasCamera,
     };
+  }
+
+  // -------------------------------------------------------------------------
+  // Compression path
+  // -------------------------------------------------------------------------
+
+  /**
+   * Re-encode the local chunk buffer at a lower bitrate via ffmpeg.wasm,
+   * discard the chunks we already streamed up (they'd assemble to the
+   * un-compressed source), and upload the compressed result starting at
+   * index 0. Triggered when `totalRecordedBytes > COMPRESS_THRESHOLD_BYTES`
+   * because the assembled blob would otherwise blow Builder.io's 100 MB
+   * per-file upload limit and 500 mid-stream.
+   *
+   * Throws a clean user-facing error if the compressed blob is STILL larger
+   * than `MAX_UPLOAD_BYTES`, so the UI can suggest "shorter recording / lower
+   * resolution" rather than letting the upload fail with a 500.
+   */
+  private async compressAndReupload(meta: {
+    durationMs: number;
+    dimensions: { width: number; height: number };
+    hasAudio: boolean;
+    hasCamera: boolean;
+  }): Promise<Record<string, unknown> | undefined> {
+    this.transition("compressing");
+
+    const assembled = new Blob(this.localChunks, { type: this.mimeType });
+    const originalBytes = assembled.size;
+
+    let compression: CompressionResult | null = null;
+    let compressionError: {
+      message: string;
+      stderrTail: string[];
+      elapsedMs: number;
+    } | null = null;
+    try {
+      compression = await compressBlobIfTooLarge(assembled, this.mimeType, {
+        width: meta.dimensions.width,
+        height: meta.dimensions.height,
+        onProgress: (p) => {
+          this.opts.onCompressionProgress?.({
+            stage: p.stage,
+            progress: p.progress,
+          });
+        },
+        onError: (err) => {
+          compressionError = err;
+        },
+      });
+    } catch (err) {
+      // compressBlobIfTooLarge swallows ffmpeg failures (returns the input
+      // blob with compressed=false). A throw here would mean something
+      // genuinely unexpected, e.g. an OOM during the assembled-blob
+      // creation. Surface it as the user-facing error.
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+
+    const finalBlob = compression.blob;
+    const compressedBytes = finalBlob.size;
+
+    // Tell the server to wipe the chunks we streamed up during recording
+    // (they came from an un-compressed source) and stash the compression
+    // metadata so finalize-recording can include it in any Sentry capture
+    // if the upload still fails downstream.
+    try {
+      const resetUrl = `${appBasePath()}/api/uploads/${
+        this.opts.recordingId
+      }/reset-chunks`;
+      const compressionPayload = compression.compressed
+        ? {
+            originalBytes,
+            compressedBytes,
+            ratio: compression.ratio,
+            elapsedMs: compression.elapsedMs,
+            outputMimeType: compression.outputMimeType,
+          }
+        : null;
+      const resetRes = await fetch(resetUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ compression: compressionPayload }),
+      });
+      if (!resetRes.ok) {
+        // Reset failed but we'll plough on — the worst case is finalize
+        // assembles BOTH the old streamed chunks AND the new compressed
+        // ones, in which case its existing size handling will surface the
+        // problem. Logging here so the bug is at least visible.
+        console.warn(
+          "[recorder] reset-chunks failed; proceeding with re-upload",
+          { status: resetRes.status },
+        );
+      }
+    } catch (err) {
+      console.warn("[recorder] reset-chunks request failed", err);
+    }
+
+    if (compressionError) {
+      // Compression itself failed — we still hold the original assembled
+      // blob and we'll attempt to upload it as-is. The hard-cap check
+      // below will reject if it's still over MAX_UPLOAD_BYTES; otherwise
+      // the user's recording is small enough to squeak through.
+      console.warn(
+        "[recorder] compression failed, falling back to original blob",
+        compressionError,
+      );
+    }
+
+    if (compressedBytes > MAX_UPLOAD_BYTES) {
+      // Stop before we attempt the upload. Builder.io would 500 anyway and
+      // leave the user with the same opaque error this PR is meant to fix.
+      const detail = compression.compressed
+        ? `${formatMb(compressedBytes)} after compression`
+        : `${formatMb(compressedBytes)}`;
+      throw new Error(
+        `Recording is too large to upload (${detail}, limit is ${formatMb(
+          MAX_UPLOAD_BYTES,
+        )}). Try a shorter recording or lower the screen resolution / frame rate.`,
+      );
+    }
+
+    this.transition("uploading", { progress: 0 });
+
+    // Reset the upload index since the server just wiped its chunks.
+    this.chunkIndex = 0;
+
+    // Slice the (possibly compressed) blob into 5 MB chunks — the server's
+    // chunk handler caps each at ~6 MB so we need to slice. This is the
+    // same approach the file-upload code path uses in `record.tsx`.
+    const UPLOAD_SLICE_BYTES = 5 * 1024 * 1024;
+    const totalSlices = Math.max(
+      1,
+      Math.ceil(finalBlob.size / UPLOAD_SLICE_BYTES),
+    );
+    const outputMimeType = compression.outputMimeType;
+
+    let lastResult: Record<string, unknown> | undefined;
+    for (let i = 0; i < totalSlices; i++) {
+      const start = i * UPLOAD_SLICE_BYTES;
+      const end = Math.min(start + UPLOAD_SLICE_BYTES, finalBlob.size);
+      const slice = finalBlob.slice(start, end, outputMimeType);
+      const isFinal = i === totalSlices - 1;
+      const index = this.chunkIndex++;
+      lastResult = await this.uploadChunk(slice, index, {
+        isFinal,
+        total: totalSlices,
+        mimeType: outputMimeType,
+        durationMs: isFinal ? meta.durationMs : undefined,
+        width: isFinal ? meta.dimensions.width : undefined,
+        height: isFinal ? meta.dimensions.height : undefined,
+        hasAudio: isFinal ? meta.hasAudio : undefined,
+        hasCamera: isFinal ? meta.hasCamera : undefined,
+      });
+      this.opts.onChunk?.({
+        index,
+        bytes: slice.size,
+        total: totalSlices,
+      });
+    }
+
+    return lastResult;
   }
 
   /** Cancel: release tracks immediately, then abort server-side, reset state. */
@@ -517,6 +756,8 @@ export class RecorderEngine {
     this.startedAtMs = null;
     this.pausedAccumMs = 0;
     this.pausedStartedMs = null;
+    this.localChunks = [];
+    this.totalRecordedBytes = 0;
     this.transition("idle");
 
     try {

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -678,6 +678,16 @@ export class RecorderEngine {
           signal: abort.signal,
         });
       } catch (err) {
+        // The user clicking Cancel mid-fetch makes the AbortController
+        // abort and `fetch` rejects with a DOMException whose
+        // `name === "AbortError"`. Wrapping that into a generic network
+        // error would lose the AbortError identity, so doStop()'s catch
+        // would surface a misleading "Upload failed (network error)"
+        // toast for what is actually an intentional cancel. Re-throw the
+        // abort untouched; only wrap genuine non-abort failures.
+        if ((err as { name?: string } | null)?.name === "AbortError") {
+          throw err;
+        }
         throw new Error(
           `Couldn't prepare the recording for re-upload (network error contacting reset-chunks). ${
             err instanceof Error ? err.message : String(err)
@@ -791,8 +801,15 @@ export class RecorderEngine {
     // terminates the wasm worker, and re-throws — propagating up through
     // stop() which transitions to "error". Without this, ffmpeg keeps
     // encoding for minutes against a recording the user already discarded.
+    //
+    // The abort reason carries `name === "AbortError"` so any consumer
+    // downstream (compress.ts, the reset-chunks fetch, the chunked upload
+    // loop, record.tsx's doStop catch) can identify cancellation by name
+    // alone — no regex matching against the message string.
     if (this.compressionAbort) {
-      this.compressionAbort.abort(new Error("Recording cancelled"));
+      const cancelErr = new Error("Recording cancelled");
+      cancelErr.name = "AbortError";
+      this.compressionAbort.abort(cancelErr);
       this.compressionAbort = null;
     }
     this.cleanupTracks();

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -154,6 +154,13 @@ export class RecorderEngine {
    */
   private localChunks: Blob[] = [];
   private totalRecordedBytes = 0;
+  /**
+   * Owns the abort signal threaded into the compression pass so a `cancel()`
+   * during a multi-minute ffmpeg.wasm encode actually terminates the worker
+   * (and the chunked re-upload that follows it) rather than running them to
+   * completion against a recording the user already discarded.
+   */
+  private compressionAbort: AbortController | null = null;
 
   private state: RecorderState = "idle";
 
@@ -403,6 +410,13 @@ export class RecorderEngine {
   /**
    * Stop recording, flush the final chunk, and wait for all uploads
    * (including the isFinal=1 chunk that triggers server-side finalize).
+   *
+   * State-machine guarantee: every reachable code path in this method ends
+   * with either `transition("complete")` (success) or `transition("error")`
+   * (any throw, including from `compressAndReupload`). The engine never
+   * gets stuck mid-state. The UI's spinner is wired off the engine state,
+   * so a stuck "compressing" state would hang the spinner forever — see
+   * `record.tsx`'s `onState` handler.
    */
   async stop(): Promise<RecorderFinalizeResult> {
     if (!this.recorder) throw new Error("Not recording");
@@ -421,114 +435,79 @@ export class RecorderEngine {
       }
     }
 
-    // The MediaRecorder may have auto-stopped if all its tracks ended (e.g.
-    // display-only mode with no mic). Different browsers dispatch `dataavailable`
-    // either before or after state transitions to `inactive`. Yielding one
-    // macrotask (setTimeout 0) ensures any still-pending `dataavailable` event
-    // runs first and gets queued by our start()-time listener before we drain
-    // the chunk queue and send the isFinal=1 sentinel.
     if (this.recorder.state === "inactive") {
+      // The MediaRecorder may have auto-stopped if all its tracks ended
+      // (e.g. display-only mode with no mic). Different browsers dispatch
+      // `dataavailable` either before or after state transitions to
+      // `inactive`. Yielding one macrotask ensures any still-pending
+      // `dataavailable` event runs first and gets queued by our
+      // start()-time listener before we drain the chunk queue and send
+      // the isFinal=1 sentinel.
       this.transition("stopping");
-      // Yield to the event loop so any pending dataavailable event from the
-      // auto-stop can fire and be queued before we drain chunkQueue.
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
-      await this.chunkQueue;
-      if (this.uploadFailure) throw this.uploadFailure;
-      const dimensions = this.readDimensions();
-      const durationMs = Math.round(this.getElapsedMs());
-      const hasAudio = this.hasAudioTrack();
-      const hasCamera = !!this.cameraStream;
+    } else {
+      this.transition("stopping");
 
-      // Auto-stop path: there's no extra final blob we missed. Branch on
-      // size and either finalize via the streamed chunks (small clip) or
-      // discard them and re-upload a compressed assembly (large clip).
-      let result: Record<string, unknown> | undefined;
-      try {
-        if (this.totalRecordedBytes > COMPRESS_THRESHOLD_BYTES) {
-          result = await this.compressAndReupload({
-            durationMs,
-            dimensions,
-            hasAudio,
-            hasCamera,
+      // Wait for the dataavailable event triggered by recorder.stop() to
+      // be picked up by the start()-time listener (which mirrors it into
+      // `localChunks` and queues an upload). We don't push or upload the
+      // final blob here — that listener is the single owner. Pushing
+      // again would duplicate the final ~2s slice in `localChunks`,
+      // inflating the assembled blob and corrupting the compressed
+      // re-encode.
+      const finalDataAvailable = new Promise<void>((resolve) => {
+        let resolved = false;
+        // Defer with a microtask so the start()-time listener's
+        // synchronous body (push + queue upload) runs first — both
+        // listeners fire on the same dataavailable event in registration
+        // order, and we want our pass-through to resolve only after the
+        // primary mirror has happened.
+        const passthrough = () => {
+          if (resolved) return;
+          queueMicrotask(() => {
+            if (resolved) return;
+            resolved = true;
+            resolve();
           });
-        } else {
-          this.transition("uploading", { progress: 100 });
-          result = await this.uploadChunk(
-            new Blob([], { type: this.mimeType }),
-            this.chunkIndex++,
-            {
-              isFinal: true,
-              total: this.chunkIndex,
-              mimeType: this.mimeType,
-              durationMs,
-              width: dimensions.width,
-              height: dimensions.height,
-              hasAudio,
-              hasCamera,
-            },
-          );
-        }
-      } finally {
-        // Always release hardware resources, even if the final upload failed.
+        };
+        this.recorder!.addEventListener("dataavailable", passthrough, {
+          once: true,
+        });
+        // Safety net: if dataavailable never fires (broken recorder),
+        // resolve after 10s so we don't hang forever. Normal path fires
+        // within milliseconds of recorder.stop().
+        setTimeout(() => {
+          if (resolved) return;
+          resolved = true;
+          this.recorder?.removeEventListener("dataavailable", passthrough);
+          resolve();
+        }, 10_000);
+      });
+
+      try {
+        this.recorder.stop();
+      } catch (err) {
+        // Hardware/recorder failure before we even started the post-stop
+        // pipeline — emit, transition, and bail.
         this.cleanupTracks();
-        // Drop the in-memory chunks now that they're either uploaded or no
-        // longer recoverable from this engine (a finalize failure surfaces
-        // through the thrown error path, not by retrying the chunks).
         this.localChunks = [];
+        this.emitError(err);
+        throw err;
       }
-      this.transition("complete");
-      return {
-        videoUrl: (result?.videoUrl as string | undefined) ?? null,
-        durationMs,
-        width: dimensions.width,
-        height: dimensions.height,
-        hasAudio,
-        hasCamera,
-      };
+
+      await finalDataAvailable;
     }
 
-    this.transition("stopping");
-
-    const stopPromise = new Promise<Blob>((resolve) => {
-      let resolved = false;
-      const onData = (event: BlobEvent) => {
-        if (resolved) return;
-        resolved = true;
-        this.recorder?.removeEventListener("dataavailable", onData);
-        resolve(event.data);
-      };
-      this.recorder!.addEventListener("dataavailable", onData, { once: true });
-      // Safety net: if dataavailable never fires (broken recorder),
-      // resolve with empty blob after 10s so we don't hang forever.
-      // Normal path fires within milliseconds of recorder.stop().
-      setTimeout(() => {
-        if (resolved) return;
-        resolved = true;
-        this.recorder?.removeEventListener("dataavailable", onData);
-        resolve(new Blob([], { type: this.mimeType }));
-      }, 10_000);
-    });
-
-    try {
-      this.recorder.stop();
-    } catch (err) {
-      this.emitError(err);
-      throw err;
-    }
-
-    const finalBlob = await stopPromise;
-    if (finalBlob.size > 0) {
-      // Mirror the final dataavailable into the local buffer so the
-      // compression path (if any) sees the complete recording. The
-      // streaming path also pushed every prior `dataavailable` here.
-      this.localChunks.push(finalBlob);
-      this.totalRecordedBytes += finalBlob.size;
-    }
-    const finalIndex = this.chunkIndex++;
-
-    // Wait for all pending in-flight chunks before we send the isFinal one.
+    // Drain in-flight chunk uploads queued by the start()-time listener
+    // (including the final dataavailable that just fired) before we either
+    // compress + re-upload or send the isFinal sentinel.
     await this.chunkQueue;
-    if (this.uploadFailure) throw this.uploadFailure;
+    if (this.uploadFailure) {
+      this.cleanupTracks();
+      this.localChunks = [];
+      this.transition("error", { message: this.uploadFailure.message });
+      throw this.uploadFailure;
+    }
 
     const dimensions = this.readDimensions();
     const durationMs = Math.round(this.getElapsedMs());
@@ -548,23 +527,44 @@ export class RecorderEngine {
           hasCamera,
         });
       } else {
+        // Send a 0-byte isFinal sentinel — the actual final-chunk bytes
+        // were already uploaded by the start()-time listener as a
+        // regular (non-final) chunk. Mirroring the auto-stop path so
+        // both branches share one code shape.
         this.transition("uploading", { progress: 100 });
-        result = await this.uploadChunk(finalBlob, finalIndex, {
-          isFinal: true,
-          total: this.chunkIndex,
-          mimeType: this.mimeType,
-          durationMs,
-          width: dimensions.width,
-          height: dimensions.height,
-          hasAudio,
-          hasCamera,
-        });
+        result = await this.uploadChunk(
+          new Blob([], { type: this.mimeType }),
+          this.chunkIndex++,
+          {
+            isFinal: true,
+            total: this.chunkIndex,
+            mimeType: this.mimeType,
+            durationMs,
+            width: dimensions.width,
+            height: dimensions.height,
+            hasAudio,
+            hasCamera,
+          },
+        );
       }
+      this.transition("complete");
+    } catch (err) {
+      // Reachable from compressAndReupload (compression failure, OOM,
+      // reset-chunks failure, hard-cap exceeded, abort) and from the
+      // isFinal sentinel upload. Ensure we never leave the engine stuck
+      // mid-state — the UI spinner is wired to engine state and would
+      // hang forever otherwise.
+      const e = err instanceof Error ? err : new Error(String(err));
+      this.transition("error", { message: e.message });
+      throw e;
     } finally {
+      // Always release hardware resources, even if the final upload failed.
       this.cleanupTracks();
+      // Drop the in-memory chunks now that they're either uploaded or no
+      // longer recoverable from this engine (a finalize failure surfaces
+      // through the thrown error path, not by retrying the chunks).
       this.localChunks = [];
     }
-    this.transition("complete");
 
     return {
       videoUrl: (result?.videoUrl as string | undefined) ?? null,
@@ -600,45 +600,63 @@ export class RecorderEngine {
   }): Promise<Record<string, unknown> | undefined> {
     this.transition("compressing");
 
-    const assembled = new Blob(this.localChunks, { type: this.mimeType });
-    const originalBytes = assembled.size;
+    // Owned for the lifetime of this single call so `cancel()` can abort
+    // both the ffmpeg.wasm pass and the subsequent chunk uploads.
+    const abort = new AbortController();
+    this.compressionAbort = abort;
 
-    let compression: CompressionResult | null = null;
-    let compressionError: {
-      message: string;
-      stderrTail: string[];
-      elapsedMs: number;
-    } | null = null;
     try {
-      compression = await compressBlobIfTooLarge(assembled, this.mimeType, {
-        width: meta.dimensions.width,
-        height: meta.dimensions.height,
-        onProgress: (p) => {
-          this.opts.onCompressionProgress?.({
-            stage: p.stage,
-            progress: p.progress,
-          });
-        },
-        onError: (err) => {
-          compressionError = err;
-        },
-      });
-    } catch (err) {
-      // compressBlobIfTooLarge swallows ffmpeg failures (returns the input
-      // blob with compressed=false). A throw here would mean something
-      // genuinely unexpected, e.g. an OOM during the assembled-blob
-      // creation. Surface it as the user-facing error.
-      throw err instanceof Error ? err : new Error(String(err));
-    }
+      const assembled = new Blob(this.localChunks, { type: this.mimeType });
+      const originalBytes = assembled.size;
 
-    const finalBlob = compression.blob;
-    const compressedBytes = finalBlob.size;
+      let compression: CompressionResult;
+      let compressionError: {
+        message: string;
+        stderrTail: string[];
+        elapsedMs: number;
+      } | null = null;
+      try {
+        compression = await compressBlobIfTooLarge(assembled, this.mimeType, {
+          width: meta.dimensions.width,
+          height: meta.dimensions.height,
+          signal: abort.signal,
+          onProgress: (p) => {
+            this.opts.onCompressionProgress?.({
+              stage: p.stage,
+              progress: p.progress,
+            });
+          },
+          onError: (err) => {
+            compressionError = err;
+          },
+        });
+      } catch (err) {
+        // Two failure modes reach here:
+        //  1. External abort (user clicked Cancel mid-encode) — we want
+        //     this to propagate so the caller bails out cleanly instead of
+        //     trying to upload a stale assembly behind the user's back.
+        //  2. Genuinely unexpected throw, e.g. OOM building the assembled
+        //     blob. Surface as the user-facing error.
+        // (compressBlobIfTooLarge normally swallows ffmpeg-internal
+        // failures and returns `{ compressed: false }`, so this catch is
+        // for the abort path and the truly unexpected.)
+        throw err instanceof Error ? err : new Error(String(err));
+      }
 
-    // Tell the server to wipe the chunks we streamed up during recording
-    // (they came from an un-compressed source) and stash the compression
-    // metadata so finalize-recording can include it in any Sentry capture
-    // if the upload still fails downstream.
-    try {
+      const finalBlob = compression.blob;
+      const compressedBytes = finalBlob.size;
+
+      // Tell the server to wipe the chunks we streamed up during recording
+      // (they came from an un-compressed source) and stash the compression
+      // metadata so finalize-recording can include it in any Sentry capture
+      // if the upload still fails downstream.
+      //
+      // A failure here is fatal — proceeding with the re-upload would
+      // mix compressed slices (indices 0..N) on top of the leftover
+      // un-compressed chunks at indices N+1..M, and finalize would
+      // concatenate them into a corrupted blob that decodes to a
+      // mid-clip glitch followed by garbage. Better a clean error than a
+      // silently-broken recording.
       const resetUrl = `${appBasePath()}/api/uploads/${
         this.opts.recordingId
       }/reset-chunks`;
@@ -651,89 +669,107 @@ export class RecorderEngine {
             outputMimeType: compression.outputMimeType,
           }
         : null;
-      const resetRes = await fetch(resetUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ compression: compressionPayload }),
-      });
-      if (!resetRes.ok) {
-        // Reset failed but we'll plough on — the worst case is finalize
-        // assembles BOTH the old streamed chunks AND the new compressed
-        // ones, in which case its existing size handling will surface the
-        // problem. Logging here so the bug is at least visible.
-        console.warn(
-          "[recorder] reset-chunks failed; proceeding with re-upload",
-          { status: resetRes.status },
+      let resetRes: Response;
+      try {
+        resetRes = await fetch(resetUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ compression: compressionPayload }),
+          signal: abort.signal,
+        });
+      } catch (err) {
+        throw new Error(
+          `Couldn't prepare the recording for re-upload (network error contacting reset-chunks). ${
+            err instanceof Error ? err.message : String(err)
+          }`,
         );
       }
-    } catch (err) {
-      console.warn("[recorder] reset-chunks request failed", err);
-    }
+      if (!resetRes.ok) {
+        const text = await resetRes.text().catch(() => "");
+        throw new Error(
+          `Couldn't prepare the recording for re-upload (reset-chunks ${
+            resetRes.status
+          }). ${text || resetRes.statusText}`,
+        );
+      }
 
-    if (compressionError) {
-      // Compression itself failed — we still hold the original assembled
-      // blob and we'll attempt to upload it as-is. The hard-cap check
-      // below will reject if it's still over MAX_UPLOAD_BYTES; otherwise
-      // the user's recording is small enough to squeak through.
-      console.warn(
-        "[recorder] compression failed, falling back to original blob",
-        compressionError,
+      if (compressionError) {
+        // Compression itself failed — we still hold the original assembled
+        // blob and we'll attempt to upload it as-is. The hard-cap check
+        // below will reject if it's still over MAX_UPLOAD_BYTES; otherwise
+        // the user's recording is small enough to squeak through.
+        console.warn(
+          "[recorder] compression failed, falling back to original blob",
+          compressionError,
+        );
+      }
+
+      if (compressedBytes > MAX_UPLOAD_BYTES) {
+        // Stop before we attempt the upload. Builder.io would 500 anyway and
+        // leave the user with the same opaque error this PR is meant to fix.
+        const detail = compression.compressed
+          ? `${formatMb(compressedBytes)} after compression`
+          : `${formatMb(compressedBytes)}`;
+        throw new Error(
+          `Recording is too large to upload (${detail}, limit is ${formatMb(
+            MAX_UPLOAD_BYTES,
+          )}). Try a shorter recording or lower the screen resolution / frame rate.`,
+        );
+      }
+
+      this.transition("uploading", { progress: 0 });
+
+      // Reset the upload index since the server just wiped its chunks.
+      this.chunkIndex = 0;
+
+      // Slice the (possibly compressed) blob into 5 MB chunks — the server's
+      // chunk handler caps each at ~6 MB so we need to slice. This is the
+      // same approach the file-upload code path uses in `record.tsx`.
+      const UPLOAD_SLICE_BYTES = 5 * 1024 * 1024;
+      const totalSlices = Math.max(
+        1,
+        Math.ceil(finalBlob.size / UPLOAD_SLICE_BYTES),
       );
+      const outputMimeType = compression.outputMimeType;
+
+      let lastResult: Record<string, unknown> | undefined;
+      for (let i = 0; i < totalSlices; i++) {
+        if (abort.signal.aborted) {
+          throw abort.signal.reason instanceof Error
+            ? abort.signal.reason
+            : new Error("Compression upload aborted");
+        }
+        const start = i * UPLOAD_SLICE_BYTES;
+        const end = Math.min(start + UPLOAD_SLICE_BYTES, finalBlob.size);
+        const slice = finalBlob.slice(start, end, outputMimeType);
+        const isFinal = i === totalSlices - 1;
+        const index = this.chunkIndex++;
+        lastResult = await this.uploadChunk(slice, index, {
+          isFinal,
+          total: totalSlices,
+          mimeType: outputMimeType,
+          durationMs: isFinal ? meta.durationMs : undefined,
+          width: isFinal ? meta.dimensions.width : undefined,
+          height: isFinal ? meta.dimensions.height : undefined,
+          hasAudio: isFinal ? meta.hasAudio : undefined,
+          hasCamera: isFinal ? meta.hasCamera : undefined,
+          signal: abort.signal,
+        });
+        this.opts.onChunk?.({
+          index,
+          bytes: slice.size,
+          total: totalSlices,
+        });
+      }
+
+      return lastResult;
+    } finally {
+      // Always release the controller reference even on throw — otherwise
+      // a subsequent cancel() would abort a freshly-started compression.
+      if (this.compressionAbort === abort) {
+        this.compressionAbort = null;
+      }
     }
-
-    if (compressedBytes > MAX_UPLOAD_BYTES) {
-      // Stop before we attempt the upload. Builder.io would 500 anyway and
-      // leave the user with the same opaque error this PR is meant to fix.
-      const detail = compression.compressed
-        ? `${formatMb(compressedBytes)} after compression`
-        : `${formatMb(compressedBytes)}`;
-      throw new Error(
-        `Recording is too large to upload (${detail}, limit is ${formatMb(
-          MAX_UPLOAD_BYTES,
-        )}). Try a shorter recording or lower the screen resolution / frame rate.`,
-      );
-    }
-
-    this.transition("uploading", { progress: 0 });
-
-    // Reset the upload index since the server just wiped its chunks.
-    this.chunkIndex = 0;
-
-    // Slice the (possibly compressed) blob into 5 MB chunks — the server's
-    // chunk handler caps each at ~6 MB so we need to slice. This is the
-    // same approach the file-upload code path uses in `record.tsx`.
-    const UPLOAD_SLICE_BYTES = 5 * 1024 * 1024;
-    const totalSlices = Math.max(
-      1,
-      Math.ceil(finalBlob.size / UPLOAD_SLICE_BYTES),
-    );
-    const outputMimeType = compression.outputMimeType;
-
-    let lastResult: Record<string, unknown> | undefined;
-    for (let i = 0; i < totalSlices; i++) {
-      const start = i * UPLOAD_SLICE_BYTES;
-      const end = Math.min(start + UPLOAD_SLICE_BYTES, finalBlob.size);
-      const slice = finalBlob.slice(start, end, outputMimeType);
-      const isFinal = i === totalSlices - 1;
-      const index = this.chunkIndex++;
-      lastResult = await this.uploadChunk(slice, index, {
-        isFinal,
-        total: totalSlices,
-        mimeType: outputMimeType,
-        durationMs: isFinal ? meta.durationMs : undefined,
-        width: isFinal ? meta.dimensions.width : undefined,
-        height: isFinal ? meta.dimensions.height : undefined,
-        hasAudio: isFinal ? meta.hasAudio : undefined,
-        hasCamera: isFinal ? meta.hasCamera : undefined,
-      });
-      this.opts.onChunk?.({
-        index,
-        bytes: slice.size,
-        total: totalSlices,
-      });
-    }
-
-    return lastResult;
   }
 
   /** Cancel: release tracks immediately, then abort server-side, reset state. */
@@ -749,6 +785,15 @@ export class RecorderEngine {
       }
     } catch {
       // ignore
+    }
+    // If a compression pass is mid-flight (ffmpeg.wasm encode + chunked
+    // re-upload), tear it down too. compressBlobIfTooLarge sees the abort,
+    // terminates the wasm worker, and re-throws — propagating up through
+    // stop() which transitions to "error". Without this, ffmpeg keeps
+    // encoding for minutes against a recording the user already discarded.
+    if (this.compressionAbort) {
+      this.compressionAbort.abort(new Error("Recording cancelled"));
+      this.compressionAbort = null;
     }
     this.cleanupTracks();
     this.chunkIndex = 0;
@@ -858,6 +903,7 @@ export class RecorderEngine {
       height?: number;
       hasAudio?: boolean;
       hasCamera?: boolean;
+      signal?: AbortSignal;
     } = {},
   ): Promise<Record<string, unknown> | undefined> {
     const params = new URLSearchParams();
@@ -884,6 +930,7 @@ export class RecorderEngine {
           blob.type || this.mimeType || "application/octet-stream",
       },
       body,
+      signal: extra.signal,
     });
 
     if (!res.ok) {

--- a/templates/clips/app/lib/compress.ts
+++ b/templates/clips/app/lib/compress.ts
@@ -1,0 +1,390 @@
+/**
+ * Browser-side video compression for clips that would exceed the upload
+ * provider's per-file limit.
+ *
+ * The motivating bug: Builder.io's `/api/v1/upload` caps each file at 100 MB
+ * (`fileUpload({ limits: { fileSize: 100 * 1024 * 1024 } })` plus a
+ * `express.raw({ limit: '200mb' })` body limit). When the assembled recording
+ * blob exceeds that, the streaming upload to GCS errors mid-write and the
+ * client sees `Builder.io upload failed (500): Internal Error` — a confusing
+ * dead-end with no remediation. Saee hit this on her second clip.
+ *
+ * Strategy: ride the existing ffmpeg.wasm install (we already lazy-load it
+ * for export / GIF / stitch in `ffmpeg-export.ts`). Re-encode video at a
+ * resolution-aware target bitrate, copy audio (Opus stays Opus inside WebM,
+ * AAC stays AAC inside MP4), bind the whole thing to an AbortController so
+ * it can't hang a tab forever, and return a smaller blob.
+ *
+ * Out-of-scope here:
+ *  - Raising Builder.io's per-file limit (server-side, separate work).
+ *  - Uploading via multipart instead of one POST (requires Builder.io API
+ *    changes + server-side reassembly).
+ *  - Returning 413 instead of 500 from upload (server-side, separate work).
+ *
+ * Threshold: skip compression entirely under 80 MB so the small-clip happy
+ * path pays no extra cost. Target ratio aims for ~30–60% of original on
+ * 1080p screen capture; the result is verified against the 100 MB hard cap
+ * before we attempt the upload, so a still-too-large clip surfaces a clean
+ * user-facing error rather than the opaque 500.
+ */
+
+import { loadFfmpeg, removeFfmpegLogListener } from "./ffmpeg-export";
+
+/** Start compressing at 80 MB. Below this, the upload fits and we don't pay
+ * for ffmpeg.wasm load + transcode. */
+export const COMPRESS_THRESHOLD_BYTES = 80 * 1024 * 1024;
+
+/** Builder.io's hard per-file upload limit. We reject at the client BEFORE
+ * issuing the upload if the compressed result still exceeds this — better
+ * than letting it 500 mid-stream. */
+export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+/** Hard cap on total compression time. ffmpeg.wasm is single-threaded WASM
+ * and can wedge on certain inputs; we'd rather give the user a clear error
+ * after 5 minutes than let them stare at a spinner for an hour. */
+const COMPRESSION_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Number of stderr lines retained for crash diagnostics. */
+const STDERR_TAIL_LINES = 50;
+
+export interface CompressionProgress {
+  stage: "loading-ffmpeg" | "preparing" | "encoding" | "finalizing";
+  /** 0..1, or null when indeterminate. */
+  progress: number | null;
+  message?: string;
+}
+
+export interface CompressionResult {
+  /** Output blob. May be the SAME ref as `input` when below threshold. */
+  blob: Blob;
+  /** True when we actually re-encoded (vs. passed the input through). */
+  compressed: boolean;
+  originalBytes: number;
+  compressedBytes: number;
+  /** `compressedBytes / originalBytes`. 1 when not compressed. */
+  ratio: number;
+  /** Wall-clock ms spent in this function. ~0 when below threshold. */
+  elapsedMs: number;
+  /** ffmpeg's chosen output mime type (matches container). */
+  outputMimeType: string;
+}
+
+export interface CompressOptions {
+  /** Override the threshold (mostly for testing). Defaults to 80 MB. */
+  thresholdBytes?: number;
+  /** Optional progress callback for UI plumbing. */
+  onProgress?: (p: CompressionProgress) => void;
+  /** Detected source dimensions, if known — picks the bitrate ladder. */
+  width?: number;
+  height?: number;
+  /** External abort signal (e.g. the user navigated away). Combined with
+   * the internal 5-minute timeout. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Pick a target video bitrate based on the source's larger dimension.
+ *
+ * The numbers map to what YouTube / Vimeo recommend for screen-capture style
+ * footage (high-detail UI, low motion):
+ *   - 1080p+ → 8 Mbps
+ *   - 720p   → 6 Mbps
+ *   - 480p   → 3 Mbps
+ *   - other  → 8 Mbps as a safe upper bound (we don't want to under-bitrate
+ *              an unknown-dimensions clip and produce mush)
+ */
+function pickVideoBitrate(
+  width?: number,
+  height?: number,
+): {
+  bitrate: string;
+  maxrate: string;
+  bufsize: string;
+} {
+  const longSide = Math.max(width ?? 0, height ?? 0);
+  if (longSide >= 1080) {
+    return { bitrate: "8M", maxrate: "10M", bufsize: "16M" };
+  }
+  if (longSide >= 720) {
+    return { bitrate: "6M", maxrate: "8M", bufsize: "12M" };
+  }
+  if (longSide > 0 && longSide < 720) {
+    return { bitrate: "3M", maxrate: "4M", bufsize: "6M" };
+  }
+  // Unknown — be conservative on the high side. Worse than ideal compression
+  // is still much better than a failed upload.
+  return { bitrate: "8M", maxrate: "10M", bufsize: "16M" };
+}
+
+/** Pick container + codecs to match the source. WebM keeps VP8/9 + Opus,
+ * MP4 keeps H.264 + AAC. Audio is always copy — re-encoding adds latency
+ * and compresses very little compared to video. */
+function pickEncodeArgs(
+  inputMimeType: string,
+  width: number | undefined,
+  height: number | undefined,
+): { args: string[]; outputName: string; outputMimeType: string } {
+  const isMp4 = /mp4|quicktime/i.test(inputMimeType);
+  const { bitrate, maxrate, bufsize } = pickVideoBitrate(width, height);
+
+  if (isMp4) {
+    return {
+      outputName: "compressed.mp4",
+      outputMimeType: "video/mp4",
+      args: [
+        "-c:v",
+        "libx264",
+        "-preset",
+        "fast",
+        "-b:v",
+        bitrate,
+        "-maxrate",
+        maxrate,
+        "-bufsize",
+        bufsize,
+        "-pix_fmt",
+        "yuv420p",
+        "-c:a",
+        "copy",
+        // moov before mdat so the result streams cleanly via HTTP range
+        // requests (mirrors the existing pure-TS faststart pass on the
+        // server, but cheaper to do here while we already have the
+        // transcoded mp4 in hand).
+        "-movflags",
+        "+faststart",
+      ],
+    };
+  }
+
+  // WebM / VP8 — fastest VP8 encode available; VP9 is too slow for the
+  // 5-minute wall-clock budget on a typical laptop. Audio (Opus) is left
+  // alone via copy. WebM has no faststart equivalent — the cluster index
+  // is already at the start by spec.
+  return {
+    outputName: "compressed.webm",
+    outputMimeType: "video/webm",
+    args: [
+      "-c:v",
+      "libvpx",
+      "-deadline",
+      "realtime",
+      "-cpu-used",
+      "5",
+      "-b:v",
+      bitrate,
+      "-maxrate",
+      maxrate,
+      "-bufsize",
+      bufsize,
+      "-c:a",
+      "copy",
+    ],
+  };
+}
+
+/**
+ * Compress `input` if it's larger than the threshold; otherwise return it
+ * untouched.
+ *
+ * Errors during compression are NOT thrown — we return a result with
+ * `compressed: false` and the original blob, so the caller can still attempt
+ * to upload (and let Builder.io's 500 / our hard-cap check surface to Sentry
+ * with the original-bytes context). The optional `onError` callback receives
+ * a structured failure record for Sentry tagging.
+ */
+export async function compressBlobIfTooLarge(
+  input: Blob,
+  inputMimeType: string,
+  opts: CompressOptions & {
+    /** Called with diagnostic info if compression is attempted but fails. */
+    onError?: (err: {
+      message: string;
+      stderrTail: string[];
+      elapsedMs: number;
+    }) => void;
+  } = {},
+): Promise<CompressionResult> {
+  const startedAt = performance.now();
+  const threshold = opts.thresholdBytes ?? COMPRESS_THRESHOLD_BYTES;
+  const originalBytes = input.size;
+
+  if (originalBytes <= threshold) {
+    return {
+      blob: input,
+      compressed: false,
+      originalBytes,
+      compressedBytes: originalBytes,
+      ratio: 1,
+      elapsedMs: 0,
+      outputMimeType: inputMimeType,
+    };
+  }
+
+  opts.onProgress?.({ stage: "loading-ffmpeg", progress: null });
+
+  // Capture a tail of ffmpeg stderr so a crash later in this function can be
+  // reported to Sentry with enough context to tell whether the source was
+  // unsupported, OOMed, etc.
+  const stderrTail: string[] = [];
+  const onLog = (msg: string) => {
+    stderrTail.push(msg);
+    if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift();
+  };
+
+  let ffmpeg: any;
+  try {
+    ffmpeg = await loadFfmpeg(onLog);
+  } catch (err) {
+    removeFfmpegLogListener(onLog);
+    const elapsedMs = Math.round(performance.now() - startedAt);
+    opts.onError?.({
+      message:
+        err instanceof Error
+          ? `ffmpeg.wasm load failed: ${err.message}`
+          : "ffmpeg.wasm load failed",
+      stderrTail,
+      elapsedMs,
+    });
+    return {
+      blob: input,
+      compressed: false,
+      originalBytes,
+      compressedBytes: originalBytes,
+      ratio: 1,
+      elapsedMs,
+      outputMimeType: inputMimeType,
+    };
+  }
+
+  const { args, outputName, outputMimeType } = pickEncodeArgs(
+    inputMimeType,
+    opts.width,
+    opts.height,
+  );
+
+  // Pick a container-appropriate input filename — ffmpeg.wasm uses the
+  // extension to detect the demuxer. Webm vs. mp4 matters for short-circuit
+  // probe behaviour inside libavformat.
+  const inputName = /mp4|quicktime/i.test(inputMimeType)
+    ? "input.mp4"
+    : "input.webm";
+
+  // Plumb encoder progress events back to the UI. ffmpeg.wasm reports the
+  // progress as 0..1 over the duration of the input.
+  const handleProgress = ({ progress }: { progress: number }) => {
+    opts.onProgress?.({
+      stage: "encoding",
+      progress: Math.max(0, Math.min(1, progress)),
+    });
+  };
+  ffmpeg.on("progress", handleProgress);
+
+  // Internal AbortController owns the 5-minute hard cap; if the caller
+  // passed in their own signal we forward its abort too.
+  const internalAbort = new AbortController();
+  const timeoutId = setTimeout(
+    () => internalAbort.abort(new Error("Compression timed out after 5 min")),
+    COMPRESSION_TIMEOUT_MS,
+  );
+  let externalAbortHandler: (() => void) | null = null;
+  if (opts.signal) {
+    if (opts.signal.aborted) {
+      internalAbort.abort(opts.signal.reason ?? new Error("Aborted"));
+    } else {
+      externalAbortHandler = () => {
+        internalAbort.abort(opts.signal!.reason ?? new Error("Aborted"));
+      };
+      opts.signal.addEventListener("abort", externalAbortHandler);
+    }
+  }
+
+  try {
+    opts.onProgress?.({ stage: "preparing", progress: null });
+
+    const { fetchFile } = await import("@ffmpeg/util");
+    await ffmpeg.writeFile(inputName, await fetchFile(input), {
+      signal: internalAbort.signal,
+    });
+
+    opts.onProgress?.({ stage: "encoding", progress: 0 });
+
+    const ffArgs = ["-i", inputName, ...args, outputName];
+    const exitCode = await ffmpeg.exec(ffArgs, undefined, {
+      signal: internalAbort.signal,
+    });
+
+    if (exitCode !== 0) {
+      throw new Error(
+        `ffmpeg exited with code ${exitCode} (likely encoder error or timeout)`,
+      );
+    }
+
+    opts.onProgress?.({ stage: "finalizing", progress: 1 });
+
+    const data = (await ffmpeg.readFile(outputName)) as Uint8Array;
+    const blob = new Blob([data as BlobPart], { type: outputMimeType });
+    const compressedBytes = blob.size;
+
+    // Best-effort cleanup so we don't pile up files in WASM's virtual FS
+    // across multiple recordings in the same tab.
+    try {
+      await ffmpeg.deleteFile(inputName);
+    } catch {
+      // ignore
+    }
+    try {
+      await ffmpeg.deleteFile(outputName);
+    } catch {
+      // ignore
+    }
+
+    const elapsedMs = Math.round(performance.now() - startedAt);
+    return {
+      blob,
+      compressed: true,
+      originalBytes,
+      compressedBytes,
+      ratio: originalBytes > 0 ? compressedBytes / originalBytes : 1,
+      elapsedMs,
+      outputMimeType,
+    };
+  } catch (err) {
+    const elapsedMs = Math.round(performance.now() - startedAt);
+    const message =
+      err instanceof Error ? err.message : String(err ?? "unknown error");
+    opts.onError?.({
+      message,
+      stderrTail,
+      elapsedMs,
+    });
+    // Best-effort cleanup so a failed run doesn't leak input data inside
+    // the wasm FS for the lifetime of the tab.
+    try {
+      await ffmpeg.deleteFile(inputName);
+    } catch {
+      // ignore
+    }
+    return {
+      blob: input,
+      compressed: false,
+      originalBytes,
+      compressedBytes: originalBytes,
+      ratio: 1,
+      elapsedMs,
+      outputMimeType: inputMimeType,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+    if (externalAbortHandler && opts.signal) {
+      opts.signal.removeEventListener("abort", externalAbortHandler);
+    }
+    ffmpeg.off("progress", handleProgress);
+    removeFfmpegLogListener(onLog);
+  }
+}
+
+/** Format a byte count as "12.3mb" for user-facing error strings. Lowercase
+ * and zero-padded to 1 decimal so the message reads naturally. */
+export function formatMb(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)}mb`;
+}

--- a/templates/clips/app/lib/compress.ts
+++ b/templates/clips/app/lib/compress.ts
@@ -284,12 +284,16 @@ export async function compressBlobIfTooLarge(
   ffmpeg.on("progress", handleProgress);
 
   // Internal AbortController owns the 5-minute hard cap; if the caller
-  // passed in their own signal we forward its abort too.
+  // passed in their own signal we forward its abort too. We track whether
+  // the timeout has fired separately from the external signal so the catch
+  // path below can tell timeout vs external-cancel vs ffmpeg-crash apart
+  // and throw a clearly-named error each caller can branch on.
   const internalAbort = new AbortController();
-  const timeoutId = setTimeout(
-    () => internalAbort.abort(new Error("Compression timed out after 5 min")),
-    COMPRESSION_TIMEOUT_MS,
-  );
+  let timedOut = false;
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    internalAbort.abort(new Error("Compression timed out after 5 minutes"));
+  }, COMPRESSION_TIMEOUT_MS);
   let externalAbortHandler: (() => void) | null = null;
   if (opts.signal) {
     if (opts.signal.aborted) {
@@ -363,12 +367,17 @@ export async function compressBlobIfTooLarge(
     } catch {
       // ignore
     }
-    // External cancellation (e.g. user clicked Cancel) — propagate so the
-    // caller bails out instead of falling back to uploading the original
-    // (un-compressed) blob behind the user's back. Internal timeouts and
-    // genuine ffmpeg failures still fall through to the safe-upload
-    // fallback below, with `onError` capturing the diagnostic context.
-    if (opts.signal?.aborted) {
+    // Any abort — internal 5-minute timeout OR external cancel — leaves
+    // the ffmpeg.wasm worker in an undefined state per ffmpeg.wasm docs:
+    // once an exec/writeFile is aborted, subsequent operations on the same
+    // instance silently misbehave (corrupt outputs, stuck progress, etc.)
+    // until the tab reloads. So treat both as requiring `terminate()` +
+    // `resetFfmpegInstance()` — checking only `opts.signal?.aborted` would
+    // skip cleanup on the timeout path and poison the shared instance for
+    // every subsequent compress / export op in this tab.
+    const externallyAborted = opts.signal?.aborted ?? false;
+    const anyAborted = internalAbort.signal.aborted || externallyAborted;
+    if (anyAborted) {
       // Terminate the wasm worker — once an exec/writeFile is aborted the
       // instance state is undefined per ffmpeg.wasm docs, so the next call
       // must re-load. resetFfmpegInstance() drops the cached promise.
@@ -378,14 +387,31 @@ export async function compressBlobIfTooLarge(
         // ignore — terminate is best effort.
       }
       resetFfmpegInstance();
-      throw err instanceof Error
-        ? err
-        : new Error(
-            typeof opts.signal.reason === "string"
-              ? opts.signal.reason
-              : "Compression aborted",
-          );
+      // Throw with a name the caller can branch on so the UI can
+      // distinguish "user cancelled" from "compression timed out" from
+      // "ffmpeg crashed" without string-matching error messages.
+      //  - External cancel: AbortError, "Compression cancelled"
+      //  - Internal timeout: TimeoutError, "Compression timed out…"
+      //  - Ffmpeg crash that happened during/after an unrelated abort:
+      //    re-throw original (rare — would mean the worker died on its
+      //    own and an abort fired in the same tick).
+      if (externallyAborted) {
+        const cancelErr = new Error("Compression cancelled");
+        cancelErr.name = "AbortError";
+        throw cancelErr;
+      }
+      if (timedOut) {
+        const timeoutErr = new Error("Compression timed out after 5 minutes");
+        timeoutErr.name = "TimeoutError";
+        throw timeoutErr;
+      }
+      // Internal abort fired but neither timeout nor external — should be
+      // unreachable in practice; surface the original.
+      throw err instanceof Error ? err : new Error(message);
     }
+    // Genuine ffmpeg failure (encoder error, OOM, unsupported source, …):
+    // capture diagnostics for Sentry and fall through to the safe-upload
+    // fallback so the user's recording still has a chance.
     opts.onError?.({
       message,
       stderrTail,

--- a/templates/clips/app/lib/compress.ts
+++ b/templates/clips/app/lib/compress.ts
@@ -427,12 +427,35 @@ export async function compressBlobIfTooLarge(
       outputMimeType: inputMimeType,
     };
   } finally {
-    clearTimeout(timeoutId);
-    if (externalAbortHandler && opts.signal) {
-      opts.signal.removeEventListener("abort", externalAbortHandler);
+    // Each cleanup is wrapped independently — a throw from one (e.g.
+    // `removeEventListener` after the signal was already torn down, or
+    // `ffmpeg.off` on an instance whose worker was just terminated)
+    // must NOT prevent the others from running, or stale listeners pile
+    // up on the shared ffmpeg instance and cause memory leaks across
+    // recordings. Don't collapse this to a single `try { … }` — that
+    // defeats the purpose.
+    try {
+      clearTimeout(timeoutId);
+    } catch {
+      // ignore
     }
-    ffmpeg.off("progress", handleProgress);
-    removeFfmpegLogListener(onLog);
+    try {
+      if (externalAbortHandler && opts.signal) {
+        opts.signal.removeEventListener("abort", externalAbortHandler);
+      }
+    } catch {
+      // ignore
+    }
+    try {
+      ffmpeg.off("progress", handleProgress);
+    } catch {
+      // ignore
+    }
+    try {
+      removeFfmpegLogListener(onLog);
+    } catch {
+      // ignore
+    }
   }
 }
 

--- a/templates/clips/app/lib/compress.ts
+++ b/templates/clips/app/lib/compress.ts
@@ -28,7 +28,11 @@
  * user-facing error rather than the opaque 500.
  */
 
-import { loadFfmpeg, removeFfmpegLogListener } from "./ffmpeg-export";
+import {
+  loadFfmpeg,
+  removeFfmpegLogListener,
+  resetFfmpegInstance,
+} from "./ffmpeg-export";
 
 /** Start compressing at 80 MB. Below this, the upload fits and we don't pay
  * for ffmpeg.wasm load + transcode. */
@@ -352,11 +356,6 @@ export async function compressBlobIfTooLarge(
     const elapsedMs = Math.round(performance.now() - startedAt);
     const message =
       err instanceof Error ? err.message : String(err ?? "unknown error");
-    opts.onError?.({
-      message,
-      stderrTail,
-      elapsedMs,
-    });
     // Best-effort cleanup so a failed run doesn't leak input data inside
     // the wasm FS for the lifetime of the tab.
     try {
@@ -364,6 +363,34 @@ export async function compressBlobIfTooLarge(
     } catch {
       // ignore
     }
+    // External cancellation (e.g. user clicked Cancel) — propagate so the
+    // caller bails out instead of falling back to uploading the original
+    // (un-compressed) blob behind the user's back. Internal timeouts and
+    // genuine ffmpeg failures still fall through to the safe-upload
+    // fallback below, with `onError` capturing the diagnostic context.
+    if (opts.signal?.aborted) {
+      // Terminate the wasm worker — once an exec/writeFile is aborted the
+      // instance state is undefined per ffmpeg.wasm docs, so the next call
+      // must re-load. resetFfmpegInstance() drops the cached promise.
+      try {
+        ffmpeg.terminate();
+      } catch {
+        // ignore — terminate is best effort.
+      }
+      resetFfmpegInstance();
+      throw err instanceof Error
+        ? err
+        : new Error(
+            typeof opts.signal.reason === "string"
+              ? opts.signal.reason
+              : "Compression aborted",
+          );
+    }
+    opts.onError?.({
+      message,
+      stderrTail,
+      elapsedMs,
+    });
     return {
       blob: input,
       compressed: false,

--- a/templates/clips/app/lib/ffmpeg-export.ts
+++ b/templates/clips/app/lib/ffmpeg-export.ts
@@ -54,48 +54,75 @@ export interface ExportResult {
 export const LONG_EXPORT_THRESHOLD_MS = 10 * 60 * 1000;
 
 let ffmpegInstancePromise: Promise<any> | null = null;
+let ffmpegLogListeners: Array<(msg: string) => void> = [];
 
 /**
  * Lazy-load ffmpeg.wasm once per tab. Subsequent calls resolve to the same
  * instance. The wasm core is fetched from the CDN matching the version we
  * declared in package.json.
+ *
+ * Multiple callers may pass `onLog` — every listener registered through this
+ * function is invoked for every wasm log line. Pair each `onLog` with a later
+ * `removeFfmpegLogListener(onLog)` so failed paths (e.g. compression error)
+ * don't leak subscribers across recordings.
  */
 export async function loadFfmpeg(onLog?: (msg: string) => void): Promise<any> {
   if (typeof window === "undefined") {
     throw new Error("ffmpeg.wasm is only available in the browser");
   }
-  if (ffmpegInstancePromise) return ffmpegInstancePromise;
-
-  ffmpegInstancePromise = (async () => {
-    const [{ FFmpeg }, util] = await Promise.all([
-      import("@ffmpeg/ffmpeg"),
-      import("@ffmpeg/util"),
-    ]);
-    const ffmpeg = new FFmpeg();
-    if (onLog) {
+  if (!ffmpegInstancePromise) {
+    ffmpegInstancePromise = (async () => {
+      const [{ FFmpeg }, util] = await Promise.all([
+        import("@ffmpeg/ffmpeg"),
+        import("@ffmpeg/util"),
+      ]);
+      const ffmpeg = new FFmpeg();
+      // Single shared `log` subscription that fans out to every caller's
+      // optional logger. Subscribing per-call against the wasm instance
+      // would mean we'd have to track every (instance, listener) pair
+      // for cleanup; instead we keep one wasm subscription and a small
+      // module-level listener list.
       ffmpeg.on("log", ({ message }: { message: string }) => {
-        onLog(message);
+        for (const listener of ffmpegLogListeners) {
+          try {
+            listener(message);
+          } catch {
+            // a busted listener must not block the others.
+          }
+        }
       });
-    }
-    // Match the version of @ffmpeg/ffmpeg installed in package.json.
-    const baseURL = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd";
-    await ffmpeg.load({
-      coreURL: await util.toBlobURL(
-        `${baseURL}/ffmpeg-core.js`,
-        "text/javascript",
-      ),
-      wasmURL: await util.toBlobURL(
-        `${baseURL}/ffmpeg-core.wasm`,
-        "application/wasm",
-      ),
+      // Match the version of @ffmpeg/ffmpeg installed in package.json.
+      const baseURL = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd";
+      await ffmpeg.load({
+        coreURL: await util.toBlobURL(
+          `${baseURL}/ffmpeg-core.js`,
+          "text/javascript",
+        ),
+        wasmURL: await util.toBlobURL(
+          `${baseURL}/ffmpeg-core.wasm`,
+          "application/wasm",
+        ),
+      });
+      return ffmpeg;
+    })().catch((err) => {
+      ffmpegInstancePromise = null;
+      throw err;
     });
-    return ffmpeg;
-  })().catch((err) => {
-    ffmpegInstancePromise = null;
-    throw err;
-  });
+  }
+
+  if (onLog) {
+    ffmpegLogListeners.push(onLog);
+  }
 
   return ffmpegInstancePromise;
+}
+
+/**
+ * Remove a log listener registered via `loadFfmpeg`. Safe to call with a
+ * listener that was never registered.
+ */
+export function removeFfmpegLogListener(listener: (msg: string) => void): void {
+  ffmpegLogListeners = ffmpegLogListeners.filter((l) => l !== listener);
 }
 
 /**

--- a/templates/clips/app/lib/ffmpeg-export.ts
+++ b/templates/clips/app/lib/ffmpeg-export.ts
@@ -110,7 +110,11 @@ export async function loadFfmpeg(onLog?: (msg: string) => void): Promise<any> {
     });
   }
 
-  if (onLog) {
+  if (onLog && !ffmpegLogListeners.includes(onLog)) {
+    // De-dup so callers that re-enter `loadFfmpeg` with the same listener
+    // reference (e.g. a stable function from the recorder engine that
+    // outlives a single export run) don't end up registered N times — that
+    // would emit each ffmpeg log line N times to the same handler.
     ffmpegLogListeners.push(onLog);
   }
 
@@ -123,6 +127,18 @@ export async function loadFfmpeg(onLog?: (msg: string) => void): Promise<any> {
  */
 export function removeFfmpegLogListener(listener: (msg: string) => void): void {
   ffmpegLogListeners = ffmpegLogListeners.filter((l) => l !== listener);
+}
+
+/**
+ * Drop the cached ffmpeg.wasm instance so the next `loadFfmpeg` call boots a
+ * fresh worker. Call this after `ffmpeg.terminate()` — per ffmpeg.wasm docs
+ * the instance state is undefined once an in-flight operation is aborted, so
+ * future callers must reinitialize. Also clears any registered log listeners
+ * so they don't leak across the boundary.
+ */
+export function resetFfmpegInstance(): void {
+  ffmpegInstancePromise = null;
+  ffmpegLogListeners = [];
 }
 
 /**
@@ -146,9 +162,12 @@ export async function exportMp4(
       : (editsJsonRaw ?? parseEdits("{}"));
 
   onProgress?.({ progress: 0, stage: "loading-ffmpeg" });
-  const ffmpeg = await loadFfmpeg((msg) => {
+  // Stable reference so we can remove it in `finally` — without this the
+  // listener piles up across exports and ffmpeg log lines fan out N×.
+  const onLog = (msg: string) => {
     onProgress?.({ progress: -1, stage: "encoding", message: msg });
-  });
+  };
+  const ffmpeg = await loadFfmpeg(onLog);
 
   // Hook ffmpeg progress events — they fire per frame written.
   const handleProgress = ({ progress }: { progress: number }) => {
@@ -262,6 +281,7 @@ export async function exportMp4(
     };
   } finally {
     ffmpeg.off("progress", handleProgress);
+    removeFfmpegLogListener(onLog);
   }
 }
 

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -58,6 +58,7 @@ type UiState =
   | "pickingSources"
   | "countdown"
   | "recording"
+  | "compressing"
   | "uploading"
   | "complete"
   | "error";
@@ -137,6 +138,12 @@ export default function RecordRoute() {
   const [previewStream, setPreviewStream] = useState<MediaStream | null>(null);
   const [recordingMode, setRecordingMode] =
     useState<RecordingMode>("screen+camera");
+  // Surfaced during the post-stop compression pass so the spinner can show
+  // "Compressing… 42%" instead of "Saving your recording…" — otherwise
+  // multi-minute encodes on long screen recordings look frozen.
+  const [compressionProgress, setCompressionProgress] = useState<number | null>(
+    null,
+  );
 
   const [storageConfigured, setStorageConfigured] = useState<boolean | null>(
     null,
@@ -314,6 +321,23 @@ export default function RecordRoute() {
             setError(err.message);
             setUiState("error");
           },
+          onState: (state) => {
+            // Mirror the engine's compression pass into the UI so the
+            // "Saving your recording…" spinner becomes "Compressing…" for
+            // the duration. Other engine states are managed by the UI's
+            // own state machine in startFlow / doStop.
+            if (state === "compressing") {
+              setUiState("compressing");
+            } else if (state === "uploading") {
+              // Reset compression progress when the engine moves on to
+              // upload — applies whether or not we just came from
+              // compressing.
+              setCompressionProgress(null);
+              // Always sync the UI back to "uploading"; if we were already
+              // there from doStop's pre-stop transition, this is a no-op.
+              setUiState("uploading");
+            }
+          },
           onChunk: ({ index, bytes }) => {
             void writeAppState(`recording-upload-${info.id}`, {
               recordingId: info.id,
@@ -330,6 +354,19 @@ export default function RecordRoute() {
           // though startFlow itself has empty deps.
           onDisplayTrackEnded: () => {
             void doStopRef.current();
+          },
+          onCompressionProgress: ({ stage, progress }) => {
+            // The recorder engine is responsible for transitioning into the
+            // `compressing` state. We mirror that into the UI via the
+            // generic onState handler below; here we just track the
+            // numeric progress so the spinner can show a percentage.
+            if (stage === "encoding" && typeof progress === "number") {
+              setCompressionProgress(progress);
+            } else if (stage === "loading-ffmpeg" || stage === "preparing") {
+              setCompressionProgress(null);
+            } else if (stage === "finalizing") {
+              setCompressionProgress(1);
+            }
           },
         });
         engineRef.current = engine;
@@ -850,7 +887,10 @@ export default function RecordRoute() {
   // -------------------------------------------------------------------------
   // Render.
   // -------------------------------------------------------------------------
-  const showRecordingUi = uiState === "recording" || uiState === "uploading";
+  const showRecordingUi =
+    uiState === "recording" ||
+    uiState === "uploading" ||
+    uiState === "compressing";
   const showCameraBubble =
     cameraStream !== null && recordingMode !== "screen" && uiState !== "idle";
 
@@ -986,11 +1026,27 @@ export default function RecordRoute() {
         />
       )}
 
-      {/* Uploading overlay */}
-      {uiState === "uploading" && (
+      {/* Uploading overlay (also covers the compressing pass which can run
+          for several minutes on long recordings — without a distinct copy
+          users wonder if the app froze). */}
+      {(uiState === "uploading" || uiState === "compressing") && (
         <div className="fixed inset-0 z-[120] flex flex-col items-center justify-center gap-3 bg-black/70 text-white backdrop-blur">
           <Spinner className="h-10 w-10 text-white/70" />
-          <div className="text-sm">Saving your recording…</div>
+          {uiState === "compressing" ? (
+            <>
+              <div className="text-sm">
+                Compressing your recording
+                {compressionProgress !== null
+                  ? ` — ${Math.round(compressionProgress * 100)}%`
+                  : "…"}
+              </div>
+              <div className="text-[11px] text-white/50">
+                Large clips need a quick re-encode before upload.
+              </div>
+            </>
+          ) : (
+            <div className="text-sm">Saving your recording…</div>
+          )}
           <button
             onClick={doCancel}
             className="mt-1 text-xs text-white/50 underline-offset-2 hover:text-white/80 hover:underline"

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -681,6 +681,21 @@ export default function RecordRoute() {
       }, 50);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Upload failed";
+      // Distinguish user-initiated cancel from real failure. When the user
+      // clicks Cancel mid-compression, engine.cancel() aborts the in-flight
+      // compression pass; the still-pending engine.stop() above then throws
+      // an AbortError. The recording was intentionally discarded — surfacing
+      // it as "Upload failed" is misleading (and was the original bug). So
+      // skip the error toast on the cancel path; doCancel() owns the UI
+      // teardown. Anything else (real upload failures, compression timeouts
+      // — which now throw with name === "TimeoutError" — network errors)
+      // keeps the existing error toast.
+      const isCancel =
+        err instanceof Error &&
+        (err.name === "AbortError" || /cancel/i.test(err.message));
+      if (isCancel) {
+        return;
+      }
       fetch(pending.abortUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -684,16 +684,21 @@ export default function RecordRoute() {
       // Distinguish user-initiated cancel from real failure. When the user
       // clicks Cancel mid-compression, engine.cancel() aborts the in-flight
       // compression pass; the still-pending engine.stop() above then throws
-      // an AbortError. The recording was intentionally discarded — surfacing
-      // it as "Upload failed" is misleading (and was the original bug). So
-      // skip the error toast on the cancel path; doCancel() owns the UI
-      // teardown. Anything else (real upload failures, compression timeouts
-      // — which now throw with name === "TimeoutError" — network errors)
-      // keeps the existing error toast.
-      const isCancel =
-        err instanceof Error &&
-        (err.name === "AbortError" || /cancel/i.test(err.message));
-      if (isCancel) {
+      // an error with `name === "AbortError"`. The recording was
+      // intentionally discarded — surfacing it as "Upload failed" is
+      // misleading (and was the original bug). So skip the error toast on
+      // the cancel path; doCancel() owns the UI teardown. Anything else
+      // (real upload failures, compression timeouts — which throw with
+      // `name === "TimeoutError"` — network errors) keeps the existing
+      // error toast.
+      //
+      // Detection is name-only. The abort invariant is: every cancel-shaped
+      // error from the engine arrives with `name === "AbortError"` —
+      // `RecorderEngine.cancel()` sets the name on the abort reason it
+      // creates, and downstream sites that interpret abort signals
+      // (`compress.ts`, the reset-chunks fetch catch in `recorder-engine`)
+      // preserve that identity. So we don't need to grep error messages.
+      if (err instanceof Error && err.name === "AbortError") {
         return;
       }
       fetch(pending.abortUrl, {

--- a/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
@@ -1,0 +1,138 @@
+/**
+ * Reset chunk scratch space for a recording without aborting the recording
+ * itself. Used by the recorder when it needs to discard the chunks it
+ * already streamed up (because they're going to be replaced with a
+ * compressed blob) — without flipping the row to `failed`, which is what
+ * `abort.post.ts` does.
+ *
+ * Optionally accepts compression metadata in the body — surfaced into
+ * `recording-upload-{id}` so:
+ *   1. `finalize-recording` can include it in `captureRouteError` extras
+ *      (so Sentry tells us originalBytes / compressedBytes / ratio if the
+ *      Builder.io upload still fails after compression).
+ *   2. The library card can show "Compressed from XXX MB" if we want to
+ *      surface that in the UI later.
+ *
+ * Route: POST /api/uploads/:recordingId/reset-chunks
+ */
+
+import {
+  defineEventHandler,
+  getRouterParam,
+  readBody,
+  setResponseStatus,
+  type H3Event,
+} from "h3";
+import { and, eq } from "drizzle-orm";
+import { getDb, schema } from "../../../../db/index.js";
+import { getEventOwnerEmail } from "../../../../lib/recordings.js";
+import { runWithRequestContext } from "@agent-native/core/server";
+import {
+  readAppState,
+  writeAppState,
+  deleteAppStateByPrefix,
+} from "@agent-native/core/application-state";
+
+interface CompressionMeta {
+  originalBytes?: number;
+  compressedBytes?: number;
+  ratio?: number;
+  elapsedMs?: number;
+  outputMimeType?: string;
+}
+
+function pickNumber(value: unknown): number | undefined {
+  if (typeof value !== "number") return undefined;
+  if (!Number.isFinite(value) || value < 0) return undefined;
+  return value;
+}
+
+function pickString(value: unknown, max: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, max);
+}
+
+export default defineEventHandler(async (event: H3Event) => {
+  const recordingId = getRouterParam(event, "recordingId");
+  if (!recordingId) {
+    setResponseStatus(event, 400);
+    return { error: "Missing recordingId" };
+  }
+
+  const ownerEmail = await getEventOwnerEmail(event);
+  const body = (await readBody(event).catch(() => null)) as {
+    compression?: CompressionMeta | null;
+  } | null;
+
+  // Sanitize compression metadata. The recorder is the only client we trust
+  // here, but the values land in Sentry extras — so we still bound them to
+  // numbers / strings to avoid surprise.
+  const compression: CompressionMeta | null = body?.compression
+    ? {
+        originalBytes: pickNumber(body.compression.originalBytes),
+        compressedBytes: pickNumber(body.compression.compressedBytes),
+        ratio: pickNumber(body.compression.ratio),
+        elapsedMs: pickNumber(body.compression.elapsedMs),
+        outputMimeType: pickString(body.compression.outputMimeType, 120),
+      }
+    : null;
+
+  return runWithRequestContext({ userEmail: ownerEmail }, async () => {
+    const db = getDb();
+
+    const [existing] = await db
+      .select({ id: schema.recordings.id })
+      .from(schema.recordings)
+      .where(
+        and(
+          eq(schema.recordings.id, recordingId),
+          eq(schema.recordings.ownerEmail, ownerEmail),
+        ),
+      );
+
+    if (!existing) {
+      setResponseStatus(event, 404);
+      return { error: "Recording not found" };
+    }
+
+    const cleared = await deleteAppStateByPrefix(
+      `recording-chunks-${recordingId}-`,
+    );
+
+    // Reset the per-recording upload progress and stash the compression
+    // metadata next to it so `finalize-recording` (and the UI poller) can
+    // see it.
+    const now = new Date().toISOString();
+    const previousState =
+      ((await readAppState(`recording-upload-${recordingId}`)) as Record<
+        string,
+        unknown
+      > | null) ?? {};
+    await writeAppState(`recording-upload-${recordingId}`, {
+      ...previousState,
+      recordingId,
+      status: "uploading",
+      progress: 0,
+      chunksReceived: 0,
+      compression: compression ?? previousState.compression ?? null,
+      updatedAt: now,
+    });
+
+    await db
+      .update(schema.recordings)
+      .set({
+        uploadProgress: 0,
+        updatedAt: now,
+      })
+      .where(eq(schema.recordings.id, recordingId));
+
+    return {
+      ok: true,
+      recordingId,
+      chunksCleared: cleared,
+      compressionRecorded: !!compression,
+    };
+  });
+});

--- a/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
+++ b/templates/clips/server/routes/api/uploads/[recordingId]/reset-chunks.post.ts
@@ -6,12 +6,20 @@
  * `abort.post.ts` does.
  *
  * Optionally accepts compression metadata in the body — surfaced into
- * `recording-upload-{id}` so:
+ * `recording-compression-{id}` (a separate sub-key from
+ * `recording-upload-{id}`) so:
  *   1. `finalize-recording` can include it in `captureRouteError` extras
  *      (so Sentry tells us originalBytes / compressedBytes / ratio if the
  *      Builder.io upload still fails after compression).
  *   2. The library card can show "Compressed from XXX MB" if we want to
  *      surface that in the UI later.
+ *
+ * The dedicated sub-key is important: the recorder's own `onChunk`
+ * callback overwrites `recording-upload-{id}` whole-cloth on every chunk
+ * upload (it's the simplest way to drive the progress poller), so storing
+ * compression metadata there would have it clobbered the moment the
+ * post-compression re-upload starts. The separate key is read-only from
+ * the compression path's perspective.
  *
  * Route: POST /api/uploads/:recordingId/reset-chunks
  */
@@ -28,7 +36,6 @@ import { getDb, schema } from "../../../../db/index.js";
 import { getEventOwnerEmail } from "../../../../lib/recordings.js";
 import { runWithRequestContext } from "@agent-native/core/server";
 import {
-  readAppState,
   writeAppState,
   deleteAppStateByPrefix,
 } from "@agent-native/core/application-state";
@@ -101,24 +108,29 @@ export default defineEventHandler(async (event: H3Event) => {
       `recording-chunks-${recordingId}-`,
     );
 
-    // Reset the per-recording upload progress and stash the compression
-    // metadata next to it so `finalize-recording` (and the UI poller) can
-    // see it.
+    // Reset the per-recording upload progress so the UI poller sees the
+    // re-upload restart from 0 and doesn't briefly show "100% then
+    // re-running" on the post-compression chunked upload pass.
     const now = new Date().toISOString();
-    const previousState =
-      ((await readAppState(`recording-upload-${recordingId}`)) as Record<
-        string,
-        unknown
-      > | null) ?? {};
     await writeAppState(`recording-upload-${recordingId}`, {
-      ...previousState,
       recordingId,
       status: "uploading",
       progress: 0,
       chunksReceived: 0,
-      compression: compression ?? previousState.compression ?? null,
       updatedAt: now,
     });
+
+    // Stash compression metadata under its own key. We don't merge it into
+    // `recording-upload-{id}` because the recorder client overwrites that
+    // key on every chunk upload — any compression context written there
+    // would be clobbered before `finalize-recording` could read it.
+    if (compression) {
+      await writeAppState(`recording-compression-${recordingId}`, {
+        recordingId,
+        ...compression,
+        recordedAt: now,
+      });
+    }
 
     await db
       .update(schema.recordings)


### PR DESCRIPTION
## What this fixes

A user (Saee) hit `Builder.io upload failed (500): Internal Error` on her second clip today. Her first clip was small and uploaded fine; her second was bigger and 500'd. The investigation showed:

- Builder.io's `/api/v1/upload` caps each file at **100 MB** (`fileUpload({ limits: { fileSize: 100 * 1024 * 1024 } })`) plus a 200 MB raw-body limit.
- When the assembled blob exceeds that, the streaming write to GCS errors mid-stream and the API returns `500 Internal Error` (with body `"An error occured"`) instead of the 413 you'd expect.
- Clips finalize forwards the failure verbatim, so the user sees an opaque "upload failed" with no remediation path.

## What this PR does

Browser-side video compression that kicks in only when the assembled recording would blow the 100 MB cap. We reuse the `@ffmpeg/ffmpeg` install that's already in the clips template for export / GIF / stitch — no new dependency.

### Flow

1. While `MediaRecorder` produces chunks, the engine streams each chunk to the server (status quo) **and** mirrors it into a local `Blob[]` buffer.
2. After `recorder.stop()` drains the final `dataavailable`, the engine checks the total recorded size:
    - **Under 80 MB**: existing path. No ffmpeg.wasm load, no extra latency. The streamed chunks are finalized as today.
    - **Over 80 MB**: engine transitions to a new `compressing` state. ffmpeg.wasm re-encodes the local buffer at a resolution-aware target bitrate. The browser then POSTs `/api/uploads/:id/reset-chunks` to wipe the chunks it streamed up during recording (they came from the un-compressed source) and stashes the compression metadata for `finalize-recording`. The compressed blob is then uploaded in 5 MB slices via the existing chunk endpoint with a fresh index sequence starting at 0.
3. If after compression the result is **still > 100 MB**, we throw a clean user-facing error before any upload attempt:

    > Recording is too large to upload (XXmb after compression, limit is 100mb). Try a shorter recording or lower the screen resolution / frame rate.

### Encoder settings

| Source long side | `-c:v`     | `-b:v` | `-maxrate` | `-bufsize` | Audio    | Container faststart        |
| ---------------- | ---------- | ------ | ---------- | ---------- | -------- | -------------------------- |
| 1080p+           | `libx264`/`libvpx` | 8M     | 10M        | 16M        | `-c:a copy` | `+faststart` for mp4       |
| 720p             | same       | 6M     | 8M         | 12M        | `-c:a copy` | `+faststart` for mp4       |
| < 720p           | same       | 3M     | 4M         | 6M         | `-c:a copy` | `+faststart` for mp4       |

- mp4 → libx264 `-preset fast -pix_fmt yuv420p`
- webm → libvpx `-deadline realtime -cpu-used 5` (libvpx-vp9 is too slow for the 5 min wall-clock budget on a typical laptop)
- Audio is always `copy` — Opus stays Opus inside webm, AAC stays AAC inside mp4. Re-encoding audio adds cost and saves almost nothing.

### UI feedback

The `/record` page's "Saving your recording…" overlay becomes "Compressing your recording — XX%" for the duration of the encode (with a percentage from `ffmpeg.on("progress")`). Without distinct copy, multi-minute encodes on long screen recordings look frozen.

### Constants

```ts
// templates/clips/app/lib/compress.ts
export const COMPRESS_THRESHOLD_BYTES = 80 * 1024 * 1024; // 80 MB
export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;        // 100 MB

// inside compress.ts
const COMPRESSION_TIMEOUT_MS = 5 * 60 * 1000;  // 5 min hard cap via AbortController
```

Defaults work without any env vars.

### Server side

- New route: `POST /api/uploads/:recordingId/reset-chunks` — wipes the chunk scratch space without aborting the recording itself (the existing `/abort` route flips the row to `failed`, which would prevent the re-upload). Optionally accepts compression metadata in the body.
- `finalize-recording.ts` reads `recording-upload-{id}.compression` (set by the reset-chunks route) and includes the metadata in the upload-failure log on a `console.error`. The `captureRouteError` Sentry call lives on a sibling branch (`updates-pr-511-followup`, commit `f74768b79`) — when that lands, the resolution is to swap this `console.error` for the `captureRouteError` call so Sentry sees `originalBytes / compressedBytes / ratio / elapsedMs` directly.

## What this PR does NOT do

- **Does NOT raise Builder.io's 100 MB per-file limit.** That's a server-side change in `builder-internal/packages/api/src/upload.ts`. Out of scope.
- **Does NOT make the upload endpoint return 413 instead of 500** when GCS rejects the stream. Also server-side, also separate.
- **Does NOT switch to multipart / resumable upload.** That would bypass the per-file cap entirely but requires Builder.io API + storage-side reassembly. Larger scope.
- **Does NOT change recording behavior.** Only adds a post-stop compression pass; the `MediaRecorder` lifecycle, codecs, chunk timeslice, and streaming-up-during-recording behavior are all unchanged.
- **Does NOT add Sentry tagging for the in-flight compression case directly** — the metadata is plumbed to the server via `application_state`, but the `captureRouteError` invocation in finalize-recording is on a sibling branch (see "Server side" above).

## Trade-offs / things to know

- Memory: the local `Blob[]` buffer holds the full recording on the client until upload completes. ~8 MB/min for 1080p screen capture, well within browser memory limits even for half-hour recordings.
- Bandwidth on large clips: the streamed-during-recording chunks AND the compressed result are both uploaded — duplicate bandwidth. The compressed result is much smaller, so it's a net win, but a future optimisation could detect "this recording is going to be too big" earlier and stop streaming live to save bandwidth.
- ffmpeg.wasm is already in the bundle (lazy-loaded for export). Compression reuses the same lazy-load via a small refactor in `ffmpeg-export.ts` that lets multiple callers attach independent log listeners.
- Compression takes wall-clock time. On a typical Mac laptop, libx264 `preset fast` at 8 Mbps does roughly 1.5x realtime on 1080p — so a 10-min recording is ~6 min to compress. The progress UI prevents this from feeling like a freeze.

## Test plan

- [ ] Record a < 80 MB clip end-to-end and confirm the upload path is unchanged (no "Compressing…" overlay).
- [ ] Force a > 80 MB recording (long screen capture), confirm overlay shows "Compressing your recording — XX%" with a progress percentage.
- [ ] Confirm the compressed clip plays back successfully in the library.
- [ ] Force a > 100 MB recording that compresses to ≤ 100 MB and confirm upload succeeds.
- [ ] Force a > 100 MB recording that compresses to > 100 MB (very high motion or short record at 4K) and confirm the user sees the "Recording too large…" error before any upload attempt.
- [ ] Open a clip in Chrome (mp4 fallback) and confirm the path picks libx264 + AAC copy + faststart.
- [ ] Open in Safari (mp4 native) and confirm same.
- [ ] Confirm the 5-minute timeout aborts a hung encode.