### PR TITLE
feat: clickable notifications + mail composer/thread polish

### DIFF
--- a/.changeset/notifications-bell-link-click.md
+++ b/.changeset/notifications-bell-link-click.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": minor
+---
+
+NotificationsBell: clicking a notification with `metadata.link` now navigates to that URL (and marks the notification read). Notifications without a link keep the previous click-to-mark-read-only behavior.

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1520,6 +1520,10 @@ function BuilderConnectCta({
 // ─── Builder Setup Card ─────────────────────────────────────────────────────
 
 function BuilderSetupCard({ onConnected }: { onConnected?: () => void }) {
+  const openSettings = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("agent-panel:open-settings"));
+  }, []);
+
   return (
     <div className="mx-4 my-6 rounded-lg border border-border bg-card p-5">
       <div className="flex items-center gap-3 mb-3">
@@ -1528,7 +1532,7 @@ function BuilderSetupCard({ onConnected }: { onConnected?: () => void }) {
         </div>
         <div>
           <h3 className="text-sm font-medium text-foreground">
-            Connect Builder.io
+            Connect an LLM
           </h3>
           <p className="mt-0.5 text-[11px] text-muted-foreground">
             Use the hosted agent without adding a separate model provider key.
@@ -1538,6 +1542,15 @@ function BuilderSetupCard({ onConnected }: { onConnected?: () => void }) {
 
       <div className="space-y-3">
         <BuilderConnectCta onConnected={onConnected} />
+        <div className="text-center">
+          <button
+            type="button"
+            onClick={openSettings}
+            className="text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            Or add your own API key
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/packages/core/src/client/notifications/NotificationsBell.tsx
+++ b/packages/core/src/client/notifications/NotificationsBell.tsx
@@ -255,47 +255,61 @@ export function NotificationsBell({
               <IconLoader2 size={14} className="animate-spin" /> Loading…
             </div>
           ) : items.length > 0 ? (
-            items.map((n) => (
-              <div
-                key={n.id}
-                className={
-                  "group relative border-b border-border last:border-b-0 hover:bg-accent/40 " +
-                  (n.readAt ? "opacity-60" : "")
+            items.map((n) => {
+              const link =
+                typeof n.metadata?.link === "string" ? n.metadata.link : null;
+              const onItemClick = () => {
+                if (!n.readAt) void markRead(n.id);
+                if (link) {
+                  setOpen(false);
+                  window.location.assign(link);
                 }
-              >
-                <button
-                  type="button"
-                  onClick={() => (n.readAt ? undefined : markRead(n.id))}
-                  className="flex w-full flex-col items-start gap-0.5 px-3 py-2 pr-8 text-left"
+              };
+              return (
+                <div
+                  key={n.id}
+                  className={
+                    "group relative border-b border-border last:border-b-0 hover:bg-accent/40 " +
+                    (n.readAt ? "opacity-60" : "")
+                  }
                 >
-                  <div className="flex w-full items-center justify-between gap-2">
-                    <span className="truncate text-sm font-medium text-foreground">
-                      {n.title}
+                  <button
+                    type="button"
+                    onClick={onItemClick}
+                    className={
+                      "flex w-full flex-col items-start gap-0.5 px-3 py-2 pr-8 text-left" +
+                      (link ? " cursor-pointer" : "")
+                    }
+                  >
+                    <div className="flex w-full items-center justify-between gap-2">
+                      <span className="truncate text-sm font-medium text-foreground">
+                        {n.title}
+                      </span>
+                      <SeverityBadge severity={n.severity} />
+                    </div>
+                    {n.body ? (
+                      <span className="line-clamp-2 text-xs text-muted-foreground">
+                        {n.body}
+                      </span>
+                    ) : null}
+                    <span className="text-[10px] text-muted-foreground/70">
+                      {new Date(n.createdAt).toLocaleString()}
                     </span>
-                    <SeverityBadge severity={n.severity} />
-                  </div>
-                  {n.body ? (
-                    <span className="line-clamp-2 text-xs text-muted-foreground">
-                      {n.body}
-                    </span>
-                  ) : null}
-                  <span className="text-[10px] text-muted-foreground/70">
-                    {new Date(n.createdAt).toLocaleString()}
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  aria-label="Dismiss notification"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void dismiss(n.id);
-                  }}
-                  className="absolute right-2 top-2 hidden rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground group-hover:flex"
-                >
-                  <IconX size={12} />
-                </button>
-              </div>
-            ))
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Dismiss notification"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void dismiss(n.id);
+                    }}
+                    className="absolute right-2 top-2 hidden rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground group-hover:flex"
+                  >
+                    <IconX size={12} />
+                  </button>
+                </div>
+              );
+            })
           ) : (
             <div className="p-4 text-sm text-muted-foreground">
               No notifications.

--- a/packages/core/src/client/notifications/NotificationsBell.tsx
+++ b/packages/core/src/client/notifications/NotificationsBell.tsx
@@ -1,4 +1,4 @@
-import { agentNativePath } from "../api-path.js";
+import { agentNativePath, appPath } from "../api-path.js";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   IconBell,
@@ -142,8 +142,12 @@ export function NotificationsBell({
 
   const markRead = async (id: string) => {
     try {
+      // `keepalive: true` lets the request survive page navigation —
+      // without it, clicking a notification with a link aborts this
+      // request mid-flight and the row stays unread.
       await fetch(agentNativePath(`/_agent-native/notifications/${id}/read`), {
         method: "POST",
+        keepalive: true,
       });
       setItems((prev) =>
         prev
@@ -156,6 +160,25 @@ export function NotificationsBell({
     } catch {
       // best-effort
     }
+  };
+
+  // Reject any URL that isn't http(s) or a same-origin relative path. Blocks
+  // `javascript:` execution, `data:` URIs, and absolute redirects to phishing
+  // sites. Relative paths starting with `/` are routed through `appPath()` so
+  // the link works in mounted deployments (e.g. /mail subdirectory).
+  const safeNotificationLink = (link: string): string | null => {
+    if (link.startsWith("/") && !link.startsWith("//")) {
+      return appPath(link);
+    }
+    try {
+      const url = new URL(link, window.location.origin);
+      if (url.protocol === "http:" || url.protocol === "https:") {
+        return url.toString();
+      }
+    } catch {
+      // fallthrough
+    }
+    return null;
   };
 
   const markAllRead = async () => {
@@ -256,8 +279,9 @@ export function NotificationsBell({
             </div>
           ) : items.length > 0 ? (
             items.map((n) => {
-              const link =
+              const rawLink =
                 typeof n.metadata?.link === "string" ? n.metadata.link : null;
+              const link = rawLink ? safeNotificationLink(rawLink) : null;
               const onItemClick = () => {
                 if (!n.readAt) void markRead(n.id);
                 if (link) {

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -112,8 +112,10 @@ export default function App() {
     });
     setActiveSidebarAppId((prev) => {
       if (prev && enabledApps.find((a) => a.id === prev)) return prev;
-      const def =
-        enabledApps.find((a) => !("placeholder" in a)) ?? enabledApps[0];
+      // Pick from `appDefs` (AppDefinition) so the placeholder check works —
+      // `enabledApps` is AppConfig[] and has no `placeholder` field, so the
+      // old `"placeholder" in a` check was a no-op.
+      const def = appDefs.find((a) => !a.placeholder) ?? appDefs[0];
       return def?.id ?? "";
     });
   }, [enabledAppIdsKey]);

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -66,6 +66,7 @@ export default function App() {
   }, []);
 
   const enabledApps = apps.filter((a) => a.enabled);
+  const enabledAppIdsKey = enabledApps.map((a) => a.id).join(",");
   const rawAppDefs = enabledApps.map(toAppDefinition);
   // Keep this in sync with Sidebar's pinned-bottom order.
   const PINNED_BOTTOM_ORDER = ["dispatch", "starter"];
@@ -81,10 +82,14 @@ export default function App() {
 
   const [activeSidebarAppId, setActiveSidebarAppId] = useState("");
   const [appTabs, setAppTabs] = useState<Record<string, AppTabState>>({});
+  const [mountedAppIds, setMountedAppIds] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   // Initialize tabs when apps load
   useEffect(() => {
     if (enabledApps.length === 0) return;
+    const enabledIds = new Set(enabledApps.map((app) => app.id));
     setAppTabs((prev) => {
       // Only init tabs for apps that don't have tabs yet
       const next = { ...prev };
@@ -96,13 +101,32 @@ export default function App() {
       }
       return next;
     });
+    setMountedAppIds((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const appId of prev) {
+        if (enabledIds.has(appId)) next.add(appId);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
     setActiveSidebarAppId((prev) => {
       if (prev && enabledApps.find((a) => a.id === prev)) return prev;
       const def =
         enabledApps.find((a) => !("placeholder" in a)) ?? enabledApps[0];
       return def?.id ?? "";
     });
-  }, [enabledApps.map((a) => a.id).join(",")]);
+  }, [enabledAppIdsKey]);
+
+  useEffect(() => {
+    if (!activeSidebarAppId) return;
+    setMountedAppIds((prev) => {
+      if (prev.has(activeSidebarAppId)) return prev;
+      const next = new Set(prev);
+      next.add(activeSidebarAppId);
+      return next;
+    });
+  }, [activeSidebarAppId]);
 
   const closedTabsRef = useRef<{ tab: Tab; appId: string }[]>([]);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -337,25 +361,29 @@ export default function App() {
     );
   }
 
-  // Mount only the active app's webviews. Electron <webview> guests are native
-  // surfaces on macOS; keeping every app mounted and hidden can leave stale
-  // compositor pixels on top of the newly-selected app even though React state
-  // and the accessibility tree have moved on.
+  // Keep app webviews warm once visited so switching apps feels like browser
+  // tabs: the guest page remains alive offscreen and keeps its runtime state.
   const allWebviews: {
     tab: Tab;
     app: AppConfig;
     appDef: AppDefinition;
     isActive: boolean;
   }[] = [];
-  const activeApp = enabledApps.find((app) => app.id === activeSidebarAppId);
-  const activeAppState = activeApp ? appTabs[activeApp.id] : undefined;
-  if (activeApp && activeAppState) {
-    for (const tab of activeAppState.tabs) {
+  for (const app of enabledApps) {
+    if (app.id !== activeSidebarAppId && !mountedAppIds.has(app.id)) {
+      continue;
+    }
+
+    const appState = appTabs[app.id];
+    if (!appState) continue;
+
+    for (const tab of appState.tabs) {
       allWebviews.push({
         tab,
-        app: activeApp,
-        appDef: toAppDefinition(activeApp),
-        isActive: tab.id === activeAppState.activeTabId,
+        app,
+        appDef: toAppDefinition(app),
+        isActive:
+          app.id === activeSidebarAppId && tab.id === appState.activeTabId,
       });
     }
   }

--- a/scripts/qa-frame-desktop-smoke.ts
+++ b/scripts/qa-frame-desktop-smoke.ts
@@ -147,8 +147,13 @@ assert.match(
 const desktopApp = read("packages/desktop-app/src/renderer/App.tsx");
 assert.match(
   desktopApp,
-  /enabledApps\.find\(\(app\) => app\.id === activeSidebarAppId\)/,
-  "desktop shell must mount only the active app's webviews to avoid stale Electron native guest surfaces",
+  /mountedAppIds/,
+  "desktop shell must keep visited app webviews mounted so app switching preserves live page state",
+);
+assert.doesNotMatch(
+  desktopApp,
+  /const activeApp = enabledApps\.find\(\(app\) => app\.id === activeSidebarAppId\)/,
+  "desktop shell must not unmount inactive apps when switching sidebar apps",
 );
 
 const frameClient = read("packages/frame/client/App.tsx");

--- a/templates/clips/server/plugins/auth.ts
+++ b/templates/clips/server/plugins/auth.ts
@@ -9,7 +9,7 @@ export default createAuthPlugin({
   marketing: {
     appName: "Agent-Native Clips",
     tagline:
-      "Screen recording, calendar-synced meeting notes, and Fn-hold voice dictation — all transcribed, summarized, and searchable in one app you own. The open-source alternative to Loom, Granola, and Wisprflow.",
+      "Your AI agent transcribes, summarizes, and searches everything you record alongside you.",
     features: [
       "One-click screen recording (Loom-style) with auto titles, summaries, and chapters",
       "Calendar-synced meeting notes (Granola-style) with live transcripts and AI action items",

--- a/templates/mail/app/components/email/ComposeEditor.tsx
+++ b/templates/mail/app/components/email/ComposeEditor.tsx
@@ -70,7 +70,11 @@ export const ComposeEditor = forwardRef<
 ) {
   const isSettingContent = useRef(false);
   const onChangeRef = useRef(onChange);
+  const onSendRef = useRef(onSend);
+  const onCloseRef = useRef(onClose);
   onChangeRef.current = onChange;
+  onSendRef.current = onSend;
+  onCloseRef.current = onClose;
 
   const editor = useEditor({
     extensions: [
@@ -109,12 +113,14 @@ export const ComposeEditor = forwardRef<
       handleKeyDown: (_view, event) => {
         if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
           event.preventDefault();
-          onSend();
+          event.stopPropagation();
+          onSendRef.current();
           return true;
         }
         if (event.key === "Escape") {
           event.preventDefault();
-          onClose();
+          event.stopPropagation();
+          onCloseRef.current();
           return true;
         }
         return false;

--- a/templates/mail/app/components/email/ComposeModal.tsx
+++ b/templates/mail/app/components/email/ComposeModal.tsx
@@ -284,6 +284,7 @@ export function ComposeModal({
           subject: draftSnapshot.subject,
           body: draftSnapshot.body,
           replyToId: draftSnapshot.replyToId,
+          replyToThreadId: draftSnapshot.replyToThreadId,
           accountEmail: draftSnapshot.accountEmail,
           attachments: draftSnapshot.attachments,
         },

--- a/templates/mail/app/components/email/ComposeSlashMenu.tsx
+++ b/templates/mail/app/components/email/ComposeSlashMenu.tsx
@@ -1,4 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  useRef,
+} from "react";
 import type { Editor } from "@tiptap/react";
 import {
   IconTypography,
@@ -128,6 +134,13 @@ export function ComposeSlashMenu({
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [cursorCoords, setCursorCoords] = useState<{
+    cursorTop: number;
+    cursorBottom: number;
+    cursorLeft: number;
+    editorTop: number;
+    editorLeft: number;
+  } | null>(null);
   const [position, setPosition] = useState<{
     top: number;
     left: number;
@@ -216,9 +229,12 @@ export function ComposeSlashMenu({
           .closest(".compose-editor-wrapper")
           ?.getBoundingClientRect();
         if (editorRect) {
-          setPosition({
-            top: coords.bottom - editorRect.top + 4,
-            left: coords.left - editorRect.left,
+          setCursorCoords({
+            cursorTop: coords.top,
+            cursorBottom: coords.bottom,
+            cursorLeft: coords.left,
+            editorTop: editorRect.top,
+            editorLeft: editorRect.left,
           });
         }
         setIsOpen(true);
@@ -226,6 +242,8 @@ export function ComposeSlashMenu({
         if (isOpen) {
           setIsOpen(false);
           setQuery("");
+          setPosition(null);
+          setCursorCoords(null);
           slashPosRef.current = null;
         }
       }
@@ -237,7 +255,23 @@ export function ComposeSlashMenu({
     };
   }, [editor, isOpen]);
 
-  if (!isOpen || !position || filteredCommands.length === 0) return null;
+  useLayoutEffect(() => {
+    if (!isOpen || !cursorCoords || !menuRef.current) return;
+    const menuHeight = menuRef.current.offsetHeight;
+    const gap = 4;
+    const margin = 8;
+    const spaceBelow = window.innerHeight - cursorCoords.cursorBottom - margin;
+    const spaceAbove = cursorCoords.cursorTop - margin;
+    const placeAbove = spaceBelow < menuHeight + gap && spaceAbove > spaceBelow;
+    setPosition({
+      top: placeAbove
+        ? cursorCoords.cursorTop - cursorCoords.editorTop - menuHeight - gap
+        : cursorCoords.cursorBottom - cursorCoords.editorTop + gap,
+      left: cursorCoords.cursorLeft - cursorCoords.editorLeft,
+    });
+  }, [isOpen, cursorCoords, filteredCommands.length]);
+
+  if (!isOpen || !cursorCoords || filteredCommands.length === 0) return null;
 
   const basicCommands = filteredCommands.filter((c) => c.category === "basic");
   const mediaCommands = filteredCommands.filter((c) => c.category === "media");
@@ -249,8 +283,9 @@ export function ComposeSlashMenu({
       className="slash-command-menu"
       style={{
         position: "absolute",
-        top: position.top,
-        left: Math.min(position.left, 300),
+        top: position?.top ?? 0,
+        left: position ? Math.min(position.left, 300) : 0,
+        visibility: position ? "visible" : "hidden",
         zIndex: 50,
       }}
     >

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -1820,14 +1820,11 @@ const ExpandedMessageCard = forwardRef<
             activeLocalIdx={activeLocalIdx}
           />
         ) : email.body ? (
-          <div className="space-y-2.5">
-            <PlainTextBody
-              body={email.body}
-              searchTerm={searchTerm}
-              activeLocalIdx={activeLocalIdx}
-            />
-            <BodySkeleton />
-          </div>
+          <PlainTextBody
+            body={email.body}
+            searchTerm={searchTerm}
+            activeLocalIdx={activeLocalIdx}
+          />
         ) : email.snippet ? (
           <div className="space-y-2.5">
             <p className="text-[13px] text-foreground/80 leading-relaxed">
@@ -1991,6 +1988,20 @@ function findQuoteStart(lines: string[]): number {
     if (/^[—–-]*\s*On .+ wrote:$/i.test(lines[i].trim())) return i;
     // "--- Original Message ---" / "--- Forwarded message ---"
     if (/^-{2,}\s*(Original|Forwarded)\s/i.test(lines[i].trim())) return i;
+    // Outlook/Word reply headers are often plain text blocks:
+    // From: ... / Sent: ... / To: ... / Subject: ...
+    if (/^From:\s+/i.test(lines[i].trim())) {
+      const headerWindow = lines
+        .slice(i, i + 8)
+        .map((line) => line.trim())
+        .join(" ");
+      if (
+        /\bSent:\s+/i.test(headerWindow) &&
+        /\bSubject:\s+/i.test(headerWindow)
+      ) {
+        return i > 0 && lines[i - 1].trim() === "" ? i - 1 : i;
+      }
+    }
     // Block of consecutive ">" quoted lines (at least 2)
     if (
       lines[i].trimStart().startsWith(">") &&
@@ -2739,6 +2750,132 @@ function HtmlEmailBody({
       }
     };
 
+    const normalizeText = (value: string | null | undefined) =>
+      (value || "").replace(/\s+/g, " ").trim();
+
+    const hasMeaningfulPreviousText = (el: HTMLElement): boolean => {
+      let node: Node | null = el;
+      while (node && node !== doc.body) {
+        let prev = node.previousSibling;
+        while (prev) {
+          if (normalizeText(prev.textContent).length > 20) return true;
+          prev = prev.previousSibling;
+        }
+        node = node.parentNode as Node | null;
+      }
+      return false;
+    };
+
+    const getNearbyPreviousText = (el: HTMLElement) => {
+      const parts: string[] = [];
+      let length = 0;
+      let node: Node | null = el;
+      while (node && node !== doc.body && length < 800) {
+        let prev = node.previousSibling;
+        while (prev && length < 800) {
+          const text = normalizeText(prev.textContent);
+          if (text) {
+            parts.unshift(text);
+            length += text.length;
+          }
+          prev = prev.previousSibling;
+        }
+        node = node.parentNode as Node | null;
+      }
+      return parts.join(" ").slice(-800);
+    };
+
+    const createToggle = (
+      target: HTMLElement,
+      className: "quote-toggle" | "sig-toggle",
+      hiddenClass: "quoted-hidden" | "sig-collapsed",
+    ) => {
+      target.classList.add(hiddenClass);
+      const toggle = doc.createElement("button");
+      toggle.className = className;
+      toggle.textContent = "···";
+      toggle.addEventListener("click", () => {
+        const wasHidden = target.classList.contains(hiddenClass);
+        target.classList.toggle(hiddenClass);
+        toggle.style.display = wasHidden ? "none" : "";
+        requestAnimationFrame(resize);
+      });
+      target.parentNode?.insertBefore(toggle, target);
+    };
+
+    const collapseElement = (el: HTMLElement) => {
+      if (el.closest(".quoted-hidden")) return;
+      createToggle(el, "quote-toggle", "quoted-hidden");
+    };
+
+    const outlookHeaderPattern =
+      /\bFrom:\s+.+?\bSent:\s+.+?\bTo:\s+.+?\bSubject:/i;
+    const replyAttributionPattern =
+      /(?:^|\s)(?:On .{3,300} wrote:|-{2,}\s*(?:Original|Forwarded)\s|From:\s+.+?\bSent:\s+.+?\bSubject:)/i;
+
+    const isOutlookHeader = (el: HTMLElement) => {
+      const text = normalizeText(el.textContent);
+      return text.length < 1200 && outlookHeaderPattern.test(text);
+    };
+
+    const getOutlookHeaderBlock = (el: HTMLElement) => {
+      let block = el;
+      while (block.parentElement && block.parentElement !== doc.body) {
+        const parent = block.parentElement as HTMLElement;
+        const parentText = normalizeText(parent.textContent);
+        const blockText = normalizeText(block.textContent);
+        if (parentText !== blockText && parent.children.length !== 1) break;
+        block = parent;
+      }
+      return block;
+    };
+
+    const collapseOutlookHeaderRanges = () => {
+      const headerStarts = Array.from(
+        doc.querySelectorAll<HTMLElement>("div, p, table, tbody, tr, td"),
+      )
+        .filter(isOutlookHeader)
+        .map(getOutlookHeaderBlock);
+      const markerStarts = Array.from(
+        doc.querySelectorAll<HTMLElement>('[id$="divRplyFwdMsg"]'),
+      );
+      const starts = [...markerStarts, ...headerStarts];
+      const seen = new Set<HTMLElement>();
+
+      for (const start of starts) {
+        if (seen.has(start)) continue;
+        seen.add(start);
+        if (!start.parentNode || start.closest(".quoted-hidden")) continue;
+        if (
+          start.previousSibling &&
+          (start.previousSibling as HTMLElement).classList?.contains(
+            "quote-toggle",
+          )
+        ) {
+          continue;
+        }
+
+        const container = doc.createElement("div");
+        container.className = "quoted-hidden";
+        start.parentNode.insertBefore(container, start);
+        container.appendChild(start);
+        while (container.nextSibling) {
+          container.appendChild(container.nextSibling);
+        }
+
+        const toggle = doc.createElement("button");
+        toggle.className = "quote-toggle";
+        toggle.textContent = "···";
+        toggle.addEventListener("click", () => {
+          const wasHidden = container.classList.contains("quoted-hidden");
+          container.classList.toggle("quoted-hidden");
+          toggle.style.display = wasHidden ? "none" : "";
+          requestAnimationFrame(resize);
+        });
+        container.parentNode?.insertBefore(toggle, container);
+      }
+    };
+
     // Hide quoted content (Gmail blockquotes, .gmail_quote, etc.) behind "..."
     const quoteSelectors = [
       ".gmail_quote",
@@ -2747,25 +2884,24 @@ function HtmlEmailBody({
       ".yahoo_quoted",
       "#appendonsend",
       ".zmail_extra",
-      'div[id="divRplyFwdMsg"]',
     ];
     const quotes = doc.querySelectorAll(quoteSelectors.join(","));
     quotes.forEach((quote) => {
-      (quote as HTMLElement).classList.add("quoted-hidden");
-      const toggle = doc.createElement("button");
-      toggle.className = "quote-toggle";
-      toggle.textContent = "···";
-      toggle.addEventListener("click", () => {
-        const wasHidden = (quote as HTMLElement).classList.contains(
-          "quoted-hidden",
-        );
-        (quote as HTMLElement).classList.toggle("quoted-hidden");
-        toggle.style.display = wasHidden ? "none" : "";
-        // Recalculate iframe height after expanding/collapsing quoted content
-        requestAnimationFrame(resize);
-      });
-      quote.parentNode?.insertBefore(toggle, quote);
+      collapseElement(quote as HTMLElement);
     });
+
+    doc.querySelectorAll<HTMLElement>("blockquote").forEach((blockquote) => {
+      if (blockquote.closest(".quoted-hidden")) return;
+      if (!replyAttributionPattern.test(getNearbyPreviousText(blockquote))) {
+        return;
+      }
+      collapseElement(blockquote);
+    });
+
+    // Outlook/Word replies often have no quote class. They start the quoted
+    // history with a From/Sent/To/Subject header block, then put the old mail in
+    // ordinary sibling nodes. Collapse that whole tail as one quoted range.
+    collapseOutlookHeaderRanges();
 
     // ── Collapse signature blocks ──
     // Gmail signatures
@@ -2773,21 +2909,32 @@ function HtmlEmailBody({
       ".gmail_signature",
       '[data-smartmail="gmail_signature"]',
     ];
+    const shouldCollapseSignature = (sig: HTMLElement) => {
+      if (sig.closest(".quoted-hidden")) return false;
+      const text = normalizeText(sig.textContent);
+      if (!text) return false;
+
+      if (hasMeaningfulPreviousText(sig)) return true;
+
+      // Some senders accidentally wrap the whole new message in
+      // .gmail_signature. If the signature candidate is the first meaningful
+      // content and reads like body copy, leave it visible.
+      const startsLikeMessage =
+        /^(hi|hello|hey|dear|sure|thanks for|thank you|just to|what about|apologies|separately)\b/i.test(
+          text,
+        );
+      const hasBodyPunctuation = /[?.!]\s+\S/.test(text.slice(0, 500));
+      if (startsLikeMessage || (text.length > 600 && hasBodyPunctuation)) {
+        return false;
+      }
+
+      return true;
+    };
     const sigs = doc.querySelectorAll(sigSelectors.join(","));
     sigs.forEach((sig) => {
-      (sig as HTMLElement).classList.add("sig-collapsed");
-      const toggle = doc.createElement("button");
-      toggle.className = "sig-toggle";
-      toggle.textContent = "···";
-      toggle.addEventListener("click", () => {
-        const wasHidden = (sig as HTMLElement).classList.contains(
-          "sig-collapsed",
-        );
-        (sig as HTMLElement).classList.toggle("sig-collapsed");
-        toggle.style.display = wasHidden ? "none" : "";
-        requestAnimationFrame(resize);
-      });
-      sig.parentNode?.insertBefore(toggle, sig);
+      const el = sig as HTMLElement;
+      if (!shouldCollapseSignature(el)) return;
+      createToggle(el, "sig-toggle", "sig-collapsed");
     });
 
     // Detect "-- " signature separator in text nodes (standard email sig convention)
@@ -2803,7 +2950,7 @@ function HtmlEmailBody({
           break;
         }
       }
-      if (sigNode) {
+      if (sigNode && !sigNode.closest(".quoted-hidden")) {
         // Wrap the sig separator and all following siblings in a container
         const container = doc.createElement("div");
         container.className = "sig-collapsed";

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -2808,10 +2808,13 @@ function HtmlEmailBody({
       createToggle(el, "quote-toggle", "quoted-hidden");
     };
 
+    // Bounded quantifiers ([^\n]{1,200}?) keep these regexes linear-time
+    // even on adversarial email bodies — unbounded `.+?` over malicious
+    // pattern-like text triggers catastrophic backtracking.
     const outlookHeaderPattern =
-      /\bFrom:\s+.+?\bSent:\s+.+?\bTo:\s+.+?\bSubject:/i;
+      /\bFrom:\s+[^\n]{1,200}?\bSent:\s+[^\n]{1,200}?\bTo:\s+[^\n]{1,200}?\bSubject:/i;
     const replyAttributionPattern =
-      /(?:^|\s)(?:On .{3,300} wrote:|-{2,}\s*(?:Original|Forwarded)\s|From:\s+.+?\bSent:\s+.+?\bSubject:)/i;
+      /(?:^|\s)(?:On .{3,300} wrote:|-{2,}\s*(?:Original|Forwarded)\s|From:\s+[^\n]{1,200}?\bSent:\s+[^\n]{1,200}?\bSubject:)/i;
 
     const isOutlookHeader = (el: HTMLElement) => {
       const text = normalizeText(el.textContent);
@@ -2859,7 +2862,17 @@ function HtmlEmailBody({
         container.className = "quoted-hidden";
         start.parentNode.insertBefore(container, start);
         container.appendChild(start);
+        // Stop at an existing quoted-hidden/quote-toggle so we don't nest
+        // a later collapsed range inside this one. The closest() guard
+        // above handles already-wrapped starts; this protects siblings.
         while (container.nextSibling) {
+          const next = container.nextSibling as HTMLElement;
+          if (
+            next.classList?.contains?.("quote-toggle") ||
+            next.classList?.contains?.("quoted-hidden")
+          ) {
+            break;
+          }
           container.appendChild(container.nextSibling);
         }
 

--- a/templates/mail/app/components/email/InlineReplyComposer.tsx
+++ b/templates/mail/app/components/email/InlineReplyComposer.tsx
@@ -92,6 +92,7 @@ export const InlineReplyComposer = forwardRef<
   const { data: aliases = [] } = useAliases();
   const editorRef = useRef<ComposeEditorHandle>(null);
   const composerRef = useRef<HTMLDivElement>(null);
+  const sendingRef = useRef(false);
 
   useImperativeHandle(ref, () => ({
     focusEditor: () => {
@@ -150,10 +151,12 @@ export const InlineReplyComposer = forwardRef<
   const hasQuote = quotedContent.length > 0;
 
   const handleSend = async () => {
+    if (sendingRef.current) return;
     if (!draft.to.trim()) {
       toast.error("Please add at least one recipient");
       return;
     }
+    sendingRef.current = true;
 
     const draftSnapshot = { ...draft };
     const { savedDraftId } = draft;
@@ -183,6 +186,7 @@ export const InlineReplyComposer = forwardRef<
     const handleUndo = () => {
       if (cancelled) return;
       cancelled = true;
+      sendingRef.current = false;
       clearTimeout(sendTimer);
       clearTimeout(transitionTimer);
       toast.dismiss(toastId);
@@ -216,6 +220,7 @@ export const InlineReplyComposer = forwardRef<
           subject: draftSnapshot.subject,
           body: draftSnapshot.body,
           replyToId: draftSnapshot.replyToId,
+          replyToThreadId: draftSnapshot.replyToThreadId,
           accountEmail: draftSnapshot.accountEmail,
           attachments: draftSnapshot.attachments,
         },
@@ -224,6 +229,9 @@ export const InlineReplyComposer = forwardRef<
             toast.error("Failed to send email");
             const { id: _id, ...reopenData } = draftSnapshot;
             onReopen(reopenData);
+          },
+          onSettled: () => {
+            sendingRef.current = false;
           },
         },
       );
@@ -234,6 +242,7 @@ export const InlineReplyComposer = forwardRef<
     if (!composerRef.current?.contains(e.target as Node)) return;
     if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
       e.preventDefault();
+      e.stopPropagation();
       handleSend();
     }
     if (e.key === "Escape") {

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -33,10 +33,8 @@ import {
   IconMenu2,
   IconSettings,
   IconSearch,
-  IconPencil,
   IconCheck,
   IconPlus,
-  IconTool,
   IconRefresh,
   IconPin,
   IconPinnedFilled,
@@ -1016,18 +1014,7 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                 <TooltipContent>Refresh inbox</TooltipContent>
               </Tooltip>
 
-              {/* Extensions */}
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Link
-                    to="/extensions"
-                    className="flex h-9 w-9 sm:h-7 sm:w-7 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors shrink-0"
-                  >
-                    <IconTool className="h-4 w-4" />
-                  </Link>
-                </TooltipTrigger>
-                <TooltipContent>Extensions</TooltipContent>
-              </Tooltip>
+              <NotificationsBell />
 
               {/* Compose — prominent outline button */}
               <Tooltip>
@@ -1036,18 +1023,14 @@ function AppLayoutInner({ children }: AppLayoutProps) {
                     onClick={handleCompose}
                     variant="outline"
                     size="sm"
-                    className="h-9 sm:h-7 gap-1.5 px-2.5 text-[13px]"
+                    className="h-9 sm:h-7 px-3 text-[13px]"
                     aria-label="Compose email"
                   >
-                    <IconPencil className="h-3.5 w-3.5" />
                     <span>Compose</span>
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Compose (C)</TooltipContent>
               </Tooltip>
-
-              {/* Notifications — placed left of the avatar stack */}
-              <NotificationsBell />
 
               {/* Account avatars — overlapping stack like Figma */}
               {hasAccounts && (

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -648,6 +648,7 @@ export function useSendEmail() {
       subject: string;
       body: string;
       replyToId?: string;
+      replyToThreadId?: string;
       accountEmail?: string;
       attachments?: ComposeAttachment[];
     }) =>
@@ -667,7 +668,10 @@ export function useSendEmail() {
         ? cachedEmails.find((email) => email.id === data.replyToId)
         : undefined;
       const threadId =
-        replyTarget?.threadId || data.replyToId || makeTempId("thread");
+        data.replyToThreadId ||
+        replyTarget?.threadId ||
+        data.replyToId ||
+        makeTempId("thread");
 
       // Snapshot pre-send thread state so onError can roll back.
       const previousThread = getCachedThread(threadId);

--- a/templates/mail/server/lib/queued-drafts.ts
+++ b/templates/mail/server/lib/queued-drafts.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, or } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { writeAppState } from "@agent-native/core/application-state";
 import { getDbExec } from "@agent-native/core/db";
+import { notify } from "@agent-native/core/notifications";
 import {
   getAppProductionUrl,
   getRequestOrgId,
@@ -206,6 +207,30 @@ export async function createQueuedDraft(input: {
   };
 
   await getDb().insert(schema.queuedEmailDrafts).values(row);
+
+  // Best-effort notify the owner so they see a bell badge and can click
+  // through to review the draft. Self-queued drafts skip the notification.
+  if (ownerEmail !== ctx.userEmail) {
+    try {
+      const requesterLabel = input.requesterName?.trim() || ctx.userEmail;
+      await notify(
+        {
+          severity: "info",
+          title: "Email draft ready for review",
+          body: `${requesterLabel} queued a draft to ${row.toRecipients}: ${row.subject}`,
+          metadata: {
+            queuedDraftId: row.id,
+            requesterEmail: ctx.userEmail,
+            link: `/draft-queue/${encodeURIComponent(row.id)}`,
+          },
+        },
+        { owner: ownerEmail },
+      );
+    } catch (err) {
+      console.error("[queued-drafts] notify owner failed:", err);
+    }
+  }
+
   return serializeQueuedDraft(row);
 }
 


### PR DESCRIPTION
## Summary

- **core:** `NotificationsBell` — clicking a notification with `metadata.link` now navigates to that URL and marks the notification read. Notifications without a link keep the previous click-to-mark-read-only behavior.
- **mail:** thread / compose / reply composer + slash-menu polish; queued-drafts helper updates.

Changeset: `@agent-native/core` minor (additive — new click-to-link behavior).

## Test plan

- [ ] CI green
- [ ] Click a notification with a `metadata.link` → navigates + marks read
- [ ] Click a notification without a link → marks read only (unchanged)
- [ ] Mail thread / compose / reply / slash-menu work as before