### PR TITLE
[Clips] pre-record device test panel + Brave-friendly permission flow

### DIFF
--- a/packages/core/src/client/settings/VoiceTranscriptionSection.tsx
+++ b/packages/core/src/client/settings/VoiceTranscriptionSection.tsx
@@ -817,6 +817,19 @@ interface VersionStatusPayload {
   reason?: string;
 }
 
+// Hides the `@tauri-apps/api/core` specifier from Vite's static import-analysis
+// (Vite 8 ignores `/* @vite-ignore */` on string literals and tries to resolve
+// the path, which fails because the dep only exists inside the desktop shell's
+// node_modules). Using a variable makes the import opaque to the bundler; it
+// only resolves at runtime, gated by `__TAURI_INTERNALS__`.
+type TauriCore = {
+  invoke: (cmd: string, args?: unknown) => Promise<unknown>;
+};
+function loadTauriCore(): Promise<TauriCore> {
+  const mod = "@tauri-apps/api/core";
+  return import(/* @vite-ignore */ mod) as Promise<TauriCore>;
+}
+
 function SystemAudioStatus() {
   const [state, setState] = useState<SystemAudioState | null>(null);
 
@@ -827,17 +840,7 @@ function SystemAudioStatus() {
       .__TAURI_INTERNALS__;
     if (!tauri) return; // Web users: render nothing.
     setState({ kind: "loading" });
-    // Dynamic import keeps `@tauri-apps/api` out of the web bundle's static
-    // graph; it is only resolved inside the desktop shell where the dep is
-    // present at build time.
-    // Cast to suppress missing types — `@tauri-apps/api` is a desktop-shell
-    // dep, not a static dep of `packages/core`. Resolves at runtime only when
-    // we're inside Tauri (gated by the `__TAURI_INTERNALS__` check above).
-    (
-      import(/* @vite-ignore */ "@tauri-apps/api/core" as string) as Promise<{
-        invoke: (cmd: string, args?: unknown) => Promise<unknown>;
-      }>
-    )
+    loadTauriCore()
       .then(async ({ invoke }) => {
         try {
           const status = (await invoke("system_audio_version_status")) as
@@ -906,14 +909,7 @@ function SystemAudioStatus() {
     const tauri = (window as unknown as { __TAURI_INTERNALS__?: unknown })
       .__TAURI_INTERNALS__;
     if (!tauri) return;
-    // Cast to suppress missing types — `@tauri-apps/api` is a desktop-shell
-    // dep, not a static dep of `packages/core`. Resolves at runtime only when
-    // we're inside Tauri (gated by the `__TAURI_INTERNALS__` check above).
-    (
-      import(/* @vite-ignore */ "@tauri-apps/api/core" as string) as Promise<{
-        invoke: (cmd: string, args?: unknown) => Promise<unknown>;
-      }>
-    )
+    loadTauriCore()
       .then(({ invoke }) => invoke("system_audio_open_privacy_settings"))
       .catch(() => {
         // Older desktop builds without this command — no-op.

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -94,15 +94,16 @@ Visibility and sharing use the framework `sharing` system — recordings are reg
 
 Ephemeral UI state lives in `application_state`, accessed via `readAppState(key)` / `writeAppState(key, value)` from `@agent-native/core/application-state`. The UI syncs here so the agent always knows what's on screen.
 
-| State Key        | Purpose                                                               | Direction               |
-| ---------------- | --------------------------------------------------------------------- | ----------------------- |
-| `navigation`     | Current view + selected IDs (see shape below)                         | UI -> Agent (read-only) |
-| `navigate`       | One-shot navigation command (auto-deleted after UI reads)             | Agent -> UI             |
-| `refresh-signal` | Bump timestamp — invalidates lists (recordings, comments, etc.)       | Agent -> UI             |
-| `record-intent`  | Request that the UI start a new recording (mode: `screen` / `camera`) | Agent -> UI             |
-| `player-state`   | Current video time, playing, speed — set by the player                | UI -> Agent (read-only) |
-| `editor-draft`   | In-progress non-destructive edits for the recording being edited      | Bidirectional           |
-| `selection`      | User's current text selection inside transcript or comment            | UI -> Agent (read-only) |
+| State Key         | Purpose                                                                  | Direction               |
+| ----------------- | ------------------------------------------------------------------------ | ----------------------- |
+| `navigation`      | Current view + selected IDs (see shape below)                            | UI -> Agent (read-only) |
+| `navigate`        | One-shot navigation command (auto-deleted after UI reads)                | Agent -> UI             |
+| `refresh-signal`  | Bump timestamp — invalidates lists (recordings, comments, etc.)          | Agent -> UI             |
+| `record-intent`   | Request that the UI start a new recording (mode: `screen` / `camera`)    | Agent -> UI             |
+| `recording-setup` | Current `/record` mode, selected mic/camera labels, and mic-check status | UI -> Agent (read-only) |
+| `player-state`    | Current video time, playing, speed — set by the player                   | UI -> Agent (read-only) |
+| `editor-draft`    | In-progress non-destructive edits for the recording being edited         | Bidirectional           |
+| `selection`       | User's current text selection inside transcript or comment               | UI -> Agent (read-only) |
 
 > Active organization lives in the better-auth session (`session.activeOrganizationId`), **not** in application state. An older `current-workspace` app-state key is deprecated. To switch orgs, use `useSwitchOrg()` on the client or better-auth's `setActiveOrganization` API. The previous session's active org is restored automatically on login.
 

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -94,16 +94,16 @@ Visibility and sharing use the framework `sharing` system — recordings are reg
 
 Ephemeral UI state lives in `application_state`, accessed via `readAppState(key)` / `writeAppState(key, value)` from `@agent-native/core/application-state`. The UI syncs here so the agent always knows what's on screen.
 
-| State Key         | Purpose                                                                  | Direction               |
-| ----------------- | ------------------------------------------------------------------------ | ----------------------- |
-| `navigation`      | Current view + selected IDs (see shape below)                            | UI -> Agent (read-only) |
-| `navigate`        | One-shot navigation command (auto-deleted after UI reads)                | Agent -> UI             |
-| `refresh-signal`  | Bump timestamp — invalidates lists (recordings, comments, etc.)          | Agent -> UI             |
-| `record-intent`   | Request that the UI start a new recording (mode: `screen` / `camera`)    | Agent -> UI             |
-| `recording-setup` | Current `/record` mode, selected mic/camera labels, and mic-check status | UI -> Agent (read-only) |
-| `player-state`    | Current video time, playing, speed — set by the player                   | UI -> Agent (read-only) |
-| `editor-draft`    | In-progress non-destructive edits for the recording being edited         | Bidirectional           |
-| `selection`       | User's current text selection inside transcript or comment               | UI -> Agent (read-only) |
+| State Key         | Purpose                                                                         | Direction               |
+| ----------------- | ------------------------------------------------------------------------------- | ----------------------- |
+| `navigation`      | Current view + selected IDs (see shape below)                                   | UI -> Agent (read-only) |
+| `navigate`        | One-shot navigation command (auto-deleted after UI reads)                       | Agent -> UI             |
+| `refresh-signal`  | Bump timestamp — invalidates lists (recordings, comments, etc.)                 | Agent -> UI             |
+| `record-intent`   | Request that the UI start a new recording (mode: `screen` / `camera`)           | Agent -> UI             |
+| `recording-setup` | Current `/record` mode, selected mic/camera labels, and mic/camera check status | UI -> Agent (read-only) |
+| `player-state`    | Current video time, playing, speed — set by the player                          | UI -> Agent (read-only) |
+| `editor-draft`    | In-progress non-destructive edits for the recording being edited                | Bidirectional           |
+| `selection`       | User's current text selection inside transcript or comment                      | UI -> Agent (read-only) |
 
 > Active organization lives in the better-auth session (`session.activeOrganizationId`), **not** in application state. An older `current-workspace` app-state key is deprecated. To switch orgs, use `useSwitchOrg()` on the client or better-auth's `setActiveOrganization` API. The previous session's active org is restored automatically on login.
 

--- a/templates/clips/actions/view-screen.ts
+++ b/templates/clips/actions/view-screen.ts
@@ -396,6 +396,7 @@ export default defineAction({
     const selection = await readAppState("selection");
     const organizationId = await getActiveOrganizationId();
     const recordIntent = await readAppState("record-intent");
+    const recordingSetup = await readAppState("recording-setup");
 
     const screen: Record<string, unknown> = {};
     if (navigation) screen.navigation = navigation;
@@ -481,9 +482,12 @@ export default defineAction({
         }
         break;
       }
+      case "record": {
+        if (recordingSetup) screen.recordingSetup = recordingSetup;
+        break;
+      }
       case "archive":
       case "trash":
-      case "record":
       case "notifications":
       case "settings":
       default:

--- a/templates/clips/app/components/recorder/camera-visualizer.tsx
+++ b/templates/clips/app/components/recorder/camera-visualizer.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type CameraTestStatus = "idle" | "starting" | "live" | "error";
+
+export interface CameraVisualizerProps {
+  deviceId: string | null;
+  disabled?: boolean;
+  selectedLabel?: string | null;
+  className?: string;
+  onStatusChange?: (
+    status: CameraTestStatus,
+    detail?: { error?: string | null },
+  ) => void;
+  onPreviewChange?: (hasPreview: boolean) => void;
+}
+
+type CameraPermissionState = PermissionState | "unknown";
+
+function stopStream(stream: MediaStream | null): void {
+  if (!stream) return;
+  for (const track of stream.getTracks()) {
+    try {
+      track.stop();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function isCameraBlockedByPolicy(): boolean {
+  const policy =
+    (
+      document as Document & {
+        permissionsPolicy?: { allowsFeature: (feature: string) => boolean };
+        featurePolicy?: { allowsFeature: (feature: string) => boolean };
+      }
+    ).permissionsPolicy ??
+    (
+      document as Document & {
+        featurePolicy?: { allowsFeature: (feature: string) => boolean };
+      }
+    ).featurePolicy;
+  if (!policy?.allowsFeature) return false;
+  try {
+    return !policy.allowsFeature("camera");
+  } catch {
+    return false;
+  }
+}
+
+async function getCameraPermissionState(): Promise<CameraPermissionState> {
+  try {
+    if (!navigator.permissions?.query) return "unknown";
+    const status = await navigator.permissions.query({
+      name: "camera" as PermissionName,
+    });
+    return status.state;
+  } catch {
+    return "unknown";
+  }
+}
+
+async function friendlyCameraError(err: unknown): Promise<string> {
+  const name = (err as { name?: string } | null)?.name ?? "";
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  const combined = `${name} ${message}`;
+  const permissionState = await getCameraPermissionState();
+  const blockedByPolicy = isCameraBlockedByPolicy();
+
+  console.warn("[camera-check] getUserMedia failed", {
+    name,
+    message,
+    permissionState,
+    blockedByPolicy,
+    isSecureContext: window.isSecureContext,
+  });
+
+  if (blockedByPolicy) {
+    return "This page is blocking camera access via Permissions-Policy. Restart the dev server, reload /record, then try again.";
+  }
+  if (!window.isSecureContext) {
+    return "Camera prompts require HTTPS or localhost. Open this app on localhost or an HTTPS URL, then try again.";
+  }
+  if (permissionState === "denied") {
+    return "Brave already has Camera set to Block for this site, so it will not show the popup. Click the lock/tune icon in the address bar → Site settings → Camera → Allow, then reload.";
+  }
+  if (/NotAllowedError|Permission denied|denied|blocked/i.test(combined)) {
+    return "The browser or macOS denied camera access. If no popup appeared, check Brave site settings and macOS System Settings → Privacy & Security → Camera for Brave, then reload.";
+  }
+  if (
+    /NotFoundError|DevicesNotFoundError|no device|not found/i.test(combined)
+  ) {
+    return "No camera was found. Plug one in or choose a different camera.";
+  }
+  if (/NotReadableError|TrackStartError|in use/i.test(combined)) {
+    return "That camera is busy in another app. Close the other app or choose a different camera.";
+  }
+  return message || "Could not start the camera check.";
+}
+
+export function CameraVisualizer({
+  deviceId,
+  disabled,
+  selectedLabel,
+  className,
+  onStatusChange,
+  onPreviewChange,
+}: CameraVisualizerProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const runIdRef = useRef(0);
+  const previousDeviceIdRef = useRef(deviceId);
+
+  const [status, setStatus] = useState<CameraTestStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [hasFrame, setHasFrame] = useState(false);
+
+  const clearVideo = useCallback(() => {
+    const video = videoRef.current;
+    if (video) {
+      video.pause();
+      video.srcObject = null;
+    }
+    setHasFrame(false);
+    onPreviewChange?.(false);
+  }, [onPreviewChange]);
+
+  const stopCurrent = useCallback(() => {
+    stopStream(streamRef.current);
+    streamRef.current = null;
+    clearVideo();
+  }, [clearVideo]);
+
+  const stopTest = useCallback(() => {
+    runIdRef.current += 1;
+    stopCurrent();
+    setError(null);
+    setStatus("idle");
+    onStatusChange?.("idle", { error: null });
+  }, [onStatusChange, stopCurrent]);
+
+  const startTest = useCallback(async () => {
+    if (disabled) return;
+    if (!navigator.mediaDevices?.getUserMedia) {
+      const message =
+        "Your browser doesn't support live camera checks. Try a recent Brave, Chrome, Edge, Safari, or Firefox.";
+      setError(message);
+      setStatus("error");
+      onStatusChange?.("error", { error: message });
+      return;
+    }
+    if (isCameraBlockedByPolicy()) {
+      const message =
+        "This page is blocking camera access via Permissions-Policy. Restart the dev server, reload /record, then try again.";
+      setError(message);
+      setStatus("error");
+      onStatusChange?.("error", { error: message });
+      return;
+    }
+    if (!window.isSecureContext) {
+      const message =
+        "Camera prompts require HTTPS or localhost. Open this app on localhost or an HTTPS URL, then try again.";
+      setError(message);
+      setStatus("error");
+      onStatusChange?.("error", { error: message });
+      return;
+    }
+    const permissionState = await getCameraPermissionState();
+    if (permissionState === "denied") {
+      const message =
+        "Brave already has Camera set to Block for this site, so it will not show the popup. Click the lock/tune icon in the address bar → Site settings → Camera → Allow, then reload.";
+      setError(message);
+      setStatus("error");
+      onStatusChange?.("error", { error: message });
+      return;
+    }
+
+    const runId = runIdRef.current + 1;
+    runIdRef.current = runId;
+    stopCurrent();
+    setError(null);
+    setStatus("starting");
+    onStatusChange?.("starting", { error: null });
+
+    let stream: MediaStream | null = null;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        video: deviceId ? { deviceId: { exact: deviceId } } : true,
+        audio: false,
+      });
+      if (runIdRef.current !== runId) {
+        stopStream(stream);
+        return;
+      }
+
+      streamRef.current = stream;
+      const video = videoRef.current;
+      if (video) {
+        video.srcObject = stream;
+        await video.play().catch(() => {});
+      }
+      setStatus("live");
+      onStatusChange?.("live", { error: null });
+    } catch (err) {
+      stopStream(stream);
+      if (runIdRef.current !== runId) return;
+      const message = await friendlyCameraError(err);
+      setError(message);
+      setStatus("error");
+      onStatusChange?.("error", { error: message });
+      clearVideo();
+    }
+  }, [clearVideo, deviceId, disabled, onStatusChange, stopCurrent]);
+
+  useEffect(() => {
+    if (disabled) {
+      previousDeviceIdRef.current = deviceId;
+      if (status === "live" || status === "starting") {
+        stopTest();
+      } else {
+        clearVideo();
+      }
+      return;
+    }
+    if (previousDeviceIdRef.current === deviceId) return;
+    previousDeviceIdRef.current = deviceId;
+    if (status === "live" || status === "starting") {
+      void startTest();
+    } else {
+      clearVideo();
+    }
+  }, [clearVideo, deviceId, disabled, startTest, status, stopTest]);
+
+  useEffect(() => {
+    return () => {
+      runIdRef.current += 1;
+      stopCurrent();
+    };
+  }, [stopCurrent]);
+
+  const live = status === "live";
+  const starting = status === "starting";
+  const helper = disabled
+    ? "Camera is off for this recording mode."
+    : error
+      ? error
+      : live
+        ? hasFrame
+          ? "Preview is live — your selected camera is working."
+          : "Camera is connected. Waiting for the first frame…"
+        : starting
+          ? "Opening camera…"
+          : "Click Test camera to preview the selected camera before recording.";
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border bg-muted/25 p-3",
+        disabled && "opacity-70",
+        className,
+      )}
+    >
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-xs font-medium text-foreground">
+            Camera check
+          </div>
+          <div className="truncate text-[11px] text-muted-foreground">
+            {selectedLabel ?? "Selected camera"}
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant={live ? "outline" : "secondary"}
+          size="sm"
+          disabled={disabled || starting}
+          onClick={live ? stopTest : startTest}
+          className="h-8 px-2.5 text-xs"
+        >
+          {live ? "Stop" : starting ? "Starting…" : "Test camera"}
+        </Button>
+      </div>
+      <div
+        className={cn(
+          "relative aspect-video overflow-hidden rounded-lg border bg-background",
+          live && hasFrame ? "border-foreground/40" : "border-border",
+        )}
+      >
+        <video
+          ref={videoRef}
+          autoPlay
+          muted
+          playsInline
+          onLoadedData={() => {
+            setHasFrame(true);
+            onPreviewChange?.(true);
+          }}
+          aria-label="Selected camera preview"
+          className={cn(
+            "h-full w-full object-cover [transform:scaleX(-1)]",
+            !live && "opacity-0",
+          )}
+        />
+        {!live && (
+          <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-muted/70 to-background text-[11px] text-muted-foreground">
+            Camera preview
+          </div>
+        )}
+        {live && (
+          <div
+            className={cn(
+              "pointer-events-none absolute right-2 top-2 h-2 w-2 rounded-full",
+              hasFrame ? "bg-foreground" : "bg-muted-foreground/40",
+            )}
+          />
+        )}
+      </div>
+      <p
+        className={cn(
+          "mt-2 text-[11px] leading-snug text-muted-foreground",
+          error && "text-destructive",
+        )}
+      >
+        {helper}
+      </p>
+    </div>
+  );
+}

--- a/templates/clips/app/components/recorder/camera-visualizer.tsx
+++ b/templates/clips/app/components/recorder/camera-visualizer.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import type { CameraBubbleSize } from "./camera-bubble";
 
 export type CameraTestStatus = "idle" | "starting" | "live" | "error";
 
@@ -10,12 +11,26 @@ export interface CameraVisualizerProps {
   disabled?: boolean;
   selectedLabel?: string | null;
   className?: string;
+  size?: CameraBubbleSize;
+  onSizeChange?: (size: CameraBubbleSize) => void;
   onStatusChange?: (
     status: CameraTestStatus,
     detail?: { error?: string | null },
   ) => void;
   onPreviewChange?: (hasPreview: boolean) => void;
 }
+
+const CAMERA_BUBBLE_SIZE_PX: Record<CameraBubbleSize, number> = {
+  sm: 120,
+  md: 200,
+  lg: 320,
+};
+
+const CAMERA_SIZE_OPTIONS: Array<{ value: CameraBubbleSize; label: string }> = [
+  { value: "sm", label: "S" },
+  { value: "md", label: "M" },
+  { value: "lg", label: "L" },
+];
 
 type CameraPermissionState = PermissionState | "unknown";
 
@@ -106,6 +121,8 @@ export function CameraVisualizer({
   disabled,
   selectedLabel,
   className,
+  size = "md",
+  onSizeChange,
   onStatusChange,
   onPreviewChange,
 }: CameraVisualizerProps) {
@@ -241,19 +258,39 @@ export function CameraVisualizer({
     };
   }, [stopCurrent]);
 
+  useEffect(() => {
+    if (status !== "live" && status !== "starting") return;
+    const video = videoRef.current;
+    const stream = streamRef.current;
+    if (!video || !stream) return;
+    if (video.srcObject !== stream) {
+      video.srcObject = stream;
+    }
+    const tryPlay = () => {
+      video.play().catch(() => undefined);
+    };
+    tryPlay();
+    video.addEventListener("loadedmetadata", tryPlay, { once: true });
+    return () => {
+      video.removeEventListener("loadedmetadata", tryPlay);
+    };
+  }, [status]);
+
   const live = status === "live";
   const starting = status === "starting";
+  const showBubble = live || starting;
+  const sizePx = CAMERA_BUBBLE_SIZE_PX[size];
   const helper = disabled
     ? "Camera is off for this recording mode."
     : error
       ? error
       : live
         ? hasFrame
-          ? "Preview is live — your selected camera is working."
+          ? "Preview is live in the bottom-left bubble — this size carries into recording."
           : "Camera is connected. Waiting for the first frame…"
         : starting
           ? "Opening camera…"
-          : "Click Test camera to preview the selected camera before recording.";
+          : "Click Test camera to show the camera bubble before recording.";
 
   return (
     <div
@@ -283,41 +320,85 @@ export function CameraVisualizer({
           {live ? "Stop" : starting ? "Starting…" : "Test camera"}
         </Button>
       </div>
-      <div
-        className={cn(
-          "relative aspect-video overflow-hidden rounded-lg border bg-background",
-          live && hasFrame ? "border-foreground/40" : "border-border",
-        )}
-      >
-        <video
-          ref={videoRef}
-          autoPlay
-          muted
-          playsInline
-          onLoadedData={() => {
-            setHasFrame(true);
-            onPreviewChange?.(true);
-          }}
-          aria-label="Selected camera preview"
-          className={cn(
-            "h-full w-full object-cover [transform:scaleX(-1)]",
-            !live && "opacity-0",
-          )}
-        />
-        {!live && (
-          <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-muted/70 to-background text-[11px] text-muted-foreground">
-            Camera preview
-          </div>
-        )}
-        {live && (
+      <div className="flex items-center justify-between gap-2 rounded-lg border border-border bg-background px-2 py-1.5">
+        <span className="text-[11px] text-muted-foreground">Bubble size</span>
+        <div className="flex rounded-md bg-muted p-0.5">
+          {CAMERA_SIZE_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              disabled={disabled}
+              aria-pressed={size === option.value}
+              onClick={() => onSizeChange?.(option.value)}
+              className={cn(
+                "h-6 min-w-6 rounded px-2 text-[11px] font-medium text-muted-foreground transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+                size === option.value &&
+                  "bg-background text-foreground shadow-sm",
+              )}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      {showBubble && (
+        <div className="fixed bottom-4 left-4 z-40 flex flex-col items-start gap-2">
           <div
             className={cn(
-              "pointer-events-none absolute right-2 top-2 h-2 w-2 rounded-full",
-              hasFrame ? "bg-foreground" : "bg-muted-foreground/40",
+              "relative overflow-hidden rounded-full border-4 border-white/80 bg-black shadow-2xl ring-1",
+              live && hasFrame ? "ring-black/25" : "ring-border",
             )}
-          />
-        )}
-      </div>
+            style={{ width: sizePx, height: sizePx }}
+          >
+            <video
+              ref={videoRef}
+              autoPlay
+              muted
+              playsInline
+              onLoadedData={() => {
+                setHasFrame(true);
+                onPreviewChange?.(true);
+              }}
+              aria-label="Selected camera preview"
+              className={cn(
+                "h-full w-full rounded-full object-cover [transform:scaleX(-1)]",
+                !live && "opacity-0",
+              )}
+            />
+            {!live && (
+              <div className="absolute inset-0 flex items-center justify-center rounded-full bg-gradient-to-br from-muted/70 to-background px-5 text-center text-[11px] text-muted-foreground">
+                Camera preview
+              </div>
+            )}
+            {live && (
+              <div
+                className={cn(
+                  "pointer-events-none absolute bottom-[12%] right-[18%] h-2.5 w-2.5 rounded-full ring-2 ring-white",
+                  hasFrame ? "bg-foreground" : "bg-muted-foreground/40",
+                )}
+              />
+            )}
+          </div>
+          <div className="rounded-full border border-border bg-background/95 p-1 shadow-lg backdrop-blur">
+            {CAMERA_SIZE_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                aria-label={`Set camera bubble size ${option.label}`}
+                aria-pressed={size === option.value}
+                onClick={() => onSizeChange?.(option.value)}
+                className={cn(
+                  "h-7 min-w-7 rounded-full px-2 text-[11px] font-medium text-muted-foreground transition-colors",
+                  size === option.value &&
+                    "bg-foreground text-background shadow-sm",
+                )}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
       <p
         className={cn(
           "mt-2 text-[11px] leading-snug text-muted-foreground",

--- a/templates/clips/app/components/recorder/camera-visualizer.tsx
+++ b/templates/clips/app/components/recorder/camera-visualizer.tsx
@@ -185,7 +185,13 @@ export function CameraVisualizer({
       onStatusChange?.("error", { error: message });
       return;
     }
+
+    // Claim runId before the first await so a stale call can't win the race.
+    const runId = runIdRef.current + 1;
+    runIdRef.current = runId;
+
     const permissionState = await getCameraPermissionState();
+    if (runIdRef.current !== runId) return;
     if (permissionState === "denied") {
       const message =
         "Brave already has Camera set to Block for this site, so it will not show the popup. Click the lock/tune icon in the address bar → Site settings → Camera → Allow, then reload.";
@@ -195,8 +201,6 @@ export function CameraVisualizer({
       return;
     }
 
-    const runId = runIdRef.current + 1;
-    runIdRef.current = runId;
     stopCurrent();
     setError(null);
     setStatus("starting");

--- a/templates/clips/app/components/recorder/camera-visualizer.tsx
+++ b/templates/clips/app/components/recorder/camera-visualizer.tsx
@@ -223,6 +223,11 @@ export function CameraVisualizer({
         video.srcObject = stream;
         await video.play().catch(() => {});
       }
+      // Re-check after play()'s await so a newer startTest can't be clobbered.
+      if (runIdRef.current !== runId) {
+        stopCurrent();
+        return;
+      }
       setStatus("live");
       onStatusChange?.("live", { error: null });
     } catch (err) {

--- a/templates/clips/app/components/recorder/camera-visualizer.tsx
+++ b/templates/clips/app/components/recorder/camera-visualizer.tsx
@@ -234,6 +234,8 @@ export function CameraVisualizer({
       stopStream(stream);
       if (runIdRef.current !== runId) return;
       const message = await friendlyCameraError(err);
+      // friendlyCameraError awaits the Permissions API, so re-check after.
+      if (runIdRef.current !== runId) return;
       setError(message);
       setStatus("error");
       onStatusChange?.("error", { error: message });

--- a/templates/clips/app/components/recorder/microphone-visualizer.tsx
+++ b/templates/clips/app/components/recorder/microphone-visualizer.tsx
@@ -1,0 +1,496 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type MicrophoneTestStatus = "idle" | "starting" | "live" | "error";
+
+export interface MicrophoneVisualizerProps {
+  deviceId: string | null;
+  disabled?: boolean;
+  selectedLabel?: string;
+  className?: string;
+  onStatusChange?: (
+    status: MicrophoneTestStatus,
+    detail?: { error?: string | null },
+  ) => void;
+  onSignalChange?: (hasSignal: boolean) => void;
+}
+
+function getAudioContextCtor(): typeof AudioContext | null {
+  return (
+    window.AudioContext ??
+    (window as typeof window & { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext ??
+    null
+  );
+}
+
+function stopStream(stream: MediaStream | null): void {
+  if (!stream) return;
+  for (const track of stream.getTracks()) {
+    try {
+      track.stop();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+type MicrophonePermissionState = PermissionState | "unknown";
+
+function isMicrophoneBlockedByPolicy(): boolean {
+  const policy =
+    (
+      document as Document & {
+        permissionsPolicy?: { allowsFeature: (feature: string) => boolean };
+        featurePolicy?: { allowsFeature: (feature: string) => boolean };
+      }
+    ).permissionsPolicy ??
+    (
+      document as Document & {
+        featurePolicy?: { allowsFeature: (feature: string) => boolean };
+      }
+    ).featurePolicy;
+  if (!policy?.allowsFeature) return false;
+  try {
+    return !policy.allowsFeature("microphone");
+  } catch {
+    return false;
+  }
+}
+
+async function getMicrophonePermissionState(): Promise<MicrophonePermissionState> {
+  try {
+    if (!navigator.permissions?.query) return "unknown";
+    const status = await navigator.permissions.query({
+      name: "microphone" as PermissionName,
+    });
+    return status.state;
+  } catch {
+    return "unknown";
+  }
+}
+
+async function friendlyMicError(err: unknown): Promise<string> {
+  const name = (err as { name?: string } | null)?.name ?? "";
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  const combined = `${name} ${message}`;
+  const permissionState = await getMicrophonePermissionState();
+  const blockedByPolicy = isMicrophoneBlockedByPolicy();
+
+  console.warn("[mic-check] getUserMedia failed", {
+    name,
+    message,
+    permissionState,
+    blockedByPolicy,
+    isSecureContext: window.isSecureContext,
+  });
+
+  if (blockedByPolicy) {
+    return "This page is blocking microphone access via Permissions-Policy. Restart the dev server, reload /record, then try again.";
+  }
+  if (!window.isSecureContext) {
+    return "Microphone prompts require HTTPS or localhost. Open this app on localhost or an HTTPS URL, then try again.";
+  }
+  if (permissionState === "denied") {
+    return "Brave already has Microphone set to Block for this site, so it will not show the popup. Click the lock/tune icon in the address bar → Site settings → Microphone → Allow, then reload.";
+  }
+  if (/NotAllowedError|Permission denied|denied|blocked/i.test(combined)) {
+    return "The browser or macOS denied microphone access. If no popup appeared, check Brave site settings and macOS System Settings → Privacy & Security → Microphone for Brave, then reload.";
+  }
+  if (
+    /NotFoundError|DevicesNotFoundError|no device|not found/i.test(combined)
+  ) {
+    return "No microphone was found. Plug one in or choose a different input.";
+  }
+  if (/NotReadableError|TrackStartError|in use/i.test(combined)) {
+    return "That microphone is busy in another app. Close the other app or choose a different input.";
+  }
+  return message || "Could not start the microphone check.";
+}
+
+export function MicrophoneVisualizer({
+  deviceId,
+  disabled,
+  selectedLabel,
+  className,
+  onStatusChange,
+  onSignalChange,
+}: MicrophoneVisualizerProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const runIdRef = useRef(0);
+  const streamRef = useRef<MediaStream | null>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const signalRef = useRef(false);
+  const lastSignalAtRef = useRef(0);
+  const previousDeviceIdRef = useRef(deviceId);
+
+  const [status, setStatus] = useState<MicrophoneTestStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [hasSignal, setHasSignalState] = useState(false);
+
+  const setSignal = useCallback(
+    (next: boolean) => {
+      if (signalRef.current === next) return;
+      signalRef.current = next;
+      setHasSignalState(next);
+      onSignalChange?.(next);
+    },
+    [onSignalChange],
+  );
+
+  const syncCanvasSize = useCallback((canvas: HTMLCanvasElement) => {
+    const rect = canvas.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    const width = Math.max(1, Math.floor(rect.width * dpr));
+    const height = Math.max(1, Math.floor(rect.height * dpr));
+    if (canvas.width !== width || canvas.height !== height) {
+      canvas.width = width;
+      canvas.height = height;
+    }
+    return { width, height, dpr };
+  }, []);
+
+  const drawIdle = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const { width, height, dpr } = syncCanvasSize(canvas);
+    ctx.clearRect(0, 0, width, height);
+
+    ctx.strokeStyle = "rgba(113, 113, 122, 0.22)";
+    ctx.lineWidth = Math.max(1, dpr);
+    ctx.beginPath();
+    ctx.moveTo(0, height / 2);
+    ctx.lineTo(width, height / 2);
+    ctx.stroke();
+
+    ctx.strokeStyle = "rgba(113, 113, 122, 0.38)";
+    ctx.lineWidth = Math.max(1.5, 1.5 * dpr);
+    ctx.beginPath();
+    const points = 72;
+    for (let i = 0; i <= points; i++) {
+      const x = (i / points) * width;
+      const envelope = Math.sin((i / points) * Math.PI);
+      const y =
+        height / 2 +
+        Math.sin((i / points) * Math.PI * 6) * envelope * height * 0.13;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }, [syncCanvasSize]);
+
+  const stopCurrent = useCallback(
+    (emitSignal = true) => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      try {
+        sourceRef.current?.disconnect();
+      } catch {
+        // ignore
+      }
+      sourceRef.current = null;
+      const audioContext = audioContextRef.current;
+      audioContextRef.current = null;
+      if (audioContext && audioContext.state !== "closed") {
+        audioContext.close().catch(() => {});
+      }
+      stopStream(streamRef.current);
+      streamRef.current = null;
+      lastSignalAtRef.current = 0;
+      if (emitSignal) {
+        setSignal(false);
+      } else {
+        signalRef.current = false;
+      }
+      drawIdle();
+    },
+    [drawIdle, setSignal],
+  );
+
+  const drawLive = useCallback(
+    (analyser: AnalyserNode) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      const data = new Uint8Array(analyser.fftSize);
+
+      const draw = () => {
+        const { width, height, dpr } = syncCanvasSize(canvas);
+        analyser.getByteTimeDomainData(data);
+
+        let sum = 0;
+        for (const sample of data) {
+          const normalized = (sample - 128) / 128;
+          sum += normalized * normalized;
+        }
+        const rms = Math.sqrt(sum / data.length);
+        const now = performance.now();
+        if (rms > 0.035) {
+          lastSignalAtRef.current = now;
+          setSignal(true);
+        } else if (now - lastSignalAtRef.current > 700) {
+          setSignal(false);
+        }
+
+        ctx.clearRect(0, 0, width, height);
+        ctx.strokeStyle = "rgba(113, 113, 122, 0.2)";
+        ctx.lineWidth = Math.max(1, dpr);
+        ctx.beginPath();
+        ctx.moveTo(0, height / 2);
+        ctx.lineTo(width, height / 2);
+        ctx.stroke();
+
+        const gradient = ctx.createLinearGradient(0, 0, width, 0);
+        gradient.addColorStop(0, "rgba(39, 39, 42, 0.55)");
+        gradient.addColorStop(0.45, "rgba(24, 24, 27, 0.95)");
+        gradient.addColorStop(1, "rgba(39, 39, 42, 0.55)");
+        ctx.strokeStyle = gradient;
+        ctx.lineWidth = Math.max(1.75 * dpr, Math.min(5 * dpr, rms * 22 * dpr));
+        ctx.lineJoin = "round";
+        ctx.lineCap = "round";
+        ctx.beginPath();
+        const step = width / Math.max(1, data.length - 1);
+        for (let i = 0; i < data.length; i++) {
+          const x = i * step;
+          const normalized = (data[i] - 128) / 128;
+          const y = height / 2 + normalized * height * 0.42;
+          if (i === 0) ctx.moveTo(x, y);
+          else ctx.lineTo(x, y);
+        }
+        ctx.stroke();
+
+        rafRef.current = requestAnimationFrame(draw);
+      };
+
+      draw();
+    },
+    [setSignal, syncCanvasSize],
+  );
+
+  const stopTest = useCallback(() => {
+    runIdRef.current += 1;
+    stopCurrent();
+    setError(null);
+    setStatus("idle");
+    onStatusChange?.("idle", { error: null });
+  }, [onStatusChange, stopCurrent]);
+
+  const startTest = useCallback(async () => {
+    if (disabled) return;
+    const AudioContextCtor = getAudioContextCtor();
+    if (!navigator.mediaDevices?.getUserMedia || !AudioContextCtor) {
+      const message =
+        "Your browser doesn't support live microphone checks. Try a recent Brave, Chrome, Edge, Safari, or Firefox.";
+      setError(message);
+      setStatus("error");
+      onStatusChange?.("error", { error: message });
+      return;
+    }
+    if (isMicrophoneBlockedByPolicy()) {
+      const message =
+        "This page is blocking microphone access via Permissions-Policy. Restart the dev server, reload /record, then try again.";
+      setError(message);
+      setStatus("error");
+      onStatusChange?.("error", { error: message });
+      return;
+    }
+    if (!window.isSecureContext) {
+      const message =
+        "Microphone prompts require HTTPS or localhost. Open this app on localhost or an HTTPS URL, then try again.";
+      setError(message);
+      setStatus("error");
+      onStatusChange?.("error", { error: message });
+      return;
+    }
+    const permissionState = await getMicrophonePermissionState();
+    if (permissionState === "denied") {
+      const message =
+        "Brave already has Microphone set to Block for this site, so it will not show the popup. Click the lock/tune icon in the address bar → Site settings → Microphone → Allow, then reload.";
+      setError(message);
+      setStatus("error");
+      onStatusChange?.("error", { error: message });
+      return;
+    }
+
+    const runId = runIdRef.current + 1;
+    runIdRef.current = runId;
+    stopCurrent();
+    setError(null);
+    setStatus("starting");
+    onStatusChange?.("starting", { error: null });
+
+    let stream: MediaStream | null = null;
+    let audioContext: AudioContext | null = null;
+    let source: MediaStreamAudioSourceNode | null = null;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+        video: false,
+      });
+      audioContext = new AudioContextCtor();
+      if (audioContext.state === "suspended") {
+        await audioContext.resume().catch(() => {});
+      }
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 512;
+      analyser.smoothingTimeConstant = 0.72;
+      source = audioContext.createMediaStreamSource(stream);
+      source.connect(analyser);
+
+      if (runIdRef.current !== runId) {
+        try {
+          source.disconnect();
+        } catch {
+          // ignore
+        }
+        if (audioContext.state !== "closed") {
+          audioContext.close().catch(() => {});
+        }
+        stopStream(stream);
+        return;
+      }
+
+      streamRef.current = stream;
+      audioContextRef.current = audioContext;
+      sourceRef.current = source;
+      setStatus("live");
+      onStatusChange?.("live", { error: null });
+      drawLive(analyser);
+    } catch (err) {
+      try {
+        source?.disconnect();
+      } catch {
+        // ignore
+      }
+      if (audioContext && audioContext.state !== "closed") {
+        audioContext.close().catch(() => {});
+      }
+      stopStream(stream);
+      if (runIdRef.current !== runId) return;
+      const message = await friendlyMicError(err);
+      setSignal(false);
+      setError(message);
+      setStatus("error");
+      onStatusChange?.("error", { error: message });
+      drawIdle();
+    }
+  }, [
+    deviceId,
+    disabled,
+    drawIdle,
+    drawLive,
+    onStatusChange,
+    setSignal,
+    stopCurrent,
+  ]);
+
+  useEffect(() => {
+    if (disabled) {
+      previousDeviceIdRef.current = deviceId;
+      if (status === "live" || status === "starting") {
+        stopTest();
+      } else {
+        drawIdle();
+      }
+      return;
+    }
+    if (previousDeviceIdRef.current === deviceId) return;
+    previousDeviceIdRef.current = deviceId;
+    if (status === "live" || status === "starting") {
+      void startTest();
+    } else {
+      drawIdle();
+    }
+  }, [deviceId, disabled, drawIdle, startTest, status, stopTest]);
+
+  useEffect(() => {
+    if (status === "idle" || status === "error") drawIdle();
+  }, [drawIdle, status]);
+
+  useEffect(() => {
+    return () => {
+      runIdRef.current += 1;
+      stopCurrent(false);
+    };
+  }, [stopCurrent]);
+
+  const live = status === "live";
+  const starting = status === "starting";
+  const helper = disabled
+    ? "Microphone is disabled for this recording."
+    : error
+      ? error
+      : live
+        ? hasSignal
+          ? "Signal detected — your selected microphone is picking you up."
+          : "Speak now — the waveform should move with your voice."
+        : starting
+          ? "Opening microphone…"
+          : "Click Test mic, then speak to verify input before recording.";
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border bg-muted/25 p-3",
+        disabled && "opacity-70",
+        className,
+      )}
+    >
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-xs font-medium text-foreground">Mic check</div>
+          <div className="truncate text-[11px] text-muted-foreground">
+            {selectedLabel ?? "Selected microphone"}
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant={live ? "outline" : "secondary"}
+          size="sm"
+          disabled={disabled || starting}
+          onClick={live ? stopTest : startTest}
+          className="h-8 px-2.5 text-xs"
+        >
+          {live ? "Stop" : starting ? "Listening…" : "Test mic"}
+        </Button>
+      </div>
+      <div
+        className={cn(
+          "relative overflow-hidden rounded-lg border bg-background",
+          live && hasSignal ? "border-foreground/40" : "border-border",
+        )}
+      >
+        <canvas
+          ref={canvasRef}
+          aria-label="Selected microphone waveform"
+          className="h-12 w-full"
+        />
+        {live && (
+          <div
+            className={cn(
+              "pointer-events-none absolute right-2 top-2 h-2 w-2 rounded-full",
+              hasSignal ? "bg-foreground" : "bg-muted-foreground/40",
+            )}
+          />
+        )}
+      </div>
+      <p
+        className={cn(
+          "mt-2 text-[11px] leading-snug text-muted-foreground",
+          error && "text-destructive",
+        )}
+      >
+        {helper}
+      </p>
+    </div>
+  );
+}

--- a/templates/clips/app/components/recorder/microphone-visualizer.tsx
+++ b/templates/clips/app/components/recorder/microphone-visualizer.tsx
@@ -311,7 +311,13 @@ export function MicrophoneVisualizer({
       onStatusChange?.("error", { error: message });
       return;
     }
+
+    // Claim runId before the first await so a stale call can't win the race.
+    const runId = runIdRef.current + 1;
+    runIdRef.current = runId;
+
     const permissionState = await getMicrophonePermissionState();
+    if (runIdRef.current !== runId) return;
     if (permissionState === "denied") {
       const message =
         "Brave already has Microphone set to Block for this site, so it will not show the popup. Click the lock/tune icon in the address bar → Site settings → Microphone → Allow, then reload.";
@@ -321,8 +327,6 @@ export function MicrophoneVisualizer({
       return;
     }
 
-    const runId = runIdRef.current + 1;
-    runIdRef.current = runId;
     stopCurrent();
     setError(null);
     setStatus("starting");

--- a/templates/clips/app/components/recorder/microphone-visualizer.tsx
+++ b/templates/clips/app/components/recorder/microphone-visualizer.tsx
@@ -381,6 +381,8 @@ export function MicrophoneVisualizer({
       stopStream(stream);
       if (runIdRef.current !== runId) return;
       const message = await friendlyMicError(err);
+      // friendlyMicError awaits the Permissions API, so re-check after.
+      if (runIdRef.current !== runId) return;
       setSignal(false);
       setError(message);
       setStatus("error");

--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   IconCamera,
   IconDeviceScreen,
@@ -6,6 +6,7 @@ import {
   IconUpload,
   IconVideo,
 } from "@tabler/icons-react";
+import { agentNativePath } from "@agent-native/core/client";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -15,6 +16,10 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { NO_MIC_DEVICE_ID, type RecordingMode } from "./recorder-engine";
+import {
+  MicrophoneVisualizer,
+  type MicrophoneTestStatus,
+} from "./microphone-visualizer";
 
 export interface PreRecordPanelProps {
   onStart: (opts: {
@@ -26,6 +31,23 @@ export interface PreRecordPanelProps {
   onUpload?: (file: File) => void;
   onCancel?: () => void;
   busy?: boolean;
+}
+
+type MicTestState = {
+  status: MicrophoneTestStatus;
+  error: string | null;
+  hasSignal: boolean;
+};
+
+async function writeRecordingSetupState(value: unknown): Promise<void> {
+  await fetch(
+    agentNativePath("/_agent-native/application-state/recording-setup"),
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(value),
+    },
+  );
 }
 
 const MODE_OPTIONS: Array<{
@@ -67,6 +89,11 @@ export function PreRecordPanel({
   const [micId, setMicId] = useState<string>("default");
   const [cameraId, setCameraId] = useState<string>("default");
   const [enumError, setEnumError] = useState<string | null>(null);
+  const [micTest, setMicTest] = useState<MicTestState>({
+    status: "idle",
+    error: null,
+    hasSignal: false,
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -99,6 +126,79 @@ export function PreRecordPanel({
   }, []);
 
   const needsCamera = mode === "camera" || mode === "screen+camera";
+
+  const selectedMicLabel = useMemo(() => {
+    if (micId === NO_MIC_DEVICE_ID) return "No microphone";
+    if (micId === "default") return "Default microphone";
+    return (
+      mics.find((mic) => mic.deviceId === micId)?.label ||
+      `Mic ${micId.slice(0, 4)}`
+    );
+  }, [micId, mics]);
+
+  const selectedCameraLabel = useMemo(() => {
+    if (!needsCamera) return null;
+    if (cameraId === "default") return "Default camera";
+    return (
+      cameras.find((camera) => camera.deviceId === cameraId)?.label ||
+      `Camera ${cameraId.slice(0, 4)}`
+    );
+  }, [cameraId, cameras, needsCamera]);
+
+  const handleMicStatusChange = useCallback(
+    (status: MicrophoneTestStatus, detail?: { error?: string | null }) => {
+      setMicTest({
+        status,
+        error: detail?.error ?? null,
+        hasSignal: false,
+      });
+    },
+    [],
+  );
+
+  const handleMicSignalChange = useCallback((hasSignal: boolean) => {
+    setMicTest((prev) => ({ ...prev, hasSignal }));
+  }, []);
+
+  useEffect(() => {
+    void writeRecordingSetupState({
+      view: "record",
+      mode,
+      microphone: {
+        enabled: micId !== NO_MIC_DEVICE_ID,
+        selected:
+          micId === NO_MIC_DEVICE_ID
+            ? "none"
+            : micId === "default"
+              ? "default"
+              : "specific",
+        label: selectedMicLabel,
+        testStatus: micTest.status,
+        testHasSignal: micTest.hasSignal,
+        testError: micTest.error,
+      },
+      camera: {
+        enabled: needsCamera,
+        selected: needsCamera
+          ? cameraId === "default"
+            ? "default"
+            : "specific"
+          : "none",
+        label: selectedCameraLabel,
+      },
+      updatedAt: new Date().toISOString(),
+    }).catch(() => {});
+  }, [
+    cameraId,
+    micId,
+    micTest.error,
+    micTest.hasSignal,
+    micTest.status,
+    mode,
+    needsCamera,
+    selectedCameraLabel,
+    selectedMicLabel,
+  ]);
 
   const startDisabled = useMemo(() => {
     if (busy) return true;
@@ -159,6 +259,15 @@ export function PreRecordPanel({
             </SelectContent>
           </Select>
         </div>
+
+        <MicrophoneVisualizer
+          className="ml-7"
+          deviceId={micId === "default" ? null : micId}
+          disabled={busy || micId === NO_MIC_DEVICE_ID}
+          selectedLabel={selectedMicLabel}
+          onStatusChange={handleMicStatusChange}
+          onSignalChange={handleMicSignalChange}
+        />
 
         {needsCamera && (
           <div className="flex items-center gap-3">

--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { NO_MIC_DEVICE_ID, type RecordingMode } from "./recorder-engine";
+import type { CameraBubbleSize } from "./camera-bubble";
 import { CameraVisualizer, type CameraTestStatus } from "./camera-visualizer";
 import {
   MicrophoneVisualizer,
@@ -32,6 +33,8 @@ export interface PreRecordPanelProps {
   onUpload?: (file: File) => void;
   onCancel?: () => void;
   busy?: boolean;
+  cameraSize?: CameraBubbleSize;
+  onCameraSizeChange?: (size: CameraBubbleSize) => void;
 }
 
 type MicTestState = {
@@ -88,6 +91,8 @@ export function PreRecordPanel({
   onUpload,
   onCancel,
   busy,
+  cameraSize = "md",
+  onCameraSizeChange,
 }: PreRecordPanelProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [mode, setMode] = useState<RecordingMode>("screen+camera");
@@ -331,6 +336,8 @@ export function PreRecordPanel({
               deviceId={cameraId === "default" ? null : cameraId}
               disabled={busy}
               selectedLabel={selectedCameraLabel}
+              size={cameraSize}
+              onSizeChange={onCameraSizeChange}
               onStatusChange={handleCameraStatusChange}
               onPreviewChange={handleCameraPreviewChange}
             />

--- a/templates/clips/app/components/recorder/pre-record-panel.tsx
+++ b/templates/clips/app/components/recorder/pre-record-panel.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { NO_MIC_DEVICE_ID, type RecordingMode } from "./recorder-engine";
+import { CameraVisualizer, type CameraTestStatus } from "./camera-visualizer";
 import {
   MicrophoneVisualizer,
   type MicrophoneTestStatus,
@@ -37,6 +38,12 @@ type MicTestState = {
   status: MicrophoneTestStatus;
   error: string | null;
   hasSignal: boolean;
+};
+
+type CameraTestState = {
+  status: CameraTestStatus;
+  error: string | null;
+  hasPreview: boolean;
 };
 
 async function writeRecordingSetupState(value: unknown): Promise<void> {
@@ -93,6 +100,11 @@ export function PreRecordPanel({
     status: "idle",
     error: null,
     hasSignal: false,
+  });
+  const [cameraTest, setCameraTest] = useState<CameraTestState>({
+    status: "idle",
+    error: null,
+    hasPreview: false,
   });
 
   useEffect(() => {
@@ -160,6 +172,26 @@ export function PreRecordPanel({
     setMicTest((prev) => ({ ...prev, hasSignal }));
   }, []);
 
+  const handleCameraStatusChange = useCallback(
+    (status: CameraTestStatus, detail?: { error?: string | null }) => {
+      setCameraTest({
+        status,
+        error: detail?.error ?? null,
+        hasPreview: false,
+      });
+    },
+    [],
+  );
+
+  const handleCameraPreviewChange = useCallback((hasPreview: boolean) => {
+    setCameraTest((prev) => ({ ...prev, hasPreview }));
+  }, []);
+
+  useEffect(() => {
+    if (needsCamera) return;
+    setCameraTest({ status: "idle", error: null, hasPreview: false });
+  }, [needsCamera]);
+
   useEffect(() => {
     void writeRecordingSetupState({
       view: "record",
@@ -185,11 +217,17 @@ export function PreRecordPanel({
             : "specific"
           : "none",
         label: selectedCameraLabel,
+        testStatus: cameraTest.status,
+        testHasPreview: cameraTest.hasPreview,
+        testError: cameraTest.error,
       },
       updatedAt: new Date().toISOString(),
     }).catch(() => {});
   }, [
     cameraId,
+    cameraTest.error,
+    cameraTest.hasPreview,
+    cameraTest.status,
     micId,
     micTest.error,
     micTest.hasSignal,
@@ -270,22 +308,33 @@ export function PreRecordPanel({
         />
 
         {needsCamera && (
-          <div className="flex items-center gap-3">
-            <IconCamera className="h-4 w-4 text-muted-foreground" />
-            <Select value={cameraId} onValueChange={setCameraId}>
-              <SelectTrigger className="flex-1">
-                <SelectValue placeholder="Default camera" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="default">Default camera</SelectItem>
-                {cameras.map((c) => (
-                  <SelectItem key={c.deviceId} value={c.deviceId}>
-                    {c.label || `Camera ${c.deviceId.slice(0, 4)}`}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+          <>
+            <div className="flex items-center gap-3">
+              <IconCamera className="h-4 w-4 text-muted-foreground" />
+              <Select value={cameraId} onValueChange={setCameraId}>
+                <SelectTrigger className="flex-1">
+                  <SelectValue placeholder="Default camera" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="default">Default camera</SelectItem>
+                  {cameras.map((c) => (
+                    <SelectItem key={c.deviceId} value={c.deviceId}>
+                      {c.label || `Camera ${c.deviceId.slice(0, 4)}`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <CameraVisualizer
+              className="ml-7"
+              deviceId={cameraId === "default" ? null : cameraId}
+              disabled={busy}
+              selectedLabel={selectedCameraLabel}
+              onStatusChange={handleCameraStatusChange}
+              onPreviewChange={handleCameraPreviewChange}
+            />
+          </>
         )}
 
         {enumError && (

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -172,6 +172,12 @@ export class RecorderEngine {
    * completion against a recording the user already discarded.
    */
   private compressionAbort: AbortController | null = null;
+  /**
+   * Aborts in-flight chunk uploads (queueChunk + the non-compression finalize
+   * sentinel) when cancel() runs, so a Cancel during upload doesn't let the
+   * fetch quietly complete and the recording finalise server-side.
+   */
+  private uploadAbort: AbortController | null = null;
 
   private state: RecorderState = "idle";
 
@@ -436,6 +442,7 @@ export class RecorderEngine {
     this.uploadFailure = null;
     this.localChunks = [];
     this.totalRecordedBytes = 0;
+    this.uploadAbort = new AbortController();
 
     this.recorder.addEventListener("dataavailable", (event) => {
       const blob = event.data;
@@ -629,6 +636,7 @@ export class RecorderEngine {
             height: dimensions.height,
             hasAudio,
             hasCamera,
+            signal: this.uploadAbort?.signal,
           },
         );
       }
@@ -897,6 +905,13 @@ export class RecorderEngine {
       this.compressionAbort.abort(cancelErr);
       this.compressionAbort = null;
     }
+    // Abort streaming-chunk uploads + the non-compression finalize sentinel.
+    if (this.uploadAbort) {
+      const cancelErr = new Error("Recording cancelled");
+      cancelErr.name = "AbortError";
+      this.uploadAbort.abort(cancelErr);
+      this.uploadAbort = null;
+    }
     this.cleanupTracks();
     this.chunkIndex = 0;
     this.uploadFailure = null;
@@ -962,10 +977,12 @@ export class RecorderEngine {
   private queueChunk(blob: Blob, index: number, isFinal: boolean): void {
     this.chunkQueue = this.chunkQueue.then(async () => {
       if (this.uploadFailure) return;
+      if (this.uploadAbort?.signal.aborted) return;
       try {
         await this.uploadChunk(blob, index, {
           isFinal,
           mimeType: this.mimeType,
+          signal: this.uploadAbort?.signal,
         });
         this.opts.onChunk?.({
           index,
@@ -974,6 +991,8 @@ export class RecorderEngine {
         });
       } catch (err) {
         const failure = err instanceof Error ? err : new Error(String(err));
+        // User-initiated cancel — cancel() already runs the abortUrl path.
+        if (failure.name === "AbortError") return;
         await this.markUploadFailed(failure);
         this.emitError(failure);
       }
@@ -984,6 +1003,7 @@ export class RecorderEngine {
     if (!this.uploadFailure) {
       this.uploadFailure = err;
     }
+    if (!this.opts.abortUrl) return;
     try {
       await fetch(this.opts.abortUrl, {
         method: "POST",

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -212,37 +212,89 @@ export class RecorderEngine {
   async acquire(): Promise<RecorderStartResult> {
     this.transition("pickingSources");
 
+    const wantsDisplay =
+      this.opts.mode === "screen" || this.opts.mode === "screen+camera";
+    const wantsCamera =
+      this.opts.mode === "camera" || this.opts.mode === "screen+camera";
+    const wantsMic = this.opts.micDeviceId !== NO_MIC_DEVICE_ID;
+
     try {
-      if (this.opts.mode === "screen" || this.opts.mode === "screen+camera") {
-        this.displayStream = await navigator.mediaDevices.getDisplayMedia({
-          video: { frameRate: { ideal: 30 } },
-          audio: true,
-        });
+      if (!navigator.mediaDevices?.getUserMedia) {
+        throw new Error(
+          "Your browser doesn't support camera or microphone capture. Try a recent Brave, Chrome, Edge, Safari, or Firefox.",
+        );
+      }
+      if (wantsDisplay && !navigator.mediaDevices.getDisplayMedia) {
+        throw new Error(
+          "Your browser doesn't support screen capture. Try a recent Brave, Chrome, Edge, Safari, or Firefox.",
+        );
       }
 
-      if (this.opts.mode === "camera" || this.opts.mode === "screen+camera") {
-        this.cameraStream = await navigator.mediaDevices.getUserMedia({
-          video: this.opts.cameraDeviceId
-            ? { deviceId: { exact: this.opts.cameraDeviceId } }
-            : true,
-          audio: false,
-        });
-      }
-
-      if (this.opts.micDeviceId !== NO_MIC_DEVICE_ID) {
-        // Mic is separate so user can pick explicitly; combined with system audio later.
-        try {
-          this.micStream = await navigator.mediaDevices.getUserMedia({
+      // Start every browser media request synchronously before the first
+      // `await`. Brave (and stricter Chromium/WebKit builds) require
+      // getDisplayMedia to be directly anchored to the user's click. If we
+      // await a network request or another media prompt first, the browser can
+      // reject without showing any permission picker.
+      const displayPromise = wantsDisplay
+        ? navigator.mediaDevices.getDisplayMedia({
+            video: { frameRate: { ideal: 30 } },
+            audio: true,
+          })
+        : Promise.resolve<MediaStream | null>(null);
+      const cameraPromise = wantsCamera
+        ? navigator.mediaDevices.getUserMedia({
+            video: this.opts.cameraDeviceId
+              ? { deviceId: { exact: this.opts.cameraDeviceId } }
+              : true,
+            audio: false,
+          })
+        : Promise.resolve<MediaStream | null>(null);
+      const micPromise = wantsMic
+        ? navigator.mediaDevices.getUserMedia({
             audio: this.opts.micDeviceId
               ? { deviceId: { exact: this.opts.micDeviceId } }
               : true,
             video: false,
-          });
-        } catch {
-          // Mic is optional — if denied we still record without it.
-          this.micStream = null;
+          })
+        : Promise.resolve<MediaStream | null>(null);
+
+      const [displayResult, cameraResult, micResult] = await Promise.allSettled(
+        [displayPromise, cameraPromise, micPromise],
+      );
+      const settledStreams = [displayResult, cameraResult, micResult]
+        .filter(
+          (result): result is PromiseFulfilledResult<MediaStream> =>
+            result.status === "fulfilled" && result.value !== null,
+        )
+        .map((result) => result.value);
+
+      const requiredFailure =
+        (wantsDisplay && displayResult.status === "rejected"
+          ? displayResult.reason
+          : null) ??
+        (wantsCamera && cameraResult.status === "rejected"
+          ? cameraResult.reason
+          : null);
+      if (requiredFailure) {
+        for (const stream of settledStreams) {
+          for (const track of stream.getTracks()) {
+            try {
+              track.stop();
+            } catch {
+              // ignore
+            }
+          }
         }
+        throw requiredFailure;
       }
+
+      this.displayStream =
+        displayResult.status === "fulfilled" ? displayResult.value : null;
+      this.cameraStream =
+        cameraResult.status === "fulfilled" ? cameraResult.value : null;
+      // Mic is optional — if denied we still record without it.
+      this.micStream =
+        micResult.status === "fulfilled" ? micResult.value : null;
 
       // If the display stream's video track ends (user hit "Stop sharing" in
       // browser chrome) we want to end the recording gracefully.
@@ -282,6 +334,21 @@ export class RecorderEngine {
       this.transition("error", { reason: String(err) });
       throw this.friendlyError(err);
     }
+  }
+
+  /**
+   * Attach the server-created upload target after media has been acquired.
+   * Acquisition intentionally happens first so permission prompts remain
+   * anchored to the user's click in Brave/Chromium.
+   */
+  setUploadTarget(target: {
+    recordingId: string;
+    uploadUrl: string;
+    abortUrl: string;
+  }): void {
+    this.opts.recordingId = target.recordingId;
+    this.opts.uploadUrl = target.uploadUrl;
+    this.opts.abortUrl = target.abortUrl;
   }
 
   // -------------------------------------------------------------------------
@@ -822,10 +889,12 @@ export class RecorderEngine {
     this.totalRecordedBytes = 0;
     this.transition("idle");
 
-    try {
-      await fetch(this.opts.abortUrl, { method: "POST" });
-    } catch {
-      // ignore — best effort
+    if (this.opts.abortUrl) {
+      try {
+        await fetch(this.opts.abortUrl, { method: "POST" });
+      } catch {
+        // ignore — best effort
+      }
     }
   }
 
@@ -1024,7 +1093,7 @@ export class RecorderEngine {
       err instanceof Error ? err.message : String(err || "Unknown error");
     if (/Permission denied|NotAllowedError|denied/i.test(message)) {
       return new Error(
-        "Screen, camera, or microphone access was blocked. In Chrome, open Site settings for this app and allow Camera and Microphone. On macOS, also check System Settings > Privacy & Security for Screen Recording, Camera, and Microphone, then quit and reopen Chrome.",
+        "Screen, camera, or microphone access was blocked. In Brave/Chrome, open Site settings for this app and allow Camera and Microphone. On macOS, also check System Settings > Privacy & Security for Screen Recording, Camera, and Microphone, then quit and reopen the browser.",
       );
     }
     if (/NotFoundError|no device/i.test(message)) {

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -85,9 +85,9 @@ function isPermissionError(message: string): boolean {
 function permissionGuidance(message: string): string | null {
   if (!isPermissionError(message)) return null;
   if (isMacPlatform()) {
-    return "Check Chrome Site settings first. If it still fails, open macOS System Settings > Privacy & Security and enable Screen Recording, Camera, and Microphone for Chrome, then quit and reopen Chrome.";
+    return "Check Brave/Chrome Site settings first. If it still fails, open macOS System Settings > Privacy & Security and enable Screen Recording, Camera, and Microphone for your browser, then quit and reopen it.";
   }
-  return "Open Chrome Site settings for this app and allow Camera and Microphone, then reload this page.";
+  return "Open Brave/Chrome Site settings for this app and allow Camera and Microphone, then reload this page.";
 }
 
 function captureThumbnailFromPreview(
@@ -237,7 +237,7 @@ export default function RecordRoute() {
   }, []);
 
   // -------------------------------------------------------------------------
-  // Create recording row, acquire media, start countdown.
+  // Acquire media, create recording row, start countdown.
   // -------------------------------------------------------------------------
   const startFlow = useCallback(
     async (opts: {
@@ -251,6 +251,79 @@ export default function RecordRoute() {
       setUiState("pickingSources");
 
       try {
+        // Build the engine and trigger browser media prompts before any
+        // network await. Brave drops the transient user activation after async
+        // work, so calling getDisplayMedia after create-recording can fail
+        // silently without showing a picker.
+        const engine = new RecorderEngine({
+          recordingId: "__pending__",
+          mode: opts.mode,
+          micDeviceId: opts.micDeviceId,
+          cameraDeviceId: opts.cameraDeviceId,
+          uploadUrl: "",
+          abortUrl: "",
+          onError: (err) => {
+            console.error("[recorder] error:", err);
+            showRecordingErrorToast(err.message);
+            setError(err.message);
+            setUiState("error");
+          },
+          onState: (state) => {
+            // Mirror the engine's compression pass into the UI so the
+            // "Saving your recording…" spinner becomes "Compressing…" for
+            // the duration. Other engine states are managed by the UI's
+            // own state machine in startFlow / doStop.
+            if (state === "compressing") {
+              setUiState("compressing");
+            } else if (state === "uploading") {
+              // Reset compression progress when the engine moves on to
+              // upload — applies whether or not we just came from
+              // compressing.
+              setCompressionProgress(null);
+              // Always sync the UI back to "uploading"; if we were already
+              // there from doStop's pre-stop transition, this is a no-op.
+              setUiState("uploading");
+            }
+          },
+          onChunk: ({ index, bytes }) => {
+            const recordingId = pendingRef.current?.id;
+            if (!recordingId) return;
+            void writeAppState(`recording-upload-${recordingId}`, {
+              recordingId,
+              status: "uploading",
+              chunksReceived: index + 1,
+              lastChunkBytes: bytes,
+              updatedAt: new Date().toISOString(),
+            }).catch(() => {});
+          },
+          // When the user clicks the browser's native "Stop sharing" button,
+          // delegate to doStop() so the UI runs its full stop flow: thumbnail
+          // capture, transcription flush, state updates, and navigation.
+          // Using a ref so we always call the latest version of doStop even
+          // though startFlow itself has empty deps.
+          onDisplayTrackEnded: () => {
+            void doStopRef.current();
+          },
+          onCompressionProgress: ({ stage, progress }) => {
+            // The recorder engine is responsible for transitioning into the
+            // `compressing` state. We mirror that into the UI via the
+            // generic onState handler below; here we just track the
+            // numeric progress so the spinner can show a percentage.
+            if (stage === "encoding" && typeof progress === "number") {
+              setCompressionProgress(progress);
+            } else if (stage === "loading-ffmpeg" || stage === "preparing") {
+              setCompressionProgress(null);
+            } else if (stage === "finalizing") {
+              setCompressionProgress(1);
+            }
+          },
+        });
+        engineRef.current = engine;
+
+        // 1. Acquire media (triggers permission prompts) while the click's
+        // transient activation is still live.
+        const { previewStream: ps, cameraStream: cs } = await engine.acquire();
+
         const statusRes = await fetch(
           agentNativePath("/_agent-native/file-upload/status"),
         );
@@ -263,7 +336,7 @@ export default function RecordRoute() {
           }
         }
 
-        // 1. Create the recording row server-side.
+        // 2. Create the recording row server-side once permissions are granted.
         const res = await fetch(
           agentNativePath("/_agent-native/actions/create-recording"),
           {
@@ -301,85 +374,26 @@ export default function RecordRoute() {
         if (!info?.id) {
           throw new Error("create-recording did not return an id");
         }
+        const uploadChunkUrl = `${appBasePath()}${info.uploadChunkUrl!}`;
+        const abortUrl = `${appBasePath()}${info.abortUrl!}`;
         pendingRef.current = {
           id: info.id,
-          uploadChunkUrl: `${appBasePath()}${info.uploadChunkUrl!}`,
-          abortUrl: `${appBasePath()}${info.abortUrl!}`,
+          uploadChunkUrl,
+          abortUrl,
         };
-
-        // 2. Build the engine and acquire media (triggers permission prompts).
-        const engine = new RecorderEngine({
+        engine.setUploadTarget({
           recordingId: info.id,
-          mode: opts.mode,
-          micDeviceId: opts.micDeviceId,
-          cameraDeviceId: opts.cameraDeviceId,
-          uploadUrl: `${appBasePath()}${info.uploadChunkUrl!}`,
-          abortUrl: `${appBasePath()}${info.abortUrl!}`,
-          onError: (err) => {
-            console.error("[recorder] error:", err);
-            showRecordingErrorToast(err.message);
-            setError(err.message);
-            setUiState("error");
-          },
-          onState: (state) => {
-            // Mirror the engine's compression pass into the UI so the
-            // "Saving your recording…" spinner becomes "Compressing…" for
-            // the duration. Other engine states are managed by the UI's
-            // own state machine in startFlow / doStop.
-            if (state === "compressing") {
-              setUiState("compressing");
-            } else if (state === "uploading") {
-              // Reset compression progress when the engine moves on to
-              // upload — applies whether or not we just came from
-              // compressing.
-              setCompressionProgress(null);
-              // Always sync the UI back to "uploading"; if we were already
-              // there from doStop's pre-stop transition, this is a no-op.
-              setUiState("uploading");
-            }
-          },
-          onChunk: ({ index, bytes }) => {
-            void writeAppState(`recording-upload-${info.id}`, {
-              recordingId: info.id,
-              status: "uploading",
-              chunksReceived: index + 1,
-              lastChunkBytes: bytes,
-              updatedAt: new Date().toISOString(),
-            }).catch(() => {});
-          },
-          // When the user clicks the browser's native "Stop sharing" button,
-          // delegate to doStop() so the UI runs its full stop flow: thumbnail
-          // capture, transcription flush, state updates, and navigation.
-          // Using a ref so we always call the latest version of doStop even
-          // though startFlow itself has empty deps.
-          onDisplayTrackEnded: () => {
-            void doStopRef.current();
-          },
-          onCompressionProgress: ({ stage, progress }) => {
-            // The recorder engine is responsible for transitioning into the
-            // `compressing` state. We mirror that into the UI via the
-            // generic onState handler below; here we just track the
-            // numeric progress so the spinner can show a percentage.
-            if (stage === "encoding" && typeof progress === "number") {
-              setCompressionProgress(progress);
-            } else if (stage === "loading-ffmpeg" || stage === "preparing") {
-              setCompressionProgress(null);
-            } else if (stage === "finalizing") {
-              setCompressionProgress(1);
-            }
-          },
+          uploadUrl: uploadChunkUrl,
+          abortUrl,
         });
-        engineRef.current = engine;
 
-        const { previewStream: ps, cameraStream: cs } = await engine.acquire();
         setPreviewStream(ps);
         setCameraStream(cs);
         setUiState("countdown");
       } catch (err) {
         const message =
           err instanceof Error ? err.message : "Could not start recording";
-        // If the recording row was created before the failure (i.e. media
-        // acquisition failed *after* create-recording), trash it so it
+        // If the recording row was created before the failure, trash it so it
         // doesn't sit in the library forever in 'uploading' status. This
         // is the bug that produced "stuck UPLOADING" cards from failed
         // record attempts.

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -53,6 +53,13 @@ export function meta() {
   return [{ title: "New recording — Clips" }];
 }
 
+export function headers() {
+  return {
+    "Permissions-Policy":
+      "camera=(self), microphone=(self), display-capture=(self), geolocation=(), screen-wake-lock=()",
+  };
+}
+
 type UiState =
   | "idle"
   | "pickingSources"

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -983,7 +983,12 @@ export default function RecordRoute() {
               </span>
             </div>
             {storageConfigured === null ? null : storageConfigured ? (
-              <PreRecordPanel onStart={startFlow} onUpload={uploadFile} />
+              <PreRecordPanel
+                onStart={startFlow}
+                onUpload={uploadFile}
+                cameraSize={cameraSize}
+                onCameraSizeChange={setCameraSize}
+              />
             ) : (
               <StorageSetupCard
                 onConfigured={() => setStorageConfigured(true)}

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -231,6 +231,8 @@ export default function RecordRoute() {
   } | null>(null);
   const tickRef = useRef<number | null>(null);
   const previewVideoRef = useRef<HTMLVideoElement>(null);
+  // Bumped by doCancel() to invalidate any in-flight startFlow().
+  const startSessionRef = useRef(0);
 
   // -------------------------------------------------------------------------
   // Timer
@@ -293,6 +295,11 @@ export default function RecordRoute() {
       micDeviceId: string | null;
       cameraDeviceId: string | null;
     }) => {
+      // Claim a session id; doCancel() bumps the ref to invalidate us.
+      const session = startSessionRef.current + 1;
+      startSessionRef.current = session;
+      const isStale = () => startSessionRef.current !== session;
+
       setError(null);
       setRecordingMode(opts.mode);
       pendingStartOptsRef.current = opts;
@@ -372,8 +379,16 @@ export default function RecordRoute() {
         // 1. Acquire media (triggers permission prompts) while the click's
         // transient activation is still live.
         const { previewStream: ps, cameraStream: cs } = await engine.acquire();
+        if (isStale()) {
+          await engine.cancel().catch(() => {});
+          return;
+        }
 
         const status = await fetchVideoStorageStatus();
+        if (isStale()) {
+          await engine.cancel().catch(() => {});
+          return;
+        }
         setStorageConfigured(status.configured);
         if (!status.configured) {
           throw new Error(
@@ -419,6 +434,16 @@ export default function RecordRoute() {
         if (!info?.id) {
           throw new Error("create-recording did not return an id");
         }
+        // Cancelled mid-POST: pendingRef is still null, so trash directly.
+        if (isStale()) {
+          fetch(agentNativePath("/_agent-native/actions/trash-recording"), {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ id: info.id }),
+          }).catch(() => {});
+          await engine.cancel().catch(() => {});
+          return;
+        }
         const uploadChunkUrl = `${appBasePath()}${info.uploadChunkUrl!}`;
         const abortUrl = `${appBasePath()}${info.abortUrl!}`;
         pendingRef.current = {
@@ -436,6 +461,8 @@ export default function RecordRoute() {
         setCameraStream(cs);
         setUiState("countdown");
       } catch (err) {
+        // doCancel() owns teardown if a cancel raced ahead — don't clobber it.
+        if (isStale()) return;
         const message =
           err instanceof Error ? err.message : "Could not start recording";
         // If the recording row was created before the failure, trash it so it
@@ -803,6 +830,8 @@ export default function RecordRoute() {
   }, []);
 
   const doCancel = useCallback(async () => {
+    // Invalidate any in-flight startFlow().
+    startSessionRef.current += 1;
     const engine = engineRef.current;
     const pendingId = pendingRef.current?.id;
     liveTranscription.stop();

--- a/templates/clips/server/lib/media-permissions.ts
+++ b/templates/clips/server/lib/media-permissions.ts
@@ -1,0 +1,12 @@
+export const MEDIA_CAPTURE_PERMISSIONS_POLICY =
+  "camera=(self), microphone=(self), display-capture=(self), geolocation=(), screen-wake-lock=()";
+
+export function withMediaCapturePermissions(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set("Permissions-Policy", MEDIA_CAPTURE_PERMISSIONS_POLICY);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/templates/clips/server/routes/[...page].get.ts
+++ b/templates/clips/server/routes/[...page].get.ts
@@ -1,5 +1,20 @@
 import { createH3SSRHandler } from "@agent-native/core/server/ssr-handler";
+import { defineEventHandler, setResponseHeader } from "h3";
+import {
+  MEDIA_CAPTURE_PERMISSIONS_POLICY,
+  withMediaCapturePermissions,
+} from "../lib/media-permissions.js";
 
-export default createH3SSRHandler(
+const ssrHandler = createH3SSRHandler(
   () => import("virtual:react-router/server-build"),
 );
+
+export default defineEventHandler(async (event) => {
+  const response = (await ssrHandler(event)) as Response;
+  setResponseHeader(
+    event,
+    "Permissions-Policy",
+    MEDIA_CAPTURE_PERMISSIONS_POLICY,
+  );
+  return withMediaCapturePermissions(response);
+});

--- a/templates/clips/server/routes/[...page].head.ts
+++ b/templates/clips/server/routes/[...page].head.ts
@@ -2,20 +2,24 @@ import { defineEventHandler, getRequestURL, setResponseHeader } from "h3";
 import { MEDIA_CAPTURE_PERMISSIONS_POLICY } from "../lib/media-permissions.js";
 
 export default defineEventHandler((event) => {
-  const { pathname } = getRequestURL(event);
-
-  if (pathname === "/") {
-    return new Response(null, {
-      status: 302,
-      headers: { location: "/library" },
-    });
-  }
-
+  // Set before any short-circuit so the `/` redirect inherits it too.
   setResponseHeader(
     event,
     "Permissions-Policy",
     MEDIA_CAPTURE_PERMISSIONS_POLICY,
   );
+
+  const { pathname } = getRequestURL(event);
+
+  if (pathname === "/") {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        location: "/library",
+        "Permissions-Policy": MEDIA_CAPTURE_PERMISSIONS_POLICY,
+      },
+    });
+  }
 
   return new Response(null, {
     status: 200,

--- a/templates/clips/server/routes/[...page].head.ts
+++ b/templates/clips/server/routes/[...page].head.ts
@@ -1,4 +1,5 @@
-import { defineEventHandler, getRequestURL } from "h3";
+import { defineEventHandler, getRequestURL, setResponseHeader } from "h3";
+import { MEDIA_CAPTURE_PERMISSIONS_POLICY } from "../lib/media-permissions.js";
 
 export default defineEventHandler((event) => {
   const { pathname } = getRequestURL(event);
@@ -10,8 +11,17 @@ export default defineEventHandler((event) => {
     });
   }
 
+  setResponseHeader(
+    event,
+    "Permissions-Policy",
+    MEDIA_CAPTURE_PERMISSIONS_POLICY,
+  );
+
   return new Response(null, {
     status: 200,
-    headers: { "content-type": "text/html" },
+    headers: {
+      "content-type": "text/html",
+      "Permissions-Policy": MEDIA_CAPTURE_PERMISSIONS_POLICY,
+    },
   });
 });


### PR DESCRIPTION
- Add a pre-record device test panel with live **microphone visualizer** (signal meter + level history) and **camera visualizer** (live preview + bubble-size picker S/M/L) so users can verify their inputs before clicking Start.
- Previously, you had to manually go and fix the site permissions - Allow Mic, camera to provide access. Fix permission prompts on Brave by anchoring `getDisplayMedia` / `getUserMedia` to the user-gesture click — Brave drops the transient activation across awaits, which previously caused the picker to silently never appear.
- Serve a `Permissions-Policy: camera=(self), microphone=(self), display-capture=(self), …` header on `/record` (and its HEAD response) so the page is allow-listed by the browser policy engine.
- Surface friendly, platform-specific error messages when camera/mic permissions are denied (Brave site-settings hint, macOS Privacy & Security pointer).

<img width="2539" height="1316" alt="image" src="https://github.com/user-attachments/assets/9859de43-bb8e-4150-b5f1-05c773167ec1" />
Permissions:
<img width="1514" height="676" alt="image" src="https://github.com/user-attachments/assets/b9b0d73d-34eb-41af-afd1-34a146657001" />
