### PR TITLE
refactor(clips): queue title helper + shared transcript segments + concurrent sweeps

### DIFF
--- a/.changeset/calm-feedback-polish.md
+++ b/.changeset/calm-feedback-polish.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Polish setup, navigation, editor, and feedback affordances from user feedback.

--- a/.changeset/chat-attachments-recovery.md
+++ b/.changeset/chat-attachments-recovery.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Preserve chat attachments and completed history during interrupted-run recovery.

--- a/.changeset/fresh-panel-presence.md
+++ b/.changeset/fresh-panel-presence.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix stale collaboration presence cleanup, stale run handling, and agent panel recovery.

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -233,4 +233,53 @@ describe("buildAssistantMessage", () => {
       content: [{ type: "text", text: "New answer." }],
     });
   });
+
+  it("does not replace a completed different-run answer with a prefix-matching recovery answer", () => {
+    const finalMessage = buildAssistantMessage(
+      [
+        {
+          seq: 0,
+          event: {
+            type: "text",
+            text: "Let me start a subagent to analyze the data. Finished.",
+          },
+        },
+        { seq: 1, event: { type: "done" } },
+      ],
+      "run-new",
+    );
+    expect(finalMessage).not.toBeNull();
+
+    const repo = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Let me start a subagent to analyze the data.",
+            },
+          ],
+          status: { type: "complete", reason: "stop" },
+          metadata: { runId: "run-old" },
+        },
+      ],
+    };
+
+    const updated = upsertAssistantMessage(repo, finalMessage!);
+
+    expect(updated.messages).toHaveLength(2);
+    expect(updated.messages[0]).toMatchObject({
+      metadata: { runId: "run-old" },
+    });
+    expect(updated.messages[1]).toMatchObject({
+      id: "server-run-new",
+      content: [
+        {
+          type: "text",
+          text: "Let me start a subagent to analyze the data. Finished.",
+        },
+      ],
+    });
+  });
 });

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildAssistantMessage,
+  mergeThreadDataForClientSave,
   upsertAssistantMessage,
 } from "./thread-data-builder.js";
 import type { RunEvent } from "./types.js";
@@ -281,5 +282,70 @@ describe("buildAssistantMessage", () => {
         },
       ],
     });
+  });
+});
+
+describe("mergeThreadDataForClientSave", () => {
+  it("preserves server-only assistant messages when a stale client save arrives", () => {
+    const existing = {
+      queuedMessages: [{ id: "queued", text: "next" }],
+      messages: [
+        {
+          role: "user",
+          id: "user-1",
+          content: [{ type: "text", text: "start" }],
+        },
+        {
+          role: "assistant",
+          id: "server-run-1",
+          content: [{ type: "text", text: "server answer" }],
+          status: { type: "complete", reason: "stop" },
+          metadata: { runId: "run-1" },
+        },
+      ],
+    };
+    const staleIncoming = {
+      messages: [
+        {
+          role: "user",
+          id: "user-1",
+          content: [{ type: "text", text: "start" }],
+        },
+      ],
+    };
+
+    const merged = mergeThreadDataForClientSave(existing, staleIncoming);
+
+    expect(merged.queuedMessages).toEqual([{ id: "queued", text: "next" }]);
+    expect(merged.messages).toEqual(existing.messages);
+  });
+
+  it("keeps a terminal server message over a stale same-run partial", () => {
+    const existing = {
+      messages: [
+        {
+          role: "assistant",
+          id: "server-run-1",
+          content: [{ type: "text", text: "Final answer" }],
+          status: { type: "complete", reason: "stop" },
+          metadata: { runId: "run-1" },
+        },
+      ],
+    };
+    const staleIncoming = {
+      messages: [
+        {
+          role: "assistant",
+          id: "assistant-partial",
+          content: [{ type: "text", text: "Final" }],
+          status: { type: "running" },
+          metadata: { custom: { runId: "run-1" } },
+        },
+      ],
+    };
+
+    const merged = mergeThreadDataForClientSave(existing, staleIncoming);
+
+    expect(merged.messages).toEqual(existing.messages);
   });
 });

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -232,6 +232,104 @@ function isTerminalAssistantStatus(status: unknown): boolean {
   return type === "complete" || type === "incomplete";
 }
 
+function messageIdentityKeys(message: any): string[] {
+  const keys: string[] = [];
+  if (typeof message?.id === "string" && message.id) {
+    keys.push(`id:${message.id}`);
+  }
+  const runId = getMessageRunId(message);
+  if (runId) keys.push(`run:${runId}`);
+
+  try {
+    keys.push(
+      `fingerprint:${JSON.stringify({
+        role: message?.role,
+        content: message?.content,
+        attachments: message?.attachments,
+      })}`,
+    );
+  } catch {
+    // Best effort. id/runId usually exist for persisted assistant-ui rows.
+  }
+  return keys;
+}
+
+function chooseMergedMessageEntry(existingEntry: any, incomingEntry: any): any {
+  const existing = getStoredMessage(existingEntry);
+  const incoming = getStoredMessage(incomingEntry);
+  if (
+    existing?.role === "assistant" &&
+    incoming?.role === "assistant" &&
+    isTerminalAssistantStatus(existing?.status) &&
+    !isTerminalAssistantStatus(incoming?.status)
+  ) {
+    return existingEntry;
+  }
+  return incomingEntry;
+}
+
+/**
+ * Merge an incoming client-side full-thread save over the current SQL copy.
+ *
+ * The browser exports and PUTs the whole assistant-ui repository. If a server
+ * completion save lands first, an older browser export can otherwise replace
+ * `thread_data` wholesale and delete the assistant message the server just
+ * reconstructed from run events. Preserve server-only messages while still
+ * accepting client-only messages and metadata.
+ */
+export function mergeThreadDataForClientSave(existingRepo: any, incomingRepo: any) {
+  const merged =
+    incomingRepo && typeof incomingRepo === "object" ? incomingRepo : {};
+  if (
+    existingRepo &&
+    typeof existingRepo === "object" &&
+    existingRepo.queuedMessages !== undefined &&
+    merged.queuedMessages === undefined
+  ) {
+    merged.queuedMessages = existingRepo.queuedMessages;
+  }
+
+  const existingMessages = Array.isArray(existingRepo?.messages)
+    ? existingRepo.messages
+    : null;
+  const incomingMessages = Array.isArray(merged.messages)
+    ? merged.messages
+    : null;
+  if (!existingMessages || !incomingMessages) return merged;
+
+  const incomingKeySets = incomingMessages.map((entry: any) =>
+    new Set(messageIdentityKeys(getStoredMessage(entry))),
+  );
+  const usedIncoming = new Set<number>();
+  const nextMessages: any[] = [];
+
+  for (const existingEntry of existingMessages) {
+    const existingKeys = messageIdentityKeys(getStoredMessage(existingEntry));
+    const incomingIndex = incomingKeySets.findIndex(
+      (keys, index) =>
+        !usedIncoming.has(index) &&
+        existingKeys.some((key) => keys.has(key)),
+    );
+
+    if (incomingIndex === -1) {
+      nextMessages.push(existingEntry);
+      continue;
+    }
+
+    usedIncoming.add(incomingIndex);
+    nextMessages.push(
+      chooseMergedMessageEntry(existingEntry, incomingMessages[incomingIndex]),
+    );
+  }
+
+  for (let index = 0; index < incomingMessages.length; index++) {
+    if (!usedIncoming.has(index)) nextMessages.push(incomingMessages[index]);
+  }
+
+  merged.messages = nextMessages;
+  return merged;
+}
+
 function shouldReplaceLastAssistant(
   lastMessage: any,
   assistantMsg: AssistantMessage,

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -242,6 +242,7 @@ function shouldReplaceLastAssistant(
   const lastRunId = getMessageRunId(lastMessage);
   const nextRunId = getMessageRunId(assistantMsg);
   if (lastRunId && nextRunId && lastRunId === nextRunId) return true;
+  if (lastRunId && nextRunId && lastRunId !== nextRunId) return false;
 
   const lastStatus = lastMessage?.status;
   if (lastStatus && !isTerminalAssistantStatus(lastStatus)) return true;
@@ -256,6 +257,7 @@ function shouldReplaceLastAssistant(
 
   const lastText = messageText(lastContent).trim();
   const nextText = messageText(assistantMsg.content).trim();
+  if (isTerminalAssistantStatus(lastStatus)) return false;
   return Boolean(lastText && nextText && nextText.startsWith(lastText));
 }
 

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -277,7 +277,10 @@ function chooseMergedMessageEntry(existingEntry: any, incomingEntry: any): any {
  * reconstructed from run events. Preserve server-only messages while still
  * accepting client-only messages and metadata.
  */
-export function mergeThreadDataForClientSave(existingRepo: any, incomingRepo: any) {
+export function mergeThreadDataForClientSave(
+  existingRepo: any,
+  incomingRepo: any,
+) {
   const merged =
     incomingRepo && typeof incomingRepo === "object" ? incomingRepo : {};
   if (
@@ -297,8 +300,8 @@ export function mergeThreadDataForClientSave(existingRepo: any, incomingRepo: an
     : null;
   if (!existingMessages || !incomingMessages) return merged;
 
-  const incomingKeySets = incomingMessages.map((entry: any) =>
-    new Set(messageIdentityKeys(getStoredMessage(entry))),
+  const incomingKeySets = incomingMessages.map(
+    (entry: any) => new Set(messageIdentityKeys(getStoredMessage(entry))),
   );
   const usedIncoming = new Set<number>();
   const nextMessages: any[] = [];
@@ -307,8 +310,7 @@ export function mergeThreadDataForClientSave(existingRepo: any, incomingRepo: an
     const existingKeys = messageIdentityKeys(getStoredMessage(existingEntry));
     const incomingIndex = incomingKeySets.findIndex(
       (keys, index) =>
-        !usedIncoming.has(index) &&
-        existingKeys.some((key) => keys.has(key)),
+        !usedIncoming.has(index) && existingKeys.some((key) => keys.has(key)),
     );
 
     if (incomingIndex === -1) {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -87,6 +87,11 @@ export interface AgentChatAttachment {
 
 export interface AgentChatRequest {
   message: string;
+  /**
+   * User-visible text to persist in chat history. `message` may be normalized
+   * for the model (for example mention markup or internal continuation text).
+   */
+  displayMessage?: string;
   history?: AgentMessage[];
   /**
    * Provider-neutral transcript used for run recovery. Unlike `history`,
@@ -97,6 +102,8 @@ export interface AgentChatRequest {
   references?: AgentChatReference[];
   threadId?: string;
   attachments?: AgentChatAttachment[];
+  /** Internal retry/continuation requests should not create visible user turns. */
+  internalContinuation?: boolean;
   /** Execution mode for this turn. Plan mode is read-only and proposes before acting. */
   mode?: "act" | "plan";
   /** Per-request model override (ephemeral, from the composer model picker). */

--- a/packages/core/src/cli/create.ts
+++ b/packages/core/src/cli/create.ts
@@ -184,7 +184,7 @@ async function createWorkspaceInteractive(
 
   const s = clack.spinner();
   s.start(
-    `Preparing env... scaffolding workspace with ${templates.length} app(s).`,
+    `Working... no action needed. Scaffolding workspace with ${templates.length} app(s).`,
   );
 
   const firstApp = templates[0];
@@ -387,7 +387,9 @@ async function scaffoldOneAppIntoWorkspace(
   }
 
   const s = clack.spinner();
-  s.start(`Preparing env... scaffolding apps/${appName} from ${templateName}.`);
+  s.start(
+    `Working... no action needed. Scaffolding apps/${appName} from ${templateName}.`,
+  );
 
   try {
     await scaffoldAppTemplate(appDir, templateName);
@@ -476,7 +478,7 @@ async function createStandaloneApp(
   }
 
   const s = clack.spinner();
-  s.start("Preparing env... scaffolding your app.");
+  s.start("Working... no action needed. Scaffolding your app.");
   try {
     await scaffoldAppTemplate(targetDir, template);
     postProcessStandalone(name, targetDir, template);

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1639,9 +1639,16 @@ class AgentPanelErrorBoundary extends React.Component<
 
 export function AgentPanel(props: AgentPanelProps) {
   const [resetKey, setResetKey] = useState(0);
+  const resetPanel = useCallback(() => {
+    try {
+      const keyPrefix = props.storageKey ? `:${props.storageKey}` : "";
+      localStorage.setItem(`agent-native-panel-mode${keyPrefix}`, "chat");
+    } catch {}
+    setResetKey((key) => key + 1);
+  }, [props.storageKey]);
   return (
     <TooltipProvider delayDuration={200}>
-      <AgentPanelErrorBoundary onReset={() => setResetKey((key) => key + 1)}>
+      <AgentPanelErrorBoundary onReset={resetPanel}>
         <AgentPanelInner key={resetKey} {...props} />
       </AgentPanelErrorBoundary>
     </TooltipProvider>

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2882,7 +2882,6 @@ const AssistantChatInner = forwardRef<
 
     const repo = threadRuntime.export();
     const { title, preview } = extractThreadMeta(repo);
-    if (!title) return;
 
     lastSaveTimeRef.current = now;
     savedTitleRef.current = title;

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2452,6 +2452,7 @@ const AssistantChatInner = forwardRef<
   const [authError, setAuthError] = useState<{
     sessionExpired?: boolean;
   } | null>(null);
+  const [authSessionAvailable, setAuthSessionAvailable] = useState(false);
   const [queuedMessages, setQueuedMessages] = useState<
     Array<{
       id: string;
@@ -3008,6 +3009,24 @@ const AssistantChatInner = forwardRef<
   }, []);
 
   // Listen for auth error events from the adapter
+  const checkAuthSession = useCallback(async () => {
+    try {
+      const res = await fetch(agentNativePath("/_agent-native/auth/session"), {
+        cache: "no-store",
+      });
+      if (!res.ok) return false;
+      const data = await res.json().catch(() => null);
+      const hasSession = !!data && !data.error;
+      setAuthSessionAvailable(hasSession);
+      if (hasSession) {
+        setAuthError(null);
+      }
+      return hasSession;
+    } catch {
+      return false;
+    }
+  }, []);
+
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent).detail as
@@ -3028,11 +3047,26 @@ const AssistantChatInner = forwardRef<
       ) {
         return;
       }
+      setAuthSessionAvailable(false);
       setAuthError({ sessionExpired: detail?.reason === "session-expired" });
+      void checkAuthSession();
     };
     window.addEventListener("agent-chat:auth-error", handler);
     return () => window.removeEventListener("agent-chat:auth-error", handler);
-  }, [tabId, threadId]);
+  }, [checkAuthSession, tabId, threadId]);
+
+  useEffect(() => {
+    if (!authError) return;
+    const handler = () => void checkAuthSession();
+    const timer = window.setTimeout(handler, 250);
+    window.addEventListener("focus", handler);
+    window.addEventListener("agent-engine:configured-changed", handler);
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("focus", handler);
+      window.removeEventListener("agent-engine:configured-changed", handler);
+    };
+  }, [authError, checkAuthSession]);
 
   // Listen for loop-limit events from the adapter
   useEffect(() => {
@@ -3443,18 +3477,22 @@ const AssistantChatInner = forwardRef<
                   </div>
                   <div className="text-center max-w-[280px]">
                     <p className="text-sm font-medium text-foreground mb-1">
-                      {authError.sessionExpired
-                        ? "Session expired"
-                        : "Authentication required"}
+                      {authSessionAvailable
+                        ? "Chat session needs refresh"
+                        : authError.sessionExpired
+                          ? "Session expired"
+                          : "Authentication required"}
                     </p>
                     <p className="text-xs text-muted-foreground leading-relaxed">
-                      {authError.sessionExpired
-                        ? "Your session may have expired. Log out and log back in to reconnect."
-                        : "You need to log in to use the agent."}
+                      {authSessionAvailable
+                        ? "You're signed in, but this chat connection needs to reconnect."
+                        : authError.sessionExpired
+                          ? "Your session may have expired. Log out and log back in to reconnect."
+                          : "You need to log in to use the agent."}
                     </p>
                   </div>
                   <div className="flex gap-2">
-                    {!authError.sessionExpired && (
+                    {!authError.sessionExpired && !authSessionAvailable && (
                       <button
                         onClick={() => {
                           const ret =
@@ -3468,7 +3506,7 @@ const AssistantChatInner = forwardRef<
                         Log in
                       </button>
                     )}
-                    {authError.sessionExpired && (
+                    {authError.sessionExpired && !authSessionAvailable && (
                       <button
                         onClick={async () => {
                           try {
@@ -3491,9 +3529,13 @@ const AssistantChatInner = forwardRef<
                         setAuthError(null);
                         window.location.reload();
                       }}
-                      className="text-xs text-muted-foreground hover:text-foreground px-3 py-1.5 rounded-md border border-border hover:bg-accent"
+                      className={
+                        authSessionAvailable
+                          ? "text-xs text-background bg-foreground hover:opacity-90 px-3 py-1.5 rounded-md"
+                          : "text-xs text-muted-foreground hover:text-foreground px-3 py-1.5 rounded-md border border-border hover:bg-accent"
+                      }
                     >
-                      Retry
+                      Refresh chat
                     </button>
                   </div>
                 </div>

--- a/packages/core/src/client/ErrorBoundary.tsx
+++ b/packages/core/src/client/ErrorBoundary.tsx
@@ -43,7 +43,9 @@ function ErrorScreen({
     status = error.status;
     if (error.status === 404) {
       title = "Page not found";
-      details = "This page doesn’t exist. It may have been moved or deleted.";
+      const path =
+        typeof window !== "undefined" ? window.location.pathname : "this path";
+      details = `The app does not define a route for ${path}. If this should be a workspace app, make sure it is added and enabled in Dispatch; if it is a new screen, it may need to be shipped first.`;
     } else {
       title = `${error.status} Error`;
       details = error.statusText || details;
@@ -91,6 +93,13 @@ function ErrorScreen({
             Go home
           </a>
         )}
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="mt-3 inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground shadow-sm hover:bg-accent"
+        >
+          Reload
+        </button>
         {stack && (
           <pre className="mt-6 w-full text-left text-xs overflow-auto p-4 bg-muted rounded">
             <code>{stack}</code>

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -406,6 +406,76 @@ describe("createAgentChatAdapter", () => {
     ]);
   });
 
+  it("includes prior-turn text attachments in chat history", async () => {
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(sseResponse([{ type: "done" }]));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-history-attachments",
+    });
+
+    await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "" }],
+            attachments: [
+              {
+                name: "prior-transcript.txt",
+                contentType: "text/plain",
+                content: [
+                  {
+                    type: "file",
+                    data: "data:text/plain;base64,Q3VzdG9tZXIgY2FsbCBub3Rlcw==",
+                    mimeType: "text/plain",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "I read the transcript." }],
+          },
+          {
+            role: "user",
+            content: [{ type: "text", text: "What were the next steps?" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.history[0].content).toContain(
+      '<attachment name="prior-transcript.txt" contentType="text/plain" type="file">',
+    );
+    expect(body.history[0].content).toContain("Customer call notes");
+    expect(body.structuredHistory[0]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: expect.stringContaining("Customer call notes"),
+        },
+      ],
+    });
+  });
+
   it("treats authentication failures as auth errors, not AI setup", async () => {
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -312,6 +312,100 @@ describe("createAgentChatAdapter", () => {
     ]);
   });
 
+  it("keeps attachments and references when auto-continuing an interrupted attachment turn", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("window", { dispatchEvent: vi.fn() });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        sseResponse([
+          { type: "text", text: "I found 700 readings." },
+          {
+            type: "error",
+            error: "The worker was interrupted.",
+            errorCode: "stale_run",
+            recoverable: true,
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        sseResponse([{ type: "text", text: "finished" }, { type: "done" }]),
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-attachment-recovery",
+      threadId: "thread-attachment-recovery",
+    });
+
+    const promise = drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "" }],
+            attachments: [
+              {
+                name: "readings.csv",
+                contentType: "text/csv",
+                content: [{ type: "text", text: "time,value\n1,42" }],
+              },
+            ],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+        runConfig: {
+          custom: {
+            references: [
+              {
+                type: "file",
+                path: "scripts/import-readings.ts",
+                name: "import-readings.ts",
+                source: "codebase",
+              },
+            ],
+          },
+        },
+      } as any),
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(fetchSpy.mock.calls[1][1].body);
+    expect(secondBody.message).toContain("Continue from where you left off");
+    expect(secondBody.attachments).toEqual([
+      {
+        type: "file",
+        name: "readings.csv",
+        contentType: "text/csv",
+        text: "time,value\n1,42",
+      },
+    ]);
+    expect(secondBody.references).toEqual([
+      {
+        type: "file",
+        path: "scripts/import-readings.ts",
+        name: "import-readings.ts",
+        source: "codebase",
+      },
+    ]);
+  });
+
   it("treats authentication failures as auth errors, not AI setup", async () => {
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -24,6 +24,20 @@ type AdapterHistoryMessage = {
   content: string;
 };
 
+type AssistantUiAttachment = {
+  name: string;
+  contentType?: string;
+  content: readonly Record<string, unknown>[];
+};
+
+type AgentChatAdapterAttachment = {
+  type: string;
+  name: string;
+  contentType?: string;
+  data?: string;
+  text?: string;
+};
+
 const TEXT_ATTACHMENT_CONTENT_TYPES = new Set([
   "application/json",
   "application/x-ndjson",
@@ -45,6 +59,7 @@ const MAX_STALLED_TRANSIENT_CONTINUATIONS = 8;
 const MAX_TOTAL_TRANSIENT_CONTINUATIONS = 32;
 const RETRY_BASE_DELAY_MS = 500;
 const RETRY_MAX_DELAY_MS = 8_000;
+const MAX_HISTORY_ATTACHMENT_CHARS = 60_000;
 
 function normalizeMentions(text: string): string {
   return text.replace(/@\[([^\]|]+)\|[^\]]+\]/g, "@$1");
@@ -85,6 +100,14 @@ function messageTextFromContent(
     .join("\n");
 }
 
+function escapeAttachmentAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 function isTextAttachmentContentType(value: string | undefined): boolean {
   if (!value) return false;
   const contentType = value.split(";")[0]?.trim().toLowerCase();
@@ -118,6 +141,88 @@ function decodeTextDataUrl(dataUrl: string): string | null {
   } catch {
     return null;
   }
+}
+
+function extractAttachmentsFromMessage(message: {
+  attachments?: readonly AssistantUiAttachment[];
+}): AgentChatAdapterAttachment[] {
+  const attachments: AgentChatAdapterAttachment[] = [];
+  for (const att of message.attachments ?? []) {
+    for (const part of att.content) {
+      if (part.type === "image" && typeof part.image === "string") {
+        attachments.push({
+          type: "image",
+          name: att.name,
+          contentType: att.contentType,
+          data: part.image,
+        });
+      } else if (part.type === "file" && typeof part.data === "string") {
+        const contentType =
+          att.contentType ??
+          (typeof part.mimeType === "string" ? part.mimeType : undefined);
+        const decodedText = part.data.startsWith("data:")
+          ? decodeTextDataUrl(part.data)
+          : null;
+        attachments.push({
+          type: "file",
+          name: att.name,
+          contentType,
+          ...(decodedText !== null
+            ? { text: decodedText }
+            : part.data.startsWith("data:")
+              ? { data: part.data }
+              : { text: part.data }),
+        });
+      } else if (part.type === "text" && typeof part.text === "string") {
+        attachments.push({
+          type: "file",
+          name: att.name,
+          contentType: att.contentType,
+          text: unwrapAttachmentEnvelope(part.text),
+        });
+      }
+    }
+  }
+  return attachments;
+}
+
+function truncateHistoryAttachment(text: string): string {
+  if (text.length <= MAX_HISTORY_ATTACHMENT_CHARS) return text;
+  const omitted = text.length - MAX_HISTORY_ATTACHMENT_CHARS;
+  return `${text.slice(0, MAX_HISTORY_ATTACHMENT_CHARS)}\n\n[Attachment truncated after ${MAX_HISTORY_ATTACHMENT_CHARS.toLocaleString()} characters; ${omitted.toLocaleString()} characters omitted from prior chat history.]`;
+}
+
+function attachmentHistoryText(
+  attachment: AgentChatAdapterAttachment,
+): string | null {
+  if (typeof attachment.text === "string" && attachment.text.length > 0) {
+    const attrs = [
+      `name="${escapeAttachmentAttribute(attachment.name || "attachment")}"`,
+      attachment.contentType
+        ? `contentType="${escapeAttachmentAttribute(attachment.contentType)}"`
+        : null,
+      attachment.type
+        ? `type="${escapeAttachmentAttribute(attachment.type)}"`
+        : null,
+    ].filter(Boolean);
+    return `<attachment ${attrs.join(" ")}>\n${truncateHistoryAttachment(attachment.text)}\n</attachment>`;
+  }
+
+  if (attachment.name) {
+    return `[Attached ${attachment.type || "file"}: ${attachment.name}${attachment.contentType ? ` (${attachment.contentType})` : ""}]`;
+  }
+  return null;
+}
+
+function messageTextForHistory(message: {
+  content: readonly { type: string; text?: string }[];
+  attachments?: readonly AssistantUiAttachment[];
+}): string {
+  const text = messageTextFromContent(message.content);
+  const attachments = extractAttachmentsFromMessage(message)
+    .map(attachmentHistoryText)
+    .filter((part): part is string => !!part && part.trim().length > 0);
+  return [text, ...attachments].filter((part) => part.trim()).join("\n\n");
 }
 
 function isToolCallContentPart(
@@ -194,6 +299,7 @@ function assistantUiMessagesToStructuredHistory(
   messages: readonly {
     role: string;
     content: readonly any[];
+    attachments?: readonly AssistantUiAttachment[];
   }[],
 ): AgentChatStructuredMessage[] {
   let nextId = 0;
@@ -202,7 +308,7 @@ function assistantUiMessagesToStructuredHistory(
 
   for (const message of messages) {
     if (message.role === "user") {
-      const text = messageTextFromContent(message.content);
+      const text = messageTextForHistory(message);
       if (text.trim()) {
         structured.push({
           role: "user",
@@ -471,60 +577,9 @@ export function createAgentChatAdapter(options?: {
       // Extract attachments (images as base64, text as content).
       // assistant-ui puts user attachments on msg.attachments (not on content);
       // each attachment carries its own content parts from the adapter.
-      const attachments: {
-        type: string;
-        name: string;
-        contentType?: string;
-        data?: string;
-        text?: string;
-      }[] = [];
-      if (lastUserMsg && "attachments" in lastUserMsg) {
-        const msgAttachments = (
-          lastUserMsg as {
-            attachments?: readonly {
-              name: string;
-              contentType?: string;
-              content: readonly Record<string, unknown>[];
-            }[];
-          }
-        ).attachments;
-        for (const att of msgAttachments ?? []) {
-          for (const part of att.content) {
-            if (part.type === "image" && typeof part.image === "string") {
-              attachments.push({
-                type: "image",
-                name: att.name,
-                contentType: att.contentType,
-                data: part.image,
-              });
-            } else if (part.type === "file" && typeof part.data === "string") {
-              const contentType =
-                att.contentType ??
-                (typeof part.mimeType === "string" ? part.mimeType : undefined);
-              const decodedText = part.data.startsWith("data:")
-                ? decodeTextDataUrl(part.data)
-                : null;
-              attachments.push({
-                type: "file",
-                name: att.name,
-                contentType,
-                ...(decodedText !== null
-                  ? { text: decodedText }
-                  : part.data.startsWith("data:")
-                    ? { data: part.data }
-                    : { text: part.data }),
-              });
-            } else if (part.type === "text" && typeof part.text === "string") {
-              attachments.push({
-                type: "file",
-                name: att.name,
-                contentType: att.contentType,
-                text: unwrapAttachmentEnvelope(part.text),
-              });
-            }
-          }
-        }
-      }
+      const attachments = lastUserMsg
+        ? extractAttachmentsFromMessage(lastUserMsg as any)
+        : [];
       const userMessageText =
         rawMessageText.trim() || attachments.length === 0
           ? rawMessageText
@@ -535,7 +590,10 @@ export function createAgentChatAdapter(options?: {
         .filter((m) => m.role === "user" || m.role === "assistant")
         .map((m) => ({
           role: m.role as "user" | "assistant",
-          content: messageTextFromContent(m.content),
+          content:
+            m.role === "user"
+              ? messageTextForHistory(m as any)
+              : messageTextFromContent(m.content),
         }))
         .filter((m) => m.content.trim());
       const structuredHistory =

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -908,8 +908,12 @@ export function createAgentChatAdapter(options?: {
             ...structuredCombinedHistory,
           ];
           currentMessageText = autoContinueMessage(signal);
-          includeAttachments = false;
-          includeReferences = false;
+          // Continuation requests are stateless new POSTs. If the interrupted
+          // turn depended on uploaded context, re-send that context; otherwise
+          // an attachment-only prompt degrades to "Use the attached context."
+          // with nothing attached after a stale run or reconnect recovery.
+          includeAttachments = attachments.length > 0;
+          includeReferences = Boolean(runConfig?.custom?.references);
           startupRecoveryAttempts = 0;
           clearActiveRun();
           if (!isTransient) {

--- a/packages/core/src/client/composer/PromptComposer.tsx
+++ b/packages/core/src/client/composer/PromptComposer.tsx
@@ -166,11 +166,11 @@ function AttachmentChip({
 
   if (src) {
     return (
-      <div className="group relative h-16 w-16 overflow-hidden rounded-lg border border-border/70 bg-muted/50">
+      <div className="group relative flex h-16 min-w-16 max-w-28 items-center justify-center overflow-hidden rounded-lg border border-border/70 bg-muted/50">
         <img
           src={src}
           alt={attachment.name}
-          className="h-full w-full object-cover"
+          className="max-h-full max-w-full object-contain p-1"
         />
         <button
           type="button"

--- a/packages/core/src/client/composer/TiptapComposer.spec.ts
+++ b/packages/core/src/client/composer/TiptapComposer.spec.ts
@@ -2,7 +2,10 @@
 
 import { describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
-import { createTiptapComposerExtensions } from "./TiptapComposer.js";
+import {
+  canSubmitComposerContent,
+  createTiptapComposerExtensions,
+} from "./TiptapComposer.js";
 
 describe("createTiptapComposerExtensions", () => {
   it("keeps the prompt composer schema minimal and restores legacy draft HTML", () => {
@@ -37,5 +40,21 @@ describe("createTiptapComposerExtensions", () => {
     expect(editor.getHTML()).toContain('data-type="file-reference"');
 
     editor.destroy();
+  });
+
+  it("allows sending an attachment-only prompt", () => {
+    expect(
+      canSubmitComposerContent({
+        hasEditorContent: false,
+        attachmentCount: 1,
+      }),
+    ).toBe(true);
+    expect(
+      canSubmitComposerContent({
+        hasEditorContent: false,
+        attachmentCount: 1,
+        disabled: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -69,6 +69,17 @@ export interface TiptapComposerHandle {
   focus(): void;
 }
 
+export function canSubmitComposerContent(options: {
+  hasEditorContent: boolean;
+  attachmentCount: number;
+  disabled?: boolean;
+}): boolean {
+  return (
+    !options.disabled &&
+    (options.hasEditorContent || options.attachmentCount > 0)
+  );
+}
+
 const BUILT_IN_COMMANDS: SlashCommand[] = [
   { name: "clear", description: "Start a new chat", icon: "clear" },
   { name: "new", description: "Start a new chat", icon: "new" },
@@ -735,7 +746,12 @@ export function TiptapComposer({
   const composerRuntime = useComposerRuntime();
   const [editorHasText, setEditorHasText] = useState(false);
   const composerText = useComposer((state) => state.text);
-  const canSend = editorHasText && !disabled;
+  const composerAttachments = useComposer((state) => state.attachments);
+  const canSend = canSubmitComposerContent({
+    hasEditorContent: editorHasText,
+    attachmentCount: composerAttachments.length,
+    disabled,
+  });
   const [composerMode, setComposerMode] = useState<ComposerMode | null>(null);
   const composerModeRef = useRef<ComposerMode | null>(null);
   const isMac =

--- a/packages/core/src/client/onboarding/OnboardingPanel.tsx
+++ b/packages/core/src/client/onboarding/OnboardingPanel.tsx
@@ -973,6 +973,7 @@ const styles: Record<string, React.CSSProperties> = {
     outline: "none",
     boxSizing: "border-box" as const,
   },
+  methodHint: { margin: 0, fontSize: 11, color: "rgba(255,255,255,0.62)" },
   errText: { margin: 0, fontSize: 11, color: "#f87171" },
   footer: {
     padding: "0 12px 10px",

--- a/packages/core/src/client/onboarding/OnboardingPanel.tsx
+++ b/packages/core/src/client/onboarding/OnboardingPanel.tsx
@@ -665,6 +665,12 @@ function BuilderCliAuthMethod({
           "Connect Builder"
         )}
       </button>
+      {connecting && (
+        <p style={styles.methodHint}>
+          A Builder tab opened. Choose your team or app space there; setup will
+          continue here automatically.
+        </p>
+      )}
       {error && <p style={styles.errText}>{error}</p>}
     </>
   );

--- a/packages/core/src/client/progress/RunsTray.tsx
+++ b/packages/core/src/client/progress/RunsTray.tsx
@@ -45,7 +45,26 @@ export function RunsTray({
     }
   }, [limit]);
 
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
   usePausingInterval(refresh, pollMs);
+
+  const dismissRun = useCallback(
+    async (runId: string) => {
+      setRuns((current) => current.filter((run) => run.id !== runId));
+      try {
+        await fetch(agentNativePath(`/_agent-native/runs/${runId}`), {
+          method: "DELETE",
+          headers: { "X-Agent-Native-CSRF": "1" },
+        });
+      } catch {
+        refresh();
+      }
+    },
+    [refresh],
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -108,7 +127,7 @@ export function RunsTray({
           </div>
           <div className="max-h-96 divide-y divide-border overflow-y-auto">
             {runs.map((r) => (
-              <RunRow key={r.id} run={r} />
+              <RunRow key={r.id} run={r} onDismiss={dismissRun} />
             ))}
           </div>
         </div>
@@ -117,14 +136,30 @@ export function RunsTray({
   );
 }
 
-function RunRow({ run }: { run: AgentRunDto }) {
+function RunRow({
+  run,
+  onDismiss,
+}: {
+  run: AgentRunDto;
+  onDismiss: (runId: string) => void;
+}) {
   return (
     <div className="flex flex-col gap-1 px-3 py-2 text-sm">
       <div className="flex items-center justify-between gap-2">
         <span className="truncate font-medium text-foreground">
           {run.title}
         </span>
-        <StatusGlyph status={run.status} />
+        <div className="flex shrink-0 items-center gap-1">
+          <StatusGlyph status={run.status} />
+          <button
+            type="button"
+            aria-label={`Dismiss ${run.title}`}
+            className="inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-accent/60 hover:text-foreground"
+            onClick={() => onDismiss(run.id)}
+          >
+            <IconX size={13} aria-hidden />
+          </button>
+        </div>
       </div>
       {run.step ? (
         <span className="truncate text-xs text-muted-foreground">

--- a/packages/core/src/client/resources/ResourceTree.tsx
+++ b/packages/core/src/client/resources/ResourceTree.tsx
@@ -113,19 +113,20 @@ interface CreatingState {
 }
 
 function McpStatusDot({ server }: { server: McpServer }) {
-  if (server.status.state === "connected") {
+  const status = server.status ?? { state: "unknown" as const };
+  if (status.state === "connected") {
     return (
       <StatusDot
         className="rounded-full bg-green-500"
-        tooltip={`Connected — ${server.status.toolCount} tool${server.status.toolCount === 1 ? "" : "s"}`}
+        tooltip={`Connected — ${status.toolCount} tool${status.toolCount === 1 ? "" : "s"}`}
       />
     );
   }
-  if (server.status.state === "error") {
+  if (status.state === "error") {
     return (
       <StatusDot
         className="rounded-full bg-red-500"
-        tooltip={`Error: ${server.status.error}`}
+        tooltip={`Error: ${status.error}`}
       />
     );
   }

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -275,7 +275,9 @@ export function useBuilderConnectFlow(
     try {
       const opened = window.open(url, "_blank", "noopener,noreferrer");
       if (!opened) {
-        setError("Popup blocked. Allow popups, then click Connect Builder again.");
+        setError(
+          "Popup blocked. Allow popups, then click Connect Builder again.",
+        );
       }
     } catch {
       setError("Couldn't open Builder. Allow popups and try again.");

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -273,10 +273,12 @@ export function useBuilderConnectFlow(
       popupUrl ??
       new URL(agentNativePath("/_agent-native/builder/connect"), origin).href;
     try {
-      window.open(url, "_blank", "noopener,noreferrer");
+      const opened = window.open(url, "_blank", "noopener,noreferrer");
+      if (!opened) {
+        setError("Popup blocked. Allow popups, then click Connect Builder again.");
+      }
     } catch {
-      // Fall through — polling still detects completion if the user
-      // opens the URL themselves.
+      setError("Couldn't open Builder. Allow popups and try again.");
     }
 
     const started = Date.now();

--- a/packages/core/src/collab/client.spec.ts
+++ b/packages/core/src/collab/client.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { dedupeCollabUsersByEmail } from "./client.js";
+import {
+  dedupeCollabUsersByEmail,
+  reconcileRemoteAwarenessStates,
+} from "./client.js";
 
 describe("dedupeCollabUsersByEmail", () => {
   it("keeps one presence entry per email", () => {
@@ -38,5 +41,23 @@ describe("dedupeCollabUsersByEmail", () => {
         color: "#34d399",
       },
     ]);
+  });
+});
+
+describe("reconcileRemoteAwarenessStates", () => {
+  it("removes remote clients missing from the latest server response", () => {
+    const states = new Map<number, unknown>([
+      [1, { user: { email: "local@example.com" } }],
+      [2, { user: { email: "stale@example.com" } }],
+      [3, { user: { email: "active@example.com" } }],
+    ]);
+
+    const changes = reconcileRemoteAwarenessStates(states, 1, [
+      { clientId: 3, state: { user: { email: "active@example.com" } } },
+      { clientId: 4, state: { user: { email: "new@example.com" } } },
+    ]);
+
+    expect(changes).toEqual({ added: [4], updated: [3], removed: [2] });
+    expect(Array.from(states.keys())).toEqual([1, 3, 4]);
   });
 });

--- a/packages/core/src/collab/client.ts
+++ b/packages/core/src/collab/client.ts
@@ -97,6 +97,44 @@ export function dedupeCollabUsersByEmail(users: CollabUser[]): CollabUser[] {
   return Array.from(byEmail.values());
 }
 
+export interface RemoteAwarenessSnapshot {
+  clientId: number;
+  state: unknown;
+}
+
+export function reconcileRemoteAwarenessStates(
+  states: Map<number, unknown>,
+  localClientId: number,
+  remoteStates: RemoteAwarenessSnapshot[],
+): { added: number[]; updated: number[]; removed: number[] } {
+  const incoming = new Set<number>();
+  const added: number[] = [];
+  const updated: number[] = [];
+  const removed: number[] = [];
+
+  for (const remote of remoteStates) {
+    if (
+      !Number.isFinite(remote.clientId) ||
+      remote.clientId === localClientId
+    ) {
+      continue;
+    }
+    incoming.add(remote.clientId);
+    const hadState = states.has(remote.clientId);
+    states.set(remote.clientId, remote.state);
+    (hadState ? updated : added).push(remote.clientId);
+  }
+
+  for (const clientId of Array.from(states.keys())) {
+    if (clientId === localClientId) continue;
+    if (incoming.has(clientId)) continue;
+    states.delete(clientId);
+    removed.push(clientId);
+  }
+
+  return { added, updated, removed };
+}
+
 // Base64 helpers
 function uint8ArrayToBase64(arr: Uint8Array): string {
   let binary = "";
@@ -322,25 +360,29 @@ export function useCollaborativeDoc(
             });
             if (awarenessRes.ok) {
               const awarenessData = await awarenessRes.json();
-              // Apply remote awareness states
+              const remoteStates: RemoteAwarenessSnapshot[] = [];
               for (const remote of awarenessData.states || []) {
                 try {
                   const remoteState = JSON.parse(remote.state);
-                  awareness.setLocalStateField(
-                    `remote_${remote.clientId}`,
-                    null,
-                  );
-                  // Manually update the awareness state map for remote clients
-                  const states = awareness.getStates();
-                  states.set(remote.clientId, remoteState);
-                  // Trigger awareness change event
-                  awareness.emit("change", [
-                    { added: [], updated: [remote.clientId], removed: [] },
-                    "remote",
-                  ]);
+                  remoteStates.push({
+                    clientId: Number(remote.clientId),
+                    state: remoteState,
+                  });
                 } catch {
                   // Invalid state — skip
                 }
+              }
+              const changes = reconcileRemoteAwarenessStates(
+                awareness.getStates() as Map<number, unknown>,
+                ydoc.clientID,
+                remoteStates,
+              );
+              if (
+                changes.added.length ||
+                changes.updated.length ||
+                changes.removed.length
+              ) {
+                awareness.emit("change", [changes, "remote"]);
               }
             }
           }

--- a/packages/core/src/onboarding/default-steps.ts
+++ b/packages/core/src/onboarding/default-steps.ts
@@ -80,7 +80,7 @@ const llmStep: OnboardingStep = {
       kind: "builder-cli-auth",
       label: "Connect Builder",
       description:
-        "Free credits for Claude, GPT, Gemini, and more — no API key needed.",
+        "Connect the Builder space where this app should run. This unlocks managed LLM credits, browser automation, cloud code changes, and file uploads.",
       primary: true,
       payload: {
         scope: "llm",

--- a/packages/core/src/progress/store.spec.ts
+++ b/packages/core/src/progress/store.spec.ts
@@ -87,7 +87,7 @@ describe("progress store", () => {
     expect(update?.sql).toMatch(/AND status = 'running'/);
     expect(update?.sql).toMatch(/AND updated_at < \?/);
     expect(update?.args).toEqual([
-      "Stopped after 30 minutes without progress.",
+      "Stopped after 5 minutes without progress.",
       now,
       now,
       "alice@example.com",

--- a/packages/core/src/progress/store.ts
+++ b/packages/core/src/progress/store.ts
@@ -21,7 +21,7 @@ function bumpPoll(owner: string): void {
 
 let _initPromise: Promise<void> | undefined;
 
-export const DEFAULT_PROGRESS_RUN_STALE_MS = 30 * 60 * 1000;
+export const DEFAULT_PROGRESS_RUN_STALE_MS = 5 * 60 * 1000;
 
 function normalizeLimit(value: number | undefined, fallback = 50): number {
   if (!Number.isFinite(value) || value == null || value <= 0) return fallback;

--- a/packages/core/src/server/action-routes.ts
+++ b/packages/core/src/server/action-routes.ts
@@ -81,6 +81,10 @@ function handleOptionsRequest(event: any): string {
 export interface MountActionRoutesOptions {
   /** Resolve owner email from the H3 event (for data scoping). */
   getOwnerFromEvent?: (event: any) => string | Promise<string>;
+  /** Resolve display name from the H3 event, when available. */
+  getUserNameFromEvent?: (
+    event: any,
+  ) => string | undefined | Promise<string | undefined>;
   /** Resolve org ID from the H3 event (for org scoping). */
   resolveOrgId?: (event: any) => string | null | Promise<string | null>;
 }
@@ -150,13 +154,16 @@ export function mountActionRoutes(
         const userEmail = options?.getOwnerFromEvent
           ? await options.getOwnerFromEvent(event)
           : undefined;
+        const userName = options?.getUserNameFromEvent
+          ? await options.getUserNameFromEvent(event)
+          : undefined;
         const orgId = options?.resolveOrgId
           ? ((await options.resolveOrgId(event)) ?? undefined)
           : undefined;
         const timezone = readTimezoneHeader(event);
 
         return runWithRequestContext(
-          { userEmail, orgId, timezone },
+          { userEmail, userName, orgId, timezone },
           async () => {
             // Parse params based on method. On web-standard runtimes (Netlify
             // Functions, CF Workers), event.req IS the web Request — use .json()

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -3165,7 +3165,11 @@ export function createAgentChatPlugin(
         },
       });
 
-      type OwnerContext = { owner: string; anonymous: boolean };
+      type OwnerContext = {
+        owner: string;
+        anonymous: boolean;
+        name?: string;
+      };
       const OWNER_CONTEXT_KEY = "__agentNativeOwnerContext";
 
       // Resolve owner from the H3 event's session, with an optional
@@ -3180,7 +3184,11 @@ export function createAgentChatPlugin(
 
         const session = await getSession(event);
         if (session?.email) {
-          const resolved = { owner: session.email, anonymous: false };
+          const resolved = {
+            owner: session.email,
+            anonymous: false,
+            name: session.name,
+          };
           if (eventContext) eventContext[OWNER_CONTEXT_KEY] = resolved;
           return resolved;
         }
@@ -3201,6 +3209,11 @@ export function createAgentChatPlugin(
 
       const getOwnerFromEvent = async (event: any): Promise<string> => {
         return (await resolveOwnerContext(event)).owner;
+      };
+      const getUserNameFromEvent = async (
+        event: any,
+      ): Promise<string | undefined> => {
+        return (await resolveOwnerContext(event)).name;
       };
 
       // Auto-mount template actions as HTTP endpoints under /_agent-native/actions/
@@ -3227,6 +3240,7 @@ export function createAgentChatPlugin(
         const { mountActionRoutes } = await import("./action-routes.js");
         mountActionRoutes(nitroApp, httpActions, {
           getOwnerFromEvent,
+          getUserNameFromEvent,
           resolveOrgId: options?.resolveOrgId,
         });
       }
@@ -4689,8 +4703,7 @@ export function createAgentChatPlugin(
                 }
                 const body = await readBody(event);
                 let newThreadData = body.threadData || thread.threadData;
-                let newMessageCount =
-                  body.messageCount ?? thread.messageCount;
+                let newMessageCount = body.messageCount ?? thread.messageCount;
                 // Merge the incoming full-thread blob over the current SQL
                 // copy. Periodic saves can be stale relative to server-side
                 // run completion, and threadRuntime.export() does not carry
@@ -4855,7 +4868,12 @@ export function createAgentChatPlugin(
               : undefined;
 
           return runWithRequestContext(
-            { userEmail: owner, orgId: resolvedOrgId, timezone },
+            {
+              userEmail: owner,
+              userName: ownerContext.name,
+              orgId: resolvedOrgId,
+              timezone,
+            },
             () => {
               const handler =
                 ownerContext.anonymous && anonymousHandler

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -56,6 +56,7 @@ import { loadSchemaPromptBlock } from "./schema-prompt.js";
 import {
   buildAssistantMessage,
   extractThreadMeta,
+  mergeThreadDataForClientSave,
   upsertAssistantMessage,
 } from "../agent/thread-data-builder.js";
 import {
@@ -4688,20 +4689,23 @@ export function createAgentChatPlugin(
                 }
                 const body = await readBody(event);
                 let newThreadData = body.threadData || thread.threadData;
-                // Preserve queuedMessages from the existing thread_data when the
-                // incoming blob doesn't include it. Periodic full-thread saves
-                // (exported via threadRuntime.export) don't carry the queue, and
-                // we don't want them to clobber queued-message state persisted
-                // via POST /threads/:id/queued.
+                let newMessageCount =
+                  body.messageCount ?? thread.messageCount;
+                // Merge the incoming full-thread blob over the current SQL
+                // copy. Periodic saves can be stale relative to server-side
+                // run completion, and threadRuntime.export() does not carry
+                // queuedMessages.
                 if (body.threadData) {
                   try {
                     const existing = JSON.parse(thread.threadData);
-                    if (existing.queuedMessages !== undefined) {
-                      const incoming = JSON.parse(newThreadData);
-                      if (incoming.queuedMessages === undefined) {
-                        incoming.queuedMessages = existing.queuedMessages;
-                        newThreadData = JSON.stringify(incoming);
-                      }
+                    const incoming = JSON.parse(newThreadData);
+                    const merged = mergeThreadDataForClientSave(
+                      existing,
+                      incoming,
+                    );
+                    newThreadData = JSON.stringify(merged);
+                    if (Array.isArray(merged.messages)) {
+                      newMessageCount = merged.messages.length;
                     }
                   } catch {
                     // Invalid JSON in either side — fall back to raw body blob.
@@ -4712,7 +4716,7 @@ export function createAgentChatPlugin(
                   newThreadData,
                   body.title ?? thread.title,
                   body.preview ?? thread.preview,
-                  body.messageCount || thread.messageCount,
+                  newMessageCount,
                 );
                 return { ok: true };
               });

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -142,6 +142,7 @@ export {
   hasRequestContext,
   getRequestContext,
   getRequestUserEmail,
+  getRequestUserName,
   getRequestOrgId,
   getRequestTimezone,
   getRequestRunContext,

--- a/packages/core/src/server/request-context.ts
+++ b/packages/core/src/server/request-context.ts
@@ -51,6 +51,7 @@ export interface RequestRunContext {
 
 export interface RequestContext {
   userEmail?: string;
+  userName?: string;
   orgId?: string;
   timezone?: string;
   /**
@@ -176,6 +177,19 @@ export function getRequestUserEmail(): string | undefined {
   const store = als.getStore();
   if (store !== undefined) return store.userEmail;
   return process.env.AGENT_USER_EMAIL;
+}
+
+/**
+ * Get the current request's display name, when the auth provider supplied one.
+ *
+ * The same request-context fallback rules as `getRequestUserEmail()` apply:
+ * HTTP/A2A calls only read AsyncLocalStorage, while CLI scripts may opt in via
+ * `AGENT_USER_NAME`.
+ */
+export function getRequestUserName(): string | undefined {
+  const store = als.getStore();
+  if (store !== undefined) return store.userName;
+  return process.env.AGENT_USER_NAME;
 }
 
 /**

--- a/packages/desktop-app/electron-builder.yml
+++ b/packages/desktop-app/electron-builder.yml
@@ -22,6 +22,7 @@ protocols:
 mac:
   category: public.app-category.developer-tools
   identity: "Builder.io, Inc (W3PMF2T3MW)"
+  icon: build/agent-native.icns
   notarize: true
   target:
     - target: dmg
@@ -37,6 +38,7 @@ dmg:
   artifactName: ${productName}-${arch}.${ext}
 
 win:
+  icon: build/icon.png
   target:
     - target: nsis
       arch:
@@ -49,6 +51,7 @@ nsis:
   perMachine: false
 
 linux:
+  icon: build/icon.png
   target:
     - target: AppImage
       arch:

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -564,8 +564,10 @@ export default function App() {
         theme="dark"
         position="bottom-center"
         offset={20}
+        closeButton
         visibleToasts={1}
         toastOptions={{
+          duration: 4000,
           classNames: {
             toast: "shell-snackbar",
             title: "shell-snackbar-title",

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -3,6 +3,7 @@ import { NavLink, useLocation } from "react-router";
 import {
   AgentSidebar,
   FeedbackButton,
+  appBasePath,
   appPath,
   useActionQuery,
 } from "@agent-native/core/client";
@@ -206,6 +207,26 @@ function navItemsForSection(
   return items.filter((item) => sectionFor(item) === section);
 }
 
+function localDispatchPath(pathname: string): string {
+  const basePath = appBasePath();
+  if (!basePath) return pathname;
+  if (pathname === basePath) return "/";
+  if (pathname.startsWith(`${basePath}/`)) {
+    return pathname.slice(basePath.length) || "/";
+  }
+  return pathname;
+}
+
+function dispatchNavLinkTarget(path: string): string {
+  if (typeof window === "undefined") return path;
+  const basePath = appBasePath();
+  if (!basePath) return path;
+  const context = (
+    window as Window & { __reactRouterContext?: { basename?: string } }
+  ).__reactRouterContext;
+  return context?.basename === basePath ? path : appPath(path);
+}
+
 export function NavContent({
   onNavigate,
   extensions,
@@ -230,8 +251,9 @@ export function NavContent({
     ...OPERATIONS_NAV_ITEMS,
     ...navItemsForSection(extensionNavItems, "operations"),
   ];
+  const localPathname = localDispatchPath(location.pathname);
   const operationsOpen = operationsNavItems.some((item) =>
-    navItemMatchesPath(item, location.pathname),
+    navItemMatchesPath(item, localPathname),
   );
 
   const renderNavItem = (item: DispatchNavItem) => {
@@ -239,11 +261,10 @@ export function NavContent({
     return (
       <li key={item.id}>
         <NavLink
-          to={item.to}
+          to={dispatchNavLinkTarget(item.to)}
           onClick={onNavigate}
           className={({ isActive }) => {
-            const active =
-              isActive || navItemMatchesPath(item, location.pathname);
+            const active = isActive || navItemMatchesPath(item, localPathname);
             return cn(
               "flex h-8 w-full items-center gap-2 rounded-md px-2 text-sm",
               active

--- a/packages/dispatch/src/hooks/use-navigation-state.ts
+++ b/packages/dispatch/src/hooks/use-navigation-state.ts
@@ -23,9 +23,10 @@ export function useNavigationState(extensions?: DispatchExtensionConfig) {
 
   // Sync current route to application state
   useEffect(() => {
+    const localPathname = routerPath(location.pathname);
     const state: NavigationState = {
-      view: resolveView(location.pathname, extensions),
-      path: appPath(location.pathname),
+      view: resolveView(localPathname, extensions),
+      path: appPath(localPathname),
     };
 
     fetch(agentNativePath("/_agent-native/application-state/navigation"), {

--- a/templates/clips/actions/get-recording-player-data.ts
+++ b/templates/clips/actions/get-recording-player-data.ts
@@ -24,6 +24,10 @@ import { getDb, schema } from "../server/db/index.js";
 import { parseSpaceIds } from "../server/lib/recordings.js";
 import { resolveAccess, ForbiddenError } from "@agent-native/core/sharing";
 import { readAppState } from "@agent-native/core/application-state";
+import {
+  normalizeTranscriptSegments,
+  parseTranscriptSegments,
+} from "../shared/transcript-segments.js";
 
 export default defineAction({
   description:
@@ -112,19 +116,11 @@ export default defineAction({
       }
     } catch {}
 
-    let transcriptSegments: { startMs: number; endMs: number; text: string }[] =
-      [];
-    if (transcript?.segmentsJson) {
-      try {
-        const parsed = JSON.parse(transcript.segmentsJson);
-        if (Array.isArray(parsed)) {
-          transcriptSegments = parsed.filter(
-            (segment) =>
-              typeof segment?.text === "string" && segment.text.trim(),
-          );
-        }
-      } catch {}
-    }
+    const transcriptSegments = normalizeTranscriptSegments({
+      segments: parseTranscriptSegments(transcript?.segmentsJson),
+      fullText: transcript?.fullText,
+      durationMs: rec.durationMs,
+    });
     const transcriptReadyButEmpty =
       transcript?.status === "ready" &&
       !transcript.fullText?.trim() &&

--- a/templates/clips/actions/regenerate-title.ts
+++ b/templates/clips/actions/regenerate-title.ts
@@ -128,6 +128,47 @@ function buildTitleContext({
   return parts.length > 0 ? parts.join("\n\n") : undefined;
 }
 
+export async function queueTitleRegenerationRequest({
+  recordingId,
+  currentTitle,
+  transcriptText,
+  transcriptStatus = "ready",
+  segmentsJson = "[]",
+  ownerEmail,
+}: {
+  recordingId: string;
+  currentTitle: string | null | undefined;
+  transcriptText: string;
+  transcriptStatus?: string;
+  segmentsJson?: string | null;
+  ownerEmail?: string | null;
+}) {
+  const agentsContext = await loadAgentsMdContext({
+    ownerEmail,
+    purpose: "title",
+  });
+  const request = {
+    kind: "regenerate-title" as const,
+    recordingId,
+    requestedAt: new Date().toISOString(),
+    currentTitle: currentTitle ?? "",
+    transcriptStatus,
+    transcriptText,
+    segmentsJson: segmentsJson ?? "[]",
+    agentsContext,
+    message:
+      `Regenerate the title for recording ${recordingId}. ` +
+      `Read the native transcript and AGENTS.md context in this request's context and call ` +
+      `\`update-recording --id=${recordingId} --title="..."\` with a concise ` +
+      `4-9 word descriptive title. Current title: "${currentTitle ?? ""}". ` +
+      "Do not prompt the user.",
+  };
+
+  await writeAppState(`clips-ai-request-${recordingId}`, request as any);
+  await writeAppState("refresh-signal", { ts: Date.now() });
+  return request;
+}
+
 export default defineAction({
   description:
     "Regenerate this recording's title from its transcript using the configured cleanup/title path, falling back to a local transcript title when unavailable.",
@@ -280,25 +321,14 @@ export default defineAction({
       }
     }
 
-    const request = {
-      kind: "regenerate-title" as const,
+    await queueTitleRegenerationRequest({
       recordingId: args.recordingId,
-      requestedAt: new Date().toISOString(),
       currentTitle: rec.title,
       transcriptStatus: transcript?.status ?? "pending",
       transcriptText,
       segmentsJson: transcript?.segmentsJson ?? "[]",
-      agentsContext,
-      message:
-        `Regenerate the title for recording ${args.recordingId}. ` +
-        `Read the native transcript and AGENTS.md context in this request's context and call ` +
-        `\`update-recording --id=${args.recordingId} --title="..."\` with a concise ` +
-        `4-9 word descriptive title. Current title: "${rec.title}". ` +
-        "Do not prompt the user.",
-    };
-
-    await writeAppState(`clips-ai-request-${args.recordingId}`, request as any);
-    await writeAppState("refresh-signal", { ts: Date.now() });
+      ownerEmail: getRequestUserEmail() ?? transcript?.ownerEmail,
+    });
 
     console.log(`Delegation queued: regenerate-title for ${args.recordingId}`);
     return {

--- a/templates/clips/actions/request-transcript.ts
+++ b/templates/clips/actions/request-transcript.ts
@@ -48,10 +48,17 @@ import {
 } from "@agent-native/core/server/request-context";
 import { resolveHasBuilderPrivateKey } from "@agent-native/core/server";
 import { transcribeWithBuilder } from "@agent-native/core/transcription/builder";
-import regenerateTitle from "./regenerate-title.js";
+import regenerateTitle, {
+  queueTitleRegenerationRequest,
+} from "./regenerate-title.js";
 import cleanupTranscript from "./cleanup-transcript.js";
 import { loadAgentsMdContext } from "./lib/agents-md-context.js";
 import { isAutoTitleReplaceable } from "./lib/title-source.js";
+import {
+  buildCaptionSegmentsFromText,
+  normalizeTranscriptSegments,
+  parseTranscriptSegments,
+} from "../shared/transcript-segments.js";
 
 interface SpeechToTextSegment {
   start: number; // seconds
@@ -137,13 +144,7 @@ function fullTextSegmentJson(
   text: string,
   durationMs: number | null | undefined,
 ): string {
-  return JSON.stringify([
-    {
-      startMs: 0,
-      endMs: Math.max(1000, Math.round(durationMs ?? 0)),
-      text: text.trim(),
-    },
-  ]);
+  return JSON.stringify(buildCaptionSegmentsFromText(text, durationMs));
 }
 
 function providerTranscriptText(
@@ -313,6 +314,28 @@ async function completeReadyTranscript({
     )
     .limit(1);
 
+  const normalizedSegments = normalizeTranscriptSegments({
+    segments: parseTranscriptSegments(segmentsJson),
+    fullText,
+    durationMs: recForTitle?.durationMs,
+  });
+  if (normalizedSegments.length) {
+    const normalizedSegmentsJson = JSON.stringify(normalizedSegments);
+    if (normalizedSegmentsJson !== (segmentsJson ?? "[]")) {
+      await upsertTranscriptRow(db, {
+        recordingId,
+        ownerEmail,
+        status: "ready",
+        failureReason: null,
+        language: "en",
+        segmentsJson: normalizedSegmentsJson,
+        fullText,
+        now: new Date().toISOString(),
+      });
+      segmentsJson = normalizedSegmentsJson;
+    }
+  }
+
   void cleanupNativeTranscript({
     db,
     recordingId,
@@ -331,6 +354,20 @@ async function completeReadyTranscript({
     isAutoTitleReplaceable(recForTitle.title, recForTitle.titleSource)
   );
   if (titleQueued) {
+    await queueTitleRegenerationRequest({
+      recordingId,
+      currentTitle: recForTitle.title,
+      transcriptText: fullText,
+      transcriptStatus: "ready",
+      segmentsJson,
+      ownerEmail,
+    }).catch((err) => {
+      console.warn(
+        `[clips] native-transcript title request queue failed for ${recordingId}:`,
+        (err as Error)?.message ?? String(err),
+      );
+    });
+
     void regenerateTitle
       .run({
         recordingId,

--- a/templates/clips/actions/save-browser-transcript.ts
+++ b/templates/clips/actions/save-browser-transcript.ts
@@ -15,17 +15,14 @@ import { eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import { getCurrentOwnerEmail } from "../server/lib/recordings.js";
 import { writeAppState } from "@agent-native/core/application-state";
-import regenerateTitle from "./regenerate-title.js";
+import regenerateTitle, {
+  queueTitleRegenerationRequest,
+} from "./regenerate-title.js";
 import { isAutoTitleReplaceable } from "./lib/title-source.js";
+import { buildCaptionSegmentsFromText } from "../shared/transcript-segments.js";
 
 function nativeSegmentsJson(fullText: string): string {
-  return JSON.stringify([
-    {
-      startMs: 0,
-      endMs: 1000,
-      text: fullText.trim(),
-    },
-  ]);
+  return JSON.stringify(buildCaptionSegmentsFromText(fullText));
 }
 
 export default defineAction({
@@ -53,6 +50,7 @@ export default defineAction({
     const now = new Date().toISOString();
     const fullText = args.fullText.trim();
     const failureReason = args.failureReason?.trim() || "";
+    const segmentsJson = nativeSegmentsJson(fullText);
 
     const [current] = await db
       .select({
@@ -141,7 +139,7 @@ export default defineAction({
         .set({
           ownerEmail,
           fullText,
-          segmentsJson: nativeSegmentsJson(fullText),
+          segmentsJson,
           status: "ready",
           failureReason: null,
           updatedAt: now,
@@ -152,7 +150,7 @@ export default defineAction({
         recordingId: args.recordingId,
         ownerEmail,
         language: "en",
-        segmentsJson: nativeSegmentsJson(fullText),
+        segmentsJson,
         fullText,
         status: "ready",
         failureReason: null,
@@ -180,6 +178,20 @@ export default defineAction({
       rec && isAutoTitleReplaceable(rec.title, rec.titleSource)
     );
     if (titleQueued) {
+      await queueTitleRegenerationRequest({
+        recordingId: args.recordingId,
+        currentTitle: rec.title,
+        transcriptText: fullText,
+        transcriptStatus: "ready",
+        segmentsJson,
+        ownerEmail,
+      }).catch((err) => {
+        console.warn(
+          `[clips] native transcript title request queue failed for ${args.recordingId}:`,
+          (err as Error)?.message ?? String(err),
+        );
+      });
+
       void regenerateTitle
         .run({
           recordingId: args.recordingId,

--- a/templates/clips/app/components/player/captions-overlay.tsx
+++ b/templates/clips/app/components/player/captions-overlay.tsx
@@ -99,7 +99,7 @@ export function CaptionsOverlay({
     <div
       ref={ref}
       data-player-ui
-      className="absolute z-20 -translate-x-1/2 -translate-y-1/2 cursor-move select-none"
+      className="absolute z-20 w-max max-w-[min(82%,720px)] -translate-x-1/2 -translate-y-1/2 cursor-move select-none"
       style={{
         left: pos.xPct + "%",
         top: pos.yPct + "%",
@@ -107,7 +107,7 @@ export function CaptionsOverlay({
       onMouseDown={onMouseDown}
     >
       <div
-        className="rounded-md bg-black/80 text-white px-4 py-1.5 text-[15px] leading-snug font-medium max-w-[70vw] text-center"
+        className="rounded-md bg-black/85 px-4 py-1.5 text-center text-[15px] font-medium leading-snug text-white shadow-lg"
         style={{
           outline: dragging ? "2px solid hsl(var(--primary))" : undefined,
         }}

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -187,6 +187,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     const [speed, setSpeed] = useState(defaultSpeed);
     const [showControls, setShowControls] = useState(true);
     const [captionsOn, setCaptionsOn] = useState(false);
+    const [hasPlaybackStarted, setHasPlaybackStarted] = useState(false);
     const [isFullscreen, setIsFullscreen] = useState(false);
     const [isPip, setIsPip] = useState(false);
     const [canPlay, setCanPlay] = useState(false);
@@ -259,6 +260,10 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       isPlaying,
       resolvedVideoSrc,
     ]);
+
+    useEffect(() => {
+      setHasPlaybackStarted(false);
+    }, [activeVideoSourceIdentity]);
 
     // Hide controls after 2s of idle movement.
     const bumpControls = useCallback(() => {
@@ -738,10 +743,12 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
             }}
             onPlay={() => {
               setIsPlaying(true);
+              setHasPlaybackStarted(true);
               onPlay?.();
             }}
             onPlaying={() => {
               setIsPlaying(true);
+              setHasPlaybackStarted(true);
               setCanPlay(true);
               setIsPreparing(false);
               setIsBuffering(false);
@@ -809,11 +816,13 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
               if (visibleMs !== ms) {
                 v.currentTime = visibleMs / 1000;
                 setCurrentMs(visibleMs);
+                if (visibleMs > 0) setHasPlaybackStarted(true);
                 if (visibleMs > 0) setIsPreparing(false);
                 onTimeUpdate?.(visibleMs, resolvedDurationMs);
                 return;
               }
               setCurrentMs(ms);
+              if (ms > 0) setHasPlaybackStarted(true);
               if (ms > 0) setIsPreparing(false);
               onTimeUpdate?.(ms, resolvedDurationMs);
             }}
@@ -854,7 +863,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         ) : null}
 
         {/* Captions */}
-        {!hideCaptions && captionsOn && currentSegment ? (
+        {!hideCaptions && captionsOn && hasPlaybackStarted && currentSegment ? (
           <CaptionsOverlay text={currentSegment.text} />
         ) : null}
 

--- a/templates/clips/app/hooks/use-auto-title.ts
+++ b/templates/clips/app/hooks/use-auto-title.ts
@@ -24,6 +24,17 @@ export function isDefaultTitle(title: string | null | undefined): boolean {
   return trimmed === DEFAULT_TITLE;
 }
 
+export function isAutoTitleReplaceable(
+  title: string | null | undefined,
+  titleSource: string | null | undefined,
+): boolean {
+  return (
+    isDefaultTitle(title) ||
+    titleSource === "default" ||
+    titleSource === "context"
+  );
+}
+
 interface AiRequest {
   kind?: string;
   recordingId?: string;
@@ -89,6 +100,9 @@ export function useAutoTitleBridge(): void {
   const inflight = useRef<boolean>(false);
 
   const readyRecordings = recordings.filter((r) => r.status === "ready");
+  const readyRecordingsKey = readyRecordings
+    .map((r) => `${r.id}:${r.titleSource ?? ""}:${r.title}:${r.updatedAt}`)
+    .join("|");
 
   useEffect(() => {
     if (readyRecordings.length === 0) return;
@@ -129,7 +143,7 @@ export function useAutoTitleBridge(): void {
             });
 
             void clearRequest(rec.id);
-          } else if (isDefaultTitle(rec.title)) {
+          } else if (isAutoTitleReplaceable(rec.title, rec.titleSource)) {
             // No server-queued delegation. Only dispatch the fallback for
             // recordings that are old enough (>2 min) that the server has had
             // ample time to write its own clips-ai-request entry. For freshly-
@@ -165,7 +179,7 @@ export function useAutoTitleBridge(): void {
       clearInterval(handle);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [readyRecordings.map((r) => r.id).join(",")]);
+  }, [readyRecordingsKey]);
 }
 
 function buildRequestContext(rec: RecordingSummary, request: AiRequest) {

--- a/templates/clips/app/hooks/use-library.ts
+++ b/templates/clips/app/hooks/use-library.ts
@@ -40,6 +40,16 @@ export interface ListRecordingsArgs {
   offset?: number;
 }
 
+function isAwaitingAutoTitle(recording: RecordingSummary): boolean {
+  const title = (recording.title ?? "").trim();
+  return (
+    title === "" ||
+    title === "Untitled recording" ||
+    recording.titleSource === "default" ||
+    recording.titleSource === "context"
+  );
+}
+
 export function useRecordings(args: ListRecordingsArgs = {}) {
   return useActionQuery<{ recordings: RecordingSummary[] }>(
     "list-recordings",
@@ -50,8 +60,7 @@ export function useRecordings(args: ListRecordingsArgs = {}) {
           recordings: Array.isArray(data?.recordings) ? data.recordings : [],
         };
       },
-      // If any recording is still on the seeded "Untitled recording" title
-      // (i.e. the agent hasn't landed a generated title yet), keep a 3s
+      // If any recording is still on a replaceable seed title, keep a 3s
       // refetch cadence so the skeleton in `recording-card` upgrades to
       // the real title promptly even if the refresh-signal poll is missed.
       refetchInterval: (q) => {
@@ -59,10 +68,7 @@ export function useRecordings(args: ListRecordingsArgs = {}) {
           | RecordingSummary[]
           | undefined;
         if (!recs || recs.length === 0) return false;
-        const pendingTitle = recs.some((r) => {
-          const t = (r.title ?? "").trim();
-          return t === "" || t === "Untitled recording";
-        });
+        const pendingTitle = recs.some(isAwaitingAutoTitle);
         return pendingTitle ? 3000 : false;
       },
     },

--- a/templates/clips/server/routes/api/public-recording.get.ts
+++ b/templates/clips/server/routes/api/public-recording.get.ts
@@ -23,6 +23,10 @@ import { asc, eq } from "drizzle-orm";
 import { getSession, signShortLivedToken } from "@agent-native/core/server";
 import { getDb, schema } from "../../db/index.js";
 import { parseSpaceIds } from "../../lib/recordings.js";
+import {
+  normalizeTranscriptSegments,
+  parseTranscriptSegments,
+} from "../../../shared/transcript-segments.js";
 
 function appPath(path: string): string {
   if (!path.startsWith("/")) return path;
@@ -122,17 +126,11 @@ export default defineEventHandler(async (event) => {
     }
   } catch {}
 
-  let transcriptSegments: {
-    startMs: number;
-    endMs: number;
-    text: string;
-  }[] = [];
-  if (transcript?.segmentsJson) {
-    try {
-      const parsed = JSON.parse(transcript.segmentsJson);
-      if (Array.isArray(parsed)) transcriptSegments = parsed;
-    } catch {}
-  }
+  const transcriptSegments = normalizeTranscriptSegments({
+    segments: parseTranscriptSegments(transcript?.segmentsJson),
+    fullText: transcript?.fullText,
+    durationMs: rec.durationMs,
+  });
 
   // Normalize the dev-fallback videoUrl:
   //   1. Rewrite the legacy `/api/uploads/:id/blob` shape to the current

--- a/templates/clips/shared/transcript-segments.ts
+++ b/templates/clips/shared/transcript-segments.ts
@@ -48,7 +48,9 @@ export function buildCaptionSegmentsFromText(
     totalWords * ESTIMATED_MS_PER_WORD,
   );
   const totalDurationMs =
-    typeof durationMs === "number" && Number.isFinite(durationMs) && durationMs > 0
+    typeof durationMs === "number" &&
+    Number.isFinite(durationMs) &&
+    durationMs > 0
       ? Math.max(durationMs, chunks.length * MIN_CAPTION_MS)
       : estimatedDurationMs;
 
@@ -85,8 +87,15 @@ export function normalizeTranscriptSegments({
 
   const sourceText =
     fullText?.trim() ||
-    validSegments.map((segment) => segment.text.trim()).join(" ").trim();
-  return buildCaptionSegmentsFromText(sourceText, durationMs);
+    validSegments
+      .map((segment) => segment.text.trim())
+      .join(" ")
+      .trim();
+  if (validSegments.length <= 1) {
+    return buildCaptionSegmentsFromText(sourceText, durationMs);
+  }
+
+  return validSegments.flatMap(splitTimedSegmentIntoCaptions);
 }
 
 function splitIntoCaptionChunks(text: string): string[] {
@@ -103,10 +112,7 @@ function splitIntoCaptionChunks(text: string): string[] {
       current.length >= MIN_WORDS_BEFORE_PUNCTUATION_BREAK &&
       (strongBreak || softBreak);
 
-    if (
-      current.length >= MAX_WORDS_PER_CAPTION ||
-      canBreakOnPunctuation
-    ) {
+    if (current.length >= MAX_WORDS_PER_CAPTION || canBreakOnPunctuation) {
       chunks.push(current.join(" "));
       current = [];
     }
@@ -120,12 +126,48 @@ function countWords(text: string): number {
   return text.split(/\s+/).filter(Boolean).length;
 }
 
+function splitTimedSegmentIntoCaptions(
+  segment: TranscriptSegment,
+): TranscriptSegment[] {
+  const chunks = splitIntoCaptionChunks(segment.text);
+  if (chunks.length <= 1) return [segment];
+
+  const totalWords =
+    chunks.reduce((sum, chunk) => sum + countWords(chunk), 0) || 1;
+  const durationMs = Math.max(MIN_CAPTION_MS, segment.endMs - segment.startMs);
+  const minChunkMs =
+    durationMs >= chunks.length * MIN_CAPTION_MS
+      ? MIN_CAPTION_MS
+      : Math.max(250, Math.floor(durationMs / chunks.length));
+  let cursorMs = segment.startMs;
+
+  return chunks.map((chunk, index) => {
+    const isLast = index === chunks.length - 1;
+    const rawDuration = Math.round(
+      (durationMs * countWords(chunk)) / totalWords,
+    );
+    const remainingChunks = chunks.length - index - 1;
+    const latestEndMs = segment.endMs - remainingChunks * 250;
+    const endMs = isLast
+      ? segment.endMs
+      : Math.min(
+          latestEndMs,
+          Math.max(cursorMs + minChunkMs, cursorMs + rawDuration),
+        );
+    const next = { startMs: cursorMs, endMs, text: chunk };
+    cursorMs = endMs;
+    return next;
+  });
+}
+
 function shouldRechunkSegments(
   segments: TranscriptSegment[],
   fullText: string | null | undefined,
 ): boolean {
   if (segments.length === 0) return Boolean(fullText?.trim());
-  if (segments.some((segment) => countWords(segment.text) > MAX_WORDS_PER_CAPTION))
+  if (
+    segments.some((segment) => countWords(segment.text) > MAX_WORDS_PER_CAPTION)
+  )
     return true;
   if (segments.length === 1 && countWords(segments[0].text) > 3) return true;
   return false;

--- a/templates/clips/shared/transcript-segments.ts
+++ b/templates/clips/shared/transcript-segments.ts
@@ -1,0 +1,132 @@
+export interface TranscriptSegment {
+  startMs: number;
+  endMs: number;
+  text: string;
+}
+
+const MAX_WORDS_PER_CAPTION = 7;
+const MIN_WORDS_BEFORE_PUNCTUATION_BREAK = 3;
+const ESTIMATED_MS_PER_WORD = 420;
+const MIN_CAPTION_MS = 900;
+
+export function parseTranscriptSegments(
+  raw: string | null | undefined,
+): TranscriptSegment[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((segment) => ({
+        startMs: Number(segment?.startMs),
+        endMs: Number(segment?.endMs),
+        text: typeof segment?.text === "string" ? segment.text.trim() : "",
+      }))
+      .filter(
+        (segment) =>
+          Number.isFinite(segment.startMs) &&
+          Number.isFinite(segment.endMs) &&
+          segment.endMs > segment.startMs &&
+          segment.text,
+      );
+  } catch {
+    return [];
+  }
+}
+
+export function buildCaptionSegmentsFromText(
+  text: string,
+  durationMs?: number | null,
+): TranscriptSegment[] {
+  const chunks = splitIntoCaptionChunks(text);
+  if (chunks.length === 0) return [];
+
+  const wordCounts = chunks.map(countWords);
+  const totalWords = wordCounts.reduce((sum, count) => sum + count, 0) || 1;
+  const estimatedDurationMs = Math.max(
+    chunks.length * MIN_CAPTION_MS,
+    totalWords * ESTIMATED_MS_PER_WORD,
+  );
+  const totalDurationMs =
+    typeof durationMs === "number" && Number.isFinite(durationMs) && durationMs > 0
+      ? Math.max(durationMs, chunks.length * MIN_CAPTION_MS)
+      : estimatedDurationMs;
+
+  let cursorMs = 0;
+  return chunks.map((chunk, index) => {
+    const isLast = index === chunks.length - 1;
+    const rawDuration = Math.round(
+      (totalDurationMs * wordCounts[index]) / totalWords,
+    );
+    const endMs = isLast
+      ? Math.max(cursorMs + MIN_CAPTION_MS, Math.round(totalDurationMs))
+      : Math.max(cursorMs + MIN_CAPTION_MS, cursorMs + rawDuration);
+    const segment = {
+      startMs: cursorMs,
+      endMs,
+      text: chunk,
+    };
+    cursorMs = endMs;
+    return segment;
+  });
+}
+
+export function normalizeTranscriptSegments({
+  segments,
+  fullText,
+  durationMs,
+}: {
+  segments: TranscriptSegment[];
+  fullText?: string | null;
+  durationMs?: number | null;
+}): TranscriptSegment[] {
+  const validSegments = segments.filter((segment) => segment.text.trim());
+  if (!shouldRechunkSegments(validSegments, fullText)) return validSegments;
+
+  const sourceText =
+    fullText?.trim() ||
+    validSegments.map((segment) => segment.text.trim()).join(" ").trim();
+  return buildCaptionSegmentsFromText(sourceText, durationMs);
+}
+
+function splitIntoCaptionChunks(text: string): string[] {
+  const words = text.replace(/\s+/g, " ").trim().split(" ").filter(Boolean);
+  const chunks: string[] = [];
+  let current: string[] = [];
+
+  for (const word of words) {
+    current.push(word);
+    const cleanWord = word.replace(/["')\]}]+$/g, "");
+    const strongBreak = /[.!?]$/.test(cleanWord);
+    const softBreak = /[,;:]$/.test(cleanWord);
+    const canBreakOnPunctuation =
+      current.length >= MIN_WORDS_BEFORE_PUNCTUATION_BREAK &&
+      (strongBreak || softBreak);
+
+    if (
+      current.length >= MAX_WORDS_PER_CAPTION ||
+      canBreakOnPunctuation
+    ) {
+      chunks.push(current.join(" "));
+      current = [];
+    }
+  }
+
+  if (current.length) chunks.push(current.join(" "));
+  return chunks;
+}
+
+function countWords(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+function shouldRechunkSegments(
+  segments: TranscriptSegment[],
+  fullText: string | null | undefined,
+): boolean {
+  if (segments.length === 0) return Boolean(fullText?.trim());
+  if (segments.some((segment) => countWords(segment.text) > MAX_WORDS_PER_CAPTION))
+    return true;
+  if (segments.length === 1 && countWords(segments[0].text) > 3) return true;
+  return false;
+}

--- a/templates/content/app/components/EmptyState.tsx
+++ b/templates/content/app/components/EmptyState.tsx
@@ -43,7 +43,7 @@ export function EmptyState() {
       },
     );
     queryClient.setQueryData(["action", "get-document", { id }], tempDoc);
-    navigate(`/page/${id}`);
+    navigate(`/page/${id}`, { flushSync: true });
 
     try {
       await createDocument.mutateAsync({ id, title: "" });

--- a/templates/content/app/components/editor/DocumentEditor.tsx
+++ b/templates/content/app/components/editor/DocumentEditor.tsx
@@ -19,11 +19,11 @@ import {
   appApiPath,
   type CollabUser,
 } from "@agent-native/core/client";
-import { IconLoader2 } from "@tabler/icons-react";
 import { CommentsSidebar } from "./CommentsSidebar";
 import { useComments } from "@/hooks/use-comments";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useLocalStorage } from "@/hooks/use-local-storage";
 import { useQueryClient } from "@tanstack/react-query";
 import type { Document, DocumentSyncStatus } from "@shared/api";
@@ -32,6 +32,41 @@ const TAB_ID = generateTabId();
 
 interface DocumentEditorProps {
   documentId: string;
+}
+
+function DocumentEditorSkeleton() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-background">
+      <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-6 w-6 rounded-md" />
+          <Skeleton className="h-4 w-36" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-7 w-20 rounded-md" />
+          <Skeleton className="h-7 w-7 rounded-md" />
+          <Skeleton className="h-7 w-7 rounded-md" />
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <div className="mx-auto w-full max-w-3xl px-4 pt-14 pb-16 sm:px-8 md:px-16 md:pt-16">
+          <Skeleton className="mb-4 h-12 w-12 rounded-lg" />
+          <Skeleton className="h-11 w-2/3 rounded-md" />
+          <div className="space-y-3 pt-12">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-11/12" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+          <div className="space-y-3 pt-8">
+            <Skeleton className="h-4 w-10/12" />
+            <Skeleton className="h-4 w-4/5" />
+            <Skeleton className="h-4 w-7/12" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -51,11 +86,7 @@ export function DocumentEditor({ documentId }: DocumentEditorProps) {
   }
 
   if (isLoading || !document) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <IconLoader2 className="w-6 h-6 animate-spin text-muted-foreground" />
-      </div>
-    );
+    return <DocumentEditorSkeleton />;
   }
 
   return <DocumentEditorBody documentId={documentId} document={document} />;
@@ -264,11 +295,7 @@ function DocumentEditorBody({ documentId, document }: DocumentEditorBodyProps) {
   });
 
   if (collabLoading) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <IconLoader2 className="w-6 h-6 animate-spin text-muted-foreground" />
-      </div>
-    );
+    return <DocumentEditorSkeleton />;
   }
 
   const sidebar = (

--- a/templates/content/app/components/editor/DocumentToolbar.tsx
+++ b/templates/content/app/components/editor/DocumentToolbar.tsx
@@ -261,7 +261,7 @@ export function DocumentToolbar({
   };
 
   return (
-    <div className="absolute top-2 right-2 z-10 flex items-center gap-0.5 sm:top-3 sm:right-4 sm:gap-1">
+    <div className="absolute top-2 right-2 z-10 flex items-center gap-0.5 rounded-xl border border-border/70 bg-background/95 p-1 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/85 sm:top-3 sm:right-4 sm:gap-1">
       {/* Presence — shared PresenceBar (agent + collaborator avatars) */}
       <PresenceBar
         activeUsers={activeUsers ?? []}
@@ -518,8 +518,8 @@ export function DocumentToolbar({
                   <div className="p-1.5 border-b border-border">
                     {requiresExplicitCreateParent ? (
                       <p className="px-2.5 py-2 text-xs text-muted-foreground">
-                        Choose a parent page below before creating a new Notion
-                        page.
+                        Notion API-key connections need a parent page shared
+                        with the integration. Pick where to create this page.
                       </p>
                     ) : (
                       <button

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -24,7 +24,6 @@ import { defaultMarkdownSerializer } from "prosemirror-markdown";
 import {
   Plugin,
   PluginKey,
-  TextSelection,
   AllSelection,
 } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
@@ -239,56 +238,13 @@ const TypographyReplacements = Extension.create({
   },
 });
 
-/**
- * Two-stage Cmd+A: first press selects the current block,
- * second press (when block is already fully selected) selects the whole document.
- */
-const SelectAllBlock = Extension.create({
-  name: "selectAllBlock",
+const SelectAllDocument = Extension.create({
+  name: "selectAllDocument",
   addKeyboardShortcuts() {
     return {
       "Mod-a": ({ editor }) => {
-        const { state } = editor;
-        const { selection, doc } = state;
-
-        // Find the nearest top-level block node containing the cursor
-        const $from = selection.$from;
-        let blockStart: number | null = null;
-        let blockEnd: number | null = null;
-
-        // Walk up to find the top-level (depth 1) block
-        for (let depth = $from.depth; depth >= 1; depth--) {
-          if (depth === 1) {
-            blockStart = $from.before(depth);
-            blockEnd = $from.after(depth);
-            break;
-          }
-        }
-
-        if (blockStart == null || blockEnd == null) {
-          // Fallback: select all
-          editor.commands.setTextSelection({ from: 0, to: doc.content.size });
-          return true;
-        }
-
-        // Check if the current block is already fully selected
-        const blockContentStart = blockStart + 1;
-        const blockContentEnd = blockEnd - 1;
-        const isBlockSelected =
-          selection.from <= blockContentStart &&
-          selection.to >= blockContentEnd;
-
-        if (isBlockSelected) {
-          // Second Cmd+A: select entire document
-          editor.commands.setTextSelection({ from: 0, to: doc.content.size });
-        } else {
-          // First Cmd+A: select current block content
-          editor.commands.setTextSelection({
-            from: blockContentStart,
-            to: blockContentEnd,
-          });
-        }
-
+        const { state, view } = editor;
+        view.dispatch(state.tr.setSelection(new AllSelection(state.doc)));
         return true;
       },
     };
@@ -506,7 +462,7 @@ export function createVisualEditorExtensions({
     DragHandle,
     TypographyReplacements,
     MarkdownPasteDetection,
-    SelectAllBlock,
+    SelectAllDocument,
     NotionBlockIndent,
     Markdown.configure({
       html: true,

--- a/templates/content/app/components/editor/VisualEditor.tsx
+++ b/templates/content/app/components/editor/VisualEditor.tsx
@@ -21,11 +21,7 @@ import { TableCell } from "@tiptap/extension-table-cell";
 import { TableHeader } from "@tiptap/extension-table-header";
 import { Markdown } from "tiptap-markdown";
 import { defaultMarkdownSerializer } from "prosemirror-markdown";
-import {
-  Plugin,
-  PluginKey,
-  AllSelection,
-} from "@tiptap/pm/state";
+import { Plugin, PluginKey, AllSelection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 import { useEffect, useRef, useMemo, useState } from "react";
 import { IconPhoto } from "@tabler/icons-react";

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { Link, useLocation, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import type { Document } from "@shared/api";
 import {
@@ -83,7 +83,6 @@ export function DocumentSidebar({
   onResize,
 }: DocumentSidebarProps) {
   const navigate = useNavigate();
-  const location = useLocation();
   const queryClient = useQueryClient();
   const { data: documents = [], isLoading } = useDocuments();
   const createDocument = useCreateDocument();
@@ -170,6 +169,13 @@ export function DocumentSidebar({
     forceUpdate((n) => n + 1);
   }, []);
 
+  const navigateToDocument = useCallback(
+    (id: string) => {
+      navigate(`/page/${id}`, { flushSync: true });
+    },
+    [navigate],
+  );
+
   const handleCreatePage = useCallback(
     async (parentId?: string) => {
       const id = nanoid();
@@ -194,7 +200,7 @@ export function DocumentSidebar({
       });
       queryClient.setQueryData(["action", "get-document", { id }], tempDoc);
 
-      navigate(`/page/${id}`);
+      navigateToDocument(id);
       onNavigate?.();
 
       try {
@@ -218,7 +224,7 @@ export function DocumentSidebar({
         });
       }
     },
-    [createDocument, navigate, onNavigate, queryClient],
+    [createDocument, navigate, navigateToDocument, onNavigate, queryClient],
   );
 
   const handleDelete = useCallback(
@@ -435,7 +441,7 @@ export function DocumentSidebar({
                         : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
                     )}
                     onClick={() => {
-                      navigate(`/page/${doc.id}`);
+                      navigateToDocument(doc.id);
                       setIsSearching(false);
                       setSearchQuery("");
                       onNavigate?.();
@@ -468,7 +474,7 @@ export function DocumentSidebar({
                           : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
                       )}
                       onClick={() => {
-                        navigate(`/page/${doc.id}`);
+                        navigateToDocument(doc.id);
                         onNavigate?.();
                       }}
                     >
@@ -517,7 +523,7 @@ export function DocumentSidebar({
                       expandedIds={expandedIds}
                       onToggleExpanded={handleToggleExpanded}
                       onSelect={(id) => {
-                        navigate(`/page/${id}`);
+                        navigateToDocument(id);
                         onNavigate?.();
                       }}
                       onCreateChild={(parentId) => handleCreatePage(parentId)}

--- a/templates/content/app/hooks/use-navigation-state.ts
+++ b/templates/content/app/hooks/use-navigation-state.ts
@@ -74,7 +74,7 @@ export function useNavigationState() {
       headers: { "X-Agent-Native-CSRF": "1" },
     }).catch(() => {});
 
-    navigate(navCommand.path);
+    navigate(navCommand.path, { flushSync: true });
     qc.setQueryData(["navigate-command"], null);
   }, [navCommand, navigate, qc]);
 }

--- a/templates/content/app/hooks/use-navigation-watcher.ts
+++ b/templates/content/app/hooks/use-navigation-watcher.ts
@@ -55,7 +55,7 @@ export function useNavigationWatcher() {
                 path?: string;
               } | null;
               if (stateData?.path) {
-                navigate(stateData.path);
+                navigate(stateData.path, { flushSync: true });
               }
             }
           }

--- a/templates/content/app/root.tsx
+++ b/templates/content/app/root.tsx
@@ -155,7 +155,7 @@ export default function Root() {
         >
           <TooltipProvider>
             <Toaster />
-            <Sonner position="bottom-left" />
+            <Sonner closeButton position="bottom-left" />
             <PublicAgentShell>
               <Outlet />
             </PublicAgentShell>
@@ -172,7 +172,7 @@ export default function Root() {
           <AppSetup />
           <TooltipProvider>
             <Toaster />
-            <Sonner position="bottom-left" />
+            <Sonner closeButton position="bottom-left" />
             <CommandMenu open={cmdkOpen} onOpenChange={setCmdkOpen}>
               <CommandMenu.Group heading="Content">
                 <CommandMenu.Item onSelect={() => {}}>

--- a/templates/content/app/routes/_app._index.tsx
+++ b/templates/content/app/routes/_app._index.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router";
 import { EmptyState } from "@/components/EmptyState";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Spinner } from "@/components/ui/spinner";
 import { useDocuments } from "@/hooks/use-documents";
 
 export function meta() {
@@ -17,11 +16,7 @@ export function meta() {
 }
 
 export function HydrateFallback() {
-  return (
-    <div className="flex items-center justify-center h-screen w-full">
-      <Spinner className="size-8 text-foreground" />
-    </div>
-  );
+  return <DocumentSkeleton />;
 }
 
 function DocumentSkeleton() {
@@ -52,7 +47,7 @@ export default function IndexRoute() {
     if (documents && documents.length > 0) {
       const firstFavorite = documents.find((d) => d.isFavorite);
       const target = firstFavorite ?? documents[0];
-      navigate(`/page/${target.id}`, { replace: true });
+      navigate(`/page/${target.id}`, { replace: true, flushSync: true });
     }
   }, [documents, navigate]);
 

--- a/templates/design/app/hooks/use-agent-generating.ts
+++ b/templates/design/app/hooks/use-agent-generating.ts
@@ -4,7 +4,10 @@ import {
   type AgentChatMessage,
 } from "@agent-native/core/client";
 
-const GENERATION_TIMEOUT_MS = 120_000;
+// This is only a lost-signal recovery guard. Large design prompts can
+// legitimately take several minutes, so avoid treating normal latency as
+// failure.
+const GENERATION_ORPHAN_TIMEOUT_MS = 30 * 60_000;
 
 interface UseAgentGeneratingOptions {
   onComplete?: (tabId: string | null) => void;
@@ -44,7 +47,7 @@ export function useAgentGenerating(options: UseAgentGeneratingOptions = {}) {
           callbacksRef.current.onStale?.(tabId);
           reset();
         }
-      }, GENERATION_TIMEOUT_MS);
+      }, GENERATION_ORPHAN_TIMEOUT_MS);
     },
     [clearGenerationTimeout, reset],
   );

--- a/templates/design/app/lib/pending-generation.test.ts
+++ b/templates/design/app/lib/pending-generation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPendingGenerationStale,
+  PENDING_GENERATION_STALE_MS,
+} from "./pending-generation";
+
+describe("pending generation freshness", () => {
+  it("keeps multi-minute design generations active", () => {
+    const startedAt = 10_000;
+
+    expect(
+      isPendingGenerationStale({ startedAt }, startedAt + 5 * 60_000),
+    ).toBe(false);
+  });
+
+  it("expires abandoned generation state after the orphan timeout", () => {
+    const startedAt = 10_000;
+
+    expect(
+      isPendingGenerationStale(
+        { startedAt },
+        startedAt + PENDING_GENERATION_STALE_MS + 1,
+      ),
+    ).toBe(true);
+  });
+});

--- a/templates/design/app/lib/pending-generation.ts
+++ b/templates/design/app/lib/pending-generation.ts
@@ -1,7 +1,9 @@
 import type { UploadedFile } from "@/components/editor/PromptDialog";
 import type { PromptComposerSubmitOptions } from "@agent-native/core/client";
 
-export const PENDING_GENERATION_STALE_MS = 120_000;
+// Pending generation state is a UI recovery aid, not a generation deadline.
+// Keep it long enough for thorough designs while still clearing abandoned runs.
+export const PENDING_GENERATION_STALE_MS = 30 * 60_000;
 
 export interface PendingGeneration {
   prompt?: string;

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -214,12 +214,12 @@ export default function DesignEditor() {
     clearGenerationCompleteTimer();
     clearPendingGeneration(id);
     setHasPendingGeneration(false);
-    setGenerationIssue("Generation is taking longer than expected. Try again.");
+    setGenerationIssue(
+      "Generation may have stopped before creating files. Check the agent message or try again.",
+    );
     if (!staleToastShownRef.current) {
       staleToastShownRef.current = true;
-      toast.info(
-        "Generation is taking longer than expected. You can try again.",
-      );
+      toast.info("Generation may have stopped before creating files.");
     }
   }, [clearGenerationCompleteTimer, id]);
   const handleGenerationComplete = useCallback(() => {

--- a/templates/dispatch/app/hooks/use-navigation-state.ts
+++ b/templates/dispatch/app/hooks/use-navigation-state.ts
@@ -23,9 +23,10 @@ export function useNavigationState(extensions?: DispatchExtensionConfig) {
 
   // Sync current route to application state
   useEffect(() => {
+    const localPathname = routerPath(location.pathname);
     const state: NavigationState = {
-      view: resolveView(location.pathname, extensions),
-      path: appPath(location.pathname),
+      view: resolveView(localPathname, extensions),
+      path: appPath(localPathname),
     };
 
     fetch(agentNativePath("/_agent-native/application-state/navigation"), {

--- a/templates/dispatch/app/root.tsx
+++ b/templates/dispatch/app/root.tsx
@@ -199,7 +199,7 @@ export default function Root() {
             <AppLayout extensions={dispatchExtensions}>
               <Outlet />
             </AppLayout>
-            <Toaster richColors position="bottom-left" />
+            <Toaster closeButton richColors position="bottom-left" />
           </TooltipProvider>
         </QueryClientProvider>
       </ThemeProvider>

--- a/templates/slides/actions/add-slide-comment.ts
+++ b/templates/slides/actions/add-slide-comment.ts
@@ -1,9 +1,18 @@
 import { defineAction } from "@agent-native/core";
 import { getDbExec, isPostgres } from "@agent-native/core/db";
-import { getRequestUserEmail } from "@agent-native/core/server";
+import {
+  getRequestRunContext,
+  getRequestUserEmail,
+  getRequestUserName,
+} from "@agent-native/core/server";
 import { assertAccess } from "@agent-native/core/sharing";
 import { z } from "zod";
 import "../server/db/index.js"; // ensure registerShareableResource runs
+
+function displayNameFromEmail(email: string): string {
+  const local = email.split("@")[0] || email;
+  return local.charAt(0).toUpperCase() + local.slice(1);
+}
 
 export default defineAction({
   description:
@@ -31,7 +40,9 @@ export default defineAction({
     const threadId = args.threadId ?? id;
     const authorEmail = getRequestUserEmail();
     if (!authorEmail) throw new Error("no authenticated user");
-    const authorName = "AI Agent";
+    const authorName = getRequestRunContext()
+      ? "AI Agent"
+      : getRequestUserName()?.trim() || displayNameFromEmail(authorEmail);
 
     const nowExpr = isPostgres() ? "NOW()::text" : "datetime('now')";
     await client.execute({

--- a/templates/slides/app/components/comments/SlideCommentsPanel.tsx
+++ b/templates/slides/app/components/comments/SlideCommentsPanel.tsx
@@ -513,18 +513,39 @@ export function SlideCommentsPanel({
         )}
 
         {/* Empty state */}
-        {!showInput && visibleThreads.length === 0 && (
-          <div className="text-center py-10">
-            <IconMessageCircle
-              size={28}
-              className="mx-auto mb-2 text-muted-foreground/60"
-            />
-            <p className="text-[12px] text-muted-foreground">No comments yet</p>
-            <p className="text-[11px] text-muted-foreground/70 mt-1">
-              Select text and click the comment icon to add one
-            </p>
-          </div>
-        )}
+        {!showInput &&
+          visibleThreads.length === 0 &&
+          (deckId && slideId ? (
+            <button
+              type="button"
+              onClick={() => setAddingComment(true)}
+              className="w-full text-center py-10 rounded-lg border border-dashed border-border/70 hover:border-[#609FF8]/50 hover:bg-accent transition-colors"
+            >
+              <IconMessageCircle
+                size={28}
+                className="mx-auto mb-2 text-muted-foreground/60"
+              />
+              <p className="text-[12px] text-muted-foreground">
+                No comments yet
+              </p>
+              <p className="text-[11px] text-muted-foreground/70 mt-1">
+                Click to add a comment
+              </p>
+            </button>
+          ) : (
+            <div className="text-center py-10">
+              <IconMessageCircle
+                size={28}
+                className="mx-auto mb-2 text-muted-foreground/60"
+              />
+              <p className="text-[12px] text-muted-foreground">
+                No comments yet
+              </p>
+              <p className="text-[11px] text-muted-foreground/70 mt-1">
+                Select a slide to add one
+              </p>
+            </div>
+          ))}
       </div>
     </div>
   );

--- a/templates/slides/app/hooks/use-deck-presence.ts
+++ b/templates/slides/app/hooks/use-deck-presence.ts
@@ -18,6 +18,7 @@ export function useDeckPresence(options: {
 }) {
   const { deckId, activeSlideId, user } = options;
   const selfEmail = user?.email;
+  const normalizedSelfEmail = selfEmail?.trim().toLowerCase();
 
   const { awareness } = useCollaborativeDoc({
     docId: deckId ? `deck-${deckId}` : null,
@@ -30,6 +31,9 @@ export function useDeckPresence(options: {
   useEffect(() => {
     if (!awareness || !activeSlideId) return;
     awareness.setLocalStateField("slide", activeSlideId);
+    return () => {
+      awareness.setLocalStateField("slide", null);
+    };
   }, [awareness, activeSlideId]);
 
   // Build Map<slideId, CollabUser[]> from all remote awareness states
@@ -48,7 +52,8 @@ export function useDeckPresence(options: {
         if (clientId === selfId) return;
         const u = state.user as CollabUser | undefined;
         const slide = state.slide as string | undefined;
-        if (u && slide && u.email !== selfEmail) {
+        const email = u?.email?.trim().toLowerCase();
+        if (u && slide && email !== normalizedSelfEmail) {
           if (!map.has(slide)) map.set(slide, []);
           map.get(slide)!.push(u);
         }
@@ -59,7 +64,7 @@ export function useDeckPresence(options: {
     awareness.on("change", update);
     update();
     return () => awareness.off("change", update);
-  }, [awareness]);
+  }, [awareness, normalizedSelfEmail]);
 
   return { slidePresence };
 }


### PR DESCRIPTION
## Summary

Seed PR for the next concurrent-agent batch. First commit extracts a reusable `queueTitleRegenerationRequest` helper from `regenerate-title.ts` and adds a new `templates/clips/shared/transcript-segments.ts` library (`parseTranscriptSegments` + `buildCaptionSegmentsFromText`) so caption work doesn't duplicate the parsing heuristics across actions. Concurrent agent sweeps will land here as they arrive.

## Test plan

- [ ] Build, Lint, Test, Typecheck, Guard, Changeset all green
- [ ] Title regeneration still routes through the agent chat for ready recordings
- [ ] Caption segment derivation lines up with existing transcript JSON shape