### PR TITLE
feat: AI SDK Responses for OpenAI + Gmail label scoping + clips tray stop + cross-org library view

### DIFF
--- a/.changeset/gentle-microphones-listen.md
+++ b/.changeset/gentle-microphones-listen.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow composer dictation to request same-origin microphone access and improve blocked-microphone guidance.

--- a/.changeset/pinpoint-toolbar-sidebar-aware.md
+++ b/.changeset/pinpoint-toolbar-sidebar-aware.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/pinpoint": patch
+---
+
+Keep the pinpoint toolbar inside the viewport when the agent sidebar is open by tracking the visible sidebar width via MutationObserver + ResizeObserver and clamping toolbar position + drag bounds.

--- a/.changeset/quiet-openai-responses.md
+++ b/.changeset/quiet-openai-responses.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use the AI SDK's default OpenAI Responses path for first-party OpenAI agent models.

--- a/.changeset/reconnect-builder-chat-errors.md
+++ b/.changeset/reconnect-builder-chat-errors.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Show a Builder reconnect action when agent chat hits Builder or model-provider auth errors.

--- a/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.spec.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+async function drain(iterable: AsyncIterable<unknown>) {
+  for await (const _ of iterable) {
+    // consume stream
+  }
+}
+
+function mockAiSdk() {
+  const streamText = vi.fn().mockReturnValue({
+    fullStream: (async function* () {
+      yield { type: "finish", finishReason: "stop", usage: {} };
+    })(),
+  });
+  vi.doMock("ai", () => ({ streamText, jsonSchema: (s: unknown) => s }));
+  return { streamText };
+}
+
+function mockOpenAIProvider() {
+  const responsesModel = { id: "responses-model" };
+  const chatModel = { id: "chat-model" };
+  const provider = Object.assign(vi.fn().mockReturnValue(responsesModel), {
+    chat: vi.fn().mockReturnValue(chatModel),
+  });
+  const createOpenAI = vi.fn().mockReturnValue(provider);
+  vi.doMock("@ai-sdk/openai", () => ({ createOpenAI }));
+  return { createOpenAI, provider, responsesModel, chatModel };
+}
+
+const BASE_STREAM_OPTIONS = {
+  model: "gpt-5.5",
+  systemPrompt: "",
+  messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+  tools: [],
+  abortSignal: new AbortController().signal,
+} as const;
+
+describe("AISDKEngine OpenAI model selection", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it("uses the default OpenAI provider path for first-party OpenAI models", async () => {
+    const { streamText } = mockAiSdk();
+    const { createOpenAI, provider, responsesModel } = mockOpenAIProvider();
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("openai", { apiKey: "sk-test" });
+
+    await drain(engine.stream(BASE_STREAM_OPTIONS));
+
+    expect(createOpenAI).toHaveBeenCalledWith({ apiKey: "sk-test" });
+    expect(provider).toHaveBeenCalledWith("gpt-5.5");
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({ model: responsesModel }),
+    );
+  });
+
+  it("keeps Chat Completions for custom OpenAI-compatible base URLs", async () => {
+    const { streamText } = mockAiSdk();
+    const { createOpenAI, provider, chatModel } = mockOpenAIProvider();
+
+    const { createAISDKEngine } = await import("./ai-sdk-engine.js");
+    const engine = createAISDKEngine("openai", {
+      apiKey: "sk-test",
+      baseUrl: "https://gateway.example/v1",
+    });
+
+    await drain(engine.stream(BASE_STREAM_OPTIONS));
+
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: "sk-test",
+      baseURL: "https://gateway.example/v1",
+    });
+    expect(provider).not.toHaveBeenCalled();
+    expect(provider.chat).toHaveBeenCalledWith("gpt-5.5");
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({ model: chatModel }),
+    );
+  });
+});

--- a/packages/core/src/agent/engine/ai-sdk-engine.ts
+++ b/packages/core/src/agent/engine/ai-sdk-engine.ts
@@ -358,9 +358,13 @@ class AISDKEngine implements AgentEngine {
     }
 
     const provider = createFn(config);
-    // @ai-sdk/openai@3 defaults to the Responses API; force Chat Completions
-    // so OpenAI-compatible gateways (OpenRouter, Groq, Together, …) work too.
-    return this.provider === "openai" ? provider.chat(model) : provider(model);
+    // Let first-party OpenAI use the AI SDK's default Responses path so newer
+    // GPT reasoning models get the API OpenAI recommends. If someone points
+    // the OpenAI provider at an OpenAI-compatible gateway, keep using Chat
+    // Completions because many gateway base URLs do not implement Responses.
+    return this.provider === "openai" && this.baseUrl
+      ? provider.chat(model)
+      : provider(model);
   }
 }
 

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -461,7 +461,7 @@ export interface ProductionAgentOptions {
   onRunStart?: (
     send: (event: AgentChatEvent) => void,
     threadId: string,
-  ) => void;
+  ) => void | Promise<void>;
   /**
    * Called after the engine + model are resolved for this request. Used by
    * the plugin layer to thread the parent's choices into sub-agents so
@@ -1964,7 +1964,7 @@ export function createProductionAgentHandler(
       async (send, signal) => {
         // Notify listeners that a run has started (used by agent teams)
         if (options.onRunStart) {
-          options.onRunStart(send, threadId ?? runId);
+          await options.onRunStart(send, threadId ?? runId);
         }
 
         // Resolve custom workspace agent mentions first.

--- a/packages/core/src/checkpoints/service.spec.ts
+++ b/packages/core/src/checkpoints/service.spec.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   createCheckpoint,
   getChangedFileNames,
+  getUncommittedStatus,
   hasUncommittedChanges,
   isGitRepo,
   restoreToCheckpoint,
@@ -26,6 +27,16 @@ describe("checkpoint service", () => {
     execFileSync("git", ["init"], { cwd, stdio: "pipe" });
     return cwd;
   }
+
+  it("reports raw clean and dirty status for checkpoint guards", () => {
+    const cwd = createTempRepo();
+
+    expect(getUncommittedStatus(cwd)).toBe("");
+
+    fs.writeFileSync(path.join(cwd, "new.txt"), "new\n");
+
+    expect(getUncommittedStatus(cwd)).toContain("?? new.txt");
+  });
 
   it("creates a checkpoint commit and restores tracked and added files", () => {
     const cwd = createTempRepo();
@@ -60,6 +71,7 @@ describe("checkpoint service", () => {
     tmpDirs.push(cwd);
 
     expect(isGitRepo(cwd)).toBe(false);
+    expect(getUncommittedStatus(cwd)).toBeNull();
     expect(createCheckpoint(cwd, "No repo")).toBeNull();
     expect(restoreToCheckpoint(cwd, "HEAD")).toBe(false);
   });

--- a/packages/core/src/checkpoints/service.ts
+++ b/packages/core/src/checkpoints/service.ts
@@ -26,16 +26,20 @@ export function isGitRepo(cwd: string): boolean {
 }
 
 export function hasUncommittedChanges(cwd: string): boolean {
+  const output = getUncommittedStatus(cwd);
+  return output !== null && output.trim().length > 0;
+}
+
+export function getUncommittedStatus(cwd: string): string | null {
   try {
-    const output = execFileSync("git", ["status", "--porcelain"], {
+    return execFileSync("git", ["status", "--porcelain"], {
       cwd,
       stdio: "pipe",
       timeout: TIMEOUT,
       encoding: "utf-8",
     });
-    return output.trim().length > 0;
   } catch {
-    return false;
+    return null;
   }
 }
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1804,11 +1804,15 @@ function getRunErrorMetadata(message: unknown): RunErrorInfo | null {
 function isBuilderReconnectRunError(info: RunErrorInfo): boolean {
   const code = (info.errorCode ?? "").toLowerCase();
   const message = info.message.toLowerCase();
+  const isAuthCode =
+    code === "authentication_error" ||
+    code === "unauthorized" ||
+    code === "http_401" ||
+    code === "http_403";
   return (
     code === "builder_auth_error" ||
-    code === "authentication_error" ||
     message.includes("builder authentication failed") ||
-    message.includes("invalid token")
+    (isAuthCode && message.includes("invalid token"))
   );
 }
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -1801,6 +1801,17 @@ function getRunErrorMetadata(message: unknown): RunErrorInfo | null {
   };
 }
 
+function isBuilderReconnectRunError(info: RunErrorInfo): boolean {
+  const code = (info.errorCode ?? "").toLowerCase();
+  const message = info.message.toLowerCase();
+  return (
+    code === "builder_auth_error" ||
+    code === "authentication_error" ||
+    message.includes("builder authentication failed") ||
+    message.includes("invalid token")
+  );
+}
+
 function getMessageText(message: unknown): string {
   const msg = (message as { message?: unknown })?.message ?? message;
   const content = (msg as { content?: unknown })?.content;
@@ -1830,6 +1841,7 @@ function RunErrorRecoveryCard({
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const canRecover = info.recoverable === true;
+  const shouldShowBuilderReconnect = isBuilderReconnectRunError(info);
   const copyDetails = useCallback(() => {
     const text = [
       info.message,
@@ -1859,6 +1871,12 @@ function RunErrorRecoveryCard({
           <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
             {info.message}
           </p>
+          {shouldShowBuilderReconnect && (
+            <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+              The current Builder.io or model-provider credential was rejected.
+              Reconnect Builder.io, then retry this message.
+            </p>
+          )}
           {(info.runId || info.errorCode || info.details) && (
             <button
               type="button"
@@ -1897,6 +1915,17 @@ function RunErrorRecoveryCard({
         </button>
       </div>
       <div className="mt-3 flex flex-wrap items-center gap-2">
+        {shouldShowBuilderReconnect && (
+          <a
+            href={agentNativePath("/_agent-native/builder/connect")}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-foreground px-3 text-xs font-medium text-background hover:opacity-90"
+          >
+            <IconExternalLink size={13} />
+            Reconnect Builder.io
+          </a>
+        )}
         {canRecover && (
           <>
             <button

--- a/packages/core/src/client/composer/useVoiceDictation.spec.ts
+++ b/packages/core/src/client/composer/useVoiceDictation.spec.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { voiceDictationStartErrorMessage } from "./useVoiceDictation.js";
+
+describe("voiceDictationStartErrorMessage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("explains permissions policy blocks separately from site settings", () => {
+    vi.stubGlobal("document", {
+      permissionsPolicy: { allowsFeature: () => false },
+    });
+
+    expect(
+      voiceDictationStartErrorMessage({
+        name: "NotAllowedError",
+        message: "Permission denied",
+      }),
+    ).toContain("browser permissions policy");
+  });
+
+  it("points denied microphone permissions at site controls", () => {
+    expect(
+      voiceDictationStartErrorMessage({
+        name: "NotAllowedError",
+        message: "Permission denied",
+      }),
+    ).toContain("site controls icon");
+  });
+});

--- a/packages/core/src/client/composer/useVoiceDictation.ts
+++ b/packages/core/src/client/composer/useVoiceDictation.ts
@@ -177,6 +177,74 @@ function pickMimeType(): string {
   return "audio/webm";
 }
 
+type BrowserDocumentPolicy = {
+  allowsFeature: (feature: string) => boolean;
+};
+
+function microphoneBlockedByPermissionsPolicy(): boolean {
+  if (typeof document === "undefined") return false;
+  const doc = document as Document & {
+    permissionsPolicy?: BrowserDocumentPolicy;
+    featurePolicy?: BrowserDocumentPolicy;
+  };
+  const policy = doc.permissionsPolicy ?? doc.featurePolicy ?? null;
+  if (!policy?.allowsFeature) return false;
+  try {
+    return !policy.allowsFeature("microphone");
+  } catch {
+    return false;
+  }
+}
+
+export function voiceDictationStartErrorMessage(error: unknown): string {
+  const name =
+    typeof (error as { name?: unknown } | null)?.name === "string"
+      ? (error as { name: string }).name
+      : "";
+  const message =
+    typeof (error as { message?: unknown } | null)?.message === "string"
+      ? (error as { message: string }).message
+      : "";
+
+  if (
+    microphoneBlockedByPermissionsPolicy() ||
+    /permissions[- ]policy|feature policy/i.test(message)
+  ) {
+    return "This app is blocking microphone access through its browser permissions policy. Reload the app, or open it directly in a browser tab.";
+  }
+
+  if (
+    name === "NotAllowedError" ||
+    name === "SecurityError" ||
+    /permission|denied|not allowed/i.test(message)
+  ) {
+    return "Microphone access is blocked. Click the site controls icon in the address bar, set Microphone to Allow for this app, then try again.";
+  }
+
+  if (name === "NotFoundError" || name === "DevicesNotFoundError") {
+    return "No microphone was found. Plug one in or choose a different input, then try again.";
+  }
+
+  if (name === "NotReadableError" || name === "TrackStartError") {
+    return "Your microphone is busy in another app. Close the other app or choose a different input, then try again.";
+  }
+
+  return message || "Could not start recording";
+}
+
+function voiceDictationSpeechErrorMessage(error: string | undefined): string {
+  if (error === "not-allowed" || error === "service-not-allowed") {
+    return voiceDictationStartErrorMessage({
+      name: "NotAllowedError",
+      message: error,
+    });
+  }
+  if (error === "audio-capture") {
+    return "No microphone was found. Plug one in or choose a different input, then try again.";
+  }
+  return `Speech recognition error: ${error ?? "unknown"}`;
+}
+
 export function useVoiceDictation(
   options: UseVoiceDictationOptions,
 ): VoiceDictationApi {
@@ -524,11 +592,7 @@ export function useVoiceDictation(
     };
     recognition.onerror = (event: any) => {
       if (event?.error === "no-speech" || event?.error === "aborted") return;
-      failWith(
-        event?.error === "not-allowed"
-          ? "Microphone permission denied. Enable it in your browser settings."
-          : `Speech recognition error: ${event?.error ?? "unknown"}`,
-      );
+      failWith(voiceDictationSpeechErrorMessage(event?.error));
     };
     recognition.onend = () => {
       const text = speechTranscriptRef.current.trim();
@@ -806,11 +870,7 @@ export function useVoiceDictation(
         setState("idle");
         return;
       }
-      const message =
-        (err as Error)?.name === "NotAllowedError"
-          ? "Microphone permission denied. Enable it in your browser settings."
-          : ((err as Error)?.message ?? "Could not start recording");
-      failWith(message);
+      failWith(voiceDictationStartErrorMessage(err));
     }
   }, [
     state,

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -3230,10 +3230,31 @@ export function createAgentChatPlugin(
         });
       }
 
+      const preRunGitStatusByThread = new Map<string, string | null>();
+
+      async function recordPreRunGitStatus(threadId: string): Promise<void> {
+        if (!isDevMode()) return;
+        try {
+          const { getUncommittedStatus, isGitRepo } =
+            await import("../checkpoints/service.js");
+          const cwd = process.cwd();
+          preRunGitStatusByThread.set(
+            threadId,
+            isGitRepo(cwd) ? getUncommittedStatus(cwd) : null,
+          );
+        } catch {
+          preRunGitStatusByThread.set(threadId, null);
+        }
+      }
+
       // Callback to persist agent response when run finishes (even if client disconnected).
       // Reconstructs the assistant message from buffered events and appends to thread_data.
       const onRunComplete = async (run: any, threadId: string | undefined) => {
-        if (!threadId) return;
+        const runThreadId = String(run?.threadId ?? threadId ?? "");
+        if (!threadId) {
+          if (runThreadId) preRunGitStatusByThread.delete(runThreadId);
+          return;
+        }
         // Serialize the read-modify-write against the same thread's other
         // `thread_data` writers (setThreadQueuedMessages, setThreadEngineMeta,
         // the frontend-triggered saves below). Without the lock, a concurrent
@@ -3347,9 +3368,24 @@ export function createAgentChatPlugin(
                 isGitRepo,
                 hasUncommittedChanges,
                 getChangedFileNames,
+                getUncommittedStatus,
               } = await import("../checkpoints/service.js");
               const cwd = process.cwd();
-              if (isGitRepo(cwd) && hasUncommittedChanges(cwd)) {
+              const preRunStatus = runThreadId
+                ? preRunGitStatusByThread.get(runThreadId)
+                : undefined;
+              if (runThreadId) preRunGitStatusByThread.delete(runThreadId);
+
+              // Only auto-commit checkpoints for changes produced by this run.
+              // If the tree was already dirty, a checkpoint commit would sweep
+              // up the user's unrelated work when a reconnect/refresh finishes.
+              const postRunStatus = getUncommittedStatus(cwd);
+              if (
+                preRunStatus === "" &&
+                postRunStatus?.trim() &&
+                isGitRepo(cwd) &&
+                hasUncommittedChanges(cwd)
+              ) {
                 let summary = "";
 
                 // Try to extract the first sentence of the assistant's text response
@@ -3603,10 +3639,11 @@ export function createAgentChatPlugin(
             runCtx.model = model;
           }
         },
-        onRunStart: (
+        onRunStart: async (
           send: (event: import("../agent/types.js").AgentChatEvent) => void,
           threadId: string,
         ) => {
+          await recordPreRunGitStatus(threadId);
           _runSendByThread.set(threadId, send);
           const runCtx = ensureRequestRunContext();
           if (runCtx) runCtx.threadId = threadId;
@@ -3643,12 +3680,13 @@ export function createAgentChatPlugin(
                   runCtx.model = model;
                 }
               },
-              onRunStart: (
+              onRunStart: async (
                 send: (
                   event: import("../agent/types.js").AgentChatEvent,
                 ) => void,
                 threadId: string,
               ) => {
+                await recordPreRunGitStatus(threadId);
                 _runSendByThread.set(threadId, send);
                 const runCtx = ensureRequestRunContext();
                 if (runCtx) runCtx.threadId = threadId;
@@ -3738,10 +3776,11 @@ export function createAgentChatPlugin(
               runCtx.model = model;
             }
           },
-          onRunStart: (
+          onRunStart: async (
             send: (event: import("../agent/types.js").AgentChatEvent) => void,
             threadId: string,
           ) => {
+            await recordPreRunGitStatus(threadId);
             _runSendByThread.set(threadId, send);
             const runCtx = ensureRequestRunContext();
             if (runCtx) runCtx.threadId = threadId;

--- a/packages/core/src/server/security-headers.spec.ts
+++ b/packages/core/src/server/security-headers.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+const headers = new Map<string, string>();
+
+vi.mock("h3", () => ({
+  defineEventHandler: (handler: any) => handler,
+  setResponseHeader: (_event: any, name: string, value: string) => {
+    headers.set(name, value);
+  },
+}));
+
+import { createSecurityHeadersMiddleware } from "./security-headers.js";
+
+describe("security headers middleware", () => {
+  it("allows same-origin microphone prompts for composer dictation", () => {
+    headers.clear();
+
+    const handler = createSecurityHeadersMiddleware();
+    handler({ url: { protocol: "https:" }, node: { req: { headers: {} } } });
+
+    expect(headers.get("Permissions-Policy")).toBe(
+      "camera=(), microphone=(self), geolocation=(), screen-wake-lock=()",
+    );
+  });
+});

--- a/packages/core/src/server/security-headers.ts
+++ b/packages/core/src/server/security-headers.ts
@@ -28,10 +28,11 @@
  *   - `Referrer-Policy: strict-origin-when-cross-origin` — strips path/query
  *     from outbound Referer headers when the request crosses origin, so a
  *     public-share viewer's outbound link clicks never leak the share token.
- *   - `Permissions-Policy: camera=(), microphone=(), geolocation=(),
- *     screen-wake-lock=()` — blocks iframed children from inheriting camera
- *     / mic / location grants. Templates that need camera/mic for recording
- *     UI override this on their own routes.
+ *   - `Permissions-Policy: camera=(), microphone=(self), geolocation=(),
+ *     screen-wake-lock=()` — allows the app shell to request microphone access
+ *     for composer dictation while keeping camera/location/wake-lock blocked
+ *     by default. Templates that need broader media capture for recording UI
+ *     override this on their own routes.
  *   - `Cross-Origin-Opener-Policy: same-origin` — isolates window.opener so
  *     a popup-window opener reference can't read or modify our document.
  *   - `Cross-Origin-Resource-Policy: same-site` — prevents other origins from
@@ -48,7 +49,7 @@ import { defineEventHandler, setResponseHeader } from "h3";
 
 const HSTS = "max-age=31536000; includeSubDomains; preload";
 const PERMISSIONS_POLICY =
-  "camera=(), microphone=(), geolocation=(), screen-wake-lock=()";
+  "camera=(), microphone=(self), geolocation=(), screen-wake-lock=()";
 
 /**
  * Returns true when the request was received over HTTPS. We trust both the

--- a/packages/pinpoint/src/ui/components/Toolbar.tsx
+++ b/packages/pinpoint/src/ui/components/Toolbar.tsx
@@ -4,7 +4,14 @@
 // Collapsed: small pill with pin count. Expanded: mode-tabbed controls.
 // Modes: Select (element picking), Draw (freehand/shapes), Queue (batch send).
 
-import { createSignal, Show, For, type Component } from "solid-js";
+import {
+  createSignal,
+  Show,
+  For,
+  onCleanup,
+  onMount,
+  type Component,
+} from "solid-js";
 import type {
   Pin,
   OutputFormat,
@@ -26,6 +33,46 @@ const LINE_WIDTHS = [
   { width: 4, name: "Medium" },
   { width: 8, name: "Thick" },
 ];
+
+const EDGE_GAP = 16;
+const COLLAPSED_TOOLBAR_SIZE = 60;
+const EXPANDED_TOOLBAR_WIDTH = 320;
+const AGENT_SIDEBAR_SELECTOR = ".agent-sidebar-panel";
+
+function clampRightOffset(right: number, toolbarWidth: number): number {
+  if (typeof window === "undefined") return right;
+
+  const maxRight = Math.max(0, window.innerWidth - toolbarWidth - EDGE_GAP);
+  return Math.min(right, maxRight);
+}
+
+function getVisibleRightSidebarInset(): number {
+  if (typeof window === "undefined") return 0;
+
+  let inset = 0;
+  for (const panel of document.querySelectorAll<HTMLElement>(
+    AGENT_SIDEBAR_SELECTOR,
+  )) {
+    const style = window.getComputedStyle(panel);
+    if (
+      style.display === "none" ||
+      style.visibility === "hidden" ||
+      panel.getAttribute("aria-hidden") === "true"
+    ) {
+      continue;
+    }
+
+    const rect = panel.getBoundingClientRect();
+    const isVisible = rect.width > 0 && rect.height > 0;
+    const isAnchoredToRight =
+      rect.right >= window.innerWidth - 1 && rect.left < window.innerWidth - 1;
+    if (!isVisible || !isAnchoredToRight) continue;
+
+    inset = Math.max(inset, Math.ceil(window.innerWidth - rect.left));
+  }
+
+  return inset;
+}
 
 interface ToolbarProps {
   expanded: boolean;
@@ -86,8 +133,9 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
           right: window.innerWidth - props.position.x,
           bottom: window.innerHeight - props.position.y,
         }
-      : { right: 16, bottom: 16 },
+      : { right: EDGE_GAP, bottom: EDGE_GAP },
   );
+  const [reservedRight, setReservedRight] = createSignal(0);
   const [dragging, setDragging] = createSignal(false);
   const [dragStart, setDragStart] = createSignal({
     x: 0,
@@ -96,6 +144,55 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
     bottom: 0,
   });
   const [didDrag, setDidDrag] = createSignal(false);
+
+  onMount(() => {
+    if (typeof window === "undefined") return;
+
+    let resizeObserver: ResizeObserver | undefined;
+    const updateReservedRight = () => {
+      setReservedRight(getVisibleRightSidebarInset());
+
+      resizeObserver?.disconnect();
+      if (typeof ResizeObserver === "undefined") return;
+
+      resizeObserver = new ResizeObserver(() => {
+        setReservedRight(getVisibleRightSidebarInset());
+      });
+      for (const panel of document.querySelectorAll<HTMLElement>(
+        AGENT_SIDEBAR_SELECTOR,
+      )) {
+        resizeObserver.observe(panel);
+      }
+    };
+
+    updateReservedRight();
+
+    const mutationObserver = new MutationObserver(updateReservedRight);
+    mutationObserver.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["class", "style", "aria-hidden"],
+      childList: true,
+      subtree: true,
+    });
+
+    window.addEventListener("resize", updateReservedRight);
+
+    onCleanup(() => {
+      mutationObserver.disconnect();
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updateReservedRight);
+    });
+  });
+
+  const toolbarRight = () => {
+    const toolbarWidth = props.expanded
+      ? EXPANDED_TOOLBAR_WIDTH
+      : COLLAPSED_TOOLBAR_SIZE;
+    return clampRightOffset(
+      (props.expanded ? EDGE_GAP : pos().right) + reservedRight(),
+      toolbarWidth,
+    );
+  };
 
   function handleMouseDown(e: MouseEvent) {
     if (props.expanded) return;
@@ -113,11 +210,18 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       const start = dragStart();
       const dx = e.clientX - start.x;
       const dy = e.clientY - start.y;
+      const maxRight = Math.max(
+        0,
+        window.innerWidth - reservedRight() - COLLAPSED_TOOLBAR_SIZE,
+      );
       setPos({
-        right: Math.max(0, Math.min(window.innerWidth - 60, start.right - dx)),
+        right: Math.max(0, Math.min(maxRight, start.right - dx)),
         bottom: Math.max(
           0,
-          Math.min(window.innerHeight - 60, start.bottom - dy),
+          Math.min(
+            window.innerHeight - COLLAPSED_TOOLBAR_SIZE,
+            start.bottom - dy,
+          ),
         ),
       });
     };
@@ -161,8 +265,8 @@ export const Toolbar: Component<ToolbarProps> = (props) => {
       class={`pp-toolbar ${props.expanded ? "pp-toolbar--expanded" : "pp-toolbar--collapsed"}`}
       style={{
         ...(props.expanded
-          ? { bottom: "16px", right: "16px" }
-          : { right: `${pos().right}px`, bottom: `${pos().bottom}px` }),
+          ? { bottom: `${EDGE_GAP}px`, right: `${toolbarRight()}px` }
+          : { right: `${toolbarRight()}px`, bottom: `${pos().bottom}px` }),
       }}
       onMouseDown={props.expanded ? undefined : handleMouseDown}
       on:click={handleClick}

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -116,7 +116,9 @@ Ephemeral UI state lives in `application_state`, accessed via `readAppState(key)
   "spaceId": "spc_xyz",
   "folderId": "fld_123",
   "shareId": "shr_888",
-  "search": "onboarding"
+  "search": "onboarding",
+  "panel": "transcript",
+  "searchHitMs": 83000
 }
 ```
 
@@ -184,7 +186,7 @@ Start / stop / pause are **UI gestures** — there is no server action. MediaRec
 | Action                       | Args                                                                                                                                                                       | Purpose                                                                                           |
 | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | `list-recordings`            | `[--view library\|space\|archive\|trash\|all] [--folderId] [--spaceId] [--search] [--tag] [--sort recent\|views\|oldest] [--limit] [--offset]`                             | List recordings the user has access to                                                            |
-| `search-recordings`          | `--query <term> [--limit]`                                                                                                                                                 | Fuzzy search over title / description / transcripts                                               |
+| `search-recordings`          | `--query <term> [--limit]`                                                                                                                                                 | Search title / description / transcripts / comments; transcript/comment matches include `matchMs` |
 | `get-recording-player-data`  | `--recordingId <id>`                                                                                                                                                       | Everything the player page needs (metadata + transcript + comments + reactions + chapters + CTAs) |
 | `update-recording`           | `--id <id> [--title] [--description] [--folderId] [--spaceIds] [--password] [--expiresAt] [--defaultSpeed] [--enableComments] [--enableReactions] [--enableDownloads] ...` | Update recording metadata                                                                         |
 | `move-recording`             | `--id <id> --folderId <fid>`                                                                                                                                               | Move to a folder                                                                                  |

--- a/templates/clips/actions/list-recordings.ts
+++ b/templates/clips/actions/list-recordings.ts
@@ -61,12 +61,11 @@ export default defineAction({
       accessFilter(schema.recordings, schema.recordingShares),
     ];
 
-    // Org isolation — all list views are scoped to the user's active org so
-    // public recordings from other orgs don't leak across tenants.
+    // `accessFilter` already scopes org-visible rows to the active org and
+    // never includes public rows in list views. Keep owner rows visible across
+    // org switches so joining a new organization does not hide older personal
+    // recordings.
     const orgId = await getActiveOrganizationId();
-    if (orgId) {
-      whereClauses.push(eq(schema.recordings.organizationId, orgId));
-    }
 
     // Library = "Your personal recordings" — further scope to the current
     // user's own clips so org-visible recordings from teammates don't appear.
@@ -102,6 +101,9 @@ export default defineAction({
     if (args.view === "space") {
       if (!args.spaceId) {
         throw new Error("spaceId is required when view='space'");
+      }
+      if (orgId) {
+        whereClauses.push(eq(schema.recordings.organizationId, orgId));
       }
       // Match recordings where spaceIds JSON array contains spaceId.
       // Use a LIKE check — works across SQLite/Postgres without JSON ops.

--- a/templates/clips/actions/search-recordings.ts
+++ b/templates/clips/actions/search-recordings.ts
@@ -22,9 +22,44 @@ function buildSnippet(fullText: string, query: string): string | null {
   return `${prefix}${fullText.slice(start, end)}${suffix}`;
 }
 
+function parseSegments(raw: string | null | undefined) {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((seg) => ({
+        startMs: Number(seg?.startMs ?? 0),
+        endMs: Number(seg?.endMs ?? seg?.startMs ?? 0),
+        text: String(seg?.text ?? ""),
+      }))
+      .filter((seg) => Number.isFinite(seg.startMs) && seg.text.trim());
+  } catch {
+    return [];
+  }
+}
+
+function transcriptMatch(
+  fullText: string,
+  segmentsJson: string | null | undefined,
+  query: string,
+): { snippet: string | null; matchMs: number | null } {
+  const q = query.toLowerCase();
+  for (const segment of parseSegments(segmentsJson)) {
+    if (segment.text.toLowerCase().includes(q)) {
+      return {
+        snippet: buildSnippet(segment.text, query) ?? segment.text,
+        matchMs: Math.max(0, Math.floor(segment.startMs)),
+      };
+    }
+  }
+
+  return { snippet: buildSnippet(fullText, query), matchMs: null };
+}
+
 export default defineAction({
   description:
-    "Search recordings by title, description, or transcript text. Returns matches with a highlighted transcript snippet.",
+    "Search recordings by title, description, transcript text, or comments. Transcript and comment matches include timestamps for jumping to the matching moment.",
   schema: z.object({
     query: z.string().min(1).describe("Search text"),
     limit: z.coerce.number().int().min(1).max(100).default(30),
@@ -62,6 +97,7 @@ export default defineAction({
       .select({
         recordingId: schema.recordingTranscripts.recordingId,
         fullText: schema.recordingTranscripts.fullText,
+        segmentsJson: schema.recordingTranscripts.segmentsJson,
         id: schema.recordings.id,
         title: schema.recordings.title,
         description: schema.recordings.description,
@@ -85,9 +121,37 @@ export default defineAction({
       )
       .limit(args.limit);
 
+    const commentRows = await db
+      .select({
+        recordingId: schema.recordingComments.recordingId,
+        content: schema.recordingComments.content,
+        videoTimestampMs: schema.recordingComments.videoTimestampMs,
+        id: schema.recordings.id,
+        title: schema.recordings.title,
+        description: schema.recordings.description,
+        thumbnailUrl: schema.recordings.thumbnailUrl,
+        durationMs: schema.recordings.durationMs,
+        ownerEmail: schema.recordings.ownerEmail,
+        visibility: schema.recordings.visibility,
+        createdAt: schema.recordings.createdAt,
+        updatedAt: schema.recordings.updatedAt,
+      })
+      .from(schema.recordingComments)
+      .innerJoin(
+        schema.recordings,
+        eq(schema.recordingComments.recordingId, schema.recordings.id),
+      )
+      .where(
+        and(
+          accessFilter(schema.recordings, schema.recordingShares),
+          sql`${schema.recordingComments.content} LIKE ${pattern} ESCAPE '\\'`,
+        ),
+      )
+      .limit(args.limit);
+
     const transcriptMatches = transcriptRows.map((r) => ({
       recordingId: r.recordingId,
-      fullText: r.fullText,
+      ...transcriptMatch(r.fullText, r.segmentsJson, args.query),
     }));
     const transcriptRecordings = transcriptRows.map((r) => ({
       id: r.id,
@@ -100,39 +164,95 @@ export default defineAction({
       createdAt: r.createdAt,
       updatedAt: r.updatedAt,
     }));
+    const commentRecordings = commentRows.map((r) => ({
+      id: r.id,
+      title: r.title,
+      description: r.description,
+      thumbnailUrl: r.thumbnailUrl,
+      durationMs: r.durationMs,
+      ownerEmail: r.ownerEmail,
+      visibility: r.visibility,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+      snippet: buildSnippet(r.content, args.query) ?? r.content,
+      matchMs: Math.max(0, Math.floor(r.videoTimestampMs ?? 0)),
+    }));
 
     // Merge matches by id. Prefer transcript snippet if present.
-    const snippetById = new Map<string, string | null>();
+    const transcriptById = new Map<
+      string,
+      { snippet: string | null; matchMs: number | null }
+    >();
     for (const t of transcriptMatches) {
-      if (t.recordingId && t.fullText) {
-        snippetById.set(t.recordingId, buildSnippet(t.fullText, args.query));
+      if (t.recordingId) {
+        transcriptById.set(t.recordingId, {
+          snippet: t.snippet,
+          matchMs: t.matchMs,
+        });
       }
     }
 
     const merged = new Map<string, any>();
     for (const r of recMatches) {
-      merged.set(r.id, { ...r, matchType: "title-description", snippet: null });
+      merged.set(r.id, {
+        ...r,
+        matchType: "title-description",
+        snippet: buildSnippet(r.description, args.query),
+        matchMs: null,
+        matchPanel: null,
+      });
     }
     for (const r of transcriptRecordings) {
       const existing = merged.get(r.id);
-      const snippet = snippetById.get(r.id) ?? null;
+      const match = transcriptById.get(r.id);
+      const snippet = match?.snippet ?? null;
       if (existing) {
         existing.matchType = "title-transcript";
         existing.snippet = snippet;
+        existing.matchMs = match?.matchMs ?? null;
+        existing.matchPanel = "transcript";
       } else {
-        merged.set(r.id, { ...r, matchType: "transcript", snippet });
+        merged.set(r.id, {
+          ...r,
+          matchType: "transcript",
+          snippet,
+          matchMs: match?.matchMs ?? null,
+          matchPanel: "transcript",
+        });
+      }
+    }
+    for (const r of commentRecordings) {
+      const existing = merged.get(r.id);
+      if (existing) {
+        if (existing.matchPanel !== "transcript") {
+          existing.matchType =
+            existing.matchType === "title-description"
+              ? "title-comment"
+              : "comment";
+          existing.snippet = r.snippet;
+          existing.matchMs = r.matchMs;
+          existing.matchPanel = "comments";
+        }
+      } else {
+        merged.set(r.id, {
+          ...r,
+          matchType: "comment",
+          matchPanel: "comments",
+        });
       }
     }
 
     const results = Array.from(merged.values()).sort((a, b) => {
-      // Title matches first, then transcript
+      // Metadata matches first, then timed transcript/comment content.
       const order = {
         "title-description": 0,
         "title-transcript": 1,
-        transcript: 2,
+        "title-comment": 2,
+        transcript: 3,
+        comment: 4,
       } as const;
-      const oa = order[a.matchType as keyof typeof order] ?? 3;
-      const ob = order[b.matchType as keyof typeof order] ?? 3;
+      const oa = order[a.matchType as keyof typeof order] ?? 5;
+      const ob = order[b.matchType as keyof typeof order] ?? 5;
       if (oa !== ob) return oa - ob;
       return (b.updatedAt ?? "").localeCompare(a.updatedAt ?? "");
     });

--- a/templates/clips/app/components/library/search-bar.tsx
+++ b/templates/clips/app/components/library/search-bar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
-import { IconSearch, IconX } from "@tabler/icons-react";
+import { IconClock, IconSearch, IconX } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import {
   Popover,
@@ -8,6 +8,7 @@ import {
   PopoverContent,
 } from "@/components/ui/popover";
 import { useRecordingSearch, type SearchHit } from "@/hooks/use-library";
+import { msToClock } from "@/components/player/scrubber";
 
 function highlight(
   text: string,
@@ -40,6 +41,21 @@ function highlight(
 
 interface SearchBarProps {
   className?: string;
+}
+
+function matchLabel(hit: SearchHit): string {
+  switch (hit.matchType) {
+    case "title-transcript":
+      return "Title + transcript";
+    case "title-comment":
+      return "Title + comment";
+    case "transcript":
+      return "Transcript";
+    case "comment":
+      return "Comment";
+    default:
+      return "Title or description";
+  }
 }
 
 export function SearchBar({ className }: SearchBarProps) {
@@ -86,7 +102,13 @@ export function SearchBar({ className }: SearchBarProps) {
   function pickResult(hit: SearchHit) {
     setOpen(false);
     setQuery("");
-    navigate(`/r/${hit.id}`);
+    const params = new URLSearchParams();
+    if (typeof hit.matchMs === "number" && Number.isFinite(hit.matchMs)) {
+      params.set("t", Math.max(0, Math.floor(hit.matchMs / 1000)).toString());
+    }
+    if (hit.matchPanel) params.set("panel", hit.matchPanel);
+    const suffix = params.toString() ? `?${params.toString()}` : "";
+    navigate(`/r/${hit.id}${suffix}`);
   }
 
   const showPopover = open && query.length >= 2;
@@ -110,6 +132,7 @@ export function SearchBar({ className }: SearchBarProps) {
             />
             {query ? (
               <button
+                aria-label="Clear search"
                 onClick={() => {
                   setQuery("");
                   inputRef.current?.focus();
@@ -174,12 +197,17 @@ export function SearchBar({ className }: SearchBarProps) {
                     )}
                     <div className="mt-1 flex items-center gap-1.5 text-[10px] text-muted-foreground/80">
                       <span className="uppercase tracking-wide">
-                        {hit.matchType === "transcript"
-                          ? "Transcript match"
-                          : hit.matchType === "title-transcript"
-                            ? "Title + Transcript"
-                            : "Title match"}
+                        {matchLabel(hit)}
                       </span>
+                      {typeof hit.matchMs === "number" ? (
+                        <>
+                          <span>·</span>
+                          <span className="inline-flex items-center gap-1 tabular-nums">
+                            <IconClock className="h-3 w-3" />
+                            {msToClock(hit.matchMs)}
+                          </span>
+                        </>
+                      ) : null}
                     </div>
                   </div>
                 </li>

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -366,11 +366,11 @@ export class RecorderEngine {
         throw new Error(policyBlock);
       }
 
-      // Start every browser media request synchronously before the first
-      // `await`. Brave (and stricter Chromium/WebKit builds) require
-      // getDisplayMedia to be directly anchored to the user's click. If we
-      // await a network request or another media prompt first, the browser can
-      // reject without showing any permission picker.
+      // Start display capture synchronously before the first `await`. Brave
+      // (and stricter Chromium/WebKit builds) require getDisplayMedia to be
+      // directly anchored to the user's click. Camera/mic prompts do not need
+      // that transient activation, and launching them in parallel with the
+      // screen picker can make Chrome/macOS report a false permission failure.
       const displaySurface = this.opts.displaySurface ?? "window";
       const displayOptions: ExtendedDisplayMediaOptions = {
         video: { frameRate: { ideal: 30 }, displaySurface },
@@ -381,69 +381,41 @@ export class RecorderEngine {
         surfaceSwitching: "include",
         systemAudio: "include",
       };
-      const displayPromise = wantsDisplay
-        ? navigator.mediaDevices.getDisplayMedia(displayOptions)
-        : Promise.resolve<MediaStream | null>(null);
-      const cameraPromise = wantsCamera
-        ? navigator.mediaDevices.getUserMedia({
+
+      if (wantsDisplay) {
+        try {
+          this.displayStream =
+            await navigator.mediaDevices.getDisplayMedia(displayOptions);
+        } catch (err) {
+          throw this.friendlyError(err, "screen");
+        }
+      }
+
+      if (wantsCamera) {
+        try {
+          this.cameraStream = await navigator.mediaDevices.getUserMedia({
             video: this.opts.cameraDeviceId
               ? { deviceId: { exact: this.opts.cameraDeviceId } }
               : true,
             audio: false,
-          })
-        : Promise.resolve<MediaStream | null>(null);
-      const micPromise = wantsMic
-        ? navigator.mediaDevices.getUserMedia({
+          });
+        } catch (err) {
+          throw this.friendlyError(err, "camera");
+        }
+      }
+
+      if (wantsMic) {
+        try {
+          this.micStream = await navigator.mediaDevices.getUserMedia({
             audio: this.opts.micDeviceId
               ? { deviceId: { exact: this.opts.micDeviceId } }
               : true,
             video: false,
-          })
-        : Promise.resolve<MediaStream | null>(null);
-
-      const [displayResult, cameraResult, micResult] = await Promise.allSettled(
-        [displayPromise, cameraPromise, micPromise],
-      );
-      const settledStreams = [displayResult, cameraResult, micResult]
-        .filter(
-          (result): result is PromiseFulfilledResult<MediaStream> =>
-            result.status === "fulfilled" && result.value !== null,
-        )
-        .map((result) => result.value);
-
-      const requiredFailure: { source: CaptureSource; reason: unknown } | null =
-        wantsDisplay && displayResult.status === "rejected"
-          ? { source: "screen", reason: displayResult.reason }
-          : wantsCamera && cameraResult.status === "rejected"
-            ? { source: "camera", reason: cameraResult.reason }
-            : wantsMic && micResult.status === "rejected"
-              ? { source: "microphone", reason: micResult.reason }
-              : null;
-      if (requiredFailure) {
-        for (const stream of settledStreams) {
-          for (const track of stream.getTracks()) {
-            try {
-              track.stop();
-            } catch {
-              // ignore
-            }
-          }
+          });
+        } catch (err) {
+          throw this.friendlyError(err, "microphone");
         }
-        throw this.friendlyError(
-          requiredFailure.reason,
-          requiredFailure.source,
-        );
       }
-
-      this.displayStream =
-        displayResult.status === "fulfilled" ? displayResult.value : null;
-      this.cameraStream =
-        cameraResult.status === "fulfilled" ? cameraResult.value : null;
-      // If the user explicitly picked a microphone and getUserMedia rejected,
-      // we threw above. The only way this lands is wantsMic=false (user chose
-      // "No microphone") — micResult fulfills with null in that case.
-      this.micStream =
-        micResult.status === "fulfilled" ? micResult.value : null;
 
       // If the display stream's video track ends (user hit "Stop sharing" in
       // browser chrome) we want to end the recording gracefully.

--- a/templates/clips/app/hooks/use-library.ts
+++ b/templates/clips/app/hooks/use-library.ts
@@ -75,8 +75,15 @@ export interface SearchHit {
   description: string;
   thumbnailUrl: string | null;
   durationMs: number;
-  matchType: "title-description" | "title-transcript" | "transcript";
+  matchType:
+    | "title-description"
+    | "title-transcript"
+    | "title-comment"
+    | "transcript"
+    | "comment";
   snippet: string | null;
+  matchMs: number | null;
+  matchPanel: "transcript" | "comments" | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -80,12 +80,40 @@ function failureDetail(reason: string | null | undefined): string | null {
   return trimmed.length > 1200 ? `${trimmed.slice(0, 1200)}...` : trimmed;
 }
 
+function parseTimeParam(raw: string | null): number {
+  if (!raw) return 0;
+  const value = raw.trim();
+  if (!value) return 0;
+
+  if (/^\d+(\.\d+)?$/.test(value)) {
+    return Math.floor(parseFloat(value) * 1000);
+  }
+
+  if (/^\d+:\d+(:\d+)?$/.test(value)) {
+    const parts = value.split(":").map((part) => parseInt(part, 10));
+    if (parts.length === 2) return (parts[0] * 60 + parts[1]) * 1000;
+    if (parts.length === 3) {
+      return (parts[0] * 3600 + parts[1] * 60 + parts[2]) * 1000;
+    }
+  }
+
+  const match = value.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+  if (!match) return 0;
+  const hours = parseInt(match[1] ?? "0", 10);
+  const minutes = parseInt(match[2] ?? "0", 10);
+  const seconds = parseInt(match[3] ?? "0", 10);
+  return (hours * 3600 + minutes * 60 + seconds) * 1000;
+}
+
 export default function RecordingPage() {
   useAutoTitleBridge();
 
   const { recordingId } = useParams<{ recordingId: string }>();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const search = searchParams.toString();
+  const startMs = parseTimeParam(searchParams.get("t"));
+  const panelParam = searchParams.get("panel");
   const { session } = useSession();
   const playerRef = useRef<VideoPlayerHandle | null>(null);
 
@@ -100,6 +128,12 @@ export default function RecordingPage() {
   // can retry or report the issue instead of staring at a spinner.
   const [processingTimeout, setProcessingTimeout] = useState(false);
   const [retryingFinalize, setRetryingFinalize] = useState(false);
+
+  useEffect(() => {
+    if (panelParam === "comments" || panelParam === "transcript") {
+      setPanel(panelParam);
+    }
+  }, [panelParam]);
 
   const playerDataQ = useActionQuery<any>(
     "get-recording-player-data",
@@ -300,10 +334,12 @@ export default function RecordingPage() {
       body: JSON.stringify({
         view: "recording",
         recordingId,
-        path: `/r/${recordingId}`,
+        path: `/r/${recordingId}${search ? `?${search}` : ""}`,
+        panel,
+        ...(startMs > 0 ? { searchHitMs: startMs } : {}),
       }),
     }).catch(() => {});
-  }, [recordingId]);
+  }, [panel, recordingId, search, startMs]);
 
   usePlayerShortcuts({ playerRef, speed, setSpeed, chapters });
 
@@ -653,6 +689,7 @@ export default function RecordingPage() {
                   thumbnailUrl={recording.thumbnailUrl}
                   role={role}
                   defaultSpeed={speed}
+                  startMs={startMs}
                   comments={comments}
                   chapters={chapters}
                   reactions={reactions}

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -117,10 +117,87 @@ const MAC_CAMERA_PREF_URL =
 const MAC_MICROPHONE_PREF_URL =
   "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone";
 
+type BrowserDocumentPolicy = {
+  allowsFeature?: (feature: string) => boolean;
+};
+
 function isMacPlatform(): boolean {
   return /^darwin|mac/i.test(
     typeof navigator !== "undefined" ? navigator.platform : "",
   );
+}
+
+function isEmbeddedWindow(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.self !== window.top;
+  } catch {
+    return true;
+  }
+}
+
+function openUrlFromUserGesture(url: string): void {
+  const opened = window.open(url, "_blank", "noopener,noreferrer");
+  if (!opened) {
+    window.location.href = url;
+  }
+}
+
+function capturePolicy(): BrowserDocumentPolicy | null {
+  if (typeof document === "undefined") return null;
+  const doc = document as Document & {
+    permissionsPolicy?: BrowserDocumentPolicy;
+    featurePolicy?: BrowserDocumentPolicy;
+  };
+  return doc.permissionsPolicy ?? doc.featurePolicy ?? null;
+}
+
+function isCaptureFeatureBlockedByPolicy(feature: string): boolean {
+  const policy = capturePolicy();
+  if (!policy?.allowsFeature) return false;
+  try {
+    return !policy.allowsFeature(feature);
+  } catch {
+    return false;
+  }
+}
+
+function getPolicyBlockedCaptureLabel(opts: {
+  mode: RecordingMode;
+  micDeviceId?: string | null;
+}): "screen" | "camera" | "microphone" | null {
+  if (
+    (opts.mode === "screen" || opts.mode === "screen+camera") &&
+    isCaptureFeatureBlockedByPolicy("display-capture")
+  ) {
+    return "screen";
+  }
+  if (
+    (opts.mode === "camera" || opts.mode === "screen+camera") &&
+    isCaptureFeatureBlockedByPolicy("camera")
+  ) {
+    return "camera";
+  }
+  if (
+    wantsMicrophone(opts.micDeviceId) &&
+    isCaptureFeatureBlockedByPolicy("microphone")
+  ) {
+    return "microphone";
+  }
+  return null;
+}
+
+function directRecorderUrl(opts?: {
+  mode: RecordingMode;
+  displaySurface: DisplaySurface;
+}): string {
+  if (typeof window === "undefined") return "/record";
+  const url = new URL(window.location.href);
+  if (opts) {
+    url.searchParams.set("mode", opts.mode);
+    url.searchParams.set("surface", opts.displaySurface);
+  }
+  return url.toString();
 }
 
 function isPermissionError(message: string): boolean {
@@ -205,6 +282,9 @@ function permissionGuidance(
     return "Browser site permissions are not the blocker here. Open Clips directly in a browser tab, or use an app frame that delegates the selected capture sources.";
   }
   if (isScreenPermissionError(message)) {
+    if (isEmbeddedWindow()) {
+      return "The web client is running Clips inside a frame. Open the recorder in its own tab, then start recording; Chrome can block screen sharing in embedded pages even when macOS access is enabled.";
+    }
     if (isMacPlatform()) {
       return "Chrome can have Camera and Microphone allowed while macOS still blocks screen capture. Enable your browser in System Settings > Privacy & Security > Screen & System Audio Recording, then quit and reopen it.";
     }
@@ -387,9 +467,9 @@ function RecordingErrorCard({
   const guidance = permissionGuidance(error, { mode, micDeviceId });
   const permissionError = isPermissionError(error);
   const policyError = isPolicyPermissionError(error);
+  const embeddedScreenError = isEmbeddedWindow() && isScreenPermissionError(error);
   const settings = getModePermissionLabels(mode, micDeviceId);
-  const directUrl =
-    typeof window !== "undefined" ? window.location.href : "/record";
+  const directUrl = directRecorderUrl();
 
   return (
     <div className="w-full max-w-md overflow-hidden rounded-2xl border border-border bg-card shadow-lg">
@@ -421,12 +501,14 @@ function RecordingErrorCard({
           <IconRefresh className="h-4 w-4" />
           Try again
         </Button>
-        {policyError && (
-          <Button asChild className="w-full gap-2">
-            <a href={directUrl} target="_blank" rel="noreferrer">
-              <IconExternalLink className="h-4 w-4" />
-              Open in tab
-            </a>
+        {(policyError || embeddedScreenError) && (
+          <Button
+            type="button"
+            onClick={() => openUrlFromUserGesture(directUrl)}
+            className="w-full gap-2"
+          >
+            <IconExternalLink className="h-4 w-4" />
+            Open recorder in tab
           </Button>
         )}
         {permissionError &&
@@ -448,7 +530,7 @@ function RecordingErrorCard({
                   variant="ghost"
                   size="sm"
                   onClick={() => {
-                    window.location.href = MAC_SCREEN_RECORDING_PREF_URL;
+                    openUrlFromUserGesture(MAC_SCREEN_RECORDING_PREF_URL);
                   }}
                   className="gap-1.5 px-2 text-xs"
                 >
@@ -461,7 +543,7 @@ function RecordingErrorCard({
                   variant="ghost"
                   size="sm"
                   onClick={() => {
-                    window.location.href = MAC_CAMERA_PREF_URL;
+                    openUrlFromUserGesture(MAC_CAMERA_PREF_URL);
                   }}
                   className="gap-1.5 px-2 text-xs"
                 >
@@ -474,7 +556,7 @@ function RecordingErrorCard({
                   variant="ghost"
                   size="sm"
                   onClick={() => {
-                    window.location.href = MAC_MICROPHONE_PREF_URL;
+                    openUrlFromUserGesture(MAC_MICROPHONE_PREF_URL);
                   }}
                   className="gap-1.5 px-2 text-xs"
                 >
@@ -608,7 +690,7 @@ export default function RecordRoute() {
         ? {
             label: "Open settings",
             onClick: () => {
-              window.location.href = settingsUrl;
+              openUrlFromUserGesture(settingsUrl);
             },
           }
         : undefined,

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -467,7 +467,8 @@ function RecordingErrorCard({
   const guidance = permissionGuidance(error, { mode, micDeviceId });
   const permissionError = isPermissionError(error);
   const policyError = isPolicyPermissionError(error);
-  const embeddedScreenError = isEmbeddedWindow() && isScreenPermissionError(error);
+  const embeddedScreenError =
+    isEmbeddedWindow() && isScreenPermissionError(error);
   const settings = getModePermissionLabels(mode, micDeviceId);
   const directUrl = directRecorderUrl();
 
@@ -707,6 +708,21 @@ export default function RecordRoute() {
       micDeviceId: string | null;
       cameraDeviceId: string | null;
     }) => {
+      const blockedFeature = isEmbeddedWindow()
+        ? getPolicyBlockedCaptureLabel({
+            mode: opts.mode,
+            micDeviceId: opts.micDeviceId,
+          })
+        : null;
+      if (blockedFeature) {
+        openUrlFromUserGesture(directRecorderUrl(opts));
+        toast.info("Opened recorder in a new tab", {
+          description: `Chrome is blocking ${blockedFeature} access in this embedded web client.`,
+          duration: 8000,
+        });
+        return;
+      }
+
       // Claim a session id; doCancel() bumps the ref to invalidate us.
       const session = startSessionRef.current + 1;
       startSessionRef.current = session;

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -492,8 +492,7 @@ pub async fn resize_popover(app: AppHandle, height: f64, width: Option<f64>) -> 
             .or_else(|| w.primary_monitor().ok().flatten())
             .map(|monitor| {
                 let scale = monitor.scale_factor().max(1.0);
-                ((monitor.size().height as f64) / scale - 24.0)
-                    .clamp(260.0, 820.0)
+                ((monitor.size().height as f64) / scale - 24.0).clamp(260.0, 820.0)
             })
             .unwrap_or(820.0);
         let clamped = height.clamp(200.0, max_logical_height);
@@ -519,9 +518,7 @@ pub fn open_macos_privacy_settings(pane: String) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
         let url = match pane.as_str() {
-            "camera" => {
-                "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
-            }
+            "camera" => "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera",
             "microphone" => {
                 "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
             }

--- a/templates/clips/desktop/src-tauri/src/clips/mod.rs
+++ b/templates/clips/desktop/src-tauri/src/clips/mod.rs
@@ -485,7 +485,18 @@ pub async fn resize_popover(app: AppHandle, height: f64, width: Option<f64>) -> 
         return Ok(());
     }
     if let Some(w) = app.get_webview_window("popover") {
-        let clamped = height.clamp(200.0, 820.0);
+        let max_logical_height = w
+            .current_monitor()
+            .ok()
+            .flatten()
+            .or_else(|| w.primary_monitor().ok().flatten())
+            .map(|monitor| {
+                let scale = monitor.scale_factor().max(1.0);
+                ((monitor.size().height as f64) / scale - 24.0)
+                    .clamp(260.0, 820.0)
+            })
+            .unwrap_or(820.0);
+        let clamped = height.clamp(200.0, max_logical_height);
         let width = width.unwrap_or(360.0).clamp(320.0, 480.0);
         let _ = w.set_size(tauri::Size::Logical(tauri::LogicalSize::new(
             width, clamped,
@@ -495,6 +506,45 @@ pub async fn resize_popover(app: AppHandle, height: f64, width: Option<f64>) -> 
         position_popover(&app, &w);
     }
     Ok(())
+}
+
+#[tauri::command]
+pub fn open_macos_privacy_settings(pane: String) -> Result<(), String> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = pane;
+        return Ok(());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let url = match pane.as_str() {
+            "camera" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
+            }
+            "microphone" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+            }
+            "screen" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+            }
+            "speech" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition"
+            }
+            "accessibility" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+            }
+            "input-monitoring" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+            }
+            _ => return Err(format!("Unknown macOS privacy pane: {pane}")),
+        };
+        Command::new("open")
+            .arg(url)
+            .status()
+            .map_err(|e| format!("failed to open System Settings: {e}"))?;
+        Ok(())
+    }
 }
 
 /// Open a login window pointed at the Clips server's /login route. The
@@ -1144,16 +1194,25 @@ pub fn position_popover(app: &AppHandle, window: &WebviewWindow) {
         let mut x = icon_x + icon_w / 2 - (win_size.width as i32) / 2;
         // Drop below the icon with a tiny gap.
         let gap = 6_i32;
-        let y = icon_y + icon_h + gap;
+        let mut y = icon_y + icon_h + gap;
 
-        // Clamp horizontally so we don't run off the edge of the screen.
+        // Clamp so settings and long error states don't run off the edge of
+        // shorter displays or get stranded in a corner after a resize.
         let min_x = mon_pos.x + 8;
         let max_x = mon_pos.x + mon_size.width as i32 - win_size.width as i32 - 8;
+        let min_y = mon_pos.y + 8;
+        let max_y = mon_pos.y + mon_size.height as i32 - win_size.height as i32 - 8;
         if x < min_x {
             x = min_x;
         }
         if x > max_x {
             x = max_x;
+        }
+        if y < min_y {
+            y = min_y;
+        }
+        if y > max_y.max(min_y) {
+            y = max_y.max(min_y);
         }
         let _ = window.set_position(PhysicalPosition::new(x, y));
         return;
@@ -1164,7 +1223,12 @@ pub fn position_popover(app: &AppHandle, window: &WebviewWindow) {
     let scale = monitor.scale_factor();
     let margin_right = (12.0 * scale) as i32;
     let margin_top = (36.0 * scale) as i32;
-    let x = mon_pos.x + mon_size.width as i32 - win_size.width as i32 - margin_right;
-    let y = mon_pos.y + margin_top;
+    let min_x = mon_pos.x + 8;
+    let max_x = mon_pos.x + mon_size.width as i32 - win_size.width as i32 - 8;
+    let min_y = mon_pos.y + 8;
+    let max_y = mon_pos.y + mon_size.height as i32 - win_size.height as i32 - 8;
+    let x = (mon_pos.x + mon_size.width as i32 - win_size.width as i32 - margin_right)
+        .clamp(min_x, max_x.max(min_x));
+    let y = (mon_pos.y + margin_top).clamp(min_y, max_y.max(min_y));
     let _ = window.set_position(PhysicalPosition::new(x, y));
 }

--- a/templates/clips/desktop/src-tauri/src/config.rs
+++ b/templates/clips/desktop/src-tauri/src/config.rs
@@ -11,6 +11,8 @@ pub struct FeatureConfig {
     pub voice_enabled: bool,
     #[serde(default = "default_launch_at_login_enabled")]
     pub launch_at_login_enabled: bool,
+    #[serde(default)]
+    pub auto_hide_popover_enabled: bool,
     pub onboarding_complete: bool,
 }
 
@@ -25,6 +27,7 @@ impl Default for FeatureConfig {
             meetings_enabled: true,
             voice_enabled: true,
             launch_at_login_enabled: true,
+            auto_hide_popover_enabled: false,
             onboarding_complete: false,
         }
     }
@@ -104,6 +107,10 @@ pub fn sync_launch_at_login(app: &AppHandle) {
     }
 }
 
+pub fn auto_hide_popover_enabled(app: &AppHandle) -> bool {
+    load_config(app).auto_hide_popover_enabled
+}
+
 /// Load feature config from disk and return it to the frontend.
 #[tauri::command]
 pub async fn get_feature_config(app: AppHandle) -> Result<FeatureConfig, String> {
@@ -115,7 +122,9 @@ pub async fn get_feature_config(app: AppHandle) -> Result<FeatureConfig, String>
 pub async fn set_feature_config(app: AppHandle, config: FeatureConfig) -> Result<(), String> {
     let previous = load_config(&app);
     if previous.launch_at_login_enabled != config.launch_at_login_enabled {
-        apply_launch_at_login(&app, config.launch_at_login_enabled)?;
+        if let Err(err) = apply_launch_at_login(&app, config.launch_at_login_enabled) {
+            eprintln!("[clips-tray] launch-at-login apply failed: {err}");
+        }
     }
     save_config(&app, &config)?;
     let _ = app.emit("app:feature-config-changed", config);

--- a/templates/clips/desktop/src-tauri/src/lib.rs
+++ b/templates/clips/desktop/src-tauri/src/lib.rs
@@ -63,6 +63,7 @@ pub fn run() {
             clips::close_bubble,
             clips::show_popover,
             clips::park_popover_offscreen,
+            clips::open_macos_privacy_settings,
             clips::resize_popover,
             clips::show_signin,
             clips::close_signin,
@@ -191,6 +192,10 @@ pub fn run() {
                         // is relying on to stop.
                         if is_recording_active(&app_handle) {
                             dlog!("[clips-tray] popover blur ignored — recording active");
+                            return;
+                        }
+                        if !config::auto_hide_popover_enabled(&app_handle) {
+                            dlog!("[clips-tray] popover blur ignored — auto-hide disabled");
                             return;
                         }
                         let shown_at = app_handle

--- a/templates/clips/desktop/src-tauri/src/tray.rs
+++ b/templates/clips/desktop/src-tauri/src/tray.rs
@@ -21,6 +21,7 @@ fn build_menu_with_meetings(
 ) -> Result<Menu<tauri::Wry>, Box<dyn std::error::Error>> {
     let meetings_submenu = build_meetings_section(app, meetings)?;
     let show_item = MenuItem::with_id(app, "show", "Show popover", true, None::<&str>)?;
+    let stop_item = MenuItem::with_id(app, "stop", "Stop recording", true, None::<&str>)?;
     let devtools_item =
         MenuItem::with_id(app, "devtools", "Toggle DevTools", true, Some("Cmd+Alt+I"))?;
     let quit_item = MenuItem::with_id(app, "quit", "Quit Clips", true, None::<&str>)?;
@@ -31,6 +32,7 @@ fn build_menu_with_meetings(
             &meetings_submenu,
             &separator,
             &show_item,
+            &stop_item,
             &devtools_item,
             &quit_item,
         ],
@@ -64,6 +66,9 @@ pub fn build_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
             }
             match id_ref {
                 "show" => toggle_popover(app),
+                "stop" => {
+                    let _ = app.emit("clips:recorder-stop", ());
+                }
                 "devtools" => {
                     #[cfg(debug_assertions)]
                     {

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -83,6 +83,7 @@ const CAM_KEY = "clips:last-camera-id";
 const MIC_KEY = "clips:last-mic-id";
 const CAM_ON_KEY = "clips:camera-on";
 const MIC_ON_KEY = "clips:mic-on";
+const READINESS_REVIEWED_KEY = "clips:readiness-reviewed";
 
 // Sensible defaults so the user never has to type a URL on first launch.
 // Dev builds point at the local dev server; production builds point at the
@@ -94,9 +95,9 @@ const DEFAULT_URL = import.meta.env.DEV
   : "https://clips.agent-native.com";
 
 const MACOS_CAPTURE_PERMISSION_MESSAGE =
-  "Recording permission is blocked. Try starting again so macOS can show the Camera and Microphone prompts, then open System Settings → Privacy & Security and enable Clips for Camera, Microphone, and Screen & System Audio Recording. In Tauri dev, macOS may list the debug binary separately from Ghostty or node, so restart Clips after granting it.";
+  "Grant the required macOS permissions below, then try again. If you just changed access, restart Clips before retrying.";
 const MACOS_SPEECH_PERMISSION_MESSAGE =
-  "Speech recognition permission is blocked. Open System Settings → Privacy & Security → Speech Recognition and enable Clips, then start a new recording.";
+  "Grant Speech Recognition and Microphone access, then try again. If you just changed access, restart Clips before retrying.";
 
 function isHardCapturePermissionError(message: string): boolean {
   return /permission denied by system|blocked by system|system settings|screen recording|privacy|sandbox/i.test(
@@ -501,6 +502,9 @@ export function App() {
   );
   const [retryingUploadId, setRetryingUploadId] = useState<string | null>(null);
   const [showRecent, setShowRecent] = useState(false);
+  const [readinessOpen, setReadinessOpen] = useState<boolean>(
+    () => !loadBool(READINESS_REVIEWED_KEY, false),
+  );
   const [showSettings, setShowSettings] = useState(false);
   const [recorder, setRecorder] = useState<RecorderHandle | null>(null);
   const [recError, setRecError] = useState<string | null>(null);
@@ -1597,6 +1601,21 @@ export function App() {
     setRecError(message);
   }
 
+  function updateReadinessOpen(next: boolean) {
+    setReadinessOpen(next);
+    if (!next) saveBool(READINESS_REVIEWED_KEY, true);
+  }
+
+  function retryCameraPreview() {
+    setCameraError(null);
+    if (!cameraOn) {
+      setCameraOn(true);
+      return;
+    }
+    setCameraOn(false);
+    window.setTimeout(() => setCameraOn(true), 0);
+  }
+
   // When the toolbar or countdown triggers stop/cancel the popover auto-
   // rehydrates into a "last recording" state so the user has a single-click
   // path to the playback page + knows the upload landed.
@@ -1844,21 +1863,47 @@ export function App() {
         />
       </div>
 
+      <ReadinessPanel
+        mode={mode}
+        source={source}
+        cameraOn={cameraOn}
+        micOn={micOn}
+        includeFnMonitoring={fnShortcutEnabled}
+        open={readinessOpen}
+        onOpenChange={updateReadinessOpen}
+        onOpenPermission={openMacosPrivacySettings}
+      />
+
       <button className="primary start" onClick={startRecording}>
         Start recording
       </button>
       {recError ? (
         recError === MACOS_CAPTURE_PERMISSION_MESSAGE ? (
-          <PermissionErrorBanner message={recError} defaultPane="screen" />
+          <PermissionRecoveryBanner
+            kind="recording"
+            message={recError}
+            panes={permissionPanesForRecording(mode, cameraOn, micOn)}
+            onRetry={startRecording}
+          />
         ) : recError === MACOS_SPEECH_PERMISSION_MESSAGE ? (
-          <PermissionErrorBanner message={recError} defaultPane="speech" />
+          <PermissionRecoveryBanner
+            kind="speech"
+            message={recError}
+            panes={["speech", "microphone"]}
+            onRetry={startRecording}
+          />
         ) : (
           <div className="error-banner">{recError}</div>
         )
       ) : null}
       {cameraError && !recError ? (
         cameraError === MACOS_CAPTURE_PERMISSION_MESSAGE ? (
-          <PermissionErrorBanner message={cameraError} defaultPane="camera" />
+          <PermissionRecoveryBanner
+            kind="camera"
+            message={cameraError}
+            panes={["camera"]}
+            onRetry={retryCameraPreview}
+          />
         ) : (
           <div className="error-banner">{cameraError}</div>
         )
@@ -1925,38 +1970,212 @@ function hidePopover() {
   emit("clips:popover-visible", false).catch(() => {});
 }
 
-function PermissionErrorBanner({
-  message,
-  defaultPane,
+function permissionPanesForRecording(
+  mode: CaptureMode,
+  cameraOn: boolean,
+  micOn: boolean,
+): MacosPrivacyPane[] {
+  const panes: MacosPrivacyPane[] = [];
+  if (mode !== "camera") panes.push("screen");
+  if (micOn) panes.push("microphone", "speech");
+  if (mode !== "screen" && cameraOn) panes.push("camera");
+  return Array.from(new Set(panes));
+}
+
+function permissionPaneLabel(pane: MacosPrivacyPane): string {
+  return {
+    camera: "Camera",
+    microphone: "Microphone",
+    screen: "Screen",
+    speech: "Speech",
+    accessibility: "Accessibility",
+    "input-monitoring": "Input Monitoring",
+  }[pane];
+}
+
+function captureModeLabel(mode: CaptureMode, source: CaptureSource): string {
+  if (mode === "camera") return "Camera";
+  const base = source === "window" ? "Window" : "Full screen";
+  return mode === "screen-camera" ? `${base} + camera` : base;
+}
+
+function recordingSummaryParts({
+  mode,
+  source,
+  cameraOn,
+  micOn,
 }: {
-  message: string;
-  defaultPane: MacosPrivacyPane;
+  mode: CaptureMode;
+  source: CaptureSource;
+  cameraOn: boolean;
+  micOn: boolean;
+}): string[] {
+  const parts = [captureModeLabel(mode, source)];
+  if (mode !== "screen") parts.push(cameraOn ? "Camera on" : "Camera off");
+  parts.push(micOn ? "Mic on" : "Mic off");
+  return parts;
+}
+
+function readinessItems({
+  mode,
+  cameraOn,
+  micOn,
+  includeFnMonitoring,
+}: {
+  mode: CaptureMode;
+  cameraOn: boolean;
+  micOn: boolean;
+  includeFnMonitoring: boolean;
+}): Array<{
+  label: string;
+  detail: string;
+  pane: MacosPrivacyPane;
+  active: boolean;
+}> {
+  return [
+    {
+      label: "Screen Recording",
+      detail: "Needed for screen or window capture.",
+      pane: "screen",
+      active: mode !== "camera",
+    },
+    {
+      label: "Microphone",
+      detail: "Needed when the mic is on.",
+      pane: "microphone",
+      active: micOn,
+    },
+    {
+      label: "Speech Recognition",
+      detail: "Used for native transcripts.",
+      pane: "speech",
+      active: micOn,
+    },
+    {
+      label: "Camera",
+      detail: "Needed when camera is on.",
+      pane: "camera",
+      active: mode !== "screen" && cameraOn,
+    },
+    {
+      label: "Input Monitoring",
+      detail: "Only needed for the Fn dictation shortcut.",
+      pane: "input-monitoring",
+      active: includeFnMonitoring,
+    },
+  ].filter((item) => item.active);
+}
+
+function ReadinessPanel({
+  mode,
+  source,
+  cameraOn,
+  micOn,
+  includeFnMonitoring,
+  open,
+  onOpenChange,
+  onOpenPermission,
+}: {
+  mode: CaptureMode;
+  source: CaptureSource;
+  cameraOn: boolean;
+  micOn: boolean;
+  includeFnMonitoring: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onOpenPermission: (pane: MacosPrivacyPane) => void;
 }) {
-  useEffect(() => {
-    openMacosPrivacySettings(defaultPane);
-  }, [defaultPane]);
+  const items = readinessItems({
+    mode,
+    cameraOn,
+    micOn,
+    includeFnMonitoring,
+  });
+  const summary = recordingSummaryParts({
+    mode,
+    source,
+    cameraOn,
+    micOn,
+  }).join(" · ");
+
+  return (
+    <div className={`readiness ${open ? "readiness-open" : ""}`}>
+      <button
+        type="button"
+        className="readiness-summary"
+        aria-expanded={open}
+        onClick={() => onOpenChange(!open)}
+      >
+        <span className="readiness-title">Setup</span>
+        <span className="readiness-copy">{summary}</span>
+        <span className="readiness-action">{open ? "Hide" : "Review"}</span>
+      </button>
+      {open ? (
+        <div className="readiness-list">
+          {items.length ? (
+            items.map((item) => (
+              <div className="readiness-item" key={item.pane}>
+                <div className="readiness-item-copy">
+                  <span className="readiness-item-title">{item.label}</span>
+                  <span className="readiness-item-detail">{item.detail}</span>
+                </div>
+                <button
+                  type="button"
+                  className="readiness-open-button"
+                  onClick={() => onOpenPermission(item.pane)}
+                >
+                  Open
+                </button>
+              </div>
+            ))
+          ) : (
+            <div className="readiness-empty">
+              Turn on camera or mic when you need them.
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function PermissionRecoveryBanner({
+  kind,
+  message,
+  panes,
+  onRetry,
+}: {
+  kind: "recording" | "speech" | "camera";
+  message: string;
+  panes: MacosPrivacyPane[];
+  onRetry: () => void;
+}) {
+  const title =
+    kind === "speech"
+      ? "Transcript setup blocked"
+      : kind === "camera"
+        ? "Camera setup blocked"
+        : "Recording setup blocked";
+  const uniquePanes = Array.from(new Set(panes));
 
   return (
     <div className="error-banner permission-banner">
-      <div>{message}</div>
+      <div className="permission-copy">
+        <div className="permission-title">{title}</div>
+        <div>{message}</div>
+      </div>
       <div className="permission-actions" aria-label="Open macOS permissions">
-        <button
-          type="button"
-          onClick={() => openMacosPrivacySettings("camera")}
-        >
-          Camera
-        </button>
-        <button
-          type="button"
-          onClick={() => openMacosPrivacySettings("microphone")}
-        >
-          Microphone
-        </button>
-        <button
-          type="button"
-          onClick={() => openMacosPrivacySettings("screen")}
-        >
-          Screen
+        {uniquePanes.map((pane) => (
+          <button
+            type="button"
+            key={pane}
+            onClick={() => openMacosPrivacySettings(pane)}
+          >
+            {permissionPaneLabel(pane)}
+          </button>
+        ))}
+        <button type="button" className="permission-retry" onClick={onRetry}>
+          Try again
         </button>
       </div>
     </div>

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -3632,7 +3632,24 @@ function ShortcutRecorder({
 }) {
   const [recording, setRecording] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+    };
+  }, []);
+
+  function flashSaved() {
+    setSaved(true);
+    if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+    savedTimerRef.current = setTimeout(() => {
+      savedTimerRef.current = null;
+      setSaved(false);
+    }, 1600);
+  }
 
   return (
     <div className="setup-shortcut-row">
@@ -3646,6 +3663,7 @@ function ShortcutRecorder({
             return;
           }
           setError(null);
+          setSaved(false);
           setRecording(true);
           requestAnimationFrame(() => buttonRef.current?.focus());
         }}
@@ -3663,6 +3681,7 @@ function ShortcutRecorder({
             onChange("");
             setRecording(false);
             setError(null);
+            setSaved(false);
             return;
           }
           const next = shortcutFromKeyboardEvent(event);
@@ -3677,6 +3696,7 @@ function ShortcutRecorder({
           onChange(next);
           setRecording(false);
           setError(null);
+          flashSaved();
         }}
         onKeyUp={(event) => {
           if (!recording) return;
@@ -3693,12 +3713,18 @@ function ShortcutRecorder({
           onClick={() => {
             onChange("");
             setError(null);
+            setSaved(false);
           }}
         >
           Clear
         </button>
       ) : null}
       {error ? <p className="setup-warning">{error}</p> : null}
+      {saved && !error ? (
+        <p className="setup-success" aria-live="polite">
+          Saved
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -2779,8 +2779,7 @@ function Setup({
   const featureConfig = useFeatureConfig();
   const voiceEnabled = featureConfig?.voiceEnabled !== false;
   const launchAtLoginEnabled = featureConfig?.launchAtLoginEnabled !== false;
-  const autoHidePopoverEnabled =
-    featureConfig?.autoHidePopoverEnabled === true;
+  const autoHidePopoverEnabled = featureConfig?.autoHidePopoverEnabled === true;
   const [providerStatus, setProviderStatus] =
     useState<VoiceProviderStatus | null>(null);
   const [providerStatusLoading, setProviderStatusLoading] = useState(true);

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -285,8 +285,14 @@ function isMacPlatform(): boolean {
 
 function openMacosPrivacySettings(pane: MacosPrivacyPane): void {
   if (!isMacPlatform()) return;
-  openExternal(MACOS_PRIVACY_URLS[pane]).catch((err) => {
-    console.error("[clips-tray] open macOS privacy settings failed:", err);
+  invoke("open_macos_privacy_settings", { pane }).catch((nativeErr) => {
+    console.warn(
+      "[clips-tray] native macOS privacy settings open failed; falling back:",
+      nativeErr,
+    );
+    openExternal(MACOS_PRIVACY_URLS[pane]).catch((err) => {
+      console.error("[clips-tray] open macOS privacy settings failed:", err);
+    });
   });
 }
 
@@ -452,7 +458,7 @@ export function App() {
   );
   const [micId, setMicId] = useState<string>(() => loadString(MIC_KEY, ""));
   const [cameraOn, setCameraOn] = useState<boolean>(() =>
-    loadBool(CAM_ON_KEY, true),
+    loadBool(CAM_ON_KEY, false),
   );
   const [micOn, setMicOn] = useState<boolean>(() => loadBool(MIC_ON_KEY, true));
   const [voiceShortcut, setVoiceShortcut] = useState<VoiceShortcutPreference>(
@@ -2034,6 +2040,7 @@ function Header({
           title="Screen only"
         >
           <ScreenIcon />
+          <span className="mode-label">Screen</span>
         </button>
         <button
           className={mode === "screen-camera" ? "active" : ""}
@@ -2042,6 +2049,7 @@ function Header({
           title="Screen + Camera"
         >
           <ScreenCamIcon />
+          <span className="mode-label">Screen + Cam</span>
         </button>
         <button
           className={mode === "camera" ? "active" : ""}
@@ -2050,6 +2058,7 @@ function Header({
           title="Camera only"
         >
           <CamIcon />
+          <span className="mode-label">Camera</span>
         </button>
       </div>
       <button
@@ -2770,6 +2779,8 @@ function Setup({
   const featureConfig = useFeatureConfig();
   const voiceEnabled = featureConfig?.voiceEnabled !== false;
   const launchAtLoginEnabled = featureConfig?.launchAtLoginEnabled !== false;
+  const autoHidePopoverEnabled =
+    featureConfig?.autoHidePopoverEnabled === true;
   const [providerStatus, setProviderStatus] =
     useState<VoiceProviderStatus | null>(null);
   const [providerStatusLoading, setProviderStatusLoading] = useState(true);
@@ -2793,6 +2804,15 @@ function Setup({
     if (!featureConfig) return;
     invoke("set_feature_config", {
       config: { ...featureConfig, launchAtLoginEnabled: enabled },
+    }).catch((err) =>
+      console.error("[settings] set_feature_config failed", err),
+    );
+  }
+
+  function setAutoHidePopoverEnabled(enabled: boolean) {
+    if (!featureConfig) return;
+    invoke("set_feature_config", {
+      config: { ...featureConfig, autoHidePopoverEnabled: enabled },
     }).catch((err) =>
       console.error("[settings] set_feature_config failed", err),
     );
@@ -3027,6 +3047,20 @@ function Setup({
             on={launchAtLoginEnabled}
             onChange={setLaunchAtLoginEnabled}
             label="Open Clips at login"
+          />
+        </div>
+      </div>
+
+      <div className="setup-section">
+        <div className="setup-toggle-row">
+          <SettingLabel
+            label="Hide when inactive"
+            hint="When off, the Clips window stays open until you close it."
+          />
+          <Switch
+            on={autoHidePopoverEnabled}
+            onChange={setAutoHidePopoverEnabled}
+            label="Hide Clips when focus leaves"
           />
         </div>
       </div>
@@ -3365,6 +3399,10 @@ function shortcutFromKeyboardEvent(event: React.KeyboardEvent): string | null {
   return [...parts, formatShortcutKey(event.key)].join("+");
 }
 
+function hasShortcutModifier(event: React.KeyboardEvent): boolean {
+  return event.metaKey || event.ctrlKey || event.altKey || event.shiftKey;
+}
+
 function ShortcutRecorder({
   value,
   placeholder,
@@ -3384,7 +3422,11 @@ function ShortcutRecorder({
         ref={buttonRef}
         type="button"
         className={`setup-shortcut-recorder ${recording ? "recording" : ""}`}
-        onClick={() => {
+        onClick={(event) => {
+          if (recording) {
+            event.preventDefault();
+            return;
+          }
           setError(null);
           setRecording(true);
           requestAnimationFrame(() => buttonRef.current?.focus());
@@ -3407,12 +3449,21 @@ function ShortcutRecorder({
           }
           const next = shortcutFromKeyboardEvent(event);
           if (!next) {
-            setError("Use at least one modifier plus a key.");
+            setError(
+              event.key === " " && !hasShortcutModifier(event)
+                ? "Space needs Cmd, Ctrl, Option, or Shift so it does not hijack typing."
+                : "Use at least one modifier plus a key.",
+            );
             return;
           }
           onChange(next);
           setRecording(false);
           setError(null);
+        }}
+        onKeyUp={(event) => {
+          if (!recording) return;
+          event.preventDefault();
+          event.stopPropagation();
         }}
       >
         {recording ? "Press shortcut..." : value || placeholder}

--- a/templates/clips/desktop/src/overlays/bubble.tsx
+++ b/templates/clips/desktop/src/overlays/bubble.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { emit, listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { IconCameraOff } from "@tabler/icons-react";
 
 type BubbleSize = "small" | "medium";
 const LOCAL_CAMERA_TARGET_FPS = 60;
@@ -1033,6 +1034,16 @@ export function Bubble() {
         className={`bubble-controls ${showControls ? "is-visible" : ""}`}
         data-no-drag
       >
+        <button
+          type="button"
+          className="bubble-control-button"
+          onClick={onClose}
+          aria-label="Turn camera off"
+          title="Turn camera off"
+          data-no-drag
+        >
+          <IconCameraOff size={14} stroke={2} />
+        </button>
         <button
           type="button"
           className={`bubble-dot bubble-dot-small ${size === "small" ? "is-active" : ""}`}

--- a/templates/clips/desktop/src/shared/config.ts
+++ b/templates/clips/desktop/src/shared/config.ts
@@ -7,6 +7,7 @@ interface FeatureConfig {
   meetingsEnabled: boolean;
   voiceEnabled: boolean;
   launchAtLoginEnabled: boolean;
+  autoHidePopoverEnabled: boolean;
   onboardingComplete: boolean;
 }
 

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -123,7 +123,7 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
 .app-settings {
   gap: 0;
   padding: 0;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 /* Header — logo + mode toggle + close */
@@ -201,7 +201,8 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
+  gap: 5px;
+  min-width: 68px;
   height: 28px;
   border: none;
   background: transparent;
@@ -222,6 +223,13 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   background: var(--bg);
   color: var(--brand);
   box-shadow: var(--shadow-sm);
+}
+
+.mode-label {
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .icon-button {
@@ -1011,8 +1019,8 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  max-height: calc(100vh - 2px);
-  overflow-y: auto;
+  max-height: none;
+  overflow: visible;
   overscroll-behavior: contain;
 }
 
@@ -2000,6 +2008,29 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
   transition:
     background 120ms,
     box-shadow 120ms;
+}
+
+.bubble-control-button {
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.86);
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition:
+    background 120ms,
+    color 120ms;
+}
+
+.bubble-control-button:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
 }
 
 .bubble-dot:hover {

--- a/templates/clips/server/plugins/auth.ts
+++ b/templates/clips/server/plugins/auth.ts
@@ -19,6 +19,7 @@ export default createAuthPlugin({
   },
   publicPaths: [
     "/share",
+    "/r",
     "/embed",
     "/download",
     // React Router's lazy route-discovery endpoint. If this is gated by

--- a/templates/clips/server/routes/[...page].get.ts
+++ b/templates/clips/server/routes/[...page].get.ts
@@ -1,5 +1,12 @@
 import { createH3SSRHandler } from "@agent-native/core/server/ssr-handler";
-import { defineEventHandler, setResponseHeader } from "h3";
+import {
+  defineEventHandler,
+  getRequestURL,
+  setResponseHeader,
+  type H3Event,
+} from "h3";
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import { resolveAccess } from "@agent-native/core/sharing";
 import {
   MEDIA_CAPTURE_PERMISSIONS_POLICY,
   withMediaCapturePermissions,
@@ -9,7 +16,54 @@ const ssrHandler = createH3SSRHandler(
   () => import("virtual:react-router/server-build"),
 );
 
+function recordingIdFromAuthenticatedPath(pathname: string): string | null {
+  const match = pathname.match(/^\/r\/([^/]+)\/?$/);
+  if (!match?.[1]) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+function shareRedirect(recordingId: string, search: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      location: `/share/${encodeURIComponent(recordingId)}${search}`,
+      "Permissions-Policy": MEDIA_CAPTURE_PERMISSIONS_POLICY,
+    },
+  });
+}
+
+async function redirectNonOwnerRecordingPath(
+  event: H3Event,
+): Promise<Response | null> {
+  const url = getRequestURL(event);
+  const recordingId = recordingIdFromAuthenticatedPath(url.pathname);
+  if (!recordingId) return null;
+
+  const session = await getSession(event).catch(() => null);
+  if (!session?.email) return shareRedirect(recordingId, url.search);
+
+  try {
+    const access = await runWithRequestContext(
+      { userEmail: session.email, orgId: session.orgId },
+      () => resolveAccess("recording", recordingId),
+    );
+    if (access.role === "owner") return null;
+  } catch {
+    // Treat missing/inaccessible recordings the same as non-owner access here;
+    // the share route can render the canonical public/not-found state.
+  }
+
+  return shareRedirect(recordingId, url.search);
+}
+
 export default defineEventHandler(async (event) => {
+  const redirect = await redirectNonOwnerRecordingPath(event);
+  if (redirect) return redirect;
+
   const response = (await ssrHandler(event)) as Response;
   setResponseHeader(
     event,

--- a/templates/mail/app/components/layout/AppLayout.tsx
+++ b/templates/mail/app/components/layout/AppLayout.tsx
@@ -1480,26 +1480,26 @@ function AppLayoutInner({ children }: AppLayoutProps) {
           </>
         )}
 
-        <InvitationBanner />
+        <div
+          className={cn(
+            "flex min-h-0 flex-1 flex-col",
+            sidebarPinned && !isMobile && "pl-64",
+          )}
+        >
+          <InvitationBanner />
 
-        {/* Show full-page takeover when no accounts connected (except on settings page) */}
-        {!googleStatus.isLoading &&
-        !googleStatus.isError &&
-        !hasAccounts &&
-        !hasLocalMailboxData &&
-        view !== "settings" &&
-        view !== "draft-queue" ? (
-          <GoogleConnectBanner variant="hero" />
-        ) : (
-          <main
-            className={cn(
-              "flex flex-1 overflow-hidden",
-              sidebarPinned && !isMobile && "pl-64",
-            )}
-          >
-            {children}
-          </main>
-        )}
+          {/* Show full-page takeover when no accounts connected (except on settings page) */}
+          {!googleStatus.isLoading &&
+          !googleStatus.isError &&
+          !hasAccounts &&
+          !hasLocalMailboxData &&
+          view !== "settings" &&
+          view !== "draft-queue" ? (
+            <GoogleConnectBanner variant="hero" />
+          ) : (
+            <main className="flex flex-1 overflow-hidden">{children}</main>
+          )}
+        </div>
       </div>
 
       {(() => {

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -21,8 +21,12 @@ import { IntegrationsSidebar } from "@/components/email/IntegrationsSidebar";
 import { GoogleConnectBanner } from "@/components/GoogleConnectBanner";
 import { useAccountFilter } from "@/hooks/use-account-filter";
 import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
-import { Button } from "@/components/ui/button";
 import type { EmailMessage } from "@shared/types";
+import {
+  isInboxScopedAppLabel,
+  mailLabelMatches,
+  shortMailLabel,
+} from "@shared/gmail-labels";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 
 function ContactPanel({
@@ -79,6 +83,7 @@ function ThreadListSidebar({
   routeSearchSuffix,
   selectedIds,
   setSelectedIds,
+  onNavigateThread,
 }: {
   emails: EmailMessage[];
   activeThreadId: string;
@@ -86,6 +91,7 @@ function ThreadListSidebar({
   routeSearchSuffix: string;
   selectedIds: Set<string>;
   setSelectedIds: React.Dispatch<React.SetStateAction<Set<string>>>;
+  onNavigateThread: (threadId: string) => void;
 }) {
   const navigate = useNavigate();
   const markRead = useMarkRead();
@@ -125,6 +131,7 @@ function ThreadListSidebar({
                     isRead: true,
                     accountEmail: email.accountEmail,
                   });
+                onNavigateThread(threadKey);
                 navigate(`/${view}/${threadKey}${routeSearchSuffix}`);
               }}
               className={cn(
@@ -176,23 +183,34 @@ export function InboxPage() {
     threadId: string;
   }>();
   const navigate = useNavigate();
-  // Immediate thread ID for instant list→thread transition. React Router
-  // wraps navigations in startTransition, which keeps the old list view
-  // visible until the route commits. This local state bypasses that: the
-  // click handler sets it synchronously, so the thread view renders on the
-  // next frame. The URL catches up via navigate() in the background.
-  const [pendingThreadId, setPendingThreadId] = useState<string | undefined>(
-    undefined,
+  // Immediate thread route override. React Router wraps navigations in
+  // startTransition, which can leave the previous route visible until the new
+  // route commits. `undefined` means "use the URL", a string means "show this
+  // thread now", and `null` means "show the list now".
+  const [optimisticThreadId, setOptimisticThreadId] = useState<
+    string | null | undefined
+  >(undefined);
+  const threadId =
+    optimisticThreadId === undefined
+      ? routeThreadId
+      : (optimisticThreadId ?? undefined);
+  const handleOptimisticThreadNavigation = useCallback(
+    (nextThreadId: string | undefined) => {
+      setOptimisticThreadId(nextThreadId ?? null);
+    },
+    [],
   );
-  const threadId = pendingThreadId || routeThreadId;
-  // Clear pending once the route catches up
+  // Clear the override once the URL catches up.
   useEffect(() => {
-    if (routeThreadId === pendingThreadId) setPendingThreadId(undefined);
-  }, [routeThreadId, pendingThreadId]);
-  // Clear pending when going back to list
-  useEffect(() => {
-    if (!routeThreadId) setPendingThreadId(undefined);
-  }, [routeThreadId]);
+    if (optimisticThreadId === undefined) return;
+    if (
+      optimisticThreadId === null
+        ? !routeThreadId
+        : routeThreadId === optimisticThreadId
+    ) {
+      setOptimisticThreadId(undefined);
+    }
+  }, [routeThreadId, optimisticThreadId]);
 
   const [focusedId, setFocusedId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -218,7 +236,7 @@ export function InboxPage() {
     data: rawEmails = [],
     isLoading,
     isError,
-    refetch,
+    error: emailsError,
   } = useEmails(view, searchQuery, activeLabel ?? undefined);
   const googleStatus = useGoogleAuthStatus();
   const { activeAccounts } = useAccountFilter();
@@ -279,20 +297,19 @@ export function InboxPage() {
     }
 
     if (activeLabel) {
-      // Label tab: show threads where the latest message has this label
-      // (mirrors Superhuman behavior — a thread belongs to a label based on its latest message)
-      const shortLabel = activeLabel.includes("/")
-        ? activeLabel
-            .slice(activeLabel.lastIndexOf("/") + 1)
-            .replace(/_/g, " ")
-            .toLowerCase()
-        : activeLabel.toLowerCase();
+      // App triage labels are inbox slices, so the latest message controls
+      // membership. User Gmail labels/folders are archive-like: keep the
+      // conversation if any message in the thread has that label, so filed
+      // customer history doesn't disappear when the latest message differs.
+      const isInboxScopedLabel = isInboxScopedAppLabel(activeLabel);
       const hasLabel = (e: (typeof filtered)[0]) =>
-        e.labelIds.some((l) => l === activeLabel || l === shortLabel);
+        e.labelIds.some((l) => mailLabelMatches(l, activeLabel));
       // Find the latest message per thread
       const latestByThread = new Map<string, (typeof filtered)[0]>();
+      const labelThreadIds = new Set<string>();
       for (const e of filtered) {
         const key = e.threadId || e.id;
+        if (hasLabel(e)) labelThreadIds.add(key);
         const existing = latestByThread.get(key);
         if (!existing || new Date(e.date) > new Date(existing.date)) {
           latestByThread.set(key, e);
@@ -304,19 +321,17 @@ export function InboxPage() {
         activeLabel === "important"
           ? pinnedUserLabels
               .filter((l) => l !== "important")
-              .map((l) =>
-                l.includes("/")
-                  ? l
-                      .slice(l.lastIndexOf("/") + 1)
-                      .replace(/_/g, " ")
-                      .toLowerCase()
-                  : l.toLowerCase(),
-              )
+              .map((l) => shortMailLabel(l))
           : [];
       const qualifiedThreadIds = new Set(
         [...latestByThread.entries()]
-          .filter(([, latest]) => {
-            if (!hasLabel(latest)) return false;
+          .filter(([threadKey, latest]) => {
+            if (
+              isInboxScopedLabel
+                ? !hasLabel(latest)
+                : !labelThreadIds.has(threadKey)
+            )
+              return false;
             // If viewing "important", skip threads that match another pinned tab
             if (
               otherPinnedShorts.length > 0 &&
@@ -332,14 +347,7 @@ export function InboxPage() {
     if (!searchQuery && view === "inbox" && pinnedUserLabels.length > 0) {
       // "Other" is the inbox remainder: messages that do not belong to one of
       // the pinned triage labels.
-      const pinnedShortNames = pinnedUserLabels.map((l) =>
-        l.includes("/")
-          ? l
-              .slice(l.lastIndexOf("/") + 1)
-              .replace(/_/g, " ")
-              .toLowerCase()
-          : l.toLowerCase(),
-      );
+      const pinnedShortNames = pinnedUserLabels.map((l) => shortMailLabel(l));
       return filtered.filter(
         (e) =>
           !e.labelIds.some(
@@ -441,21 +449,22 @@ export function InboxPage() {
     [threads],
   );
 
-  // Safety valve: if pendingThreadId points to a thread that was removed from
+  // Safety valve: if optimisticThreadId points to a thread that was removed from
   // the view (archived/trashed before the route caught up), clear it so the
   // app doesn't get stuck rendering a ghost thread.
   useEffect(() => {
     if (
-      pendingThreadId &&
+      optimisticThreadId &&
       threads.length > 0 &&
       !threads.some(
         (t) =>
-          (t.latestMessage.threadId || t.latestMessage.id) === pendingThreadId,
+          (t.latestMessage.threadId || t.latestMessage.id) ===
+          optimisticThreadId,
       )
     ) {
-      setPendingThreadId(undefined);
+      setOptimisticThreadId(undefined);
     }
-  }, [pendingThreadId, threads]);
+  }, [optimisticThreadId, threads]);
 
   const handleCompose = useCallback(
     (email: EmailMessage, mode: "reply" | "forward") => {
@@ -535,29 +544,19 @@ export function InboxPage() {
   const contactEmailId = threadId ?? focusedId ?? undefined;
 
   // Error state — only show connect banner when Google is definitively not connected.
-  // For transient errors (rate limits, network blips), show a retry message instead.
+  // For transient errors (rate limits, network blips), let EmailList render its
+  // richer retry/cooldown state instead of replacing it with a generic error.
   if (isError && !hasThread && threads.length === 0) {
-    if (!googleStatus.isLoading && googleStatus.data?.connected === false) {
-      return <GoogleConnectBanner variant="hero" />;
-    }
-    if (!googleStatus.isLoading) {
-      return (
-        <div className="flex flex-1 items-center justify-center text-center">
-          <div>
-            <p className="text-sm text-muted-foreground">
-              Failed to load emails
-            </p>
-            <Button
-              variant="outline"
-              size="sm"
-              className="mt-2"
-              onClick={() => refetch()}
-            >
-              Retry
-            </Button>
-          </div>
-        </div>
+    const message = emailsError?.message ?? "";
+    const needsGoogleConnection =
+      /No Google account connected|GOOGLE_CLIENT_ID|GOOGLE_CLIENT_SECRET/i.test(
+        message,
       );
+    if (
+      needsGoogleConnection ||
+      (!googleStatus.isLoading && googleStatus.data?.connected === false)
+    ) {
+      return <GoogleConnectBanner variant="hero" />;
     }
   }
 
@@ -577,6 +576,7 @@ export function InboxPage() {
           routeSearchSuffix={routeSearchSuffix}
           selectedIds={selectedIds}
           setSelectedIds={setSelectedIds}
+          onNavigateThread={handleOptimisticThreadNavigation}
         />
       )}
 
@@ -591,7 +591,7 @@ export function InboxPage() {
             selectedIds={selectedIds}
             setSelectedIds={setSelectedIds}
             onContactSelect={setSidebarContactEmail}
-            onNavigateThread={setPendingThreadId}
+            onNavigateThread={handleOptimisticThreadNavigation}
             isMaximized={isMaximized}
             onToggleMaximize={() => setIsMaximized((v) => !v)}
           />
@@ -605,7 +605,7 @@ export function InboxPage() {
             onCompose={handleCompose}
             onArchived={setLastArchivedId}
             onDraftOpen={handleDraftOpen}
-            onNavigateThread={setPendingThreadId}
+            onNavigateThread={handleOptimisticThreadNavigation}
           />
         )}
       </div>

--- a/templates/mail/app/root.tsx
+++ b/templates/mail/app/root.tsx
@@ -1,4 +1,12 @@
-import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
+import {
+  isRouteErrorResponse,
+  Links,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+  useRouteError,
+} from "react-router";
 import { useEffect, useRef, useState } from "react";
 import {
   QueryClient,
@@ -15,6 +23,7 @@ import { getThemeInitScript } from "@agent-native/core/client";
 import { appApiPath } from "@/lib/api-path";
 import { TAB_ID } from "@/lib/tab-id";
 import { markExternalEmailRefresh } from "@/hooks/use-emails";
+import { Button } from "@/components/ui/button";
 import type { LinksFunction } from "react-router";
 import stylesheet from "./global.css?url";
 import { configureTracking } from "@agent-native/core/client";
@@ -240,4 +249,48 @@ export default function Root() {
   );
 }
 
-export { ErrorBoundary } from "@agent-native/core/client";
+function routeErrorMessage(error: unknown): string {
+  if (isRouteErrorResponse(error)) {
+    if (typeof error.data === "string" && error.data.trim()) {
+      return error.data;
+    }
+    if (
+      error.data &&
+      typeof error.data === "object" &&
+      "message" in error.data &&
+      typeof error.data.message === "string"
+    ) {
+      return error.data.message;
+    }
+    return error.statusText || `Request failed (${error.status})`;
+  }
+  if (error instanceof Error && error.message.trim()) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  return "Something went wrong while loading Mail.";
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const message = routeErrorMessage(error);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-6 text-foreground">
+      <div className="w-full max-w-md text-center">
+        <p className="text-sm font-semibold">Mail could not load this view.</p>
+        <p className="mt-2 text-sm text-muted-foreground">{message}</p>
+        <div className="mt-5 flex justify-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => window.history.back()}
+          >
+            Back
+          </Button>
+          <Button size="sm" onClick={() => window.location.reload()}>
+            Reload
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -49,6 +49,10 @@ import {
 } from "../lib/google-auth.js";
 import { buildGmailEmailSearchQuery } from "../lib/gmail-query.js";
 import {
+  isInboxScopedAppLabel,
+  mailLabelMatches,
+} from "@shared/gmail-labels.js";
+import {
   incrementSendFrequency,
   getContactFrequencyMap,
 } from "../lib/contact-frequency.js";
@@ -373,6 +377,15 @@ function filterInboxScopedMessages(
 ): EmailMessage[] {
   if (view !== "inbox" && view !== "unread") return emails;
 
+  if (label && !isInboxScopedAppLabel(label)) {
+    return emails.filter(
+      (message) =>
+        !message.isDraft &&
+        !message.isTrashed &&
+        (view !== "unread" || !message.isRead),
+    );
+  }
+
   const allowSentToSelf = label?.toLowerCase() === "note-to-self";
   return emails.filter(
     (message) =>
@@ -527,44 +540,58 @@ export const listEmails = defineEventHandler(async (event: H3Event) => {
 
   let emails = await readEmails(email);
 
-  // Filter by view
-  switch (view) {
-    case "inbox":
-      emails = emails.filter(
-        (e) => !e.isArchived && !e.isTrashed && !e.isDraft && !e.isSent,
-      );
-      break;
-    case "unread":
-      emails = emails.filter(
-        (e) =>
-          !e.isRead && !e.isArchived && !e.isTrashed && !e.isDraft && !e.isSent,
-      );
-      break;
-    case "starred":
-      emails = emails.filter((e) => e.isStarred && !e.isTrashed);
-      break;
-    case "sent":
-      emails = emails.filter((e) => e.isSent && !e.isTrashed);
-      break;
-    case "drafts":
-      emails = emails.filter((e) => e.isDraft);
-      break;
-    case "archive":
-      emails = emails.filter((e) => e.isArchived && !e.isTrashed);
-      break;
-    case "trash":
-      emails = emails.filter((e) => e.isTrashed);
-      break;
-    case "all":
-      break;
-    default:
-      // label: prefixed or raw label id
-      const labelId = view.startsWith("label:")
-        ? view.replace("label:", "")
-        : view;
-      emails = emails.filter(
-        (e) => e.labelIds.includes(labelId) && !e.isTrashed,
-      );
+  if (label && (view === "inbox" || view === "unread")) {
+    emails = emails.filter(
+      (e) =>
+        e.labelIds.some((labelId) => mailLabelMatches(labelId, label)) &&
+        !e.isDraft &&
+        !e.isTrashed &&
+        (view !== "unread" || !e.isRead),
+    );
+  } else {
+    // Filter by view
+    switch (view) {
+      case "inbox":
+        emails = emails.filter(
+          (e) => !e.isArchived && !e.isTrashed && !e.isDraft && !e.isSent,
+        );
+        break;
+      case "unread":
+        emails = emails.filter(
+          (e) =>
+            !e.isRead &&
+            !e.isArchived &&
+            !e.isTrashed &&
+            !e.isDraft &&
+            !e.isSent,
+        );
+        break;
+      case "starred":
+        emails = emails.filter((e) => e.isStarred && !e.isTrashed);
+        break;
+      case "sent":
+        emails = emails.filter((e) => e.isSent && !e.isTrashed);
+        break;
+      case "drafts":
+        emails = emails.filter((e) => e.isDraft);
+        break;
+      case "archive":
+        emails = emails.filter((e) => e.isArchived && !e.isTrashed);
+        break;
+      case "trash":
+        emails = emails.filter((e) => e.isTrashed);
+        break;
+      case "all":
+        break;
+      default:
+        // label: prefixed or raw label id
+        const labelId = view.startsWith("label:")
+          ? view.replace("label:", "")
+          : view;
+        emails = emails.filter(
+          (e) => e.labelIds.includes(labelId) && !e.isTrashed,
+        );
+    }
   }
 
   // Full-text search

--- a/templates/mail/server/lib/gmail-query.spec.ts
+++ b/templates/mail/server/lib/gmail-query.spec.ts
@@ -23,14 +23,24 @@ describe("buildGmailEmailSearchQuery", () => {
     );
   });
 
-  it("scopes inbox label tabs to inbox results", () => {
+  it("keeps user label tabs unscoped so filed history appears", () => {
     expect(
       buildGmailEmailSearchQuery({
         view: "inbox",
         label: "customer success",
         q: "renewal",
       }),
-    ).toBe("in:inbox -in:sent label:customer-success renewal");
+    ).toBe("label:customer-success renewal");
+  });
+
+  it("scopes unread user label tabs to unread results without requiring inbox", () => {
+    expect(
+      buildGmailEmailSearchQuery({
+        view: "unread",
+        label: "customer success",
+        q: "renewal",
+      }),
+    ).toBe("is:unread label:customer-success renewal");
   });
 
   it("keeps all-mail label searches unscoped", () => {

--- a/templates/mail/server/lib/gmail-query.ts
+++ b/templates/mail/server/lib/gmail-query.ts
@@ -1,3 +1,5 @@
+import { isInboxScopedAppLabel } from "@shared/gmail-labels.js";
+
 export const VIEW_QUERIES: Record<string, string> = {
   inbox: "in:inbox -in:sent",
   unread: "is:unread in:inbox -in:sent",
@@ -34,6 +36,11 @@ export function gmailAppLabelSearchClause(label: string): string {
 
 function viewSearchClauseForLabelTab(view: string, label: string): string {
   if (view === "all") return "";
+  if (!isInboxScopedAppLabel(label)) {
+    if (view === "unread") return "is:unread";
+    if (view === "archive" || view === "trash") return VIEW_QUERIES[view];
+    return "";
+  }
   if (view === "inbox" && label.toLowerCase() === "note-to-self") {
     // Self-sent notes can carry both INBOX and SENT. Keep them in this inbox
     // tab while still excluding sent-only/archive-only results.

--- a/templates/mail/shared/gmail-labels.ts
+++ b/templates/mail/shared/gmail-labels.ts
@@ -1,0 +1,36 @@
+export function normalizeMailLabel(value: string): string {
+  return value.trim().replace(/_/g, " ").toLowerCase();
+}
+
+export function shortMailLabel(value: string): string {
+  const normalized = normalizeMailLabel(value);
+  const lastSlash = normalized.lastIndexOf("/");
+  return lastSlash >= 0 ? normalized.slice(lastSlash + 1) : normalized;
+}
+
+export function mailLabelMatches(candidate: string, target: string): boolean {
+  const normalizedCandidate = normalizeMailLabel(candidate);
+  const normalizedTarget = normalizeMailLabel(target);
+  return (
+    normalizedCandidate === normalizedTarget ||
+    shortMailLabel(normalizedCandidate) === normalizedTarget ||
+    normalizedCandidate === shortMailLabel(normalizedTarget)
+  );
+}
+
+const INBOX_SCOPED_APP_LABEL_IDS = new Set([
+  "important",
+  "note-to-self",
+  "personal",
+  "social",
+  "updates",
+  "promotions",
+  "forums",
+]);
+
+export function isInboxScopedAppLabel(
+  label: string | null | undefined,
+): boolean {
+  if (!label) return false;
+  return INBOX_SCOPED_APP_LABEL_IDS.has(normalizeMailLabel(label));
+}


### PR DESCRIPTION
## Summary

- **AI SDK Responses for first-party OpenAI** — drop the unconditional `provider.chat(model)` rewrite. The AI SDK's default openai entrypoint goes through Responses (recommended for GPT-5 reasoning models); we keep `chat()` only when the user pointed the openai provider at a custom baseUrl (OpenRouter/Groq/Together — most don't implement Responses). New ai-sdk-engine spec covers both branches.
- **Async `onRunStart`** — `ProductionAgentOptions.onRunStart` now allows `Promise<void>`, awaited before engine resolution. Lets the plugin layer thread parent-run choices into sub-agents without racing.
- **Checkpoints `getUncommittedStatus()`** — split out from `hasUncommittedChanges()` so callers that want the raw porcelain (file list for "you have N uncommitted files" UX) reuse one git invocation.
- **Clips library view: cross-org owner-visible** — drop the global `organizationId` clause from list-recordings library view. `accessFilter` already org-scopes shared rows correctly, so the extra clause was hiding the user's own personal clips when they joined a new org. Space view keeps org-scoping (where spaceId is meaningless across orgs).
- **Clips tray "Stop recording"** — new tray menu item between Show popover and Toggle DevTools; click emits `clips:recorder-stop`. Lets the user halt a screen capture without focusing the popover (useful when fullscreen recording covers it).
- **Gmail label scoping module** — new `templates/mail/shared/gmail-labels.ts` centralizes `normalizeMailLabel`, `shortMailLabel`, `mailLabelMatches`, `isInboxScopedAppLabel`. Server query builder, client filtering, and rendering now agree. Label-tab queries no longer force `in:inbox` for non-inbox-scoped labels (so opening a label tab on Receipts shows everything tagged Receipts, not just inbox-Receipts). Spec coverage.
- **Mail UX**: route `ErrorBoundary` in root.tsx so server 5xx don't blank the page; AppLayout sidebar-pinned offset is now a single flex column wrapping the InvitationBanner + main body so the banner doesn't sit behind the pinned sidebar.

## Test plan

- [ ] CI: Build, Lint, Test, Typecheck (Scaffold E2E informational)
- [ ] Manual: agent chat with OpenAI BYOK uses Responses; OpenAI provider with custom baseUrl still uses chat()
- [ ] Manual: clips library view shows the user's personal recordings even after joining a fresh org
- [ ] Manual: open a non-inbox-scoped Gmail label tab and confirm sent/archive results appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)