### PR TITLE
fix: clips failing to start recordings

### DIFF
--- a/templates/clips/actions/create-recording.ts
+++ b/templates/clips/actions/create-recording.ts
@@ -47,13 +47,13 @@ export default defineAction({
       .string()
       .trim()
       .max(200)
-      .optional()
+      .nullish()
       .describe("Captured application name, when known"),
     sourceWindowTitle: z
       .string()
       .trim()
       .max(500)
-      .optional()
+      .nullish()
       .describe("Captured window or browser tab title, when known"),
     folderId: z.string().nullish().describe("Optional folder ID"),
     organizationId: z


### PR DESCRIPTION
This PR will:
- fix the issue that it's not possible to start the recording in clips
- The issue is that the FE was sending `null` for sourceAppName and sourceWindowTitle, but the `.optional` property doesn't allow that