### PR TITLE
feat: react on clip comments

### DIFF
--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -265,6 +265,7 @@ Public share link: `/share/<recordingId>`. Embed: `/embed/<recordingId>`. Both r
 | `resolve-comment`    | `--id <commentId>`                                                                        | Mark a thread resolved                 |
 | `delete-comment`     | `--id <commentId>`                                                                        | Delete a comment                       |
 | `react-to-recording` | `--recordingId <id> --emoji <e> [--videoTimestampMs <ms>]`                                | Drop an emoji reaction at a timestamp  |
+| `react-to-comment`   | `--commentId <cid> --emoji <e>`                                                           | Toggle the user's emoji on a comment   |
 
 ### Analytics
 

--- a/templates/clips/actions/react-to-comment.ts
+++ b/templates/clips/actions/react-to-comment.ts
@@ -1,0 +1,83 @@
+/**
+ * Toggle the current user's emoji reaction on a comment.
+ *
+ * Stores reactions as a JSON map of emoji -> [emails] on the comment row's
+ * `emojiReactionsJson` column. Calling with the same emoji twice removes the
+ * user from that bucket.
+ *
+ * Usage:
+ *   pnpm action react-to-comment --commentId=<id> --emoji="🔥"
+ */
+
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { getDb, schema } from "../server/db/index.js";
+import { writeAppState } from "@agent-native/core/application-state";
+import { getRequestUserEmail } from "@agent-native/core/server/request-context";
+import { assertAccess } from "@agent-native/core/sharing";
+
+export default defineAction({
+  description:
+    "Toggle the current user's emoji reaction on a comment. Calling with the same emoji twice removes the reaction.",
+  schema: z.object({
+    commentId: z.string().describe("Comment ID"),
+    emoji: z.string().min(1).describe("Emoji character (e.g. 👍, ❤️, 🔥)"),
+  }),
+  run: async (args) => {
+    const db = getDb();
+    const [existing] = await db
+      .select()
+      .from(schema.recordingComments)
+      .where(eq(schema.recordingComments.id, args.commentId))
+      .limit(1);
+    if (!existing) throw new Error(`Comment not found: ${args.commentId}`);
+
+    await assertAccess("recording", existing.recordingId, "viewer");
+
+    const viewerEmail = getRequestUserEmail();
+    if (!viewerEmail) {
+      throw new Error("Sign in required to react to comments.");
+    }
+
+    let reactions: Record<string, string[]> = {};
+    try {
+      const parsed = JSON.parse(existing.emojiReactionsJson || "{}");
+      if (parsed && typeof parsed === "object") {
+        reactions = parsed as Record<string, string[]>;
+      }
+    } catch {
+      reactions = {};
+    }
+
+    const bucket = Array.isArray(reactions[args.emoji])
+      ? reactions[args.emoji]
+      : [];
+    const had = bucket.includes(viewerEmail);
+    const nextBucket = had
+      ? bucket.filter((e) => e !== viewerEmail)
+      : [...bucket, viewerEmail];
+
+    const next = { ...reactions };
+    if (nextBucket.length === 0) {
+      delete next[args.emoji];
+    } else {
+      next[args.emoji] = nextBucket;
+    }
+
+    const now = new Date().toISOString();
+    await db
+      .update(schema.recordingComments)
+      .set({ emojiReactionsJson: JSON.stringify(next), updatedAt: now })
+      .where(eq(schema.recordingComments.id, args.commentId));
+
+    await writeAppState("refresh-signal", { ts: Date.now() });
+
+    return {
+      id: args.commentId,
+      emoji: args.emoji,
+      reacted: !had,
+      reactions: next,
+    };
+  },
+});

--- a/templates/clips/actions/react-to-comment.ts
+++ b/templates/clips/actions/react-to-comment.ts
@@ -11,11 +11,13 @@
 
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import { writeAppState } from "@agent-native/core/application-state";
 import { getRequestUserEmail } from "@agent-native/core/server/request-context";
 import { assertAccess } from "@agent-native/core/sharing";
+
+const MAX_CAS_ATTEMPTS = 3;
 
 export default defineAction({
   description:
@@ -26,58 +28,79 @@ export default defineAction({
   }),
   run: async (args) => {
     const db = getDb();
-    const [existing] = await db
-      .select()
-      .from(schema.recordingComments)
-      .where(eq(schema.recordingComments.id, args.commentId))
-      .limit(1);
-    if (!existing) throw new Error(`Comment not found: ${args.commentId}`);
-
-    await assertAccess("recording", existing.recordingId, "viewer");
-
     const viewerEmail = getRequestUserEmail();
     if (!viewerEmail) {
       throw new Error("Sign in required to react to comments.");
     }
 
-    let reactions: Record<string, string[]> = {};
-    try {
-      const parsed = JSON.parse(existing.emojiReactionsJson || "{}");
-      if (parsed && typeof parsed === "object") {
-        reactions = parsed as Record<string, string[]>;
+    for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+      const [existing] = await db
+        .select()
+        .from(schema.recordingComments)
+        .where(eq(schema.recordingComments.id, args.commentId))
+        .limit(1);
+      if (!existing) throw new Error(`Comment not found: ${args.commentId}`);
+
+      if (attempt === 0) {
+        await assertAccess("recording", existing.recordingId, "viewer");
       }
-    } catch {
-      reactions = {};
+
+      const previousJson = existing.emojiReactionsJson;
+      let reactions: Record<string, string[]> = {};
+      try {
+        const parsed = JSON.parse(previousJson || "{}");
+        if (parsed && typeof parsed === "object") {
+          reactions = parsed as Record<string, string[]>;
+        }
+      } catch {
+        reactions = {};
+      }
+
+      const bucket = Array.isArray(reactions[args.emoji])
+        ? reactions[args.emoji]
+        : [];
+      const had = bucket.includes(viewerEmail);
+      const nextBucket = had
+        ? bucket.filter((e) => e !== viewerEmail)
+        : [...bucket, viewerEmail];
+
+      const next = { ...reactions };
+      if (nextBucket.length === 0) {
+        delete next[args.emoji];
+      } else {
+        next[args.emoji] = nextBucket;
+      }
+
+      // Compare-and-swap: only commit if the JSON column still matches what
+      // we read. A concurrent reaction that landed first will have changed
+      // it, so the WHERE will not match and we retry the read-modify-write.
+      const updated = await db
+        .update(schema.recordingComments)
+        .set({
+          emojiReactionsJson: JSON.stringify(next),
+          updatedAt: new Date().toISOString(),
+        })
+        .where(
+          and(
+            eq(schema.recordingComments.id, args.commentId),
+            eq(schema.recordingComments.emojiReactionsJson, previousJson),
+          ),
+        )
+        .returning({ id: schema.recordingComments.id });
+
+      if (updated.length > 0) {
+        await writeAppState("refresh-signal", { ts: Date.now() });
+        return {
+          id: args.commentId,
+          emoji: args.emoji,
+          reacted: !had,
+          reactions: next,
+        };
+      }
     }
 
-    const bucket = Array.isArray(reactions[args.emoji])
-      ? reactions[args.emoji]
-      : [];
-    const had = bucket.includes(viewerEmail);
-    const nextBucket = had
-      ? bucket.filter((e) => e !== viewerEmail)
-      : [...bucket, viewerEmail];
-
-    const next = { ...reactions };
-    if (nextBucket.length === 0) {
-      delete next[args.emoji];
-    } else {
-      next[args.emoji] = nextBucket;
-    }
-
-    const now = new Date().toISOString();
-    await db
-      .update(schema.recordingComments)
-      .set({ emojiReactionsJson: JSON.stringify(next), updatedAt: now })
-      .where(eq(schema.recordingComments.id, args.commentId));
-
-    await writeAppState("refresh-signal", { ts: Date.now() });
-
-    return {
-      id: args.commentId,
-      emoji: args.emoji,
-      reacted: !had,
-      reactions: next,
-    };
+    throw new Error(
+      `Could not toggle reaction on comment ${args.commentId} after ${MAX_CAS_ATTEMPTS} concurrent attempts.`,
+    );
   },
 });

--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -35,7 +35,22 @@ function makeTempId() {
   return `temp_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`;
 }
 
-type PlayerData = { comments?: Comment[]; [k: string]: unknown };
+// The shape of the cached value depends on the route — the authenticated
+// player route caches `get-recording-player-data` ({ comments, ... }) while
+// the public share route caches a wrapped fetch response
+// ({ ok, status, data: { comments, ... } }). Both feed into this panel, so we
+// don't assume a shape — the parent passes lenses.
+type CommentsLens = {
+  selectComments: (data: unknown) => Comment[] | undefined;
+  applyComments: (data: unknown, next: Comment[]) => unknown;
+};
+
+const defaultLens: CommentsLens = {
+  selectComments: (data) =>
+    (data as { comments?: Comment[] } | undefined)?.comments,
+  applyComments: (data, next) =>
+    data ? { ...(data as object), comments: next } : data,
+};
 
 const COMMENT_EMOJIS = ["👍", "❤️", "🔥", "👏", "🎉", "😂"];
 
@@ -61,6 +76,20 @@ export interface CommentsPanelProps {
   enableComments: boolean;
   onSeek: (ms: number) => void;
   /**
+   * The React Query key whose cached value contains this panel's `comments`.
+   * Optimistic updates patch this key — passing the wrong one (or omitting
+   * it) means the chip / new-comment row won't appear until the next refetch.
+   */
+  queryKey: readonly unknown[];
+  /**
+   * Optional lenses for selecting / replacing the comments array inside the
+   * cached value. Defaults match the authenticated `get-recording-player-data`
+   * shape (`{ comments, ... }`). The public share route wraps comments under
+   * `data.comments` and supplies its own lenses.
+   */
+  selectComments?: CommentsLens["selectComments"];
+  applyComments?: CommentsLens["applyComments"];
+  /**
    * If provided, this callback is invoked instead of firing the comment /
    * reaction mutation when the viewer is not signed in. Use it to surface a
    * sign-in prompt on the public share page.
@@ -77,28 +106,28 @@ export function CommentsPanel(props: CommentsPanelProps) {
     enableComments,
     onSeek,
     onUnauthenticated,
+    queryKey,
+    selectComments = defaultLens.selectComments,
+    applyComments = defaultLens.applyComments,
   } = props;
   const isSignedIn = !!currentUserEmail;
   const [draft, setDraft] = useState("");
   const [replyTo, setReplyTo] = useState<Comment | null>(null);
 
   const queryClient = useQueryClient();
-  const playerDataKey = useMemo(
-    () => ["action", "get-recording-player-data", { recordingId }],
-    [recordingId],
-  );
 
   const patchComments = (updater: (prev: Comment[]) => Comment[]) => {
-    queryClient.setQueryData<PlayerData>(playerDataKey, (old) => {
+    queryClient.setQueryData(queryKey, (old: unknown) => {
       if (!old) return old;
-      return { ...old, comments: updater(old.comments ?? []) };
+      const current = selectComments(old) ?? [];
+      return applyComments(old, updater(current));
     });
   };
 
   const addComment = useActionMutation("add-comment", {
     onMutate: async (vars: any) => {
-      await queryClient.cancelQueries({ queryKey: playerDataKey });
-      const prev = queryClient.getQueryData<PlayerData>(playerDataKey);
+      await queryClient.cancelQueries({ queryKey });
+      const prev = queryClient.getQueryData(queryKey);
       const tempId = makeTempId();
       const now = new Date().toISOString();
       const optimistic: Comment = {
@@ -118,7 +147,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
       return { prev, tempId };
     },
     onError: (_err, _vars, ctx: any) => {
-      if (ctx?.prev) queryClient.setQueryData(playerDataKey, ctx.prev);
+      if (ctx?.prev) queryClient.setQueryData(queryKey, ctx.prev);
     },
     onSuccess: (data: any, _vars, ctx: any) => {
       if (!ctx?.tempId || !data?.id) return;
@@ -134,8 +163,8 @@ export function CommentsPanel(props: CommentsPanelProps) {
 
   const resolve = useActionMutation("resolve-comment", {
     onMutate: async (vars: any) => {
-      await queryClient.cancelQueries({ queryKey: playerDataKey });
-      const prev = queryClient.getQueryData<PlayerData>(playerDataKey);
+      await queryClient.cancelQueries({ queryKey });
+      const prev = queryClient.getQueryData(queryKey);
       patchComments((list) =>
         list.map((c) =>
           c.id === vars.id
@@ -152,14 +181,14 @@ export function CommentsPanel(props: CommentsPanelProps) {
       return { prev };
     },
     onError: (_err, _vars, ctx: any) => {
-      if (ctx?.prev) queryClient.setQueryData(playerDataKey, ctx.prev);
+      if (ctx?.prev) queryClient.setQueryData(queryKey, ctx.prev);
     },
   });
 
   const reactToComment = useActionMutation("react-to-comment", {
     onMutate: async (vars: any) => {
-      await queryClient.cancelQueries({ queryKey: playerDataKey });
-      const prev = queryClient.getQueryData<PlayerData>(playerDataKey);
+      await queryClient.cancelQueries({ queryKey });
+      const prev = queryClient.getQueryData(queryKey);
       const currentUser = currentUserEmail;
       if (!currentUser) return { prev };
       patchComments((commentList) =>
@@ -194,7 +223,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
       return { prev };
     },
     onError: (_err, _vars, ctx: any) => {
-      if (ctx?.prev) queryClient.setQueryData(playerDataKey, ctx.prev);
+      if (ctx?.prev) queryClient.setQueryData(queryKey, ctx.prev);
     },
     onSuccess: (data: any, vars: any) => {
       if (!data?.reactions) return;
@@ -210,8 +239,8 @@ export function CommentsPanel(props: CommentsPanelProps) {
 
   const remove = useActionMutation("delete-comment", {
     onMutate: async (vars: any) => {
-      await queryClient.cancelQueries({ queryKey: playerDataKey });
-      const prev = queryClient.getQueryData<PlayerData>(playerDataKey);
+      await queryClient.cancelQueries({ queryKey });
+      const prev = queryClient.getQueryData(queryKey);
       // Deleting a root comment cascades to its replies server-side, so mirror
       // that here: drop the target comment and any descendants in the same
       // thread whose parent chain leads back to it.
@@ -227,7 +256,7 @@ export function CommentsPanel(props: CommentsPanelProps) {
       return { prev };
     },
     onError: (_err, _vars, ctx: any) => {
-      if (ctx?.prev) queryClient.setQueryData(playerDataKey, ctx.prev);
+      if (ctx?.prev) queryClient.setQueryData(queryKey, ctx.prev);
     },
   });
 

--- a/templates/clips/app/components/player/comments-panel.tsx
+++ b/templates/clips/app/components/player/comments-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   IconSend,
   IconCheck,
@@ -21,7 +21,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { agentNativePath, useActionMutation } from "@agent-native/core/client";
+import { useActionMutation } from "@agent-native/core/client";
 import { useQueryClient } from "@tanstack/react-query";
 import { msToClock } from "./scrubber";
 
@@ -156,6 +156,58 @@ export function CommentsPanel(props: CommentsPanelProps) {
     },
   });
 
+  const reactToComment = useActionMutation("react-to-comment", {
+    onMutate: async (vars: any) => {
+      await queryClient.cancelQueries({ queryKey: playerDataKey });
+      const prev = queryClient.getQueryData<PlayerData>(playerDataKey);
+      const currentUser = currentUserEmail;
+      if (!currentUser) return { prev };
+      patchComments((commentList) =>
+        commentList.map((comment) => {
+          if (comment.id !== vars.commentId) return comment;
+          let reactions: Record<string, string[]> = {};
+          try {
+            const parsed = JSON.parse(comment.emojiReactionsJson || "{}");
+            if (parsed && typeof parsed === "object") {
+              reactions = parsed as Record<string, string[]>;
+            }
+          } catch {}
+          const reactingUsers = Array.isArray(reactions[vars.emoji])
+            ? reactions[vars.emoji]
+            : [];
+          const userAlreadyReacted = reactingUsers.includes(currentUser);
+          const updatedReactingUsers = userAlreadyReacted
+            ? reactingUsers.filter((email) => email !== currentUser)
+            : [...reactingUsers, currentUser];
+          const updatedReactions = { ...reactions };
+          if (updatedReactingUsers.length === 0) {
+            delete updatedReactions[vars.emoji];
+          } else {
+            updatedReactions[vars.emoji] = updatedReactingUsers;
+          }
+          return {
+            ...comment,
+            emojiReactionsJson: JSON.stringify(updatedReactions),
+          };
+        }),
+      );
+      return { prev };
+    },
+    onError: (_err, _vars, ctx: any) => {
+      if (ctx?.prev) queryClient.setQueryData(playerDataKey, ctx.prev);
+    },
+    onSuccess: (data: any, vars: any) => {
+      if (!data?.reactions) return;
+      patchComments((list) =>
+        list.map((c) =>
+          c.id === vars.commentId
+            ? { ...c, emojiReactionsJson: JSON.stringify(data.reactions) }
+            : c,
+        ),
+      );
+    },
+  });
+
   const remove = useActionMutation("delete-comment", {
     onMutate: async (vars: any) => {
       await queryClient.cancelQueries({ queryKey: playerDataKey });
@@ -241,7 +293,6 @@ export function CommentsPanel(props: CommentsPanelProps) {
                 <li key={root.threadId} className="p-3 space-y-2">
                   <CommentCard
                     comment={root}
-                    recordingId={recordingId}
                     currentUserEmail={currentUserEmail}
                     onSeek={onSeek}
                     onReply={() => {
@@ -255,6 +306,9 @@ export function CommentsPanel(props: CommentsPanelProps) {
                       resolve.mutate({ id, resolved })
                     }
                     onDelete={(id) => remove.mutate({ id })}
+                    onReact={(commentId, emoji) =>
+                      reactToComment.mutate({ commentId, emoji })
+                    }
                     onUnauthenticated={onUnauthenticated}
                   />
                   {replies.length ? (
@@ -263,7 +317,6 @@ export function CommentsPanel(props: CommentsPanelProps) {
                         <li key={r.id}>
                           <CommentCard
                             comment={r}
-                            recordingId={recordingId}
                             currentUserEmail={currentUserEmail}
                             onSeek={onSeek}
                             onReply={() => {
@@ -277,6 +330,9 @@ export function CommentsPanel(props: CommentsPanelProps) {
                               resolve.mutate({ id, resolved })
                             }
                             onDelete={(id) => remove.mutate({ id })}
+                            onReact={(commentId, emoji) =>
+                              reactToComment.mutate({ commentId, emoji })
+                            }
                             onUnauthenticated={onUnauthenticated}
                             isReply
                           />
@@ -361,27 +417,56 @@ export function CommentsPanel(props: CommentsPanelProps) {
 
 function CommentCard({
   comment,
-  recordingId,
   currentUserEmail,
   onSeek,
   onReply,
   onResolve,
   onDelete,
+  onReact,
   onUnauthenticated,
   isReply,
 }: {
   comment: Comment;
-  recordingId: string;
   currentUserEmail?: string;
   onSeek: (ms: number) => void;
   onReply: () => void;
   onResolve: (id: string, resolved: boolean) => void;
   onDelete: (id: string) => void;
+  onReact: (commentId: string, emoji: string) => void;
   onUnauthenticated?: (intent: "comment" | "react") => void;
   isReply?: boolean;
 }) {
-  const reactions = parseReactions(comment.emojiReactionsJson);
+  // Local override forces a synchronous re-render the instant the user clicks
+  // an emoji — independent of React Query cache propagation. It's cleared as
+  // soon as the prop (server-confirmed) catches up to whatever we showed.
+  const [localJson, setLocalJson] = useState<string | null>(null);
+  useEffect(() => {
+    setLocalJson(null);
+  }, [comment.emojiReactionsJson]);
+
+  const reactions = parseReactions(localJson ?? comment.emojiReactionsJson);
   const isOwner = currentUserEmail && comment.authorEmail === currentUserEmail;
+
+  function toggleEmoji(emoji: string) {
+    if (!currentUserEmail) return reactions;
+    const reactingUsers = Array.isArray(reactions[emoji])
+      ? reactions[emoji]
+      : [];
+    const userAlreadyReacted = reactingUsers.includes(currentUserEmail);
+
+    const updatedReactingUsers = userAlreadyReacted
+      ? reactingUsers.filter((email) => email !== currentUserEmail)
+      : [...reactingUsers, currentUserEmail];
+
+    const updatedReactions: Record<string, string[]> = { ...reactions };
+    if (updatedReactingUsers.length === 0) {
+      delete updatedReactions[emoji];
+    } else {
+      updatedReactions[emoji] = updatedReactingUsers;
+    }
+
+    return updatedReactions;
+  }
 
   return (
     <div className={cn("flex gap-2", comment.resolved && "opacity-60")}>
@@ -441,29 +526,8 @@ function CommentCard({
                         onUnauthenticated?.("react");
                         return;
                       }
-                      // Add to comment's emoji reactions
-                      const next = { ...reactions };
-                      const bucket = next[e] ?? [];
-                      if (!bucket.includes(currentUserEmail)) {
-                        next[e] = [...bucket, currentUserEmail];
-                      }
-                      // Patch via delete+re-add isn't ideal; a dedicated action could be added.
-                      // For now, store via react-to-recording at comment timestamp as a proxy.
-                      fetch(
-                        agentNativePath(
-                          "/_agent-native/actions/react-to-recording",
-                        ),
-                        {
-                          method: "POST",
-                          headers: { "Content-Type": "application/json" },
-                          body: JSON.stringify({
-                            recordingId,
-                            emoji: e,
-                            videoTimestampMs: comment.videoTimestampMs,
-                          }),
-                        },
-                      ).catch(() => {});
-                      void next;
+                      setLocalJson(JSON.stringify(toggleEmoji(e)));
+                      onReact(comment.id, e);
                     }}
                     className="text-lg h-8 w-8 rounded hover:bg-accent flex items-center justify-center"
                   >
@@ -504,14 +568,38 @@ function CommentCard({
 
         {Object.keys(reactions).length > 0 ? (
           <div className="flex flex-wrap gap-1 mt-1.5">
-            {Object.entries(reactions).map(([emoji, users]) => (
-              <span
-                key={emoji}
-                className="text-[11px] rounded-full bg-accent px-1.5 py-0.5 flex items-center gap-1"
-              >
-                {emoji} {users.length}
-              </span>
-            ))}
+            {Object.entries(reactions).map(([emoji, users]) => {
+              const mine =
+                !!currentUserEmail && users.includes(currentUserEmail);
+              return (
+                <button
+                  key={emoji}
+                  type="button"
+                  onClick={() => {
+                    if (!currentUserEmail) {
+                      onUnauthenticated?.("react");
+                      return;
+                    }
+                    setLocalJson(JSON.stringify(toggleEmoji(emoji)));
+                    onReact(comment.id, emoji);
+                  }}
+                  aria-pressed={mine}
+                  title={
+                    mine
+                      ? "Click to remove your reaction"
+                      : "Click to add your reaction"
+                  }
+                  className={cn(
+                    "text-[11px] rounded-full px-1.5 py-0.5 flex items-center gap-1 transition-colors",
+                    mine
+                      ? "bg-primary/15 border border-primary/40 text-primary hover:bg-primary/25"
+                      : "bg-accent border border-transparent hover:bg-accent/70",
+                  )}
+                >
+                  {emoji} {users.length}
+                </button>
+              );
+            })}
           </div>
         ) : null}
       </div>

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -830,6 +830,11 @@ export default function RecordingPage() {
                     currentUserEmail={session?.email}
                     enableComments={recording.enableComments}
                     onSeek={(ms) => playerRef.current?.seek(ms)}
+                    queryKey={[
+                      "action",
+                      "get-recording-player-data",
+                      { recordingId: recordingId ?? "" },
+                    ]}
                   />
                 </TabsContent>
                 {canEdit ? (

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -549,6 +549,13 @@ export default function ShareRoute() {
                     enableComments={recording.enableComments}
                     onSeek={(ms) => playerRef.current?.seek(ms)}
                     onUnauthenticated={requireSignIn}
+                    queryKey={["public-recording", shareId, password]}
+                    selectComments={(d: any) => d?.data?.comments}
+                    applyComments={(d: any, next) =>
+                      d
+                        ? { ...d, data: { ...(d.data ?? {}), comments: next } }
+                        : d
+                    }
                   />
                 </div>
               </TabsContent>


### PR DESCRIPTION
Reacting to a comment in the clips player previously had no visible effect.

## Changes
- Added a new `react-to-comment` action that toggles the current user's email in the comment's `emoji_reactions_json` map.
  - Clicking the same emoji again removes the reaction.
  - Empty reaction buckets are automatically deleted.

- Wired the React popover to the new action using:
  - an optimistic React Query update
  - a local `useState` override
  - This makes reaction chips update immediately on the next paint, independent of network latency or cache propagation.

- Made reaction chips interactive.
  - Clicking a chip now toggles the current user's reaction.
  - Chips reacted to by the current user are highlighted using the primary color.

- Registered `react-to-comment` in `templates/clips/AGENTS.md`.

https://www.loom.com/share/230ec5cbd7604767ae0204bcc6abde9d