### PR TITLE
feat: workspace Vercel preset + recorder iframe permissions + sidebar popover/terminal/usage fixes

### DIFF
--- a/.changeset/calm-sidebar-popovers.md
+++ b/.changeset/calm-sidebar-popovers.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix sidebar popover clipping, terminal startup visibility, automation test routing, and tiny usage rounding.

--- a/.changeset/clever-vercel-workspaces.md
+++ b/.changeset/clever-vercel-workspaces.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add Vercel workspace deploy packaging and make the shared-token login gate provider-neutral.

--- a/.changeset/quiet-cli-watchers.md
+++ b/.changeset/quiet-cli-watchers.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Reduce noisy CLI Sentry reports for handled workspace watcher limits and skip first-party agent symlinks during GitHub tarball extraction on Windows.

--- a/.changeset/steady-sentry-templates.md
+++ b/.changeset/steady-sentry-templates.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Collect browser and server Sentry errors from shared DSN deploy configuration.

--- a/.changeset/workspace-deploy-vercel-preset.md
+++ b/.changeset/workspace-deploy-vercel-preset.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add `vercel` as a third workspace-deploy preset alongside `cloudflare_pages` and `netlify`. When `preset=vercel`, the build emits into `.vercel/output` so the standard Vercel build pipeline picks it up unmodified.

--- a/packages/core/docs/content/deployment.md
+++ b/packages/core/docs/content/deployment.md
@@ -18,7 +18,7 @@ agent-native deploy
 # https://your-agents.com/forms/*      → apps/forms
 ```
 
-Each app is built with `APP_BASE_PATH=/<name>` and `VITE_APP_BASE_PATH=/<name>`, then packaged into `dist/<name>/`. Cloudflare Pages is the default preset and uses a generated dispatcher worker at `dist/_worker.js`; Netlify uses one function per app in `.netlify/functions-internal/<app>-server` plus generated redirects.
+Each app is built with `APP_BASE_PATH=/<name>` and `VITE_APP_BASE_PATH=/<name>`, then packaged for the target Nitro preset. Cloudflare Pages is the default preset and uses a generated dispatcher worker at `dist/_worker.js`; Netlify uses one function per app in `.netlify/functions-internal/<app>-server` plus generated redirects; Vercel writes a workspace-level `.vercel/output` using the Build Output API.
 
 Same-origin deploy gives you two big wins for free:
 
@@ -37,7 +37,13 @@ For Netlify unified deploys, use the Netlify preset:
 agent-native deploy --preset netlify
 ```
 
-Generated workspaces include a root `netlify.toml` that runs `agent-native deploy --preset netlify --build-only`, publishes `dist`, and points Netlify at `.netlify/functions-internal`.
+For Vercel unified deploys, use the Vercel preset:
+
+```bash
+agent-native deploy --preset vercel
+```
+
+When configuring a provider build command, use the same command with `--build-only`. Vercel should run `pnpm exec agent-native deploy --preset vercel --build-only`; the command writes `.vercel/output` directly, so no `vercel.json` is required for workspace routing.
 
 Hosted workspace builds require `A2A_SECRET` in the deploy provider environment.
 This makes Slack, inbound webhooks, and cross-app A2A resume work through signed
@@ -128,6 +134,20 @@ Deploy via the Vercel CLI or git push:
 vercel deploy
 ```
 
+For a workspace, build every app into one Vercel Build Output API bundle:
+
+```bash
+agent-native deploy --preset vercel
+```
+
+For Vercel Git deployments, set the build command to:
+
+```bash
+pnpm exec agent-native deploy --preset vercel --build-only
+```
+
+The workspace build copies each app's Nitro `vercel` output into the root `.vercel/output`, gives each function its own mount-path environment, and writes the route config that serves apps at `/<app-id>`.
+
 ## Netlify {#netlify}
 
 The Nitro `netlify` preset works well and, in practice, has given us much faster cold starts than Cloudflare Pages (~200ms TTFB vs ~9s) for templates that talk to external Postgres (Neon). Either set the preset in `vite.config.ts`:
@@ -147,7 +167,7 @@ For a workspace, deploy every app from one Netlify site by running:
 agent-native deploy --preset netlify
 ```
 
-The workspace build writes static assets to `dist/<app>/` and routes each app to its own Netlify function without forced redirects, so files like `/mail/assets/...` are served statically before the server function handles app routes.
+The workspace build writes static assets under `dist/_workspace_static/` and routes each app to its own Netlify function without forced asset redirects, so files like `/mail/assets/...` are served statically before the server function handles app routes.
 
 ## Cloudflare Pages {#cloudflare-pages}
 

--- a/packages/core/docs/content/multi-app-workspace.md
+++ b/packages/core/docs/content/multi-app-workspace.md
@@ -205,7 +205,7 @@ agent-native deploy
 # https://your-agents.com/forms/*      → apps/forms
 ```
 
-Each app is built with `APP_BASE_PATH=/<name>` and `VITE_APP_BASE_PATH=/<name>` and emitted into `dist/<name>/`. Cloudflare Pages is the default preset and uses a dispatcher worker at `dist/_worker.js` plus `_routes.json`. Netlify is also supported with `agent-native deploy --preset netlify`; it emits app functions under `.netlify/functions-internal/<app>-server` and generated redirects that leave static assets unforced so the CDN serves files first.
+Each app is built with `APP_BASE_PATH=/<name>` and `VITE_APP_BASE_PATH=/<name>` and emitted through the selected Nitro preset. Cloudflare Pages is the default preset and uses a dispatcher worker at `dist/_worker.js` plus `_routes.json`. Netlify is supported with `agent-native deploy --preset netlify`; it emits app functions under `.netlify/functions-internal/<app>-server` and generated redirects that leave static assets unforced so the CDN serves files first. Vercel is supported with `agent-native deploy --preset vercel`; it writes a root `.vercel/output` bundle using Vercel's Build Output API.
 
 Being on the **same origin** is where the real payoff lives:
 
@@ -219,10 +219,16 @@ Publish the `dist/` output:
 wrangler pages deploy dist
 ```
 
-For Netlify, generated workspaces already include a root `netlify.toml`. Existing workspaces can use:
+For Netlify:
 
 ```bash
 agent-native deploy --preset netlify --build-only
+```
+
+For Vercel Git deployments, set the build command to:
+
+```bash
+pnpm exec agent-native deploy --preset vercel --build-only
 ```
 
 ### Per-app independent deploy

--- a/packages/core/docs/content/observability.md
+++ b/packages/core/docs/content/observability.md
@@ -187,11 +187,11 @@ The framework emits `gen_ai.*` semantic convention spans compatible with the Ope
 
 Server-side errors that escape Nitro route handlers are reported to Sentry when a DSN is configured. Without it the SDK silently no-ops, so it's safe to leave the env vars unset in dev. Browser and server events can go to the same Sentry project; split them into separate projects only when you want operational separation for ownership, volume, quotas, or alert routing.
 
-| Surface            | SDK               | Env var                  | Notes                                                                 |
-| ------------------ | ----------------- | ------------------------ | --------------------------------------------------------------------- |
+| Surface            | SDK               | Env var                                                        | Notes                                                                 |
+| ------------------ | ----------------- | -------------------------------------------------------------- | --------------------------------------------------------------------- |
 | Browser / SPA      | `@sentry/browser` | `VITE_SENTRY_CLIENT_DSN`, `SENTRY_CLIENT_DSN`, or `SENTRY_DSN` | Captures unhandled errors and route-change breadcrumbs in the client. |
-| Nitro server       | `@sentry/node`    | `SENTRY_SERVER_DSN` or `SENTRY_DSN` | Captures 5xx responses and Nitro lifecycle errors. Per-request user.  |
-| `agent-native` CLI | `@sentry/node`    | _hardcoded_              | Crash reports from the published CLI binary; not user-configurable.   |
+| Nitro server       | `@sentry/node`    | `SENTRY_SERVER_DSN` or `SENTRY_DSN`                            | Captures 5xx responses and Nitro lifecycle errors. Per-request user.  |
+| `agent-native` CLI | `@sentry/node`    | _hardcoded_                                                    | Crash reports from the published CLI binary; not user-configurable.   |
 
 ### Server-side configuration
 

--- a/packages/core/docs/content/observability.md
+++ b/packages/core/docs/content/observability.md
@@ -185,17 +185,17 @@ The framework emits `gen_ai.*` semantic convention spans compatible with the Ope
 
 ## Error Reporting (Sentry)
 
-Server-side errors that escape Nitro route handlers are reported to Sentry when a DSN is configured. Without it the SDK silently no-ops, so it's safe to leave the env vars unset in dev. Three independent Sentry projects cover the framework:
+Server-side errors that escape Nitro route handlers are reported to Sentry when a DSN is configured. Without it the SDK silently no-ops, so it's safe to leave the env vars unset in dev. Browser and server events can go to the same Sentry project; split them into separate projects only when you want operational separation for ownership, volume, quotas, or alert routing.
 
 | Surface            | SDK               | Env var                  | Notes                                                                 |
 | ------------------ | ----------------- | ------------------------ | --------------------------------------------------------------------- |
-| Browser / SPA      | `@sentry/browser` | `VITE_SENTRY_CLIENT_DSN` | Captures unhandled errors and route-change breadcrumbs in the client. |
-| Nitro server       | `@sentry/node`    | `SENTRY_SERVER_DSN`      | Captures 5xx responses and Nitro lifecycle errors. Per-request user.  |
+| Browser / SPA      | `@sentry/browser` | `VITE_SENTRY_CLIENT_DSN`, `SENTRY_CLIENT_DSN`, or `SENTRY_DSN` | Captures unhandled errors and route-change breadcrumbs in the client. |
+| Nitro server       | `@sentry/node`    | `SENTRY_SERVER_DSN` or `SENTRY_DSN` | Captures 5xx responses and Nitro lifecycle errors. Per-request user.  |
 | `agent-native` CLI | `@sentry/node`    | _hardcoded_              | Crash reports from the published CLI binary; not user-configurable.   |
 
 ### Server-side configuration
 
-Set `SENTRY_SERVER_DSN` in the deploy environment (Netlify dashboard, Cloudflare secrets, etc.). The framework auto-mounts a Nitro plugin that:
+Set `SENTRY_SERVER_DSN` or the shared `SENTRY_DSN` in the deploy environment (Netlify dashboard, Cloudflare secrets, etc.). The framework auto-mounts a Nitro plugin that:
 
 1. Calls `Sentry.init` once at startup (idempotent — safe to call from multiple plugins).
 2. Resolves the user via `getSession(event)` on every API/framework request and attaches `id` / `email` / `username` plus an `orgId` tag to Sentry's per-request isolation scope. Static-asset paths are skipped to avoid extra DB hits.
@@ -208,7 +208,7 @@ Optional knobs:
 
 ### Templates
 
-Every template inherits this automatically — there's nothing to import. Templates that want custom behavior (extra tags, different DSN per template, hard-disable Sentry) can override by exporting their own plugin from `server/plugins/sentry.ts`:
+Every template inherits this automatically — there's nothing to import. For SSR apps, the server injects a tiny browser config script when `SENTRY_CLIENT_DSN`, `VITE_SENTRY_CLIENT_DSN`, or shared `SENTRY_DSN` is available at runtime, so browser capture is not limited to Vite build-time env. Templates that want custom behavior (extra tags, different DSN per template, hard-disable Sentry) can override by exporting their own plugin from `server/plugins/sentry.ts`:
 
 ```ts
 // server/plugins/sentry.ts

--- a/packages/core/src/cli/create-e2e.spec.ts
+++ b/packages/core/src/cli/create-e2e.spec.ts
@@ -28,6 +28,7 @@ import {
   _getGitHubTemplateRef,
   _getGitHubTemplateRefCandidates,
   _shouldSkipScaffoldEntry,
+  _tarExtractArgs,
 } from "./create.js";
 import { workspacifyApp } from "./workspacify.js";
 import { setupAgentSymlinks } from "./setup-agents.js";
@@ -477,6 +478,24 @@ describe("workspace scaffold defaults", () => {
 
   it("does not copy local agent-native runtime state", () => {
     expect(_shouldSkipScaffoldEntry(".agent-native")).toBe(true);
+  });
+
+  it("can skip first-party agent symlinks while extracting GitHub tarballs", () => {
+    expect(
+      _tarExtractArgs("/tmp/archive.tar.gz", "/tmp/out", {
+        skipAgentSymlinks: true,
+      }),
+    ).toEqual([
+      "xzf",
+      "/tmp/archive.tar.gz",
+      "--strip-components=1",
+      "--exclude",
+      "*/CLAUDE.md",
+      "--exclude",
+      "*/.claude/skills",
+      "-C",
+      "/tmp/out",
+    ]);
   });
 });
 

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -21,6 +21,10 @@ const __dirname = path.dirname(__filename);
 const REPO = "BuilderIO/agent-native";
 const TEMPLATES_DIR = "templates";
 const POSTGRES_DEPENDENCY_VERSION = "^3.4.9";
+const FIRST_PARTY_TARBALL_SYMLINK_EXCLUDES = [
+  "*/CLAUDE.md",
+  "*/.claude/skills",
+];
 
 /**
  * Tagged error for input that fails CLI-level validation (repo names, app
@@ -906,6 +910,7 @@ export {
   getGitHubTemplateRef as _getGitHubTemplateRef,
   getGitHubTemplateRefCandidates as _getGitHubTemplateRefCandidates,
   shouldSkipScaffoldEntry as _shouldSkipScaffoldEntry,
+  tarExtractArgs as _tarExtractArgs,
 };
 
 /* ─────────────────────────────────────────────────────────────────────────
@@ -920,7 +925,25 @@ function validateRepoName(repo: string): void {
   }
 }
 
-function downloadAndExtract(url: string, destDir: string): void {
+function tarExtractArgs(
+  tarPath: string,
+  destDir: string,
+  options: { skipAgentSymlinks?: boolean } = {},
+): string[] {
+  const excludes = options.skipAgentSymlinks
+    ? FIRST_PARTY_TARBALL_SYMLINK_EXCLUDES.flatMap((pattern) => [
+        "--exclude",
+        pattern,
+      ])
+    : [];
+  return ["xzf", tarPath, "--strip-components=1", ...excludes, "-C", destDir];
+}
+
+function downloadAndExtract(
+  url: string,
+  destDir: string,
+  options: { skipAgentSymlinks?: boolean } = {},
+): void {
   fs.mkdirSync(destDir, { recursive: true });
   // --fail-with-body so curl exits non-zero on HTTP 4xx/5xx instead of writing
   // the error body (HTML/JSON) to disk where tar then fails with the opaque
@@ -931,11 +954,9 @@ function downloadAndExtract(url: string, destDir: string): void {
   const tarPath = path.join(destDir, ".download.tar.gz");
   fs.writeFileSync(tarPath, tarball);
   try {
-    execFileSync(
-      "tar",
-      ["xzf", tarPath, "--strip-components=1", "-C", destDir],
-      { stdio: "pipe" },
-    );
+    execFileSync("tar", tarExtractArgs(tarPath, destDir, options), {
+      stdio: "pipe",
+    });
   } finally {
     fs.unlinkSync(tarPath);
   }
@@ -957,7 +978,7 @@ async function downloadGitHubSubdir(
       `.agent-native-tmp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     );
     try {
-      downloadAndExtract(tarUrl, tmpDir);
+      downloadAndExtract(tarUrl, tmpDir, { skipAgentSymlinks: repo === REPO });
       const srcDir = path.join(tmpDir, subdir);
       if (!fs.existsSync(srcDir)) {
         throw new Error(

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -626,7 +626,7 @@ Options:
                                 github:user/repo for community templates
   --standalone                  Scaffold a single standalone app (no workspace)
   --preset <name>               Workspace deploy preset:
-                                cloudflare_pages (default) or netlify
+                                cloudflare_pages (default), netlify, or vercel
   --build-only                  Build workspace deploy artifacts without publishing
   --eager                       With workspace dev, start every app immediately
 

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -6,6 +6,7 @@ import type { ChildProcess, spawn } from "node:child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   initialWorkspaceAppIds,
+  isWorkspaceWatcherLimitError,
   runWorkspaceDev,
   shouldEagerStartWorkspaceApps,
   type WorkspaceDevHandle,
@@ -202,6 +203,12 @@ describe("workspace dev helpers", () => {
       "dispatch",
       "starter",
     ]);
+  });
+
+  it("treats file watcher limit errors as handled polling fallback", () => {
+    expect(isWorkspaceWatcherLimitError({ code: "ENOSPC" })).toBe(true);
+    expect(isWorkspaceWatcherLimitError({ code: "EMFILE" })).toBe(true);
+    expect(isWorkspaceWatcherLimitError({ code: "EACCES" })).toBe(false);
   });
 });
 

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -52,6 +52,12 @@ const DEFAULT_APP_PORT_START = 8100;
 const PROXY_READY_RETRY_DELAY_MS = 250;
 const APP_RESTART_MAX_DELAY_MS = 10_000;
 
+export function isWorkspaceWatcherLimitError(
+  err: Pick<NodeJS.ErrnoException, "code">,
+): boolean {
+  return err.code === "ENOSPC" || err.code === "EMFILE";
+}
+
 export function shouldEagerStartWorkspaceApps(
   args: string[] = [],
   env: NodeJS.ProcessEnv = process.env,
@@ -632,19 +638,18 @@ export function runWorkspaceDev(
   }
 
   function handleWatcherError(err: NodeJS.ErrnoException): void {
-    if (err.code === "ENOSPC") {
+    if (isWorkspaceWatcherLimitError(err)) {
       stderr.write(
-        `[workspace] Recursive file watcher hit the system limit (ENOSPC). ` +
+        `[workspace] Recursive file watcher hit the system limit (${err.code}). ` +
           `New apps will still be detected via polling every ~2s. ` +
-          `On Linux you can raise the limit with ` +
-          `\`sudo sysctl fs.inotify.max_user_watches=524288\` ` +
-          `(persist via /etc/sysctl.d/*.conf). On macOS/Windows this usually ` +
+          (err.code === "ENOSPC"
+            ? `On Linux you can raise the limit with ` +
+              `\`sudo sysctl fs.inotify.max_user_watches=524288\` ` +
+              `(persist via /etc/sysctl.d/*.conf). `
+            : `Try closing other dev servers or raising your open-file limit. `) +
+          `On macOS/Windows this usually ` +
           `means too many other watchers are running.\n`,
       );
-      Sentry.captureException(err, {
-        tags: { handled: "dev-watch-enospc" },
-        level: "warning",
-      });
       return;
     }
     if (err.code === "ENOENT") {

--- a/packages/core/src/client/analytics.spec.ts
+++ b/packages/core/src/client/analytics.spec.ts
@@ -1,5 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const sentryMock = vi.hoisted(() => ({
+  init: vi.fn(),
+  setTag: vi.fn(),
+  setUser: vi.fn(),
+  withScope: vi.fn((fn: (scope: any) => unknown) =>
+    fn({
+      setTag: vi.fn(),
+      setExtra: vi.fn(),
+      setContext: vi.fn(),
+    }),
+  ),
+  captureException: vi.fn(() => "event_id"),
+}));
+
+vi.mock("@sentry/browser", () => sentryMock);
+
 const pageviewStateKey = Symbol.for("agent-native.client.pageviewTracking");
 
 function resetPageviewState() {
@@ -83,6 +99,11 @@ function installBrowser(url = "https://mail.agent-native.com/inbox") {
 describe("browser analytics pageviews", () => {
   afterEach(() => {
     resetPageviewState();
+    sentryMock.init.mockClear();
+    sentryMock.setTag.mockClear();
+    sentryMock.setUser.mockClear();
+    sentryMock.withScope.mockClear();
+    sentryMock.captureException.mockClear();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
@@ -160,5 +181,24 @@ describe("browser analytics pageviews", () => {
     await tick();
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("initializes browser Sentry from SSR runtime config", async () => {
+    installBrowser();
+    (window as any).__AGENT_NATIVE_CONFIG__ = {
+      sentryDsn: "https://public@example/4511270423822336",
+      sentryEnvironment: "production",
+    };
+    const { configureTracking } = await freshAnalytics();
+
+    configureTracking({});
+
+    expect(sentryMock.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dsn: "https://public@example/4511270423822336",
+        environment: "production",
+      }),
+    );
+    expect(sentryMock.setTag).toHaveBeenCalledWith("runtime", "browser");
   });
 });

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -4,6 +4,10 @@ import * as Sentry from "@sentry/browser";
 declare global {
   interface Window {
     gtag?: (...args: any[]) => void;
+    __AGENT_NATIVE_CONFIG__?: {
+      sentryDsn?: string;
+      sentryEnvironment?: string;
+    };
   }
 }
 
@@ -98,13 +102,25 @@ function scrubUrl(url: string | undefined): string | undefined {
   }
 }
 
+function getClientSentryDsn(): string | undefined {
+  const env = (import.meta.env as Record<string, string | undefined>) ?? {};
+  return (
+    env.VITE_SENTRY_CLIENT_DSN ||
+    env.VITE_SENTRY_DSN ||
+    window.__AGENT_NATIVE_CONFIG__?.sentryDsn
+  );
+}
+
 function ensureSentry(): void {
   if (_sentryInitialized) return;
-  const dsn = (import.meta.env as Record<string, string | undefined>)
-    ?.VITE_SENTRY_CLIENT_DSN;
+  const dsn = getClientSentryDsn();
   if (!dsn) return;
   Sentry.init({
     dsn,
+    environment:
+      window.__AGENT_NATIVE_CONFIG__?.sentryEnvironment ||
+      (import.meta.env as Record<string, string | undefined>)?.MODE ||
+      "production",
     beforeSend(event) {
       // Strip sensitive query params from the request URL. React Router
       // history can include share tokens, ?signin=1, password reset codes,
@@ -133,6 +149,7 @@ function ensureSentry(): void {
       return event;
     },
   });
+  Sentry.setTag("runtime", "browser");
   _sentryInitialized = true;
   // Flush any user/tag that was set before init.
   if (_pendingSentryUser !== undefined) {

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -56,6 +56,11 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../components/ui/popover.js";
 
 const WORKSPACE_DOCS_URL = "https://agent-native.com/docs/workspace";
 
@@ -155,8 +160,6 @@ function CreateMenu({
     message: string;
   } | null>(null);
   const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (open) {
@@ -195,38 +198,6 @@ function CreateMenu({
     setMcpError(null);
     setMcpTestResult(null);
   };
-
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (
-        popoverRef.current &&
-        !popoverRef.current.contains(e.target as Node) &&
-        buttonRef.current &&
-        !buttonRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleKey(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        if (view !== "menu") {
-          if (view === "mcp-server") clearMcpFeedback();
-          setView("menu");
-        } else {
-          setOpen(false);
-        }
-      }
-    }
-    document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
-  }, [open, view]);
 
   const submitFile = () => {
     const trimmed = value.trim();
@@ -544,406 +515,405 @@ The result should be a reusable agent profile, not a one-off task response.`,
   ];
 
   return (
-    <div className="relative">
+    <Popover open={open} onOpenChange={setOpen}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <button
-            ref={buttonRef}
-            onClick={() => setOpen(!open)}
-            className={cn(
-              "flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50",
-              open && "bg-accent/50 text-foreground",
-            )}
-          >
-            <IconPlus className="h-3.5 w-3.5" />
-          </button>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                "flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent/50",
+                open && "bg-accent/50 text-foreground",
+              )}
+            >
+              <IconPlus className="h-3.5 w-3.5" />
+            </button>
+          </PopoverTrigger>
         </TooltipTrigger>
         <TooltipContent>Create new...</TooltipContent>
       </Tooltip>
-      {open && (
-        <div
-          ref={popoverRef}
-          className="absolute right-0 top-full mt-1.5 z-[220] rounded-lg border border-border bg-popover shadow-lg"
-          style={{
-            width: view === "menu" || view === "file" ? 260 : 380,
-            fontSize: 13,
-            lineHeight: "normal",
-          }}
-        >
-          {view === "menu" && (
-            <div className="py-1">
-              {menuItems.map((item) => (
-                <button
-                  key={item.label}
-                  onClick={item.action}
-                  className="flex w-full items-center gap-2.5 px-3 py-2 text-left hover:bg-accent/50"
-                >
-                  <span className="text-muted-foreground">{item.icon}</span>
-                  <div className="min-w-0">
-                    <div className="text-[12px] font-medium text-foreground">
-                      {item.label}
-                    </div>
-                    <div className="mt-0.5 text-[10px] text-muted-foreground/60">
-                      {item.desc}
-                    </div>
+      <PopoverContent
+        align="end"
+        sideOffset={6}
+        collisionPadding={8}
+        className={cn(
+          "z-[260] p-0 text-[13px] leading-normal",
+          view === "menu" || view === "file"
+            ? "w-[260px]"
+            : "max-h-[70vh] w-[calc(100vw-24px)] max-w-[380px] overflow-y-auto",
+        )}
+      >
+        {view === "menu" && (
+          <div className="py-1">
+            {menuItems.map((item) => (
+              <button
+                key={item.label}
+                onClick={item.action}
+                className="flex w-full items-center gap-2.5 px-3 py-2 text-left hover:bg-accent/50"
+              >
+                <span className="text-muted-foreground">{item.icon}</span>
+                <div className="min-w-0">
+                  <div className="text-[12px] font-medium text-foreground">
+                    {item.label}
                   </div>
-                </button>
-              ))}
-            </div>
-          )}
+                  <div className="mt-0.5 text-[10px] text-muted-foreground/60">
+                    {item.desc}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
 
-          {view === "file" && (
-            <div className="p-3">
-              <label className="mb-1.5 block text-[11px] font-medium text-muted-foreground">
-                File path
-              </label>
+        {view === "file" && (
+          <div className="p-3">
+            <label className="mb-1.5 block text-[11px] font-medium text-muted-foreground">
+              File path
+            </label>
+            <input
+              ref={inputRef as React.RefObject<HTMLInputElement>}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submitFile();
+                if (e.key === "Escape") {
+                  e.stopPropagation();
+                  setView("menu");
+                }
+              }}
+              className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+              placeholder="notes/ideas.md"
+            />
+            <div className="mt-2.5 flex justify-end">
+              <button
+                onClick={submitFile}
+                disabled={!value.trim()}
+                className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
+              >
+                Create
+              </button>
+            </div>
+          </div>
+        )}
+
+        {view === "skill" && (
+          <div className="p-3">
+            <label className="mb-1 block text-[11px] font-semibold text-foreground">
+              Create Skill
+            </label>
+            <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
+              Describe what kind of skill you want and the agent will create it.
+            </p>
+            <PromptComposer
+              autoFocus
+              placeholder="e.g. A skill that reviews PRs for security issues and OWASP top 10 vulnerabilities"
+              draftScope="resources:create-skill"
+              onSubmit={(text) => submitSkill(text)}
+            />
+          </div>
+        )}
+
+        {view === "job" && (
+          <div className="p-3">
+            <label className="mb-1 block text-[11px] font-semibold text-foreground">
+              Scheduled Task
+            </label>
+            <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
+              Describe what should happen and when.
+            </p>
+            <PromptComposer
+              autoFocus
+              placeholder="e.g. Every weekday at 9am, check for overdue scorecards and send a Slack update"
+              draftScope="resources:create-job"
+              onSubmit={(text) => submitJob(text)}
+            />
+          </div>
+        )}
+
+        {view === "agent-mode" && (
+          <div className="p-3">
+            <label className="mb-1 block text-[11px] font-semibold text-foreground">
+              Create Agent
+            </label>
+            <p className="mb-2 text-[10px] leading-relaxed text-muted-foreground/60">
+              Build a reusable sub-agent profile for this workspace.
+            </p>
+            <div className="space-y-2">
+              <button
+                onClick={() => setView("agent-prompt")}
+                className="flex w-full items-start gap-2 rounded-md border border-border px-3 py-2 text-left hover:bg-accent/40"
+              >
+                <IconPencil className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <div>
+                  <div className="text-[12px] font-medium text-foreground">
+                    Describe It
+                  </div>
+                  <div className="text-[10px] text-muted-foreground/60">
+                    Let the agent draft the profile from a prompt.
+                  </div>
+                </div>
+              </button>
+              <button
+                onClick={() => setView("agent-form")}
+                className="flex w-full items-start gap-2 rounded-md border border-border px-3 py-2 text-left hover:bg-accent/40"
+              >
+                <IconMessageChatbot className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <div>
+                  <div className="text-[12px] font-medium text-foreground">
+                    Fill Form
+                  </div>
+                  <div className="text-[10px] text-muted-foreground/60">
+                    Set the fields manually and start with a markdown template.
+                  </div>
+                </div>
+              </button>
+            </div>
+          </div>
+        )}
+
+        {view === "agent-prompt" && (
+          <div className="p-3">
+            <label className="mb-1 block text-[11px] font-semibold text-foreground">
+              Create Agent From Prompt
+            </label>
+            <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
+              Describe the agent you want. It will be saved under{" "}
+              <code>agents/</code>.
+            </p>
+            <PromptComposer
+              autoFocus
+              placeholder="e.g. A design agent that critiques layouts, suggests UI direction, and prefers concise product reasoning"
+              draftScope="resources:create-agent"
+              onSubmit={(text) => submitAgentPrompt(text)}
+            />
+          </div>
+        )}
+
+        {view === "agent-form" && (
+          <div className="p-3">
+            <label className="mb-2 block text-[11px] font-semibold text-foreground">
+              Create Agent Manually
+            </label>
+            <div className="space-y-2">
               <input
-                ref={inputRef as React.RefObject<HTMLInputElement>}
-                value={value}
-                onChange={(e) => setValue(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") submitFile();
-                  if (e.key === "Escape") {
-                    e.stopPropagation();
-                    setView("menu");
-                  }
+                value={agentName}
+                onChange={(e) => setAgentName(e.target.value)}
+                className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                placeholder="Agent name"
+              />
+              <input
+                value={agentDescription}
+                onChange={(e) => setAgentDescription(e.target.value)}
+                className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                placeholder="Short description"
+              />
+              <label className="block text-[11px] font-medium text-muted-foreground">
+                Model
+              </label>
+              <select
+                value={agentModel}
+                onChange={(e) => setAgentModel(e.target.value)}
+                className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none focus:ring-1 focus:ring-accent"
+              >
+                {AGENT_MODEL_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              <label className="block text-[11px] font-medium text-muted-foreground">
+                Instructions
+              </label>
+              <textarea
+                value={agentInstructions}
+                onChange={(e) => setAgentInstructions(e.target.value)}
+                rows={8}
+                className="w-full resize-y rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                style={{
+                  fontFamily:
+                    'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+                  lineHeight: 1.5,
+                }}
+              />
+            </div>
+            <div className="mt-2.5 flex justify-end">
+              <button
+                onClick={submitAgentManual}
+                disabled={
+                  !agentName.trim() ||
+                  !agentDescription.trim() ||
+                  !agentInstructions.trim()
+                }
+                className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
+              >
+                Create
+              </button>
+            </div>
+          </div>
+        )}
+
+        {view === "mcp-server" && (
+          <div className="p-3">
+            <label className="mb-1 block text-[11px] font-semibold text-foreground">
+              Connect MCP Server
+            </label>
+            <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
+              Point at any Streamable HTTP MCP server (Zapier, Cloudflare,
+              internal tools). Its tools become available to the agent. Use
+              Personal for private or staging servers; use Organization only for
+              vetted servers the whole org should share.{" "}
+              <a
+                href="https://agent-native.com/docs/mcp-clients#remote-via-ui"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-0.5 text-muted-foreground/80 underline hover:text-foreground"
+              >
+                Learn more
+                <IconExternalLink className="inline h-2.5 w-2.5" />
+              </a>
+            </p>
+            <div className="space-y-2">
+              <div className="flex gap-1 rounded-md border border-border p-0.5">
+                <button
+                  type="button"
+                  onClick={() => setMcpScope("user")}
+                  className={cn(
+                    "flex-1 rounded px-2 py-1 text-[11px] font-medium",
+                    mcpScope === "user"
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  Personal
+                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        hasOrg && canCreateOrgMcp && setMcpScope("org")
+                      }
+                      disabled={!hasOrg || !canCreateOrgMcp}
+                      className={cn(
+                        "flex-1 rounded px-2 py-1 text-[11px] font-medium",
+                        mcpScope === "org"
+                          ? "bg-accent text-foreground"
+                          : "text-muted-foreground hover:text-foreground",
+                        (!hasOrg || !canCreateOrgMcp) &&
+                          "cursor-not-allowed opacity-50 hover:text-muted-foreground",
+                      )}
+                    >
+                      Organization
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {!hasOrg
+                      ? "Join an organization to share MCP servers"
+                      : !canCreateOrgMcp
+                        ? "Only owners and admins can add org-scope servers"
+                        : undefined}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+              <input
+                value={mcpName}
+                onChange={(e) => {
+                  setMcpName(e.target.value);
+                  clearMcpFeedback();
                 }}
                 className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                placeholder="notes/ideas.md"
+                placeholder="Server name (e.g. zapier-staging)"
               />
-              <div className="mt-2.5 flex justify-end">
-                <button
-                  onClick={submitFile}
-                  disabled={!value.trim()}
-                  className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
-                >
-                  Create
-                </button>
-              </div>
-            </div>
-          )}
-
-          {view === "skill" && (
-            <div className="p-3">
-              <label className="mb-1 block text-[11px] font-semibold text-foreground">
-                Create Skill
-              </label>
-              <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
-                Describe what kind of skill you want and the agent will create
-                it.
-              </p>
-              <PromptComposer
-                autoFocus
-                placeholder="e.g. A skill that reviews PRs for security issues and OWASP top 10 vulnerabilities"
-                draftScope="resources:create-skill"
-                onSubmit={(text) => submitSkill(text)}
+              <input
+                value={mcpUrl}
+                onChange={(e) => {
+                  setMcpUrl(e.target.value);
+                  clearMcpFeedback();
+                }}
+                className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                placeholder="https://mcp.example.com/"
               />
-            </div>
-          )}
-
-          {view === "job" && (
-            <div className="p-3">
-              <label className="mb-1 block text-[11px] font-semibold text-foreground">
-                Scheduled Task
-              </label>
-              <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
-                Describe what should happen and when.
-              </p>
-              <PromptComposer
-                autoFocus
-                placeholder="e.g. Every weekday at 9am, check for overdue scorecards and send a Slack update"
-                draftScope="resources:create-job"
-                onSubmit={(text) => submitJob(text)}
+              <input
+                value={mcpDescription}
+                onChange={(e) => {
+                  setMcpDescription(e.target.value);
+                  clearMcpFeedback();
+                }}
+                className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                placeholder="Description (optional)"
               />
-            </div>
-          )}
-
-          {view === "agent-mode" && (
-            <div className="p-3">
-              <label className="mb-1 block text-[11px] font-semibold text-foreground">
-                Create Agent
-              </label>
-              <p className="mb-2 text-[10px] leading-relaxed text-muted-foreground/60">
-                Build a reusable sub-agent profile for this workspace.
-              </p>
-              <div className="space-y-2">
-                <button
-                  onClick={() => setView("agent-prompt")}
-                  className="flex w-full items-start gap-2 rounded-md border border-border px-3 py-2 text-left hover:bg-accent/40"
-                >
-                  <IconPencil className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                  <div>
-                    <div className="text-[12px] font-medium text-foreground">
-                      Describe It
-                    </div>
-                    <div className="text-[10px] text-muted-foreground/60">
-                      Let the agent draft the profile from a prompt.
-                    </div>
-                  </div>
-                </button>
-                <button
-                  onClick={() => setView("agent-form")}
-                  className="flex w-full items-start gap-2 rounded-md border border-border px-3 py-2 text-left hover:bg-accent/40"
-                >
-                  <IconMessageChatbot className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                  <div>
-                    <div className="text-[12px] font-medium text-foreground">
-                      Fill Form
-                    </div>
-                    <div className="text-[10px] text-muted-foreground/60">
-                      Set the fields manually and start with a markdown
-                      template.
-                    </div>
-                  </div>
-                </button>
-              </div>
-            </div>
-          )}
-
-          {view === "agent-prompt" && (
-            <div className="p-3">
-              <label className="mb-1 block text-[11px] font-semibold text-foreground">
-                Create Agent From Prompt
-              </label>
-              <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
-                Describe the agent you want. It will be saved under{" "}
-                <code>agents/</code>.
-              </p>
-              <PromptComposer
-                autoFocus
-                placeholder="e.g. A design agent that critiques layouts, suggests UI direction, and prefers concise product reasoning"
-                draftScope="resources:create-agent"
-                onSubmit={(text) => submitAgentPrompt(text)}
-              />
-            </div>
-          )}
-
-          {view === "agent-form" && (
-            <div className="p-3">
-              <label className="mb-2 block text-[11px] font-semibold text-foreground">
-                Create Agent Manually
-              </label>
-              <div className="space-y-2">
-                <input
-                  value={agentName}
-                  onChange={(e) => setAgentName(e.target.value)}
-                  className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                  placeholder="Agent name"
-                />
-                <input
-                  value={agentDescription}
-                  onChange={(e) => setAgentDescription(e.target.value)}
-                  className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                  placeholder="Short description"
-                />
-                <label className="block text-[11px] font-medium text-muted-foreground">
-                  Model
+              <div>
+                <label className="block text-[10px] font-medium text-foreground">
+                  Headers
                 </label>
-                <select
-                  value={agentModel}
-                  onChange={(e) => setAgentModel(e.target.value)}
-                  className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none focus:ring-1 focus:ring-accent"
-                >
-                  {AGENT_MODEL_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-                <label className="block text-[11px] font-medium text-muted-foreground">
-                  Instructions
-                </label>
-                <textarea
-                  value={agentInstructions}
-                  onChange={(e) => setAgentInstructions(e.target.value)}
-                  rows={8}
-                  className="w-full resize-y rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                  style={{
-                    fontFamily:
-                      'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
-                    lineHeight: 1.5,
-                  }}
-                />
+                <p className="mt-0.5 text-[10px] leading-snug text-muted-foreground/70">
+                  Optional. One per line, for example Authorization: Bearer
+                  sk-...
+                </p>
               </div>
-              <div className="mt-2.5 flex justify-end">
-                <button
-                  onClick={submitAgentManual}
-                  disabled={
-                    !agentName.trim() ||
-                    !agentDescription.trim() ||
-                    !agentInstructions.trim()
-                  }
-                  className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
-                >
-                  Create
-                </button>
-              </div>
-            </div>
-          )}
-
-          {view === "mcp-server" && (
-            <div className="p-3">
-              <label className="mb-1 block text-[11px] font-semibold text-foreground">
-                Connect MCP Server
-              </label>
-              <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
-                Point at any Streamable HTTP MCP server (Zapier, Cloudflare,
-                internal tools). Its tools become available to the agent. Use
-                Personal for private or staging servers; use Organization only
-                for vetted servers the whole org should share.{" "}
-                <a
-                  href="https://agent-native.com/docs/mcp-clients#remote-via-ui"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-0.5 text-muted-foreground/80 underline hover:text-foreground"
-                >
-                  Learn more
-                  <IconExternalLink className="inline h-2.5 w-2.5" />
-                </a>
-              </p>
-              <div className="space-y-2">
-                <div className="flex gap-1 rounded-md border border-border p-0.5">
-                  <button
-                    type="button"
-                    onClick={() => setMcpScope("user")}
-                    className={cn(
-                      "flex-1 rounded px-2 py-1 text-[11px] font-medium",
-                      mcpScope === "user"
-                        ? "bg-accent text-foreground"
-                        : "text-muted-foreground hover:text-foreground",
-                    )}
-                  >
-                    Personal
-                  </button>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          hasOrg && canCreateOrgMcp && setMcpScope("org")
-                        }
-                        disabled={!hasOrg || !canCreateOrgMcp}
-                        className={cn(
-                          "flex-1 rounded px-2 py-1 text-[11px] font-medium",
-                          mcpScope === "org"
-                            ? "bg-accent text-foreground"
-                            : "text-muted-foreground hover:text-foreground",
-                          (!hasOrg || !canCreateOrgMcp) &&
-                            "cursor-not-allowed opacity-50 hover:text-muted-foreground",
-                        )}
-                      >
-                        Organization
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {!hasOrg
-                        ? "Join an organization to share MCP servers"
-                        : !canCreateOrgMcp
-                          ? "Only owners and admins can add org-scope servers"
-                          : undefined}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-                <input
-                  value={mcpName}
-                  onChange={(e) => {
-                    setMcpName(e.target.value);
-                    clearMcpFeedback();
-                  }}
-                  className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                  placeholder="Server name (e.g. zapier-staging)"
-                />
-                <input
-                  value={mcpUrl}
-                  onChange={(e) => {
-                    setMcpUrl(e.target.value);
-                    clearMcpFeedback();
-                  }}
-                  className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                  placeholder="https://mcp.example.com/"
-                />
-                <input
-                  value={mcpDescription}
-                  onChange={(e) => {
-                    setMcpDescription(e.target.value);
-                    clearMcpFeedback();
-                  }}
-                  className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                  placeholder="Description (optional)"
-                />
-                <div>
-                  <label className="block text-[10px] font-medium text-foreground">
-                    Headers
-                  </label>
-                  <p className="mt-0.5 text-[10px] leading-snug text-muted-foreground/70">
-                    Optional. One per line, for example Authorization: Bearer
-                    sk-...
-                  </p>
-                </div>
-                <textarea
-                  value={mcpHeadersText}
-                  onChange={(e) => {
-                    setMcpHeadersText(e.target.value);
-                    clearMcpFeedback();
-                  }}
-                  rows={2}
-                  className="w-full resize-y rounded-md border border-border bg-background px-2.5 py-1.5 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
-                  style={{
-                    fontFamily:
-                      'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
-                  }}
-                  placeholder="Authorization: Bearer sk-..."
-                />
-                {mcpTestResult && (
-                  <div
-                    className={cn(
-                      "flex items-start gap-1 text-[11px] leading-snug",
-                      mcpTestResult.ok
-                        ? "text-green-600 dark:text-green-400"
-                        : "text-red-600 dark:text-red-400",
-                    )}
-                  >
-                    {mcpTestResult.ok && (
-                      <IconCheck className="mt-0.5 h-3 w-3 shrink-0" />
-                    )}
-                    <span className="min-w-0 break-words">
-                      {mcpTestResult.message}
-                    </span>
-                  </div>
-                )}
-                {mcpError && (
-                  <div className="break-words text-[11px] leading-snug text-red-600 dark:text-red-400">
-                    {mcpError}
-                  </div>
-                )}
-              </div>
-              <div className="mt-2.5 flex items-center justify-between gap-2">
-                <button
-                  type="button"
-                  onClick={runMcpTest}
-                  disabled={!mcpUrl.trim() || mcpBusy}
-                  className="rounded-md border border-border bg-background px-2.5 py-1.5 text-[11px] font-medium text-foreground hover:bg-accent disabled:opacity-40 disabled:pointer-events-none"
-                >
-                  Test
-                </button>
-                <button
-                  type="button"
-                  onClick={submitMcpServer}
-                  disabled={!mcpName.trim() || !mcpUrl.trim() || mcpBusy}
-                  className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
-                >
-                  {mcpBusy ? (
-                    <IconLoader2 className="h-3 w-3 animate-spin" />
-                  ) : (
-                    "Connect"
+              <textarea
+                value={mcpHeadersText}
+                onChange={(e) => {
+                  setMcpHeadersText(e.target.value);
+                  clearMcpFeedback();
+                }}
+                rows={2}
+                className="w-full resize-y rounded-md border border-border bg-background px-2.5 py-1.5 text-[12px] text-foreground outline-none placeholder:text-muted-foreground/50 focus:ring-1 focus:ring-accent"
+                style={{
+                  fontFamily:
+                    'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace',
+                }}
+                placeholder="Authorization: Bearer sk-..."
+              />
+              {mcpTestResult && (
+                <div
+                  className={cn(
+                    "flex items-start gap-1 text-[11px] leading-snug",
+                    mcpTestResult.ok
+                      ? "text-green-600 dark:text-green-400"
+                      : "text-red-600 dark:text-red-400",
                   )}
-                </button>
-              </div>
+                >
+                  {mcpTestResult.ok && (
+                    <IconCheck className="mt-0.5 h-3 w-3 shrink-0" />
+                  )}
+                  <span className="min-w-0 break-words">
+                    {mcpTestResult.message}
+                  </span>
+                </div>
+              )}
+              {mcpError && (
+                <div className="break-words text-[11px] leading-snug text-red-600 dark:text-red-400">
+                  {mcpError}
+                </div>
+              )}
             </div>
-          )}
-        </div>
-      )}
-    </div>
+            <div className="mt-2.5 flex items-center justify-between gap-2">
+              <button
+                type="button"
+                onClick={runMcpTest}
+                disabled={!mcpUrl.trim() || mcpBusy}
+                className="rounded-md border border-border bg-background px-2.5 py-1.5 text-[11px] font-medium text-foreground hover:bg-accent disabled:opacity-40 disabled:pointer-events-none"
+              >
+                Test
+              </button>
+              <button
+                type="button"
+                onClick={submitMcpServer}
+                disabled={!mcpName.trim() || !mcpUrl.trim() || mcpBusy}
+                className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-medium text-foreground hover:bg-accent/80 disabled:opacity-40 disabled:pointer-events-none"
+              >
+                {mcpBusy ? (
+                  <IconLoader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  "Connect"
+                )}
+              </button>
+            </div>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/packages/core/src/client/settings/AutomationsSection.tsx
+++ b/packages/core/src/client/settings/AutomationsSection.tsx
@@ -1,5 +1,5 @@
 import { agentNativePath } from "../api-path.js";
-import React, { useEffect, useState, useCallback, useRef } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import {
   IconBolt,
   IconClock,
@@ -15,6 +15,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "../components/ui/tooltip.js";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../components/ui/popover.js";
 
 interface TreeNode {
   name: string;
@@ -231,35 +236,6 @@ export function AutomationsSection() {
   const [newScope, setNewScope] = useState<"personal" | "organization">(
     "personal",
   );
-  const newPopoverRef = useRef<HTMLDivElement>(null);
-  const newButtonRef = useRef<HTMLButtonElement>(null);
-
-  // Close popover on outside click
-  useEffect(() => {
-    if (!newOpen) return;
-    function handleClick(e: MouseEvent) {
-      if (
-        newPopoverRef.current &&
-        !newPopoverRef.current.contains(e.target as Node) &&
-        newButtonRef.current &&
-        !newButtonRef.current.contains(e.target as Node)
-      ) {
-        setNewOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [newOpen]);
-
-  // Close popover on Escape
-  useEffect(() => {
-    if (!newOpen) return;
-    function handleKey(e: KeyboardEvent) {
-      if (e.key === "Escape") setNewOpen(false);
-    }
-    document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
-  }, [newOpen]);
 
   const handleNewSubmit = useCallback(
     (text: string) => {
@@ -301,53 +277,55 @@ export function AutomationsSection() {
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-1.5">
-        <div className="relative">
+        <Popover open={newOpen} onOpenChange={setNewOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] font-medium text-muted-foreground hover:text-foreground hover:bg-accent/40"
+            >
+              <IconPlus size={10} />
+              New Automation
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            sideOffset={6}
+            collisionPadding={8}
+            className="z-[260] w-[calc(100vw-24px)] max-w-[380px] p-3"
+          >
+            <p className="px-1 pb-2 text-sm font-semibold text-foreground">
+              New automation
+            </p>
+            <PromptComposer
+              autoFocus
+              placeholder="Describe what you want to automate..."
+              draftScope="automations:create"
+              onSubmit={handleNewSubmit}
+            />
+            <div className="mt-2">
+              <select
+                value={newScope}
+                onChange={(e) =>
+                  setNewScope(e.target.value as "personal" | "organization")
+                }
+                className="w-full cursor-pointer rounded-md border border-input bg-background px-3 py-1.5 text-[12px] text-foreground"
+              >
+                <option value="personal">Personal</option>
+                <option value="organization">Organization</option>
+              </select>
+            </div>
+          </PopoverContent>
+        </Popover>
+        {automations.length > 0 && (
           <button
-            ref={newButtonRef}
             type="button"
-            onClick={() => setNewOpen(!newOpen)}
+            onClick={handleFireTestEvent}
             className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] font-medium text-muted-foreground hover:text-foreground hover:bg-accent/40"
           >
-            <IconPlus size={10} />
-            New Automation
+            <IconPlayerPlay size={10} />
+            Fire Test Event
           </button>
-          {newOpen && (
-            <div
-              ref={newPopoverRef}
-              className="absolute left-0 top-full mt-1.5 z-[220] w-[380px] rounded-lg border border-border bg-popover p-3 shadow-lg"
-            >
-              <p className="px-1 pb-2 text-sm font-semibold text-foreground">
-                New automation
-              </p>
-              <PromptComposer
-                autoFocus
-                placeholder="Describe what you want to automate..."
-                draftScope="automations:create"
-                onSubmit={handleNewSubmit}
-              />
-              <div className="mt-2">
-                <select
-                  value={newScope}
-                  onChange={(e) =>
-                    setNewScope(e.target.value as "personal" | "organization")
-                  }
-                  className="w-full cursor-pointer rounded-md border border-input bg-background px-3 py-1.5 text-[12px] text-foreground"
-                >
-                  <option value="personal">Personal</option>
-                  <option value="organization">Organization</option>
-                </select>
-              </div>
-            </div>
-          )}
-        </div>
-        <button
-          type="button"
-          onClick={handleFireTestEvent}
-          className="inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-[10px] font-medium text-muted-foreground hover:text-foreground hover:bg-accent/40"
-        >
-          <IconPlayerPlay size={10} />
-          Fire Test Event
-        </button>
+        )}
       </div>
 
       {automations.length === 0 ? (

--- a/packages/core/src/client/terminal/AgentTerminal.tsx
+++ b/packages/core/src/client/terminal/AgentTerminal.tsx
@@ -199,25 +199,60 @@ export function AgentTerminal({
       term.loadAddon(webLinksAddon);
       term.open(container);
 
-      requestAnimationFrame(() => {
-        try {
-          fitAddon.fit();
-        } catch {}
-      });
-
-      // Resize observer for auto-fitting
-      const resizeObserver = new ResizeObserver(() => {
+      let fitPending = false;
+      function fitAndResize() {
+        if (fitPending) return;
+        fitPending = true;
         requestAnimationFrame(() => {
+          fitPending = false;
+          if (
+            disposed ||
+            !container.isConnected ||
+            container.clientWidth <= 0 ||
+            container.clientHeight <= 0
+          ) {
+            return;
+          }
           try {
             fitAddon.fit();
             sendResize();
           } catch {}
         });
+      }
+
+      fitAndResize();
+      const initialFitTimers = [
+        setTimeout(fitAndResize, 50),
+        setTimeout(fitAndResize, 250),
+      ];
+
+      const handleVisibilityOrFocus = () => fitAndResize();
+      window.addEventListener("focus", handleVisibilityOrFocus);
+      document.addEventListener("visibilitychange", handleVisibilityOrFocus);
+
+      // Resize observer for auto-fitting
+      const resizeObserver = new ResizeObserver(() => {
+        fitAndResize();
       });
       resizeObserver.observe(container);
 
+      let terminalDisposed = false;
+      function disposeTerminal() {
+        if (terminalDisposed) return;
+        terminalDisposed = true;
+        initialFitTimers.forEach(clearTimeout);
+        window.removeEventListener("focus", handleVisibilityOrFocus);
+        document.removeEventListener(
+          "visibilitychange",
+          handleVisibilityOrFocus,
+        );
+        resizeObserver.disconnect();
+        term.dispose();
+      }
+
       // Discover WebSocket URL
       let wsUrl = wsUrlProp;
+      let resolvedCommand = command;
       if (!wsUrl) {
         try {
           const res = await fetch(
@@ -226,26 +261,32 @@ export function AgentTerminal({
           const info: TerminalInfo = await res.json();
           if (!info.available) {
             setError(info.error || "Agent terminal not available");
+            disposeTerminal();
             return;
           }
           const protocol = location.protocol === "https:" ? "wss:" : "ws:";
           const host = formatWebSocketHostname(location.hostname);
           wsUrl = `${protocol}//${host}:${info.wsPort}/ws`;
-          if (!command && info.command) {
-            command = info.command;
+          if (!resolvedCommand && info.command) {
+            resolvedCommand = info.command;
           }
         } catch (err) {
           setError("Failed to discover terminal server");
+          disposeTerminal();
           return;
         }
       }
 
       // Build WebSocket URL with query params
       const qs = new URLSearchParams();
-      if (command) qs.set("command", command);
+      if (resolvedCommand) qs.set("command", resolvedCommand);
       if (flags) qs.set("flags", flags);
       const qsStr = qs.toString();
       const fullWsUrl = qsStr ? `${wsUrl}?${qsStr}` : wsUrl;
+
+      term.write(
+        `\x1b[2m[terminal] Starting ${resolvedCommand || "CLI"}...\x1b[0m\r\n`,
+      );
 
       // Connect WebSocket
       let agentRunning = false;
@@ -382,12 +423,11 @@ export function AgentTerminal({
         disposed = true;
         connectionId++;
         if (idleTimer) clearTimeout(idleTimer);
-        resizeObserver.disconnect();
+        disposeTerminal();
         if (ws) {
           ws.close();
           ws = null;
         }
-        term.dispose();
       };
     }
 

--- a/packages/core/src/deploy/build.spec.ts
+++ b/packages/core/src/deploy/build.spec.ts
@@ -33,8 +33,8 @@ export function createRequestHandler() {
       });
     }
     return new Response(
-      '<a href="/next">next</a><form action="/api/search"></form><style>.hero{background:url("/hero.png")}</style>' +
-        request.method + ' ' + url.pathname,
+      '<html><head></head><body><a href="/next">next</a><form action="/api/search"></form><style>.hero{background:url("/hero.png")}</style>' +
+        request.method + ' ' + url.pathname + '</body></html>',
       { headers: { "content-type": "text/html; charset=utf-8" } },
     );
   };
@@ -159,6 +159,20 @@ export default (event) =>
     );
     expect(redirect.status).toBe(302);
     expect(redirect.headers.get("location")).toBe("/docs/login");
+  });
+
+  it("injects runtime browser Sentry config into generated worker SSR HTML", async () => {
+    const worker = await importGeneratedWorker(generateWorkerEntry([], []));
+
+    const response = await worker.fetch(
+      new Request("https://app.test/inbox", { method: "GET" }),
+      { SENTRY_DSN: "https://public@example/4511270423822336" },
+      {},
+    );
+    const html = await response.text();
+
+    expect(html).toContain("data-agent-native-sentry-config");
+    expect(html).toContain("https://public@example/4511270423822336");
   });
 
   it("keeps mounted SSR HEAD responses bodyless and leaves missing API paths as 404", async () => {

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -251,8 +251,60 @@ function prefixMountedHtml(html, basePath) {
     });
 }
 
+function firstNonEmpty() {
+  for (const value of arguments) {
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (trimmed) return trimmed;
+  }
+}
+
+function getSentryClientConfigScript() {
+  const env = globalThis.process?.env || {};
+  const key = firstNonEmpty(env.SENTRY_CLIENT_KEY, env.VITE_SENTRY_CLIENT_KEY);
+  const projectId = firstNonEmpty(
+    env.SENTRY_PROJECT_ID,
+    env.VITE_SENTRY_PROJECT_ID,
+  );
+  const host = firstNonEmpty(
+    env.SENTRY_INGEST_HOST,
+    env.VITE_SENTRY_INGEST_HOST,
+  );
+  const dsn =
+    firstNonEmpty(
+      env.SENTRY_CLIENT_DSN,
+      env.VITE_SENTRY_CLIENT_DSN,
+      env.VITE_SENTRY_DSN,
+      env.SENTRY_DSN,
+    ) || (key && projectId && host ? "https://" + key + "@" + host + "/" + projectId : undefined);
+  if (!dsn) return null;
+  const config = {
+    sentryDsn: dsn,
+    sentryEnvironment:
+      firstNonEmpty(
+        env.SENTRY_ENVIRONMENT,
+        env.NETLIFY_CONTEXT,
+        env.VERCEL_ENV,
+        env.NODE_ENV,
+      ) || "production",
+  };
+  return (
+    '<script data-agent-native-sentry-config>' +
+    'window.__AGENT_NATIVE_CONFIG__=Object.assign({},window.__AGENT_NATIVE_CONFIG__,' +
+    JSON.stringify(config) +
+    ");</script>"
+  );
+}
+
+function injectHeadScript(html, script) {
+  if (!script) return html;
+  const headCloseIdx = html.indexOf("</head>");
+  if (headCloseIdx === -1) return html;
+  return html.slice(0, headCloseIdx) + script + html.slice(headCloseIdx);
+}
+
 async function rewriteMountedResponse(response, basePath) {
-  if (!basePath) return response;
+  const sentryClientConfigScript = getSentryClientConfigScript();
+  if (!basePath && !sentryClientConfigScript) return response;
 
   const headers = new Headers(response.headers);
   const location = headers.get("location");
@@ -271,11 +323,14 @@ async function rewriteMountedResponse(response, basePath) {
 
   const html = await response.text();
   headers.delete("content-length");
-  return new Response(prefixMountedHtml(html, basePath), {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
+  return new Response(
+    injectHeadScript(prefixMountedHtml(html, basePath), sentryClientConfigScript),
+    {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    },
+  );
 }
 
 function requestWithMethod(request, method) {

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -527,11 +527,7 @@ describe("workspace deploy", () => {
 
     const manifest = JSON.parse(
       fs.readFileSync(
-        path.join(
-          dispatchFunc,
-          ".agent-native",
-          "workspace-apps.json",
-        ),
+        path.join(dispatchFunc, ".agent-native", "workspace-apps.json"),
         "utf-8",
       ),
     );

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -15,15 +15,22 @@ let previousUnpooledDatabaseUrl: string | undefined;
 let previousNetlify: string | undefined;
 let previousNetlifyLocal: string | undefined;
 let previousNitroPreset: string | undefined;
+let previousVercel: string | undefined;
 let previousViteAppBasePath: string | undefined;
 let previousWorkspaceAppsJson: string | undefined;
 let execFile: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "an-workspace-deploy-"));
-  execFile = vi.fn(((_cmd, args) => {
+  execFile = vi.fn(((_cmd, args, options) => {
     if (Array.isArray(args) && args[0] === "--filter") {
-      writeAppBuildOutput(tmpDir, String(args[1]));
+      const preset = (options as { env?: NodeJS.ProcessEnv } | undefined)?.env
+        ?.NITRO_PRESET;
+      if (preset === "vercel") {
+        writeVercelAppBuildOutput(tmpDir, String(args[1]));
+      } else {
+        writeAppBuildOutput(tmpDir, String(args[1]));
+      }
     }
     return Buffer.from("");
   }) as typeof execFileSync);
@@ -35,6 +42,7 @@ beforeEach(() => {
   previousNetlify = process.env.NETLIFY;
   previousNetlifyLocal = process.env.NETLIFY_LOCAL;
   previousNitroPreset = process.env.NITRO_PRESET;
+  previousVercel = process.env.VERCEL;
   previousViteAppBasePath = process.env.VITE_APP_BASE_PATH;
   previousWorkspaceAppsJson = process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
   delete process.env.APP_BASE_PATH;
@@ -45,6 +53,7 @@ beforeEach(() => {
   delete process.env.NETLIFY;
   delete process.env.NETLIFY_LOCAL;
   delete process.env.NITRO_PRESET;
+  delete process.env.VERCEL;
   delete process.env.VITE_APP_BASE_PATH;
   delete process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
 });
@@ -58,6 +67,7 @@ afterEach(() => {
   restoreEnv("NETLIFY", previousNetlify);
   restoreEnv("NETLIFY_LOCAL", previousNetlifyLocal);
   restoreEnv("NITRO_PRESET", previousNitroPreset);
+  restoreEnv("VERCEL", previousVercel);
   restoreEnv("VITE_APP_BASE_PATH", previousViteAppBasePath);
   restoreEnv("AGENT_NATIVE_WORKSPACE_APPS_JSON", previousWorkspaceAppsJson);
   fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -422,6 +432,170 @@ describe("workspace deploy", () => {
     });
   });
 
+  it("collects Vercel static assets, functions, and routing config for a workspace", async () => {
+    makeWorkspaceApp(tmpDir, "dispatch");
+    makeWorkspaceApp(tmpDir, "starter");
+
+    await runWorkspaceDeploy({
+      workspaceRoot: tmpDir,
+      args: ["--preset=vercel", "--build-only"],
+      execFile: execFile as typeof execFileSync,
+    });
+
+    const dispatchCall = buildCallForApp("dispatch");
+    expect(dispatchCall?.env).toMatchObject({
+      NITRO_PRESET: "vercel",
+      APP_BASE_PATH: "/dispatch",
+      VITE_APP_BASE_PATH: "/dispatch",
+    });
+
+    const starterCall = buildCallForApp("starter");
+    expect(starterCall?.env).toMatchObject({
+      NITRO_PRESET: "vercel",
+      APP_BASE_PATH: "/starter",
+      VITE_APP_BASE_PATH: "/starter",
+    });
+
+    expect(
+      fs.existsSync(
+        path.join(
+          tmpDir,
+          ".vercel",
+          "output",
+          "static",
+          "dispatch",
+          "assets",
+          "app.js",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          tmpDir,
+          ".vercel",
+          "output",
+          "static",
+          "starter",
+          "assets",
+          "app.js",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          tmpDir,
+          ".vercel",
+          "output",
+          "static",
+          "dispatch",
+          "dispatch",
+        ),
+      ),
+    ).toBe(false);
+
+    const dispatchFunc = path.join(
+      tmpDir,
+      ".vercel",
+      "output",
+      "functions",
+      "dispatch-server.func",
+    );
+    const starterFunc = path.join(
+      tmpDir,
+      ".vercel",
+      "output",
+      "functions",
+      "starter-server.func",
+    );
+    expect(fs.existsSync(path.join(dispatchFunc, "index.mjs"))).toBe(true);
+    expect(fs.existsSync(path.join(dispatchFunc, "main.mjs"))).toBe(true);
+    expect(fs.existsSync(path.join(starterFunc, "index.mjs"))).toBe(true);
+    expect(fs.existsSync(path.join(starterFunc, "main.mjs"))).toBe(true);
+
+    const dispatchWrapper = fs.readFileSync(
+      path.join(dispatchFunc, "index.mjs"),
+      "utf-8",
+    );
+    expect(dispatchWrapper).toContain('const basePath = "/dispatch";');
+    expect(dispatchWrapper).toContain("Object.assign(processRef.env");
+    expect(dispatchWrapper).toContain("APP_BASE_PATH: basePath");
+    expect(dispatchWrapper).toContain("AGENT_NATIVE_WORKSPACE_APPS_JSON");
+    expect(dispatchWrapper).toContain('\\"path\\":\\"/starter\\"');
+    expect(dispatchWrapper).toContain('await import("./main.mjs")');
+
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          dispatchFunc,
+          ".agent-native",
+          "workspace-apps.json",
+        ),
+        "utf-8",
+      ),
+    );
+    expect(manifest.apps.map((app: { id: string }) => app.id)).toEqual([
+      "dispatch",
+      "starter",
+    ]);
+
+    const starterModule = await import(
+      `${pathToFileURL(path.join(starterFunc, "index.mjs")).href}?t=${Date.now()}-vercel-starter`
+    );
+    const req = { url: "/starter" };
+    await expect(starterModule.default(req, {})).resolves.toBe("/starter//");
+
+    const config = JSON.parse(
+      fs.readFileSync(
+        path.join(tmpDir, ".vercel", "output", "config.json"),
+        "utf-8",
+      ),
+    );
+    expect(config.version).toBe(3);
+    expect(config.routes).toContainEqual({ handle: "filesystem" });
+    expect(config.routes).toContainEqual({
+      src: "/_agent-native/(.*)",
+      dest: "/dispatch-server",
+    });
+    expect(config.routes).toContainEqual({
+      src: "/\\.well-known/(.*)",
+      dest: "/dispatch-server",
+    });
+    expect(config.routes).toContainEqual({
+      src: "/",
+      status: 302,
+      headers: { Location: "/dispatch/overview" },
+    });
+    expect(config.routes).toContainEqual({
+      src: "/dispatch",
+      status: 302,
+      headers: { Location: "/dispatch/overview" },
+    });
+    expect(config.routes).toContainEqual({
+      src: "/login",
+      status: 302,
+      headers: { Location: "/dispatch/login" },
+    });
+    expect(config.routes).toContainEqual({
+      src: "/apps/(.*)",
+      status: 302,
+      headers: { Location: "/dispatch/apps/$1" },
+    });
+    expect(config.routes).toContainEqual({
+      src: "/dispatch/(.*)",
+      dest: "/dispatch-server",
+    });
+    expect(config.routes).toContainEqual({
+      src: "/starter",
+      dest: "/starter-server",
+    });
+    expect(config.routes).toContainEqual({
+      src: "/starter/(.*)",
+      dest: "/starter-server",
+    });
+  });
+
   it("allows local build-only deploy checks without A2A_SECRET", async () => {
     makeWorkspaceApp(tmpDir, "dispatch");
 
@@ -458,6 +632,21 @@ describe("workspace deploy", () => {
       runWorkspaceDeploy({
         workspaceRoot: tmpDir,
         preset: "cloudflare_pages",
+        buildOnly: true,
+        execFile: execFile as typeof execFileSync,
+      }),
+    ).rejects.toThrow(/A2A_SECRET is required/);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("requires A2A_SECRET for hosted Vercel workspace deploy builds", async () => {
+    process.env.VERCEL = "1";
+    makeWorkspaceApp(tmpDir, "dispatch");
+
+    await expect(
+      runWorkspaceDeploy({
+        workspaceRoot: tmpDir,
+        preset: "vercel",
         buildOnly: true,
         execFile: execFile as typeof execFileSync,
       }),
@@ -727,6 +916,37 @@ function writeAppBuildOutput(workspaceRoot: string, app: string): void {
       "};",
       "",
     ].join("\n"),
+  );
+}
+
+function writeVercelAppBuildOutput(workspaceRoot: string, app: string): void {
+  const appDir = path.join(workspaceRoot, "apps", app);
+  const staticDir = path.join(appDir, ".vercel", "output", "static", app);
+  const functionDir = path.join(
+    appDir,
+    ".vercel",
+    "output",
+    "functions",
+    "__server.func",
+  );
+  fs.mkdirSync(path.join(staticDir, "assets"), { recursive: true });
+  fs.mkdirSync(functionDir, { recursive: true });
+  fs.writeFileSync(path.join(staticDir, "assets", "app.js"), "export {};");
+  fs.writeFileSync(path.join(staticDir, "favicon.ico"), "");
+  fs.writeFileSync(path.join(staticDir, "favicon.svg"), "<svg></svg>");
+  fs.writeFileSync(path.join(staticDir, "manifest.json"), "{}");
+  fs.mkdirSync(path.join(staticDir, app, "assets"), { recursive: true });
+  fs.writeFileSync(
+    path.join(staticDir, app, "assets", "duplicate.js"),
+    "export {};",
+  );
+  fs.writeFileSync(
+    path.join(functionDir, "index.mjs"),
+    "export default async function handler(req) { return req?.url ?? 'ok'; }\n",
+  );
+  fs.writeFileSync(
+    path.join(functionDir, ".vc-config.json"),
+    JSON.stringify({ handler: "index.mjs", runtime: "nodejs24.x" }),
   );
 }
 

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -20,7 +20,7 @@ import path from "path";
 import { findWorkspaceRoot } from "../scripts/utils.js";
 import { DISPATCH_WORKSPACE_ROOT_REDIRECTS } from "../shared/workspace-app-id.js";
 
-export type WorkspaceDeployPreset = "cloudflare_pages" | "netlify";
+export type WorkspaceDeployPreset = "cloudflare_pages" | "netlify" | "vercel";
 
 const NETLIFY_WORKSPACE_STATIC_DIR = "_workspace_static";
 const NETLIFY_PUBLIC_ASSET_EXTENSIONS = new Set([
@@ -47,6 +47,7 @@ const NETLIFY_PUBLIC_ASSET_EXTENSIONS = new Set([
 const WORKSPACE_APPS_ENV_KEY = "AGENT_NATIVE_WORKSPACE_APPS_JSON";
 const WORKSPACE_APPS_MANIFEST_DIR = ".agent-native";
 const WORKSPACE_APPS_MANIFEST_FILE = "workspace-apps.json";
+const VERCEL_OUTPUT_DIR = ".vercel/output";
 
 interface WorkspaceAppManifestEntry {
   id: string;
@@ -103,8 +104,17 @@ export async function runWorkspaceDeploy(
   const preset = resolvePreset(opts.preset, rawArgs);
   assertWorkspaceDeployProductionEnv({ buildOnly, preset });
   const distDir = path.join(workspaceRoot, "dist");
-  fs.rmSync(distDir, { recursive: true, force: true });
-  fs.mkdirSync(distDir, { recursive: true });
+  const vercelOutputDir = path.join(workspaceRoot, VERCEL_OUTPUT_DIR);
+  if (preset === "vercel") {
+    fs.rmSync(vercelOutputDir, { recursive: true, force: true });
+    fs.mkdirSync(path.join(vercelOutputDir, "static"), { recursive: true });
+    fs.mkdirSync(path.join(vercelOutputDir, "functions"), {
+      recursive: true,
+    });
+  } else {
+    fs.rmSync(distDir, { recursive: true, force: true });
+    fs.mkdirSync(distDir, { recursive: true });
+  }
 
   if (preset === "netlify") {
     const functionsDir = netlifyFunctionsDir(workspaceRoot);
@@ -119,7 +129,14 @@ export async function runWorkspaceDeploy(
   const execFile = opts.execFile ?? execFileSync;
   for (const app of apps) {
     buildOneApp(workspaceRoot, app, preset, execFile, workspaceApps);
-    moveAppBuildIntoDist(workspaceRoot, app, distDir, preset, workspaceApps);
+    moveAppBuildIntoWorkspaceOutput(
+      workspaceRoot,
+      app,
+      preset,
+      distDir,
+      vercelOutputDir,
+      workspaceApps,
+    );
   }
   writeWorkspaceAppManifests(
     workspaceRoot,
@@ -131,13 +148,16 @@ export async function runWorkspaceDeploy(
 
   if (preset === "netlify") {
     writeNetlifyRedirects(distDir, apps);
+  } else if (preset === "vercel") {
+    writeVercelBuildConfig(vercelOutputDir, apps);
   } else {
     writeCloudflareRoutingManifest(distDir, apps);
   }
 
   if (buildOnly) {
+    const outputDir = preset === "vercel" ? vercelOutputDir : distDir;
     console.log(
-      `\n[workspace-deploy] Build complete at ${distDir}. Skipping publish (--build-only).`,
+      `\n[workspace-deploy] Build complete at ${outputDir}. Skipping publish (--build-only).`,
     );
     return;
   }
@@ -148,6 +168,8 @@ export async function runWorkspaceDeploy(
     console.log(
       `  netlify deploy --prod --dir=dist --functions=.netlify/functions-internal\n`,
     );
+  } else if (preset === "vercel") {
+    console.log(`  vercel deploy --prebuilt\n`);
   } else {
     console.log(`  wrangler pages deploy dist\n`);
   }
@@ -194,14 +216,25 @@ function buildOneApp(
   });
 }
 
-function moveAppBuildIntoDist(
+function moveAppBuildIntoWorkspaceOutput(
   workspaceRoot: string,
   app: string,
-  distDir: string,
   preset: WorkspaceDeployPreset,
+  distDir: string,
+  vercelOutputDir: string,
   workspaceApps: WorkspaceAppManifestEntry[],
 ): void {
   const appDir = path.join(workspaceRoot, "apps", app);
+  if (preset === "vercel") {
+    copyVercelAppBuildIntoWorkspace(
+      workspaceRoot,
+      app,
+      vercelOutputDir,
+      workspaceApps,
+    );
+    return;
+  }
+
   // Resolve the per-app build output: prefer dist/ (standard), fall back to
   // .output/ (Nitro's default). The Cloudflare preset emits into dist/
   // containing the worker + assets.
@@ -230,6 +263,50 @@ function moveAppBuildIntoDist(
     fs.mkdirSync(target, { recursive: true });
     copyDir(src, target);
   }
+}
+
+function copyVercelAppBuildIntoWorkspace(
+  workspaceRoot: string,
+  app: string,
+  vercelOutputDir: string,
+  workspaceApps: WorkspaceAppManifestEntry[],
+): void {
+  const appDir = path.join(workspaceRoot, "apps", app);
+  const src = path.join(appDir, VERCEL_OUTPUT_DIR);
+  if (!fs.existsSync(src)) {
+    throw new Error(
+      `Expected Vercel output at ${src} after building ${app}. Check the app's build script and NITRO_PRESET.`,
+    );
+  }
+
+  const staticSrc = path.join(src, "static");
+  const staticDest = path.join(vercelOutputDir, "static");
+  if (fs.existsSync(staticSrc)) {
+    copyDir(staticSrc, staticDest);
+    // Nitro's Vercel preset already nests assets under baseURL. The shared
+    // deploy build also mirrors client assets under baseURL for other Nitro
+    // presets, so mounted apps can contain a duplicate /<app>/<app> copy.
+    fs.rmSync(path.join(staticDest, app, app), {
+      recursive: true,
+      force: true,
+    });
+  }
+
+  const functionSrc = path.join(src, "functions", "__server.func");
+  if (!fs.existsSync(functionSrc)) {
+    throw new Error(
+      `Expected Vercel function at ${functionSrc} after building ${app}. Check the app's build script and NITRO_PRESET.`,
+    );
+  }
+
+  const functionDest = path.join(
+    vercelOutputDir,
+    "functions",
+    `${app}-server.func`,
+  );
+  fs.rmSync(functionDest, { recursive: true, force: true });
+  copyDir(functionSrc, functionDest);
+  patchVercelFunctionEntry(functionDest, app, workspaceApps);
 }
 
 /**
@@ -346,6 +423,66 @@ function writeNetlifyRedirects(distDir: string, apps: string[]): void {
   fs.writeFileSync(path.join(distDir, "_redirects"), lines.join("\n") + "\n");
 }
 
+function writeVercelBuildConfig(outputDir: string, apps: string[]): void {
+  const routes: Array<Record<string, any>> = [
+    { handle: "filesystem" },
+  ];
+
+  if (apps.includes("dispatch")) {
+    routes.push(
+      { src: "/_agent-native", dest: "/dispatch-server" },
+      { src: "/_agent-native/(.*)", dest: "/dispatch-server" },
+      { src: "/\\.well-known", dest: "/dispatch-server" },
+      { src: "/\\.well-known/(.*)", dest: "/dispatch-server" },
+    );
+
+    const faviconAsset = dispatchRootFaviconAsset(
+      path.join(outputDir, "static"),
+    );
+    if (faviconAsset) {
+      routes.push(vercelRedirect("/favicon.ico", `/dispatch/${faviconAsset}`));
+    }
+
+    routes.push(
+      vercelRedirect("/", "/dispatch/overview"),
+      vercelRedirect("/dispatch", "/dispatch/overview"),
+    );
+    for (const [from, to] of DISPATCH_WORKSPACE_ROOT_REDIRECTS) {
+      routes.push(vercelRedirect(`/${from}`, `/dispatch/${to}`));
+    }
+    routes.push(vercelRedirect("/apps/(.*)", "/dispatch/apps/$1"));
+  } else {
+    routes.push(vercelRedirect("/", `/${apps[0]}/`));
+  }
+
+  for (const app of apps) {
+    if (app !== "dispatch") {
+      routes.push({ src: `/${app}`, dest: `/${app}-server` });
+    }
+    routes.push({ src: `/${app}/(.*)`, dest: `/${app}-server` });
+  }
+
+  const config = {
+    version: 3,
+    routes,
+  };
+  fs.writeFileSync(
+    path.join(outputDir, "config.json"),
+    JSON.stringify(config, null, 2) + "\n",
+  );
+}
+
+function vercelRedirect(
+  src: string,
+  location: string,
+): Record<string, any> {
+  return {
+    src,
+    status: 302,
+    headers: { Location: location },
+  };
+}
+
 function netlifyAssetRedirectsFor(app: string, distDir: string): string[] {
   const from = `/${app}`;
   const to = `/${NETLIFY_WORKSPACE_STATIC_DIR}/${app}`;
@@ -447,6 +584,67 @@ function normalizeBasePathArgs(args) {
   }
   return args;
 }
+
+function patchVercelFunctionEntry(
+  functionDir: string,
+  app: string,
+  workspaceApps: WorkspaceAppManifestEntry[],
+): void {
+  const entryPath = path.join(functionDir, "index.mjs");
+  if (!fs.existsSync(entryPath)) return;
+
+  const mainPath = path.join(functionDir, "main.mjs");
+  fs.rmSync(mainPath, { force: true });
+  fs.renameSync(entryPath, mainPath);
+
+  const basePath = `/${app}`;
+  const entry = `const basePath = ${JSON.stringify(basePath)};
+
+function setBasePathEnv() {
+  const processRef = globalThis.process ??= { env: {} };
+  processRef.env ??= {};
+  Object.assign(processRef.env, {
+    AGENT_NATIVE_WORKSPACE: "1",
+    APP_BASE_PATH: basePath,
+    VITE_AGENT_NATIVE_WORKSPACE: "1",
+    VITE_APP_BASE_PATH: basePath,
+    ${JSON.stringify(WORKSPACE_APPS_ENV_KEY)}: ${JSON.stringify(JSON.stringify(workspaceApps))},
+  });
+}
+
+function normalizeBasePathArgs(args) {
+  const request = args[0];
+  if (!request) return args;
+
+  if (typeof Request === "function" && request instanceof Request) {
+    const url = new URL(request.url);
+    if (url.pathname === basePath || url.pathname === \`\${basePath}/\`) {
+      url.pathname = \`\${basePath}//\`;
+      return [new Request(url, request), ...args.slice(1)];
+    }
+    return args;
+  }
+
+  if (typeof request.url !== "string") return args;
+  const url = new URL(request.url, "http://agent-native.local");
+  if (url.pathname === basePath || url.pathname === \`\${basePath}/\`) {
+    request.url = \`\${basePath}//\${url.search}\`;
+  }
+  return args;
+}
+
+setBasePathEnv();
+
+let cachedHandler;
+
+export default async function handler(...args) {
+  setBasePathEnv();
+  cachedHandler ??= (await import("./main.mjs")).default;
+  return cachedHandler(...normalizeBasePathArgs(args));
+}
+`;
+  fs.writeFileSync(entryPath, entry);
+}
 `;
   const handlerArgs =
     app === "dispatch" ? "...args" : "...normalizeBasePathArgs(args)";
@@ -532,6 +730,10 @@ function cleanAppBuildOutputs(appDir: string): void {
     recursive: true,
     force: true,
   });
+  fs.rmSync(path.join(appDir, ".vercel", "output"), {
+    recursive: true,
+    force: true,
+  });
 }
 
 function appUsesNetlifyUnpooledDatabaseUrl(appDir: string): boolean {
@@ -572,6 +774,17 @@ function writeWorkspaceAppManifests(
             WORKSPACE_APPS_MANIFEST_FILE,
           ),
         )
+      : preset === "vercel"
+        ? apps.map((app) =>
+            path.join(
+              workspaceRoot,
+              VERCEL_OUTPUT_DIR,
+              "functions",
+              `${app}-server.func`,
+              WORKSPACE_APPS_MANIFEST_DIR,
+              WORKSPACE_APPS_MANIFEST_FILE,
+            ),
+          )
       : apps.map((app) =>
           path.join(
             distDir,
@@ -786,6 +999,9 @@ function isProductionWorkspaceDeploy(opts: {
   if (opts.preset === "cloudflare_pages" && process.env.CF_PAGES === "1") {
     return true;
   }
+  if (opts.preset === "vercel" && process.env.VERCEL === "1") {
+    return true;
+  }
   return false;
 }
 
@@ -797,8 +1013,9 @@ function normalizePreset(
     return "cloudflare_pages";
   }
   if (value === "netlify") return "netlify";
+  if (value === "vercel") return "vercel";
   throw new Error(
-    `Unsupported workspace deploy preset "${value}". Supported presets: cloudflare_pages, netlify.`,
+    `Unsupported workspace deploy preset "${value}". Supported presets: cloudflare_pages, netlify, vercel.`,
   );
 }
 

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -424,9 +424,7 @@ function writeNetlifyRedirects(distDir: string, apps: string[]): void {
 }
 
 function writeVercelBuildConfig(outputDir: string, apps: string[]): void {
-  const routes: Array<Record<string, any>> = [
-    { handle: "filesystem" },
-  ];
+  const routes: Array<Record<string, any>> = [{ handle: "filesystem" }];
 
   if (apps.includes("dispatch")) {
     routes.push(
@@ -472,10 +470,7 @@ function writeVercelBuildConfig(outputDir: string, apps: string[]): void {
   );
 }
 
-function vercelRedirect(
-  src: string,
-  location: string,
-): Record<string, any> {
+function vercelRedirect(src: string, location: string): Record<string, any> {
   return {
     src,
     status: 302,
@@ -585,9 +580,6 @@ function normalizeBasePathArgs(args) {
   return args;
 }
 `;
-  fs.writeFileSync(entryPath, entry);
-}
-`;
   const handlerArgs =
     app === "dispatch" ? "...args" : "...normalizeBasePathArgs(args)";
   const server = `const basePath = ${JSON.stringify(basePath)};
@@ -633,6 +625,67 @@ export const config = {
 `;
   fs.rmSync(serverPath, { force: true });
   fs.writeFileSync(path.join(functionDir, `${app}-server.mjs`), server);
+}
+
+function patchVercelFunctionEntry(
+  functionDir: string,
+  app: string,
+  workspaceApps: WorkspaceAppManifestEntry[],
+): void {
+  const entryPath = path.join(functionDir, "index.mjs");
+  if (!fs.existsSync(entryPath)) return;
+
+  const mainPath = path.join(functionDir, "main.mjs");
+  fs.rmSync(mainPath, { force: true });
+  fs.renameSync(entryPath, mainPath);
+
+  const basePath = `/${app}`;
+  const entry = `const basePath = ${JSON.stringify(basePath)};
+
+function setBasePathEnv() {
+  const processRef = globalThis.process ??= { env: {} };
+  processRef.env ??= {};
+  Object.assign(processRef.env, {
+    AGENT_NATIVE_WORKSPACE: "1",
+    APP_BASE_PATH: basePath,
+    VITE_AGENT_NATIVE_WORKSPACE: "1",
+    VITE_APP_BASE_PATH: basePath,
+    ${JSON.stringify(WORKSPACE_APPS_ENV_KEY)}: ${JSON.stringify(JSON.stringify(workspaceApps))},
+  });
+}
+
+function normalizeBasePathArgs(args) {
+  const request = args[0];
+  if (!request) return args;
+
+  if (typeof Request === "function" && request instanceof Request) {
+    const url = new URL(request.url);
+    if (url.pathname === basePath || url.pathname === \`\${basePath}/\`) {
+      url.pathname = \`\${basePath}//\`;
+      return [new Request(url, request), ...args.slice(1)];
+    }
+    return args;
+  }
+
+  if (typeof request.url !== "string") return args;
+  const url = new URL(request.url, "http://agent-native.local");
+  if (url.pathname === basePath || url.pathname === \`\${basePath}/\`) {
+    request.url = \`\${basePath}//\${url.search}\`;
+  }
+  return args;
+}
+
+setBasePathEnv();
+
+let cachedHandler;
+
+export default async function handler(...args) {
+  setBasePathEnv();
+  cachedHandler ??= (await import("./main.mjs")).default;
+  return cachedHandler(...normalizeBasePathArgs(args));
+}
+`;
+  fs.writeFileSync(entryPath, entry);
 }
 
 function netlifyFunctionExcludedPaths(
@@ -727,14 +780,14 @@ function writeWorkspaceAppManifests(
               WORKSPACE_APPS_MANIFEST_FILE,
             ),
           )
-      : apps.map((app) =>
-          path.join(
-            distDir,
-            app,
-            WORKSPACE_APPS_MANIFEST_DIR,
-            WORKSPACE_APPS_MANIFEST_FILE,
-          ),
-        );
+        : apps.map((app) =>
+            path.join(
+              distDir,
+              app,
+              WORKSPACE_APPS_MANIFEST_DIR,
+              WORKSPACE_APPS_MANIFEST_FILE,
+            ),
+          );
 
   for (const target of targets) {
     fs.mkdirSync(path.dirname(target), { recursive: true });

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -584,64 +584,6 @@ function normalizeBasePathArgs(args) {
   }
   return args;
 }
-
-function patchVercelFunctionEntry(
-  functionDir: string,
-  app: string,
-  workspaceApps: WorkspaceAppManifestEntry[],
-): void {
-  const entryPath = path.join(functionDir, "index.mjs");
-  if (!fs.existsSync(entryPath)) return;
-
-  const mainPath = path.join(functionDir, "main.mjs");
-  fs.rmSync(mainPath, { force: true });
-  fs.renameSync(entryPath, mainPath);
-
-  const basePath = `/${app}`;
-  const entry = `const basePath = ${JSON.stringify(basePath)};
-
-function setBasePathEnv() {
-  const processRef = globalThis.process ??= { env: {} };
-  processRef.env ??= {};
-  Object.assign(processRef.env, {
-    AGENT_NATIVE_WORKSPACE: "1",
-    APP_BASE_PATH: basePath,
-    VITE_AGENT_NATIVE_WORKSPACE: "1",
-    VITE_APP_BASE_PATH: basePath,
-    ${JSON.stringify(WORKSPACE_APPS_ENV_KEY)}: ${JSON.stringify(JSON.stringify(workspaceApps))},
-  });
-}
-
-function normalizeBasePathArgs(args) {
-  const request = args[0];
-  if (!request) return args;
-
-  if (typeof Request === "function" && request instanceof Request) {
-    const url = new URL(request.url);
-    if (url.pathname === basePath || url.pathname === \`\${basePath}/\`) {
-      url.pathname = \`\${basePath}//\`;
-      return [new Request(url, request), ...args.slice(1)];
-    }
-    return args;
-  }
-
-  if (typeof request.url !== "string") return args;
-  const url = new URL(request.url, "http://agent-native.local");
-  if (url.pathname === basePath || url.pathname === \`\${basePath}/\`) {
-    request.url = \`\${basePath}//\${url.search}\`;
-  }
-  return args;
-}
-
-setBasePathEnv();
-
-let cachedHandler;
-
-export default async function handler(...args) {
-  setBasePathEnv();
-  cachedHandler ??= (await import("./main.mjs")).default;
-  return cachedHandler(...normalizeBasePathArgs(args));
-}
 `;
   fs.writeFileSync(entryPath, entry);
 }

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -268,11 +268,34 @@ describe("server/auth", () => {
 
       const html = await (result as Response).text();
       expect(html).toContain("This app is private");
-      expect(html).toContain("not your Netlify personal access token");
+      expect(html).toContain("not your deploy provider account token");
       expect(html).toContain('var configuredBasePath = "/demo";');
       expect(html).toContain("__anPath('/_agent-native/auth/login')");
       expect(html).toContain("__anPath('/_agent-native/auth/session')");
       expect(html).toContain("The token was accepted, but the browser");
+    });
+
+    it("infers mounted workspace auth paths when APP_BASE_PATH is absent", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
+      delete process.env.APP_BASE_PATH;
+      const { autoMountAuth } = await import("./auth.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const result = await guard(createMockEvent({ path: "/starter" }));
+      expect(result).toBeInstanceOf(Response);
+
+      const html = await (result as Response).text();
+      expect(html).toContain('var configuredBasePath = "/starter";');
+      expect(html).toContain("__anPath('/_agent-native/auth/login')");
     });
 
     it("recognizes auth routes under APP_BASE_PATH in the global guard", async () => {

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -557,6 +557,7 @@ let customGetSession: ((event: H3Event) => Promise<AuthSession | null>) | null =
  */
 interface AuthGuardConfig {
   loginHtml: string;
+  getLoginHtml?: (event: H3Event, rawPath: string) => string;
   publicPaths: string[];
 }
 let _authGuardConfig: AuthGuardConfig | null = null;
@@ -883,11 +884,12 @@ function createAuthGuardFn(): (
   return async (event: H3Event) => {
     const config = _authGuardConfig;
     if (!config) return;
-    const { loginHtml, publicPaths } = config;
+    const { publicPaths } = config;
 
     const url = event.node?.req?.url ?? event.path ?? "/";
     const queryStart = url.indexOf("?");
     const rawPath = queryStart >= 0 ? url.slice(0, queryStart) : url;
+    const loginHtml = config.getLoginHtml?.(event, rawPath) ?? config.loginHtml;
     const p = stripAppBasePath(rawPath);
     const normalizedUrl = queryStart >= 0 ? `${p}${url.slice(queryStart)}` : p;
     const callbackRelay = workspaceOAuthCallbackRelayResponse(event);
@@ -1249,8 +1251,35 @@ function stripAppBasePath(pathname: string): string {
 // Login page HTML (ACCESS_TOKEN mode)
 // ---------------------------------------------------------------------------
 
-function getTokenLoginHtml(): string {
-  const configuredBasePath = getAppBasePath();
+function inferWorkspaceBasePathFromRequest(requestPath?: string): string {
+  if (
+    process.env.AGENT_NATIVE_WORKSPACE !== "1" &&
+    process.env.VITE_AGENT_NATIVE_WORKSPACE !== "1"
+  ) {
+    return "";
+  }
+  if (!requestPath || !requestPath.startsWith("/")) return "";
+  const firstSegment = requestPath.split(/[/?#]/)[1];
+  if (!firstSegment) return "";
+  const reservedRootPaths = new Set([
+    "_agent-native",
+    ".well-known",
+    "api",
+    "login",
+    "signup",
+    "apps",
+    "new-app",
+    "approval",
+    "extensions",
+  ]);
+  if (reservedRootPaths.has(firstSegment)) return "";
+  if (!isValidWorkspaceAppIdFormat(firstSegment)) return "";
+  return `/${firstSegment}`;
+}
+
+function getTokenLoginHtml(options: { requestPath?: string } = {}): string {
+  const configuredBasePath =
+    getAppBasePath() || inferWorkspaceBasePathFromRequest(options.requestPath);
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -1436,7 +1465,7 @@ function getTokenLoginHtml(): string {
 <div class="card">
   <div class="eyebrow">Private deployment</div>
   <h1>This app is private</h1>
-  <p class="intro">Enter the shared app access token to continue. This is the value configured for this app, not your Netlify personal access token.</p>
+  <p class="intro">Enter the shared app access token to continue. This is the value configured for this app, not your deploy provider account token.</p>
   <form id="form">
     <label for="token"><span>App ACCESS_TOKEN</span><span>Required</span></label>
     <div class="input-wrap">
@@ -1448,7 +1477,7 @@ function getTokenLoginHtml(): string {
   </form>
   <details>
     <summary>Where do I find this?</summary>
-    <p>In Netlify, create or copy the app's shared token from Site configuration, Environment variables. The key should be <code>ACCESS_TOKEN</code> for one token or <code>ACCESS_TOKENS</code> for a comma-separated list. Redeploy after changing it.</p>
+    <p>Create or copy the app's shared token from your deployment environment variables. The key should be <code>ACCESS_TOKEN</code> for one token or <code>ACCESS_TOKENS</code> for a comma-separated list. Redeploy after changing it.</p>
   </details>
 </div>
 <script>
@@ -1524,7 +1553,7 @@ function getTokenLoginHtml(): string {
         body: JSON.stringify({ token: token }),
       });
       if (!res.ok) {
-        var badTokenMessage = 'That token was not accepted. Use this app\\'s shared ACCESS_TOKEN, not a Netlify personal access token.';
+        var badTokenMessage = 'That token was not accepted. Use this app\\'s shared ACCESS_TOKEN, not your deploy provider account token.';
         if (res.status === 404) {
           badTokenMessage = 'Could not reach this app\\'s auth endpoint. If this app is mounted under a path, confirm APP_BASE_PATH and VITE_APP_BASE_PATH match the deploy path.';
         }
@@ -2292,7 +2321,12 @@ function mountTokenOnlyRoutes(
     }),
   );
 
-  _authGuardConfig = { loginHtml: getTokenLoginHtml(), publicPaths };
+  _authGuardConfig = {
+    loginHtml: getTokenLoginHtml(),
+    getLoginHtml: (_event, rawPath) =>
+      getTokenLoginHtml({ requestPath: rawPath }),
+    publicPaths,
+  };
   const guardFn = createAuthGuardFn();
   _authGuardFn = guardFn;
   app.use(defineEventHandler(guardFn));
@@ -2555,7 +2589,16 @@ export async function autoMountAuth(
     );
 
     const byoaLoginHtml = options.loginHtml ?? getTokenLoginHtml();
-    _authGuardConfig = { loginHtml: byoaLoginHtml, publicPaths };
+    _authGuardConfig = {
+      loginHtml: byoaLoginHtml,
+      ...(options.loginHtml
+        ? {}
+        : {
+            getLoginHtml: (_event, rawPath) =>
+              getTokenLoginHtml({ requestPath: rawPath }),
+          }),
+      publicPaths,
+    };
     const guardFn = createAuthGuardFn();
     _authGuardFn = guardFn;
     app.use(defineEventHandler(guardFn));

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -1858,7 +1858,8 @@ export function createCoreRoutesPlugin(
       `${P}/automations`,
       defineEventHandler(async (event: H3Event) => {
         const method = getMethod(event);
-        const pathname = (event.url?.pathname || "")
+        const pathname = (event.path || event.url?.pathname || "")
+          .split("?")[0]
           .replace(/^\/+/, "")
           .replace(/\/+$/, "");
 
@@ -1873,7 +1874,10 @@ export function createCoreRoutesPlugin(
           return { error: "Unauthenticated" };
         }
 
-        if (pathname === "fire-test" && method === "POST") {
+        if (
+          (pathname === "fire-test" || pathname.endsWith("/fire-test")) &&
+          method === "POST"
+        ) {
           try {
             const { emit } = await import("../event-bus/index.js");
             const body = (await readBody(event).catch(() => ({}))) as Record<

--- a/packages/core/src/server/sentry-config.ts
+++ b/packages/core/src/server/sentry-config.ts
@@ -1,4 +1,6 @@
-function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+function firstNonEmpty(
+  ...values: Array<string | undefined>
+): string | undefined {
   for (const value of values) {
     const trimmed = value?.trim();
     if (trimmed) return trimmed;
@@ -62,7 +64,7 @@ export function getSentryClientConfigScript(): string | null {
   };
 
   return [
-    '<script data-agent-native-sentry-config>',
+    "<script data-agent-native-sentry-config>",
     "window.__AGENT_NATIVE_CONFIG__=Object.assign({},window.__AGENT_NATIVE_CONFIG__,",
     JSON.stringify(config),
     ");",

--- a/packages/core/src/server/sentry-config.ts
+++ b/packages/core/src/server/sentry-config.ts
@@ -1,0 +1,71 @@
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+function resolveSentryDsnFromKeyProject(): string | undefined {
+  const key = firstNonEmpty(
+    process.env.SENTRY_CLIENT_KEY,
+    process.env.VITE_SENTRY_CLIENT_KEY,
+  );
+  const projectId = firstNonEmpty(
+    process.env.SENTRY_PROJECT_ID,
+    process.env.VITE_SENTRY_PROJECT_ID,
+  );
+  const host = firstNonEmpty(
+    process.env.SENTRY_INGEST_HOST,
+    process.env.VITE_SENTRY_INGEST_HOST,
+  );
+  if (!key || !projectId || !host) return undefined;
+  return `https://${key}@${host}/${projectId}`;
+}
+
+export function resolveSentryEnvironment(): string {
+  return (
+    firstNonEmpty(
+      process.env.SENTRY_ENVIRONMENT,
+      process.env.NETLIFY_CONTEXT,
+      process.env.VERCEL_ENV,
+      process.env.NODE_ENV,
+    ) ?? "production"
+  );
+}
+
+export function resolveServerSentryDsn(): string | undefined {
+  return (
+    firstNonEmpty(process.env.SENTRY_SERVER_DSN, process.env.SENTRY_DSN) ??
+    resolveSentryDsnFromKeyProject()
+  );
+}
+
+export function resolvePublicSentryDsn(): string | undefined {
+  return (
+    firstNonEmpty(
+      process.env.SENTRY_CLIENT_DSN,
+      process.env.VITE_SENTRY_CLIENT_DSN,
+      process.env.VITE_SENTRY_DSN,
+      process.env.SENTRY_DSN,
+    ) ?? resolveSentryDsnFromKeyProject()
+  );
+}
+
+export function getSentryClientConfigScript(): string | null {
+  const dsn = resolvePublicSentryDsn();
+  if (!dsn) return null;
+
+  const config = {
+    sentryDsn: dsn,
+    sentryEnvironment: resolveSentryEnvironment(),
+  };
+
+  return [
+    '<script data-agent-native-sentry-config>',
+    "window.__AGENT_NATIVE_CONFIG__=Object.assign({},window.__AGENT_NATIVE_CONFIG__,",
+    JSON.stringify(config),
+    ");",
+    "</script>",
+  ].join("");
+}

--- a/packages/core/src/server/sentry-plugin.ts
+++ b/packages/core/src/server/sentry-plugin.ts
@@ -3,7 +3,7 @@
  * user context.
  *
  * Wires three pieces:
- *   1. On startup, `initServerSentry()` reads `SENTRY_SERVER_DSN` and arms
+ *   1. On startup, `initServerSentry()` reads `SENTRY_SERVER_DSN`/`SENTRY_DSN` and arms
  *      the SDK (no-op when the env var is unset).
  *   2. On every request, hook into Nitro's `request` event: resolve the
  *      session via `getSession(event)` and tag the per-request isolation
@@ -127,7 +127,7 @@ export function createSentryPlugin(): NitroPluginDef {
 
 /**
  * Default Sentry plugin — auto-mounts when a template doesn't define its
- * own `server/plugins/sentry.ts`. Reads `SENTRY_SERVER_DSN` from env and
+ * own `server/plugins/sentry.ts`. Reads `SENTRY_SERVER_DSN`/`SENTRY_DSN` from env and
  * silently no-ops when it's unset, so this is safe to default-mount in
  * every template (including local dev with no DSN configured).
  */

--- a/packages/core/src/server/sentry.spec.ts
+++ b/packages/core/src/server/sentry.spec.ts
@@ -45,6 +45,10 @@ describe("server/sentry", () => {
   describe("initServerSentry", () => {
     it("does not call Sentry.init when SENTRY_SERVER_DSN is unset", async () => {
       delete process.env.SENTRY_SERVER_DSN;
+      delete process.env.SENTRY_DSN;
+      delete process.env.SENTRY_CLIENT_KEY;
+      delete process.env.SENTRY_PROJECT_ID;
+      delete process.env.SENTRY_INGEST_HOST;
       const { initServerSentry, isServerSentryEnabled } =
         await import("./sentry.js");
 
@@ -68,6 +72,31 @@ describe("server/sentry", () => {
       expect(cfg.tracesSampleRate).toBe(0);
       expect(typeof cfg.beforeSend).toBe("function");
       expect(isServerSentryEnabled()).toBe(true);
+    });
+
+    it("falls back to the common SENTRY_DSN when SENTRY_SERVER_DSN is unset", async () => {
+      delete process.env.SENTRY_SERVER_DSN;
+      process.env.SENTRY_DSN = "https://common@example/456";
+      const { initServerSentry } = await import("./sentry.js");
+
+      expect(initServerSentry()).toBe(true);
+      expect(sentryMock.init.mock.calls[0][0].dsn).toBe(
+        "https://common@example/456",
+      );
+    });
+
+    it("can construct a DSN from Netlify client key and project env vars", async () => {
+      delete process.env.SENTRY_SERVER_DSN;
+      delete process.env.SENTRY_DSN;
+      process.env.SENTRY_CLIENT_KEY = "public_key";
+      process.env.SENTRY_PROJECT_ID = "4511270423822336";
+      process.env.SENTRY_INGEST_HOST = "o1.ingest.us.sentry.io";
+      const { initServerSentry } = await import("./sentry.js");
+
+      expect(initServerSentry()).toBe(true);
+      expect(sentryMock.init.mock.calls[0][0].dsn).toBe(
+        "https://public_key@o1.ingest.us.sentry.io/4511270423822336",
+      );
     });
 
     it("respects SENTRY_SERVER_TRACES_SAMPLE_RATE override", async () => {
@@ -187,6 +216,7 @@ describe("server/sentry", () => {
   describe("setSentryUserForRequest", () => {
     it("no-ops when Sentry isn't initialized", async () => {
       delete process.env.SENTRY_SERVER_DSN;
+      delete process.env.SENTRY_DSN;
       const { setSentryUserForRequest } = await import("./sentry.js");
       setSentryUserForRequest({ email: "a@b.com" });
       expect(sentryMock.mockScope.setUser).not.toHaveBeenCalled();
@@ -251,6 +281,7 @@ describe("server/sentry", () => {
   describe("captureRouteError", () => {
     it("no-ops when Sentry isn't initialized", async () => {
       delete process.env.SENTRY_SERVER_DSN;
+      delete process.env.SENTRY_DSN;
       const { captureRouteError } = await import("./sentry.js");
       const result = captureRouteError(new Error("boom"));
       expect(result).toBeUndefined();

--- a/packages/core/src/server/sentry.ts
+++ b/packages/core/src/server/sentry.ts
@@ -9,19 +9,22 @@
  *
  * This module is the third Sentry init point in the framework:
  *   - cli/index.ts          → @sentry/node, hardcoded DSN, "agent-native-cli"
- *   - client/analytics.ts   → @sentry/browser, VITE_SENTRY_CLIENT_DSN
- *   - server/sentry.ts      → @sentry/node, SENTRY_SERVER_DSN
+ *   - client/analytics.ts   → @sentry/browser, VITE_SENTRY_CLIENT_DSN / runtime config
+ *   - server/sentry.ts      → @sentry/node, SENTRY_SERVER_DSN / SENTRY_DSN
  *
- * Each maps to a different Sentry project so we can route errors to the
- * right team without one project drowning out the others. Don't wire the
- * three together — they share the SDK package but live in different
- * processes / runtimes / call sites.
+ * The browser and server can share a Sentry project/DSN. Separate projects
+ * are an operational choice for noise, ownership, or quotas; not a runtime
+ * requirement.
  */
 import * as Sentry from "@sentry/node";
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { AuthSession } from "./auth.js";
+import {
+  resolveSentryEnvironment,
+  resolveServerSentryDsn,
+} from "./sentry-config.js";
 
 let _initStarted = false;
 let _initSucceeded = false;
@@ -62,20 +65,20 @@ function parseTracesSampleRate(): number {
  * plugin entrypoints. Returns `true` if initialization actually happened
  * (DSN was set), `false` if Sentry is disabled (no DSN).
  *
- * No DSN is hardcoded: unlike the CLI (a published binary that always
- * wants to phone home crashes), the server runs in customer environments.
- * Operators set `SENTRY_SERVER_DSN` when they want their own Sentry
- * project to receive these events; without it the module no-ops.
+ * No DSN is hardcoded: unlike the CLI (a published binary that always wants
+ * to phone home crashes), the server runs in customer environments. Operators
+ * set `SENTRY_SERVER_DSN` or the common `SENTRY_DSN` when they want their own
+ * Sentry project to receive these events; without one the module no-ops.
  */
 export function initServerSentry(): boolean {
   if (_initStarted) return _initSucceeded;
   _initStarted = true;
 
-  const dsn = process.env.SENTRY_SERVER_DSN;
+  const dsn = resolveServerSentryDsn();
   if (!dsn) {
     if (process.env.DEBUG) {
       console.log(
-        "[agent-native] SENTRY_SERVER_DSN not set — server Sentry disabled.",
+        "[agent-native] SENTRY_SERVER_DSN/SENTRY_DSN not set — server Sentry disabled.",
       );
     }
     return false;
@@ -83,7 +86,7 @@ export function initServerSentry(): boolean {
 
   Sentry.init({
     dsn,
-    environment: process.env.NODE_ENV || "production",
+    environment: resolveSentryEnvironment(),
     release: resolveServerRelease(),
     tracesSampleRate: parseTracesSampleRate(),
     // sendDefaultPii MUST stay false — the framework runs inside customer

--- a/packages/core/src/server/ssr-handler.spec.ts
+++ b/packages/core/src/server/ssr-handler.spec.ts
@@ -27,6 +27,9 @@ describe("createH3SSRHandler", () => {
   afterEach(() => {
     delete process.env.APP_BASE_PATH;
     delete process.env.VITE_APP_BASE_PATH;
+    delete process.env.SENTRY_CLIENT_DSN;
+    delete process.env.SENTRY_DSN;
+    delete process.env.SENTRY_ENVIRONMENT;
     mocks.requestHandler.mockClear();
   });
 
@@ -114,6 +117,24 @@ describe("createH3SSRHandler", () => {
     expect(html).toContain('src="/docs/logo.svg"');
     expect(html).toContain('action="/docs/api/search"');
     expect(html).toContain('src="/docs/app.js"');
+  });
+
+  it("injects runtime browser Sentry config into SSR HTML", async () => {
+    process.env.SENTRY_DSN = "https://public@example/4511270423822336";
+    process.env.SENTRY_ENVIRONMENT = "production";
+    mocks.requestHandler.mockResolvedValueOnce(
+      new Response("<html><head></head><body>ok</body></html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      }),
+    );
+    const handler = createH3SSRHandler(() => ({})) as any;
+
+    const response = await handler(createEvent("/"));
+    const html = await response.text();
+
+    expect(html).toContain("data-agent-native-sentry-config");
+    expect(html).toContain("https://public@example/4511270423822336");
+    expect(html).toContain('"sentryEnvironment":"production"');
   });
 
   it("prefixes mounted SSR redirects", async () => {

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -17,6 +17,7 @@
  */
 import { createRequestHandler } from "react-router";
 import { defineEventHandler } from "h3";
+import { getSentryClientConfigScript } from "./sentry-config.js";
 
 function normalizeAppBasePath(value: string | undefined): string {
   if (!value || value === "/") return "";
@@ -111,6 +112,13 @@ function prefixMountedHtml(html: string, basePath: string): string {
     });
 }
 
+function injectHeadScript(html: string, script: string | null): string {
+  if (!script) return html;
+  const headCloseIdx = html.indexOf("</head>");
+  if (headCloseIdx === -1) return html;
+  return html.slice(0, headCloseIdx) + script + html.slice(headCloseIdx);
+}
+
 function isFrameworkOrAssetPath(pathname: string): boolean {
   return (
     pathname.startsWith("/.well-known/") ||
@@ -133,7 +141,8 @@ async function rewriteMountedResponse(
   response: Response,
   basePath: string,
 ): Promise<Response> {
-  if (!basePath) return response;
+  const sentryClientConfigScript = getSentryClientConfigScript();
+  if (!basePath && !sentryClientConfigScript) return response;
 
   const headers = new Headers(response.headers);
   const location = headers.get("location");
@@ -152,11 +161,14 @@ async function rewriteMountedResponse(
 
   const html = await response.text();
   headers.delete("content-length");
-  return new Response(prefixMountedHtml(html, basePath), {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
+  return new Response(
+    injectHeadScript(prefixMountedHtml(html, basePath), sentryClientConfigScript),
+    {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    },
+  );
 }
 
 /**

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -162,7 +162,10 @@ async function rewriteMountedResponse(
   const html = await response.text();
   headers.delete("content-length");
   return new Response(
-    injectHeadScript(prefixMountedHtml(html, basePath), sentryClientConfigScript),
+    injectHeadScript(
+      prefixMountedHtml(html, basePath),
+      sentryClientConfigScript,
+    ),
     {
       status: response.status,
       statusText: response.statusText,

--- a/packages/core/src/templates/workspace-root/_gitignore
+++ b/packages/core/src/templates/workspace-root/_gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .netlify/
+.vercel/
 dist/
 build/
 apps/*/dist/

--- a/packages/core/src/usage/store.spec.ts
+++ b/packages/core/src/usage/store.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { builderCreditsFromCostCents, usageBillingForEngine } from "./store.js";
+import {
+  builderCreditsFromCostCents,
+  calculateCost,
+  usageBillingForEngine,
+} from "./store.js";
 
 describe("usage billing", () => {
   it("maps Builder hard costs to agent credits with margin", () => {
@@ -15,5 +19,9 @@ describe("usage billing", () => {
     expect(usageBillingForEngine("builder").unit).toBe("builder-credits");
     expect(usageBillingForEngine("anthropic").unit).toBe("usd");
     expect(usageBillingForEngine(null).unit).toBe("usd");
+  });
+
+  it("does not round tiny completed calls down to zero spend", () => {
+    expect(calculateCost(10, 2, "claude-sonnet-4-5")).toBe(1);
   });
 });

--- a/packages/core/src/usage/store.ts
+++ b/packages/core/src/usage/store.ts
@@ -175,14 +175,12 @@ export function calculateCost(
   cacheWriteTokens = 0,
 ): number {
   const p = pricingFor(model);
-  const toX100 = (tokens: number, costPerM: number) =>
-    Math.round((tokens / 1_000_000) * costPerM * 100);
-  return (
-    toX100(inputTokens, p.input) +
-    toX100(outputTokens, p.output) +
-    toX100(cacheReadTokens, p.cacheRead) +
-    toX100(cacheWriteTokens, p.cacheWrite)
-  );
+  const rawCenticents =
+    (inputTokens / 1_000_000) * p.input * 100 +
+    (outputTokens / 1_000_000) * p.output * 100 +
+    (cacheReadTokens / 1_000_000) * p.cacheRead * 100 +
+    (cacheWriteTokens / 1_000_000) * p.cacheWrite * 100;
+  return rawCenticents > 0 ? Math.max(1, Math.round(rawCenticents)) : 0;
 }
 
 /**

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -516,15 +516,24 @@ ipcMain.on(
 
 function getActiveWebviewContents() {
   const allContents = webContents.getAllWebContents();
-  const webviewContents = allContents.filter(
-    (wc) => wc.getType() === "webview",
-  );
+  const liveWebviewContents = (contents?: Electron.WebContents | null) => {
+    if (!contents) return undefined;
+    try {
+      if (contents.isDestroyed()) return undefined;
+      return contents.getType() === "webview" ? contents : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+  const webviewContents = allContents.filter((wc) => liveWebviewContents(wc));
 
   const activeTarget =
     activeWebviewContentsId &&
-    webContents.fromId(activeWebviewContentsId)?.getType() === "webview"
-      ? webContents.fromId(activeWebviewContentsId)
-      : undefined;
+    liveWebviewContents(webContents.fromId(activeWebviewContentsId));
+
+  if (activeWebviewContentsId && !activeTarget) {
+    activeWebviewContentsId = undefined;
+  }
 
   // Fall back to the currently focused guest, then to the active app by URL.
   return (

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -153,13 +153,18 @@ export default function App() {
 
   const handleTabSelect = useCallback(
     (tabId: string) => {
-      setAppTabs((prev) => ({
-        ...prev,
-        [activeSidebarAppId]: {
-          ...prev[activeSidebarAppId],
-          activeTabId: tabId,
-        },
-      }));
+      setAppTabs((prev) => {
+        const appState = prev[activeSidebarAppId];
+        if (!appState?.tabs.some((tab) => tab.id === tabId)) return prev;
+
+        return {
+          ...prev,
+          [activeSidebarAppId]: {
+            ...appState,
+            activeTabId: tabId,
+          },
+        };
+      });
     },
     [activeSidebarAppId],
   );
@@ -177,7 +182,11 @@ export default function App() {
 
       setAppTabs((prev) => {
         const prevAppState = prev[activeSidebarAppId];
+        if (!prevAppState) return prev;
+
         const idx = prevAppState.tabs.findIndex((t) => t.id === tabId);
+        if (idx === -1) return prev;
+
         const next = prevAppState.tabs.filter((t) => t.id !== tabId);
 
         if (next.length === 0) {
@@ -208,27 +217,39 @@ export default function App() {
   const handleReopenTab = useCallback(() => {
     const entry = closedTabsRef.current.pop();
     if (!entry) return;
+    if (!enabledApps.some((app) => app.id === entry.appId)) return;
+
     setActiveSidebarAppId(entry.appId);
-    setAppTabs((prev) => ({
-      ...prev,
-      [entry.appId]: {
-        tabs: [...prev[entry.appId].tabs, entry.tab],
-        activeTabId: entry.tab.id,
-      },
-    }));
-  }, []);
+    setAppTabs((prev) => {
+      const appState = prev[entry.appId];
+      if (!appState) return prev;
+
+      return {
+        ...prev,
+        [entry.appId]: {
+          tabs: [...appState.tabs, entry.tab],
+          activeTabId: entry.tab.id,
+        },
+      };
+    });
+  }, [enabledApps]);
 
   const handleNewTab = useCallback(() => {
     const app = enabledApps.find((a) => a.id === activeSidebarAppId);
     if (!app) return;
     const tab = createTab(app);
-    setAppTabs((prev) => ({
-      ...prev,
-      [activeSidebarAppId]: {
-        tabs: [...prev[activeSidebarAppId].tabs, tab],
-        activeTabId: tab.id,
-      },
-    }));
+    setAppTabs((prev) => {
+      const appState = prev[activeSidebarAppId];
+      if (!appState) return prev;
+
+      return {
+        ...prev,
+        [activeSidebarAppId]: {
+          tabs: [...appState.tabs, tab],
+          activeTabId: tab.id,
+        },
+      };
+    });
   }, [activeSidebarAppId, enabledApps]);
 
   const handleCopyCurrentUrl = useCallback(async () => {

--- a/packages/docs/app/components/CodeBlock.tsx
+++ b/packages/docs/app/components/CodeBlock.tsx
@@ -23,9 +23,13 @@ export default function CodeBlock({
         light: "github-light-default",
         dark: "github-dark-default",
       },
-    }).then((result) => {
-      if (!cancelled) setHtml(result);
-    });
+    })
+      .then((result) => {
+        if (!cancelled) setHtml(result);
+      })
+      .catch(() => {
+        if (!cancelled) setHtml("");
+      });
     return () => {
       cancelled = true;
     };

--- a/packages/docs/app/routes/_index.tsx
+++ b/packages/docs/app/routes/_index.tsx
@@ -110,7 +110,9 @@ function BidirectionalTabs() {
       if (!video) return;
       if (i === activeTab) {
         video.currentTime = 0;
-        video.play();
+        void video.play().catch(() => {
+          // Browsers reject play() if the tab/video unmounts mid-request.
+        });
       } else {
         video.pause();
       }

--- a/packages/frame/client/App.tsx
+++ b/packages/frame/client/App.tsx
@@ -40,6 +40,7 @@ const FRAME_MODE_KEY = "frame-mode";
 const SIDEBAR_OPEN_KEY = "frame-sidebar-open";
 const SIDEBAR_FULLSCREEN_KEY = "frame-sidebar-fullscreen";
 const DESKTOP_APP_NUDGE_DISMISSED_KEY = "frame.desktop-app-nudge.dismissed";
+const APP_IFRAME_ALLOW = "camera; microphone; display-capture; fullscreen";
 
 function getAppId(): string {
   const params = new URLSearchParams(window.location.search);
@@ -386,7 +387,7 @@ export function App() {
           src={appUrl}
           className="w-full h-full border-none"
           title={app?.label || "App"}
-          allow="fullscreen"
+          allow={APP_IFRAME_ALLOW}
         />
         {/* Overlay during drag to prevent iframe from capturing mouse events */}
         {isDragging && (

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -121,6 +121,56 @@ function makeAbortError(message: string): Error {
   return error;
 }
 
+type CapturePolicyFeature = "camera" | "microphone" | "display-capture";
+
+function isBrowserSecureContext(): boolean {
+  if (typeof window === "undefined") return true;
+  return window.isSecureContext;
+}
+
+function isCaptureFeatureBlockedByPolicy(
+  feature: CapturePolicyFeature,
+): boolean {
+  if (typeof document === "undefined") return false;
+  const policy =
+    (
+      document as Document & {
+        permissionsPolicy?: { allowsFeature: (feature: string) => boolean };
+        featurePolicy?: { allowsFeature: (feature: string) => boolean };
+      }
+    ).permissionsPolicy ??
+    (
+      document as Document & {
+        featurePolicy?: { allowsFeature: (feature: string) => boolean };
+      }
+    ).featurePolicy;
+  if (!policy?.allowsFeature) return false;
+  try {
+    return !policy.allowsFeature(feature);
+  } catch {
+    return false;
+  }
+}
+
+function capturePolicyBlockMessage(source: CaptureSource): string | null {
+  if (
+    source === "screen" &&
+    isCaptureFeatureBlockedByPolicy("display-capture")
+  ) {
+    return "This page is blocking screen recording via Permissions-Policy. Open Clips directly in a browser tab, or use a frame that allows screen capture, camera, and microphone.";
+  }
+  if (source === "camera" && isCaptureFeatureBlockedByPolicy("camera")) {
+    return "This page is blocking camera access via Permissions-Policy. Open Clips directly in a browser tab, or use a frame that allows camera and microphone.";
+  }
+  if (
+    source === "microphone" &&
+    isCaptureFeatureBlockedByPolicy("microphone")
+  ) {
+    return "This page is blocking microphone access via Permissions-Policy. Open Clips directly in a browser tab, or use a frame that allows camera and microphone.";
+  }
+  return null;
+}
+
 function isHardScreenPermissionError(err: unknown): boolean {
   const combined = `${errorName(err)} ${errorMessage(err)}`;
   return /permission denied by system|blocked by system|system settings|screen recording|screen capture|screen & system audio|privacy|could not start video source|notreadableerror/i.test(
@@ -278,6 +328,11 @@ export class RecorderEngine {
     const wantsMic = this.opts.micDeviceId !== NO_MIC_DEVICE_ID;
 
     try {
+      if (!isBrowserSecureContext()) {
+        throw new Error(
+          "Camera, microphone, and screen recording prompts require HTTPS or localhost. Open Clips on a secure URL, then try again.",
+        );
+      }
       if (!navigator.mediaDevices?.getUserMedia) {
         throw new Error(
           "Your browser doesn't support camera or microphone capture. Try a recent Brave, Chrome, Edge, Safari, or Firefox.",
@@ -287,6 +342,13 @@ export class RecorderEngine {
         throw new Error(
           "Your browser doesn't support screen capture. Try a recent Brave, Chrome, Edge, Safari, or Firefox.",
         );
+      }
+      const policyBlock =
+        (wantsDisplay && capturePolicyBlockMessage("screen")) ||
+        (wantsCamera && capturePolicyBlockMessage("camera")) ||
+        (wantsMic && capturePolicyBlockMessage("microphone"));
+      if (policyBlock) {
+        throw new Error(policyBlock);
       }
 
       // Start every browser media request synchronously before the first
@@ -1230,6 +1292,13 @@ export class RecorderEngine {
     const name = errorName(err);
     const message = errorMessage(err);
     const combined = `${name} ${message}`;
+    const policyBlock = capturePolicyBlockMessage(source);
+    if (policyBlock) return new Error(policyBlock);
+    if (!isBrowserSecureContext()) {
+      return new Error(
+        "Camera, microphone, and screen recording prompts require HTTPS or localhost. Open Clips on a secure URL, then try again.",
+      );
+    }
 
     if (source === "screen") {
       if (isScreenPickerDismissal(err)) {
@@ -1241,7 +1310,7 @@ export class RecorderEngine {
         )
       ) {
         return new Error(
-          "Screen recording is blocked for this browser. Chrome camera and microphone permissions can be allowed while macOS still blocks Screen & System Audio Recording. Open macOS System Settings > Privacy & Security > Screen & System Audio Recording, enable your browser, then quit and reopen it.",
+          "Screen recording is blocked by the browser, macOS, or this app frame.",
         );
       }
     }
@@ -1254,7 +1323,7 @@ export class RecorderEngine {
       }
       if (/Permission denied|NotAllowedError|denied|blocked/i.test(combined)) {
         return new Error(
-          "Camera access is blocked for this browser or by macOS. Check this site's Camera permission, then check macOS System Settings > Privacy & Security > Camera for your browser and reload Clips.",
+          "Camera access is blocked by the browser, macOS, or this app frame.",
         );
       }
     }
@@ -1267,14 +1336,14 @@ export class RecorderEngine {
       }
       if (/Permission denied|NotAllowedError|denied|blocked/i.test(combined)) {
         return new Error(
-          "Microphone access is blocked for this browser or by macOS. Check this site's Microphone permission, then check macOS System Settings > Privacy & Security > Microphone for your browser and reload Clips.",
+          "Microphone access is blocked by the browser, macOS, or this app frame.",
         );
       }
     }
 
     if (/Permission denied|NotAllowedError|denied/i.test(combined)) {
       return new Error(
-        "Screen, camera, or microphone access was blocked. Open this site's browser permissions and allow Camera and Microphone. On macOS, also check System Settings > Privacy & Security for Screen & System Audio Recording, Camera, and Microphone, then quit and reopen the browser.",
+        "Screen, camera, or microphone access was blocked by the browser, macOS, or this app frame.",
       );
     }
     if (/NotFoundError|no device/i.test(combined)) {

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -6,12 +6,17 @@ import {
   IconArrowLeft,
   IconCamera,
   IconDeviceDesktop,
+  IconExternalLink,
   IconMicrophone,
   IconRefresh,
   IconVideo,
 } from "@tabler/icons-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { agentNativePath, appBasePath } from "@agent-native/core/client";
+import {
+  agentNativePath,
+  appBasePath,
+  captureClientException,
+} from "@agent-native/core/client";
 import { RequireActiveOrg } from "@agent-native/core/client/org";
 import { useLiveTranscription } from "@agent-native/core/client/transcription/use-live-transcription";
 import { useDesktopPromo } from "@/hooks/use-desktop-promo";
@@ -31,6 +36,12 @@ import {
   defaultRecordingTitle,
   inferWindowTitleFromDisplayStream,
 } from "@/lib/recording-title";
+import {
+  COMPRESS_THRESHOLD_BYTES,
+  MAX_UPLOAD_BYTES,
+  compressBlobIfTooLarge,
+  formatMb,
+} from "@/lib/compress";
 
 // Client-side app-state writer (the server module pulls in Node's `events`
 // and cannot be bundled for the browser).
@@ -130,6 +141,12 @@ function isPermissionError(message: string): boolean {
   );
 }
 
+function isPolicyPermissionError(message: string): boolean {
+  return /permissions-policy|app frame|embedding frame|frame that allows/i.test(
+    message,
+  );
+}
+
 function isScreenPermissionError(message: string): boolean {
   return (
     isPermissionError(message) &&
@@ -149,6 +166,9 @@ function isMicrophonePermissionError(message: string): boolean {
 
 function permissionGuidance(message: string): string | null {
   if (!isPermissionError(message)) return null;
+  if (isPolicyPermissionError(message)) {
+    return "Browser site permissions are not the blocker here. Open Clips directly in a browser tab, or use an app frame that delegates camera, microphone, and screen capture.";
+  }
   if (isScreenPermissionError(message)) {
     if (isMacPlatform()) {
       return "Chrome can have Camera and Microphone allowed while macOS still blocks screen capture. Enable your browser in System Settings > Privacy & Security > Screen & System Audio Recording, then quit and reopen it.";
@@ -173,6 +193,14 @@ function permissionGuidance(message: string): string | null {
   return "Open this site's browser settings and allow Camera and Microphone, then reload this page.";
 }
 
+function permissionSettingsUrl(message: string): string | null {
+  if (!isMacPlatform() || isPolicyPermissionError(message)) return null;
+  if (isScreenPermissionError(message)) return MAC_SCREEN_RECORDING_PREF_URL;
+  if (isCameraPermissionError(message)) return MAC_CAMERA_PREF_URL;
+  if (isMicrophonePermissionError(message)) return MAC_MICROPHONE_PREF_URL;
+  return MAC_SCREEN_RECORDING_PREF_URL;
+}
+
 function isDismissedCapturePicker(err: unknown, message: string): boolean {
   const name = err instanceof Error ? err.name : "";
   return (
@@ -191,6 +219,12 @@ function getRecordingModeParam(value: string | null): RecordingMode | null {
     return "screen+camera";
   }
   return null;
+}
+
+function makeAbortError(message: string): Error {
+  const error = new Error(message);
+  error.name = "AbortError";
+  return error;
 }
 
 function getDisplaySurfaceParam(value: string | null): DisplaySurface | null {
@@ -296,6 +330,9 @@ function RecordingErrorCard({
 }) {
   const guidance = permissionGuidance(error);
   const permissionError = isPermissionError(error);
+  const policyError = isPolicyPermissionError(error);
+  const directUrl =
+    typeof window !== "undefined" ? window.location.href : "/record";
 
   return (
     <div className="w-full max-w-md overflow-hidden rounded-2xl border border-border bg-card shadow-lg">
@@ -327,7 +364,15 @@ function RecordingErrorCard({
           <IconRefresh className="h-4 w-4" />
           Try again
         </Button>
-        {permissionError && isMacPlatform() && (
+        {policyError && (
+          <Button asChild className="w-full gap-2">
+            <a href={directUrl} target="_blank" rel="noreferrer">
+              <IconExternalLink className="h-4 w-4" />
+              Open in tab
+            </a>
+          </Button>
+        )}
+        {permissionError && isMacPlatform() && !policyError && (
           <div className="grid grid-cols-3 gap-2">
             <Button
               variant="ghost"
@@ -439,6 +484,7 @@ export default function RecordRoute() {
   } | null>(null);
   const tickRef = useRef<number | null>(null);
   const previewVideoRef = useRef<HTMLVideoElement>(null);
+  const fileUploadAbortRef = useRef<AbortController | null>(null);
   // Bumped by doCancel() to invalidate any in-flight startFlow().
   const startSessionRef = useRef(0);
 
@@ -478,18 +524,18 @@ export default function RecordRoute() {
 
   const showRecordingErrorToast = useCallback((message: string) => {
     const guidance = permissionGuidance(message);
+    const settingsUrl = permissionSettingsUrl(message);
     toast.error("Couldn't start recording", {
       description: guidance ?? message,
       duration: guidance ? 20_000 : 10_000,
-      action:
-        guidance && isMacPlatform()
-          ? {
-              label: "Open settings",
-              onClick: () => {
-                window.location.href = MAC_SCREEN_RECORDING_PREF_URL;
-              },
-            }
-          : undefined,
+      action: settingsUrl
+        ? {
+            label: "Open settings",
+            onClick: () => {
+              window.location.href = settingsUrl;
+            },
+          }
+        : undefined,
     });
   }, []);
 
@@ -772,8 +818,16 @@ export default function RecordRoute() {
 
   const uploadFile = useCallback(
     async (file: File) => {
+      const session = startSessionRef.current + 1;
+      startSessionRef.current = session;
+      const isStale = () => startSessionRef.current !== session;
+      const abort = new AbortController();
+      fileUploadAbortRef.current?.abort(makeAbortError("Upload cancelled"));
+      fileUploadAbortRef.current = abort;
+
       setError(null);
       setUiState("uploading");
+      setCompressionProgress(null);
 
       const acceptedMime = new Set([
         "video/mp4",
@@ -793,6 +847,9 @@ export default function RecordRoute() {
       if (!mimeType) {
         const message =
           "That file type isn't supported. Try MP4, WebM, or MOV.";
+        if (fileUploadAbortRef.current === abort) {
+          fileUploadAbortRef.current = null;
+        }
         setError(message);
         setUiState("error");
         toast.error(message);
@@ -802,12 +859,82 @@ export default function RecordRoute() {
       let createdId: string | null = null;
       try {
         const meta = await probeVideoMetadata(file);
+        if (isStale()) return;
+
+        let uploadBlob: Blob = file;
+        let uploadMimeType = mimeType;
+        let compressionError: {
+          message: string;
+          stderrTail: string[];
+          elapsedMs: number;
+        } | null = null;
+
+        if (file.size > COMPRESS_THRESHOLD_BYTES) {
+          setUiState("compressing");
+          const compression = await compressBlobIfTooLarge(file, mimeType, {
+            width: meta.width,
+            height: meta.height,
+            signal: abort.signal,
+            onProgress: ({ stage, progress }) => {
+              if (stage === "encoding" && typeof progress === "number") {
+                setCompressionProgress(progress);
+              } else if (stage === "finalizing") {
+                setCompressionProgress(1);
+              } else {
+                setCompressionProgress(null);
+              }
+            },
+            onError: (err) => {
+              compressionError = err;
+              captureClientException(
+                new Error(`Upload compression failed: ${err.message}`),
+                {
+                  tags: {
+                    uploadStep: "local-file-compression",
+                    mimeType,
+                  },
+                  extra: {
+                    filename: file.name,
+                    fileBytes: file.size,
+                    width: meta.width,
+                    height: meta.height,
+                    stderrTail: err.stderrTail,
+                    elapsedMs: err.elapsedMs,
+                  },
+                },
+              );
+            },
+          });
+          if (isStale()) return;
+
+          uploadBlob = compression.blob;
+          uploadMimeType = compression.outputMimeType || mimeType;
+          if (compressionError) {
+            console.warn(
+              "[recorder] upload compression failed, falling back to source file",
+              compressionError,
+            );
+          }
+          if (uploadBlob.size > MAX_UPLOAD_BYTES) {
+            const detail = compression.compressed
+              ? `${formatMb(uploadBlob.size)} after compression`
+              : `${formatMb(uploadBlob.size)}`;
+            throw new Error(
+              `Video is too large to upload (${detail}, limit is ${formatMb(
+                MAX_UPLOAD_BYTES,
+              )}). Try a shorter recording or lower the screen resolution / frame rate.`,
+            );
+          }
+          setCompressionProgress(null);
+          setUiState("uploading");
+        }
 
         const res = await fetch(
           agentNativePath("/_agent-native/actions/create-recording"),
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
+            signal: abort.signal,
             body: JSON.stringify({
               title:
                 file.name.replace(/\.[^/.]+$/, "") || defaultRecordingTitle(),
@@ -847,23 +974,25 @@ export default function RecordRoute() {
           throw new Error("create-recording did not return an id");
         }
         createdId = info.id;
+        if (isStale()) throw makeAbortError("Upload cancelled");
         const uploadBase = `${appBasePath()}${info.uploadChunkUrl}`;
 
         const totalChunks = Math.max(
           1,
-          Math.ceil(file.size / UPLOAD_CHUNK_BYTES),
+          Math.ceil(uploadBlob.size / UPLOAD_CHUNK_BYTES),
         );
         let finalChunkResult: Record<string, unknown> | null = null;
         for (let i = 0; i < totalChunks; i++) {
+          if (isStale()) throw makeAbortError("Upload cancelled");
           const start = i * UPLOAD_CHUNK_BYTES;
-          const end = Math.min(start + UPLOAD_CHUNK_BYTES, file.size);
-          const slice = file.slice(start, end, mimeType);
+          const end = Math.min(start + UPLOAD_CHUNK_BYTES, uploadBlob.size);
+          const slice = uploadBlob.slice(start, end, uploadMimeType);
           const isFinal = i === totalChunks - 1;
           const params = new URLSearchParams({
             index: String(i),
             total: String(totalChunks),
             isFinal: isFinal ? "1" : "0",
-            mimeType,
+            mimeType: uploadMimeType,
           });
           if (isFinal) {
             params.set("durationMs", String(meta.durationMs));
@@ -874,8 +1003,9 @@ export default function RecordRoute() {
           }
           const chunkRes = await fetch(`${uploadBase}?${params.toString()}`, {
             method: "POST",
-            headers: { "Content-Type": mimeType },
+            headers: { "Content-Type": uploadMimeType },
             body: await slice.arrayBuffer(),
+            signal: abort.signal,
           });
           if (!chunkRes.ok) {
             const text = await chunkRes.text().catch(() => "");
@@ -916,6 +1046,7 @@ export default function RecordRoute() {
         }, 50);
       } catch (err) {
         const message = err instanceof Error ? err.message : "Upload failed";
+        const aborted = err instanceof Error && err.name === "AbortError";
         if (createdId) {
           fetch(`${appBasePath()}/api/uploads/${createdId}/abort`, {
             method: "POST",
@@ -923,6 +1054,7 @@ export default function RecordRoute() {
             body: JSON.stringify({ reason: message }),
           }).catch(() => {});
         }
+        if (aborted || isStale()) return;
         setError(message);
         setUiState("error");
         if (message !== "SESSION_EXPIRED") {
@@ -932,6 +1064,11 @@ export default function RecordRoute() {
             duration: 12_000,
           });
         }
+      } finally {
+        if (fileUploadAbortRef.current === abort) {
+          fileUploadAbortRef.current = null;
+        }
+        setCompressionProgress(null);
       }
     },
     [navigate, probeVideoMetadata],
@@ -1100,6 +1237,10 @@ export default function RecordRoute() {
   const doCancel = useCallback(async () => {
     // Invalidate any in-flight startFlow().
     startSessionRef.current += 1;
+    if (fileUploadAbortRef.current) {
+      fileUploadAbortRef.current.abort(makeAbortError("Upload cancelled"));
+      fileUploadAbortRef.current = null;
+    }
     const engine = engineRef.current;
     const pendingId = pendingRef.current?.id;
     liveTranscription.stop();


### PR DESCRIPTION
## Summary

- **Vercel deploy preset for workspace apps** — adds `vercel` alongside `cloudflare_pages` and `netlify` to `workspace-deploy`. Build emits to `.vercel/output`, the shared-token login gate is now provider-neutral copy + auto-detects the workspace mount segment, and `_gitignore` excludes `.vercel/`. Drops the unreachable `patchVercelFunctionEntry` helper.
- **Recorder + Frame iframe permissions** — Frame's app iframe now delegates camera, microphone, and display-capture (plus fullscreen) so embedded apps like Clips can prompt for those features inside the workspace shell. Clips recorder-engine probes `Permissions-Policy` for each capture feature and surfaces a tailored explanation when the parent frame is the actual blocker, plus an early friendly error for non-secure contexts. `record.tsx` mirrors the policy-vs-permission distinction in guidance text + the macOS settings deep-link.
- **Sidebar popovers via shadcn** — `ResourcesPanel` and `AutomationsSection` swap the hand-rolled positioned popovers for shadcn `Popover` primitives. The custom impls were getting clipped by ancestor `overflow:hidden` / stacking contexts and lacked focus trap + click-outside semantics.
- **AgentTerminal startup race** — fits/resizes are coalesced to one rAF and bail when the container is detached or has zero dimensions, so mount/unmount cycles don't leave dangling rAFs or fit() the wrong dimensions.
- **Automation route prefix fix** — `/_agent-native/automations/fire-test` now matches both bare and prefix-mounted paths and reads `event.path`, fixing the test-fire button under non-root framework prefixes.
- **Sub-cent usage rounding** — `calculateCost` now floors non-zero costs to 1 centicent so a single-token completion records at least the smallest billable unit instead of $0.00.
- **Quiet CLI watcher noise** — `workspace-dev` no longer reports per-process watcher-limit hits to Sentry; they're operator-fixable, not bugs.
- **Windows tarball symlinks** — `create` skips first-party `CLAUDE.md` and `.claude/skills` symlinks during GitHub tarball extraction so bsdtar on Windows doesn't materialize them as broken plain-text files; setup-agents recreates them at scaffold time.
- **Desktop app webview stability** — guards `getActiveWebviewContents` against destroyed `webContents` and stops `handleTabSelect` from drifting to a phantom tab id.
- **Docs robustness** — swallows shiki and `video.play()` rejections so unmount races don't crash into the React tree.

## Test plan

- [ ] CI: Build, Lint, Test, Typecheck (Scaffold E2E informational)
- [ ] Manual: scaffold a workspace via `agent-native create` and run `pnpm deploy --preset=vercel` to confirm `.vercel/output` is populated
- [ ] Manual: open a Clips iframe inside the workspace shell and confirm screen/camera/mic prompts appear
- [ ] Manual: trigger an automation `fire-test` from a workspace deploy at a non-root prefix
- [ ] Manual: send a single-token completion through the agent and confirm a 1-centicent cost row lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)