### PR TITLE
fix(clips): scope calendar fetch-status updates + framework GPT-5.5 default + Builder/Plan-mode CTA + workspace gateway

### DIFF
--- a/.changeset/desktop-plan-mode-gate.md
+++ b/.changeset/desktop-plan-mode-gate.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Disable Plan mode in local browser dev surfaces and point users to Agent Native Desktop for planning.

--- a/.changeset/fresh-calendar-chat-cookie.md
+++ b/.changeset/fresh-calendar-chat-cookie.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use cross-site session cookie attributes for Google OAuth sessions so embedded app chat remains authenticated.

--- a/.changeset/gpt-5-5-default-and-builder-cta.md
+++ b/.changeset/gpt-5-5-default-and-builder-cta.md
@@ -3,4 +3,4 @@
 "@agent-native/frame": patch
 ---
 
-Default the framework to the Builder gateway's `gpt-5-5` model alias, split provider-native default IDs (`DEFAULT_OPENAI_MODEL` / `DEFAULT_ANTHROPIC_MODEL`) so direct BYOK engines stay on valid provider IDs, and stop hard-coding `DEFAULT_MODEL` for A2A / MCP / integrations runs — the resolved engine's default is used instead. Also adds a "Use Builder" cloud CTA alongside the Desktop CTA in the AgentPanel and CodeRequiredDialog code-access-unavailable surfaces, including a `useBuilderConnectUrl()` hook that wires up the secondary link from `/_agent-native/builder/status`.
+Default the framework to the Builder gateway's `gpt-5-5` model alias, centralize built-in engine model defaults/catalogs in `model-config.ts`, and stop hard-coding `DEFAULT_MODEL` for A2A / MCP / integrations runs — the resolved engine's default is used instead. Also adds a "Use Builder" cloud CTA alongside the Desktop CTA in the AgentPanel and CodeRequiredDialog code-access-unavailable surfaces, including a `useBuilderConnectUrl()` hook that wires up the secondary link from `/_agent-native/builder/status`.

--- a/.changeset/gpt-5-5-default-and-builder-cta.md
+++ b/.changeset/gpt-5-5-default-and-builder-cta.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/frame": patch
+---
+
+Default the framework to the Builder gateway's `gpt-5-5` model alias, split provider-native default IDs (`DEFAULT_OPENAI_MODEL` / `DEFAULT_ANTHROPIC_MODEL`) so direct BYOK engines stay on valid provider IDs, and stop hard-coding `DEFAULT_MODEL` for A2A / MCP / integrations runs — the resolved engine's default is used instead. Also adds a "Use Builder" cloud CTA alongside the Desktop CTA in the AgentPanel and CodeRequiredDialog code-access-unavailable surfaces, including a `useBuilderConnectUrl()` hook that wires up the secondary link from `/_agent-native/builder/status`.

--- a/.changeset/lazy-workspace-refresh.md
+++ b/.changeset/lazy-workspace-refresh.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Fix lazy workspace dev root routing, live app discovery, and generated app dependency startup.

--- a/.changeset/pasted-transcript-context.md
+++ b/.changeset/pasted-transcript-context.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep oversized pasted-text chat attachments from overflowing agent context and render them consistently as pasted-text chips.

--- a/packages/core/src/agent/default-model.ts
+++ b/packages/core/src/agent/default-model.ts
@@ -1,20 +1,19 @@
 /**
- * The framework-wide default model.
+ * The framework-wide default model for the managed Builder gateway.
  *
- * One place to bump the default when a new Claude model ships. Everything
- * that needs a default model fallback (agent chat, A2A handler, integration
- * agent, MCP askAgent, etc.) imports this constant — there are no hardcoded
- * model ID literals scattered across the codebase.
+ * Builder gateway public model IDs use hyphenated version numbers. Direct
+ * provider SDKs can use provider-native IDs, so keep those in separate
+ * constants below.
  *
  * Templates and apps can still override per-call by passing `model: "..."`
  * in their plugin options; this is just the value used when no override is
  * provided.
- *
- * Why sonnet (not haiku): the agent makes user-facing decisions (URLs, IDs,
- * delegated answers). Haiku is fast and cheap but hallucinates slugs and
- * paths in user-facing text often enough that we hit it during normal use
- * (e.g. a Slack reply with a deck URL pointing to a host that doesn't exist).
- * Sonnet's accuracy at the same task is dramatically better and the latency
- * cost is acceptable for the cross-app A2A path.
  */
-export const DEFAULT_MODEL = "claude-sonnet-4-6";
+export const DEFAULT_MODEL = "gpt-5-5";
+
+/**
+ * Provider-native IDs for direct BYOK engines. These must stay valid for
+ * their provider even when the framework-wide managed default changes.
+ */
+export const DEFAULT_OPENAI_MODEL = "gpt-5.5";
+export const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";

--- a/packages/core/src/agent/default-model.ts
+++ b/packages/core/src/agent/default-model.ts
@@ -1,19 +1,5 @@
-/**
- * The framework-wide default model for the managed Builder gateway.
- *
- * Builder gateway public model IDs use hyphenated version numbers. Direct
- * provider SDKs can use provider-native IDs, so keep those in separate
- * constants below.
- *
- * Templates and apps can still override per-call by passing `model: "..."`
- * in their plugin options; this is just the value used when no override is
- * provided.
- */
-export const DEFAULT_MODEL = "gpt-5-5";
-
-/**
- * Provider-native IDs for direct BYOK engines. These must stay valid for
- * their provider even when the framework-wide managed default changes.
- */
-export const DEFAULT_OPENAI_MODEL = "gpt-5.5";
-export const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
+export {
+  DEFAULT_MODEL,
+  DEFAULT_OPENAI_MODEL,
+  DEFAULT_ANTHROPIC_MODEL,
+} from "./model-config.js";

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -25,7 +25,10 @@ import {
   aiSdkPartToEngineEvents,
   aiSdkStepToAssistantContent,
 } from "./translate-ai-sdk.js";
-import { DEFAULT_MODEL } from "../default-model.js";
+import {
+  DEFAULT_ANTHROPIC_MODEL,
+  DEFAULT_OPENAI_MODEL,
+} from "../default-model.js";
 import { readDeployCredentialEnv } from "../../server/credential-provider.js";
 import { normalizeReasoningEffortForModel } from "../../shared/reasoning-effort.js";
 
@@ -103,9 +106,9 @@ const PROVIDER_CAPABILITIES: Record<AISDKProvider, EngineCapabilities> = {
 };
 
 const PROVIDER_DEFAULT_MODELS: Record<AISDKProvider, string> = {
-  anthropic: DEFAULT_MODEL,
-  openai: "gpt-5.4",
-  openrouter: "anthropic/claude-sonnet-4.6",
+  anthropic: DEFAULT_ANTHROPIC_MODEL,
+  openai: DEFAULT_OPENAI_MODEL,
+  openrouter: "openai/gpt-5.5",
   google: "gemini-3-flash-preview",
   groq: "llama-3.3-70b-versatile",
   mistral: "mistral-large-latest",
@@ -123,6 +126,7 @@ const PROVIDER_SUPPORTED_MODELS: Record<AISDKProvider, readonly string[]> = {
   openrouter: [
     "anthropic/claude-opus-4.7",
     "anthropic/claude-sonnet-4.6",
+    "openai/gpt-5.5",
     "openai/gpt-5.4",
     "google/gemini-2.5-flash",
   ],

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -25,26 +25,15 @@ import {
   aiSdkPartToEngineEvents,
   aiSdkStepToAssistantContent,
 } from "./translate-ai-sdk.js";
-import {
-  DEFAULT_ANTHROPIC_MODEL,
-  DEFAULT_OPENAI_MODEL,
-} from "../default-model.js";
+import { AI_SDK_MODEL_CONFIG, type AISDKProvider } from "../model-config.js";
 import { readDeployCredentialEnv } from "../../server/credential-provider.js";
 import { normalizeReasoningEffortForModel } from "../../shared/reasoning-effort.js";
+
+export type { AISDKProvider } from "../model-config.js";
 
 // ---------------------------------------------------------------------------
 // Provider definitions
 // ---------------------------------------------------------------------------
-
-export type AISDKProvider =
-  | "anthropic"
-  | "openai"
-  | "openrouter"
-  | "google"
-  | "groq"
-  | "mistral"
-  | "cohere"
-  | "ollama";
 
 const PROVIDER_CAPABILITIES: Record<AISDKProvider, EngineCapabilities> = {
   anthropic: {
@@ -105,45 +94,23 @@ const PROVIDER_CAPABILITIES: Record<AISDKProvider, EngineCapabilities> = {
   },
 };
 
-const PROVIDER_DEFAULT_MODELS: Record<AISDKProvider, string> = {
-  anthropic: DEFAULT_ANTHROPIC_MODEL,
-  openai: DEFAULT_OPENAI_MODEL,
-  openrouter: "openai/gpt-5.5",
-  google: "gemini-3-flash-preview",
-  groq: "llama-3.3-70b-versatile",
-  mistral: "mistral-large-latest",
-  cohere: "command-r-plus",
-  ollama: "llama3.1",
-};
+const providerModelEntries = Object.entries(AI_SDK_MODEL_CONFIG) as Array<
+  [AISDKProvider, (typeof AI_SDK_MODEL_CONFIG)[AISDKProvider]]
+>;
 
-const PROVIDER_SUPPORTED_MODELS: Record<AISDKProvider, readonly string[]> = {
-  anthropic: [
-    "claude-opus-4-7",
-    "claude-sonnet-4-6",
-    "claude-haiku-4-5-20251001",
-  ],
-  openai: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"],
-  openrouter: [
-    "anthropic/claude-opus-4.7",
-    "anthropic/claude-sonnet-4.6",
-    "openai/gpt-5.5",
-    "openai/gpt-5.4",
-    "google/gemini-2.5-flash",
-  ],
-  google: ["gemini-3-flash-preview", "gemini-3.1-pro-preview"],
-  groq: [
-    "llama-3.3-70b-versatile",
-    "llama-3.1-70b-versatile",
-    "mixtral-8x7b-32768",
-  ],
-  mistral: [
-    "mistral-large-latest",
-    "mistral-medium-latest",
-    "mistral-small-latest",
-  ],
-  cohere: ["command-r-plus", "command-r"],
-  ollama: ["llama3.1", "llama3.2", "mistral", "codestral"],
-};
+const PROVIDER_DEFAULT_MODELS = Object.fromEntries(
+  providerModelEntries.map(([provider, config]) => [
+    provider,
+    config.defaultModel,
+  ]),
+) as Record<AISDKProvider, string>;
+
+const PROVIDER_SUPPORTED_MODELS = Object.fromEntries(
+  providerModelEntries.map(([provider, config]) => [
+    provider,
+    config.supportedModels,
+  ]),
+) as unknown as Record<AISDKProvider, readonly string[]>;
 
 const PROVIDER_ENV_VARS: Record<AISDKProvider, string[]> = {
   anthropic: ["ANTHROPIC_API_KEY"],

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -41,12 +41,8 @@ export const ANTHROPIC_SUPPORTED_MODELS = [
   "claude-haiku-4-5-20251001",
 ] as const;
 
-// Single source of truth for the framework default lives in
-// agent/default-model.ts. Engines, integrations, and the agent-chat plugin
-// all read from the same constant, so bumping the default model is a
-// one-line change.
-import { DEFAULT_MODEL } from "../default-model.js";
-export const ANTHROPIC_DEFAULT_MODEL = DEFAULT_MODEL;
+import { DEFAULT_ANTHROPIC_MODEL } from "../default-model.js";
+export const ANTHROPIC_DEFAULT_MODEL = DEFAULT_ANTHROPIC_MODEL;
 
 class AnthropicEngine implements AgentEngine {
   readonly name = "anthropic";

--- a/packages/core/src/agent/engine/anthropic-engine.ts
+++ b/packages/core/src/agent/engine/anthropic-engine.ts
@@ -26,6 +26,7 @@ import {
   LLM_MISSING_CREDENTIALS_ERROR_CODE,
   LLM_MISSING_CREDENTIALS_MESSAGE,
 } from "./credential-errors.js";
+import { ANTHROPIC_MODEL_CONFIG } from "../model-config.js";
 
 export const ANTHROPIC_CAPABILITIES: EngineCapabilities = {
   thinking: true,
@@ -35,14 +36,9 @@ export const ANTHROPIC_CAPABILITIES: EngineCapabilities = {
   parallelToolCalls: true,
 };
 
-export const ANTHROPIC_SUPPORTED_MODELS = [
-  "claude-opus-4-7",
-  "claude-sonnet-4-6",
-  "claude-haiku-4-5-20251001",
-] as const;
-
-import { DEFAULT_ANTHROPIC_MODEL } from "../default-model.js";
-export const ANTHROPIC_DEFAULT_MODEL = DEFAULT_ANTHROPIC_MODEL;
+export const ANTHROPIC_SUPPORTED_MODELS =
+  ANTHROPIC_MODEL_CONFIG.supportedModels;
+export const ANTHROPIC_DEFAULT_MODEL = ANTHROPIC_MODEL_CONFIG.defaultModel;
 
 class AnthropicEngine implements AgentEngine {
   readonly name = "anthropic";

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -94,8 +94,10 @@ describe("createBuilderEngine", () => {
     const engine = createBuilderEngine();
     expect(engine.name).toBe("builder");
     expect(engine.defaultModel).toBe(BUILDER_DEFAULT_MODEL);
+    expect(engine.defaultModel).toBe("gpt-5-5");
     expect(engine.capabilities).toMatchObject(BUILDER_CAPABILITIES);
     expect(engine.supportedModels).toContain("claude-sonnet-4-6");
+    expect(engine.supportedModels).toContain("gpt-5-5");
     expect(engine.supportedModels).toContain("gpt-5-4");
     expect(engine.supportedModels).toContain("z-ai-glm-4-5");
   });

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -37,6 +37,7 @@ import {
   LLM_MISSING_CREDENTIALS_ERROR_CODE,
   LLM_MISSING_CREDENTIALS_MESSAGE,
 } from "./credential-errors.js";
+import { BUILDER_MODEL_CONFIG } from "../model-config.js";
 
 export const BUILDER_CAPABILITIES: EngineCapabilities = {
   thinking: true,
@@ -50,31 +51,12 @@ export const BUILDER_CAPABILITIES: EngineCapabilities = {
   parallelToolCalls: true,
 };
 
-export const BUILDER_SUPPORTED_MODELS = [
-  "claude-opus-4-7",
-  "claude-sonnet-4-6",
-  "claude-haiku-4-5",
-  "gpt-5-5",
-  "gpt-5-4",
-  "gpt-5-4-mini",
-  "gpt-5-1-codex-mini",
-  "gemini-3-1-pro",
-  "gemini-3-0-flash",
-  "gemini-3-1-flash-lite",
-  "grok-code-fast",
-  "qwen3-coder",
-  "kimi-k2-5",
-  "deepseek-v3-1",
-  "z-ai-glm-4-5",
-  "z-ai-glm-5-1",
-] as const;
+export const BUILDER_SUPPORTED_MODELS = BUILDER_MODEL_CONFIG.supportedModels;
 
 const DEFAULT_BUILDER_GATEWAY_TIMEOUT_MS = 45_000;
 const MAX_BUILDER_GATEWAY_TIMEOUT_MS = 55_000;
 
-// Builder gateway public IDs are provider-neutral aliases owned by the gateway.
-import { DEFAULT_MODEL } from "../default-model.js";
-export const BUILDER_DEFAULT_MODEL = DEFAULT_MODEL;
+export const BUILDER_DEFAULT_MODEL = BUILDER_MODEL_CONFIG.defaultModel;
 
 /**
  * Bucket an Anthropic `thinking.budgetTokens` value into the gateway's

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -54,6 +54,7 @@ export const BUILDER_SUPPORTED_MODELS = [
   "claude-opus-4-7",
   "claude-sonnet-4-6",
   "claude-haiku-4-5",
+  "gpt-5-5",
   "gpt-5-4",
   "gpt-5-4-mini",
   "gpt-5-1-codex-mini",
@@ -71,8 +72,7 @@ export const BUILDER_SUPPORTED_MODELS = [
 const DEFAULT_BUILDER_GATEWAY_TIMEOUT_MS = 45_000;
 const MAX_BUILDER_GATEWAY_TIMEOUT_MS = 55_000;
 
-// Inherits from agent/default-model.ts — single source of truth so a
-// new model release is a one-line bump.
+// Builder gateway public IDs are provider-neutral aliases owned by the gateway.
 import { DEFAULT_MODEL } from "../default-model.js";
 export const BUILDER_DEFAULT_MODEL = DEFAULT_MODEL;
 

--- a/packages/core/src/agent/engine/openrouter-engine.spec.ts
+++ b/packages/core/src/agent/engine/openrouter-engine.spec.ts
@@ -16,9 +16,9 @@ describe("OpenRouter builtin engine", () => {
     expect(entry).toBeDefined();
     expect(entry?.label).toContain("OpenRouter");
     expect(entry?.requiredEnvVars).toEqual(["OPENROUTER_API_KEY"]);
-    expect(entry?.defaultModel).toMatch(/\//); // vendor/model form
+    expect(entry?.defaultModel).toBe("openai/gpt-5.5");
     expect(entry?.supportedModels).toEqual(
-      expect.arrayContaining(["anthropic/claude-sonnet-4.6"]),
+      expect.arrayContaining(["openai/gpt-5.5"]),
     );
     expect(entry?.installPackage).toContain("@openrouter/ai-sdk-provider");
   });

--- a/packages/core/src/agent/model-config.ts
+++ b/packages/core/src/agent/model-config.ts
@@ -1,0 +1,125 @@
+/**
+ * Central model catalog for built-in agent engines.
+ *
+ * To bump the framework's managed default, update
+ * FRAMEWORK_DEFAULT_OPENAI_MODEL. Builder gateway and OpenRouter IDs are
+ * derived from that provider-native OpenAI ID so the usual default bump stays
+ * in this one file.
+ */
+
+const FRAMEWORK_DEFAULT_OPENAI_MODEL = "gpt-5.5";
+const ANTHROPIC_DEFAULT_MODEL_ID = "claude-sonnet-4-6";
+
+function builderGatewayModelId(model: string): string {
+  return model.replace(/\./g, "-");
+}
+
+function openRouterModelId(provider: string, model: string): string {
+  return `${provider}/${model}`;
+}
+
+const FRAMEWORK_DEFAULT_BUILDER_MODEL = builderGatewayModelId(
+  FRAMEWORK_DEFAULT_OPENAI_MODEL,
+);
+const FRAMEWORK_DEFAULT_OPENROUTER_MODEL = openRouterModelId(
+  "openai",
+  FRAMEWORK_DEFAULT_OPENAI_MODEL,
+);
+
+export const AGENT_MODEL_CONFIG = {
+  builder: {
+    defaultModel: FRAMEWORK_DEFAULT_BUILDER_MODEL,
+    supportedModels: [
+      "claude-opus-4-7",
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5",
+      FRAMEWORK_DEFAULT_BUILDER_MODEL,
+      "gpt-5-4",
+      "gpt-5-4-mini",
+      "gpt-5-1-codex-mini",
+      "gemini-3-1-pro",
+      "gemini-3-0-flash",
+      "gemini-3-1-flash-lite",
+      "grok-code-fast",
+      "qwen3-coder",
+      "kimi-k2-5",
+      "deepseek-v3-1",
+      "z-ai-glm-4-5",
+      "z-ai-glm-5-1",
+    ],
+  },
+  anthropic: {
+    defaultModel: ANTHROPIC_DEFAULT_MODEL_ID,
+    supportedModels: [
+      "claude-opus-4-7",
+      ANTHROPIC_DEFAULT_MODEL_ID,
+      "claude-haiku-4-5-20251001",
+    ],
+  },
+  aiSdk: {
+    anthropic: {
+      defaultModel: ANTHROPIC_DEFAULT_MODEL_ID,
+      supportedModels: [
+        "claude-opus-4-7",
+        ANTHROPIC_DEFAULT_MODEL_ID,
+        "claude-haiku-4-5-20251001",
+      ],
+    },
+    openai: {
+      defaultModel: FRAMEWORK_DEFAULT_OPENAI_MODEL,
+      supportedModels: [
+        FRAMEWORK_DEFAULT_OPENAI_MODEL,
+        "gpt-5.4",
+        "gpt-5.4-mini",
+      ],
+    },
+    openrouter: {
+      defaultModel: FRAMEWORK_DEFAULT_OPENROUTER_MODEL,
+      supportedModels: [
+        "anthropic/claude-opus-4.7",
+        "anthropic/claude-sonnet-4.6",
+        FRAMEWORK_DEFAULT_OPENROUTER_MODEL,
+        "openai/gpt-5.4",
+        "google/gemini-2.5-flash",
+      ],
+    },
+    google: {
+      defaultModel: "gemini-3-flash-preview",
+      supportedModels: ["gemini-3-flash-preview", "gemini-3.1-pro-preview"],
+    },
+    groq: {
+      defaultModel: "llama-3.3-70b-versatile",
+      supportedModels: [
+        "llama-3.3-70b-versatile",
+        "llama-3.1-70b-versatile",
+        "mixtral-8x7b-32768",
+      ],
+    },
+    mistral: {
+      defaultModel: "mistral-large-latest",
+      supportedModels: [
+        "mistral-large-latest",
+        "mistral-medium-latest",
+        "mistral-small-latest",
+      ],
+    },
+    cohere: {
+      defaultModel: "command-r-plus",
+      supportedModels: ["command-r-plus", "command-r"],
+    },
+    ollama: {
+      defaultModel: "llama3.1",
+      supportedModels: ["llama3.1", "llama3.2", "mistral", "codestral"],
+    },
+  },
+} as const;
+
+export const BUILDER_MODEL_CONFIG = AGENT_MODEL_CONFIG.builder;
+export const ANTHROPIC_MODEL_CONFIG = AGENT_MODEL_CONFIG.anthropic;
+export const AI_SDK_MODEL_CONFIG = AGENT_MODEL_CONFIG.aiSdk;
+
+export type AISDKProvider = keyof typeof AI_SDK_MODEL_CONFIG;
+
+export const DEFAULT_MODEL = BUILDER_MODEL_CONFIG.defaultModel;
+export const DEFAULT_OPENAI_MODEL = AI_SDK_MODEL_CONFIG.openai.defaultModel;
+export const DEFAULT_ANTHROPIC_MODEL = ANTHROPIC_MODEL_CONFIG.defaultModel;

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -105,6 +105,29 @@ describe("buildUserContentWithAttachments", () => {
     );
   });
 
+  it("unwraps and truncates oversized text attachments before model input", () => {
+    const longBody = "A".repeat(60_010);
+    const content = buildUserContentWithAttachments({
+      text: "Summarize the transcript",
+      attachments: [
+        {
+          type: "file",
+          name: "transcript.txt",
+          contentType: "text/plain",
+          text: `<attachment name=transcript.txt>\n${longBody}\n</attachment>`,
+        },
+      ],
+    });
+
+    const text = content[0].type === "text" ? content[0].text : "";
+    expect(text).toContain("A".repeat(60_000));
+    expect(text).toContain(
+      "[Attachment truncated after 60,000 characters; 10 characters omitted",
+    );
+    expect(text).not.toContain("<attachment name=transcript.txt>");
+    expect(text).toContain("Summarize the transcript");
+  });
+
   it("adds binary file attachments before the prompt text", () => {
     expect(
       buildUserContentWithAttachments({

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -488,6 +488,7 @@ export interface ProductionAgentOptions {
 const MAX_RETRIES = 3;
 const RETRY_BASE_DELAY_MS = 2000;
 const TOOL_INPUT_ACTIVITY_INTERVAL_MS = 1500;
+const MAX_TEXT_ATTACHMENT_CHARS = 60_000;
 
 function generateRunId(): string {
   return `run-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -588,8 +589,21 @@ function escapeAttachmentAttribute(value: string): string {
     .replace(/>/g, "&gt;");
 }
 
+function unwrapTextAttachmentEnvelope(text: string): string {
+  const match = text.match(/^<attachment\b[^>]*>\n([\s\S]*)\n<\/attachment>$/);
+  return match ? match[1] : text;
+}
+
+function truncateTextAttachment(text: string): string {
+  if (text.length <= MAX_TEXT_ATTACHMENT_CHARS) return text;
+
+  const omitted = text.length - MAX_TEXT_ATTACHMENT_CHARS;
+  return `${text.slice(0, MAX_TEXT_ATTACHMENT_CHARS)}\n\n[Attachment truncated after ${MAX_TEXT_ATTACHMENT_CHARS.toLocaleString()} characters; ${omitted.toLocaleString()} characters omitted to keep the agent request within model context limits.]`;
+}
+
 function formatTextAttachment(att: AgentChatAttachment): string | null {
   if (typeof att.text !== "string" || att.text.length === 0) return null;
+  const text = truncateTextAttachment(unwrapTextAttachmentEnvelope(att.text));
 
   const attrs = [
     `name="${escapeAttachmentAttribute(att.name || "attachment")}"`,
@@ -599,7 +613,7 @@ function formatTextAttachment(att: AgentChatAttachment): string | null {
     att.type ? `type="${escapeAttachmentAttribute(att.type)}"` : null,
   ].filter(Boolean);
 
-  return `<attachment ${attrs.join(" ")}>\n${att.text}\n</attachment>`;
+  return `<attachment ${attrs.join(" ")}>\n${text}\n</attachment>`;
 }
 
 function dataUrlToFilePart(

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -444,7 +444,7 @@ export interface ProductionAgentOptions {
     | AgentEngine
     | string
     | { name: string; config: Record<string, unknown> };
-  /** Model to use. Default: claude-sonnet-4-6 */
+  /** Model to use. Defaults to the resolved engine's default model. */
   model?: string;
   /** Default reasoning effort for requests that do not supply an override. */
   reasoningEffort?: ReasoningEffort;

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -159,7 +159,9 @@ describe("workspace dev startup", () => {
     const res = await fetch(`${url}/todo`, {
       headers: { accept: "text/html" },
     });
-    expect(await res.text()).toContain("installing this app's dependencies");
+    expect(await res.text()).toContain(
+      "installing this app&#39;s dependencies",
+    );
 
     const installCall = fake.calls().at(-1);
     expect(installCall).toMatchObject({

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -79,6 +79,45 @@ describe("workspace dev startup", () => {
     expect(fake.startedApps()).toEqual([]);
   });
 
+  it("redirects root requests with query strings to Dispatch", async () => {
+    tmpDir = makeWorkspace(["dispatch", "starter"]);
+    const fake = fakeSpawn();
+    handle = runWorkspaceDev({
+      root: tmpDir,
+      env: testEnv(),
+      spawnProcess: fake.spawnProcess,
+      openBrowser: false,
+    });
+    const { url } = await handle.ready;
+
+    const res = await fetch(`${url}/?builderPreview=1`, {
+      redirect: "manual",
+    });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/dispatch?builderPreview=1");
+  });
+
+  it("refreshes the root fallback app list before rendering", async () => {
+    tmpDir = makeWorkspace(["starter"]);
+    const fake = fakeSpawn();
+    handle = runWorkspaceDev({
+      root: tmpDir,
+      env: testEnv(),
+      spawnProcess: fake.spawnProcess,
+      openBrowser: false,
+    });
+    const { url } = await handle.ready;
+    makeApp(tmpDir, "todo");
+
+    const res = await fetch(`${url}/?fallback=1`);
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain("/todo");
+    expect(html).toContain("Todo");
+  });
+
   it("detects new apps without starting them until requested", async () => {
     tmpDir = makeWorkspace(["dispatch"]);
     const fake = fakeSpawn();
@@ -102,6 +141,42 @@ describe("workspace dev startup", () => {
     expect(fake.startedApps()).toEqual(["dispatch"]);
 
     await fetch(`${url}/todo`, { headers: { accept: "text/html" } });
+    expect(fake.startedApps()).toEqual(["dispatch", "todo"]);
+  });
+
+  it("runs a workspace install before starting a newly generated app without installed bins", async () => {
+    tmpDir = makeWorkspace(["dispatch"]);
+    const fake = fakeSpawn();
+    handle = runWorkspaceDev({
+      root: tmpDir,
+      env: testEnv(),
+      spawnProcess: fake.spawnProcess,
+      openBrowser: false,
+    });
+    const { url } = await handle.ready;
+    makeApp(tmpDir, "todo", { installVite: false });
+
+    const res = await fetch(`${url}/todo`, {
+      headers: { accept: "text/html" },
+    });
+    expect(await res.text()).toContain("installing this app's dependencies");
+
+    const installCall = fake.calls().at(-1);
+    expect(installCall).toMatchObject({
+      command: "pnpm",
+      args: [
+        "--dir",
+        tmpDir,
+        "install",
+        "--no-frozen-lockfile",
+        "--prefer-offline",
+      ],
+    });
+    expect(fake.startedApps()).toEqual(["dispatch"]);
+
+    createViteBin(path.join(tmpDir, "apps", "todo"));
+    installCall?.child.emit("exit", 0, null);
+
     expect(fake.startedApps()).toEqual(["dispatch", "todo"]);
   });
 });
@@ -146,7 +221,11 @@ function makeWorkspace(apps: string[]): string {
   return dir;
 }
 
-function makeApp(workspaceRoot: string, app: string): void {
+function makeApp(
+  workspaceRoot: string,
+  app: string,
+  opts: { installVite?: boolean } = {},
+): void {
   const appDir = path.join(workspaceRoot, "apps", app);
   fs.mkdirSync(appDir, { recursive: true });
   fs.writeFileSync(
@@ -156,15 +235,30 @@ function makeApp(workspaceRoot: string, app: string): void {
       displayName: app.charAt(0).toUpperCase() + app.slice(1),
     }),
   );
+  if (opts.installVite !== false) createViteBin(appDir);
+}
+
+function createViteBin(appDir: string): void {
+  const binDir = path.join(appDir, "node_modules", ".bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, "vite"), "");
 }
 
 function fakeSpawn(): {
   spawnProcess: typeof spawn;
+  calls: () => Array<{
+    command: string;
+    args: string[];
+    child: ChildProcess & EventEmitter;
+  }>;
   startedApps: () => string[];
 } {
-  const calls: Array<{ command: string; args: string[] }> = [];
+  const calls: Array<{
+    command: string;
+    args: string[];
+    child: ChildProcess & EventEmitter;
+  }> = [];
   const spawnProcess = vi.fn((command: string, args: string[]) => {
-    calls.push({ command, args });
     const child = new EventEmitter() as ChildProcess;
     child.stdout = new EventEmitter() as ChildProcess["stdout"];
     child.stderr = new EventEmitter() as ChildProcess["stderr"];
@@ -175,14 +269,21 @@ function fakeSpawn(): {
       return true;
     }) as ChildProcess["kill"];
     child.unref = vi.fn() as ChildProcess["unref"];
+    calls.push({ command, args, child: child as ChildProcess & EventEmitter });
     return child;
   }) as unknown as typeof spawn;
 
   return {
     spawnProcess,
+    calls: () => calls,
     startedApps: () =>
       calls
-        .filter((call) => call.command === "pnpm" && call.args[0] === "--dir")
+        .filter(
+          (call) =>
+            call.command === "pnpm" &&
+            call.args[0] === "--dir" &&
+            call.args[2] === "exec",
+        )
         .map((call) => path.basename(call.args[1])),
   };
 }

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -17,6 +17,8 @@ export interface WorkspaceApp {
   process?: ChildProcess;
   restartTimer?: NodeJS.Timeout;
   restartAttempts?: number;
+  installing?: boolean;
+  installAttempted?: boolean;
   /**
    * Set true once we've successfully connected to the upstream. After that we
    * skip the readiness probe on every request; the child server stays
@@ -197,6 +199,9 @@ function wantsHtml(req: http.IncomingMessage): boolean {
 
 function renderStartingApp(app: WorkspaceApp): string {
   const escapedName = escapeHtml(app.name || app.id);
+  const message = app.installing
+    ? "The workspace gateway is installing this app's dependencies before starting it."
+    : "The workspace gateway is waking this app's dev server.";
   return `<!doctype html>
 <html>
   <head>
@@ -218,7 +223,7 @@ function renderStartingApp(app: WorkspaceApp): string {
     <main>
       <div class="bar"></div>
       <h1>Starting ${escapedName}</h1>
-      <p>The workspace gateway is waking this app's dev server.</p>
+      <p>${escapeHtml(message)}</p>
     </main>
   </body>
 </html>`;
@@ -272,6 +277,15 @@ function renderIndex(apps: WorkspaceApp[]): string {
     </main>
   </body>
 </html>`;
+}
+
+function hasLocalBin(dir: string, command: string): boolean {
+  const binDir = path.join(dir, "node_modules", ".bin");
+  return (
+    fs.existsSync(path.join(binDir, command)) ||
+    fs.existsSync(path.join(binDir, `${command}.cmd`)) ||
+    fs.existsSync(path.join(binDir, `${command}.ps1`))
+  );
 }
 
 export function runWorkspaceDev(
@@ -389,37 +403,46 @@ export function runWorkspaceDev(
     }
 
     const basePath = `/${app.id}`;
-    const child = spawnProcess(
-      "pnpm",
-      [
-        "--dir",
-        app.dir,
-        "exec",
-        "vite",
-        "--host",
-        "127.0.0.1",
-        "--port",
-        String(app.port),
-        "--strictPort",
-        ...(forceVite ? ["--force"] : []),
-      ],
-      {
-        cwd: root,
-        stdio: ["ignore", "pipe", "pipe"],
-        env: {
-          ...env,
-          APP_NAME: app.id,
-          AGENT_NATIVE_WORKSPACE: "1",
-          AGENT_NATIVE_WORKSPACE_APPS_JSON: workspaceAppsJson(),
-          APP_BASE_PATH: basePath,
-          VITE_AGENT_NATIVE_WORKSPACE: "1",
-          VITE_APP_BASE_PATH: basePath,
-          PORT: String(app.port),
-          WORKSPACE_GATEWAY_URL: gatewayUrl,
-        },
+    const shouldInstall =
+      !app.installAttempted && !hasLocalBin(app.dir, "vite");
+    const childArgs = shouldInstall
+      ? ["--dir", root, "install", "--no-frozen-lockfile", "--prefer-offline"]
+      : [
+          "--dir",
+          app.dir,
+          "exec",
+          "vite",
+          "--host",
+          "127.0.0.1",
+          "--port",
+          String(app.port),
+          "--strictPort",
+          ...(forceVite ? ["--force"] : []),
+        ];
+
+    if (shouldInstall) {
+      stdout.write(
+        `[workspace] Installing dependencies before starting /${app.id}\n`,
+      );
+    }
+
+    const child = spawnProcess("pnpm", childArgs, {
+      cwd: root,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...env,
+        APP_NAME: app.id,
+        AGENT_NATIVE_WORKSPACE: "1",
+        AGENT_NATIVE_WORKSPACE_APPS_JSON: workspaceAppsJson(),
+        APP_BASE_PATH: basePath,
+        VITE_AGENT_NATIVE_WORKSPACE: "1",
+        VITE_APP_BASE_PATH: basePath,
+        PORT: String(app.port),
+        WORKSPACE_GATEWAY_URL: gatewayUrl,
       },
-    );
+    });
     app.process = child;
+    app.installing = shouldInstall;
 
     const prefix = `[${app.id}]`;
     const stableTimer = setTimeout(() => {
@@ -435,9 +458,18 @@ export function runWorkspaceDev(
     });
     child.on("exit", (code) => {
       clearTimeout(stableTimer);
+      const wasInstalling = app.installing;
       app.process = undefined;
+      app.installing = false;
       app.ready = false;
-      if (code === 0 || shuttingDown) return;
+      if (code === 0 || shuttingDown) {
+        if (wasInstalling && code === 0 && !shuttingDown) {
+          app.installAttempted = true;
+          startApp(app);
+        }
+        return;
+      }
+      if (wasInstalling) app.installAttempted = false;
       app.restartAttempts = (app.restartAttempts ?? 0) + 1;
       const delay = appRestartDelay(app.restartAttempts);
       stderr.write(
@@ -669,9 +701,24 @@ export function runWorkspaceDev(
   }
 
   const server = http.createServer((req, res) => {
-    if (req.url === "/" || req.url === "/index.html") {
-      if (redirectRootToDefault) {
-        res.writeHead(302, { location: `/${defaultApp}` });
+    const parsedUrl = new URL(req.url || "/", "http://workspace.local");
+    const pathname = parsedUrl.pathname;
+
+    if (pathname === "/" || pathname === "/index.html") {
+      syncApps();
+      const currentDefaultApp =
+        explicitDefaultApp && appById.has(explicitDefaultApp)
+          ? explicitDefaultApp
+          : appById.has("dispatch")
+            ? "dispatch"
+            : defaultApp;
+      const shouldRedirectRoot =
+        Boolean(explicitDefaultApp && appById.has(explicitDefaultApp)) ||
+        appById.has("dispatch");
+      if (shouldRedirectRoot) {
+        res.writeHead(302, {
+          location: `/${currentDefaultApp}${parsedUrl.search}`,
+        });
         res.end();
         return;
       }
@@ -680,7 +727,7 @@ export function runWorkspaceDev(
       return;
     }
 
-    if (req.url === "/_workspace/apps") {
+    if (pathname === "/_workspace/apps") {
       syncApps();
       res.writeHead(200, { "content-type": "application/json" });
       res.end(

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -238,8 +238,33 @@ export interface AgentPanelCodeAccess {
   unavailableCtaLabel?: string;
   /** Optional CTA URL for the unavailable state. */
   unavailableCtaHref?: string;
+  /** Optional secondary CTA label, usually for Builder cloud code changes. */
+  unavailableSecondaryCtaLabel?: string;
+  /** Optional secondary CTA URL, usually the Builder connect URL. */
+  unavailableSecondaryCtaHref?: string;
   /** Disabled composer placeholder while code access is unavailable. */
   unavailableComposerPlaceholder?: string;
+}
+
+function useBuilderConnectUrl() {
+  const [connectUrl, setConnectUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(agentNativePath("/_agent-native/builder/status"))
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && data?.connectUrl) {
+          setConnectUrl(data.connectUrl);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return connectUrl;
 }
 
 export interface AgentPanelProps extends Omit<
@@ -277,14 +302,22 @@ function CodeAccessUnavailablePanel({
   description,
   ctaLabel,
   ctaHref,
+  secondaryCtaLabel = "Use Builder",
+  secondaryCtaHref,
   compact = false,
 }: {
   title: string;
   description: string;
   ctaLabel: string;
   ctaHref?: string;
+  secondaryCtaLabel?: string;
+  secondaryCtaHref?: string;
   compact?: boolean;
 }) {
+  const builderConnectUrl = useBuilderConnectUrl();
+  const builderHref =
+    secondaryCtaHref ?? builderConnectUrl ?? "https://builder.io";
+
   return (
     <div
       className={cn(
@@ -309,17 +342,28 @@ function CodeAccessUnavailablePanel({
       >
         {description}
       </p>
-      {ctaHref ? (
+      <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+        {ctaHref ? (
+          <a
+            href={ctaHref}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs font-medium text-background hover:opacity-90"
+          >
+            {ctaLabel}
+            <IconExternalLink className="h-3 w-3" />
+          </a>
+        ) : null}
         <a
-          href={ctaHref}
+          href={builderHref}
           target="_blank"
           rel="noreferrer"
-          className="mt-3 inline-flex items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs font-medium text-background hover:opacity-90"
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-3 py-1.5 text-xs font-medium text-foreground hover:bg-accent"
         >
-          {ctaLabel}
+          {secondaryCtaLabel}
           <IconExternalLink className="h-3 w-3" />
         </a>
-      ) : null}
+      </div>
     </div>
   );
 }
@@ -516,11 +560,26 @@ function AgentPanelInner({
     codeAccess?.unavailableCtaLabel ?? "Download Desktop";
   const codeUnavailableCtaHref =
     codeAccess?.unavailableCtaHref ?? "https://agent-native.com/download";
+  const codeUnavailableSecondaryCtaLabel =
+    codeAccess?.unavailableSecondaryCtaLabel ?? "Use Builder";
+  const codeUnavailableSecondaryCtaHref =
+    codeAccess?.unavailableSecondaryCtaHref;
   const codeUnavailableComposerPlaceholder =
     codeAccess?.unavailableComposerPlaceholder ??
     "Open Desktop to edit code or run commands.";
   const canUseCodeTools = isDevMode && codeAccessEnabled;
+  const planModeDisabled = isDevMode && !codeAccessEnabled;
+  const effectiveExecMode = planModeDisabled ? "build" : execMode;
+  const planModeDisabledReason =
+    "Plan mode uses the local code agent. Open Agent Native Desktop to use Plan mode.";
   const showCliMode = isDevMode || !codeAccessEnabled;
+  const handleExecModeChange = useCallback(
+    (next: ExecMode) => {
+      if (planModeDisabled && next === "plan") return;
+      switchExecMode(next);
+    },
+    [planModeDisabled, switchExecMode],
+  );
 
   // Notify frame when dev mode changes — use both a local CustomEvent (for
   // when AgentPanel is rendered directly in the frame) AND postMessage (for
@@ -1185,8 +1244,10 @@ function AgentPanelInner({
             }
             suggestions={codeAccessEnabled ? suggestions : undefined}
             onSwitchToCli={() => switchMode("cli")}
-            execMode={canUseCodeTools ? execMode : undefined}
-            onExecModeChange={canUseCodeTools ? switchExecMode : undefined}
+            execMode={isDevMode ? effectiveExecMode : undefined}
+            onExecModeChange={isDevMode ? handleExecModeChange : undefined}
+            planModeDisabled={planModeDisabled}
+            planModeDisabledReason={planModeDisabledReason}
             storageKey={storageKey}
             composerSlot={
               codeAccessEnabled ? undefined : (
@@ -1195,6 +1256,8 @@ function AgentPanelInner({
                   description={codeUnavailableDescription}
                   ctaLabel={codeUnavailableCtaLabel}
                   ctaHref={codeUnavailableCtaHref}
+                  secondaryCtaLabel={codeUnavailableSecondaryCtaLabel}
+                  secondaryCtaHref={codeUnavailableSecondaryCtaHref}
                   compact
                 />
               )
@@ -1247,6 +1310,8 @@ function AgentPanelInner({
                 }
                 ctaLabel={codeUnavailableCtaLabel}
                 ctaHref={codeAccessEnabled ? undefined : codeUnavailableCtaHref}
+                secondaryCtaLabel={codeUnavailableSecondaryCtaLabel}
+                secondaryCtaHref={codeUnavailableSecondaryCtaHref}
               />
             </div>
           )}
@@ -1276,6 +1341,8 @@ function AgentPanelInner({
                 description={codeUnavailableDescription}
                 ctaLabel={codeUnavailableCtaLabel}
                 ctaHref={codeUnavailableCtaHref}
+                secondaryCtaLabel={codeUnavailableSecondaryCtaLabel}
+                secondaryCtaHref={codeUnavailableSecondaryCtaHref}
               />
             </div>
           )}

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2159,6 +2159,10 @@ export interface AssistantChatProps {
   execMode?: "build" | "plan";
   /** Callback to change execution mode */
   onExecModeChange?: (mode: "build" | "plan") => void;
+  /** Disable Plan mode while leaving Act mode available. */
+  planModeDisabled?: boolean;
+  /** Explanation shown next to the disabled Plan option. */
+  planModeDisabledReason?: string;
   /** Selected model override for this conversation (undefined = use server default) */
   selectedModel?: string;
   /** Default model from server config (shown in picker when no override is set) */
@@ -2252,6 +2256,8 @@ const AssistantChatInner = forwardRef<
     onSlashCommand,
     execMode,
     onExecModeChange,
+    planModeDisabled,
+    planModeDisabledReason,
     selectedModel,
     defaultModel,
     selectedEngine,
@@ -3531,6 +3537,8 @@ const AssistantChatInner = forwardRef<
                   onSlashCommand={onSlashCommand}
                   execMode={execMode}
                   onExecModeChange={onExecModeChange}
+                  planModeDisabled={planModeDisabled}
+                  planModeDisabledReason={planModeDisabledReason}
                   selectedModel={selectedModel ?? defaultModel}
                   selectedEffort={selectedEffort}
                   availableModels={availableModels}

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -69,6 +69,8 @@ import {
   type TiptapComposerHandle,
 } from "./composer/TiptapComposer.js";
 import type { Reference } from "./composer/types.js";
+import { isPastedTextAttachmentName } from "./composer/pasted-text.js";
+import { PastedTextChip } from "./composer/PastedTextChip.js";
 import {
   IconMessage,
   IconX,
@@ -662,6 +664,10 @@ function ComposerAttachmentPreviewCard({
     };
   }, [attachment]);
 
+  if (isPastedTextAttachmentName(attachment.name)) {
+    return <PastedTextChip attachment={attachment} onRemove={onRemove} />;
+  }
+
   const isImage = !!imageSrc;
 
   return (
@@ -1112,6 +1118,10 @@ function UserMessageAttachments() {
   return (
     <div className="flex flex-wrap justify-end gap-1.5 mb-1.5">
       {attachments.map((att) => {
+        if (isPastedTextAttachmentName(att.name)) {
+          return <PastedTextChip key={att.id} attachment={att} compact />;
+        }
+
         const imagePart = att.content?.find(
           (p): p is { type: "image"; image: string } =>
             p.type === "image" && "image" in p && !!p.image,

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -145,7 +145,12 @@ describe("createAgentChatAdapter", () => {
               {
                 name: "notes.txt",
                 contentType: "text/plain",
-                content: [{ type: "text", text: "Attachment text" }],
+                content: [
+                  {
+                    type: "text",
+                    text: "<attachment name=notes.txt>\nAttachment text\n</attachment>",
+                  },
+                ],
               },
               {
                 name: "report.md",
@@ -154,6 +159,17 @@ describe("createAgentChatAdapter", () => {
                     type: "file",
                     data: "# Report",
                     mimeType: "text/markdown",
+                  },
+                ],
+              },
+              {
+                name: "transcript.txt",
+                contentType: "text/plain",
+                content: [
+                  {
+                    type: "file",
+                    data: "data:text/plain;base64,VHJhbnNjcmlwdCB0ZXh0",
+                    mimeType: "text/plain",
                   },
                 ],
               },
@@ -218,6 +234,12 @@ describe("createAgentChatAdapter", () => {
           name: "report.md",
           contentType: "text/markdown",
           text: "# Report",
+        },
+        {
+          type: "file",
+          name: "transcript.txt",
+          contentType: "text/plain",
+          text: "Transcript text",
         },
       ],
     });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -95,7 +95,9 @@ function isTextAttachmentContentType(value: string | undefined): boolean {
 }
 
 function decodeTextDataUrl(dataUrl: string): string | null {
-  const match = dataUrl.match(/^data:([^;,]+)(?:;charset=[^;,]+)?(;base64)?,(.*)$/i);
+  const match = dataUrl.match(
+    /^data:([^;,]+)(?:;charset=[^;,]+)?(;base64)?,(.*)$/i,
+  );
   if (!match || !isTextAttachmentContentType(match[1])) return null;
 
   try {
@@ -103,8 +105,9 @@ function decodeTextDataUrl(dataUrl: string): string | null {
     if (match[2]) {
       if (typeof atob === "function") {
         return decodeURIComponent(
-          Array.from(atob(payload), (char) =>
-            `%${char.charCodeAt(0).toString(16).padStart(2, "0")}`,
+          Array.from(
+            atob(payload),
+            (char) => `%${char.charCodeAt(0).toString(16).padStart(2, "0")}`,
           ).join(""),
         );
       }

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -11,6 +11,7 @@ import {
 } from "./sse-event-processor.js";
 import { agentNativePath } from "./api-path.js";
 import { normalizeChatError } from "./error-format.js";
+import { unwrapAttachmentEnvelope } from "./composer/pasted-text.js";
 import type { ReasoningEffort } from "../shared/reasoning-effort.js";
 import type {
   AgentChatStructuredContentPart,
@@ -21,6 +22,18 @@ type AdapterHistoryMessage = {
   role: "user" | "assistant";
   content: string;
 };
+
+const TEXT_ATTACHMENT_CONTENT_TYPES = new Set([
+  "application/json",
+  "application/x-ndjson",
+  "text/csv",
+  "text/css",
+  "text/html",
+  "text/json",
+  "text/markdown",
+  "text/plain",
+  "text/xml",
+]);
 
 const AUTO_CONTINUE_PROMPT =
   "Continue from where you left off and finish the user's original request. Do not repeat completed work, do not mention internal reconnects, time limits, or step limits, and continue as if this is the same uninterrupted run.";
@@ -69,6 +82,38 @@ function messageTextFromContent(
     .filter((p): p is { type: "text"; text: string } => p.type === "text")
     .map((p) => normalizeMentions(p.text))
     .join("\n");
+}
+
+function isTextAttachmentContentType(value: string | undefined): boolean {
+  if (!value) return false;
+  const contentType = value.split(";")[0]?.trim().toLowerCase();
+  return (
+    !!contentType &&
+    (contentType.startsWith("text/") ||
+      TEXT_ATTACHMENT_CONTENT_TYPES.has(contentType))
+  );
+}
+
+function decodeTextDataUrl(dataUrl: string): string | null {
+  const match = dataUrl.match(/^data:([^;,]+)(?:;charset=[^;,]+)?(;base64)?,(.*)$/i);
+  if (!match || !isTextAttachmentContentType(match[1])) return null;
+
+  try {
+    const payload = match[3] ?? "";
+    if (match[2]) {
+      if (typeof atob === "function") {
+        return decodeURIComponent(
+          Array.from(atob(payload), (char) =>
+            `%${char.charCodeAt(0).toString(16).padStart(2, "0")}`,
+          ).join(""),
+        );
+      }
+      return null;
+    }
+    return decodeURIComponent(payload.replace(/\+/g, "%20"));
+  } catch {
+    return null;
+  }
 }
 
 function isToolCallContentPart(
@@ -449,24 +494,28 @@ export function createAgentChatAdapter(options?: {
                 data: part.image,
               });
             } else if (part.type === "file" && typeof part.data === "string") {
+              const contentType =
+                att.contentType ??
+                (typeof part.mimeType === "string" ? part.mimeType : undefined);
+              const decodedText = part.data.startsWith("data:")
+                ? decodeTextDataUrl(part.data)
+                : null;
               attachments.push({
                 type: "file",
                 name: att.name,
-                contentType:
-                  att.contentType ??
-                  (typeof part.mimeType === "string"
-                    ? part.mimeType
-                    : undefined),
-                ...(part.data.startsWith("data:")
-                  ? { data: part.data }
-                  : { text: part.data }),
+                contentType,
+                ...(decodedText !== null
+                  ? { text: decodedText }
+                  : part.data.startsWith("data:")
+                    ? { data: part.data }
+                    : { text: part.data }),
               });
             } else if (part.type === "text" && typeof part.text === "string") {
               attachments.push({
                 type: "file",
                 name: att.name,
                 contentType: att.contentType,
-                text: part.text,
+                text: unwrapAttachmentEnvelope(part.text),
               });
             }
           }

--- a/packages/core/src/client/components/CodeRequiredDialog.tsx
+++ b/packages/core/src/client/components/CodeRequiredDialog.tsx
@@ -50,6 +50,8 @@ export function CodeRequiredDialog({
   const [submitting, setSubmitting] = useState(false);
   const [branchUrl, setBranchUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const builderHref =
+    connectUrl || agentNativePath("/_agent-native/builder/connect");
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -127,25 +129,25 @@ export function CodeRequiredDialog({
             <h2 style={s.title}>Code changes required</h2>
             <p style={s.subtitle}>
               {featureLabel
-                ? `"${featureLabel}" creates or modifies source code, which isn't available in deployed apps.`
-                : "This action creates or modifies source code, which isn't available in deployed apps."}
+                ? `"${featureLabel}" creates or modifies source code, which needs Desktop or Builder from this surface.`
+                : "This action creates or modifies source code, which needs Desktop or Builder from this surface."}
             </p>
           </div>
         </div>
 
         {/* Options */}
         <div style={s.options}>
-          <button
-            style={s.optionCard}
+          <a
+            href="https://agent-native.com/download"
+            target="_blank"
+            rel="noreferrer"
+            style={{ ...s.optionCard, ...s.optionLink }}
             onMouseEnter={(e) =>
               Object.assign(e.currentTarget.style, s.optionCardHover)
             }
             onMouseLeave={(e) =>
               Object.assign(e.currentTarget.style, { borderColor: "#e5e7eb" })
             }
-            onClick={() => {
-              onClose();
-            }}
           >
             <div style={s.optionIcon}>
               <IconCode size={24} />
@@ -157,49 +159,70 @@ export function CodeRequiredDialog({
                 Workspace files, and CLI access.
               </span>
             </div>
-          </button>
+          </a>
 
-          <button
-            style={{
-              ...s.optionCard,
-              ...(submitting
-                ? { opacity: 0.7, pointerEvents: "none" as const }
-                : {}),
-            }}
-            onMouseEnter={(e) =>
-              Object.assign(e.currentTarget.style, s.optionCardHover)
-            }
-            onMouseLeave={(e) =>
-              Object.assign(e.currentTarget.style, { borderColor: "#e5e7eb" })
-            }
-            onClick={handleBuilderAgent}
-          >
-            <div style={s.optionIcon}>
-              {submitting ? (
-                <IconLoader2
-                  size={24}
-                  style={{ animation: "spin 1s linear infinite" }}
-                />
-              ) : (
+          {builderConnected ? (
+            <button
+              style={{
+                ...s.optionCard,
+                ...(submitting
+                  ? { opacity: 0.7, pointerEvents: "none" as const }
+                  : {}),
+              }}
+              onMouseEnter={(e) =>
+                Object.assign(e.currentTarget.style, s.optionCardHover)
+              }
+              onMouseLeave={(e) =>
+                Object.assign(e.currentTarget.style, { borderColor: "#e5e7eb" })
+              }
+              onClick={handleBuilderAgent}
+            >
+              <div style={s.optionIcon}>
+                {submitting ? (
+                  <IconLoader2
+                    size={24}
+                    style={{ animation: "spin 1s linear infinite" }}
+                  />
+                ) : (
+                  <IconExternalLink size={24} />
+                )}
+              </div>
+              <div style={s.optionText}>
+                <span style={s.optionTitle}>Use Builder.io Agent</span>
+                <span style={s.optionDesc}>
+                  Let our cloud agent make the changes for you. You'll get a
+                  link to preview and deploy.
+                </span>
+              </div>
+            </button>
+          ) : (
+            <a
+              href={builderHref}
+              target="_blank"
+              rel="noreferrer"
+              style={{ ...s.optionCard, ...s.optionLink }}
+              onMouseEnter={(e) =>
+                Object.assign(e.currentTarget.style, s.optionCardHover)
+              }
+              onMouseLeave={(e) =>
+                Object.assign(e.currentTarget.style, {
+                  borderColor: "#e5e7eb",
+                })
+              }
+            >
+              <div style={s.optionIcon}>
                 <IconExternalLink size={24} />
-              )}
-            </div>
-            <div style={s.optionText}>
-              <span style={s.optionTitle}>
-                {builderConnected
-                  ? "Use Builder.io Agent"
-                  : "Connect Builder.io"}
-              </span>
-              <span style={s.optionDesc}>
-                {builderConnected
-                  ? "Let our cloud agent make the changes for you. You'll get a link to preview and deploy."
-                  : "Connect Builder to enable cloud-based code changes. Opens the Setup tab."}
-              </span>
-            </div>
-            {!builderConnected && !connectUrl && (
-              <span style={s.badge}>Setup required</span>
-            )}
-          </button>
+              </div>
+              <div style={s.optionText}>
+                <span style={s.optionTitle}>Connect Builder.io</span>
+                <span style={s.optionDesc}>
+                  Connect Builder to enable cloud-based code changes from this
+                  app.
+                </span>
+              </div>
+              {!connectUrl && <span style={s.badge}>Setup required</span>}
+            </a>
+          )}
         </div>
 
         {/* Branch result */}
@@ -311,6 +334,10 @@ const s: Record<string, React.CSSProperties> = {
   },
   optionCardHover: {
     borderColor: "#a5b4fc",
+  },
+  optionLink: {
+    textDecoration: "none",
+    boxSizing: "border-box",
   },
   optionIcon: {
     flexShrink: 0,

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -224,6 +224,10 @@ interface TiptapComposerProps {
   execMode?: ExecMode;
   /** Callback to change execution mode */
   onExecModeChange?: (mode: ExecMode) => void;
+  /** Disable Plan mode while leaving Act mode available. */
+  planModeDisabled?: boolean;
+  /** Explanation shown next to the disabled Plan option. */
+  planModeDisabledReason?: string;
   /** Show the microphone button for voice dictation. Default true. */
   voiceEnabled?: boolean;
   /** Selected model override for this conversation */
@@ -299,9 +303,13 @@ export function createTiptapComposerExtensions(
 function ModeSelector({
   mode,
   onChange,
+  planModeDisabled = false,
+  planModeDisabledReason = "Open Agent Native Desktop to use Plan mode.",
 }: {
   mode: ExecMode;
   onChange: (mode: ExecMode) => void;
+  planModeDisabled?: boolean;
+  planModeDisabledReason?: string;
 }) {
   const [open, setOpen] = useState(false);
   const ActiveIcon = mode === "build" ? IconPencil : IconClipboardList;
@@ -354,22 +362,37 @@ function ModeSelector({
           </button>
           <button
             type="button"
+            disabled={planModeDisabled}
+            title={planModeDisabled ? planModeDisabledReason : undefined}
             onClick={() => {
+              if (planModeDisabled) return;
               onChange("plan");
               setOpen(false);
             }}
-            className="flex w-full items-center gap-3 px-3 py-2 hover:bg-accent/50 text-left"
+            className={`flex w-full items-center gap-3 px-3 py-2 text-left ${
+              planModeDisabled
+                ? "cursor-not-allowed opacity-60"
+                : "hover:bg-accent/50"
+            }`}
           >
-            <IconClipboardList className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-300" />
+            <IconClipboardList
+              className={`h-4 w-4 shrink-0 ${
+                planModeDisabled
+                  ? "text-muted-foreground"
+                  : "text-amber-600 dark:text-amber-300"
+              }`}
+            />
             <div className="flex-1 min-w-0">
               <span className="font-medium text-foreground text-[13px]">
                 Plan
               </span>
               <p className="text-[11px] text-muted-foreground mt-0.5">
-                Read-only research and approval first
+                {planModeDisabled
+                  ? planModeDisabledReason
+                  : "Read-only research and approval first"}
               </p>
             </div>
-            {mode === "plan" && (
+            {mode === "plan" && !planModeDisabled && (
               <IconCheck className="h-3.5 w-3.5 shrink-0 text-blue-500" />
             )}
           </button>
@@ -703,6 +726,8 @@ export function TiptapComposer({
   onSlashCommand,
   execMode,
   onExecModeChange,
+  planModeDisabled = false,
+  planModeDisabledReason,
   voiceEnabled = true,
   selectedModel,
   selectedEffort,
@@ -731,6 +756,8 @@ export function TiptapComposer({
   execModeRef.current = execMode;
   const onExecModeChangeRef = useRef(onExecModeChange);
   onExecModeChangeRef.current = onExecModeChange;
+  const planModeDisabledRef = useRef(planModeDisabled);
+  planModeDisabledRef.current = planModeDisabled;
 
   const { items: mentionItems, isLoading: mentionsLoading } = useMentionSearch(
     popover?.type === "@" ? popover.query : "",
@@ -988,7 +1015,10 @@ export function TiptapComposer({
           const current = execModeRef.current;
           const cb = onExecModeChangeRef.current;
           if (current && cb) {
-            cb(current === "build" ? "plan" : "build");
+            const next = current === "build" ? "plan" : "build";
+            if (next !== "plan" || !planModeDisabledRef.current) {
+              cb(next);
+            }
           }
           return true;
         }
@@ -1614,7 +1644,12 @@ export function TiptapComposer({
               />
             )}
             {execMode && onExecModeChange && (
-              <ModeSelector mode={execMode} onChange={onExecModeChange} />
+              <ModeSelector
+                mode={execMode}
+                onChange={onExecModeChange}
+                planModeDisabled={planModeDisabled}
+                planModeDisabledReason={planModeDisabledReason}
+              />
             )}
             {voiceEnabled && (
               <VoiceButton voice={voice} isMac={isMac} disabled={disabled} />

--- a/packages/core/src/client/composer/pasted-text.spec.ts
+++ b/packages/core/src/client/composer/pasted-text.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { shouldConvertPasteToAttachment } from "./pasted-text.js";
+import {
+  shouldConvertPasteToAttachment,
+  unwrapAttachmentEnvelope,
+} from "./pasted-text.js";
 
 describe("shouldConvertPasteToAttachment", () => {
   it("keeps a paragraph or two inline", () => {
@@ -43,5 +46,13 @@ describe("shouldConvertPasteToAttachment", () => {
     ).join("\n");
 
     expect(shouldConvertPasteToAttachment(pageOfLines)).toBe(true);
+  });
+
+  it("unwraps assistant-ui text attachment envelopes with attributes", () => {
+    expect(
+      unwrapAttachmentEnvelope(
+        '<attachment name="notes.txt" contentType="text/plain">\nLine one\nLine two\n</attachment>',
+      ),
+    ).toBe("Line one\nLine two");
   });
 });

--- a/packages/core/src/client/composer/pasted-text.ts
+++ b/packages/core/src/client/composer/pasted-text.ts
@@ -34,9 +34,7 @@ export function isPastedTextAttachmentName(name: string | undefined): boolean {
 // SimpleTextAttachmentAdapter wraps the file body in when sending. Returns the
 // raw body for previewing.
 export function unwrapAttachmentEnvelope(text: string): string {
-  const match = text.match(
-    /^<attachment name=[^>]+>\n([\s\S]*)\n<\/attachment>$/,
-  );
+  const match = text.match(/^<attachment\b[^>]*>\n([\s\S]*)\n<\/attachment>$/);
   return match ? match[1] : text;
 }
 

--- a/packages/core/src/client/use-chat-models.ts
+++ b/packages/core/src/client/use-chat-models.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { agentNativePath } from "./api-path.js";
 import { DEFAULT_MODEL } from "../agent/default-model.js";
 import {
@@ -81,6 +81,19 @@ export function useChatModels({
   const [selectedEffort, setSelectedEffort] = useState<ReasoningEffort>(
     initialPersisted.effort ?? "auto",
   );
+  const selectionRef = useRef({
+    selectedModel,
+    selectedEngine,
+    selectedEffort,
+  });
+
+  useEffect(() => {
+    selectionRef.current = {
+      selectedModel,
+      selectedEngine,
+      selectedEffort,
+    };
+  }, [selectedEffort, selectedEngine, selectedModel]);
 
   const onModelChange = useCallback(
     (model: string, engine: string) => {
@@ -237,11 +250,44 @@ export function useChatModels({
               };
             });
         }
+        const nextDefaultModel = currentModel ?? DEFAULT_MODEL;
         setAvailableModels(groups);
-        setDefaultModel(currentModel ?? DEFAULT_MODEL);
+        setDefaultModel(nextDefaultModel);
+
+        const selection = selectionRef.current;
+        const selectedGroup = groups.find(
+          (group) =>
+            group.models.includes(selection.selectedModel) &&
+            (!selection.selectedEngine ||
+              group.engine === selection.selectedEngine),
+        );
+        if (!selectedGroup) {
+          const defaultGroup =
+            groups.find((group) => group.models.includes(nextDefaultModel)) ??
+            groups[0];
+          const nextModel =
+            defaultGroup?.models.find((model) => model === nextDefaultModel) ??
+            defaultGroup?.models[0] ??
+            nextDefaultModel;
+          const nextEngine = defaultGroup?.engine ?? "";
+          const effortOptions = getReasoningEffortOptionsForModel(nextModel);
+          const nextEffort =
+            selection.selectedEffort === "auto" ||
+            effortOptions.includes(selection.selectedEffort)
+              ? selection.selectedEffort
+              : "auto";
+          setSelectedModel(nextModel);
+          setSelectedEngine(nextEngine);
+          setSelectedEffort(nextEffort);
+          writePersisted(storageKey, {
+            model: nextModel,
+            engine: nextEngine,
+            effort: nextEffort,
+          });
+        }
       })
       .catch(() => {});
-  }, []);
+  }, [storageKey]);
 
   useEffect(() => {
     refreshEngines();

--- a/packages/core/src/integrations/plugin.ts
+++ b/packages/core/src/integrations/plugin.ts
@@ -11,7 +11,6 @@ import type {
   IntegrationStatus,
 } from "./types.js";
 import { handleWebhook, processIntegrationTask } from "./webhook-handler.js";
-import { DEFAULT_MODEL } from "../agent/default-model.js";
 import {
   claimPendingTask,
   getPendingTask,
@@ -185,7 +184,7 @@ export function createIntegrationsPlugin(
       adapterMap.set(adapter.platform, adapter);
     }
 
-    const model = options?.model ?? DEFAULT_MODEL;
+    const model = options?.model;
     // Read the API key at REQUEST time, not plugin-init time. On Netlify
     // Lambda the plugin module loads in a context where env vars from the
     // site's runtime config may not yet be populated, so capturing at

--- a/packages/core/src/integrations/types.ts
+++ b/packages/core/src/integrations/types.ts
@@ -177,7 +177,7 @@ export interface IntegrationsPluginOptions {
   systemPrompt?: string;
   /** Actions registry (same as agent-chat). */
   actions?: Record<string, import("../agent/production-agent.js").ActionEntry>;
-  /** Model to use. Default: claude-sonnet-4-6 */
+  /** Model to use. Defaults to the resolved engine's default model. */
   model?: string;
   /** Anthropic API key. Falls back to ANTHROPIC_API_KEY env var. */
   apiKey?: string;

--- a/packages/core/src/integrations/webhook-handler.ts
+++ b/packages/core/src/integrations/webhook-handler.ts
@@ -72,8 +72,8 @@ export interface WebhookHandlerOptions {
   systemPrompt: string;
   /** Action entries for the agent */
   actions: Record<string, ActionEntry>;
-  /** Model to use */
-  model: string;
+  /** Model to use. Defaults to the resolved engine's default model. */
+  model?: string;
   /** Anthropic API key */
   apiKey: string;
   /** Agent engine to use. Defaults to the same resolver as web chat. */

--- a/packages/core/src/scripts/agent-engines/manage-agent-engine.ts
+++ b/packages/core/src/scripts/agent-engines/manage-agent-engine.ts
@@ -30,7 +30,7 @@ export const tool: ActionTool = {
       model: {
         type: "string",
         description:
-          "Model ID (e.g. 'claude-sonnet-4-6', 'gpt-4o'). Optional for \"set\" and \"test\"; defaults to the engine's default model.",
+          "Model ID (e.g. 'gpt-5.5', 'claude-sonnet-4-6'). Optional for \"set\" and \"test\"; defaults to the engine's default model.",
       },
     },
     required: ["action"],

--- a/packages/core/src/scripts/agent-engines/set-agent-engine.ts
+++ b/packages/core/src/scripts/agent-engines/set-agent-engine.ts
@@ -24,7 +24,7 @@ export const tool: ActionTool = {
       model: {
         type: "string",
         description:
-          "Model ID to use with this engine (e.g. 'claude-sonnet-4-6', 'gpt-4o'). Defaults to the engine's default model if omitted.",
+          "Model ID to use with this engine (e.g. 'gpt-5.5', 'claude-sonnet-4-6'). Defaults to the engine's default model if omitted.",
       },
     },
     required: ["engine"],

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -25,8 +25,12 @@ import {
 } from "../agent/production-agent.js";
 import { resolveRunSoftTimeoutMs } from "../agent/run-manager.js";
 import type { AgentEngine, EngineMessage } from "../agent/engine/types.js";
-import { resolveEngine, createAnthropicEngine } from "../agent/engine/index.js";
-import { DEFAULT_MODEL } from "../agent/default-model.js";
+import {
+  resolveEngine,
+  createAnthropicEngine,
+  getStoredModelForEngine,
+} from "../agent/engine/index.js";
+import { DEFAULT_ANTHROPIC_MODEL } from "../agent/default-model.js";
 import type {
   AgentChatEvent,
   ActionTool,
@@ -1330,7 +1334,7 @@ export interface AgentChatPluginOptions {
   systemPrompt?: string;
   /** Additional system prompt prepended in dev mode */
   devSystemPrompt?: string;
-  /** Claude model to use. Default: claude-sonnet-4-6 */
+  /** Model to use. Defaults to the resolved engine's default model. */
   model?: string;
   /** Optional per-app agent run chunk budget in milliseconds. Defaults to
    * AGENT_RUN_SOFT_TIMEOUT_MS when set, otherwise no framework-imposed
@@ -2881,7 +2885,10 @@ export function createAgentChatPlugin(
             ? devPrompt + runtimeContext + resources + schemaBlock + extra
             : basePrompt + runtimeContext + resources + schemaBlock + extra;
 
-          const model = options?.model ?? DEFAULT_MODEL;
+          const model =
+            options?.model ??
+            (await getStoredModelForEngine(a2aEngine)) ??
+            a2aEngine.defaultModel;
 
           // Build tools — same as interactive handler but WITHOUT call-agent
           // to prevent infinite recursive A2A loops (agent calling itself).
@@ -3060,7 +3067,10 @@ export function createAgentChatPlugin(
             engineOption: options?.engine,
             apiKey: options?.apiKey,
           });
-          const model = options?.model ?? DEFAULT_MODEL;
+          const model =
+            options?.model ??
+            (await getStoredModelForEngine(mcpEngine)) ??
+            mcpEngine.defaultModel;
 
           // Same actions as A2A — without call-agent to prevent loops.
           // In dev mode, template actions go through shell, not native tools.
@@ -3395,7 +3405,7 @@ export function createAgentChatPlugin(
         string,
         (event: import("../agent/types.js").AgentChatEvent) => void
       >();
-      const resolvedModel = options?.model ?? DEFAULT_MODEL;
+      const resolvedModel = options?.model ?? DEFAULT_ANTHROPIC_MODEL;
 
       const teamTools = createTeamTools({
         getOwner: () => requireCurrentRunOwner("spawn or manage sub-agents"),
@@ -3573,7 +3583,7 @@ export function createAgentChatPlugin(
             basePrompt + runtimeContext + resources + schemaBlock + extra,
           );
         },
-        model: options?.model ?? DEFAULT_MODEL,
+        model: options?.model,
         apiKey: options?.apiKey,
         runSoftTimeoutMs: options?.runSoftTimeoutMs,
         finalResponseGuard: options?.finalResponseGuard,
@@ -3613,7 +3623,7 @@ export function createAgentChatPlugin(
                     extra,
                 );
               },
-              model: options?.model ?? DEFAULT_MODEL,
+              model: options?.model,
               apiKey: options?.apiKey,
               runSoftTimeoutMs: options?.runSoftTimeoutMs,
               finalResponseGuard: options?.finalResponseGuard,

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1338,6 +1338,37 @@ describe("server/auth", () => {
     });
   });
 
+  describe("OAuth session creation", () => {
+    it("uses cross-site cookie attributes for HTTPS Google sign-in sessions", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+
+      const mockExecute = vi.fn(async () => ({ rows: [] }));
+      vi.doMock("../db/client.js", () => ({
+        getDbExec: () => ({ execute: mockExecute }),
+        isPostgres: () => false,
+        isLocalDatabase: () => false,
+        intType: () => "INTEGER",
+        retryOnDdlRace: (fn: () => Promise<unknown>) => fn(),
+      }));
+
+      const { createOAuthSession } = await import("./google-oauth.js");
+      const event = createMockEvent({
+        headers: { "x-forwarded-proto": "https" },
+      });
+      delete event.node.req.headers["x-forwarded-proto"];
+
+      const result = await createOAuthSession(event, "user@gmail.com", {
+        hasProductionSession: false,
+      });
+
+      expect(result.sessionToken).toBeTypeOf("string");
+      const setCookie = event.res.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain(result.sessionToken);
+      expect(setCookie).toContain("SameSite=None");
+      expect(setCookie).toContain("Secure");
+    });
+  });
+
   describe("OAuth callback copy", () => {
     it("uses the requested app name for desktop exchange completion", async () => {
       const { oauthCallbackResponse } = await import("./google-oauth.js");

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -1200,7 +1200,7 @@ function crossSiteCookieAttrs(event: H3Event): {
     : { sameSite: "lax", secure: false };
 }
 
-function setFrameworkSessionCookie(event: H3Event, token: string): void {
+export function setFrameworkSessionCookie(event: H3Event, token: string): void {
   setCookie(event, COOKIE_NAME, token, {
     httpOnly: true,
     ...crossSiteCookieAttrs(event),

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -11,7 +11,6 @@ import crypto from "node:crypto";
 import {
   getHeader,
   getQuery,
-  setCookie,
   setResponseStatus,
   setResponseHeader,
   type H3Event,
@@ -19,9 +18,9 @@ import {
 import {
   addSession,
   getSession,
-  COOKIE_NAME,
   getSessionMaxAge,
   safeReturnPath,
+  setFrameworkSessionCookie,
 } from "./auth.js";
 import { getAppName } from "./app-name.js";
 import { writeDesktopSso } from "./desktop-sso.js";
@@ -553,13 +552,7 @@ export async function createOAuthSession(
   if (!opts.hasProductionSession || needsDeepLink) {
     sessionToken = crypto.randomBytes(32).toString("hex");
     await addSession(sessionToken, email);
-    setCookie(event, COOKIE_NAME, sessionToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-      path: "/",
-      maxAge,
-    });
+    setFrameworkSessionCookie(event, sessionToken);
     // Desktop SSO: record this session in the home-dir broker file so
     // sibling templates (each with its own database) can resolve the
     // same token without a DB row of their own. Only the PRIMARY

--- a/packages/dispatch/src/server/lib/app-creation-store.spec.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.spec.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runWithRequestContext } from "@agent-native/core/server";
+import { listWorkspaceApps } from "./app-creation-store.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  globalThis.fetch = originalFetch;
+});
+
+describe("listWorkspaceApps", () => {
+  it("prefers the live workspace gateway manifest when available", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          apps: [
+            {
+              id: "dispatch",
+              name: "Agent-Native Dispatch",
+              path: "/dispatch",
+            },
+            { id: "todo", name: "Todo", path: "/todo" },
+          ],
+        }),
+        { headers: { "content-type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("WORKSPACE_GATEWAY_URL", "http://127.0.0.1:8080");
+    vi.stubEnv(
+      "AGENT_NATIVE_WORKSPACE_APPS_JSON",
+      JSON.stringify([{ id: "dispatch", name: "Dispatch", path: "/dispatch" }]),
+    );
+
+    const apps = await runWithRequestContext(
+      { userEmail: "dev@example.test" },
+      () => listWorkspaceApps({ includeAgentCards: false }),
+    );
+
+    const [urlArg, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(urlArg)).toBe("http://127.0.0.1:8080/_workspace/apps");
+    expect(init).toEqual(
+      expect.objectContaining({
+        headers: { accept: "application/json" },
+      }),
+    );
+    expect(apps.map((app) => app.id)).toEqual(["dispatch", "todo"]);
+  });
+});

--- a/packages/dispatch/src/server/lib/app-creation-store.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.ts
@@ -29,6 +29,8 @@ import {
 const SETTINGS_KEY = "dispatch-app-creation-settings";
 const WORKSPACE_APPS_ENV_KEY = "AGENT_NATIVE_WORKSPACE_APPS_JSON";
 const WORKSPACE_APPS_MANIFEST_FILE = "workspace-apps.json";
+const WORKSPACE_APPS_GATEWAY_PATH = "/_workspace/apps";
+const WORKSPACE_APPS_GATEWAY_TIMEOUT_MS = 1_000;
 const MAX_PENDING_APPS = 50;
 const AGENT_CARD_PATH = "/.well-known/agent-card.json";
 const AGENT_CARD_FETCH_TIMEOUT_MS = 1_500;
@@ -455,6 +457,35 @@ function readWorkspaceAppsFromEnv(): WorkspaceAppSummary[] | null {
   }
 }
 
+async function readWorkspaceAppsFromGateway(): Promise<
+  WorkspaceAppSummary[] | null
+> {
+  const base = process.env.WORKSPACE_GATEWAY_URL;
+  if (!base) return null;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    WORKSPACE_APPS_GATEWAY_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(
+      new URL(WORKSPACE_APPS_GATEWAY_PATH, `${base.replace(/\/$/, "")}/`),
+      {
+        headers: { accept: "application/json" },
+        signal: controller.signal,
+      },
+    );
+    if (!response.ok) return null;
+    return parseWorkspaceAppsManifest(await response.json().catch(() => null));
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 function workspaceAppsManifestCandidates(): string[] {
   const candidates: string[] = [];
   try {
@@ -569,6 +600,14 @@ export function getWorkspaceInfo(): WorkspaceInfo {
 export async function listWorkspaceApps(
   options: ListWorkspaceAppsOptions = {},
 ): Promise<WorkspaceAppSummary[]> {
+  const gatewayApps = await readWorkspaceAppsFromGateway();
+  if (gatewayApps) {
+    return maybeIncludeAgentCards(
+      await appendPendingWorkspaceApps(gatewayApps),
+      options,
+    );
+  }
+
   const workspaceRoot = findWorkspaceRoot();
   const localFilesystemApps =
     workspaceRoot && isLocalAppCreationRuntime()

--- a/packages/frame/client/App.tsx
+++ b/packages/frame/client/App.tsx
@@ -109,8 +109,8 @@ function DesktopAppNudge() {
           <span className="font-medium text-foreground">
             Code editing needs Desktop.
           </span>{" "}
-          Source edits, CLI, and Workspace files are disabled in this browser
-          frame.{" "}
+          Use Desktop for local source/CLI access, or Builder for cloud code
+          changes.{" "}
           <a
             href="https://agent-native.com/download"
             target="_blank"
@@ -446,9 +446,10 @@ export function App() {
                   enabled: isDesktop,
                   unavailableTitle: "Open Desktop to edit code",
                   unavailableDescription:
-                    "Source edits, CLI, and Workspace files run in Agent Native Desktop. This browser frame is preview-only for code changes.",
+                    "Use Agent Native Desktop for local source edits, CLI, and Workspace files, or use Builder for cloud code changes.",
                   unavailableCtaLabel: "Download Desktop",
                   unavailableCtaHref: "https://agent-native.com/download",
+                  unavailableSecondaryCtaLabel: "Use Builder",
                   unavailableComposerPlaceholder:
                     "Open Desktop to edit code or run CLI.",
                 }}

--- a/scripts/fusion-analytics-migration/verify-extensions.ts
+++ b/scripts/fusion-analytics-migration/verify-extensions.ts
@@ -1440,22 +1440,32 @@ async function verifyQuery(page: CdpPage, contextId: number) {
     contextId,
     90_000,
   );
-  const output = await page.evaluate<{
-    error?: string;
-    rowCount?: number;
-    historyCount?: number;
-  }>(
-    `(async () => {
+  await page.evaluate(
+    `(() => {
       const state = [...document.querySelectorAll('*')]
         .map((el) => el._x_dataStack?.[0])
         .find((candidate) => candidate && typeof candidate.run === 'function' && Array.isArray(candidate.history));
       if (!state) throw new Error('Missing Query Explorer Alpine state');
       state.sql = 'SELECT 1 AS ok';
-      await state.run();
+      state.run();
+      return true;
+    })()`,
+    contextId,
+  );
+  const output = await page.waitFor<{
+    error?: string;
+    rowCount?: number;
+    historyCount?: number;
+  }>(
+    `(() => {
+      const state = [...document.querySelectorAll('*')]
+        .map((el) => el._x_dataStack?.[0])
+        .find((candidate) => candidate && typeof candidate.run === 'function' && Array.isArray(candidate.history));
+      if (!state || state.loading) return null;
       return { error: state.error || '', rowCount: (state.result?.rows || []).length, historyCount: state.history.length };
     })()`,
     contextId,
-    45_000,
+    75_000,
   );
   const history = await page.evaluate<
     Array<{

--- a/scripts/fusion-analytics-migration/verify-extensions.ts
+++ b/scripts/fusion-analytics-migration/verify-extensions.ts
@@ -1275,21 +1275,32 @@ async function verifyDiscoveryCoach(page: CdpPage, contextId: number) {
   await clickButton(page, contextId, "Developer / Engineer");
   await clickButton(page, contextId, "What they say vs. mean");
   await page.evaluate(
-    `(() => {
-      const label = [...document.querySelectorAll('*')]
-        .find((el) => el.textContent && el.textContent.trim() === 'They say:');
-      const card = label?.closest('.overflow-hidden');
-      const trigger = card?.querySelector('.cursor-pointer');
-      if (!trigger) throw new Error('Missing persona pain trigger');
-      trigger.click();
-      return true;
+    `(async () => {
+      const state = [...document.querySelectorAll('*')]
+        .map((el) => el._x_dataStack?.[0])
+        .find((candidate) => candidate && candidate.opPains && candidate.stages);
+      if (!state) throw new Error('Missing Discovery Coach Alpine state');
+      state.selectPersona('developer');
+      state.setPersonaSection('pains');
+      state.toggleIn('expandedPersonaIndexes', 0);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return document.body.innerText;
     })()`,
     contextId,
   );
-  await page.waitFor<string>(
-    `document.body.innerText.includes('What they mean') && document.body.innerText.includes('Business pain to find')`,
+  const personaText = await page.evaluate<string>(
+    `document.body.innerText`,
     contextId,
   );
+  if (
+    !/What they mean/i.test(personaText) ||
+    !/Business pain to find/i.test(personaText)
+  ) {
+    throw new Error(
+      `Persona pain details did not render. Visible text: ${personaText.slice(0, 1200)}`,
+    );
+  }
   await clickButton(page, contextId, "Pain translation map");
   await page.waitFor<string>(
     `document.body.innerText.includes('Pain translation map')`,
@@ -1297,7 +1308,7 @@ async function verifyDiscoveryCoach(page: CdpPage, contextId: number) {
   );
   await clickButton(page, contextId, "Win / loss signals");
   await page.waitFor<string>(
-    `document.body.innerText.includes('Won deals') && document.body.innerText.includes('Lost deals')`,
+    `/Won deals/i.test(document.body.innerText) && /Lost deals/i.test(document.body.innerText)`,
     contextId,
   );
   await clickButton(page, contextId, "Operational pains");
@@ -1330,7 +1341,7 @@ async function verifyDiscoveryCoach(page: CdpPage, contextId: number) {
     contextId,
   );
   await page.waitFor<string>(
-    `document.body.innerText.includes('Forcing function question') && document.body.innerText.includes('Won examples')`,
+    `/Forcing function question/i.test(document.body.innerText) && /Won examples/i.test(document.body.innerText)`,
     contextId,
   );
   return `stages=${counts.stages}, pains=${counts.pains}, personas=${counts.personas}, businessPains=${counts.businessPains}, signals=${counts.wonSignals + counts.lostSignals}`;

--- a/templates/clips/actions/list-meetings.ts
+++ b/templates/clips/actions/list-meetings.ts
@@ -162,7 +162,7 @@ export default defineAction({
           if (!accessToken) {
             calendarErrors.push(
               await recordCalendarFetchError(
-                account.id,
+                account,
                 new Error("Token refresh failed"),
               ),
             );
@@ -230,9 +230,9 @@ export default defineAction({
             if (liveMeeting) liveMeetings.push(liveMeeting);
           }
 
-          await recordCalendarFetchSuccess(account.id).catch(() => {});
+          await recordCalendarFetchSuccess(account).catch(() => {});
         } catch (err) {
-          calendarErrors.push(await recordCalendarFetchError(account.id, err));
+          calendarErrors.push(await recordCalendarFetchError(account, err));
         }
       }
     }

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -64,7 +64,9 @@ function readSidebarCollapsedPreference() {
   if (typeof window === "undefined") return false;
 
   try {
-    return window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true";
+    return (
+      window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true"
+    );
   } catch {
     return false;
   }
@@ -281,139 +283,195 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="right">
-                    {showCollapsedSidebar ? "Expand sidebar" : "Collapse sidebar"}
+                    {showCollapsedSidebar
+                      ? "Expand sidebar"
+                      : "Collapse sidebar"}
                   </TooltipContent>
                 </Tooltip>
               </div>
               <div className="min-h-0 flex-1 overflow-y-auto">
-                <div className="px-3 py-3">
-                  <Button
-                    className="w-full gap-1.5 bg-primary text-primary-foreground shadow-sm hover:bg-primary/90"
-                    size="sm"
-                    asChild
-                  >
-                    <NavLink to="/record">
-                      <IconPlayerRecord className="h-4 w-4" />
-                      New recording
-                    </NavLink>
-                  </Button>
-                </div>
-
-                <nav className="mt-3 space-y-0.5 px-2">
-                  {navItems.map(({ to, label, icon: Icon, match }) => {
-                    const active = match(location.pathname);
-                    return (
-                      <NavLink
-                        key={to}
-                        to={to}
-                        className={cn(
-                          "flex items-center gap-2 rounded px-2 py-1.5 text-xs",
-                          active
-                            ? "bg-primary/10 font-medium text-primary"
-                            : "text-foreground hover:bg-accent/60",
-                        )}
-                      >
-                        <Icon className="h-4 w-4" />
-                        {label}
-                      </NavLink>
-                    );
-                  })}
-                </nav>
-
-                <div className="mt-4 space-y-4 px-2 pb-3">
-                  <div>
-                    <div className="flex items-center justify-between px-2 pb-1">
-                      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                        Folders
-                      </span>
+                {showCollapsedSidebar ? (
+                  <>
+                    <div className="flex justify-center px-2 py-3">
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            className="rounded p-1 text-muted-foreground hover:bg-accent"
-                            onClick={() => setNewFolderOpen(true)}
+                          <NavLink
+                            to="/record"
+                            aria-label="New recording"
+                            className="flex h-9 w-9 items-center justify-center rounded-md bg-primary text-primary-foreground shadow-sm hover:bg-primary/90"
                           >
-                            <IconFolderPlus className="h-3.5 w-3.5" />
-                          </button>
+                            <IconPlayerRecord className="h-4 w-4" />
+                          </NavLink>
                         </TooltipTrigger>
-                        <TooltipContent>New folder</TooltipContent>
+                        <TooltipContent side="right">
+                          New recording
+                        </TooltipContent>
                       </Tooltip>
                     </div>
-                    <FolderTree
-                      folders={libFolderList}
-                      organizationId={currentOrganizationId}
-                      spaceId={null}
-                      buildPath={(id) => `/library/folder/${id}`}
-                      activeFolderId={folderId ?? null}
-                    />
-                  </div>
 
-                  <div>
-                    <div className="flex items-center justify-between px-2 pb-1">
-                      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                        Spaces
-                      </span>
-                    </div>
-                    <ul className="space-y-0.5">
-                      {(spaces?.spaces ?? []).map((s: any) => {
-                        const active = spaceId === s.id;
+                    <nav className="mt-3 flex flex-col items-center gap-1 px-2">
+                      {navItems.map(({ to, label, icon: Icon, match }) => {
+                        const active = match(location.pathname);
                         return (
-                          <li key={s.id}>
-                            <NavLink
-                              to={`/spaces/${s.id}`}
-                              className={cn(
-                                "flex items-center gap-2 rounded px-2 py-1 text-xs",
-                                active
-                                  ? "bg-primary/10 text-primary"
-                                  : "text-foreground hover:bg-accent/60",
-                              )}
-                            >
-                              <div
-                                className="flex h-4 w-4 items-center justify-center rounded text-[10px]"
-                                style={{
-                                  background: s.color ?? "hsl(var(--primary))",
-                                  color: "white",
-                                }}
+                          <Tooltip key={to}>
+                            <TooltipTrigger asChild>
+                              <NavLink
+                                to={to}
+                                aria-label={label}
+                                className={cn(
+                                  "flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+                                  active &&
+                                    "bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary",
+                                )}
                               >
-                                {s.iconEmoji ??
-                                  s.name.slice(0, 1).toUpperCase()}
-                              </div>
-                              <span className="truncate">{s.name}</span>
-                            </NavLink>
-                          </li>
+                                <Icon className="h-4 w-4" />
+                              </NavLink>
+                            </TooltipTrigger>
+                            <TooltipContent side="right">
+                              {label}
+                            </TooltipContent>
+                          </Tooltip>
                         );
                       })}
-                      {(spaces?.spaces ?? []).length === 0 && (
-                        <li className="px-2 py-1 text-[11px] text-muted-foreground/70">
-                          No spaces yet
-                        </li>
-                      )}
-                    </ul>
-                  </div>
-                </div>
-              </div>
+                    </nav>
+                  </>
+                ) : (
+                  <>
+                    <div className="px-3 py-3">
+                      <Button
+                        className="w-full gap-1.5 bg-primary text-primary-foreground shadow-sm hover:bg-primary/90"
+                        size="sm"
+                        asChild
+                      >
+                        <NavLink to="/record">
+                          <IconPlayerRecord className="h-4 w-4" />
+                          New recording
+                        </NavLink>
+                      </Button>
+                    </div>
 
-              <div className="shrink-0 space-y-1.5 border-t border-border px-2 py-1.5">
-                {shouldShowSidebarLink && (
-                  <NavLink
-                    to="/download"
-                    className="flex items-center gap-2 rounded px-2 py-1.5 text-xs text-foreground hover:bg-accent/60"
-                  >
-                    <IconAppWindow className="h-4 w-4" />
-                    Get desktop app
-                  </NavLink>
+                    <nav className="mt-3 space-y-0.5 px-2">
+                      {navItems.map(({ to, label, icon: Icon, match }) => {
+                        const active = match(location.pathname);
+                        return (
+                          <NavLink
+                            key={to}
+                            to={to}
+                            className={cn(
+                              "flex items-center gap-2 rounded px-2 py-1.5 text-xs",
+                              active
+                                ? "bg-primary/10 font-medium text-primary"
+                                : "text-foreground hover:bg-accent/60",
+                            )}
+                          >
+                            <Icon className="h-4 w-4" />
+                            {label}
+                          </NavLink>
+                        );
+                      })}
+                    </nav>
+
+                    <div className="mt-4 space-y-4 px-2 pb-3">
+                      <div>
+                        <div className="flex items-center justify-between px-2 pb-1">
+                          <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                            Folders
+                          </span>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                type="button"
+                                className="rounded p-1 text-muted-foreground hover:bg-accent"
+                                onClick={() => setNewFolderOpen(true)}
+                              >
+                                <IconFolderPlus className="h-3.5 w-3.5" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>New folder</TooltipContent>
+                          </Tooltip>
+                        </div>
+                        <FolderTree
+                          folders={libFolderList}
+                          organizationId={currentOrganizationId}
+                          spaceId={null}
+                          buildPath={(id) => `/library/folder/${id}`}
+                          activeFolderId={folderId ?? null}
+                        />
+                      </div>
+
+                      <div>
+                        <div className="flex items-center justify-between px-2 pb-1">
+                          <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                            Spaces
+                          </span>
+                        </div>
+                        <ul className="space-y-0.5">
+                          {(spaces?.spaces ?? []).map((s: any) => {
+                            const active = spaceId === s.id;
+                            return (
+                              <li key={s.id}>
+                                <NavLink
+                                  to={`/spaces/${s.id}`}
+                                  className={cn(
+                                    "flex items-center gap-2 rounded px-2 py-1 text-xs",
+                                    active
+                                      ? "bg-primary/10 text-primary"
+                                      : "text-foreground hover:bg-accent/60",
+                                  )}
+                                >
+                                  <div
+                                    className="flex h-4 w-4 items-center justify-center rounded text-[10px]"
+                                    style={{
+                                      background:
+                                        s.color ?? "hsl(var(--primary))",
+                                      color: "white",
+                                    }}
+                                  >
+                                    {s.iconEmoji ??
+                                      s.name.slice(0, 1).toUpperCase()}
+                                  </div>
+                                  <span className="truncate">{s.name}</span>
+                                </NavLink>
+                              </li>
+                            );
+                          })}
+                          {(spaces?.spaces ?? []).length === 0 && (
+                            <li className="px-2 py-1 text-[11px] text-muted-foreground/70">
+                              No spaces yet
+                            </li>
+                          )}
+                        </ul>
+                      </div>
+                    </div>
+                  </>
                 )}
-                <SearchBar />
               </div>
 
-              <div className="shrink-0 border-t border-border px-1 py-1">
-                <ExtensionsSidebarSection />
-              </div>
+              {!showCollapsedSidebar && (
+                <>
+                  <div className="shrink-0 space-y-1.5 border-t border-border px-2 py-1.5">
+                    {shouldShowSidebarLink && (
+                      <NavLink
+                        to="/download"
+                        className="flex items-center gap-2 rounded px-2 py-1.5 text-xs text-foreground hover:bg-accent/60"
+                      >
+                        <IconAppWindow className="h-4 w-4" />
+                        Get desktop app
+                      </NavLink>
+                    )}
+                    <SearchBar />
+                  </div>
 
-              <div className="shrink-0 space-y-2 border-t border-border px-3 py-2">
-                <OrgSwitcher />
-                <FeedbackButton />
-              </div>
+                  <div className="shrink-0 border-t border-border px-1 py-1">
+                    <ExtensionsSidebarSection />
+                  </div>
+
+                  <div className="shrink-0 space-y-2 border-t border-border px-3 py-2">
+                    <OrgSwitcher />
+                    <FeedbackButton />
+                  </div>
+                </>
+              )}
             </aside>
 
             {/* Main content area */}

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -225,24 +225,65 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
                   : "-translate-x-full md:translate-x-0",
               )}
             >
-              <div className="flex h-12 shrink-0 items-center border-b border-border px-4">
-                <div className="flex min-w-0 items-center gap-2">
-                  <img
-                    src={appPath("/agent-native-icon-light.svg")}
-                    alt=""
-                    aria-hidden="true"
-                    className="block h-4 w-auto shrink-0 dark:hidden"
-                  />
-                  <img
-                    src={appPath("/agent-native-icon-dark.svg")}
-                    alt=""
-                    aria-hidden="true"
-                    className="hidden h-4 w-auto shrink-0 dark:block"
-                  />
-                  <span className="truncate text-sm font-semibold text-foreground">
-                    Clips
-                  </span>
+              <div
+                className={cn(
+                  "flex h-12 shrink-0 items-center border-b border-border",
+                  showCollapsedSidebar ? "justify-center px-2" : "px-4",
+                )}
+              >
+                <div
+                  className={cn(
+                    "flex min-w-0 items-center gap-2",
+                    !showCollapsedSidebar && "flex-1",
+                  )}
+                >
+                  {!showCollapsedSidebar && (
+                    <>
+                      <img
+                        src={appPath("/agent-native-icon-light.svg")}
+                        alt=""
+                        aria-hidden="true"
+                        className="block h-4 w-auto shrink-0 dark:hidden"
+                      />
+                      <img
+                        src={appPath("/agent-native-icon-dark.svg")}
+                        alt=""
+                        aria-hidden="true"
+                        className="hidden h-4 w-auto shrink-0 dark:block"
+                      />
+                      <span className="truncate text-sm font-semibold text-foreground">
+                        Clips
+                      </span>
+                    </>
+                  )}
                 </div>
+
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="hidden h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground md:inline-flex"
+                      aria-label={
+                        showCollapsedSidebar
+                          ? "Expand sidebar"
+                          : "Collapse sidebar"
+                      }
+                      aria-expanded={!showCollapsedSidebar}
+                      onClick={() => setSidebarCollapsed((value) => !value)}
+                    >
+                      {showCollapsedSidebar ? (
+                        <IconLayoutSidebarLeftExpand className="h-4 w-4" />
+                      ) : (
+                        <IconLayoutSidebarLeftCollapse className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">
+                    {showCollapsedSidebar ? "Expand sidebar" : "Collapse sidebar"}
+                  </TooltipContent>
+                </Tooltip>
               </div>
               <div className="min-h-0 flex-1 overflow-y-auto">
                 <div className="px-3 py-3">

--- a/templates/clips/app/components/library/library-layout.tsx
+++ b/templates/clips/app/components/library/library-layout.tsx
@@ -12,6 +12,8 @@ import {
   IconAppWindow,
   IconX,
   IconMenu2,
+  IconLayoutSidebarLeftCollapse,
+  IconLayoutSidebarLeftExpand,
 } from "@tabler/icons-react";
 import {
   AgentSidebar,
@@ -54,6 +56,18 @@ import {
 
 interface LibraryLayoutProps {
   children: ReactNode;
+}
+
+const SIDEBAR_COLLAPSED_STORAGE_KEY = "clips:left-sidebar-collapsed";
+
+function readSidebarCollapsedPreference() {
+  if (typeof window === "undefined") return false;
+
+  try {
+    return window.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
 }
 
 function ClipsAgentToggleButton() {
@@ -100,7 +114,11 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
   );
 
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(
+    readSidebarCollapsedPreference,
+  );
   const [headerSlot, setHeaderSlot] = useState<HTMLElement | null>(null);
+  const showCollapsedSidebar = sidebarCollapsed && !isMobile;
 
   // Routes whose page renders its own h-12 toolbar (with NotificationsBell +
   // AgentToggleButton). Layout still mounts Sidebar + AgentSidebar, but skips
@@ -112,6 +130,17 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
   useEffect(() => {
     setSidebarOpen(false);
   }, [location.pathname]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        SIDEBAR_COLLAPSED_STORAGE_KEY,
+        sidebarCollapsed ? "true" : "false",
+      );
+    } catch {
+      // Ignore browsers that block localStorage; the toggle still works.
+    }
+  }, [sidebarCollapsed]);
 
   const [newFolderOpen, setNewFolderOpen] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
@@ -189,7 +218,8 @@ export function LibraryLayout({ children }: LibraryLayoutProps) {
             {/* Left sidebar */}
             <aside
               className={cn(
-                "fixed inset-y-0 left-0 z-50 flex h-full w-[260px] flex-col border-r border-border bg-sidebar md:static md:z-auto",
+                "fixed inset-y-0 left-0 z-50 flex h-full w-[260px] flex-col overflow-hidden border-r border-border bg-sidebar transition-[width,transform] duration-200 ease-out md:static md:z-auto",
+                showCollapsedSidebar && "md:w-14",
                 sidebarOpen
                   ? "translate-x-0"
                   : "-translate-x-full md:translate-x-0",

--- a/templates/clips/server/lib/calendar-event-meetings.ts
+++ b/templates/clips/server/lib/calendar-event-meetings.ts
@@ -139,7 +139,10 @@ export async function resolveCalendarAccessToken(
   return refreshed.access_token;
 }
 
-export async function recordCalendarFetchSuccess(accountId: string) {
+export async function recordCalendarFetchSuccess(
+  account: CalendarAccountForEvents,
+) {
+  if (!account.ownerEmail) return;
   const db = getDb();
   const now = new Date().toISOString();
   await db
@@ -150,17 +153,25 @@ export async function recordCalendarFetchSuccess(accountId: string) {
       status: "connected",
       updatedAt: now,
     })
-    .where(eq(schema.calendarAccounts.id, accountId));
+    .where(
+      and(
+        eq(schema.calendarAccounts.id, account.id),
+        eq(schema.calendarAccounts.ownerEmail, account.ownerEmail),
+      ),
+    );
 }
 
 export async function recordCalendarFetchError(
-  accountId: string,
+  account: CalendarAccountForEvents,
   error: unknown,
 ): Promise<CalendarFetchError> {
-  const db = getDb();
   const message =
     error instanceof Error ? error.message : String(error || "Calendar failed");
   const needsReauth = shouldMarkNeedsReauth(message);
+  if (!account.ownerEmail) {
+    return { accountId: account.id, error: message, needsReauth };
+  }
+  const db = getDb();
   await db
     .update(schema.calendarAccounts)
     .set({
@@ -170,14 +181,19 @@ export async function recordCalendarFetchError(
         : message,
       updatedAt: new Date().toISOString(),
     })
-    .where(eq(schema.calendarAccounts.id, accountId))
+    .where(
+      and(
+        eq(schema.calendarAccounts.id, account.id),
+        eq(schema.calendarAccounts.ownerEmail, account.ownerEmail),
+      ),
+    )
     .catch((writeErr: any) => {
       console.warn(
-        `[calendar] failed to record calendar error for ${accountId}:`,
+        `[calendar] failed to record calendar error for ${account.id}:`,
         writeErr?.message ?? writeErr,
       );
     });
-  return { accountId, error: message, needsReauth };
+  return { accountId: account.id, error: message, needsReauth };
 }
 
 export function encodeCalendarMeetingId(
@@ -267,10 +283,7 @@ export async function fetchLiveCalendarEventFromId(virtualId: string) {
 
   const accessToken = await resolveCalendarAccessToken(account);
   if (!accessToken) {
-    await recordCalendarFetchError(
-      parsed.accountId,
-      new Error("Token refresh failed"),
-    );
+    await recordCalendarFetchError(account, new Error("Token refresh failed"));
     return null;
   }
 
@@ -281,10 +294,10 @@ export async function fetchLiveCalendarEventFromId(virtualId: string) {
       eventId: parsed.externalId,
     });
     if (event.status === "cancelled") return null;
-    await recordCalendarFetchSuccess(account.id).catch(() => {});
+    await recordCalendarFetchSuccess(account).catch(() => {});
     return { account, event };
   } catch (err) {
-    await recordCalendarFetchError(parsed.accountId, err);
+    await recordCalendarFetchError(account, err);
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- **clips security**: scope `recordCalendarFetchSuccess` / `recordCalendarFetchError` updates to `(id, ownerEmail)` to satisfy `guard-no-unscoped-queries.mjs`. PR #567's Build job tripped on the unscoped UPDATE on `calendar_accounts`; this PR fixes the regression introduced there.
- **agent-engine model defaults**: bump framework `DEFAULT_MODEL` to the Builder gateway alias `gpt-5-5`, and split provider-native defaults into `DEFAULT_OPENAI_MODEL` (`gpt-5.5`) and `DEFAULT_ANTHROPIC_MODEL` (`claude-sonnet-4-6`). A2A / MCP / integrations runs no longer hard-code `DEFAULT_MODEL` — they fall back to `getStoredModelForEngine()` and the resolved engine's own default, so a Builder-connected user gets `gpt-5-5` while an Anthropic BYOK user gets `claude-sonnet-4-6` without per-call overrides.
- **Builder cloud CTA**: AgentPanel and CodeRequiredDialog now offer a "Use Builder" secondary CTA next to the Desktop primary, with `useBuilderConnectUrl()` reading `/_agent-native/builder/status` to wire the right link. Frame's code-access panel passes the secondary label through.
- **Plan-mode gate**: AssistantChat / TiptapComposer accept `planModeDisabled` + `planModeDisabledReason` so browser-only surfaces can disable Plan mode while leaving Build/Act available; tooltip explains the constraint.
- **Workspace dev gateway**: track per-app `installing` / `installAttempted` state so a long pnpm install shows correct copy; `hasLocalBin` probe; redirect `/?builderPreview=1` to Dispatch; refresh fallback app list before render. Dispatch `app-creation-store` reads workspace apps from a gateway HTTP endpoint when `WORKSPACE_GATEWAY_URL` is set (1s timeout, env/manifest fallbacks preserved).
- **Discovery-coach migration**: extend the script to extract OPERATIONAL_PAINS, BUSINESS_PAINS, PERSONAS, etc. from the new `painData.ts` / `personaData.ts` modules, and update the verifier to drive the persona/business-pains tabs through Alpine state.
- **Misc**: pin OpenRouter spec to `openai/gpt-5.5`; broaden attachment-envelope regex to allow extra attributes; inline text data-URL attachments into the chat-history adapter; selectionRef in `use-chat-models` to keep the latest pick addressable from closures.

## Test plan

- [ ] CI: Build (was failing on PR #567 — the unscoped-queries guard now passes locally)
- [ ] CI: Lint, Test, Typecheck, Scaffold E2E
- [ ] Manual smoke: `pnpm action list-meetings` for an authenticated user still records last-synced timestamp on success
- [ ] Manual smoke: a Builder-connected user lands on `gpt-5-5` without setting AGENT_ENGINE
- [ ] Manual smoke: in a Frame iframe, the AgentPanel "Code editing needs Desktop" surface shows both Download Desktop and Use Builder CTAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)