### PR TITLE
feat(clips): extract video-storage-status hook + Builder OAuth callback redesign

### DIFF
--- a/.changeset/builder-callback-onbrand.md
+++ b/.changeset/builder-callback-onbrand.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Restyle the Builder connect callback / error pages to match the rest of the framework's UI — Inter font, neutral-zinc palette, and dark/light mode that follows the user's app theme (or `prefers-color-scheme`).

--- a/.changeset/fresh-builder-chat.md
+++ b/.changeset/fresh-builder-chat.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Route Dispatch overview prompts to Builder chat in Builder frames and keep the app agent sidebar collapsed there by default.

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -70,6 +70,10 @@ import { useLocation, useNavigate } from "react-router";
 import { cn } from "./utils.js";
 import { agentNativePath } from "./api-path.js";
 import { getFrameOrigin, isTrustedFrameMessage } from "./frame.js";
+import {
+  getInitialAgentSidebarOpen,
+  SIDEBAR_OPEN_KEY,
+} from "./agent-sidebar-state.js";
 
 // Lazy-load AgentTerminal to avoid bundling xterm.js when not needed
 const AgentTerminal = lazy(() =>
@@ -1245,7 +1249,6 @@ function AgentPanelInner({
 // ─── Resize handle ──────────────────────────────────────────────────────────
 
 const SIDEBAR_STORAGE_KEY = "agent-native-sidebar-width";
-const SIDEBAR_OPEN_KEY = "agent-native-sidebar-open";
 const SIDEBAR_FULLSCREEN_KEY = "agent-native-sidebar-fullscreen";
 const SIDEBAR_MIN = 280;
 const SIDEBAR_MAX = 700;
@@ -1584,21 +1587,9 @@ export function AgentSidebar({
   animateMobile = false,
 }: AgentSidebarProps) {
   const initialWidth = defaultSidebarWidth ?? sidebarWidth ?? 380;
-  const [open, setOpen] = useState(() => {
-    // On mobile viewports the sidebar would cover most of the screen, so
-    // always start closed regardless of any persisted desktop preference.
-    if (
-      typeof window !== "undefined" &&
-      window.matchMedia("(max-width: 767px)").matches
-    ) {
-      return false;
-    }
-    try {
-      const saved = localStorage.getItem(SIDEBAR_OPEN_KEY);
-      if (saved !== null) return saved === "true";
-    } catch {}
-    return defaultOpen;
-  });
+  const [open, setOpen] = useState(() =>
+    getInitialAgentSidebarOpen(defaultOpen),
+  );
   const [presentationMode, setPresentationMode] = useState(false);
   const [width, setWidth] = useState(initialWidth);
   const [fullscreen, setFullscreen] = useState(() => {

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1519,13 +1519,35 @@ function BuilderConnectCta({
 
 // ─── Builder Setup Card ─────────────────────────────────────────────────────
 
-function BuilderSetupCard({ onConnected }: { onConnected?: () => void }) {
+function BuilderSetupCard({
+  onConnected,
+  bouncePulse,
+}: {
+  onConnected?: () => void;
+  bouncePulse?: number;
+}) {
   const openSettings = useCallback(() => {
     window.dispatchEvent(new CustomEvent("agent-panel:open-settings"));
   }, []);
 
+  const cardRef = useRef<HTMLDivElement>(null);
+  // Replay the bounce keyframe each time bouncePulse increments. Toggling the
+  // class off-then-on (with a forced reflow) restarts the animation even when
+  // the value changes back-to-back.
+  useEffect(() => {
+    if (!bouncePulse) return;
+    const el = cardRef.current;
+    if (!el) return;
+    el.classList.remove("animate-bounce-once");
+    void el.offsetWidth;
+    el.classList.add("animate-bounce-once");
+  }, [bouncePulse]);
+
   return (
-    <div className="mx-4 my-6 rounded-lg border border-border bg-card p-5">
+    <div
+      ref={cardRef}
+      className="mx-4 my-6 rounded-lg border border-border bg-card p-5"
+    >
       <div className="flex items-center gap-3 mb-3">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted">
           <IconMessage className="h-4.5 w-4.5 text-muted-foreground" />
@@ -2981,7 +3003,10 @@ const AssistantChatInner = forwardRef<
                 </div>
               ) : missingApiKey && messages.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-full px-2">
-                  <BuilderSetupCard onConnected={handleBuilderConnected} />
+                  <BuilderSetupCard
+                    onConnected={handleBuilderConnected}
+                    bouncePulse={missingKeyBouncePulse}
+                  />
                 </div>
               ) : isRestoring ? (
                 <div className="flex flex-col gap-3 p-4">
@@ -3030,7 +3055,10 @@ const AssistantChatInner = forwardRef<
                     }}
                   />
                   {missingApiKey && (
-                    <BuilderSetupCard onConnected={handleBuilderConnected} />
+                    <BuilderSetupCard
+                      onConnected={handleBuilderConnected}
+                      bouncePulse={missingKeyBouncePulse}
+                    />
                   )}
                   {visibleLoopLimit && !showRunningInUI && (
                     <LoopLimitContinueCard
@@ -3144,7 +3172,17 @@ const AssistantChatInner = forwardRef<
             {composerSlot}
             <SelectionAttachedPill />
             {/* Input area */}
-            <div className="agent-composer-area shrink-0 px-3 py-2">
+            <div
+              className={cn(
+                "agent-composer-area shrink-0 px-3 py-2",
+                missingApiKey && "cursor-pointer opacity-70",
+              )}
+              onClick={
+                missingApiKey
+                  ? () => setMissingKeyBouncePulse((p) => p + 1)
+                  : undefined
+              }
+            >
               <ComposerPrimitive.Root
                 className={cn(
                   "flex flex-col rounded-lg border border-input bg-background focus-within:ring-1 focus-within:ring-ring",

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2101,6 +2101,9 @@ const AssistantChatInner = forwardRef<
   const isRuntimeRunning = thread.isRunning;
   const messages = thread.messages;
   const [missingApiKey, setMissingApiKey] = useState(false);
+  // Increments each time the user clicks the (disabled) composer while no LLM
+  // is connected — `BuilderSetupCard` watches this to replay a one-shot bounce.
+  const [missingKeyBouncePulse, setMissingKeyBouncePulse] = useState(0);
   const [authError, setAuthError] = useState<{
     sessionExpired?: boolean;
   } | null>(null);

--- a/packages/core/src/client/agent-sidebar-state.spec.ts
+++ b/packages/core/src/client/agent-sidebar-state.spec.ts
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const frameState = vi.hoisted(() => ({ inBuilderFrame: false }));
+
+vi.mock("./builder-frame.js", () => ({
+  isInBuilderFrame: () => frameState.inBuilderFrame,
+}));
+
+const { getInitialAgentSidebarOpen, SIDEBAR_OPEN_KEY } =
+  await import("./agent-sidebar-state.js");
+
+function stubMatchMedia(matches: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation(() => ({
+      matches,
+      media: "(max-width: 767px)",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+}
+
+describe("getInitialAgentSidebarOpen", () => {
+  beforeEach(() => {
+    frameState.inBuilderFrame = false;
+    window.localStorage.clear();
+    stubMatchMedia(false);
+  });
+
+  it("uses the provided default when there is no saved preference", () => {
+    expect(getInitialAgentSidebarOpen(true)).toBe(true);
+    expect(getInitialAgentSidebarOpen(false)).toBe(false);
+  });
+
+  it("uses the saved desktop preference outside Builder", () => {
+    window.localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
+    expect(getInitialAgentSidebarOpen(false)).toBe(true);
+
+    window.localStorage.setItem(SIDEBAR_OPEN_KEY, "false");
+    expect(getInitialAgentSidebarOpen(true)).toBe(false);
+  });
+
+  it("starts closed on mobile even with a saved open preference", () => {
+    window.localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
+    stubMatchMedia(true);
+
+    expect(getInitialAgentSidebarOpen(true)).toBe(false);
+  });
+
+  it("starts closed in Builder even with a saved open preference", () => {
+    window.localStorage.setItem(SIDEBAR_OPEN_KEY, "true");
+    frameState.inBuilderFrame = true;
+
+    expect(getInitialAgentSidebarOpen(true)).toBe(false);
+  });
+});

--- a/packages/core/src/client/agent-sidebar-state.ts
+++ b/packages/core/src/client/agent-sidebar-state.ts
@@ -1,0 +1,27 @@
+import { isInBuilderFrame } from "./builder-frame.js";
+
+export const SIDEBAR_OPEN_KEY = "agent-native-sidebar-open";
+
+export function getInitialAgentSidebarOpen(defaultOpen: boolean): boolean {
+  // On mobile viewports the sidebar would cover most of the screen, so
+  // always start closed regardless of any persisted desktop preference.
+  if (
+    typeof window !== "undefined" &&
+    window.matchMedia("(max-width: 767px)").matches
+  ) {
+    return false;
+  }
+
+  // Builder owns the code/chat surface around embedded apps. Start the
+  // app-native chat collapsed there even if a previous standalone session
+  // persisted it as open.
+  if (isInBuilderFrame()) {
+    return false;
+  }
+
+  try {
+    const saved = localStorage.getItem(SIDEBAR_OPEN_KEY);
+    if (saved !== null) return saved === "true";
+  } catch {}
+  return defaultOpen;
+}

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -293,6 +293,152 @@ export function resolveSafePreviewUrl(
   return getOrigin(event);
 }
 
+/**
+ * Inline theme-detection script that runs before the body paints. Reads the
+ * app's stored theme preference (same `localStorage.theme` key used by the
+ * client-side theme manager) and falls back to `prefers-color-scheme`. This
+ * way the popup matches whatever theme the user already picked in the app
+ * — light, dark, or auto — instead of always rendering in OS-default mode.
+ */
+const BUILDER_CALLBACK_THEME_SCRIPT = `<script>
+(function () {
+  try {
+    var stored = window.localStorage && window.localStorage.getItem("theme");
+    var resolved;
+    if (stored === "light" || stored === "dark") {
+      resolved = stored;
+    } else {
+      var mq = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)");
+      resolved = mq && mq.matches ? "dark" : "light";
+    }
+    document.documentElement.classList.add(resolved);
+    document.documentElement.style.colorScheme = resolved;
+  } catch (e) {}
+})();
+</script>`;
+
+/**
+ * Brand-aligned CSS for the Builder connect callback / error pages.
+ *
+ * Uses the same neutral-zinc palette and Inter font as the rest of the
+ * framework's templates (see `templates/*\/app/global.css`). Tokens map to
+ * the same HSL values the templates set on `:root` / `.dark`, so the popup
+ * reads as part of the same app — not a stranded marketing page.
+ */
+const BUILDER_CALLBACK_BASE_CSS = `
+  :root {
+    --bg: hsl(0 0% 100%);
+    --fg: hsl(220 10% 10%);
+    --muted-fg: hsl(220 5% 45%);
+    --card: hsl(0 0% 100%);
+    --border: hsl(220 10% 90%);
+    --primary: hsl(220 10% 15%);
+    --primary-fg: hsl(0 0% 100%);
+    --primary-hover: hsl(220 10% 25%);
+    --success-bg: hsl(143 50% 96%);
+    --success-fg: hsl(143 60% 32%);
+    --error-fg: hsl(0 75% 45%);
+    --error-bg: hsl(0 80% 97%);
+    --error-border: hsl(0 80% 92%);
+  }
+  :root.dark {
+    --bg: hsl(220 6% 6%);
+    --fg: hsl(0 0% 92%);
+    --muted-fg: hsl(220 4% 60%);
+    --card: hsl(220 5% 8%);
+    --border: hsl(220 4% 14%);
+    --primary: hsl(0 0% 92%);
+    --primary-fg: hsl(220 6% 6%);
+    --primary-hover: hsl(0 0% 75%);
+    --success-bg: hsl(143 30% 12%);
+    --success-fg: hsl(143 50% 70%);
+    --error-fg: hsl(0 80% 75%);
+    --error-bg: hsl(0 35% 12%);
+    --error-border: hsl(0 30% 20%);
+  }
+  *, *::before, *::after { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.55;
+    font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    padding: 24px;
+  }
+  .card {
+    width: min(420px, 100%);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 32px 28px;
+    background: var(--card);
+    text-align: center;
+  }
+  .icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border-radius: 999px;
+    margin-bottom: 16px;
+  }
+  .icon svg { width: 22px; height: 22px; display: block; }
+  .icon-success { background: var(--success-bg); color: var(--success-fg); }
+  .icon-error { background: var(--error-bg); color: var(--error-fg); }
+  h1 {
+    margin: 0 0 6px;
+    font-size: 17px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--fg);
+  }
+  p {
+    margin: 0 0 4px;
+    color: var(--fg);
+    font-size: 14px;
+  }
+  p.muted { color: var(--muted-fg); }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 36px;
+    padding: 0 16px;
+    margin-top: 20px;
+    background: var(--primary);
+    color: var(--primary-fg);
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none;
+    border: none;
+    cursor: pointer;
+  }
+  .btn:hover { background: var(--primary-hover); }
+  pre.error-detail {
+    margin: 16px 0 0;
+    padding: 10px 12px;
+    background: var(--error-bg);
+    border: 1px solid var(--error-border);
+    border-radius: 8px;
+    color: var(--error-fg);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    text-align: left;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+`;
+
 export function createBuilderBrowserCallbackPage(previewUrl: string): string {
   const escapedUrl = JSON.stringify(previewUrl);
   return `<!doctype html>
@@ -300,38 +446,22 @@ export function createBuilderBrowserCallbackPage(previewUrl: string): string {
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
-    <title>Builder Connected</title>
-    <style>
-      body {
-        margin: 0;
-        min-height: 100vh;
-        display: grid;
-        place-items: center;
-        background:
-          radial-gradient(circle at top, rgba(20, 184, 166, 0.18), transparent 38%),
-          linear-gradient(180deg, #f7fafc 0%, #eef2f7 100%);
-        color: #0f172a;
-        font: 14px/1.5 ui-sans-serif, system-ui, sans-serif;
-      }
-      .card {
-        width: min(460px, calc(100vw - 32px));
-        border: 1px solid rgba(15, 23, 42, 0.08);
-        border-radius: 18px;
-        padding: 28px;
-        background: rgba(255, 255, 255, 0.92);
-        box-shadow: 0 24px 80px rgba(15, 23, 42, 0.12);
-      }
-      h1 { margin: 0 0 8px; font-size: 22px; }
-      p { margin: 0 0 12px; color: #475569; }
-      a { color: #0f766e; font-weight: 600; }
-    </style>
+    <title>Builder connected</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+    ${BUILDER_CALLBACK_THEME_SCRIPT}
+    <style>${BUILDER_CALLBACK_BASE_CSS}</style>
   </head>
   <body>
-    <main class="card">
+    <main class="card" role="status" aria-live="polite">
+      <span class="icon icon-success" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+      </span>
       <h1>Builder connected</h1>
-      <p>Browser access is now available to your agent-native app.</p>
-      <p>You can close this tab and return to the workspace.</p>
-      <p><a href=${escapedUrl} target="_blank" rel="noopener noreferrer">Open the workspace</a></p>
+      <p>Browser access is now available to your app.</p>
+      <p class="muted">You can close this tab and return to the workspace.</p>
+      <a class="btn" href=${escapedUrl}>Open the workspace</a>
     </main>
     <script>
       // If we're a popup opened by the app, close ourselves and let the

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -503,48 +503,21 @@ export function createBuilderBrowserCallbackErrorPage(message: string): string {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
     <title>Builder connect failed</title>
-    <style>
-      body {
-        margin: 0;
-        min-height: 100vh;
-        display: grid;
-        place-items: center;
-        background:
-          radial-gradient(circle at top, rgba(244, 63, 94, 0.14), transparent 38%),
-          linear-gradient(180deg, #f7fafc 0%, #eef2f7 100%);
-        color: #0f172a;
-        font: 14px/1.5 ui-sans-serif, system-ui, sans-serif;
-      }
-      .card {
-        width: min(460px, calc(100vw - 32px));
-        border: 1px solid rgba(15, 23, 42, 0.08);
-        border-radius: 18px;
-        padding: 28px;
-        background: rgba(255, 255, 255, 0.92);
-        box-shadow: 0 24px 80px rgba(15, 23, 42, 0.12);
-      }
-      h1 { margin: 0 0 8px; font-size: 22px; color: #b91c1c; }
-      p { margin: 0 0 12px; color: #475569; }
-      pre {
-        margin: 0 0 12px;
-        padding: 10px 12px;
-        background: #fef2f2;
-        border: 1px solid #fecaca;
-        border-radius: 8px;
-        color: #991b1b;
-        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-        font-size: 12px;
-        white-space: pre-wrap;
-        word-break: break-word;
-      }
-    </style>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+    ${BUILDER_CALLBACK_THEME_SCRIPT}
+    <style>${BUILDER_CALLBACK_BASE_CSS}</style>
   </head>
   <body>
-    <main class="card">
+    <main class="card" role="alert" aria-live="assertive">
+      <span class="icon icon-error" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
+      </span>
       <h1>Couldn't save Builder connection</h1>
-      <p>Builder authorized your account but the server couldn't persist the credentials.</p>
-      <pre id="msg"></pre>
-      <p>You can close this tab and try again from settings. The connect dialog has the same error so you can copy it.</p>
+      <p class="muted">Builder authorized your account but the server couldn't persist the credentials.</p>
+      <pre class="error-detail" id="msg"></pre>
+      <p class="muted" style="margin-top:12px">You can close this tab and try again from settings.</p>
     </main>
     <script>
       try {

--- a/packages/core/src/styles/agent-native.css
+++ b/packages/core/src/styles/agent-native.css
@@ -80,6 +80,7 @@
 
   --animate-accordion-down: accordion-down 0.2s ease-out;
   --animate-accordion-up: accordion-up 0.2s ease-out;
+  --animate-bounce-once: bounce-once 0.55s cubic-bezier(0.34, 1.56, 0.64, 1);
 
   @keyframes accordion-down {
     from {
@@ -95,6 +96,20 @@
     }
     to {
       height: 0;
+    }
+  }
+  @keyframes bounce-once {
+    0% {
+      transform: translateY(0);
+    }
+    35% {
+      transform: translateY(-8px);
+    }
+    65% {
+      transform: translateY(-2px);
+    }
+    100% {
+      transform: translateY(0);
     }
   }
 }

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -47,33 +47,148 @@ if (IS_DEV) {
 
 let pendingDeepLink: string | null = null;
 const PENDING_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
-const pendingOAuthStates = new Map<string, number>();
+
+interface OAuthInjectionTarget {
+  appId?: string | null;
+  origin?: string | null;
+  session?: Electron.Session;
+}
+
+interface PendingOAuthState extends OAuthInjectionTarget {
+  expiresAt: number;
+}
+
+const pendingOAuthStates = new Map<string, PendingOAuthState>();
 
 function prunePendingOAuthStates(now = Date.now()) {
-  for (const [state, expiresAt] of pendingOAuthStates) {
-    if (expiresAt <= now) pendingOAuthStates.delete(state);
+  for (const [state, pending] of pendingOAuthStates) {
+    if (pending.expiresAt <= now) pendingOAuthStates.delete(state);
   }
 }
 
-function rememberOAuthState(url: string) {
+function extractAppFromOAuthState(state: string | null): string | undefined {
+  if (!state) return undefined;
+  try {
+    const dotIdx = state.lastIndexOf(".");
+    if (dotIdx === -1) return undefined;
+    const data = state.slice(0, dotIdx);
+    const parsed = JSON.parse(Buffer.from(data, "base64url").toString());
+    return typeof parsed.app === "string" ? parsed.app : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getCookieNameForApp(id: string | null | undefined): string {
+  const slug = (id ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return slug ? `an_session_${slug}` : "an_session";
+}
+
+function getAppOrigin(appConfig: AppConfig): string | null {
+  const isProdMode = appConfig.mode !== "dev";
+  const rawUrl = isProdMode
+    ? appConfig.url
+    : appConfig.devUrl || `http://localhost:${appConfig.devPort}`;
+  if (!rawUrl) return null;
+  try {
+    return new URL(rawUrl).origin;
+  } catch {
+    return null;
+  }
+}
+
+function loadAppsForAuthContext(): AppConfig[] {
+  try {
+    return AppStore.loadApps();
+  } catch (err) {
+    console.error("[main] failed to load apps for auth context:", err);
+    return [];
+  }
+}
+
+function findAppForSourceUrl(sourceUrl: string | undefined): AppConfig | null {
+  if (!sourceUrl) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(sourceUrl);
+  } catch {
+    return null;
+  }
+
+  const frameAppId = parsed.searchParams.get("app");
+  const apps = loadAppsForAuthContext();
+  if (frameAppId) {
+    const match = apps.find((appConfig) => appConfig.id === frameAppId);
+    if (match) return match;
+  }
+
+  return (
+    apps.find((appConfig) => getAppOrigin(appConfig) === parsed.origin) ?? null
+  );
+}
+
+function getInjectionTargetForAppId(
+  appId: string | null | undefined,
+): OAuthInjectionTarget | null {
+  if (!appId) return null;
+  const appConfig = loadAppsForAuthContext().find((app) => app.id === appId);
+  if (!appConfig) return null;
+  return {
+    appId: appConfig.id,
+    origin: getAppOrigin(appConfig),
+    session: session.fromPartition(`persist:app-${appConfig.id}`),
+  };
+}
+
+function getOAuthInjectionTarget(
+  sourceSession: Electron.Session | undefined,
+  sourceUrl: string | undefined,
+): OAuthInjectionTarget {
+  const appConfig = findAppForSourceUrl(sourceUrl);
+  let origin: string | null = null;
+  if (sourceUrl) {
+    try {
+      origin = new URL(sourceUrl).origin;
+    } catch {
+      origin = null;
+    }
+  }
+  return {
+    appId: appConfig?.id ?? null,
+    origin: appConfig ? getAppOrigin(appConfig) : origin,
+    session: sourceSession,
+  };
+}
+
+function rememberOAuthState(url: string, target?: OAuthInjectionTarget) {
   try {
     const state = new URL(url).searchParams.get("state");
     if (!state) return;
     prunePendingOAuthStates();
-    pendingOAuthStates.set(state, Date.now() + PENDING_OAUTH_STATE_TTL_MS);
+    const existing = pendingOAuthStates.get(state);
+    pendingOAuthStates.set(state, {
+      ...existing,
+      ...target,
+      appId:
+        target?.appId ?? existing?.appId ?? extractAppFromOAuthState(state),
+      expiresAt: Date.now() + PENDING_OAUTH_STATE_TTL_MS,
+    });
   } catch {
     // Malformed URL — ignore
   }
 }
 
-function consumeOAuthState(state: string | null): boolean {
-  if (!state) return false;
+function consumeOAuthState(state: string | null): OAuthInjectionTarget | null {
+  if (!state) return null;
   const now = Date.now();
   prunePendingOAuthStates(now);
-  const expiresAt = pendingOAuthStates.get(state);
-  if (!expiresAt || expiresAt <= now) return false;
+  const pending = pendingOAuthStates.get(state);
+  if (!pending || pending.expiresAt <= now) return null;
   pendingOAuthStates.delete(state);
-  return true;
+  return pending;
 }
 
 async function handleDeepLink(url: string) {
@@ -82,13 +197,21 @@ async function handleDeepLink(url: string) {
     if (parsed.host === "oauth-complete") {
       const token = parsed.searchParams.get("token");
       if (token) {
-        if (!consumeOAuthState(parsed.searchParams.get("state"))) {
+        const state = parsed.searchParams.get("state");
+        const pendingTarget = consumeOAuthState(state);
+        if (!pendingTarget) {
           console.warn(
             "[main] rejected oauth-complete deep link without matching OAuth state",
           );
           return;
         }
-        await injectSessionAndReload(token);
+        const stateTarget = getInjectionTargetForAppId(
+          extractAppFromOAuthState(state),
+        );
+        await injectSessionAndReload(token, {
+          ...stateTarget,
+          ...pendingTarget,
+        });
       } else {
         reloadAllWebviews();
       }
@@ -98,75 +221,36 @@ async function handleDeepLink(url: string) {
   }
 }
 
-async function injectSessionAndReload(token: string) {
-  // Each webview runs in its own persisted partition (persist:app-<id>), so
-  // cookies must be written to every known app partition — not just the
-  // active webviews and not session.defaultSession. Otherwise apps that
-  // haven't been opened yet (e.g. Calendar when only Mail is visible at
-  // login) won't pick up the session cookie.
-  const frameOrigin = `http://localhost:${FRAME_PORT}`;
-  let apps: AppConfig[] = [];
-  try {
-    apps = AppStore.loadApps();
-  } catch (err) {
-    console.error("[main] failed to load apps for session injection:", err);
-  }
-  // Per-app cookie name. The framework derives session cookies from APP_NAME
-  // (e.g. an_session_mail, an_session_calendar) so apps don't share one cookie
-  // slot on localhost — browsers scope cookies by host, not host+port. Mirror
-  // that here so each partition gets the right cookie.
-  const cookieNameForApp = (id: string) => {
-    const slug = id
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "_")
-      .replace(/^_+|_+$/g, "");
-    return slug ? `an_session_${slug}` : "an_session";
-  };
+async function injectSessionAndReload(
+  token: string,
+  target: OAuthInjectionTarget,
+) {
+  // Production apps have separate auth databases. A token minted by Mail does
+  // not resolve in Calendar, so the desktop handoff must only update the app
+  // that initiated OAuth. The app-specific cookie name still matters on
+  // localhost because cookies are scoped by host, not host+port.
   const targets: {
     session: Electron.Session;
     origin: string;
     cookieName: string;
   }[] = [];
-  for (const appConfig of apps) {
-    const sess = session.fromPartition(`persist:app-${appConfig.id}`);
-    // Dev-mode apps load through the frame (localhost:3334); prod-mode apps
-    // load their production URL directly. Set the cookie on whichever origin
-    // the app actually talks to. Dev-mode always gets the frame origin;
-    // prod-mode gets the configured URL if available.
-    const isProdMode = appConfig.mode !== "dev";
-    let origin = frameOrigin;
-    if (isProdMode && appConfig.url) {
-      try {
-        origin = new URL(appConfig.url).origin;
-      } catch (err) {
-        console.error(
-          `[main] invalid production URL for ${appConfig.id} (${appConfig.url}); falling back to frame origin:`,
-          err,
-        );
-      }
+
+  const targetFromAppId = getInjectionTargetForAppId(target.appId);
+  const sess = target.session ?? targetFromAppId?.session;
+  const origin = target.origin ?? targetFromAppId?.origin;
+  if (sess && origin) {
+    const primaryCookieName = getCookieNameForApp(target.appId);
+    targets.push({ session: sess, origin, cookieName: primaryCookieName });
+    // Older deployed apps may still look for the unsuffixed legacy cookie.
+    if (primaryCookieName !== "an_session") {
+      targets.push({ session: sess, origin, cookieName: "an_session" });
     }
-    targets.push({
-      session: sess,
-      origin,
-      cookieName: cookieNameForApp(appConfig.id),
-    });
+  } else {
+    console.warn("[main] OAuth handoff had no resolvable target; reloading");
+    reloadAllWebviews();
+    return;
   }
-  // Also cover any currently-live webview origins not matched above
-  // (e.g. production URLs). For unknown origins we don't know which app they
-  // belong to, so set the legacy cookie name as a fallback.
-  const seen = new Set<string>(
-    targets.map((t) => `${t.origin}|${t.cookieName}`),
-  );
-  for (const wc of webContents.getAllWebContents()) {
-    if (wc.getType() !== "webview") continue;
-    try {
-      const origin = new URL(wc.getURL()).origin;
-      const key = `${origin}|an_session`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      targets.push({ session: wc.session, origin, cookieName: "an_session" });
-    } catch {}
-  }
+
   for (const { session: sess, origin, cookieName } of targets) {
     try {
       await sess.cookies.set({
@@ -184,11 +268,42 @@ async function injectSessionAndReload(token: string) {
       );
     }
   }
-  reloadAllWebviews();
+  reloadWebviewsForTarget({ ...targetFromAppId, ...target });
   const win = BrowserWindow.getAllWindows()[0];
   if (win) {
     if (win.isMinimized()) win.restore();
     win.focus();
+  }
+}
+
+function reloadWebviewsForTarget(target: OAuthInjectionTarget) {
+  const targetSession = target.session;
+  const targetAppId = target.appId;
+  const targetOrigin = target.origin;
+  let reloaded = false;
+
+  for (const wc of webContents.getAllWebContents()) {
+    if (wc.getType() !== "webview") continue;
+    if (targetSession && wc.session === targetSession) {
+      wc.reload();
+      reloaded = true;
+      continue;
+    }
+    try {
+      const url = new URL(wc.getURL());
+      const appId = url.searchParams.get("app");
+      if (
+        (targetAppId && appId === targetAppId) ||
+        (targetOrigin && url.origin === targetOrigin)
+      ) {
+        wc.reload();
+        reloaded = true;
+      }
+    } catch {}
+  }
+
+  if (!reloaded) {
+    console.warn("[main] OAuth handoff target had no live webview to reload");
   }
 }
 
@@ -838,11 +953,12 @@ function shouldRememberOAuthStateFromNavigation(
 function rememberOAuthStateFromNavigation(
   provider: OAuthProvider,
   url: string,
+  target?: OAuthInjectionTarget,
 ) {
   try {
     const parsed = new URL(url);
     if (shouldRememberOAuthStateFromNavigation(provider, parsed)) {
-      rememberOAuthState(url);
+      rememberOAuthState(url, target);
     }
   } catch {
     // Malformed URL — ignore
@@ -853,8 +969,10 @@ function openOAuthWindow(
   url: string,
   sourceSession: Electron.Session | undefined,
   provider: OAuthProvider,
+  sourceUrl?: string,
 ) {
-  rememberOAuthStateFromNavigation(provider, url);
+  const injectionTarget = getOAuthInjectionTarget(sourceSession, sourceUrl);
+  rememberOAuthStateFromNavigation(provider, url, injectionTarget);
   const mainWin = BrowserWindow.getAllWindows()[0];
 
   // Critical: the popup MUST share the source webview's session so the
@@ -899,7 +1017,7 @@ function openOAuthWindow(
   const onNavigate = (_event: Electron.Event, navUrl: string) => {
     try {
       const parsed = new URL(navUrl);
-      rememberOAuthStateFromNavigation(provider, navUrl);
+      rememberOAuthStateFromNavigation(provider, navUrl, injectionTarget);
       // Detect the OAuth callback (works for both /api/google/callback and
       // /_agent-native/google/callback).
       if (parsed.pathname.includes(provider.callbackPathFragment)) {
@@ -956,7 +1074,12 @@ function openOAuthFromWebviewNavigation(
       sourceUrl: sourceContents.getURL(),
     });
     if (!provider) return false;
-    openOAuthWindow(url, sourceContents.session, provider);
+    openOAuthWindow(
+      url,
+      sourceContents.session,
+      provider,
+      sourceContents.getURL(),
+    );
     return true;
   } catch {
     return false;
@@ -997,7 +1120,7 @@ app.on("web-contents-created", (_event, contents) => {
           }
           const provider = matchOAuthProvider(url, { sourceUrl: wc.getURL() });
           if (provider) {
-            openOAuthWindow(url, wc.session, provider);
+            openOAuthWindow(url, wc.session, provider, wc.getURL());
           } else {
             shell.openExternal(url).catch(() => {});
           }
@@ -1022,7 +1145,7 @@ app.on("web-contents-created", (_event, contents) => {
         sourceUrl: contents.getURL(),
       });
       if (provider) {
-        openOAuthWindow(url, contents.session, provider);
+        openOAuthWindow(url, contents.session, provider, contents.getURL());
       } else {
         shell.openExternal(url).catch(() => {});
       }

--- a/packages/dispatch/src/lib/overview-chat.spec.ts
+++ b/packages/dispatch/src/lib/overview-chat.spec.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const frameState = vi.hoisted(() => ({ inBuilderFrame: false }));
+const sendToAgentChatMock = vi.hoisted(() => vi.fn(() => "chat-tab"));
+
+vi.mock("@agent-native/core/client", () => ({
+  isInBuilderFrame: () => frameState.inBuilderFrame,
+  sendToAgentChat: sendToAgentChatMock,
+}));
+
+const { submitOverviewPrompt } = await import("./overview-chat.js");
+
+describe("submitOverviewPrompt", () => {
+  beforeEach(() => {
+    frameState.inBuilderFrame = false;
+    sendToAgentChatMock.mockClear();
+  });
+
+  it("sends overview prompts to a new local agent tab outside Builder", () => {
+    const tabId = submitOverviewPrompt(" build a metrics app ", "auto");
+
+    expect(tabId).toBe("chat-tab");
+    expect(sendToAgentChatMock).toHaveBeenCalledWith({
+      message: "build a metrics app",
+      submit: true,
+      newTab: true,
+      model: "auto",
+    });
+  });
+
+  it("routes overview prompts to Builder chat inside Builder", () => {
+    frameState.inBuilderFrame = true;
+
+    const tabId = submitOverviewPrompt("ship the onboarding flow", "auto");
+
+    expect(tabId).toBe("chat-tab");
+    expect(sendToAgentChatMock).toHaveBeenCalledWith({
+      message: "ship the onboarding flow",
+      submit: true,
+      type: "code",
+    });
+  });
+
+  it("ignores empty prompts", () => {
+    expect(submitOverviewPrompt("   ", "auto")).toBeNull();
+    expect(sendToAgentChatMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dispatch/src/lib/overview-chat.ts
+++ b/packages/dispatch/src/lib/overview-chat.ts
@@ -1,0 +1,24 @@
+import { isInBuilderFrame, sendToAgentChat } from "@agent-native/core/client";
+
+export function submitOverviewPrompt(
+  message: string,
+  selectedModel?: string | null,
+): string | null {
+  const trimmed = message.trim();
+  if (!trimmed) return null;
+
+  if (isInBuilderFrame()) {
+    return sendToAgentChat({
+      message: trimmed,
+      submit: true,
+      type: "code",
+    });
+  }
+
+  return sendToAgentChat({
+    message: trimmed,
+    submit: true,
+    newTab: true,
+    model: selectedModel || undefined,
+  });
+}

--- a/packages/dispatch/src/routes/pages/overview.tsx
+++ b/packages/dispatch/src/routes/pages/overview.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router";
 import {
   PromptComposer,
-  sendToAgentChat,
   useActionQuery,
   useChatModels,
   agentNativePath,
@@ -34,6 +33,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { submitOverviewPrompt } from "@/lib/overview-chat";
 
 interface IntegrationStatus {
   platform: string;
@@ -99,12 +99,7 @@ function HomeChatPanel() {
   const { selectedModel } = useChatModels();
 
   const send = (message: string) => {
-    sendToAgentChat({
-      message,
-      submit: true,
-      newTab: true,
-      model: selectedModel || undefined,
-    });
+    submitOverviewPrompt(message, selectedModel);
   };
 
   return (

--- a/packages/dispatch/src/routes/pages/overview.tsx
+++ b/packages/dispatch/src/routes/pages/overview.tsx
@@ -109,7 +109,7 @@ function HomeChatPanel() {
 
   return (
     <section className="px-2 py-6 sm:py-10">
-      <div className="mx-auto w-full max-w-2xl space-y-5">
+      <div className="mx-auto w-full max-w-2xl space-y-8">
         <h1 className="text-center text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
           What should we do next?
         </h1>

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/hooks/use-library";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useDesktopPromo } from "@/hooks/use-desktop-promo";
+import { usePrefetchVideoStorageStatus } from "@/hooks/use-video-storage-status";
 import { FolderTree, type FolderNode } from "./folder-tree";
 import { SearchBar } from "./search-bar";
 import { OrganizationSwitcher } from "./organization-switcher";
@@ -82,6 +83,7 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
   }>();
 
   const { shouldShowPromo, shouldShowSidebarLink, dismiss } = useDesktopPromo();
+  usePrefetchVideoStorageStatus();
   const { session } = useSession();
   const currentUserEmail = session?.email ?? null;
 

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -248,10 +248,10 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
               </nav>
 
               {shouldShowSidebarLink && (
-                <div className="mt-3 px-2">
+                <div className="mt-1 px-2">
                   <NavLink
                     to="/download"
-                    className="flex items-center gap-2 rounded px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+                    className="flex items-center gap-2 rounded px-2 py-1.5 text-xs text-foreground hover:bg-accent/60"
                   >
                     <IconAppWindow className="h-4 w-4" />
                     Get desktop app

--- a/templates/clips/app/hooks/use-desktop-promo.ts
+++ b/templates/clips/app/hooks/use-desktop-promo.ts
@@ -4,7 +4,16 @@ const DISMISSED_KEY = "clips.desktop-promo.dismissed";
 
 function detectDesktopApp(): boolean {
   if (typeof navigator === "undefined") return false;
-  return /Electron/i.test(navigator.userAgent);
+  if (/Electron/i.test(navigator.userAgent)) return true;
+  // Tauri v2 exposes `__TAURI_INTERNALS__` on window; v1 used `__TAURI__`.
+  if (typeof window !== "undefined") {
+    const w = window as unknown as {
+      __TAURI_INTERNALS__?: unknown;
+      __TAURI__?: unknown;
+    };
+    if (w.__TAURI_INTERNALS__ || w.__TAURI__) return true;
+  }
+  return false;
 }
 
 export function useDesktopPromo() {

--- a/templates/clips/app/hooks/use-video-storage-status.ts
+++ b/templates/clips/app/hooks/use-video-storage-status.ts
@@ -1,0 +1,66 @@
+import { useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { agentNativePath } from "@agent-native/core/client";
+
+export interface VideoStorageStatus {
+  configured: boolean;
+  activeProvider?: { id: string; name: string } | null;
+  builderConfigured?: boolean;
+}
+
+export const VIDEO_STORAGE_STATUS_KEY = [
+  "clips",
+  "video-storage-status",
+] as const;
+
+export async function fetchVideoStorageStatus(): Promise<VideoStorageStatus> {
+  let uploadStatus: VideoStorageStatus | null = null;
+  try {
+    const r = await fetch(agentNativePath("/_agent-native/file-upload/status"));
+    uploadStatus = r.ok ? ((await r.json()) as VideoStorageStatus) : null;
+    if (uploadStatus?.configured) return uploadStatus;
+  } catch {
+    // Fall through to the Builder status check.
+  }
+
+  try {
+    const r = await fetch(agentNativePath("/_agent-native/builder/status"));
+    const builderStatus = r.ok
+      ? ((await r.json()) as { configured?: boolean })
+      : null;
+    if (builderStatus?.configured) {
+      return {
+        configured: true,
+        activeProvider: { id: "builder", name: "Builder.io" },
+        builderConfigured: true,
+      };
+    }
+  } catch {
+    // Treat an unreachable status route as not configured.
+  }
+
+  return {
+    configured: false,
+    activeProvider: uploadStatus?.activeProvider ?? null,
+    builderConfigured: uploadStatus?.builderConfigured ?? false,
+  };
+}
+
+export function useVideoStorageStatus() {
+  return useQuery({
+    queryKey: VIDEO_STORAGE_STATUS_KEY,
+    queryFn: fetchVideoStorageStatus,
+    staleTime: 60_000,
+  });
+}
+
+export function usePrefetchVideoStorageStatus() {
+  const qc = useQueryClient();
+  useEffect(() => {
+    qc.prefetchQuery({
+      queryKey: VIDEO_STORAGE_STATUS_KEY,
+      queryFn: fetchVideoStorageStatus,
+      staleTime: 60_000,
+    });
+  }, [qc]);
+}

--- a/templates/clips/app/routes/_app.dictate.tsx
+++ b/templates/clips/app/routes/_app.dictate.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router";
 import { toast } from "sonner";
 import {
   IconArrowsExchange,
@@ -7,6 +8,7 @@ import {
   IconCommand,
   IconCopy,
   IconDeviceDesktop,
+  IconDownload,
   IconKeyboard,
   IconLoader2,
   IconMicrophone2,
@@ -31,6 +33,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useDesktopPromo } from "@/hooks/use-desktop-promo";
 
 export function meta() {
   return [{ title: "Dictate · Clips" }];

--- a/templates/clips/app/routes/_app.dictate.tsx
+++ b/templates/clips/app/routes/_app.dictate.tsx
@@ -583,7 +583,7 @@ function DictationRow({ dictation }: { dictation: Dictation }) {
   );
 }
 
-function EmptyState() {
+function EmptyState({ isDesktopApp }: { isDesktopApp: boolean }) {
   return (
     <div className="rounded-xl border border-dashed border-border bg-gradient-to-br from-accent/30 via-transparent to-transparent px-6 py-16 text-center">
       <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-foreground text-background">
@@ -592,22 +592,64 @@ function EmptyState() {
       <p className="mt-4 text-base font-medium text-foreground">
         Start your first dictation
       </p>
-      <p className="mt-1 text-xs text-muted-foreground max-w-sm mx-auto leading-relaxed">
-        Start browser dictation here, or use the desktop app for global
-        shortcuts. Your history will live here.
-      </p>
-      <div className="mt-5 flex items-center justify-center gap-3 text-xs text-muted-foreground">
-        <span className="inline-flex items-center gap-1.5">
-          <IconMicrophone2 className="h-3.5 w-3.5" />
-          <span>browser</span>
-        </span>
-        <span className="text-muted-foreground/40">or</span>
-        <span className="inline-flex items-center gap-1.5">
-          <Kbd>⌘</Kbd>
+      {isDesktopApp ? (
+        <>
+          <p className="mt-1 text-xs text-muted-foreground max-w-sm mx-auto leading-relaxed">
+            Hold <Kbd>Fn</Kbd> anywhere on your Mac, or press <Kbd>⌘</Kbd>
+            <Kbd>⇧</Kbd>
+            <Kbd>Space</Kbd>. Your history will live here.
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="mt-1 text-xs text-muted-foreground max-w-sm mx-auto leading-relaxed">
+            Dictation runs through the desktop app for global shortcuts that
+            work in any app — Slack, your editor, anywhere.
+          </p>
+          <div className="mt-5 flex items-center justify-center">
+            <Button asChild size="sm" className="gap-1.5">
+              <Link to="/download">
+                <IconDownload className="h-3.5 w-3.5" />
+                Download Clips desktop app
+              </Link>
+            </Button>
+          </div>
+          <div className="mt-3 flex items-center justify-center gap-2 text-xs text-muted-foreground">
+            <Kbd>Fn</Kbd>
+            <span className="text-muted-foreground/60">hold to dictate</span>
+            <span className="text-muted-foreground/40">·</span>
+            <Kbd>⌘</Kbd>
+            <Kbd>⇧</Kbd>
+            <Kbd>Space</Kbd>
+            <span className="text-muted-foreground/60">toggle</span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function DownloadDesktopAppCard() {
+  return (
+    <div className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-accent/20 px-4 py-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <IconDeviceDesktop className="h-4 w-4 text-foreground" />
+          Dictate from anywhere with the desktop app
+        </div>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+          Hold <Kbd>Fn</Kbd> or press <Kbd>⌘</Kbd>
           <Kbd>⇧</Kbd>
-          <Kbd>Space</Kbd>
-        </span>
+          <Kbd>Space</Kbd> in any app. Browser dictation is unreliable — the
+          desktop app is the way to use this.
+        </p>
       </div>
+      <Button asChild size="sm" className="gap-1.5">
+        <Link to="/download">
+          <IconDownload className="h-3.5 w-3.5" />
+          Download
+        </Link>
+      </Button>
     </div>
   );
 }
@@ -617,6 +659,7 @@ export default function DictateRoute() {
     { dictations: Dictation[] } | Dictation[] | undefined
   >("list-dictations", {}, { retry: false });
 
+  const { isDesktopApp } = useDesktopPromo();
   const [filter, setFilter] = useState<SourceFilter>("all");
   const [listening, setListening] = useState(false);
   const [draftText, setDraftText] = useState("");
@@ -770,6 +813,7 @@ export default function DictateRoute() {
   );
 
   useEffect(() => {
+    if (!isDesktopApp) return;
     function onKeyDown(event: KeyboardEvent) {
       if (isEditableTarget(event.target)) return;
       if (
@@ -784,7 +828,7 @@ export default function DictateRoute() {
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [listening, startBrowserDictation, stopBrowserDictation]);
+  }, [isDesktopApp, listening, startBrowserDictation, stopBrowserDictation]);
 
   useEffect(() => {
     return () => {
@@ -848,22 +892,28 @@ export default function DictateRoute() {
       <div className="p-6 max-w-5xl mx-auto w-full">
         <div className="mb-6">
           <p className="text-sm text-muted-foreground">
-            Voice-to-text dictation with AI cleanup. Use browser capture here or
-            the desktop app for global shortcuts.
+            {isDesktopApp
+              ? "Voice-to-text dictation with AI cleanup. Use the global shortcut from any app."
+              : "Voice-to-text dictation with AI cleanup. Get the desktop app to dictate from anywhere with a global shortcut."}
           </p>
         </div>
 
-        <HowToCard defaultOpen={isEmpty} />
-
-        <WebDictationPanel
-          supported={speechSupported}
-          listening={listening}
-          saving={createDictation.isPending}
-          draftText={draftText}
-          interimText={interimText}
-          onStart={() => startBrowserDictation("manual")}
-          onStop={stopBrowserDictation}
-        />
+        {isDesktopApp ? (
+          <>
+            <HowToCard defaultOpen={isEmpty} />
+            <WebDictationPanel
+              supported={speechSupported}
+              listening={listening}
+              saving={createDictation.isPending}
+              draftText={draftText}
+              interimText={interimText}
+              onStart={() => startBrowserDictation("manual")}
+              onStop={stopBrowserDictation}
+            />
+          </>
+        ) : (
+          <DownloadDesktopAppCard />
+        )}
 
         {isLoading ? (
           <div className="space-y-2">
@@ -876,7 +926,7 @@ export default function DictateRoute() {
             Couldn't load dictations.
           </div>
         ) : isEmpty ? (
-          <EmptyState />
+          <EmptyState isDesktopApp={isDesktopApp} />
         ) : (
           <>
             <FilterTabs value={filter} onChange={setFilter} counts={counts} />

--- a/templates/clips/app/routes/_app.meetings._index.tsx
+++ b/templates/clips/app/routes/_app.meetings._index.tsx
@@ -13,7 +13,7 @@ import {
   IconSearch,
   IconX,
 } from "@tabler/icons-react";
-import { useActionQuery } from "@agent-native/core/client";
+import { agentNativePath, useActionQuery } from "@agent-native/core/client";
 import { useDesktopPromo } from "@/hooks/use-desktop-promo";
 import { Button } from "@/components/ui/button";
 import {
@@ -106,7 +106,11 @@ function ConnectCalendarEmptyState({
   const handleConnect = () => {
     setError(null);
     setPending(true);
-    fetch("/_agent-native/actions/connect-calendar?provider=google")
+    fetch(
+      agentNativePath(
+        "/_agent-native/actions/connect-calendar?provider=google",
+      ),
+    )
       .then(async (r) => {
         const text = await r.text();
         let data: {
@@ -324,11 +328,14 @@ export default function MeetingsIndexRoute() {
       queryKey: ["action", "list-calendar-accounts"],
     });
     try {
-      const r = await fetch("/_agent-native/actions/sync-calendars", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
+      const r = await fetch(
+        agentNativePath("/_agent-native/actions/sync-calendars"),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      );
       if (!r.ok) {
         const text = await r.text().catch(() => "");
         let parsed: { error?: string } = {};

--- a/templates/clips/app/routes/_app.meetings._index.tsx
+++ b/templates/clips/app/routes/_app.meetings._index.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { NavLink, useSearchParams } from "react-router";
 import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
 import {
+  IconAppWindow,
   IconCalendar,
   IconCalendarOff,
   IconCalendarPlus,
@@ -12,6 +14,7 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import { useActionQuery } from "@agent-native/core/client";
+import { useDesktopPromo } from "@/hooks/use-desktop-promo";
 import { Button } from "@/components/ui/button";
 import {
   Collapsible,
@@ -120,15 +123,31 @@ function ConnectCalendarEmptyState({
         const url = data.result?.url ?? data.url;
         if (!url) throw new Error("No OAuth URL returned");
         const popupUrl = new URL(url, window.location.origin).toString();
-        window.open(
+        // Open without `noopener` so we can poll `popup.closed`. The OAuth
+        // callback page calls `window.close()` on success — once it does,
+        // we trigger the parent to refetch accounts and run sync-calendars.
+        const popup = window.open(
           popupUrl,
-          "_blank",
-          "noopener,noreferrer,width=600,height=700",
+          "clips-calendar-oauth",
+          "width=600,height=700",
         );
-        onConnected?.();
+        if (!popup) {
+          throw new Error(
+            "Popup blocked — please allow popups for this site and try again.",
+          );
+        }
+        const interval = window.setInterval(() => {
+          if (popup.closed) {
+            window.clearInterval(interval);
+            setPending(false);
+            onConnected?.();
+          }
+        }, 500);
       })
-      .catch((e: Error) => setError(e.message))
-      .finally(() => setPending(false));
+      .catch((e: Error) => {
+        setError(e.message);
+        setPending(false);
+      });
   };
 
   return (
@@ -194,10 +213,12 @@ function MeetingsHeader({
   onAddManual,
   query,
   onQueryChange,
+  showDesktopCta,
 }: {
   onAddManual: () => void;
   query: string;
   onQueryChange: (next: string) => void;
+  showDesktopCta: boolean;
 }) {
   return (
     <>
@@ -221,6 +242,15 @@ function MeetingsHeader({
         <p className="text-sm text-muted-foreground">
           Upcoming and past meetings with live transcripts and AI notes.
         </p>
+        {showDesktopCta && (
+          <NavLink
+            to="/download"
+            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground w-fit"
+          >
+            <IconAppWindow className="h-3.5 w-3.5" />
+            Get the Clips desktop app to record meetings
+          </NavLink>
+        )}
         <div className="relative max-w-sm">
           <IconSearch className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
           <Input
@@ -275,6 +305,9 @@ export default function MeetingsIndexRoute() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
+  const queryClient = useQueryClient();
+  const { shouldShowSidebarLink: showDesktopCta } = useDesktopPromo();
+
   const accounts = useActionQuery<{ accounts: CalendarAccount[] } | undefined>(
     "list-calendar-accounts",
     {},
@@ -283,6 +316,42 @@ export default function MeetingsIndexRoute() {
   const meetingsQuery = useActionQuery<
     { meetings: Meeting[] } | Meeting[] | undefined
   >("list-meetings", { view: "all" }, { retry: false });
+
+  // After the OAuth popup closes, refetch accounts, kick off a sync, and
+  // refetch meetings so the page updates without requiring a manual refresh.
+  const handleCalendarConnected = useCallback(async () => {
+    queryClient.invalidateQueries({
+      queryKey: ["action", "list-calendar-accounts"],
+    });
+    try {
+      const r = await fetch("/_agent-native/actions/sync-calendars", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!r.ok) {
+        const text = await r.text().catch(() => "");
+        let parsed: { error?: string } = {};
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          /* ignore */
+        }
+        throw new Error(parsed.error || `Sync failed (${r.status})`);
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Couldn't sync your calendar",
+      );
+    } finally {
+      queryClient.invalidateQueries({
+        queryKey: ["action", "list-meetings"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["action", "list-calendar-accounts"],
+      });
+    }
+  }, [queryClient]);
 
   const meetings: Meeting[] = useMemo(() => {
     const data = meetingsQuery.data;
@@ -410,8 +479,9 @@ export default function MeetingsIndexRoute() {
           onAddManual={handleAddManual}
           query={query}
           onQueryChange={setQuery}
+          showDesktopCta={showDesktopCta}
         />
-        <ConnectCalendarEmptyState />
+        <ConnectCalendarEmptyState onConnected={handleCalendarConnected} />
       </div>
     );
   }
@@ -424,6 +494,7 @@ export default function MeetingsIndexRoute() {
         onAddManual={handleAddManual}
         query={query}
         onQueryChange={setQuery}
+        showDesktopCta={showDesktopCta}
       />
 
       {meetings.length === 0 ? (

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -1,9 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router";
-import { IconArrowLeft, IconVideo } from "@tabler/icons-react";
+import { Link, useNavigate } from "react-router";
+import { IconAppWindow, IconArrowLeft, IconVideo } from "@tabler/icons-react";
+import { useQueryClient } from "@tanstack/react-query";
 import { agentNativePath, appBasePath } from "@agent-native/core/client";
 import { RequireActiveOrg } from "@agent-native/core/client/org";
 import { useLiveTranscription } from "@agent-native/core/client/transcription/use-live-transcription";
+import { useDesktopPromo } from "@/hooks/use-desktop-promo";
+import {
+  fetchVideoStorageStatus,
+  useVideoStorageStatus,
+  VIDEO_STORAGE_STATUS_KEY,
+  type VideoStorageStatus,
+} from "@/hooks/use-video-storage-status";
+import { Skeleton } from "@/components/ui/skeleton";
 
 // Client-side app-state writer (the server module pulls in Node's `events`
 // and cannot be bundled for the browser).
@@ -126,43 +135,23 @@ interface PendingRecording {
   abortUrl: string;
 }
 
-interface VideoStorageStatus {
-  configured: boolean;
-  activeProvider?: { id: string; name: string } | null;
-  builderConfigured?: boolean;
-}
-
-async function fetchVideoStorageStatus(): Promise<VideoStorageStatus> {
-  let uploadStatus: VideoStorageStatus | null = null;
-  try {
-    const r = await fetch(agentNativePath("/_agent-native/file-upload/status"));
-    uploadStatus = r.ok ? ((await r.json()) as VideoStorageStatus) : null;
-    if (uploadStatus?.configured) return uploadStatus;
-  } catch {
-    // Fall through to the Builder status check.
-  }
-
-  try {
-    const r = await fetch(agentNativePath("/_agent-native/builder/status"));
-    const builderStatus = r.ok
-      ? ((await r.json()) as { configured?: boolean })
-      : null;
-    if (builderStatus?.configured) {
-      return {
-        configured: true,
-        activeProvider: { id: "builder", name: "Builder.io" },
-        builderConfigured: true,
-      };
-    }
-  } catch {
-    // Treat an unreachable status route as not configured.
-  }
-
-  return {
-    configured: false,
-    activeProvider: uploadStatus?.activeProvider ?? null,
-    builderConfigured: uploadStatus?.builderConfigured ?? false,
-  };
+function PreRecordPanelSkeleton() {
+  return (
+    <div className="mx-auto flex w-full max-w-md flex-col gap-5 rounded-2xl border border-border bg-card p-6 shadow-lg">
+      <div className="space-y-2">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-3 w-56" />
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        <Skeleton className="h-[78px] rounded-xl" />
+        <Skeleton className="h-[78px] rounded-xl" />
+        <Skeleton className="h-[78px] rounded-xl" />
+      </div>
+      <Skeleton className="h-9 w-full rounded-md" />
+      <Skeleton className="h-9 w-full rounded-md" />
+      <Skeleton className="ml-auto h-9 w-32 rounded-md" />
+    </div>
+  );
 }
 
 export default function RecordRoute() {
@@ -185,24 +174,26 @@ export default function RecordRoute() {
     null,
   );
 
-  const [storageConfigured, setStorageConfigured] = useState<boolean | null>(
-    null,
+  const queryClient = useQueryClient();
+  const { isDesktopApp } = useDesktopPromo();
+  const storageQuery = useVideoStorageStatus();
+  const storageConfigured: boolean | null = storageQuery.isLoading
+    ? null
+    : !!storageQuery.data?.configured;
+  const markStorageConfigured = useCallback(
+    (status?: VideoStorageStatus) => {
+      queryClient.setQueryData<VideoStorageStatus>(
+        VIDEO_STORAGE_STATUS_KEY,
+        (prev) =>
+          status ?? {
+            configured: true,
+            activeProvider: prev?.activeProvider ?? null,
+            builderConfigured: prev?.builderConfigured ?? false,
+          },
+      );
+    },
+    [queryClient],
   );
-
-  useEffect(() => {
-    let cancelled = false;
-    fetchVideoStorageStatus()
-      .then((s) => {
-        if (cancelled) return;
-        setStorageConfigured(!!s?.configured);
-      })
-      .catch(() => {
-        if (!cancelled) setStorageConfigured(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   const liveTranscription = useLiveTranscription();
 
@@ -293,7 +284,7 @@ export default function RecordRoute() {
 
       try {
         const status = await fetchVideoStorageStatus();
-        setStorageConfigured(status.configured);
+        markStorageConfigured(status);
         if (!status.configured) {
           throw new Error(
             "No video storage configured. Open Settings to connect Builder.io or S3-compatible storage.",
@@ -1000,12 +991,22 @@ export default function RecordRoute() {
                 Clips recorder
               </span>
             </div>
-            {storageConfigured === null ? null : storageConfigured ? (
+            {storageConfigured === null ? (
+              <PreRecordPanelSkeleton />
+            ) : storageConfigured ? (
               <PreRecordPanel onStart={startFlow} onUpload={uploadFile} />
             ) : (
-              <StorageSetupCard
-                onConfigured={() => setStorageConfigured(true)}
-              />
+              <StorageSetupCard onConfigured={() => markStorageConfigured()} />
+            )}
+            {!isDesktopApp && (
+              <Link
+                to="/download"
+                className="mt-6 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+              >
+                <IconAppWindow className="h-3.5 w-3.5" />
+                Get the Clips desktop app for global shortcuts and menu-bar
+                recording
+              </Link>
             )}
           </div>
         </RequireActiveOrg>
@@ -1128,7 +1129,7 @@ export default function RecordRoute() {
               </div>
               <StorageSetupCard
                 onConfigured={() => {
-                  setStorageConfigured(true);
+                  markStorageConfigured();
                   setError(null);
                   setUiState("idle");
                 }}


### PR DESCRIPTION
## Summary

- **clips:** extract `useVideoStorageStatus` / `fetchVideoStorageStatus` into a reusable hook (`templates/clips/app/hooks/use-video-storage-status.ts`); have the library layout call `usePrefetchVideoStorageStatus()` so the record page renders without a status fetch round-trip.
- **core:** redesign the Builder OAuth callback page — Inter font, theme-script-aware styling matching the rest of the app, dropped the inline gradient / card markup.

## Test plan

- [ ] CI green
- [ ] Open `/record` in clips after navigating from the library — no flash while video storage status loads
- [ ] Connect / reconnect a Builder account — callback page renders with the new styling and closes the popup as before