### PR TITLE
feat(desktop-app): icon-only TabBar + concurrent sweeps

### DIFF
--- a/.changeset/google-oauth-popup-close.md
+++ b/.changeset/google-oauth-popup-close.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Close Google OAuth success popups after Builder workspace sign-in completes.

--- a/.changeset/green-chat-gateway.md
+++ b/.changeset/green-chat-gateway.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow explicitly deploy-managed Builder chat credentials to work for signed-in hosted apps.

--- a/.changeset/green-chat-gateway.md
+++ b/.changeset/green-chat-gateway.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Allow explicitly deploy-managed Builder chat credentials to work for signed-in hosted apps.
+Keep hosted chat credential isolation intact and show visible missing-credential errors.

--- a/.changeset/legacy-workspace-builder-credentials.md
+++ b/.changeset/legacy-workspace-builder-credentials.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Read legacy workspace-scoped Builder credentials so users who connected before org scoping no longer see "missing key" errors.

--- a/.github/workflows/cancel-stale-netlify-previews.yml
+++ b/.github/workflows/cancel-stale-netlify-previews.yml
@@ -1,0 +1,84 @@
+name: Cancel stale Netlify previews
+
+on:
+  pull_request:
+    types: [synchronize, closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          NETLIFY_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          BRANCH: ${{ github.head_ref }}
+          LATEST_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGED: ${{ github.event.pull_request.merged }}
+          ACTION: ${{ github.event.action }}
+        with:
+          script: |
+            const SITES = [
+              ['images',        '5868670b-649a-4a45-9e34-45ef3e75f3fd'],
+              ['design',        '1e6bd63d-2972-4272-86bd-7b33f493606d'],
+              ['voice',         '65ba35b8-8b97-4711-bad2-dc66ff1fe245'],
+              ['meeting-notes', '500f9618-f9a1-49ba-b533-7700ab667844'],
+              ['scheduling',    'ce197d9f-7153-40b5-a5f4-062327f05e15'],
+              ['clips',         '7e3f4fee-258d-4d16-9aaf-154a714e87e2'],
+              ['videos',        '3f0c2cd2-06cd-4ab8-bfb4-c199430d1dac'],
+              ['starter',       '864ab6ba-0889-4265-99c0-7a18d1888585'],
+              ['recruiting',    'eb4de782-2d5f-4db9-b22d-e383af2556fb'],
+              ['slides',        'fd5deb5b-5539-47e1-830c-e5fb5e105efd'],
+              ['mail',          'dee98bb0-6143-4205-8c04-afe7bf83d5b5'],
+              ['issues',        '76b94d46-f566-43cd-bddd-01123137ab9a'],
+              ['macros',        '0700a8ac-6a9f-4834-80dd-734102228132'],
+              ['forms',         'aa0b2020-9983-4d6c-8fb0-65462f960fc4'],
+              ['dispatch',      '1171ef84-ed50-418b-bced-e19470475e49'],
+              ['content',       '5c2198f5-bee4-41c3-8a6d-4869f400eec2'],
+              ['calendar',      '954fe53b-052e-4401-aac2-2e973e498af8'],
+              ['analytics',     'ba983662-dac4-478d-a481-5079e67e4d33'],
+              ['fw',            '33249da7-8dca-47f9-b61f-3a5eba3116e2'],
+            ];
+
+            const token = process.env.NETLIFY_TOKEN;
+            if (!token) { core.setFailed('NETLIFY_AUTH_TOKEN secret not set'); return; }
+
+            const branch = process.env.BRANCH;
+            const latestSha = process.env.LATEST_SHA;
+            const closed = process.env.ACTION === 'closed';
+            const headers = { Authorization: `Bearer ${token}` };
+
+            // On close (merged or not), cancel every non-terminal preview for this branch.
+            // On synchronize, cancel only deploys whose commit_ref differs from the latest SHA.
+            const STALE_STATES = new Set(['new', 'enqueued', 'building', 'uploading', 'uploaded', 'preparing', 'prepared', 'processing']);
+
+            const results = await Promise.all(SITES.map(async ([name, id]) => {
+              const url = `https://api.netlify.com/api/v1/sites/${id}/deploys?branch=${encodeURIComponent(branch)}&per_page=100`;
+              const r = await fetch(url, { headers });
+              if (!r.ok) return { name, error: `list ${r.status}` };
+              const deploys = await r.json();
+              const stale = deploys.filter(d =>
+                d.context === 'deploy-preview' &&
+                STALE_STATES.has(d.state) &&
+                (closed || d.commit_ref !== latestSha)
+              );
+              const cancelled = await Promise.all(stale.map(async d => {
+                const c = await fetch(`https://api.netlify.com/api/v1/deploys/${d.id}/cancel`, { method: 'POST', headers });
+                return { id: d.id, ok: c.ok, status: c.status, sha: (d.commit_ref || '').slice(0, 7), state: d.state };
+              }));
+              return { name, total: stale.length, cancelled };
+            }));
+
+            let total = 0;
+            for (const r of results) {
+              if (r.error) { core.warning(`[${r.name}] ${r.error}`); continue; }
+              if (!r.total) continue;
+              total += r.total;
+              core.info(`[${r.name}] cancelled ${r.cancelled.filter(x => x.ok).length}/${r.total}`);
+              for (const c of r.cancelled) {
+                core.info(`  ${c.ok ? 'OK' : 'FAIL'} ${c.id} ${c.sha} (${c.state})`);
+              }
+            }
+            core.info(`Total cancelled: ${total} (action=${process.env.ACTION}, branch=${branch})`);

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -4,8 +4,10 @@ import {
   setResponseStatus,
   getMethod,
 } from "h3";
-import { isLocalDatabase } from "../db/client.js";
-import { readDeployCredentialEnv } from "../server/credential-provider.js";
+import {
+  isDeployCredentialFallbackAllowed,
+  readDeployCredentialEnv,
+} from "../server/credential-provider.js";
 import type { EventHandler as H3EventHandler } from "h3";
 import type {
   ActionTool,
@@ -137,37 +139,31 @@ export function engineToProvider(engineName: string): string {
 }
 
 /**
- * Returns true when this process is acting as a multi-tenant deployment —
- * i.e. a hosted shared-DB environment where one user's identity must NOT be
- * silently substituted with the deploy-level API key.
+ * Returns true when this process should block generic deploy-level provider
+ * credentials for signed-in chat requests.
  *
- * Mirrors the gate in `resolveBuilderCredential` (server/credential-provider.ts).
- *
- * Heuristic:
- *   - `NODE_ENV === "production"`, AND
- *   - The DB is not a local file (i.e. it's Neon/Postgres/Turso/D1 — any
- *     backend that could be shared across multiple users).
- *
- * Self-hosted single-tenant deployments (a local sqlite file, or NODE_ENV
- * unset/development) keep the env-var fallback so the original BYO-server
- * UX continues to work without a per-user key.
+ * Self-hosted single-tenant deployments and explicitly opted-in hosted
+ * deployments keep the env-var fallback so BYO-server and intentionally
+ * deploy-managed chat setups continue to work. Builder's deploy-managed
+ * gateway has a narrower key-pair gate in `credential-provider.ts`.
  */
-function isMultiTenantDeploy(): boolean {
-  if (process.env.NODE_ENV !== "production") return false;
-  return !isLocalDatabase();
+function shouldBlockDeployCredentialFallback(): boolean {
+  return !isDeployCredentialFallbackAllowed();
 }
 
 /**
  * Resolve the active engine's provider and look up the user's API key for it.
  *
- * In multi-tenant deploys we deliberately refuse the deploy-level
- * deploy-level fallback for authenticated users. Without that gate any
+ * In shared hosted deploys we deliberately refuse the deploy-level
+ * fallback for authenticated users unless the deploy explicitly opted in.
+ * Without that gate any
  * signed-in user who hasn't configured their own provider key would silently
  * inherit the deployment's key (uncapped billing on the owner's account,
  * prompt logging tied to the deployment owner) — exactly the prior-incident
  * pattern we hit on 2026-04-29.
  *
- * Single-tenant (local-dev, self-hosted SQLite) keeps the env fallback.
+ * Single-tenant (local-dev, self-hosted SQLite) and explicit opt-in deploys
+ * keep the env fallback.
  *
  * Callers in `agent-chat-plugin.ts`, `triggers/dispatcher.ts`,
  * `jobs/scheduler.ts`, and `integrations/plugin.ts` historically layer
@@ -184,11 +180,12 @@ export async function getOwnerActiveApiKey(
     const provider = engineToProvider(activeEngine);
     const userKey = await getOwnerApiKey(provider, ownerEmail);
     if (userKey) return userKey;
-    if (isMultiTenantDeploy()) {
-      // Multi-tenant: refuse the env fallback. A null user (unauthenticated /
-      // background context with no owner) gets undefined here too — there's
-      // no user to bill, and the call site must surface a "configure a key"
-      // error to the requester rather than silently using the deploy key.
+    if (shouldBlockDeployCredentialFallback()) {
+      // Shared hosted default: refuse the env fallback. A null user
+      // (unauthenticated / background context with no owner) gets undefined
+      // here too — there's no user to bill, and the call site must surface a
+      // "configure a key" error to the requester rather than silently using
+      // the deploy key.
       return undefined;
     }
     const envVar = PROVIDER_TO_ENV[provider];
@@ -1620,11 +1617,11 @@ export function createProductionAgentHandler(
     if (requestEngine) {
       const provider = engineToProvider(requestEngine);
       userApiKey = await getOwnerApiKey(provider, ownerEmail);
-      if (!userApiKey && !isMultiTenantDeploy()) {
-        // Single-tenant only: env fallback for the requested provider.
-        // Multi-tenant deploys never silently substitute the deploy-level
-        // key for an authenticated user (see getOwnerActiveApiKey for the
-        // full rationale).
+      if (!userApiKey && !shouldBlockDeployCredentialFallback()) {
+        // Single-tenant or explicit opt-in only: env fallback for the
+        // requested provider. Shared hosted deploys never silently substitute
+        // the deploy-level key for an authenticated user (see
+        // getOwnerActiveApiKey for the full rationale).
         const envVar = PROVIDER_TO_ENV[provider];
         userApiKey = envVar ? readDeployCredentialEnv(envVar) : undefined;
       }
@@ -1633,11 +1630,12 @@ export function createProductionAgentHandler(
     }
 
     // `options.apiKey` is the value the template constructed the plugin with
-    // (e.g. wired from a deployment env var). On a multi-tenant deploy this
+    // (e.g. wired from a deployment env var). On a shared hosted deploy this
     // is the same cross-tenant hazard as any deploy-level provider key:
     // accepting it as the final fallback would silently bill every key-less
-    // user to the deployment's account. Only honour it in single-tenant mode.
-    const effectiveApiKey = isMultiTenantDeploy()
+    // user to the deployment's account. Honour it only when the generic
+    // deploy fallback policy allows it.
+    const effectiveApiKey = shouldBlockDeployCredentialFallback()
       ? userApiKey
       : (userApiKey ??
         options.apiKey ??

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -142,10 +142,8 @@ export function engineToProvider(engineName: string): string {
  * Returns true when this process should block generic deploy-level provider
  * credentials for signed-in chat requests.
  *
- * Self-hosted single-tenant deployments and explicitly opted-in hosted
- * deployments keep the env-var fallback so BYO-server and intentionally
- * deploy-managed chat setups continue to work. Builder's deploy-managed
- * gateway has a narrower key-pair gate in `credential-provider.ts`.
+ * Self-hosted single-tenant deployments keep the env-var fallback so the
+ * original BYO-server UX continues to work without a per-user key.
  */
 function shouldBlockDeployCredentialFallback(): boolean {
   return !isDeployCredentialFallbackAllowed();
@@ -154,16 +152,14 @@ function shouldBlockDeployCredentialFallback(): boolean {
 /**
  * Resolve the active engine's provider and look up the user's API key for it.
  *
- * In shared hosted deploys we deliberately refuse the deploy-level
- * fallback for authenticated users unless the deploy explicitly opted in.
- * Without that gate any
+ * In shared hosted deploys we deliberately refuse the deploy-level fallback
+ * for authenticated users. Without that gate any
  * signed-in user who hasn't configured their own provider key would silently
  * inherit the deployment's key (uncapped billing on the owner's account,
  * prompt logging tied to the deployment owner) — exactly the prior-incident
  * pattern we hit on 2026-04-29.
  *
- * Single-tenant (local-dev, self-hosted SQLite) and explicit opt-in deploys
- * keep the env fallback.
+ * Single-tenant (local-dev, self-hosted SQLite) keeps the env fallback.
  *
  * Callers in `agent-chat-plugin.ts`, `triggers/dispatcher.ts`,
  * `jobs/scheduler.ts`, and `integrations/plugin.ts` historically layer
@@ -1618,10 +1614,10 @@ export function createProductionAgentHandler(
       const provider = engineToProvider(requestEngine);
       userApiKey = await getOwnerApiKey(provider, ownerEmail);
       if (!userApiKey && !shouldBlockDeployCredentialFallback()) {
-        // Single-tenant or explicit opt-in only: env fallback for the
-        // requested provider. Shared hosted deploys never silently substitute
-        // the deploy-level key for an authenticated user (see
-        // getOwnerActiveApiKey for the full rationale).
+        // Single-tenant only: env fallback for the requested provider. Shared
+        // hosted deploys never silently substitute the deploy-level key for
+        // an authenticated user (see getOwnerActiveApiKey for the full
+        // rationale).
         const envVar = PROVIDER_TO_ENV[provider];
         userApiKey = envVar ? readDeployCredentialEnv(envVar) : undefined;
       }

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -198,7 +198,7 @@ describe("SSE event processor error classification", () => {
       },
     );
 
-    await drain(
+    const results = await drain(
       readSSEStream(
         eventStream([{ type: "error", error: "Authentication required" }]),
         [],
@@ -357,7 +357,7 @@ describe("SSE event processor error classification", () => {
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });
 
-    await drain(
+    const results = await drain(
       readSSEStream(
         eventStream([
           {

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -240,7 +240,7 @@ describe("SSE event processor error classification", () => {
       },
     );
 
-    await drain(
+    const results = await drain(
       readSSEStream(
         eventStream([
           {
@@ -375,6 +375,10 @@ describe("SSE event processor error classification", () => {
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({ type: "agent-chat:missing-api-key" }),
     );
+    expect(results[0]).toEqual({
+      content: [{ type: "text", text: "Error: No LLM provider is connected" }],
+      status: { type: "incomplete", reason: "error" },
+    });
   });
 
   it("dispatches activity events without adding visible content", async () => {

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -444,7 +444,10 @@ export function processEvent(
       if (typeof window !== "undefined") {
         window.dispatchEvent(new Event("agent-chat:missing-api-key"));
       }
-      content.push({ type: "text", text: "" });
+      content.push({
+        type: "text",
+        text: formatChatErrorText(errMsg, ev.upgradeUrl, ev.errorCode),
+      });
       return {
         action: "missing_api_key",
         result: {

--- a/packages/core/src/onboarding/default-steps.ts
+++ b/packages/core/src/onboarding/default-steps.ts
@@ -12,7 +12,10 @@ import {
   PROVIDER_ENV_META,
   PROVIDER_ENV_VARS,
 } from "../agent/engine/provider-env-vars.js";
-import { isAgentEngineSettingConfigured } from "../agent/engine/registry.js";
+import {
+  detectEngineFromUserSecrets,
+  isAgentEngineSettingConfigured,
+} from "../agent/engine/registry.js";
 import { getSetting } from "../settings/store.js";
 
 type LlmKeyMethod = {
@@ -115,6 +118,11 @@ const llmStep: OnboardingStep = {
       if (await resolveHasBuilderPrivateKey()) return true;
     } catch {
       if (process.env.BUILDER_PRIVATE_KEY) return true;
+    }
+    try {
+      if (await detectEngineFromUserSecrets()) return true;
+    } catch {
+      // Fall through to legacy/env detection.
     }
     if (PROVIDER_ENV_VARS.some((k) => !!process.env[k])) return true;
     try {

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1415,6 +1415,7 @@ describe("server/auth", () => {
       expect(response).toBeInstanceOf(Response);
       const html = await (response as Response).text();
       expect(html).toContain("return to Mail");
+      expect(html).toContain("window.close()");
       expect(html).not.toContain("return to Clips");
     });
 
@@ -1474,6 +1475,7 @@ describe("server/auth", () => {
       const html = await (response as Response).text();
       expect(html).not.toContain("agentnative://oauth-complete");
       expect(html).toContain("return to Mail");
+      expect(html).toContain("window.close()");
     });
 
     it("uses a deep link for the no-flowId desktop login when UA marks AgentNativeDesktop", async () => {

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -21,7 +21,9 @@ vi.mock("../db/client.js", () => ({
 }));
 
 import {
+  canUseBuilderDeployCredentialFallbackForRequest,
   canUseDeployCredentialFallbackForRequest,
+  isDeployCredentialFallbackAllowed,
   resolveCredentialWriteScope,
   writeBuilderCredentials,
   deleteBuilderCredentials,
@@ -39,6 +41,8 @@ beforeEach(() => {
   } else {
     process.env.NODE_ENV = ORIGINAL_NODE_ENV;
   }
+  delete process.env.AGENT_ENGINE;
+  delete process.env.AGENT_NATIVE_ALLOW_DEPLOY_CREDENTIAL_FALLBACK;
   delete process.env.BUILDER_PRIVATE_KEY;
   delete process.env.BUILDER_PUBLIC_KEY;
   delete process.env.OPENAI_API_KEY;
@@ -213,6 +217,23 @@ describe("resolveBuilderCredential", () => {
 
     expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBeNull();
     expect(canUseDeployCredentialFallbackForRequest()).toBe(false);
+  });
+
+  it("uses deploy-level Builder keys when a production shared-database deploy explicitly selects Builder", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.AGENT_ENGINE = "builder";
+    process.env.BUILDER_PRIVATE_KEY = "deploy-key";
+    process.env.BUILDER_PUBLIC_KEY = "space-id";
+    mockIsLocalDatabase.mockReturnValue(false);
+    mockGetRequestUserEmail.mockReturnValue("a@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret.mockResolvedValue(null);
+
+    expect(canUseDeployCredentialFallbackForRequest()).toBe(false);
+    expect(canUseBuilderDeployCredentialFallbackForRequest()).toBe(true);
+    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBe(
+      "deploy-key",
+    );
   });
 
   it("falls back to org scope when no user-scope row exists", async () => {
@@ -417,6 +438,31 @@ describe("resolveSecret (generic)", () => {
     mockGetRequestUserEmail.mockReturnValue("a@b.com");
     mockReadAppSecret.mockResolvedValue(null);
     expect(await resolveSecret("OPENAI_API_KEY")).toBeNull();
+  });
+
+  it("keeps non-Builder deploy env secrets blocked when only the Builder engine is deploy-managed", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.AGENT_ENGINE = "builder";
+    process.env.BUILDER_PRIVATE_KEY = "deploy-key";
+    process.env.BUILDER_PUBLIC_KEY = "space-id";
+    process.env.OPENAI_API_KEY = "openai-deploy-key";
+    mockIsLocalDatabase.mockReturnValue(false);
+    mockGetRequestUserEmail.mockReturnValue("a@b.com");
+    mockReadAppSecret.mockResolvedValue(null);
+
+    expect(await resolveSecret("OPENAI_API_KEY")).toBeNull();
+  });
+
+  it("uses process.env in authenticated production shared-database requests with explicit deploy fallback opt-in", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.AGENT_NATIVE_ALLOW_DEPLOY_CREDENTIAL_FALLBACK = "true";
+    process.env.OPENAI_API_KEY = "deploy-key";
+    mockIsLocalDatabase.mockReturnValue(false);
+    mockGetRequestUserEmail.mockReturnValue("a@b.com");
+    mockReadAppSecret.mockResolvedValue(null);
+
+    expect(isDeployCredentialFallbackAllowed()).toBe(true);
+    expect(await resolveSecret("OPENAI_API_KEY")).toBe("deploy-key");
   });
 
   it("uses process.env for authenticated requests on local/single-tenant databases", async () => {

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -192,7 +192,7 @@ describe("resolveBuilderCredential", () => {
     expect(mockReadAppSecret).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to env when no user/org scoped Builder key exists", async () => {
+  it("falls back to env when no scoped Builder key exists", async () => {
     process.env.BUILDER_PRIVATE_KEY = "deploy-key";
     mockGetRequestUserEmail.mockReturnValue("a@b.com");
     mockGetRequestOrgId.mockReturnValue("builder_io");
@@ -200,7 +200,7 @@ describe("resolveBuilderCredential", () => {
     expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBe(
       "deploy-key",
     );
-    expect(mockReadAppSecret).toHaveBeenCalledTimes(2);
+    expect(mockReadAppSecret).toHaveBeenCalledTimes(3);
   });
 
   it("does not use deploy-level Builder keys for signed-in users on production shared databases", async () => {
@@ -235,6 +235,27 @@ describe("resolveBuilderCredential", () => {
       scope: "org",
       scopeId: "builder_io",
     });
+  });
+
+  it("falls back to workspace scope for legacy shared Builder rows", async () => {
+    mockGetRequestUserEmail.mockReturnValue("member@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret
+      .mockResolvedValueOnce(null) // user scope miss
+      .mockResolvedValueOnce(null) // org scope miss
+      .mockResolvedValueOnce({
+        value: "workspace-key",
+        last4: "-key",
+        updatedAt: 1,
+      });
+    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBe(
+      "workspace-key",
+    );
+    expect(mockReadAppSecret.mock.calls.map((c) => c[0].scope)).toEqual([
+      "user",
+      "org",
+      "workspace",
+    ]);
   });
 
   it("user-scope override wins over org-scope row", async () => {

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -21,9 +21,7 @@ vi.mock("../db/client.js", () => ({
 }));
 
 import {
-  canUseBuilderDeployCredentialFallbackForRequest,
   canUseDeployCredentialFallbackForRequest,
-  isDeployCredentialFallbackAllowed,
   resolveCredentialWriteScope,
   writeBuilderCredentials,
   deleteBuilderCredentials,
@@ -42,7 +40,6 @@ beforeEach(() => {
     process.env.NODE_ENV = ORIGINAL_NODE_ENV;
   }
   delete process.env.AGENT_ENGINE;
-  delete process.env.AGENT_NATIVE_ALLOW_DEPLOY_CREDENTIAL_FALLBACK;
   delete process.env.BUILDER_PRIVATE_KEY;
   delete process.env.BUILDER_PUBLIC_KEY;
   delete process.env.OPENAI_API_KEY;
@@ -217,23 +214,6 @@ describe("resolveBuilderCredential", () => {
 
     expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBeNull();
     expect(canUseDeployCredentialFallbackForRequest()).toBe(false);
-  });
-
-  it("uses deploy-level Builder keys when a production shared-database deploy explicitly selects Builder", async () => {
-    process.env.NODE_ENV = "production";
-    process.env.AGENT_ENGINE = "builder";
-    process.env.BUILDER_PRIVATE_KEY = "deploy-key";
-    process.env.BUILDER_PUBLIC_KEY = "space-id";
-    mockIsLocalDatabase.mockReturnValue(false);
-    mockGetRequestUserEmail.mockReturnValue("a@b.com");
-    mockGetRequestOrgId.mockReturnValue("builder_io");
-    mockReadAppSecret.mockResolvedValue(null);
-
-    expect(canUseDeployCredentialFallbackForRequest()).toBe(false);
-    expect(canUseBuilderDeployCredentialFallbackForRequest()).toBe(true);
-    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBe(
-      "deploy-key",
-    );
   });
 
   it("falls back to org scope when no user-scope row exists", async () => {
@@ -440,7 +420,7 @@ describe("resolveSecret (generic)", () => {
     expect(await resolveSecret("OPENAI_API_KEY")).toBeNull();
   });
 
-  it("keeps non-Builder deploy env secrets blocked when only the Builder engine is deploy-managed", async () => {
+  it("keeps deploy env secrets blocked for signed-in production shared-database users even when AGENT_ENGINE is set", async () => {
     process.env.NODE_ENV = "production";
     process.env.AGENT_ENGINE = "builder";
     process.env.BUILDER_PRIVATE_KEY = "deploy-key";
@@ -451,18 +431,6 @@ describe("resolveSecret (generic)", () => {
     mockReadAppSecret.mockResolvedValue(null);
 
     expect(await resolveSecret("OPENAI_API_KEY")).toBeNull();
-  });
-
-  it("uses process.env in authenticated production shared-database requests with explicit deploy fallback opt-in", async () => {
-    process.env.NODE_ENV = "production";
-    process.env.AGENT_NATIVE_ALLOW_DEPLOY_CREDENTIAL_FALLBACK = "true";
-    process.env.OPENAI_API_KEY = "deploy-key";
-    mockIsLocalDatabase.mockReturnValue(false);
-    mockGetRequestUserEmail.mockReturnValue("a@b.com");
-    mockReadAppSecret.mockResolvedValue(null);
-
-    expect(isDeployCredentialFallbackAllowed()).toBe(true);
-    expect(await resolveSecret("OPENAI_API_KEY")).toBe("deploy-key");
   });
 
   it("uses process.env for authenticated requests on local/single-tenant databases", async () => {

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -272,20 +272,38 @@ describe("resolveBuilderCredential", () => {
     expect(mockReadAppSecret).toHaveBeenCalledTimes(1);
   });
 
-  it("returns null when neither user nor org scope has the key", async () => {
+  it("returns null when no scoped Builder row has the key", async () => {
     mockGetRequestUserEmail.mockReturnValue("a@b.com");
     mockGetRequestOrgId.mockReturnValue("builder_io");
     mockReadAppSecret.mockResolvedValue(null);
     expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBeNull();
   });
 
-  it("does not check org scope when caller has no active org", async () => {
+  it("checks solo workspace scope when caller has no active org", async () => {
     mockGetRequestUserEmail.mockReturnValue("a@b.com");
     mockGetRequestOrgId.mockReturnValue(undefined);
-    mockReadAppSecret.mockResolvedValue(null);
-    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBeNull();
-    expect(mockReadAppSecret).toHaveBeenCalledTimes(1);
-    expect(mockReadAppSecret.mock.calls[0][0].scope).toBe("user");
+    mockReadAppSecret
+      .mockResolvedValueOnce(null) // user scope miss
+      .mockResolvedValueOnce({
+        value: "solo-workspace-key",
+        last4: "-key",
+        updatedAt: 1,
+      });
+    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBe(
+      "solo-workspace-key",
+    );
+    expect(mockReadAppSecret.mock.calls.map((c) => c[0])).toEqual([
+      {
+        key: "BUILDER_PRIVATE_KEY",
+        scope: "user",
+        scopeId: "a@b.com",
+      },
+      {
+        key: "BUILDER_PRIVATE_KEY",
+        scope: "workspace",
+        scopeId: "solo:a@b.com",
+      },
+    ]);
   });
 
   it("reports the effective credential source", async () => {
@@ -296,6 +314,20 @@ describe("resolveBuilderCredential", () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({ value: "org-key", last4: "-key", updatedAt: 1 });
     expect(await resolveBuilderCredentialSource()).toBe("org");
+  });
+
+  it("reports workspace as the credential source for legacy shared Builder rows", async () => {
+    mockGetRequestUserEmail.mockReturnValue("member@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        value: "workspace-key",
+        last4: "-key",
+        updatedAt: 1,
+      });
+    expect(await resolveBuilderCredentialSource()).toBe("workspace");
   });
 
   it("reports env as the credential source when scoped credentials are missing", async () => {

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -103,11 +103,11 @@ export function canUseDeployCredentialFallbackForRequest(): boolean {
 // shared fallback identity is intentional.
 // ---------------------------------------------------------------------------
 
-type BuilderCredentialSource = "user" | "org" | "env";
+type BuilderCredentialSource = "user" | "org" | "workspace" | "env";
 
 async function resolveScopedBuilderCredential(
   key: string,
-): Promise<{ value: string; source: "user" | "org" } | null> {
+): Promise<{ value: string; source: "user" | "org" | "workspace" } | null> {
   const email = getRequestUserEmail();
   if (!email) return null;
 
@@ -136,6 +136,27 @@ async function resolveScopedBuilderCredential(
         scopeId: orgId,
       });
       if (orgSecret) return { value: orgSecret.value, source: "org" };
+
+      // Older setup flows wrote shared credentials at workspace scope.
+      // Keep reading those rows so status UIs and runtime resolution agree
+      // for users who connected before org-scoped Builder credentials existed.
+      const workspaceSecret = await readAppSecret({
+        key,
+        scope: "workspace",
+        scopeId: orgId,
+      });
+      if (workspaceSecret) {
+        return { value: workspaceSecret.value, source: "workspace" };
+      }
+    } else {
+      const soloWorkspaceSecret = await readAppSecret({
+        key,
+        scope: "workspace",
+        scopeId: `solo:${email}`,
+      });
+      if (soloWorkspaceSecret) {
+        return { value: soloWorkspaceSecret.value, source: "workspace" };
+      }
     }
   } catch {
     // Secrets table not ready — treat as missing.

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -73,11 +73,21 @@ export function readDeployCredentialEnv(key: string): string | undefined {
 
 /**
  * Deployment-level credentials are safe as a runtime fallback only in local /
- * single-tenant contexts. In hosted production with a shared database, every
- * signed-in user needs their own user/org/workspace credential so one deploy
- * key does not silently power another tenant's chat.
+ * single-tenant contexts unless the deploy explicitly opts in. In hosted
+ * production with a shared database, every signed-in user normally needs their
+ * own user/org/workspace credential so one deploy key does not silently power
+ * another tenant's chat.
  */
+function isTruthyEnv(value: string | undefined): boolean {
+  return /^(1|true|yes)$/i.test(value ?? "");
+}
+
+export function isDeployCredentialFallbackExplicitlyAllowed(): boolean {
+  return isTruthyEnv(process.env.AGENT_NATIVE_ALLOW_DEPLOY_CREDENTIAL_FALLBACK);
+}
+
 export function isDeployCredentialFallbackAllowed(): boolean {
+  if (isDeployCredentialFallbackExplicitlyAllowed()) return true;
   if (process.env.NODE_ENV !== "production") return true;
   return isLocalDatabase();
 }
@@ -86,6 +96,28 @@ export function canUseDeployCredentialFallbackForRequest(): boolean {
   const email = getRequestUserEmail();
   if (!email) return true;
   return isDeployCredentialFallbackAllowed();
+}
+
+/**
+ * Builder is a special deploy-managed engine. If the operator set
+ * `AGENT_ENGINE=builder` and provided the Builder key pair, that is an
+ * explicit site-wide choice to route chat through the Builder gateway. Keep
+ * this narrower than the generic fallback gate so arbitrary provider env keys
+ * stay blocked for signed-in shared-DB users.
+ */
+export function isBuilderDeployCredentialFallbackAllowed(): boolean {
+  if (isDeployCredentialFallbackAllowed()) return true;
+  return (
+    process.env.AGENT_ENGINE === "builder" &&
+    !!process.env.BUILDER_PRIVATE_KEY &&
+    !!process.env.BUILDER_PUBLIC_KEY
+  );
+}
+
+export function canUseBuilderDeployCredentialFallbackForRequest(): boolean {
+  const email = getRequestUserEmail();
+  if (!email) return true;
+  return isBuilderDeployCredentialFallbackAllowed();
 }
 
 // ---------------------------------------------------------------------------
@@ -175,7 +207,7 @@ export async function resolveBuilderCredential(
 ): Promise<string | null> {
   const scoped = await resolveScopedBuilderCredential(key);
   if (scoped) return scoped.value;
-  if (!canUseDeployCredentialFallbackForRequest()) return null;
+  if (!canUseBuilderDeployCredentialFallbackForRequest()) return null;
   return readDeployCredentialEnv(key) ?? null;
 }
 
@@ -219,7 +251,7 @@ export async function resolveHasBuilderPrivateKey(): Promise<boolean> {
 export async function resolveBuilderCredentialSource(): Promise<BuilderCredentialSource | null> {
   const scoped = await resolveScopedBuilderCredential("BUILDER_PRIVATE_KEY");
   if (scoped) return scoped.source;
-  return canUseDeployCredentialFallbackForRequest() &&
+  return canUseBuilderDeployCredentialFallbackForRequest() &&
     process.env.BUILDER_PRIVATE_KEY
     ? "env"
     : null;
@@ -360,7 +392,7 @@ export async function deleteBuilderCredentials(
 /**
  * Resolve a request-scoped secret. Reads from `app_secrets` first (current
  * user override, active org, then workspace row); falls back to `process.env`
- * only for unauthenticated/CLI/background contexts.
+ * only when the deploy fallback policy allows it.
  */
 export async function resolveSecret(key: string): Promise<string | null> {
   const email = getRequestUserEmail();

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -73,21 +73,11 @@ export function readDeployCredentialEnv(key: string): string | undefined {
 
 /**
  * Deployment-level credentials are safe as a runtime fallback only in local /
- * single-tenant contexts unless the deploy explicitly opts in. In hosted
- * production with a shared database, every signed-in user normally needs their
- * own user/org/workspace credential so one deploy key does not silently power
- * another tenant's chat.
+ * single-tenant contexts. In hosted production with a shared database, every
+ * signed-in user needs their own user/org/workspace credential so one deploy
+ * key does not silently power another tenant's chat.
  */
-function isTruthyEnv(value: string | undefined): boolean {
-  return /^(1|true|yes)$/i.test(value ?? "");
-}
-
-export function isDeployCredentialFallbackExplicitlyAllowed(): boolean {
-  return isTruthyEnv(process.env.AGENT_NATIVE_ALLOW_DEPLOY_CREDENTIAL_FALLBACK);
-}
-
 export function isDeployCredentialFallbackAllowed(): boolean {
-  if (isDeployCredentialFallbackExplicitlyAllowed()) return true;
   if (process.env.NODE_ENV !== "production") return true;
   return isLocalDatabase();
 }
@@ -96,28 +86,6 @@ export function canUseDeployCredentialFallbackForRequest(): boolean {
   const email = getRequestUserEmail();
   if (!email) return true;
   return isDeployCredentialFallbackAllowed();
-}
-
-/**
- * Builder is a special deploy-managed engine. If the operator set
- * `AGENT_ENGINE=builder` and provided the Builder key pair, that is an
- * explicit site-wide choice to route chat through the Builder gateway. Keep
- * this narrower than the generic fallback gate so arbitrary provider env keys
- * stay blocked for signed-in shared-DB users.
- */
-export function isBuilderDeployCredentialFallbackAllowed(): boolean {
-  if (isDeployCredentialFallbackAllowed()) return true;
-  return (
-    process.env.AGENT_ENGINE === "builder" &&
-    !!process.env.BUILDER_PRIVATE_KEY &&
-    !!process.env.BUILDER_PUBLIC_KEY
-  );
-}
-
-export function canUseBuilderDeployCredentialFallbackForRequest(): boolean {
-  const email = getRequestUserEmail();
-  if (!email) return true;
-  return isBuilderDeployCredentialFallbackAllowed();
 }
 
 // ---------------------------------------------------------------------------
@@ -207,7 +175,7 @@ export async function resolveBuilderCredential(
 ): Promise<string | null> {
   const scoped = await resolveScopedBuilderCredential(key);
   if (scoped) return scoped.value;
-  if (!canUseBuilderDeployCredentialFallbackForRequest()) return null;
+  if (!canUseDeployCredentialFallbackForRequest()) return null;
   return readDeployCredentialEnv(key) ?? null;
 }
 
@@ -251,7 +219,7 @@ export async function resolveHasBuilderPrivateKey(): Promise<boolean> {
 export async function resolveBuilderCredentialSource(): Promise<BuilderCredentialSource | null> {
   const scoped = await resolveScopedBuilderCredential("BUILDER_PRIVATE_KEY");
   if (scoped) return scoped.source;
-  return canUseBuilderDeployCredentialFallbackForRequest() &&
+  return canUseDeployCredentialFallbackForRequest() &&
     process.env.BUILDER_PRIVATE_KEY
     ? "env"
     : null;

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -42,7 +42,7 @@ function htmlResponse(html: string, status = 200): Response {
  *  headline and secondary line. Used by every template that goes through the
  *  shared Google OAuth flow. */
 function oauthSuccessCloseTabHtml(headline: string, footnote: string): string {
-  return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Connected</title></head><body style="background:#111;color:#ccc;font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;flex-direction:column"><svg width="44" height="44" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-bottom:14px" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9 12l2 2l4 -4"/></svg><p style="font-size:16px;margin:0 0 12px 0">${headline}</p><p style="font-size:13px;color:#888;margin:0">${footnote}</p></body></html>`;
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Connected</title></head><body style="background:#111;color:#ccc;font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;flex-direction:column"><svg width="44" height="44" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-bottom:14px" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M9 12l2 2l4 -4"/></svg><p style="font-size:16px;margin:0 0 12px 0">${headline}</p><p style="font-size:13px;color:#888;margin:0">${footnote}</p><script>setTimeout(function(){try{window.close()}catch(e){}},250)</script></body></html>`;
 }
 
 /**

--- a/packages/desktop-app/src/main/index.ts
+++ b/packages/desktop-app/src/main/index.ts
@@ -937,8 +937,8 @@ ipcMain.on(IPC.INTER_APP_SEND, (event: IpcMainEvent, msg: InterAppMessage) => {
 interface OAuthProvider {
   name: string;
   matches: (url: URL, context?: OAuthMatchContext) => boolean;
-  /** Substring to look for in the navigation URL to detect callback arrival. */
-  callbackPathFragment: string;
+  /** Substrings to look for in the navigation URL to detect callback arrival. */
+  callbackPathFragments: string[];
 }
 
 interface OAuthMatchContext {
@@ -985,7 +985,7 @@ const OAUTH_PROVIDERS: OAuthProvider[] = [
     matches: (u, context) =>
       u.hostname === "accounts.google.com" ||
       isTrustedGoogleOAuthStarter(u, context),
-    callbackPathFragment: "google/callback",
+    callbackPathFragments: ["google/callback", "google/add-account/callback"],
   },
   {
     name: "builder",
@@ -1009,7 +1009,7 @@ const OAUTH_PROVIDERS: OAuthProvider[] = [
         host === "builder.io" || host.endsWith(".builder.io");
       return isBuilderDomain && u.pathname.startsWith("/cli-auth");
     },
-    callbackPathFragment: "/_agent-native/builder/callback",
+    callbackPathFragments: ["/_agent-native/builder/callback"],
   },
 ];
 
@@ -1106,7 +1106,11 @@ function openOAuthWindow(
       rememberOAuthStateFromNavigation(provider, navUrl, injectionTarget);
       // Detect the OAuth callback (works for both /api/google/callback and
       // /_agent-native/google/callback).
-      if (parsed.pathname.includes(provider.callbackPathFragment)) {
+      if (
+        provider.callbackPathFragments.some((fragment) =>
+          parsed.pathname.includes(fragment),
+        )
+      ) {
         scheduleClose();
       }
       // Detect agentnative:// deep link — handle it and close the popup.

--- a/packages/desktop-app/src/renderer/App.tsx
+++ b/packages/desktop-app/src/renderer/App.tsx
@@ -16,6 +16,7 @@ import UpdatePrompt from "./components/UpdatePrompt.js";
 export interface Tab {
   id: string;
   appId: string;
+  icon: string;
   title: string;
 }
 
@@ -25,6 +26,7 @@ function createTab(app: AppDefinition | AppConfig): Tab {
   return {
     id: `tab-${nextTabId++}`,
     appId: app.id,
+    icon: app.icon,
     title: app.name,
   };
 }

--- a/packages/desktop-app/src/renderer/components/TabBar.tsx
+++ b/packages/desktop-app/src/renderer/components/TabBar.tsx
@@ -3,7 +3,7 @@ import {
   IconCalendar,
   IconFileText,
   IconChartBar,
-  IconLayoutGrid,
+  IconPresentation,
   IconStack2,
   IconVideo,
   IconBrandJira,
@@ -14,6 +14,12 @@ import {
   IconPlus,
   IconScreenShare,
   IconBrush,
+  IconMessageCircle,
+  IconPhone,
+  IconNote,
+  IconMicrophone,
+  IconCalendarTime,
+  IconPhoto,
 } from "@tabler/icons-react";
 import type { Tab } from "../App.js";
 
@@ -22,7 +28,7 @@ const ICON_MAP: Record<string, React.ComponentType<Record<string, unknown>>> = {
   CalendarDays: IconCalendar,
   FileText: IconFileText,
   BarChart2: IconChartBar,
-  GalleryHorizontal: IconLayoutGrid,
+  GalleryHorizontal: IconPresentation,
   Code: IconCode,
   Video: IconVideo,
   BrandJira: IconBrandJira,
@@ -30,6 +36,12 @@ const ICON_MAP: Record<string, React.ComponentType<Record<string, unknown>>> = {
   Users: IconUsers,
   ScreenShare: IconScreenShare,
   Brush: IconBrush,
+  MessageCircle: IconMessageCircle,
+  Phone: IconPhone,
+  Note: IconNote,
+  Microphone: IconMicrophone,
+  CalendarTime: IconCalendarTime,
+  Photo: IconPhoto,
 };
 
 interface TabBarProps {
@@ -51,12 +63,14 @@ export default function TabBar({
     <div className="tabbar">
       {tabs.map((tab) => {
         const isActive = tab.id === activeTabId;
+        const Icon = ICON_MAP[tab.icon] ?? IconStack2;
 
         return (
           <button
             key={tab.id}
             className={`tab${isActive ? " tab--active" : ""}`}
             tabIndex={-1}
+            aria-label={tab.title}
             onClick={() => onTabSelect(tab.id)}
             onMouseDown={(e) => {
               // Middle-click to close
@@ -67,7 +81,9 @@ export default function TabBar({
             }}
             title={tab.title}
           >
-            <span className="tab-label">{tab.title}</span>
+            <span className="tab-icon" aria-hidden="true">
+              <Icon size={15} strokeWidth={1.8} />
+            </span>
             <span
               className="tab-close"
               onClick={(e) => {
@@ -76,6 +92,8 @@ export default function TabBar({
               }}
               role="button"
               tabIndex={-1}
+              title={`Close ${tab.title}`}
+              aria-label={`Close ${tab.title}`}
             >
               <IconX size={10} strokeWidth={2} />
             </span>

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -149,11 +149,15 @@ body {
 }
 
 .tab {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 0 14px;
+  justify-content: center;
+  padding: 0;
   height: 100%;
+  width: 44px;
+  min-width: 44px;
+  max-width: 44px;
   background: var(--tab-bg);
   border: none;
   border-right: 1px solid var(--separator);
@@ -166,8 +170,6 @@ body {
     background var(--ease),
     color var(--ease);
   -webkit-app-region: no-drag;
-  min-width: 0;
-  max-width: 200px;
 }
 
 .tab:hover {
@@ -182,6 +184,9 @@ body {
 
 .tab-icon {
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   opacity: 0.5;
 }
 
@@ -189,15 +194,12 @@ body {
   opacity: 0.8;
 }
 
-.tab-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .tab-close {
-  flex-shrink: 0;
-  width: 16px;
-  height: 16px;
+  position: absolute;
+  right: 3px;
+  top: 3px;
+  width: 14px;
+  height: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -212,8 +214,7 @@ body {
     background var(--ease);
 }
 
-.tab:hover .tab-close,
-.tab--active .tab-close {
+.tab:hover .tab-close {
   opacity: 0.5;
 }
 

--- a/scripts/fusion-analytics-migration/migrate-content.ts
+++ b/scripts/fusion-analytics-migration/migrate-content.ts
@@ -2043,6 +2043,652 @@ function buildAnalyses(): AnalysisMigration[] {
   return [...generated, ...memoAnalyses()];
 }
 
+function buildFusionClosedLostAnalysis(
+  meta: AnalysisMeta,
+  sourceInfo: ReturnType<typeof sourceSnapshot>,
+): AnalysisMigration {
+  const gong = readLegacyJson<FusionMatchedDataset>(
+    "data/fusion-gong-matched.json",
+  );
+  const businessPain = readLegacyJson<FusionBusinessPainDataset>(
+    "data/fusion-business-pain.json",
+  );
+  const deals = (gong.deals ?? []).map((deal) =>
+    compactDeal(deal, {
+      emailCount: collectionCount(gong.emailsByDeal?.[deal.dealId]),
+      slackMessageCount: collectionCount(gong.slackByDeal?.[deal.dealId]),
+    }),
+  );
+  const liveDealIds = new Set(deals.map((deal) => deal.dealId));
+  const stageData = summarizeStageData(deals);
+  const compactPainDeals = (businessPain.deals ?? [])
+    .filter((deal) => !deal.dealId || liveDealIds.has(deal.dealId))
+    .map((deal) => ({
+      dealId: deal.dealId,
+      dealName: deal.dealName,
+      amount: numberValue(deal.amount),
+      businessPain: truncateText(deal.businessPain, 900),
+      operationalPain: truncateText(deal.operationalPain, 900),
+      assessedPainSummary: truncateText(deal.assessedPainSummary, 900),
+      painCategories: deal.painCategories ?? [],
+    }));
+
+  return {
+    ...meta,
+    question: meta.description,
+    instructions: legacyFusionInstructions(meta),
+    resultMarkdown: closedLostMarkdown({
+      meta,
+      summary: gong.summary ?? {},
+      deals,
+      stageData,
+      lossThemes: CLOSED_LOST_THEMES,
+      topPains: businessPain.topPains ?? [],
+      businessPains: businessPain.businessPains ?? [],
+    }),
+    resultData: {
+      migration: "fusion-analytics",
+      source: sourceInfo,
+      legacyFusion: {
+        type: "closed-lost",
+        generatedAt: gong.generatedAt,
+        analysisAsOf: gong.analysisAsOf,
+        summary: gong.summary,
+        deals,
+        stageData,
+        lossThemes: CLOSED_LOST_THEMES,
+        businessPain: {
+          generatedAt: businessPain.generatedAt,
+          totalDeals: businessPain.totalDeals,
+          topPains: (businessPain.topPains ?? [])
+            .slice(0, 8)
+            .map(compactPainTheme),
+          businessPains: (businessPain.businessPains ?? [])
+            .slice(0, 8)
+            .map(compactPainTheme),
+          deals: compactPainDeals,
+        },
+      },
+    },
+  };
+}
+
+function buildFusionClosedWonAnalysis(
+  meta: AnalysisMeta,
+  sourceInfo: ReturnType<typeof sourceSnapshot>,
+): AnalysisMigration {
+  const gong = readLegacyJson<FusionMatchedDataset>(
+    "data/fusion-won-gong-matched.json",
+  );
+  const deals = (gong.deals ?? []).map((deal) =>
+    compactDeal(deal, {
+      emailCount: collectionCount(gong.emailsByDeal?.[deal.dealId]),
+      slackMessageCount: collectionCount(gong.slackByDeal?.[deal.dealId]),
+      personaCount: collectionCount(gong.personasByDeal?.[deal.dealId]),
+    }),
+  );
+  const dealNames = new Map(deals.map((deal) => [deal.dealId, deal.dealName]));
+  const personas = Object.entries(gong.personasByDeal ?? {}).flatMap(
+    ([dealId, rows]) =>
+      rows.map((persona) => ({
+        dealId,
+        dealName: dealNames.get(dealId),
+        email: persona.email,
+        name: persona.name,
+        company: persona.company,
+      })),
+  );
+
+  return {
+    ...meta,
+    question: meta.description,
+    instructions: legacyFusionInstructions(meta),
+    resultMarkdown: closedWonMarkdown({
+      meta,
+      summary: gong.summary ?? {},
+      deals,
+      winThemes: CLOSED_WON_WIN_THEMES,
+    }),
+    resultData: {
+      migration: "fusion-analytics",
+      source: sourceInfo,
+      legacyFusion: {
+        type: "closed-won",
+        generatedAt: gong.generatedAt,
+        analysisAsOf: gong.analysisAsOf,
+        summary: gong.summary,
+        deals,
+        personas,
+        winThemes: CLOSED_WON_WIN_THEMES,
+        operationalThemes: CLOSED_WON_OPERATIONAL_THEMES,
+        businessThemes: CLOSED_WON_BUSINESS_THEMES,
+      },
+    },
+  };
+}
+
+function legacyFusionInstructions(meta: AnalysisMeta): string {
+  return [
+    `Re-run the legacy Fusion analysis "${meta.name}" using these sources: ${meta.dataSources.join(", ")}.`,
+    `Use ${meta.sourcePath} and the compact legacyFusion resultData payload as the baseline for the dashboard shape.`,
+    "Save the refreshed analysis with structured resultData.legacyFusion so charts and tables render in the analysis detail page.",
+    "When provider credentials or tables are unavailable, record the concrete provider error instead of fabricating values.",
+  ].join("\n");
+}
+
+interface FusionMatchedDataset {
+  generatedAt?: string;
+  analysisAsOf?: string;
+  summary?: Record<string, unknown>;
+  deals?: FusionMatchedDeal[];
+  transcriptsByCallId?: Record<string, unknown>;
+  emailsByDeal?: Record<string, unknown[]>;
+  slackByDeal?: Record<string, unknown[]>;
+  personasByDeal?: Record<string, FusionPersona[]>;
+}
+
+interface FusionMatchedDeal {
+  dealId: string;
+  dealName: string;
+  amount?: number;
+  closeDate?: string;
+  furthestStage?: string;
+  closedLostReason?: string;
+  contacts?: unknown[];
+  matchedCalls?: unknown[];
+  gongCallCount?: number;
+}
+
+interface FusionPersona {
+  email?: string;
+  name?: string;
+  company?: string;
+}
+
+interface FusionBusinessPainDataset {
+  generatedAt?: string;
+  totalDeals?: number;
+  topPains?: FusionPainTheme[];
+  businessPains?: FusionPainTheme[];
+  deals?: FusionPainDeal[];
+}
+
+interface FusionPainTheme {
+  rank?: number;
+  pain?: string;
+  description?: string;
+  businessImpact?: string;
+  dealCount?: number;
+  representativeDeals?: string[];
+}
+
+interface FusionPainDeal {
+  dealId?: string;
+  dealName: string;
+  amount?: number;
+  threeWhysSummary?: string;
+  assessedPainSummary?: string;
+  painCategories?: string[];
+  businessPain?: string;
+  operationalPain?: string;
+}
+
+interface CompactFusionDeal {
+  dealId: string;
+  dealName: string;
+  amount: number;
+  closeDate?: string;
+  furthestStage?: string;
+  closedLostReason?: string;
+  gongCallCount: number;
+  matchedCallCount: number;
+  contactCount: number;
+  emailCount: number;
+  slackMessageCount: number;
+  personaCount?: number;
+}
+
+function compactDeal(
+  deal: FusionMatchedDeal,
+  counts: {
+    emailCount?: number;
+    slackMessageCount?: number;
+    personaCount?: number;
+  } = {},
+): CompactFusionDeal {
+  return {
+    dealId: deal.dealId,
+    dealName: deal.dealName,
+    amount: numberValue(deal.amount),
+    closeDate: deal.closeDate,
+    furthestStage: deal.furthestStage,
+    closedLostReason: truncateText(deal.closedLostReason, 900),
+    gongCallCount: numberValue(deal.gongCallCount),
+    matchedCallCount: collectionCount(deal.matchedCalls),
+    contactCount: collectionCount(deal.contacts),
+    emailCount: counts.emailCount ?? 0,
+    slackMessageCount: counts.slackMessageCount ?? 0,
+    ...(counts.personaCount !== undefined
+      ? { personaCount: counts.personaCount }
+      : {}),
+  };
+}
+
+function compactPainTheme(theme: FusionPainTheme) {
+  return {
+    rank: theme.rank,
+    pain: theme.pain,
+    description: truncateText(theme.description, 1_100),
+    businessImpact: theme.businessImpact,
+    dealCount: theme.dealCount,
+    representativeDeals: (theme.representativeDeals ?? []).slice(0, 10),
+  };
+}
+
+function summarizeStageData(deals: CompactFusionDeal[]) {
+  const buckets = new Map<string, { stage: string; deals: number; value: number }>();
+  for (const deal of deals) {
+    const stage = deal.furthestStage || "Unknown";
+    const current = buckets.get(stage) ?? { stage, deals: 0, value: 0 };
+    current.deals += 1;
+    current.value += deal.amount;
+    buckets.set(stage, current);
+  }
+  return [...buckets.values()]
+    .map((stage) => ({
+      ...stage,
+      avgDeal: stage.deals ? Math.round(stage.value / stage.deals) : 0,
+    }))
+    .sort((a, b) => b.value - a.value);
+}
+
+function closedLostMarkdown({
+  meta,
+  summary,
+  deals,
+  stageData,
+  lossThemes,
+  topPains,
+  businessPains,
+}: {
+  meta: AnalysisMeta;
+  summary: Record<string, unknown>;
+  deals: CompactFusionDeal[];
+  stageData: ReturnType<typeof summarizeStageData>;
+  lossThemes: typeof CLOSED_LOST_THEMES;
+  topPains: FusionPainTheme[];
+  businessPains: FusionPainTheme[];
+}) {
+  const totalValue = deals.reduce((sum, deal) => sum + deal.amount, 0);
+  return [
+    `# ${meta.name}`,
+    "",
+    meta.description,
+    "",
+    "## Executive Summary",
+    "",
+    `The migrated dashboard now carries the compact structured dataset needed to render the original chart/table experience inside Agent-Native Analytics. It covers ${numberForMarkdown(metric(summary, "totalDeals") ?? deals.length)} closed-lost deals, ${moneyForMarkdown(totalValue)} of lost pipeline, ${numberForMarkdown(metric(summary, "totalCallsMatched") ?? 0)} matched Gong calls, and ${numberForMarkdown(metric(summary, "emailsFetched") ?? 0)} matched emails.`,
+    "",
+    "## Metrics",
+    "",
+    "| Metric | Value |",
+    "| --- | ---: |",
+    `| Deals | ${numberForMarkdown(metric(summary, "totalDeals") ?? deals.length)} |`,
+    `| Deals with calls | ${numberForMarkdown(metric(summary, "dealsWithCalls") ?? 0)} |`,
+    `| Matched Gong calls | ${numberForMarkdown(metric(summary, "totalCallsMatched") ?? 0)} |`,
+    `| Transcripts fetched | ${numberForMarkdown(metric(summary, "transcriptsFetched") ?? 0)} |`,
+    `| Emails fetched | ${numberForMarkdown(metric(summary, "emailsFetched") ?? 0)} |`,
+    `| Lost pipeline | ${moneyForMarkdown(totalValue)} |`,
+    "",
+    "## Stage Leakage",
+    "",
+    "| Stage | Deals | Value | Avg Deal |",
+    "| --- | ---: | ---: | ---: |",
+    ...stageData.map(
+      (stage) =>
+        `| ${stage.stage} | ${numberForMarkdown(stage.deals)} | ${moneyForMarkdown(stage.value)} | ${moneyForMarkdown(stage.avgDeal)} |`,
+    ),
+    "",
+    "## Top Loss Themes",
+    "",
+    ...lossThemes.map(
+      (theme) =>
+        `- **${theme.theme}**: ${theme.deals} deals, ${moneyForMarkdown(theme.value)}. ${theme.definition}`,
+    ),
+    "",
+    "## Top Operational Pains",
+    "",
+    ...topPains
+      .slice(0, 5)
+      .map((theme) => `- **${theme.pain}**: ${theme.dealCount} deals.`),
+    "",
+    "## Top Business Pains",
+    "",
+    ...businessPains
+      .slice(0, 5)
+      .map(
+        (theme) =>
+          `- **${theme.pain}**: ${theme.businessImpact ?? "No impact recorded"}.`,
+      ),
+  ].join("\n");
+}
+
+function closedWonMarkdown({
+  meta,
+  summary,
+  deals,
+  winThemes,
+}: {
+  meta: AnalysisMeta;
+  summary: Record<string, unknown>;
+  deals: CompactFusionDeal[];
+  winThemes: typeof CLOSED_WON_WIN_THEMES;
+}) {
+  const totalValue = deals.reduce((sum, deal) => sum + deal.amount, 0);
+  const topDeals = [...deals]
+    .sort((a, b) => b.amount - a.amount)
+    .slice(0, 10);
+  return [
+    `# ${meta.name}`,
+    "",
+    meta.description,
+    "",
+    "## Executive Summary",
+    "",
+    `The migrated dashboard now carries the compact structured dataset needed to render the original chart/table experience inside Agent-Native Analytics. It covers ${numberForMarkdown(metric(summary, "totalDeals") ?? deals.length)} closed-won deals, ${moneyForMarkdown(totalValue)} of won ARR, ${numberForMarkdown(metric(summary, "totalCallsMatched") ?? 0)} matched Gong calls, and ${numberForMarkdown(metric(summary, "emailsFetched") ?? 0)} matched emails.`,
+    "",
+    "## Metrics",
+    "",
+    "| Metric | Value |",
+    "| --- | ---: |",
+    `| Deals | ${numberForMarkdown(metric(summary, "totalDeals") ?? deals.length)} |`,
+    `| Deals with calls | ${numberForMarkdown(metric(summary, "dealsWithCalls") ?? 0)} |`,
+    `| Matched Gong calls | ${numberForMarkdown(metric(summary, "totalCallsMatched") ?? 0)} |`,
+    `| Transcripts fetched | ${numberForMarkdown(metric(summary, "transcriptsFetched") ?? 0)} |`,
+    `| Emails fetched | ${numberForMarkdown(metric(summary, "emailsFetched") ?? 0)} |`,
+    `| Won ARR | ${moneyForMarkdown(totalValue)} |`,
+    "",
+    "## Largest Wins",
+    "",
+    "| Deal | ARR | Closed | Gong Calls |",
+    "| --- | ---: | --- | ---: |",
+    ...topDeals.map(
+      (deal) =>
+        `| ${deal.dealName} | ${moneyForMarkdown(deal.amount)} | ${shortDateForMarkdown(deal.closeDate)} | ${numberForMarkdown(deal.gongCallCount)} |`,
+    ),
+    "",
+    "## Win Themes",
+    "",
+    ...winThemes.map((theme) => `- **${theme.title}**: ${theme.detail}`),
+  ].join("\n");
+}
+
+function metric(summary: Record<string, unknown>, key: string): number | undefined {
+  const raw = summary[key];
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  if (typeof raw === "string") {
+    const parsed = Number(raw.replace(/[%,$]/g, ""));
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function collectionCount(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function truncateText(value: unknown, maxLength = 600): string | undefined {
+  if (typeof value !== "string" || !value) return undefined;
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 1).trim()}...`;
+}
+
+function numberForMarkdown(value: number): string {
+  return new Intl.NumberFormat("en-US").format(Math.round(value));
+}
+
+function moneyForMarkdown(value: number | undefined): string {
+  const amount = numberValue(value);
+  if (Math.abs(amount) >= 1_000_000) return `$${(amount / 1_000_000).toFixed(1)}M`;
+  if (Math.abs(amount) >= 1_000) return `$${Math.round(amount / 1_000)}K`;
+  return `$${Math.round(amount)}`;
+}
+
+function shortDateForMarkdown(value: string | undefined): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toISOString().slice(0, 10);
+}
+
+const CLOSED_LOST_THEMES = [
+  {
+    theme: "Stale / Inherited Pipeline",
+    deals: 16,
+    value: 1_243_500,
+    pct: 22.5,
+    definition:
+      "Deals inherited from a departing rep or dormant long enough that no real sales motion happened. These were closed for CRM hygiene, but some still have reopen paths.",
+    examples: [
+      "AWS Help Me Build - security approval created a legitimate reopen path.",
+      "New York Life - inherited opportunity with no prospect response after initial contact.",
+      "OpenGov - originally a Develop deal repositioned as Fusion with no new champion found.",
+    ],
+  },
+  {
+    theme: "Competitive Displacement",
+    deals: 12,
+    value: 830_000,
+    pct: 16.4,
+    definition:
+      "Prospects chose named alternatives such as Lovable, Cursor, Claude Code, Bolt, Google Stitch, or Figma MCP while Builder was still trying to start or complete evaluation.",
+    examples: [
+      "UBER - explicit tool saturation with Lovable for product/design and Cursor for engineering.",
+      "Conservice - Claude Code adoption filled the gap during slow setup.",
+      "GE HealthCare - Bolt validated while Builder was blocked in security review.",
+    ],
+  },
+  {
+    theme: "POV / Product Friction",
+    deals: 13,
+    value: 680_000,
+    pct: 15.1,
+    definition:
+      "Setup failures, output-quality gaps, and workflow mismatches prevented the evaluation from becoming a confident enterprise purchase.",
+    examples: [
+      "Conservice - authentication and container setup failures persisted for weeks.",
+      "Cobalt - post-POC critique cited instability, inconsistent output, and setup time.",
+      "Allianz - competitor generated more complete features by default.",
+    ],
+  },
+  {
+    theme: "Not Ready / Wrong Timing",
+    deals: 11,
+    value: 585_000,
+    pct: 13,
+    definition:
+      "Genuine interest existed, but budget freezes, architecture uncertainty, or deferred evaluations paused the motion instead of killing it outright.",
+    examples: [
+      "Cisco - strong fit, then hiring freeze and budget cuts.",
+      "Snowflake - positive relationship but pausing to roll out Cursor.",
+      "Vagaro - still interested, likely revisiting in Q3.",
+    ],
+  },
+  {
+    theme: "Security Blockers",
+    deals: 9,
+    value: 700_000,
+    pct: 12.7,
+    definition:
+      "Security or compliance requirements blocked evaluation. The dangerous pattern is competitors filling the gap while Builder waits on review.",
+    examples: [
+      "Groupe Mutuel - DMZ policy blocked both cloud container and local connection paths.",
+      "AllianceBernstein - VPN restrictions blocked both cloud and local approaches.",
+      "Capital One - stalled during NDA execution.",
+    ],
+  },
+  {
+    theme: "Org / Personnel Changes",
+    deals: 8,
+    value: 620_000,
+    pct: 12.3,
+    definition:
+      "Champions left, were laid off, or new leadership reversed decisions after technical progress had already been made.",
+    examples: [
+      "SailPoint - new VP of Design put the project on hold after workshops.",
+      "Tekion - CTO changed direction at contract signing.",
+      "HP - reorg eliminated the active champion path.",
+    ],
+  },
+  {
+    theme: "Budget & Pricing",
+    deals: 8,
+    value: 420_000,
+    pct: 11.3,
+    definition:
+      "Price, budget authority, or wrong-persona selling blocked enterprise approval even when the team saw product value.",
+    examples: [
+      "Wells Fargo - champion had interest but could not get budget approved.",
+      "ZS - compared Builder to Lovable and went dark after platform pricing.",
+      "Altimetrik - reached S3 but downgraded to Team plan.",
+    ],
+  },
+] as const;
+
+const CLOSED_WON_WIN_THEMES = [
+  {
+    number: 1,
+    title:
+      "Developer Productivity Is the Universal Opener - Design System Depth Is What Closes",
+    detail:
+      "Every deal started with the same hook: a live Figma-to-code demo promising faster UI delivery. What closed each deal was proving Builder understood the customer's specific design system and production codebase.",
+    deals: ["Optum UHG", "Netflix", "Sony Pictures", "Omnicell", "Acuity Brands"],
+  },
+  {
+    number: 2,
+    title: "Every Win Had One Internal Champion",
+    detail:
+      "Each deal was carried by one identifiable champion with personal urgency, from a trade-fair deadline to a modernization mandate or a CI/CD AI bet.",
+    deals: ["Netflix", "Volue", "tiszasoft.com", "Acuity Brands", "Yotpo"],
+  },
+  {
+    number: 3,
+    title:
+      "SSO and Enterprise Security Review Were the Main Delay After Verbal Yes",
+    detail:
+      "At least three large wins had commercial agreement before weeks of SSO or enterprise security work. Product fit was decided; implementation and compliance extended the cycle.",
+    deals: ["Optum UHG", "Sony Pictures", "Thales"],
+  },
+  {
+    number: 4,
+    title: "Structured POC Converted Technical Skeptics",
+    detail:
+      "Large wins used formal trials to prove design-system fidelity, real repo compatibility, and stakeholder value. CE intervention mattered when the POC hit production-toolchain friction.",
+    deals: ["Optum UHG", "Acuity Brands", "Weedmaps", "Volue", "Porch.com"],
+  },
+  {
+    number: 5,
+    title: "Fusion Is Winning Against Internal Tools and Manual Dev",
+    detail:
+      "The transcripts show the main competitor was the status quo: manual front-end implementation, internal scripts, and design-engineering queues, not a named vendor in most cycles.",
+    deals: ["Netflix", "Omnicell", "Optum UHG", "ServiceNow"],
+  },
+  {
+    number: 6,
+    title: "AI-Native Coding Agent Framing Drives Expansion Potential",
+    detail:
+      "The initial Figma-to-code pitch opens the door, while deeper coding-agent workflows create stickiness once teams see Builder handling review, docs, repo context, and CI/CD-style tasks.",
+    deals: ["tiszasoft.com", "ServiceNow", "Weedmaps", "Yotpo"],
+  },
+] as const;
+
+const CLOSED_WON_OPERATIONAL_THEMES = [
+  {
+    number: 1,
+    title: "Manual Figma-to-Code Handoffs Blocked Design Teams",
+    detail:
+      "Designers could not convert Figma designs to production code without engineering tickets or developer availability.",
+    deals: ["Yotpo", "Weedmaps", "Porch.com", "Sony Pictures", "Optum UHG"],
+  },
+  {
+    number: 2,
+    title: "Generic AI Code Generators Failed Against Production Design Systems",
+    detail:
+      "Teams had tried tools that generated code, but the output did not match their component library, tokens, or repo conventions.",
+    deals: ["Yotpo", "ServiceNow", "Acuity Brands", "Weedmaps", "Thales"],
+  },
+  {
+    number: 3,
+    title: "Monorepo and Enterprise Toolchain Complexity Broke Standard Tools",
+    detail:
+      "Microfrontends, port conflicts, unsupported source control, and SSO friction made simplified demos insufficient.",
+    deals: ["Volue", "Omnicell", "Porch.com"],
+  },
+  {
+    number: 4,
+    title: "No Shared Source of Truth Between Design and Code",
+    detail:
+      "Teams described constant rework from designers and developers working from different references.",
+    deals: ["Netflix", "Sony Pictures", "Thales", "tiszasoft.com"],
+  },
+  {
+    number: 5,
+    title: "Prototyping Was Developer-Gated",
+    detail:
+      "Non-developers could not produce realistic prototypes with live components without waiting on engineering.",
+    deals: ["Volue", "Netflix", "Weedmaps", "Porch.com"],
+  },
+] as const;
+
+const CLOSED_WON_BUSINESS_THEMES = [
+  {
+    number: 1,
+    title: "Engineering Bandwidth Was Consumed by UI Work That Should Be Automated",
+    detail:
+      "Large deals articulated senior engineering time spent on design-to-code translation, component maintenance, or pixel-level QA.",
+    deals: ["Omnicell", "Optum UHG", "Thales", "ServiceNow", "Acuity Brands"],
+  },
+  {
+    number: 2,
+    title: "Design Engineering Was Too Small for the Product Portfolio",
+    detail:
+      "Design engineering teams were structurally too small to support the full application portfolio without automation.",
+    deals: ["Netflix"],
+  },
+  {
+    number: 3,
+    title: "Strategic AI and Modernization Initiatives Needed Production ROI",
+    detail:
+      "Buyers had AI productivity mandates, consolidation programs, or internal-tooling resets that had not delivered production-ready output.",
+    deals: ["Thales", "Acuity Brands", "ServiceNow"],
+  },
+  {
+    number: 4,
+    title: "Feature Velocity Was Too Slow for Real Business Deadlines",
+    detail:
+      "Several wins had deadlines tied to launches, trade fairs, modernization programs, or revenue-facing product areas.",
+    deals: ["Optum UHG", "Volue", "Netflix", "Sony Pictures"],
+  },
+  {
+    number: 5,
+    title: "Prior AI and Design Tool Investment Had Not Produced Production Code",
+    detail:
+      "Teams had spent budget and credibility on AI/design tooling that still required engineering cleanup or could not pass security.",
+    deals: ["Yotpo", "Weedmaps", "Netflix", "Acuity Brands"],
+  },
+  {
+    number: 6,
+    title: "Design Inconsistency at Scale Was a Platform Quality Problem",
+    detail:
+      "Multiple teams building independently created drift across surfaces, raising maintenance cost and customer-trust risk.",
+    deals: ["Sony Pictures", "Acuity Brands", "Omnicell"],
+  },
+] as const;
+
 function memoAnalyses(): AnalysisMigration[] {
   return [
     memoAnalysis(

--- a/scripts/fusion-analytics-migration/migrate-content.ts
+++ b/scripts/fusion-analytics-migration/migrate-content.ts
@@ -100,6 +100,15 @@ interface AnalysisMigration {
   resultData?: Record<string, unknown>;
 }
 
+interface AnalysisMeta {
+  id: string;
+  name: string;
+  description: string;
+  author: string;
+  sourcePath: string;
+  dataSources: string[];
+}
+
 interface ExtensionMigration {
   id: string;
   name: string;
@@ -130,19 +139,30 @@ const TARGET_ROOT = path.resolve("templates", "analytics");
 const argv = process.argv.slice(2);
 const write = argv.includes("--write");
 const validateSql = argv.includes("--validate-sql");
+const onlyAnalysesArg = argv.find((arg) => arg.startsWith("--only-analyses="));
+const onlyAnalysisIds = onlyAnalysesArg
+  ? new Set(
+      onlyAnalysesArg
+        .replace("--only-analyses=", "")
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean),
+    )
+  : null;
 const REMOVED_LEGACY_IDS = ["fusion-developer-pain", "tech-partners"];
 
 const DATE_START = "{{dateStart}}";
 const DATE_END = "{{dateEnd}}";
 
 if (argv.includes("--help")) {
-  console.log(`Usage: pnpm exec tsx scripts/fusion-analytics-migration/migrate-content.ts [--write] [--validate-sql]
+  console.log(`Usage: pnpm exec tsx scripts/fusion-analytics-migration/migrate-content.ts [--write] [--validate-sql] [--only-analyses=id,id]
 
 Migrates legacy ../fusion-analytics dashboards, analyses, and tools into the
 Agent-Native Analytics production SQL database for the Builder.io org.
 
 Default is dry-run. Pass --write to upsert SQL resources. Pass --validate-sql
-to dry-run migrated BigQuery panels after writing/generating configs.`);
+to dry-run migrated BigQuery panels after writing/generating configs. Use
+--only-analyses to upsert only selected saved-analysis rows.`);
   process.exit(0);
 }
 
@@ -156,10 +176,21 @@ async function main() {
   const db = await connect(env.databaseUrl, env.databaseAuthToken);
   try {
     const orgId = await resolveBuilderOrgId(db);
-    const dashboards = await buildDashboards();
-    const analyses = buildAnalyses();
-    const extensions = buildExtensions();
-    const explorerSettings = buildExplorerSettings();
+    const dashboards = onlyAnalysisIds ? [] : await buildDashboards();
+    const allAnalyses = buildAnalyses();
+    const analyses = onlyAnalysisIds
+      ? allAnalyses.filter((analysis) => onlyAnalysisIds.has(analysis.id))
+      : allAnalyses;
+    const extensions = onlyAnalysisIds ? [] : buildExtensions();
+    const explorerSettings = onlyAnalysisIds ? [] : buildExplorerSettings();
+
+    if (onlyAnalysisIds) {
+      const found = new Set(analyses.map((analysis) => analysis.id));
+      const missing = [...onlyAnalysisIds].filter((id) => !found.has(id));
+      if (missing.length) {
+        throw new Error(`Unknown analysis id(s): ${missing.join(", ")}`);
+      }
+    }
 
     console.log(
       `${write ? "Writing" : "Dry run"} Fusion migration into ${ORG_NAME} (${orgId})`,
@@ -174,18 +205,22 @@ async function main() {
 
     if (write) {
       await ensureTables(db);
-      await pruneRemovedLegacyResources(db);
-      for (const dashboard of dashboards) {
-        await upsertDashboard(db, dashboard, orgId);
+      if (!onlyAnalysisIds) {
+        await pruneRemovedLegacyResources(db);
+        for (const dashboard of dashboards) {
+          await upsertDashboard(db, dashboard, orgId);
+        }
       }
       for (const analysis of analyses) {
         await upsertAnalysis(db, analysis, orgId);
       }
-      for (const extension of extensions) {
-        await upsertExtension(db, extension, orgId);
-      }
-      for (const setting of explorerSettings) {
-        await upsertExplorerSetting(db, setting, orgId);
+      if (!onlyAnalysisIds) {
+        for (const extension of extensions) {
+          await upsertExtension(db, extension, orgId);
+        }
+        for (const setting of explorerSettings) {
+          await upsertExplorerSetting(db, setting, orgId);
+        }
       }
     }
 
@@ -275,6 +310,10 @@ async function legacyQueryModule(rel: string): Promise<Record<string, any>> {
 
 function readLegacy(rel: string): string {
   return fs.readFileSync(path.resolve(LEGACY_ROOT, rel), "utf8");
+}
+
+function readLegacyJson<T>(rel: string): T {
+  return JSON.parse(readLegacy(rel)) as T;
 }
 
 function extractConstSql(rel: string, name: string): string {
@@ -1747,14 +1786,7 @@ function readExplorerDashboards(): DashboardMigration[] {
 }
 
 function buildAnalyses(): AnalysisMigration[] {
-  const metas: Array<{
-    id: string;
-    name: string;
-    description: string;
-    author: string;
-    sourcePath: string;
-    dataSources: string[];
-  }> = [
+  const metas: AnalysisMeta[] = [
     {
       id: "conversion-analysis",
       name: "Traffic to Signup Conversion Analysis",
@@ -1973,6 +2005,12 @@ function buildAnalyses(): AnalysisMigration[] {
 
   const generated = metas.map((meta) => {
     const sourceInfo = sourceSnapshot(meta.sourcePath);
+    if (meta.id === "fusion-closed-lost-analysis") {
+      return buildFusionClosedLostAnalysis(meta, sourceInfo);
+    }
+    if (meta.id === "fusion-closed-won-analysis") {
+      return buildFusionClosedWonAnalysis(meta, sourceInfo);
+    }
     return {
       ...meta,
       question: meta.description,
@@ -1998,6 +2036,7 @@ function buildAnalyses(): AnalysisMigration[] {
       resultData: {
         migration: "fusion-analytics",
         source: sourceInfo,
+        renderingStatus: "source-only",
       },
     };
   });

--- a/scripts/fusion-analytics-migration/migrate-content.ts
+++ b/scripts/fusion-analytics-migration/migrate-content.ts
@@ -2286,7 +2286,10 @@ function compactPainTheme(theme: FusionPainTheme) {
 }
 
 function summarizeStageData(deals: CompactFusionDeal[]) {
-  const buckets = new Map<string, { stage: string; deals: number; value: number }>();
+  const buckets = new Map<
+    string,
+    { stage: string; deals: number; value: number }
+  >();
   for (const deal of deals) {
     const stage = deal.furthestStage || "Unknown";
     const current = buckets.get(stage) ?? { stage, deals: 0, value: 0 };
@@ -2385,9 +2388,7 @@ function closedWonMarkdown({
   winThemes: typeof CLOSED_WON_WIN_THEMES;
 }) {
   const totalValue = deals.reduce((sum, deal) => sum + deal.amount, 0);
-  const topDeals = [...deals]
-    .sort((a, b) => b.amount - a.amount)
-    .slice(0, 10);
+  const topDeals = [...deals].sort((a, b) => b.amount - a.amount).slice(0, 10);
   return [
     `# ${meta.name}`,
     "",
@@ -2423,7 +2424,10 @@ function closedWonMarkdown({
   ].join("\n");
 }
 
-function metric(summary: Record<string, unknown>, key: string): number | undefined {
+function metric(
+  summary: Record<string, unknown>,
+  key: string,
+): number | undefined {
   const raw = summary[key];
   if (typeof raw === "number" && Number.isFinite(raw)) return raw;
   if (typeof raw === "string") {
@@ -2453,7 +2457,8 @@ function numberForMarkdown(value: number): string {
 
 function moneyForMarkdown(value: number | undefined): string {
   const amount = numberValue(value);
-  if (Math.abs(amount) >= 1_000_000) return `$${(amount / 1_000_000).toFixed(1)}M`;
+  if (Math.abs(amount) >= 1_000_000)
+    return `$${(amount / 1_000_000).toFixed(1)}M`;
   if (Math.abs(amount) >= 1_000) return `$${Math.round(amount / 1_000)}K`;
   return `$${Math.round(amount)}`;
 }
@@ -2566,7 +2571,13 @@ const CLOSED_WON_WIN_THEMES = [
       "Developer Productivity Is the Universal Opener - Design System Depth Is What Closes",
     detail:
       "Every deal started with the same hook: a live Figma-to-code demo promising faster UI delivery. What closed each deal was proving Builder understood the customer's specific design system and production codebase.",
-    deals: ["Optum UHG", "Netflix", "Sony Pictures", "Omnicell", "Acuity Brands"],
+    deals: [
+      "Optum UHG",
+      "Netflix",
+      "Sony Pictures",
+      "Omnicell",
+      "Acuity Brands",
+    ],
   },
   {
     number: 2,
@@ -2616,7 +2627,8 @@ const CLOSED_WON_OPERATIONAL_THEMES = [
   },
   {
     number: 2,
-    title: "Generic AI Code Generators Failed Against Production Design Systems",
+    title:
+      "Generic AI Code Generators Failed Against Production Design Systems",
     detail:
       "Teams had tried tools that generated code, but the output did not match their component library, tokens, or repo conventions.",
     deals: ["Yotpo", "ServiceNow", "Acuity Brands", "Weedmaps", "Thales"],
@@ -2647,7 +2659,8 @@ const CLOSED_WON_OPERATIONAL_THEMES = [
 const CLOSED_WON_BUSINESS_THEMES = [
   {
     number: 1,
-    title: "Engineering Bandwidth Was Consumed by UI Work That Should Be Automated",
+    title:
+      "Engineering Bandwidth Was Consumed by UI Work That Should Be Automated",
     detail:
       "Large deals articulated senior engineering time spent on design-to-code translation, component maintenance, or pixel-level QA.",
     deals: ["Omnicell", "Optum UHG", "Thales", "ServiceNow", "Acuity Brands"],
@@ -2675,7 +2688,8 @@ const CLOSED_WON_BUSINESS_THEMES = [
   },
   {
     number: 5,
-    title: "Prior AI and Design Tool Investment Had Not Produced Production Code",
+    title:
+      "Prior AI and Design Tool Investment Had Not Produced Production Code",
     detail:
       "Teams had spent budget and credibility on AI/design tooling that still required engineering cleanup or could not pass security.",
     deals: ["Yotpo", "Weedmaps", "Netflix", "Acuity Brands"],

--- a/templates/analytics/app/components/Markdown.test.ts
+++ b/templates/analytics/app/components/Markdown.test.ts
@@ -24,4 +24,29 @@ describe("renderMarkdown", () => {
       'href="https://example.com"',
     );
   });
+
+  it("renders same-origin embed fences as iframes", () => {
+    const html = renderMarkdown(
+      [
+        "```embed",
+        "src: /api/media/chart.png",
+        "title: Revenue chart",
+        "aspect: 4/3",
+        "```",
+      ].join("\n"),
+    );
+
+    expect(html).toContain('<iframe src="/api/media/chart.png"');
+    expect(html).toContain('title="Revenue chart"');
+    expect(html).not.toContain("<pre>");
+  });
+
+  it("blocks cross-origin embed fences", () => {
+    const html = renderMarkdown(
+      ["```embed", "src: https://example.com/chart", "```"].join("\n"),
+    );
+
+    expect(html).toContain("Embed blocked");
+    expect(html).not.toContain("<iframe");
+  });
 });

--- a/templates/analytics/app/components/Markdown.tsx
+++ b/templates/analytics/app/components/Markdown.tsx
@@ -86,6 +86,88 @@ function sanitizeUrl(url: string, kind: "link" | "image" = "link"): string {
   return trimmed;
 }
 
+const ALLOWED_EMBED_ASPECTS = new Set([
+  "16/9",
+  "4/3",
+  "1/1",
+  "21/9",
+  "3/2",
+  "2/1",
+]);
+
+function parseEmbedBody(body: string): {
+  src?: string;
+  aspect?: string;
+  title?: string;
+  height?: number;
+} {
+  const out: {
+    src?: string;
+    aspect?: string;
+    title?: string;
+    height?: number;
+  } = {};
+  for (const raw of body.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const idx = line.indexOf(":");
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim().toLowerCase();
+    const value = line.slice(idx + 1).trim();
+    if (!value) continue;
+    if (key === "src") out.src = value;
+    else if (key === "aspect") out.aspect = value;
+    else if (key === "title") out.title = value;
+    else if (key === "height") {
+      const n = Number(value);
+      if (Number.isFinite(n) && n > 0) out.height = Math.min(2000, n);
+    }
+  }
+  return out;
+}
+
+function sanitizeEmbedSrc(src: string | undefined): string | null {
+  if (!src) return null;
+  const trimmed = src.trim();
+  if (!trimmed || trimmed.startsWith("//")) return null;
+  if (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("./") ||
+    trimmed.startsWith("../")
+  ) {
+    return trimmed;
+  }
+  return null;
+}
+
+function renderEmbedBlock(body: string): string {
+  const parsed = parseEmbedBody(body);
+  const safeSrc = sanitizeEmbedSrc(parsed.src);
+  if (!safeSrc) {
+    return [
+      '<div class="my-3 rounded-lg border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">',
+      '<strong class="text-foreground">Embed blocked</strong>',
+      '<div class="mt-1">Only same-origin embed paths are allowed.</div>',
+      parsed.src
+        ? `<div class="mt-1 truncate font-mono text-[10px]">${escapeHtml(parsed.src)}</div>`
+        : "",
+      "</div>",
+    ].join("");
+  }
+  const aspect =
+    parsed.aspect && ALLOWED_EMBED_ASPECTS.has(parsed.aspect)
+      ? parsed.aspect
+      : "16/9";
+  const style = parsed.height
+    ? `height:${parsed.height}px`
+    : `aspect-ratio:${aspect.replace("/", " / ")}`;
+  return [
+    `<div class="my-4 overflow-hidden rounded-lg border border-border bg-muted/20" style="${style}">`,
+    `<iframe src="${escapeHtml(safeSrc)}" title="${escapeHtml(parsed.title || "Embedded content")}" sandbox="allow-scripts allow-same-origin allow-forms allow-popups" referrerpolicy="same-origin" loading="lazy" class="h-full w-full border-0 bg-transparent"></iframe>`,
+    "</div>",
+  ].join("");
+}
+
 function renderInline(text: string): string {
   // Escape the raw text before applying markdown replacements so any
   // HTML the agent emits is inert. Note: markdown tokens like `**` and
@@ -141,12 +223,16 @@ export function renderMarkdown(md: string): string {
       const codeLines: string[] = [];
       i++;
       while (i < lines.length && !lines[i].startsWith("```")) {
-        codeLines.push(escapeHtml(lines[i]));
+        codeLines.push(lines[i]);
         i++;
       }
       i++; // skip closing ```
+      if (safeLang === "embed") {
+        out.push(renderEmbedBlock(codeLines.join("\n")));
+        continue;
+      }
       out.push(
-        `<pre><code${safeLang ? ` class="language-${escapeHtml(safeLang)}"` : ""}>${codeLines.join("\n")}</code></pre>`,
+        `<pre><code${safeLang ? ` class="language-${escapeHtml(safeLang)}"` : ""}>${codeLines.map(escapeHtml).join("\n")}</code></pre>`,
       );
       continue;
     }

--- a/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
+++ b/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
@@ -33,10 +33,14 @@ import { ShareButton, appApiPath } from "@agent-native/core/client";
 import { getIdToken } from "@/lib/auth";
 import { useSendToAgentChat } from "@agent-native/core/client";
 import Markdown from "@/components/Markdown";
+import LegacyFusionAnalysis, {
+  isLegacyFusionAnalysis,
+} from "./LegacyFusionAnalysis";
 import {
   useSetPageTitle,
   useSetHeaderActions,
 } from "@/components/layout/HeaderActions";
+import { cn } from "@/lib/utils";
 
 interface Analysis {
   id: string;
@@ -201,10 +205,17 @@ export default function AnalysisDetail() {
     );
   }
 
+  const showLegacyFusionDashboard = isLegacyFusionAnalysis(analysis.id);
+
   return (
     <>
       {codeRequiredDialog}
-      <div className="space-y-6 max-w-4xl">
+      <div
+        className={cn(
+          "space-y-6",
+          showLegacyFusionDashboard ? "max-w-6xl" : "max-w-4xl",
+        )}
+      >
         {/* Header */}
         <div>
           <Link
@@ -250,9 +261,13 @@ export default function AnalysisDetail() {
         </div>
 
         {/* Results */}
-        <div className="prose prose-sm dark:prose-invert max-w-none">
-          <Markdown content={analysis.resultMarkdown} />
-        </div>
+        {showLegacyFusionDashboard ? (
+          <LegacyFusionAnalysis analysis={analysis} />
+        ) : (
+          <div className="prose prose-sm dark:prose-invert max-w-none">
+            <Markdown content={analysis.resultMarkdown} />
+          </div>
+        )}
       </div>
     </>
   );

--- a/templates/analytics/app/pages/analyses/LegacyFusionAnalysis.tsx
+++ b/templates/analytics/app/pages/analyses/LegacyFusionAnalysis.tsx
@@ -1,0 +1,915 @@
+import { useEffect, type ComponentType, type ReactNode } from "react";
+import { captureError } from "@agent-native/core/client";
+import {
+  IconAlertTriangle,
+  IconChecks,
+  IconCurrencyDollar,
+  IconDatabase,
+  IconMessageCircle,
+  IconRefresh,
+  IconTargetArrow,
+  IconTrendingDown,
+  IconTrophy,
+  IconUsers,
+} from "@tabler/icons-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+type TablerIcon = ComponentType<{ className?: string }>;
+
+interface AnalysisLike {
+  id: string;
+  name: string;
+  resultData: Record<string, unknown> | null;
+}
+
+interface LegacyFusionBase {
+  type: "closed-lost" | "closed-won";
+  generatedAt?: string;
+  analysisAsOf?: string;
+  summary?: Record<string, unknown>;
+}
+
+interface LegacyDeal {
+  dealId?: string;
+  dealName: string;
+  amount?: number;
+  closeDate?: string;
+  furthestStage?: string;
+  closedLostReason?: string;
+  primaryReason?: string;
+  gongCallCount?: number;
+  matchedCallCount?: number;
+  contactCount?: number;
+  emailCount?: number;
+  slackMessageCount?: number;
+  personaCount?: number;
+}
+
+interface PainTheme {
+  rank?: number;
+  number?: number;
+  theme?: string;
+  title?: string;
+  pain?: string;
+  detail?: string;
+  description?: string;
+  businessImpact?: string;
+  deals?: number;
+  dealCount?: number;
+  value?: number;
+  pct?: number;
+  representativeDeals?: string[];
+  examples?: string[];
+}
+
+interface PainDeal {
+  dealId?: string;
+  dealName: string;
+  amount?: number;
+  businessPain?: string;
+  operationalPain?: string;
+  assessedPainSummary?: string;
+  painCategories?: string[];
+}
+
+interface WinTheme {
+  number: number;
+  title: string;
+  detail: string;
+  deals: string[];
+}
+
+interface ClosedLostPayload extends LegacyFusionBase {
+  type: "closed-lost";
+  deals?: LegacyDeal[];
+  stageData?: Array<{
+    stage: string;
+    deals: number;
+    value: number;
+    avgDeal?: number;
+  }>;
+  lossThemes?: PainTheme[];
+  businessPain?: {
+    generatedAt?: string;
+    totalDeals?: number;
+    topPains?: PainTheme[];
+    businessPains?: PainTheme[];
+    deals?: PainDeal[];
+  };
+}
+
+interface ClosedWonPayload extends LegacyFusionBase {
+  type: "closed-won";
+  deals?: LegacyDeal[];
+  winThemes?: WinTheme[];
+  operationalThemes?: WinTheme[];
+  businessThemes?: WinTheme[];
+  personas?: Array<{
+    dealId?: string;
+    dealName?: string;
+    email?: string;
+    name?: string;
+    company?: string;
+  }>;
+}
+
+type LegacyFusionPayload = ClosedLostPayload | ClosedWonPayload;
+
+const LEGACY_FUSION_ANALYSIS_IDS = new Set([
+  "fusion-closed-lost-analysis",
+  "fusion-closed-won-analysis",
+]);
+
+export function isLegacyFusionAnalysis(id: string): boolean {
+  return LEGACY_FUSION_ANALYSIS_IDS.has(id);
+}
+
+export default function LegacyFusionAnalysis({
+  analysis,
+}: {
+  analysis: AnalysisLike;
+}) {
+  const payload = parseLegacyFusionPayload(analysis.resultData);
+
+  useEffect(() => {
+    if (!isLegacyFusionAnalysis(analysis.id) || payload) return;
+    captureError(
+      new Error(`Missing legacy Fusion payload for analysis ${analysis.id}`),
+      {
+        tags: {
+          surface: "analytics-analysis-detail",
+          analysisId: analysis.id,
+          issue: "missing-legacy-fusion-payload",
+        },
+        extra: {
+          analysisName: analysis.name,
+          resultDataKeys: analysis.resultData
+            ? Object.keys(analysis.resultData)
+            : [],
+        },
+      },
+    );
+  }, [analysis.id, analysis.name, analysis.resultData, payload]);
+
+  if (!isLegacyFusionAnalysis(analysis.id)) return null;
+
+  if (!payload) {
+    return (
+      <Card className="border-amber-200 bg-amber-50 text-amber-950 shadow-none">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <IconAlertTriangle className="h-5 w-5" />
+            Legacy Fusion payload missing
+          </CardTitle>
+          <CardDescription className="text-amber-900">
+            This migrated analysis is a legacy React dashboard, but its compact
+            dashboard payload is not present in SQL. Sentry has captured this
+            state so the migration can be repaired instead of silently showing a
+            text placeholder.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return payload.type === "closed-lost" ? (
+    <ClosedLostDashboard data={payload} />
+  ) : (
+    <ClosedWonDashboard data={payload} />
+  );
+}
+
+function parseLegacyFusionPayload(
+  resultData: Record<string, unknown> | null,
+): LegacyFusionPayload | null {
+  const value = resultData?.legacyFusion;
+  if (!value || typeof value !== "object") return null;
+  const payload = value as Partial<LegacyFusionPayload>;
+  if (payload.type !== "closed-lost" && payload.type !== "closed-won") {
+    return null;
+  }
+  return payload as LegacyFusionPayload;
+}
+
+function ClosedLostDashboard({ data }: { data: ClosedLostPayload }) {
+  const deals = data.deals ?? [];
+  const totalValue = sumBy(deals, (deal) => deal.amount);
+  const stageData = data.stageData?.length
+    ? data.stageData
+    : summarizeStages(deals);
+  const topDeals = [...deals]
+    .sort((a, b) => valueOf(b.amount) - valueOf(a.amount))
+    .slice(0, 12);
+  const reEngageDeals = deals
+    .filter((deal) => isLikelyReEngage(deal))
+    .sort((a, b) => valueOf(b.amount) - valueOf(a.amount))
+    .slice(0, 12);
+  const lossThemes = data.lossThemes ?? [];
+  const topPains = data.businessPain?.topPains ?? [];
+  const businessPains = data.businessPain?.businessPains ?? [];
+  const painDeals = data.businessPain?.deals ?? [];
+
+  return (
+    <div className="space-y-6">
+      <DashboardHero
+        eyebrow="Fusion closed lost"
+        title="Loss reasons, stage leakage, and re-engagement paths"
+        description="Migrated from the legacy Fusion dashboard with compact Gong, HubSpot, Slack, and business-pain evidence preserved in SQL."
+        icon={IconTrendingDown}
+        generatedAt={data.generatedAt}
+      />
+
+      <MetricGrid>
+        <MetricCard
+          icon={IconDatabase}
+          label="Closed-lost deals"
+          value={formatNumber(getMetric(data.summary, "totalDeals") ?? deals.length)}
+          detail={`${formatNumber(getMetric(data.summary, "dealsWithCalls") ?? 0)} with Gong coverage`}
+        />
+        <MetricCard
+          icon={IconCurrencyDollar}
+          label="Lost pipeline"
+          value={formatCurrency(totalValue)}
+          detail={`${formatCurrency(deals.length ? totalValue / deals.length : 0)} average deal`}
+        />
+        <MetricCard
+          icon={IconMessageCircle}
+          label="Customer evidence"
+          value={formatNumber(getMetric(data.summary, "totalCallsMatched") ?? 0)}
+          detail={`${formatNumber(getMetric(data.summary, "transcriptsFetched") ?? 0)} transcripts, ${formatNumber(getMetric(data.summary, "emailsFetched") ?? 0)} emails`}
+        />
+        <MetricCard
+          icon={IconRefresh}
+          label="Re-engage candidates"
+          value={formatNumber(reEngageDeals.length)}
+          detail="Ranked by deal size and explicit revisit signals"
+        />
+      </MetricGrid>
+
+      <Tabs defaultValue="overview" className="space-y-4">
+        <TabsList className="flex h-auto flex-wrap justify-start gap-1">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="themes">Loss themes</TabsTrigger>
+          <TabsTrigger value="pain">Business pain</TabsTrigger>
+          <TabsTrigger value="reengage">Re-engage</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="space-y-4">
+          <TwoColumn>
+            <SectionCard
+              title="Stage leakage"
+              description="Where closed-lost value reached before the opportunity stopped."
+            >
+              <BarList
+                rows={stageData.map((stage) => ({
+                  label: stage.stage,
+                  value: stage.deals,
+                  detail: `${formatCurrency(stage.value)} pipeline`,
+                  percent: percentage(stage.value, totalValue),
+                }))}
+              />
+            </SectionCard>
+            <SectionCard
+              title="Largest losses"
+              description="Highest-value closed-lost opportunities in the preserved dataset."
+            >
+              <DealTable
+                deals={topDeals}
+                columns={["deal", "amount", "stage", "calls"]}
+              />
+            </SectionCard>
+          </TwoColumn>
+        </TabsContent>
+
+        <TabsContent value="themes" className="space-y-4">
+          <ThemeGrid themes={lossThemes} variant="loss" />
+        </TabsContent>
+
+        <TabsContent value="pain" className="space-y-4">
+          <TwoColumn>
+            <SectionCard
+              title="Operational pains"
+              description="Recurring day-to-day friction across lost deals."
+            >
+              <ThemeStack themes={topPains} />
+            </SectionCard>
+            <SectionCard
+              title="Business pains"
+              description="Economic and strategic impact attached to the same accounts."
+            >
+              <ThemeStack themes={businessPains} />
+            </SectionCard>
+          </TwoColumn>
+          <SectionCard
+            title="Pain by deal"
+            description="Compact evidence preserved from the business-pain enrichment file."
+          >
+            <PainDealTable deals={painDeals.slice(0, 12)} />
+          </SectionCard>
+        </TabsContent>
+
+        <TabsContent value="reengage" className="space-y-4">
+          <SectionCard
+            title="Best re-engagement paths"
+            description="Deals with revisit language, delayed timing, inherited-pipeline cleanup, or post-security reopen signals."
+          >
+            <DealTable
+              deals={reEngageDeals}
+              columns={["deal", "amount", "stage", "reason", "calls"]}
+            />
+          </SectionCard>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function ClosedWonDashboard({ data }: { data: ClosedWonPayload }) {
+  const deals = data.deals ?? [];
+  const totalValue = sumBy(deals, (deal) => deal.amount);
+  const topDeals = [...deals]
+    .sort((a, b) => valueOf(b.amount) - valueOf(a.amount))
+    .slice(0, 12);
+  const personas = data.personas ?? [];
+  const personaCompanies = countBy(personas, (persona) => persona.company || "Unknown");
+  const winThemes = data.winThemes ?? [];
+
+  return (
+    <div className="space-y-6">
+      <DashboardHero
+        eyebrow="Fusion closed won"
+        title="What turned technical interest into signed new business"
+        description="Migrated from the legacy Fusion closed-won dashboard with compact deal, Gong, Slack, email, and persona evidence preserved in SQL."
+        icon={IconTrophy}
+        generatedAt={data.generatedAt}
+      />
+
+      <MetricGrid>
+        <MetricCard
+          icon={IconChecks}
+          label="Closed-won deals"
+          value={formatNumber(getMetric(data.summary, "totalDeals") ?? deals.length)}
+          detail={`${formatNumber(getMetric(data.summary, "dealsWithCalls") ?? 0)} with Gong coverage`}
+        />
+        <MetricCard
+          icon={IconCurrencyDollar}
+          label="Won ARR"
+          value={formatCurrency(totalValue)}
+          detail={`${formatCurrency(deals.length ? totalValue / deals.length : 0)} average deal`}
+        />
+        <MetricCard
+          icon={IconMessageCircle}
+          label="Evidence captured"
+          value={formatNumber(getMetric(data.summary, "totalCallsMatched") ?? 0)}
+          detail={`${formatNumber(getMetric(data.summary, "emailsFetched") ?? 0)} emails, ${formatNumber(getMetric(data.summary, "slackMessagesFound") ?? 0)} Slack messages`}
+        />
+        <MetricCard
+          icon={IconUsers}
+          label="Buyer personas"
+          value={formatNumber(personas.length)}
+          detail={`${formatNumber(personaCompanies.length)} company/persona groups`}
+        />
+      </MetricGrid>
+
+      <Tabs defaultValue="overview" className="space-y-4">
+        <TabsList className="flex h-auto flex-wrap justify-start gap-1">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="themes">Win themes</TabsTrigger>
+          <TabsTrigger value="pain">Pain themes</TabsTrigger>
+          <TabsTrigger value="coverage">Coverage</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="space-y-4">
+          <TwoColumn>
+            <SectionCard
+              title="Won deals"
+              description="Closed-won Fusion opportunities ranked by ARR."
+            >
+              <DealTable
+                deals={topDeals}
+                columns={["deal", "amount", "closeDate", "calls"]}
+              />
+            </SectionCard>
+            <SectionCard
+              title="Persona coverage"
+              description="Buyer and stakeholder company coverage from the preserved persona map."
+            >
+              <BarList
+                rows={personaCompanies.slice(0, 8).map(([label, count]) => ({
+                  label,
+                  value: count,
+                  detail: `${formatNumber(count)} contacts`,
+                  percent: percentage(count, personas.length),
+                }))}
+              />
+            </SectionCard>
+          </TwoColumn>
+        </TabsContent>
+
+        <TabsContent value="themes" className="space-y-4">
+          <ThemeGrid themes={winThemes} variant="win" />
+        </TabsContent>
+
+        <TabsContent value="pain" className="space-y-4">
+          <TwoColumn>
+            <SectionCard
+              title="Operational themes"
+              description="The workflow frictions that opened the buying motion."
+            >
+              <ThemeStack themes={data.operationalThemes ?? []} />
+            </SectionCard>
+            <SectionCard
+              title="Business themes"
+              description="The executive-level stakes attached to those frictions."
+            >
+              <ThemeStack themes={data.businessThemes ?? []} />
+            </SectionCard>
+          </TwoColumn>
+        </TabsContent>
+
+        <TabsContent value="coverage" className="space-y-4">
+          <SectionCard
+            title="Evidence coverage by deal"
+            description="Gong, email, Slack, contact, and persona coverage preserved from the matched dataset."
+          >
+            <DealTable
+              deals={topDeals}
+              columns={["deal", "amount", "calls", "emails", "slack", "contacts"]}
+            />
+          </SectionCard>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function DashboardHero({
+  eyebrow,
+  title,
+  description,
+  icon: Icon,
+  generatedAt,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  icon: TablerIcon;
+  generatedAt?: string;
+}) {
+  return (
+    <section className="rounded-lg border bg-gradient-to-br from-background via-background to-muted/60 p-5">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <Badge variant="secondary" className="w-fit gap-1">
+            <Icon className="h-3.5 w-3.5" />
+            {eyebrow}
+          </Badge>
+          <div>
+            <h2 className="text-2xl font-semibold tracking-tight">{title}</h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+              {description}
+            </p>
+          </div>
+        </div>
+        {generatedAt && (
+          <div className="flex shrink-0 items-center gap-2 rounded-md border bg-background px-3 py-2 text-xs text-muted-foreground">
+            <IconRefresh className="h-4 w-4" />
+            Data refreshed {formatShortDate(generatedAt)}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function MetricGrid({ children }: { children: ReactNode }) {
+  return <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">{children}</div>;
+}
+
+function MetricCard({
+  icon: Icon,
+  label,
+  value,
+  detail,
+}: {
+  icon: TablerIcon;
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <Card className="shadow-none">
+      <CardContent className="flex items-start gap-3 p-4">
+        <div className="rounded-md bg-primary/10 p-2 text-primary">
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="min-w-0">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {label}
+          </p>
+          <p className="mt-1 text-2xl font-semibold tracking-tight">{value}</p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">{detail}</p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TwoColumn({ children }: { children: ReactNode }) {
+  return <div className="grid gap-4 xl:grid-cols-2">{children}</div>;
+}
+
+function SectionCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Card className="shadow-none">
+      <CardHeader className="p-4 pb-2">
+        <CardTitle className="text-base">{title}</CardTitle>
+        {description && (
+          <CardDescription className="text-xs leading-5">
+            {description}
+          </CardDescription>
+        )}
+      </CardHeader>
+      <CardContent className="p-4 pt-2">{children}</CardContent>
+    </Card>
+  );
+}
+
+function BarList({
+  rows,
+}: {
+  rows: Array<{
+    label: string;
+    value: number;
+    detail: string;
+    percent: number;
+  }>;
+}) {
+  if (!rows.length) return <EmptyState label="No rows available" />;
+  return (
+    <div className="space-y-3">
+      {rows.map((row) => (
+        <div key={row.label} className="space-y-1.5">
+          <div className="flex items-center justify-between gap-3 text-sm">
+            <span className="min-w-0 truncate font-medium">{row.label}</span>
+            <span className="shrink-0 text-muted-foreground">{row.detail}</span>
+          </div>
+          <Progress value={row.percent} className="h-2" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ThemeGrid({
+  themes,
+  variant,
+}: {
+  themes: Array<PainTheme | WinTheme>;
+  variant: "loss" | "win";
+}) {
+  if (!themes.length) return <EmptyState label="No themes available" />;
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      {themes.map((theme, index) => {
+        const title = getThemeTitle(theme);
+        const detail = getThemeDetail(theme);
+        const examples = getThemeExamples(theme);
+        const metric =
+          "value" in theme && theme.value
+            ? formatCurrency(theme.value)
+            : "dealCount" in theme && theme.dealCount
+              ? `${formatNumber(theme.dealCount)} deals`
+              : "deals" in theme && typeof theme.deals === "number"
+                ? `${formatNumber(theme.deals)} deals`
+                : null;
+        return (
+          <SectionCard
+            key={`${variant}-${title}-${index}`}
+            title={`${getThemeNumber(theme, index)}. ${title}`}
+            description={detail}
+          >
+            <div className="space-y-3">
+              {metric && (
+                <Badge variant="outline" className="gap-1">
+                  <IconTargetArrow className="h-3.5 w-3.5" />
+                  {metric}
+                </Badge>
+              )}
+              {!!examples.length && (
+                <ul className="space-y-2 text-sm text-muted-foreground">
+                  {examples.slice(0, 4).map((example) => (
+                    <li key={example} className="leading-5">
+                      {example}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </SectionCard>
+        );
+      })}
+    </div>
+  );
+}
+
+function ThemeStack({ themes }: { themes: Array<PainTheme | WinTheme> }) {
+  if (!themes.length) return <EmptyState label="No themes available" />;
+  return (
+    <div className="space-y-4">
+      {themes.slice(0, 6).map((theme, index) => {
+        const title = getThemeTitle(theme);
+        const detail = getThemeDetail(theme);
+        const count =
+          "dealCount" in theme && theme.dealCount
+            ? theme.dealCount
+            : "deals" in theme && typeof theme.deals === "number"
+              ? theme.deals
+              : undefined;
+        return (
+          <div key={`${title}-${index}`} className="space-y-1.5">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-sm font-medium leading-5">
+                {getThemeNumber(theme, index)}. {title}
+              </p>
+              {count ? (
+                <Badge variant="secondary" className="shrink-0">
+                  {formatNumber(count)}
+                </Badge>
+              ) : null}
+            </div>
+            <p className="text-xs leading-5 text-muted-foreground">{detail}</p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function DealTable({
+  deals,
+  columns,
+}: {
+  deals: LegacyDeal[];
+  columns: Array<
+    | "deal"
+    | "amount"
+    | "stage"
+    | "reason"
+    | "closeDate"
+    | "calls"
+    | "emails"
+    | "slack"
+    | "contacts"
+  >;
+}) {
+  if (!deals.length) return <EmptyState label="No deals available" />;
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[640px] text-sm">
+        <thead>
+          <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+            {columns.map((column) => (
+              <th key={column} className="px-2 py-2 font-medium">
+                {columnLabels[column]}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {deals.map((deal) => (
+            <tr key={deal.dealId ?? deal.dealName} className="border-b last:border-0">
+              {columns.map((column) => (
+                <td key={column} className="max-w-[320px] px-2 py-3 align-top">
+                  {renderDealCell(deal, column)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function PainDealTable({ deals }: { deals: PainDeal[] }) {
+  if (!deals.length) return <EmptyState label="No pain rows available" />;
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[720px] text-sm">
+        <thead>
+          <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+            <th className="px-2 py-2 font-medium">Deal</th>
+            <th className="px-2 py-2 font-medium">Amount</th>
+            <th className="px-2 py-2 font-medium">Operational pain</th>
+            <th className="px-2 py-2 font-medium">Business pain</th>
+          </tr>
+        </thead>
+        <tbody>
+          {deals.map((deal) => (
+            <tr key={deal.dealId ?? deal.dealName} className="border-b last:border-0">
+              <td className="px-2 py-3 align-top font-medium">{deal.dealName}</td>
+              <td className="px-2 py-3 align-top">{formatCurrency(deal.amount)}</td>
+              <td className="max-w-[360px] px-2 py-3 align-top text-muted-foreground">
+                {deal.operationalPain || deal.assessedPainSummary || "Unknown"}
+              </td>
+              <td className="max-w-[360px] px-2 py-3 align-top text-muted-foreground">
+                {deal.businessPain || "Unknown"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function EmptyState({ label }: { label: string }) {
+  return (
+    <div className="flex min-h-28 items-center justify-center rounded-md border border-dashed text-sm text-muted-foreground">
+      {label}
+    </div>
+  );
+}
+
+const columnLabels = {
+  deal: "Deal",
+  amount: "Amount",
+  stage: "Stage",
+  reason: "Reason",
+  closeDate: "Closed",
+  calls: "Calls",
+  emails: "Emails",
+  slack: "Slack",
+  contacts: "Contacts",
+} as const;
+
+function renderDealCell(
+  deal: LegacyDeal,
+  column: keyof typeof columnLabels,
+): ReactNode {
+  switch (column) {
+    case "deal":
+      return <span className="font-medium">{deal.dealName}</span>;
+    case "amount":
+      return formatCurrency(deal.amount);
+    case "stage":
+      return deal.furthestStage || "Unknown";
+    case "reason":
+      return (
+        <span className="line-clamp-3 text-muted-foreground">
+          {deal.primaryReason || deal.closedLostReason || "Unknown"}
+        </span>
+      );
+    case "closeDate":
+      return deal.closeDate ? formatShortDate(deal.closeDate) : "Unknown";
+    case "calls":
+      return formatNumber(deal.gongCallCount ?? deal.matchedCallCount ?? 0);
+    case "emails":
+      return formatNumber(deal.emailCount ?? 0);
+    case "slack":
+      return formatNumber(deal.slackMessageCount ?? 0);
+    case "contacts":
+      return formatNumber(deal.contactCount ?? 0);
+    default:
+      return null;
+  }
+}
+
+function getMetric(
+  summary: Record<string, unknown> | undefined,
+  key: string,
+): number | undefined {
+  const raw = summary?.[key];
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  if (typeof raw === "string") {
+    const numeric = Number(raw.replace(/[%,$]/g, ""));
+    return Number.isFinite(numeric) ? numeric : undefined;
+  }
+  return undefined;
+}
+
+function summarizeStages(deals: LegacyDeal[]) {
+  const byStage = new Map<string, { stage: string; deals: number; value: number }>();
+  for (const deal of deals) {
+    const stage = deal.furthestStage || "Unknown";
+    const existing = byStage.get(stage) ?? { stage, deals: 0, value: 0 };
+    existing.deals += 1;
+    existing.value += valueOf(deal.amount);
+    byStage.set(stage, existing);
+  }
+  return [...byStage.values()].sort((a, b) => b.value - a.value);
+}
+
+function isLikelyReEngage(deal: LegacyDeal): boolean {
+  const text = `${deal.closedLostReason ?? ""} ${deal.primaryReason ?? ""}`.toLowerCase();
+  return [
+    "re-engage",
+    "reengage",
+    "revisit",
+    "re-open",
+    "reopen",
+    "q3",
+    "later",
+    "security approval",
+    "not ready",
+    "timing",
+  ].some((token) => text.includes(token));
+}
+
+function getThemeTitle(theme: PainTheme | WinTheme): string {
+  if ("title" in theme && theme.title) return theme.title;
+  if ("theme" in theme && theme.theme) return theme.theme;
+  if ("pain" in theme && theme.pain) return theme.pain;
+  return "Untitled theme";
+}
+
+function getThemeDetail(theme: PainTheme | WinTheme): string {
+  if ("detail" in theme && theme.detail) return theme.detail;
+  if ("description" in theme && theme.description) return theme.description;
+  if ("businessImpact" in theme && theme.businessImpact) return theme.businessImpact;
+  return "";
+}
+
+function getThemeExamples(theme: PainTheme | WinTheme): string[] {
+  if ("examples" in theme && Array.isArray(theme.examples)) return theme.examples;
+  if ("representativeDeals" in theme && Array.isArray(theme.representativeDeals)) {
+    return theme.representativeDeals;
+  }
+  if ("deals" in theme && Array.isArray(theme.deals)) return theme.deals;
+  return [];
+}
+
+function getThemeNumber(theme: PainTheme | WinTheme, index: number): number {
+  if ("number" in theme && typeof theme.number === "number") return theme.number;
+  if ("rank" in theme && typeof theme.rank === "number") return theme.rank;
+  return index + 1;
+}
+
+function countBy<T>(items: T[], keyFn: (item: T) => string) {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const key = keyFn(item);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+}
+
+function sumBy<T>(items: T[], valueFn: (item: T) => number | undefined) {
+  return items.reduce((sum, item) => sum + valueOf(valueFn(item)), 0);
+}
+
+function percentage(value: number, total: number): number {
+  if (!total) return 0;
+  return Math.max(0, Math.min(100, Math.round((value / total) * 100)));
+}
+
+function valueOf(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(Math.round(value));
+}
+
+function formatCurrency(value: number | undefined): string {
+  const amount = valueOf(value);
+  if (Math.abs(amount) >= 1_000_000) {
+    return `$${(amount / 1_000_000).toFixed(1)}M`;
+  }
+  if (Math.abs(amount) >= 1_000) {
+    return `$${Math.round(amount / 1_000)}K`;
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+function formatShortDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}

--- a/templates/analytics/app/pages/analyses/LegacyFusionAnalysis.tsx
+++ b/templates/analytics/app/pages/analyses/LegacyFusionAnalysis.tsx
@@ -232,7 +232,9 @@ function ClosedLostDashboard({ data }: { data: ClosedLostPayload }) {
         <MetricCard
           icon={IconDatabase}
           label="Closed-lost deals"
-          value={formatNumber(getMetric(data.summary, "totalDeals") ?? deals.length)}
+          value={formatNumber(
+            getMetric(data.summary, "totalDeals") ?? deals.length,
+          )}
           detail={`${formatNumber(getMetric(data.summary, "dealsWithCalls") ?? 0)} with Gong coverage`}
         />
         <MetricCard
@@ -244,7 +246,9 @@ function ClosedLostDashboard({ data }: { data: ClosedLostPayload }) {
         <MetricCard
           icon={IconMessageCircle}
           label="Customer evidence"
-          value={formatNumber(getMetric(data.summary, "totalCallsMatched") ?? 0)}
+          value={formatNumber(
+            getMetric(data.summary, "totalCallsMatched") ?? 0,
+          )}
           detail={`${formatNumber(getMetric(data.summary, "transcriptsFetched") ?? 0)} transcripts, ${formatNumber(getMetric(data.summary, "emailsFetched") ?? 0)} emails`}
         />
         <MetricCard
@@ -340,7 +344,10 @@ function ClosedWonDashboard({ data }: { data: ClosedWonPayload }) {
     .sort((a, b) => valueOf(b.amount) - valueOf(a.amount))
     .slice(0, 12);
   const personas = data.personas ?? [];
-  const personaCompanies = countBy(personas, (persona) => persona.company || "Unknown");
+  const personaCompanies = countBy(
+    personas,
+    (persona) => persona.company || "Unknown",
+  );
   const winThemes = data.winThemes ?? [];
 
   return (
@@ -357,7 +364,9 @@ function ClosedWonDashboard({ data }: { data: ClosedWonPayload }) {
         <MetricCard
           icon={IconChecks}
           label="Closed-won deals"
-          value={formatNumber(getMetric(data.summary, "totalDeals") ?? deals.length)}
+          value={formatNumber(
+            getMetric(data.summary, "totalDeals") ?? deals.length,
+          )}
           detail={`${formatNumber(getMetric(data.summary, "dealsWithCalls") ?? 0)} with Gong coverage`}
         />
         <MetricCard
@@ -369,7 +378,9 @@ function ClosedWonDashboard({ data }: { data: ClosedWonPayload }) {
         <MetricCard
           icon={IconMessageCircle}
           label="Evidence captured"
-          value={formatNumber(getMetric(data.summary, "totalCallsMatched") ?? 0)}
+          value={formatNumber(
+            getMetric(data.summary, "totalCallsMatched") ?? 0,
+          )}
           detail={`${formatNumber(getMetric(data.summary, "emailsFetched") ?? 0)} emails, ${formatNumber(getMetric(data.summary, "slackMessagesFound") ?? 0)} Slack messages`}
         />
         <MetricCard
@@ -443,7 +454,14 @@ function ClosedWonDashboard({ data }: { data: ClosedWonPayload }) {
           >
             <DealTable
               deals={topDeals}
-              columns={["deal", "amount", "calls", "emails", "slack", "contacts"]}
+              columns={[
+                "deal",
+                "amount",
+                "calls",
+                "emails",
+                "slack",
+                "contacts",
+              ]}
             />
           </SectionCard>
         </TabsContent>
@@ -492,7 +510,9 @@ function DashboardHero({
 }
 
 function MetricGrid({ children }: { children: ReactNode }) {
-  return <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">{children}</div>;
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">{children}</div>
+  );
 }
 
 function MetricCard({
@@ -517,7 +537,9 @@ function MetricCard({
             {label}
           </p>
           <p className="mt-1 text-2xl font-semibold tracking-tight">{value}</p>
-          <p className="mt-1 text-xs leading-5 text-muted-foreground">{detail}</p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            {detail}
+          </p>
         </div>
       </CardContent>
     </Card>
@@ -695,7 +717,10 @@ function DealTable({
         </thead>
         <tbody>
           {deals.map((deal) => (
-            <tr key={deal.dealId ?? deal.dealName} className="border-b last:border-0">
+            <tr
+              key={deal.dealId ?? deal.dealName}
+              className="border-b last:border-0"
+            >
               {columns.map((column) => (
                 <td key={column} className="max-w-[320px] px-2 py-3 align-top">
                   {renderDealCell(deal, column)}
@@ -724,9 +749,16 @@ function PainDealTable({ deals }: { deals: PainDeal[] }) {
         </thead>
         <tbody>
           {deals.map((deal) => (
-            <tr key={deal.dealId ?? deal.dealName} className="border-b last:border-0">
-              <td className="px-2 py-3 align-top font-medium">{deal.dealName}</td>
-              <td className="px-2 py-3 align-top">{formatCurrency(deal.amount)}</td>
+            <tr
+              key={deal.dealId ?? deal.dealName}
+              className="border-b last:border-0"
+            >
+              <td className="px-2 py-3 align-top font-medium">
+                {deal.dealName}
+              </td>
+              <td className="px-2 py-3 align-top">
+                {formatCurrency(deal.amount)}
+              </td>
               <td className="max-w-[360px] px-2 py-3 align-top text-muted-foreground">
                 {deal.operationalPain || deal.assessedPainSummary || "Unknown"}
               </td>
@@ -807,7 +839,10 @@ function getMetric(
 }
 
 function summarizeStages(deals: LegacyDeal[]) {
-  const byStage = new Map<string, { stage: string; deals: number; value: number }>();
+  const byStage = new Map<
+    string,
+    { stage: string; deals: number; value: number }
+  >();
   for (const deal of deals) {
     const stage = deal.furthestStage || "Unknown";
     const existing = byStage.get(stage) ?? { stage, deals: 0, value: 0 };
@@ -819,7 +854,8 @@ function summarizeStages(deals: LegacyDeal[]) {
 }
 
 function isLikelyReEngage(deal: LegacyDeal): boolean {
-  const text = `${deal.closedLostReason ?? ""} ${deal.primaryReason ?? ""}`.toLowerCase();
+  const text =
+    `${deal.closedLostReason ?? ""} ${deal.primaryReason ?? ""}`.toLowerCase();
   return [
     "re-engage",
     "reengage",
@@ -844,13 +880,18 @@ function getThemeTitle(theme: PainTheme | WinTheme): string {
 function getThemeDetail(theme: PainTheme | WinTheme): string {
   if ("detail" in theme && theme.detail) return theme.detail;
   if ("description" in theme && theme.description) return theme.description;
-  if ("businessImpact" in theme && theme.businessImpact) return theme.businessImpact;
+  if ("businessImpact" in theme && theme.businessImpact)
+    return theme.businessImpact;
   return "";
 }
 
 function getThemeExamples(theme: PainTheme | WinTheme): string[] {
-  if ("examples" in theme && Array.isArray(theme.examples)) return theme.examples;
-  if ("representativeDeals" in theme && Array.isArray(theme.representativeDeals)) {
+  if ("examples" in theme && Array.isArray(theme.examples))
+    return theme.examples;
+  if (
+    "representativeDeals" in theme &&
+    Array.isArray(theme.representativeDeals)
+  ) {
     return theme.representativeDeals;
   }
   if ("deals" in theme && Array.isArray(theme.deals)) return theme.deals;
@@ -858,7 +899,8 @@ function getThemeExamples(theme: PainTheme | WinTheme): string[] {
 }
 
 function getThemeNumber(theme: PainTheme | WinTheme, index: number): number {
-  if ("number" in theme && typeof theme.number === "number") return theme.number;
+  if ("number" in theme && typeof theme.number === "number")
+    return theme.number;
   if ("rank" in theme && typeof theme.rank === "number") return theme.rank;
   return index + 1;
 }

--- a/templates/calendar/actions/list-events.ts
+++ b/templates/calendar/actions/list-events.ts
@@ -272,7 +272,14 @@ export async function listCalendarEvents(
 
   const icalResults = await Promise.allSettled(
     externalCalendars.map((cal) =>
-      fetchICalEvents(cal.id, cal.name, cal.url, cal.color, range.from, range.to),
+      fetchICalEvents(
+        cal.id,
+        cal.name,
+        cal.url,
+        cal.color,
+        range.from,
+        range.to,
+      ),
     ),
   );
 

--- a/templates/calendar/actions/list-events.ts
+++ b/templates/calendar/actions/list-events.ts
@@ -1,5 +1,8 @@
 import { defineAction } from "@agent-native/core";
-import { getRequestUserEmail } from "@agent-native/core/server";
+import {
+  getRequestTimezone,
+  getRequestUserEmail,
+} from "@agent-native/core/server";
 import { and, gte, inArray, lte, ne } from "drizzle-orm";
 import { accessFilter } from "@agent-native/core/sharing";
 import { z } from "zod";
@@ -8,6 +11,161 @@ import * as googleCalendar from "../server/lib/google-calendar.js";
 import { fetchICalEvents } from "../server/lib/ical-fetcher.js";
 import { getUserSetting } from "@agent-native/core/settings";
 import { getDb, schema } from "../server/db/index.js";
+
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+interface CalendarEventRange {
+  from: string;
+  to: string;
+  timezone: string;
+  defaulted: boolean;
+}
+
+interface ListCalendarEventsArgs {
+  from?: string;
+  to?: string;
+  query?: string;
+  overlayEmails?: string;
+}
+
+interface CalendarEventsResult {
+  events: CalendarEvent[];
+  errors: Array<{ email: string; error: string }>;
+  googleConnected: boolean;
+  range: CalendarEventRange;
+}
+
+function normalizeTimezone(timezone?: string): string {
+  if (!timezone) return "UTC";
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format();
+    return timezone;
+  } catch {
+    return "UTC";
+  }
+}
+
+function datePartsInTimezone(date: Date, timezone: string) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(date);
+  const get = (type: string) =>
+    Number(parts.find((part) => part.type === type)?.value ?? "0");
+  return {
+    year: get("year"),
+    month: get("month"),
+    day: get("day"),
+    hour: get("hour"),
+    minute: get("minute"),
+    second: get("second"),
+  };
+}
+
+function dateOnlyInTimezone(date: Date, timezone: string): string {
+  const parts = datePartsInTimezone(date, timezone);
+  return [
+    String(parts.year).padStart(4, "0"),
+    String(parts.month).padStart(2, "0"),
+    String(parts.day).padStart(2, "0"),
+  ].join("-");
+}
+
+function addDaysToDateOnly(dateOnly: string, days: number): string {
+  const [year, month, day] = dateOnly.split("-").map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day + days));
+  return [
+    String(date.getUTCFullYear()).padStart(4, "0"),
+    String(date.getUTCMonth() + 1).padStart(2, "0"),
+    String(date.getUTCDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function offsetMsForTimezone(date: Date, timezone: string): number {
+  const parts = datePartsInTimezone(date, timezone);
+  const asUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second,
+  );
+  return asUtc - date.getTime();
+}
+
+function zonedDateOnlyToUtcIso(dateOnly: string, timezone: string): string {
+  const [year, month, day] = dateOnly.split("-").map(Number);
+  const wallClockUtc = Date.UTC(year, month - 1, day, 0, 0, 0);
+  const firstGuess = new Date(wallClockUtc);
+  const firstOffset = offsetMsForTimezone(firstGuess, timezone);
+  const secondGuess = new Date(wallClockUtc - firstOffset);
+  const secondOffset = offsetMsForTimezone(secondGuess, timezone);
+  return new Date(wallClockUtc - secondOffset).toISOString();
+}
+
+function normalizeDateBound(value: string, timezone: string): string {
+  if (DATE_ONLY_RE.test(value)) {
+    return zonedDateOnlyToUtcIso(value, timezone);
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid date: ${value}`);
+  }
+  return parsed.toISOString();
+}
+
+export function resolveCalendarEventRange(args: {
+  from?: string;
+  to?: string;
+  timezone?: string;
+}): CalendarEventRange {
+  const timezone = normalizeTimezone(args.timezone ?? getRequestTimezone());
+  const today = dateOnlyInTimezone(new Date(), timezone);
+  let from = args.from?.trim();
+  let to = args.to?.trim();
+  let defaulted = false;
+
+  if (!from && !to) {
+    from = today;
+    to = addDaysToDateOnly(today, 1);
+    defaulted = true;
+  } else if (from && !to) {
+    if (DATE_ONLY_RE.test(from)) {
+      to = addDaysToDateOnly(from, 1);
+    } else {
+      const start = new Date(from);
+      if (Number.isNaN(start.getTime())) {
+        throw new Error(`Invalid date: ${from}`);
+      }
+      const end = new Date(start);
+      end.setDate(end.getDate() + 1);
+      to = end.toISOString();
+    }
+    defaulted = true;
+  } else if (!from && to) {
+    from = today;
+    defaulted = true;
+  }
+
+  const normalizedFrom = normalizeDateBound(from!, timezone);
+  const normalizedTo = normalizeDateBound(to!, timezone);
+  if (new Date(normalizedFrom).getTime() >= new Date(normalizedTo).getTime()) {
+    throw new Error("from must be before to");
+  }
+  return {
+    from: normalizedFrom,
+    to: normalizedTo,
+    timezone,
+    defaulted,
+  };
+}
 
 async function listLocalBookingEvents(
   from: string,
@@ -69,9 +227,109 @@ async function listLocalBookingEvents(
   });
 }
 
+export async function listCalendarEvents(
+  args: ListCalendarEventsArgs = {},
+): Promise<CalendarEventsResult> {
+  const email = getRequestUserEmail();
+  if (!email) throw new Error("no authenticated user");
+  const range = resolveCalendarEventRange({
+    from: args.from,
+    to: args.to,
+  });
+
+  // Fetch Google Calendar events
+  let googleEvents: CalendarEvent[] = [];
+  let errors: Array<{ email: string; error: string }> = [];
+  const connected = await googleCalendar.isConnected(email);
+  if (connected) {
+    const result = await googleCalendar.listEvents(range.from, range.to, email);
+    googleEvents = result.events;
+    errors = result.errors;
+
+    if (args.overlayEmails) {
+      const overlayEmails = args.overlayEmails
+        .split(",")
+        .filter(Boolean)
+        .slice(0, 10);
+      if (overlayEmails.length > 0) {
+        const { events: overlayEvents } =
+          await googleCalendar.listOverlayEvents(
+            range.from,
+            range.to,
+            overlayEmails,
+            email,
+          );
+        googleEvents = [...googleEvents, ...overlayEvents];
+      }
+    }
+  }
+
+  // Fetch external ICS calendar feeds concurrently
+  const externalCalendars =
+    ((await getUserSetting(email, "external-calendars")) as unknown as
+      | ExternalCalendar[]
+      | null) ?? [];
+
+  const icalResults = await Promise.allSettled(
+    externalCalendars.map((cal) =>
+      fetchICalEvents(cal.id, cal.name, cal.url, cal.color, range.from, range.to),
+    ),
+  );
+
+  const icalEvents: CalendarEvent[] = icalResults.flatMap((r) =>
+    r.status === "fulfilled" ? r.value : [],
+  );
+
+  const googleEventIds = new Set(
+    googleEvents.map((event) => event.googleEventId).filter(Boolean),
+  );
+  const bookingEvents = (
+    await listLocalBookingEvents(range.from, range.to)
+  ).filter(
+    (event) => !event.googleEventId || !googleEventIds.has(event.googleEventId),
+  );
+
+  let events = [...googleEvents, ...icalEvents, ...bookingEvents];
+  if (args.query) {
+    const query = args.query.toLowerCase();
+    events = events.filter((event) => {
+      const haystack = [
+        event.title,
+        event.description,
+        event.location,
+        event.organizer?.email,
+        event.organizer?.displayName,
+        ...(event.attendees ?? []).flatMap((attendee) => [
+          attendee.email,
+          attendee.displayName,
+        ]),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  }
+  const fromDate = new Date(range.from);
+  events = events.filter((e) => new Date(e.end) >= fromDate);
+  const toDate = new Date(range.to);
+  events = events.filter((e) => new Date(e.start) <= toDate);
+
+  events.sort(
+    (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+  );
+
+  return {
+    events,
+    errors,
+    googleConnected: connected,
+    range,
+  };
+}
+
 export default defineAction({
   description:
-    "List calendar events from Google Calendar and subscribed ICS feeds for a date range, optionally with overlay people's events",
+    "List calendar events from Google Calendar, subscribed ICS feeds, and local bookings for a date range. Defaults to today's local calendar day when no range is provided.",
   schema: z.object({
     from: z.string().optional().describe("Start date (ISO string)"),
     to: z.string().optional().describe("End date (ISO string)"),
@@ -86,100 +344,18 @@ export default defineAction({
   }),
   http: { method: "GET" },
   run: async (args) => {
-    const email = getRequestUserEmail();
-    if (!email) throw new Error("no authenticated user");
-    const from = args.from;
-    const to = args.to;
+    const result = await listCalendarEvents(args);
 
-    if (!from || !to) return [];
-
-    // Fetch Google Calendar events
-    let googleEvents: CalendarEvent[] = [];
-    const connected = await googleCalendar.isConnected(email);
-    if (connected) {
-      const { events, errors } = await googleCalendar.listEvents(
-        from,
-        to,
-        email,
+    if (result.events.length === 0 && result.errors.length > 0) {
+      throw new Error(
+        result.errors.map((e) => `${e.email}: ${e.error}`).join("; "),
       );
-
-      if (events.length === 0 && errors.length > 0) {
-        throw new Error(errors.map((e) => `${e.email}: ${e.error}`).join("; "));
-      }
-
-      googleEvents = events;
-
-      if (args.overlayEmails) {
-        const overlayEmails = args.overlayEmails
-          .split(",")
-          .filter(Boolean)
-          .slice(0, 10);
-        if (overlayEmails.length > 0) {
-          const { events: overlayEvents } =
-            await googleCalendar.listOverlayEvents(
-              from,
-              to,
-              overlayEmails,
-              email,
-            );
-          googleEvents = [...googleEvents, ...overlayEvents];
-        }
-      }
     }
 
-    // Fetch external ICS calendar feeds concurrently
-    const externalCalendars =
-      ((await getUserSetting(email, "external-calendars")) as unknown as
-        | ExternalCalendar[]
-        | null) ?? [];
-
-    const icalResults = await Promise.allSettled(
-      externalCalendars.map((cal) =>
-        fetchICalEvents(cal.id, cal.name, cal.url, cal.color, from, to),
-      ),
-    );
-
-    const icalEvents: CalendarEvent[] = icalResults.flatMap((r) =>
-      r.status === "fulfilled" ? r.value : [],
-    );
-
-    const googleEventIds = new Set(
-      googleEvents.map((event) => event.googleEventId).filter(Boolean),
-    );
-    const bookingEvents = (await listLocalBookingEvents(from, to)).filter(
-      (event) =>
-        !event.googleEventId || !googleEventIds.has(event.googleEventId),
-    );
-
-    let events = [...googleEvents, ...icalEvents, ...bookingEvents];
-    if (args.query) {
-      const query = args.query.toLowerCase();
-      events = events.filter((event) => {
-        const haystack = [
-          event.title,
-          event.description,
-          event.location,
-          event.organizer?.email,
-          event.organizer?.displayName,
-          ...(event.attendees ?? []).flatMap((attendee) => [
-            attendee.email,
-            attendee.displayName,
-          ]),
-        ]
-          .filter(Boolean)
-          .join(" ")
-          .toLowerCase();
-        return haystack.includes(query);
-      });
+    if (!result.googleConnected && !args.from && !args.to) {
+      return "Google Calendar is not connected. Connect via the Settings page first.";
     }
-    const fromDate = new Date(from);
-    events = events.filter((e) => new Date(e.end) >= fromDate);
-    const toDate = new Date(to);
-    events = events.filter((e) => new Date(e.start) <= toDate);
 
-    events.sort(
-      (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
-    );
-    return events;
+    return result.events;
   },
 });

--- a/templates/calendar/actions/view-screen.ts
+++ b/templates/calendar/actions/view-screen.ts
@@ -3,22 +3,38 @@ import { readAppState } from "@agent-native/core/application-state";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { z } from "zod";
 import { extractVideoLink } from "./event-action-helpers.js";
+import { listCalendarEvents } from "./list-events.js";
 import {
   CALENDAR_VIEW_PREFERENCES_KEY,
   normalizeCalendarViewPreferences,
 } from "../shared/calendar-view-preferences.js";
+import type { CalendarEvent } from "../shared/api.js";
 
-async function fetchEventsForRange(from: string, to: string): Promise<any[]> {
+async function fetchEventsForRange(from: string, to: string): Promise<{
+  events: CalendarEvent[];
+  errors: Array<{ email: string; error: string }>;
+  googleConnected: boolean;
+  range: { from: string; to: string; timezone: string; defaulted: boolean };
+}> {
   try {
-    const googleCalendar = await import("../server/lib/google-calendar.js");
-    const email = getRequestUserEmail();
-    if (!email || !(await googleCalendar.isConnected(email))) {
-      return [];
-    }
-    const { events } = await googleCalendar.listEvents(from, to, email);
-    return events;
-  } catch {
-    return [];
+    return await listCalendarEvents({ from, to });
+  } catch (error: any) {
+    return {
+      events: [],
+      errors: [
+        {
+          email: getRequestUserEmail() ?? "current-user",
+          error: error?.message || "Unable to load calendar events",
+        },
+      ],
+      googleConnected: false,
+      range: {
+        from,
+        to,
+        timezone: "UTC",
+        defaulted: false,
+      },
+    };
   }
 }
 
@@ -49,17 +65,20 @@ export default defineAction({
       const to = new Date(from);
       to.setDate(to.getDate() + 7);
 
-      const events = await fetchEventsForRange(
+      const eventResult = await fetchEventsForRange(
         from.toISOString(),
         to.toISOString(),
       );
+      const { events } = eventResult;
 
-      const compact = events.slice(0, 50).map((e: any) => {
+      const compact = events.slice(0, 50).map((e: CalendarEvent) => {
         return {
           id: e.id,
           title: e.title,
           start: e.start,
           end: e.end,
+          source: e.source,
+          accountEmail: e.accountEmail || undefined,
           location: e.location || undefined,
           allDay: e.allDay || undefined,
           attendeeCount: e.attendees?.length ?? 0,
@@ -73,11 +92,23 @@ export default defineAction({
       });
 
       screen.events = {
-        from: from.toISOString(),
-        to: to.toISOString(),
+        from: eventResult.range.from,
+        to: eventResult.range.to,
+        timezone: eventResult.range.timezone,
+        googleConnected: eventResult.googleConnected,
         count: compact.length,
         items: compact,
+        errors:
+          eventResult.errors.length > 0 ? eventResult.errors : undefined,
       };
+
+      if (!eventResult.googleConnected) {
+        screen.calendarConnection = {
+          googleConnected: false,
+          message:
+            "Google Calendar is not connected or no usable Google account was found. Connect or reconnect it from Settings.",
+        };
+      }
 
       if (nav?.eventId) {
         const match = events.find((e: any) => e.id === nav.eventId);

--- a/templates/calendar/actions/view-screen.ts
+++ b/templates/calendar/actions/view-screen.ts
@@ -10,7 +10,10 @@ import {
 } from "../shared/calendar-view-preferences.js";
 import type { CalendarEvent } from "../shared/api.js";
 
-async function fetchEventsForRange(from: string, to: string): Promise<{
+async function fetchEventsForRange(
+  from: string,
+  to: string,
+): Promise<{
   events: CalendarEvent[];
   errors: Array<{ email: string; error: string }>;
   googleConnected: boolean;
@@ -98,8 +101,7 @@ export default defineAction({
         googleConnected: eventResult.googleConnected,
         count: compact.length,
         items: compact,
-        errors:
-          eventResult.errors.length > 0 ? eventResult.errors : undefined,
+        errors: eventResult.errors.length > 0 ? eventResult.errors : undefined,
       };
 
       if (!eventResult.googleConnected) {

--- a/templates/calendar/app/components/booking/BookingForm.tsx
+++ b/templates/calendar/app/components/booking/BookingForm.tsx
@@ -14,6 +14,13 @@ import {
 } from "@/components/ui/select";
 import type { CustomField } from "@shared/api";
 
+export interface BookingFormValue {
+  name: string;
+  email: string;
+  notes: string;
+  fieldResponses: Record<string, string | boolean>;
+}
+
 interface BookingFormProps {
   onSubmit: (data: {
     name: string;
@@ -22,26 +29,30 @@ interface BookingFormProps {
     captchaToken?: string;
     fieldResponses?: Record<string, string | boolean>;
   }) => void;
+  value: BookingFormValue;
+  onChange: (value: BookingFormValue) => void;
   loading?: boolean;
   customFields?: CustomField[];
 }
 
 export function BookingForm({
   onSubmit,
+  value,
+  onChange,
   loading,
   customFields = [],
 }: BookingFormProps) {
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [notes, setNotes] = useState("");
   const [captchaToken, setCaptchaToken] = useState<string | undefined>();
-  const [fieldValues, setFieldValues] = useState<
-    Record<string, string | boolean>
-  >({});
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
-  function setFieldValue(id: string, value: string | boolean) {
-    setFieldValues((prev) => ({ ...prev, [id]: value }));
+  function updateValue(patch: Partial<BookingFormValue>) {
+    onChange({ ...value, ...patch });
+  }
+
+  function setFieldValue(id: string, fieldValue: string | boolean) {
+    updateValue({
+      fieldResponses: { ...value.fieldResponses, [id]: fieldValue },
+    });
     setFieldErrors((prev) => {
       const next = { ...prev };
       delete next[id];
@@ -52,7 +63,7 @@ export function BookingForm({
   function validateFields(): boolean {
     const errors: Record<string, string> = {};
     for (const field of customFields) {
-      const value = fieldValues[field.id];
+      const value = fieldResponses[field.id];
       if (field.required) {
         if (
           value === undefined ||
@@ -85,7 +96,7 @@ export function BookingForm({
     if (!validateFields()) return;
 
     const fieldResponses =
-      customFields.length > 0 ? { ...fieldValues } : undefined;
+      customFields.length > 0 ? { ...value.fieldResponses } : undefined;
 
     onSubmit({
       name: name.trim(),
@@ -96,6 +107,8 @@ export function BookingForm({
     });
   }
 
+  const { name, email, notes, fieldResponses } = value;
+
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-2">
@@ -103,7 +116,7 @@ export function BookingForm({
         <Input
           id="booking-name"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(e) => updateValue({ name: e.target.value })}
           placeholder="Your name"
           required
         />
@@ -115,7 +128,7 @@ export function BookingForm({
           id="booking-email"
           type="email"
           value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          onChange={(e) => updateValue({ email: e.target.value })}
           placeholder="you@example.com"
           required
         />
@@ -125,7 +138,7 @@ export function BookingForm({
         <CustomFieldInput
           key={field.id}
           field={field}
-          value={fieldValues[field.id]}
+          value={fieldResponses[field.id]}
           error={fieldErrors[field.id]}
           onChange={(val) => setFieldValue(field.id, val)}
         />
@@ -136,7 +149,7 @@ export function BookingForm({
         <Textarea
           id="booking-notes"
           value={notes}
-          onChange={(e) => setNotes(e.target.value)}
+          onChange={(e) => updateValue({ notes: e.target.value })}
           placeholder="Anything you'd like to share"
           rows={3}
         />

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -587,11 +587,30 @@ Write a short, useful meeting description. If I ask you to apply it, update this
 
   const handleSaveLocation = useCallback(() => {
     const trimmed = editLocation.trim();
+    const locationContainsMeetingLink =
+      !!meetingLink && event.location?.includes(meetingLink.url);
+    if (locationContainsMeetingLink && !trimmed) {
+      setEditLocation(event.location || "");
+      setEditingField(null);
+      return;
+    }
     if (trimmed !== (event.location || "").trim()) {
-      saveField({ location: trimmed });
+      const updates: Partial<CalendarEvent> = { location: trimmed };
+      if (
+        locationContainsMeetingLink &&
+        meetingLink &&
+        !event.description?.includes(meetingLink.url)
+      ) {
+        const label =
+          meetingLink.type === "zoom" ? "Zoom" : getMeetingLabel(meetingLink.type);
+        updates.description = event.description?.trim()
+          ? `${event.description.trim()}\n\n${label}: ${meetingLink.url}`
+          : `${label}: ${meetingLink.url}`;
+      }
+      saveField(updates);
     }
     setEditingField(null);
-  }, [editLocation, event.location, saveField]);
+  }, [editLocation, event.description, event.location, meetingLink, saveField]);
 
   const handleSaveTime = useCallback(() => {
     const allDayEnd = new Date(`${editEndDate}T00:00:00`);
@@ -1358,10 +1377,46 @@ Write a short, useful meeting description. If I ask you to apply it, update this
                   </span>
                 )}
               </div>
+            ) : locationIsMeetingLink && meetingLink ? (
+              <>
+                <div className="flex items-start gap-3 px-4 py-1.5 rounded-md">
+                  <IconVideo className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0">
+                    <a
+                      href={meetingLink.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block max-w-full truncate text-sm text-primary hover:underline"
+                    >
+                      {getMeetingLabel(meetingLink.type)}
+                    </a>
+                    <div className="text-xs text-muted-foreground">
+                      Saved as this event's video link
+                    </div>
+                  </div>
+                </div>
+                {!isOverlay && (
+                  <div
+                    className="flex items-center gap-3 px-4 py-1.5 cursor-pointer hover:bg-muted/50 rounded-md"
+                    onClick={() => {
+                      setEditLocation("");
+                      setEditingField("location");
+                    }}
+                  >
+                    <IconMapPin className="h-4 w-4 shrink-0 text-muted-foreground/40" />
+                    <span className="text-sm text-muted-foreground/40">
+                      Add location
+                    </span>
+                  </div>
+                )}
+              </>
             ) : !isOverlay ? (
               <div
                 className="flex items-center gap-3 px-4 py-1.5 cursor-pointer hover:bg-muted/50 rounded-md"
-                onClick={() => setEditingField("location")}
+                onClick={() => {
+                  setEditLocation(locationIsMeetingLink ? "" : event.location || "");
+                  setEditingField("location");
+                }}
               >
                 <IconMapPin className="h-4 w-4 shrink-0 text-muted-foreground/40" />
                 <span className="text-sm text-muted-foreground/40">

--- a/templates/calendar/app/components/calendar/EventDetailPopover.tsx
+++ b/templates/calendar/app/components/calendar/EventDetailPopover.tsx
@@ -602,7 +602,9 @@ Write a short, useful meeting description. If I ask you to apply it, update this
         !event.description?.includes(meetingLink.url)
       ) {
         const label =
-          meetingLink.type === "zoom" ? "Zoom" : getMeetingLabel(meetingLink.type);
+          meetingLink.type === "zoom"
+            ? "Zoom"
+            : getMeetingLabel(meetingLink.type);
         updates.description = event.description?.trim()
           ? `${event.description.trim()}\n\n${label}: ${meetingLink.url}`
           : `${label}: ${meetingLink.url}`;
@@ -1414,7 +1416,9 @@ Write a short, useful meeting description. If I ask you to apply it, update this
               <div
                 className="flex items-center gap-3 px-4 py-1.5 cursor-pointer hover:bg-muted/50 rounded-md"
                 onClick={() => {
-                  setEditLocation(locationIsMeetingLink ? "" : event.location || "");
+                  setEditLocation(
+                    locationIsMeetingLink ? "" : event.location || "",
+                  );
                   setEditingField("location");
                 }}
               >

--- a/templates/calendar/app/components/calendar/EventOptionControls.tsx
+++ b/templates/calendar/app/components/calendar/EventOptionControls.tsx
@@ -1,12 +1,19 @@
 import { agentNativePath } from "@agent-native/core/client";
 import {
   IconCheck,
+  IconInfoCircle,
   IconLoader2,
   IconPlus,
   IconTrash,
   IconUpload,
 } from "@tabler/icons-react";
-import { useRef, useState, type ChangeEvent, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ReactNode,
+} from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -162,6 +169,10 @@ export function AttachmentControls({
 }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
+  const [uploadStatus, setUploadStatus] = useState<{
+    configured: boolean;
+    activeProvider?: { id: string; name: string } | null;
+  } | null>(null);
   const activeAttachments =
     attachments.length > 0 ? attachments : [createAttachmentDraft()];
   const blankAttachmentIndex = activeAttachments.findIndex(
@@ -170,6 +181,33 @@ export function AttachmentControls({
   const canAddAttachment =
     activeAttachments.length < MAX_EVENT_ATTACHMENTS ||
     blankAttachmentIndex >= 0;
+  const uploadUnavailable = uploadStatus?.configured === false;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchUploadStatus() {
+      try {
+        const response = await fetch(
+          agentNativePath("/_agent-native/file-upload/status"),
+        );
+        if (!response.ok) return;
+        const status = (await response.json()) as {
+          configured: boolean;
+          activeProvider?: { id: string; name: string } | null;
+        };
+        if (!cancelled) setUploadStatus(status);
+      } catch {
+        // Status is only used to improve the UI. The upload request still
+        // reports the authoritative error if this check is unavailable.
+      }
+    }
+
+    void fetchUploadStatus();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   function updateAttachment(id: string, patch: Partial<AttachmentDraft>) {
     onChange(
@@ -238,9 +276,14 @@ export function AttachmentControls({
       }
       toast.success("Attachment uploaded");
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Could not upload attachment.",
-      );
+      const message =
+        error instanceof Error ? error.message : "Could not upload attachment.";
+      const permissionMessage = /403|permission|forbidden|unauthorized/i.test(
+        message,
+      )
+        ? "File upload is not available with the current upload provider credentials. Check Builder.io permissions in Settings, or paste a Drive/HTTPS URL instead."
+        : message;
+      toast.error(permissionMessage);
     } finally {
       setUploading(false);
     }
@@ -321,8 +364,16 @@ export function AttachmentControls({
           variant="ghost"
           size="sm"
           className="h-7 px-1.5 text-xs text-muted-foreground"
-          disabled={!canAddAttachment || uploading}
-          onClick={() => fileInputRef.current?.click()}
+          disabled={!canAddAttachment || uploading || uploadUnavailable}
+          onClick={() => {
+            if (uploadUnavailable) {
+              toast.error(
+                "File uploads are not configured. Paste a Drive or HTTPS URL instead.",
+              );
+              return;
+            }
+            fileInputRef.current?.click();
+          }}
         >
           {uploading ? (
             <IconLoader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
@@ -332,6 +383,13 @@ export function AttachmentControls({
           {uploading ? "Uploading" : "Upload file"}
         </Button>
       </div>
+      {uploadUnavailable && (
+        <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+          <IconInfoCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          File uploads need a configured upload provider. Paste a Drive or HTTPS
+          URL for now.
+        </p>
+      )}
     </div>
   );
 }

--- a/templates/calendar/app/pages/BookingPage.tsx
+++ b/templates/calendar/app/pages/BookingPage.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
-import { endOfMonth, format, startOfMonth } from "date-fns";
+import { addMinutes, endOfMonth, format, parseISO, startOfMonth } from "date-fns";
 import { IconCalendar } from "@tabler/icons-react";
 import { OpenSourceBadge, PoweredByBadge } from "@agent-native/core/client";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { DatePicker } from "@/components/booking/DatePicker";
 import { TimeSlotPicker } from "@/components/booking/TimeSlotPicker";
-import { BookingForm } from "@/components/booking/BookingForm";
+import {
+  BookingForm,
+  type BookingFormValue,
+} from "@/components/booking/BookingForm";
 import { BookingConfirmation } from "@/components/booking/BookingConfirmation";
 import {
   usePublicSettings,
@@ -60,6 +63,12 @@ export default function BookingPage() {
   );
   const [selectedDuration, setSelectedDuration] = useState<number | null>(null);
   const [viewMonth, setViewMonth] = useState(() => new Date());
+  const [bookingForm, setBookingForm] = useState<BookingFormValue>({
+    name: "",
+    email: "",
+    notes: "",
+    fieldResponses: {},
+  });
 
   const dateStr = selectedDate ? format(selectedDate, "yyyy-MM-dd") : "";
   const durationOptions =
@@ -88,6 +97,14 @@ export default function BookingPage() {
       step === "date" && !!availability,
     );
   const createBooking = useCreateBooking();
+  const selectedSlotRange = selectedSlot
+    ? {
+        start: selectedSlot,
+        end:
+          slots.find((slot) => slot.start === selectedSlot)?.end ??
+          addMinutes(parseISO(selectedSlot), duration).toISOString(),
+      }
+    : null;
 
   function handleDateSelect(date: Date) {
     setSelectedDate(date);
@@ -142,6 +159,7 @@ export default function BookingPage() {
     setSelectedSlot(null);
     setSelectedDuration(null);
     setConfirmedBooking(null);
+    setBookingForm({ name: "", email: "", notes: "", fieldResponses: {} });
   }
 
   function handleStepNavigation(target: Step) {
@@ -362,8 +380,24 @@ export default function BookingPage() {
                   Change time
                 </Button>
               </div>
+              {selectedSlotRange && (
+                <div className="mb-4 rounded-lg border border-border bg-muted/30 px-3 py-2 text-sm">
+                  <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Confirming
+                  </div>
+                  <div className="mt-1 font-medium text-foreground">
+                    {format(parseISO(selectedSlotRange.start), "EEEE, MMMM d")}
+                  </div>
+                  <div className="text-muted-foreground">
+                    {format(parseISO(selectedSlotRange.start), "h:mm a")} -{" "}
+                    {format(parseISO(selectedSlotRange.end), "h:mm a")}
+                  </div>
+                </div>
+              )}
               <BookingForm
                 onSubmit={handleBookingSubmit}
+                value={bookingForm}
+                onChange={setBookingForm}
                 loading={createBooking.isPending}
                 customFields={bookingLink?.customFields}
               />

--- a/templates/calendar/app/pages/BookingPage.tsx
+++ b/templates/calendar/app/pages/BookingPage.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
-import { addMinutes, endOfMonth, format, parseISO, startOfMonth } from "date-fns";
+import {
+  addMinutes,
+  endOfMonth,
+  format,
+  parseISO,
+  startOfMonth,
+} from "date-fns";
 import { IconCalendar } from "@tabler/icons-react";
 import { OpenSourceBadge, PoweredByBadge } from "@agent-native/core/client";
 import { ThemeToggle } from "@/components/ThemeToggle";

--- a/templates/calendar/app/pages/BookingsList.tsx
+++ b/templates/calendar/app/pages/BookingsList.tsx
@@ -15,9 +15,15 @@ import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { useBookings, useDeleteBooking } from "@/hooks/use-bookings";
 import { useBookingLinks } from "@/hooks/use-booking-links";
 import { toast } from "sonner";
@@ -179,23 +185,34 @@ function BookingDetails({
   }
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="text-xs text-muted-foreground cursor-help underline decoration-dotted">
-            {lines.length} {lines.length === 1 ? "detail" : "details"}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" className="max-w-xs">
-          <div className="space-y-1 text-xs">
-            {lines.map((line) => (
-              <div key={line.label}>
-                <span className="font-medium">{line.label}:</span> {line.value}
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="h-auto px-0 py-0 text-xs text-muted-foreground underline decoration-dotted"
+        >
+          {lines.length} {lines.length === 1 ? "detail" : "details"}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[80vh] overflow-hidden sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Booking Details</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 overflow-y-auto pr-1 text-sm">
+          {lines.map((line) => (
+            <div key={line.label} className="space-y-1">
+              <div className="text-xs font-medium text-muted-foreground">
+                {line.label}
               </div>
-            ))}
-          </div>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+              <div className="whitespace-pre-wrap break-words rounded-md bg-muted/40 p-3 text-foreground">
+                {line.value}
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/templates/calendar/app/pages/CalendarView.tsx
+++ b/templates/calendar/app/pages/CalendarView.tsx
@@ -456,52 +456,10 @@ export default function CalendarView() {
     startTime: string,
     endTime: string,
   ) {
-    const dateStr = format(clickedDate, "yyyy-MM-dd");
-    const startISO = new Date(`${dateStr}T${startTime}:00`).toISOString();
-    const endISO = new Date(`${dateStr}T${endTime}:00`).toISOString();
-    const tempId = `temp-${Date.now()}`;
-
-    createEvent.mutate(
-      {
-        title: "(No title)",
-        description: "",
-        location: "",
-        start: startISO,
-        end: endISO,
-        allDay: false,
-        _tempId: tempId,
-      },
-      {
-        onSuccess: (result) => {
-          // Synchronously swap the optimistic temp event for the real one
-          // in the cache so the inline input stays mounted when we update
-          // quickEditEventId to the real ID.
-          const { _tempId, ...realEvent } = result;
-          const stableTempId = _tempId ?? tempId;
-          setQuickEditTempIds((current) => ({
-            ...current,
-            [realEvent.id]: stableTempId,
-          }));
-          queryClient.setQueriesData<CalendarEvent[]>(
-            { queryKey: ["action", "list-events"] },
-            (old) =>
-              old?.map((e) =>
-                e.id === stableTempId
-                  ? { ...e, ...realEvent, _tempId: stableTempId }
-                  : e,
-              ),
-          );
-          setQuickEditEventId(realEvent.id);
-        },
-        onError: () => {
-          setQuickEditEventId(null);
-          toast.error("Failed to create event");
-        },
-      },
-    );
-
-    // Immediately show inline editor on the optimistic event
-    setQuickEditEventId(tempId);
+    setSelectedDate(clickedDate);
+    setCreateDefaultStart(startTime);
+    setCreateDefaultEnd(endTime);
+    setCreateDialogOpen(true);
   }
 
   function handleQuickEditSave(eventId: string, title: string) {

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -566,7 +566,7 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
     const cancelToken = nanoid();
     const attendeeName = stripCrlf(body.name);
     const attendeeEmail = stripCrlf(body.email).toLowerCase();
-    const notes = stripCrlf(body.notes);
+    const notes = String(body.notes ?? "").trim();
 
     // Validate required fields
     if (!attendeeName || !attendeeEmail || !body.start || !body.end) {
@@ -794,11 +794,13 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
     // host rather than relying on ambient user state.
     if (await googleCalendar.isConnected(hostEmail)) {
       try {
-        const descParts: string[] = [`Booking by ${body.name} (${body.email})`];
+        const descParts: string[] = [
+          `Booking by ${attendeeName} (${attendeeEmail})`,
+        ];
         if (bookingLink?.title) {
           descParts.push(`Meeting type: ${bookingLink.title}`);
         }
-        if (body.notes) descParts.push(`Notes: ${body.notes}`);
+        if (notes) descParts.push(`Notes: ${notes}`);
         if (customFields.length > 0 && Object.keys(fieldResponses).length > 0) {
           const fieldLines = customFields
             .filter(
@@ -860,13 +862,13 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
 
     const booking: Booking = {
       id,
-      name: body.name,
-      email: body.email,
+      name: attendeeName,
+      email: attendeeEmail,
       start: body.start,
       end: body.end,
       slug: body.slug || "",
       eventTitle,
-      notes: body.notes,
+      notes: notes || undefined,
       fieldResponses:
         Object.keys(fieldResponses).length > 0 ? fieldResponses : undefined,
       meetingLink,
@@ -892,8 +894,8 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
         {
           bookingId: id,
           schedulingLinkSlug: body.slug || "",
-          attendeeName: body.name,
-          attendeeEmail: body.email,
+          attendeeName,
+          attendeeEmail,
           startTime: body.start,
           endTime: body.end,
           eventTitle: booking.eventTitle || "",

--- a/templates/calendar/server/handlers/bookings.ts
+++ b/templates/calendar/server/handlers/bookings.ts
@@ -94,17 +94,25 @@ function displayNameFromEmail(email: string): string {
   return parts.map(titleCaseToken).join(" ");
 }
 
+function isValidEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
 function buildBookingEventTitle({
   explicitTitle,
+  bookingTitle,
   hostEmail,
   attendeeName,
 }: {
   explicitTitle?: unknown;
+  bookingTitle?: unknown;
   hostEmail: string;
   attendeeName: unknown;
 }) {
   const explicit = stripCrlf(explicitTitle);
   if (explicit) return explicit;
+  const meetingType = stripCrlf(bookingTitle);
+  if (meetingType) return meetingType;
 
   const hostName = displayNameFromEmail(hostEmail);
   const guestName = stripCrlf(attendeeName) || "Guest";
@@ -556,11 +564,18 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
     const now = new Date().toISOString();
     const id = nanoid();
     const cancelToken = nanoid();
+    const attendeeName = stripCrlf(body.name);
+    const attendeeEmail = stripCrlf(body.email).toLowerCase();
+    const notes = stripCrlf(body.notes);
 
     // Validate required fields
-    if (!body.name || !body.email || !body.start || !body.end) {
+    if (!attendeeName || !attendeeEmail || !body.start || !body.end) {
       setResponseStatus(event, 400);
       return { error: "name, email, start, and end are required" };
+    }
+    if (!isValidEmail(attendeeEmail)) {
+      setResponseStatus(event, 400);
+      return { error: "Enter a valid email address" };
     }
 
     const bookingLink =
@@ -586,8 +601,9 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
 
     const eventTitle = buildBookingEventTitle({
       explicitTitle: body.eventTitle,
+      bookingTitle: bookingLink?.title,
       hostEmail,
-      attendeeName: body.name,
+      attendeeName,
     });
 
     // Validate custom field responses
@@ -635,6 +651,15 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
       ) {
         setResponseStatus(event, 400);
         return { error: `${field.label} must be true or false` };
+      }
+      if (
+        field.type === "email" &&
+        typeof value === "string" &&
+        value &&
+        !isValidEmail(value.trim())
+      ) {
+        setResponseStatus(event, 400);
+        return { error: `${field.label} must be a valid email address` };
       }
       if (field.pattern && typeof value === "string" && value) {
         // Cap input length to mitigate ReDoS on user-defined patterns
@@ -690,13 +715,13 @@ export const createBooking = defineEventHandler(async (event: H3Event) => {
 
       await tx.insert(schema.bookings).values({
         id,
-        name: body.name,
-        email: body.email,
+        name: attendeeName,
+        email: attendeeEmail,
         start: body.start,
         end: body.end,
         slug: body.slug || "",
         eventTitle,
-        notes: body.notes || null,
+        notes: notes || null,
         fieldResponses:
           Object.keys(fieldResponses).length > 0
             ? JSON.stringify(fieldResponses)

--- a/templates/clips/AGENTS.md
+++ b/templates/clips/AGENTS.md
@@ -392,6 +392,8 @@ Clips has a **Meetings** tab (`/meetings`) and a **Dictate** tab (`/dictate`):
 
 **Audio capture: mic + system, tagged.** Meeting capture records two streams (`mic` and `system`) and tags every transcript segment with its `source`, so per-attendee action items can attribute speech to remote attendees. Mic-only recordings make remote attendees silent — call this out whenever the user expects coverage of people on the other end of a Zoom/Meet/Teams call. Dictations are mic-only by design.
 
+**Meeting transcription UX language.** User-facing meeting controls should say **Start notes**, **Transcribe**, **Live transcript**, or **Stop transcription**. Avoid saying "record" for Granola-style meeting notes unless referring to the internal linked `recordings` row or to a Clip video. The desktop meeting preference is `meetingTranscriptionMode` (`ask`, `auto`, `manual`) plus `showMeetingWidgetEnabled`.
+
 **Bidirectional recording↔meeting link.** A meeting recording sets `meetings.recordingId` AND `recordings.meeting_id`, so a recording opened from the Library can also be recognized as a meeting (and vice versa). When a recording row's `meeting_id` is non-null, both the Clips and Meetings answers are valid.
 
 **Calendar reminders fire 5 minutes before the meeting starts.** The desktop tray (`desktop/src-tauri/`) polls the live `list-meetings` action and filters locally for near-start reminders; `calendar_events` is only a snapshot/materialization table for meetings that have been recorded or edited. Agents do not need to schedule reminders manually.

--- a/templates/clips/app/components/meetings/auto-record-prompt.tsx
+++ b/templates/clips/app/components/meetings/auto-record-prompt.tsx
@@ -1,13 +1,13 @@
 /**
- * Granola-style auto-record prompt banner.
+ * Granola-style auto-start notes prompt banner.
  *
  * Appears at the top of the meeting detail page when the meeting's
  * `scheduledStart` is within ±2 minutes of now and `actualStart` is null.
  *
  * Behavior (matches Granola: "starts at calendar time if you're viewing the
  * event"):
- *   1. Banner appears — primary "Start recording" button.
- *   2. After 30 seconds of no interaction, recording auto-starts.
+ *   1. Banner appears — primary "Start notes" button.
+ *   2. After 30 seconds of no interaction, transcription auto-starts.
  *   3. For the first 5 seconds after auto-fire, a "Cancel" link is visible
  *      so the user can abort if they didn't notice.
  *
@@ -15,7 +15,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { IconClock, IconPlayerRecord, IconX } from "@tabler/icons-react";
+import { IconClock, IconPlayerPlayFilled, IconX } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useAutoFireCountdown, useAutoRecord } from "@/hooks/use-auto-record";
@@ -87,7 +87,7 @@ export function AutoRecordPrompt({
           <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500 opacity-60" />
           <span className="relative inline-flex h-2 w-2 rounded-full bg-red-500" />
         </span>
-        <span className="text-sm">Recording started.</span>
+        <span className="text-sm">Notes started.</span>
         <button
           type="button"
           onClick={cancel}
@@ -111,7 +111,7 @@ export function AutoRecordPrompt({
     >
       <IconClock className="h-4 w-4 shrink-0 text-primary" />
       <span className="text-sm font-medium">
-        It's time for this meeting — start recording?
+        It's time for this meeting — start notes?
       </span>
       <span className="text-xs text-muted-foreground">
         Auto-starts in {secondsRemaining}s
@@ -125,8 +125,8 @@ export function AutoRecordPrompt({
           }}
           className="cursor-pointer h-8 gap-1.5"
         >
-          <IconPlayerRecord className="h-3.5 w-3.5" />
-          Start recording
+          <IconPlayerPlayFilled className="h-3.5 w-3.5" />
+          Start notes
         </Button>
         <button
           type="button"

--- a/templates/clips/app/components/meetings/meeting-card.tsx
+++ b/templates/clips/app/components/meetings/meeting-card.tsx
@@ -156,7 +156,7 @@ export function MeetingCard({ meeting }: { meeting: MeetingCardData }) {
             {meeting.recordingId && (
               <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
                 <IconVideo className="h-3 w-3" />
-                Recording
+                Transcript source
               </span>
             )}
           </div>

--- a/templates/clips/app/components/meetings/transcript-bubbles.tsx
+++ b/templates/clips/app/components/meetings/transcript-bubbles.tsx
@@ -124,7 +124,7 @@ export function TranscriptBubbles({
         <IconNotes className="h-6 w-6 text-muted-foreground/50" />
         <span>No transcript yet.</span>
         <span className="text-xs">
-          Recording will appear here once the meeting starts.
+          The live transcript will appear here once notes start.
         </span>
       </div>
     );

--- a/templates/clips/app/components/player/player-controls.tsx
+++ b/templates/clips/app/components/player/player-controls.tsx
@@ -25,8 +25,9 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { PLAYBACK_SPEED_OPTIONS } from "@/lib/playback-speed";
 
-export const SPEED_OPTIONS = [0.5, 0.8, 1, 1.2, 1.5, 1.7, 2, 2.5];
+export const SPEED_OPTIONS = PLAYBACK_SPEED_OPTIONS;
 
 export interface PlayerControlsProps {
   isPlaying: boolean;

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -376,8 +376,8 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
         const v = videoRef.current;
         const shouldKeepPlaying = Boolean(
           v &&
-            !v.ended &&
-            (isPlaying || playAttemptPendingRef.current || !v.paused),
+          !v.ended &&
+          (isPlaying || playAttemptPendingRef.current || !v.paused),
         );
 
         if (v) v.playbackRate = nextSpeed;

--- a/templates/clips/app/components/player/video-player.tsx
+++ b/templates/clips/app/components/player/video-player.tsx
@@ -32,6 +32,11 @@ import {
   thumbnailUrlHasVisibleContent,
   uploadRecordingThumbnail,
 } from "@/lib/thumbnail-capture";
+import {
+  parsePlaybackSpeed,
+  readPlaybackSpeedPreference,
+  savePlaybackSpeedPreference,
+} from "@/lib/playback-speed";
 
 function resolveLocalUrl(url: string | null | undefined): string | undefined {
   if (!url) return undefined;
@@ -121,6 +126,7 @@ export interface VideoPlayerProps {
   onPlay?: () => void;
   onPause?: () => void;
   onSeek?: (ms: number) => void;
+  onSpeedChange?: (rate: number) => void;
   onEnded?: () => void;
   className?: string;
   /** When true the controls never hide (useful for embed with showControls). */
@@ -160,6 +166,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       onPlay,
       onPause,
       onSeek,
+      onSpeedChange,
       onEnded,
       className,
       alwaysShowControls,
@@ -184,7 +191,9 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     const [currentMs, setCurrentMs] = useState(startMs ?? 0);
     const [volume, setVolume] = useState(1);
     const [muted, setMuted] = useState(false);
-    const [speed, setSpeed] = useState(defaultSpeed);
+    const [speed, setSpeed] = useState(() =>
+      readPlaybackSpeedPreference(defaultSpeed),
+    );
     const [showControls, setShowControls] = useState(true);
     const [captionsOn, setCaptionsOn] = useState(false);
     const [hasPlaybackStarted, setHasPlaybackStarted] = useState(false);
@@ -361,10 +370,30 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       requestPlay();
     }, [isPlaying, pauseVideo, requestPlay]);
 
-    const applySpeed = useCallback((rate: number) => {
-      if (videoRef.current) videoRef.current.playbackRate = rate;
-      setSpeed(rate);
-    }, []);
+    const applySpeed = useCallback(
+      (rate: number) => {
+        const nextSpeed = parsePlaybackSpeed(rate) ?? defaultSpeed;
+        const v = videoRef.current;
+        const shouldKeepPlaying = Boolean(
+          v &&
+            !v.ended &&
+            (isPlaying || playAttemptPendingRef.current || !v.paused),
+        );
+
+        if (v) v.playbackRate = nextSpeed;
+        setSpeed(nextSpeed);
+        savePlaybackSpeedPreference(nextSpeed);
+        onSpeedChange?.(nextSpeed);
+
+        if (shouldKeepPlaying && typeof window !== "undefined") {
+          window.requestAnimationFrame(() => {
+            const current = videoRef.current;
+            if (current && current.paused && !current.ended) requestPlay();
+          });
+        }
+      },
+      [defaultSpeed, isPlaying, onSpeedChange, requestPlay],
+    );
 
     const seekToVisibleMs = useCallback(
       (ms: number) => {
@@ -411,8 +440,10 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
     useEffect(() => {
       const v = videoRef.current;
       if (!v) return;
-      v.playbackRate = defaultSpeed;
-      setSpeed(defaultSpeed);
+      const initialSpeed = readPlaybackSpeedPreference(defaultSpeed);
+      v.playbackRate = initialSpeed;
+      setSpeed(initialSpeed);
+      onSpeedChange?.(initialSpeed);
       if (startMs && startMs > 0) {
         const visibleMs = clampSeek(
           skipExcludedRange(startMs, excludedRanges, resolvedDurationMs),
@@ -426,6 +457,7 @@ export const VideoPlayer = forwardRef<VideoPlayerHandle, VideoPlayerProps>(
       activeVideoSrc,
       defaultSpeed,
       excludedRanges,
+      onSpeedChange,
       resolvedDurationMs,
       startMs,
     ]);

--- a/templates/clips/app/hooks/use-player-shortcuts.ts
+++ b/templates/clips/app/hooks/use-player-shortcuts.ts
@@ -1,6 +1,9 @@
 import { useEffect } from "react";
 import type { VideoPlayerHandle } from "@/components/player/video-player";
-import { PLAYBACK_SPEED_OPTIONS } from "@/lib/playback-speed";
+import {
+  parsePlaybackSpeed,
+  PLAYBACK_SPEED_OPTIONS,
+} from "@/lib/playback-speed";
 
 export interface Chapter {
   startMs: number;
@@ -9,8 +12,6 @@ export interface Chapter {
 
 export interface UsePlayerShortcutsOpts {
   playerRef: React.RefObject<VideoPlayerHandle | null>;
-  speed: number;
-  setSpeed: (v: number) => void;
   chapters?: Chapter[];
   enabled?: boolean;
 }
@@ -32,7 +33,7 @@ export interface UsePlayerShortcutsOpts {
  * Ignores events when focus is inside an input/textarea/contenteditable.
  */
 export function usePlayerShortcuts(opts: UsePlayerShortcutsOpts) {
-  const { playerRef, speed, setSpeed, chapters = [], enabled = true } = opts;
+  const { playerRef, chapters = [], enabled = true } = opts;
 
   useEffect(() => {
     if (!enabled) return;
@@ -118,6 +119,7 @@ export function usePlayerShortcuts(opts: UsePlayerShortcutsOpts) {
         case ">":
         case ".": {
           e.preventDefault();
+          const speed = parsePlaybackSpeed(v.playbackRate) ?? 1.2;
           const idx = PLAYBACK_SPEED_OPTIONS.indexOf(speed);
           const next =
             idx === -1
@@ -126,12 +128,12 @@ export function usePlayerShortcuts(opts: UsePlayerShortcutsOpts) {
                   Math.min(PLAYBACK_SPEED_OPTIONS.length - 1, idx + 1)
                 ];
           player.setSpeed(next);
-          setSpeed(next);
           break;
         }
         case "<":
         case ",": {
           e.preventDefault();
+          const speed = parsePlaybackSpeed(v.playbackRate) ?? 1.2;
           const idx = PLAYBACK_SPEED_OPTIONS.indexOf(speed);
           const next =
             idx === -1
@@ -140,7 +142,6 @@ export function usePlayerShortcuts(opts: UsePlayerShortcutsOpts) {
                   .find((s) => s < speed) ?? speed)
               : PLAYBACK_SPEED_OPTIONS[Math.max(0, idx - 1)];
           player.setSpeed(next);
-          setSpeed(next);
           break;
         }
       }
@@ -148,7 +149,7 @@ export function usePlayerShortcuts(opts: UsePlayerShortcutsOpts) {
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [enabled, playerRef, speed, setSpeed, chapters]);
+  }, [enabled, playerRef, chapters]);
 }
 
 function shouldIgnore(target: EventTarget | null): boolean {

--- a/templates/clips/app/hooks/use-player-shortcuts.ts
+++ b/templates/clips/app/hooks/use-player-shortcuts.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import type { VideoPlayerHandle } from "@/components/player/video-player";
-import { SPEED_OPTIONS } from "@/components/player/player-controls";
+import { PLAYBACK_SPEED_OPTIONS } from "@/lib/playback-speed";
 
 export interface Chapter {
   startMs: number;
@@ -118,11 +118,13 @@ export function usePlayerShortcuts(opts: UsePlayerShortcutsOpts) {
         case ">":
         case ".": {
           e.preventDefault();
-          const idx = SPEED_OPTIONS.indexOf(speed);
+          const idx = PLAYBACK_SPEED_OPTIONS.indexOf(speed);
           const next =
             idx === -1
-              ? (SPEED_OPTIONS.find((s) => s > speed) ?? speed)
-              : SPEED_OPTIONS[Math.min(SPEED_OPTIONS.length - 1, idx + 1)];
+              ? (PLAYBACK_SPEED_OPTIONS.find((s) => s > speed) ?? speed)
+              : PLAYBACK_SPEED_OPTIONS[
+                  Math.min(PLAYBACK_SPEED_OPTIONS.length - 1, idx + 1)
+                ];
           player.setSpeed(next);
           setSpeed(next);
           break;
@@ -130,13 +132,13 @@ export function usePlayerShortcuts(opts: UsePlayerShortcutsOpts) {
         case "<":
         case ",": {
           e.preventDefault();
-          const idx = SPEED_OPTIONS.indexOf(speed);
+          const idx = PLAYBACK_SPEED_OPTIONS.indexOf(speed);
           const next =
             idx === -1
-              ? (SPEED_OPTIONS.slice()
+              ? (PLAYBACK_SPEED_OPTIONS.slice()
                   .reverse()
                   .find((s) => s < speed) ?? speed)
-              : SPEED_OPTIONS[Math.max(0, idx - 1)];
+              : PLAYBACK_SPEED_OPTIONS[Math.max(0, idx - 1)];
           player.setSpeed(next);
           setSpeed(next);
           break;

--- a/templates/clips/app/lib/playback-speed.ts
+++ b/templates/clips/app/lib/playback-speed.ts
@@ -1,0 +1,43 @@
+export const PLAYBACK_SPEED_OPTIONS = [0.5, 0.8, 1, 1.2, 1.5, 1.7, 2, 2.5];
+
+const PLAYBACK_SPEED_STORAGE_KEY = "clips.playbackSpeed";
+const MIN_PLAYBACK_SPEED = 0.25;
+const MAX_PLAYBACK_SPEED = 4;
+
+export function parsePlaybackSpeed(value: unknown): number | null {
+  const rate =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? parseFloat(value)
+        : Number.NaN;
+
+  if (!Number.isFinite(rate)) return null;
+  if (rate < MIN_PLAYBACK_SPEED || rate > MAX_PLAYBACK_SPEED) return null;
+  return rate;
+}
+
+export function readPlaybackSpeedPreference(fallback: number): number {
+  const fallbackSpeed = parsePlaybackSpeed(fallback) ?? 1.2;
+  if (typeof window === "undefined") return fallbackSpeed;
+
+  try {
+    return (
+      parsePlaybackSpeed(window.localStorage.getItem(PLAYBACK_SPEED_STORAGE_KEY)) ??
+      fallbackSpeed
+    );
+  } catch {
+    return fallbackSpeed;
+  }
+}
+
+export function savePlaybackSpeedPreference(rate: number): void {
+  const speed = parsePlaybackSpeed(rate);
+  if (speed === null || typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(PLAYBACK_SPEED_STORAGE_KEY, String(speed));
+  } catch {
+    // Ignore storage failures; the active player should still update.
+  }
+}

--- a/templates/clips/app/lib/playback-speed.ts
+++ b/templates/clips/app/lib/playback-speed.ts
@@ -23,8 +23,9 @@ export function readPlaybackSpeedPreference(fallback: number): number {
 
   try {
     return (
-      parsePlaybackSpeed(window.localStorage.getItem(PLAYBACK_SPEED_STORAGE_KEY)) ??
-      fallbackSpeed
+      parsePlaybackSpeed(
+        window.localStorage.getItem(PLAYBACK_SPEED_STORAGE_KEY),
+      ) ?? fallbackSpeed
     );
   } catch {
     return fallbackSpeed;

--- a/templates/clips/app/routes/_app.meetings.$meetingId.tsx
+++ b/templates/clips/app/routes/_app.meetings.$meetingId.tsx
@@ -586,7 +586,7 @@ export default function MeetingDetailRoute() {
                 <AlertDialogTitle>Remove this meeting?</AlertDialogTitle>
                 <AlertDialogDescription>
                   This removes the meeting from Clips. It will not delete any
-                  linked recording or change your Google Calendar.
+                  linked transcript or change your Google Calendar.
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
@@ -652,7 +652,7 @@ export default function MeetingDetailRoute() {
             className="inline-flex items-center gap-1.5 rounded border border-border px-2 py-0.5 hover:text-foreground hover:bg-accent/40 cursor-pointer"
           >
             <IconVideo className="h-3.5 w-3.5" />
-            Open recording
+            Open transcript source
             {recordingDuration && (
               <span className="tabular-nums text-muted-foreground/80">
                 · {recordingDuration}

--- a/templates/clips/app/routes/_app.meetings._index.tsx
+++ b/templates/clips/app/routes/_app.meetings._index.tsx
@@ -311,7 +311,7 @@ function ConnectCalendarEmptyState({
             </div>
             <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
               See your upcoming meetings, get a notification a few minutes
-              before, and one-click record + transcribe.
+              before, and one-click notes + transcription.
             </p>
             <div className="mt-3">
               <CalendarConnectionAction
@@ -617,7 +617,7 @@ function MeetingsHeader({
               </NavLink>
             </Button>
             <p className="max-w-56 text-[11px] leading-snug text-muted-foreground">
-              Required for meeting reminders and recording.
+              Required for meeting reminders and transcription.
             </p>
           </div>
         )}

--- a/templates/clips/app/routes/embed.$shareId.tsx
+++ b/templates/clips/app/routes/embed.$shareId.tsx
@@ -9,6 +9,7 @@ import {
 import { AccessPasswordPrompt } from "@/components/player/access-password-prompt";
 import { Spinner } from "@/components/ui/spinner";
 import { useViewTracking } from "@/hooks/use-view-tracking";
+import { parsePlaybackSpeed } from "@/lib/playback-speed";
 
 export function meta() {
   return [{ title: "Clip" }];
@@ -169,7 +170,7 @@ export default function EmbedRoute() {
         durationMs={recording.durationMs}
         editsJson={recording.editsJson}
         thumbnailUrl={recording.thumbnailUrl}
-        defaultSpeed={parseFloat(recording.defaultSpeed || "1.2") || 1.2}
+        defaultSpeed={parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2}
         autoPlay={autoplay}
         startMs={startMs}
         chapters={chapters}

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -45,6 +45,10 @@ import { ShareRecordingPopover } from "@/components/player/share-dialog";
 import { StorageSetupCard } from "@/components/recorder/storage-setup-card";
 import { usePlayerShortcuts } from "@/hooks/use-player-shortcuts";
 import { useViewTracking } from "@/hooks/use-view-tracking";
+import {
+  parsePlaybackSpeed,
+  readPlaybackSpeedPreference,
+} from "@/lib/playback-speed";
 
 export function meta({ params }: { params: { recordingId?: string } }) {
   return [{ title: "Clip recording · Clips" }];
@@ -121,7 +125,7 @@ export default function RecordingPage() {
   const [theaterMode, setTheaterMode] = useState(false);
   const [editing, setEditing] = useState(false);
   const [currentMs, setCurrentMs] = useState(0);
-  const [speed, setSpeed] = useState(1.2);
+  const [speed, setSpeed] = useState(() => readPlaybackSpeedPreference(1.2));
   const transcriptKickedRef = useRef<string | null>(null);
   // When the recording lands in the processing state but never flips to
   // 'ready', stop spinning forever and surface an error banner so the user
@@ -271,8 +275,8 @@ export default function RecordingPage() {
 
   useEffect(() => {
     if (!recording) return;
-    const s = parseFloat(recording.defaultSpeed || "1.2");
-    if (!Number.isNaN(s)) setSpeed(s);
+    const s = parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2;
+    setSpeed(readPlaybackSpeedPreference(s));
   }, [recording?.defaultSpeed]);
 
   useEffect(() => {
@@ -696,6 +700,7 @@ export default function RecordingPage() {
                   transcriptSegments={transcriptSegments}
                   theaterMode={theaterMode}
                   onTheaterToggle={() => setTheaterMode((v) => !v)}
+                  onSpeedChange={setSpeed}
                   cta={firstCta}
                   onCtaClick={() => tracking.reportCtaClick()}
                   onTimeUpdate={(ms) => setCurrentMs(ms)}

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -682,7 +682,9 @@ export default function RecordingPage() {
                   editsJson={recording.editsJson}
                   thumbnailUrl={recording.thumbnailUrl}
                   role={role}
-                  defaultSpeed={parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2}
+                  defaultSpeed={
+                    parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2
+                  }
                   startMs={startMs}
                   comments={comments}
                   chapters={chapters}

--- a/templates/clips/app/routes/r.$recordingId.tsx
+++ b/templates/clips/app/routes/r.$recordingId.tsx
@@ -45,10 +45,7 @@ import { ShareRecordingPopover } from "@/components/player/share-dialog";
 import { StorageSetupCard } from "@/components/recorder/storage-setup-card";
 import { usePlayerShortcuts } from "@/hooks/use-player-shortcuts";
 import { useViewTracking } from "@/hooks/use-view-tracking";
-import {
-  parsePlaybackSpeed,
-  readPlaybackSpeedPreference,
-} from "@/lib/playback-speed";
+import { parsePlaybackSpeed } from "@/lib/playback-speed";
 
 export function meta({ params }: { params: { recordingId?: string } }) {
   return [{ title: "Clip recording · Clips" }];
@@ -125,7 +122,6 @@ export default function RecordingPage() {
   const [theaterMode, setTheaterMode] = useState(false);
   const [editing, setEditing] = useState(false);
   const [currentMs, setCurrentMs] = useState(0);
-  const [speed, setSpeed] = useState(() => readPlaybackSpeedPreference(1.2));
   const transcriptKickedRef = useRef<string | null>(null);
   // When the recording lands in the processing state but never flips to
   // 'ready', stop spinning forever and surface an error banner so the user
@@ -275,12 +271,6 @@ export default function RecordingPage() {
 
   useEffect(() => {
     if (!recording) return;
-    const s = parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2;
-    setSpeed(readPlaybackSpeedPreference(s));
-  }, [recording?.defaultSpeed]);
-
-  useEffect(() => {
-    if (!recording) return;
     document.title = isDefaultTitle(recording.title)
       ? "Clip recording · Clips"
       : `${recording.title.trim()} · Clips`;
@@ -345,7 +335,7 @@ export default function RecordingPage() {
     }).catch(() => {});
   }, [panel, recordingId, search, startMs]);
 
-  usePlayerShortcuts({ playerRef, speed, setSpeed, chapters });
+  usePlayerShortcuts({ playerRef, chapters });
 
   const tracking = useViewTracking({
     recordingId: recordingId ?? "",
@@ -692,7 +682,7 @@ export default function RecordingPage() {
                   editsJson={recording.editsJson}
                   thumbnailUrl={recording.thumbnailUrl}
                   role={role}
-                  defaultSpeed={speed}
+                  defaultSpeed={parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2}
                   startMs={startMs}
                   comments={comments}
                   chapters={chapters}
@@ -700,7 +690,6 @@ export default function RecordingPage() {
                   transcriptSegments={transcriptSegments}
                   theaterMode={theaterMode}
                   onTheaterToggle={() => setTheaterMode((v) => !v)}
-                  onSpeedChange={setSpeed}
                   cta={firstCta}
                   onCtaClick={() => tracking.reportCtaClick()}
                   onTimeUpdate={(ms) => setCurrentMs(ms)}

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -32,10 +32,7 @@ import { isDefaultTitle } from "@/hooks/use-auto-title";
 import { getDb, schema } from "../../server/db";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { resolveAccess } from "@agent-native/core/sharing";
-import {
-  parsePlaybackSpeed,
-  readPlaybackSpeedPreference,
-} from "@/lib/playback-speed";
+import { parsePlaybackSpeed } from "@/lib/playback-speed";
 
 type SharePageMetaRecording = {
   id: string;
@@ -168,7 +165,6 @@ export default function ShareRoute() {
   });
   const [pwError, setPwError] = useState<string | null>(null);
   const [currentMs, setCurrentMs] = useState(0);
-  const [speed, setSpeed] = useState(() => readPlaybackSpeedPreference(1.2));
   const { session } = useSession();
   const [signInIntent, setSignInIntent] = useState<"comment" | "react" | null>(
     null,
@@ -221,13 +217,7 @@ export default function ShareRoute() {
     document.title = pageTitle(recording.title);
   }, [recording?.title]);
 
-  useEffect(() => {
-    if (!recording) return;
-    const s = parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2;
-    setSpeed(readPlaybackSpeedPreference(s));
-  }, [recording?.defaultSpeed]);
-
-  usePlayerShortcuts({ playerRef, speed, setSpeed });
+  usePlayerShortcuts({ playerRef });
 
   const tracking = useViewTracking({
     recordingId: shareId ?? "",
@@ -446,13 +436,12 @@ export default function ShareRoute() {
               durationMs={recording.durationMs}
               editsJson={recording.editsJson}
               thumbnailUrl={recording.thumbnailUrl}
-              defaultSpeed={speed}
+              defaultSpeed={parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2}
               comments={comments}
               chapters={chapters}
               reactions={reactions}
               transcriptSegments={transcriptSegments}
               cta={firstCta}
-              onSpeedChange={setSpeed}
               onCtaClick={() => tracking.reportCtaClick()}
               onTimeUpdate={(ms) => setCurrentMs(ms)}
               className="w-full h-full"

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -32,6 +32,10 @@ import { isDefaultTitle } from "@/hooks/use-auto-title";
 import { getDb, schema } from "../../server/db";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { resolveAccess } from "@agent-native/core/sharing";
+import {
+  parsePlaybackSpeed,
+  readPlaybackSpeedPreference,
+} from "@/lib/playback-speed";
 
 type SharePageMetaRecording = {
   id: string;
@@ -164,7 +168,7 @@ export default function ShareRoute() {
   });
   const [pwError, setPwError] = useState<string | null>(null);
   const [currentMs, setCurrentMs] = useState(0);
-  const [speed, setSpeed] = useState(1.2);
+  const [speed, setSpeed] = useState(() => readPlaybackSpeedPreference(1.2));
   const { session } = useSession();
   const [signInIntent, setSignInIntent] = useState<"comment" | "react" | null>(
     null,
@@ -219,8 +223,8 @@ export default function ShareRoute() {
 
   useEffect(() => {
     if (!recording) return;
-    const s = parseFloat(recording.defaultSpeed || "1.2");
-    if (!Number.isNaN(s)) setSpeed(s);
+    const s = parsePlaybackSpeed(recording.defaultSpeed) ?? 1.2;
+    setSpeed(readPlaybackSpeedPreference(s));
   }, [recording?.defaultSpeed]);
 
   usePlayerShortcuts({ playerRef, speed, setSpeed });
@@ -448,6 +452,7 @@ export default function ShareRoute() {
               reactions={reactions}
               transcriptSegments={transcriptSegments}
               cta={firstCta}
+              onSpeedChange={setSpeed}
               onCtaClick={() => tracking.reportCtaClick()}
               onTimeUpdate={(ms) => setCurrentMs(ms)}
               className="w-full h-full"

--- a/templates/clips/desktop/src-tauri/src/config.rs
+++ b/templates/clips/desktop/src-tauri/src/config.rs
@@ -13,10 +13,30 @@ pub struct FeatureConfig {
     pub launch_at_login_enabled: bool,
     #[serde(default)]
     pub auto_hide_popover_enabled: bool,
+    #[serde(default = "default_meeting_transcription_mode")]
+    pub meeting_transcription_mode: MeetingTranscriptionMode,
+    #[serde(default = "default_show_meeting_widget_enabled")]
+    pub show_meeting_widget_enabled: bool,
     pub onboarding_complete: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MeetingTranscriptionMode {
+    Manual,
+    Ask,
+    Auto,
+}
+
 fn default_launch_at_login_enabled() -> bool {
+    true
+}
+
+fn default_meeting_transcription_mode() -> MeetingTranscriptionMode {
+    MeetingTranscriptionMode::Ask
+}
+
+fn default_show_meeting_widget_enabled() -> bool {
     true
 }
 
@@ -28,6 +48,8 @@ impl Default for FeatureConfig {
             voice_enabled: true,
             launch_at_login_enabled: true,
             auto_hide_popover_enabled: false,
+            meeting_transcription_mode: default_meeting_transcription_mode(),
+            show_meeting_widget_enabled: default_show_meeting_widget_enabled(),
             onboarding_complete: false,
         }
     }
@@ -109,6 +131,10 @@ pub fn sync_launch_at_login(app: &AppHandle) {
 
 pub fn auto_hide_popover_enabled(app: &AppHandle) -> bool {
     load_config(app).auto_hide_popover_enabled
+}
+
+pub fn feature_config(app: &AppHandle) -> FeatureConfig {
+    load_config(app)
 }
 
 /// Load feature config from disk and return it to the frontend.

--- a/templates/clips/desktop/src-tauri/src/meetings_watcher.rs
+++ b/templates/clips/desktop/src-tauri/src/meetings_watcher.rs
@@ -33,6 +33,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager};
 
+use crate::config::{feature_config, MeetingTranscriptionMode};
 use crate::dlog;
 use crate::tray_meetings::MeetingItem as TrayMeetingItem;
 
@@ -164,6 +165,11 @@ async fn run_watcher(app: AppHandle) {
 }
 
 async fn tick_once(app: &AppHandle, client: &reqwest::Client) -> Result<(), String> {
+    let config = feature_config(app);
+    if !config.meetings_enabled {
+        return Ok(());
+    }
+
     let (server_url, cookie, auth_token) = {
         let state = app
             .try_state::<MeetingsWatcherState>()
@@ -250,32 +256,57 @@ async fn tick_once(app: &AppHandle, client: &reqwest::Client) -> Result<(), Stri
         if already {
             continue;
         }
+        if config.meeting_transcription_mode == MeetingTranscriptionMode::Manual
+            && !config.show_meeting_widget_enabled
+        {
+            continue;
+        }
         let title = m.title.clone().unwrap_or_else(|| "Meeting".to_string());
         let join_url = m.join_url.clone();
-        let _ = app.emit(
-            "meetings:show-notification",
-            serde_json::json!({
-                "type": "calendar",
-                "title": title,
-                "subtitle": format!("Starting in {} min", (secs_until / 60).max(1)),
-                "meetingId": m.id,
-                "joinUrl": join_url,
-            }),
-        );
-        let app_clone = app.clone();
-        let id_clone = m.id.clone();
-        let title_clone = title.clone();
-        let join_clone = join_url.clone();
-        tauri::async_runtime::spawn(async move {
-            let _ = crate::notifications::notify_meeting_starting(
-                app_clone,
-                id_clone,
-                title_clone,
-                secs_until,
-                join_clone,
-            )
-            .await;
-        });
+        let subtitle = if config.meeting_transcription_mode == MeetingTranscriptionMode::Auto {
+            "Starting notes now".to_string()
+        } else {
+            format!("Starting in {} min", (secs_until / 60).max(1))
+        };
+        if config.show_meeting_widget_enabled
+            || config.meeting_transcription_mode == MeetingTranscriptionMode::Auto
+        {
+            let _ = app.emit(
+                "meetings:show-notification",
+                serde_json::json!({
+                    "type": "calendar",
+                    "title": title.clone(),
+                    "subtitle": subtitle.clone(),
+                    "meetingId": m.id.clone(),
+                    "joinUrl": join_url.clone(),
+                    "autoStart": config.meeting_transcription_mode == MeetingTranscriptionMode::Auto,
+                }),
+            );
+            let app_clone = app.clone();
+            let id_clone = m.id.clone();
+            let title_clone = title.clone();
+            let join_clone = join_url.clone();
+            tauri::async_runtime::spawn(async move {
+                let _ = crate::notifications::notify_meeting_starting(
+                    app_clone,
+                    id_clone,
+                    title_clone,
+                    secs_until,
+                    join_clone,
+                )
+                .await;
+            });
+        }
+        if config.meeting_transcription_mode == MeetingTranscriptionMode::Auto {
+            let _ = app.emit(
+                "meetings:start-transcription",
+                serde_json::json!({
+                    "meetingId": m.id.clone(),
+                    "joinUrl": join_url.clone(),
+                    "reason": "calendar-auto",
+                }),
+            );
+        }
     }
 
     Ok(())

--- a/templates/clips/desktop/src-tauri/src/notifications.rs
+++ b/templates/clips/desktop/src-tauri/src/notifications.rs
@@ -1,11 +1,8 @@
 //! Native desktop notifications for upcoming meetings.
 //!
 //! Wraps `tauri-plugin-notification` (v2). The "join_url" in the payload is
-//! intentionally NOT auto-opened by the notification system itself — the
-//! `meetings:start-recording` Tauri event fires unconditionally so the
-//! frontend can open the URL via `tauri-plugin-shell` while simultaneously
-//! invoking `start-meeting-recording`. That keeps the side-effect surface
-//! in TypeScript where it's easier to reason about.
+//! intentionally NOT auto-opened by the notification system itself. The
+//! frontend owns the "Start notes" click so consent/control stays visible.
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
@@ -39,7 +36,7 @@ pub async fn notify_meeting_starting(
         format!("in {} min", (starts_in_secs / 60).max(1))
     };
     let body = if join_url.is_some() {
-        format!("{} — Join + Record", pretty_in)
+        format!("{} — Start notes", pretty_in)
     } else {
         format!("Starts {}", pretty_in)
     };
@@ -65,20 +62,13 @@ pub async fn notify_meeting_starting(
 
     // Fire the Tauri event regardless. The renderer's banner overlay
     // (`meeting-notification.tsx`) listens for `meetings:show-notification`
-    // and renders the in-app card, and the popover listens for
-    // `meetings:start-recording` to kick off the actual recording action.
+    // and renders the in-app card.
     let _ = app.emit(
         "meetings:show-notification",
         serde_json::json!({
             "type": "calendar",
             "title": title,
             "subtitle": body,
-            "meetingId": meeting_id,
-        }),
-    );
-    let _ = app.emit(
-        "meetings:start-recording",
-        serde_json::json!({
             "meetingId": meeting_id,
             "joinUrl": join_url,
         }),

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -66,6 +66,7 @@ interface PendingNativeUpload {
 type PendingDesktopUpload = PendingNativeUpload | PendingBrowserRecordingUpload;
 
 type TranscriptSource = "mic" | "system";
+type MeetingTranscriptionMode = "manual" | "ask" | "auto";
 
 interface MeetingTranscriptionPayload {
   meetingId: string;
@@ -734,6 +735,292 @@ export function App() {
       }
     };
   }, []);
+
+  const callClipsAction = useCallback(
+    async <T,>(name: string, body: Record<string, unknown>): Promise<T> => {
+      const base = serverUrl.replace(/\/+$/, "");
+      const headers = new Headers({ "Content-Type": "application/json" });
+      const authToken = loadDesktopAuthToken(serverUrl);
+      if (authToken) headers.set("Authorization", `Bearer ${authToken}`);
+      const response = await fetch(`${base}/_agent-native/actions/${name}`, {
+        method: "POST",
+        credentials: "include",
+        headers,
+        body: JSON.stringify(body),
+      });
+      const text = await response.text().catch(() => "");
+      let json: any = null;
+      try {
+        json = text ? JSON.parse(text) : null;
+      } catch {
+        // Keep text fallback below.
+      }
+      if (!response.ok) {
+        const message =
+          json?.error ||
+          json?.message ||
+          (response.status === 401
+            ? "Sign in to transcribe meetings."
+            : text.slice(0, 180) || `Request failed (${response.status})`);
+        throw new Error(message);
+      }
+      return (json?.result ?? json) as T;
+    },
+    [serverUrl],
+  );
+
+  const flushMeetingTranscript = useCallback(async () => {
+    const session = meetingTranscriptionRef.current;
+    if (!session || !session.lines.length) return;
+    await callClipsAction("save-browser-transcript", {
+      recordingId: session.recordingId,
+      fullText: session.lines.join("\n\n"),
+      source: "macos-native",
+    });
+  }, [callClipsAction]);
+
+  const stopMeetingTranscription = useCallback(
+    async (reason: string = "manual") => {
+      const session = meetingTranscriptionRef.current;
+      if (!session || session.stopping) return;
+      session.stopping = true;
+      if (session.flushTimer) {
+        window.clearTimeout(session.flushTimer);
+        session.flushTimer = null;
+      }
+      try {
+        if (session.audioMode === "mic-system") {
+          await invoke("meeting_audio_stop");
+        } else {
+          await invoke("native_speech_stop");
+        }
+      } catch (err) {
+        console.warn("[clips-popover] meeting audio stop failed:", err);
+      }
+      session.unlisten.splice(0).forEach((unlisten) => {
+        try {
+          unlisten();
+        } catch {
+          // ignore
+        }
+      });
+      await invoke("silence_detector_stop").catch(() => {});
+      await flushMeetingTranscript().catch((err) => {
+        console.warn("[clips-popover] meeting transcript save failed:", err);
+      });
+      await callClipsAction("stop-meeting-recording", {
+        meetingId: session.meetingId,
+      }).catch((err) => {
+        console.warn("[clips-popover] stop meeting action failed:", err);
+      });
+      if (session.lines.length) {
+        await callClipsAction("finalize-meeting", {
+          meetingId: session.meetingId,
+        }).catch((err) => {
+          console.warn("[clips-popover] finalize meeting failed:", err);
+        });
+      }
+      await invoke("recording_pill_hide").catch(() => {});
+      emit("meetings:transcription-stopped", {
+        meetingId: session.meetingId,
+        reason,
+      }).catch(() => {});
+      meetingTranscriptionRef.current = null;
+    },
+    [callClipsAction, flushMeetingTranscript],
+  );
+
+  const startMeetingTranscription = useCallback(
+    async (payload: MeetingTranscriptionPayload) => {
+      const meetingId = payload.meetingId;
+      if (!meetingId) return;
+
+      const existing = meetingTranscriptionRef.current;
+      if (existing && !existing.stopping) {
+        if (existing.meetingId === meetingId) {
+          emit("meetings:transcription-started", { meetingId }).catch(
+            () => {},
+          );
+          return;
+        }
+        await stopMeetingTranscription("replaced");
+      }
+
+      try {
+        const result = await callClipsAction<{
+          meetingId?: string;
+          recording?: { id?: string | null } | null;
+        }>("start-meeting-recording", { meetingId });
+        const resolvedMeetingId = result.meetingId ?? meetingId;
+        const recordingId = result.recording?.id;
+        if (!recordingId) {
+          throw new Error("Could not create a transcript session.");
+        }
+
+        const session: MeetingTranscriptionSession = {
+          meetingId: resolvedMeetingId,
+          recordingId,
+          lines: [],
+          unlisten: [],
+          flushTimer: null,
+          stopping: false,
+          audioMode: "mic-system",
+        };
+        meetingTranscriptionRef.current = session;
+
+        const scheduleFlush = () => {
+          if (session.flushTimer) window.clearTimeout(session.flushTimer);
+          session.flushTimer = window.setTimeout(() => {
+            session.flushTimer = null;
+            flushMeetingTranscript().catch((err) => {
+              console.warn("[clips-popover] transcript flush failed:", err);
+            });
+          }, 1500);
+        };
+
+        const addUnlisten = (promise: Promise<() => void>) => {
+          promise
+            .then((unlisten) => {
+              if (meetingTranscriptionRef.current !== session || session.stopping) {
+                unlisten();
+                return;
+              }
+              session.unlisten.push(unlisten);
+            })
+            .catch(() => {});
+        };
+
+        addUnlisten(
+          listen<{ text?: string; source?: TranscriptSource }>(
+            "voice:final-transcript",
+            (event) => {
+              if (meetingTranscriptionRef.current !== session) return;
+              const text = event.payload?.text?.trim();
+              if (!text) return;
+              const speaker =
+                event.payload?.source === "system" ? "Them" : "Me";
+              session.lines.push(`${speaker}: ${text}`);
+              scheduleFlush();
+            },
+          ),
+        );
+        addUnlisten(
+          listen<{ meetingId?: string | null }>("clips:pill-stop", (event) => {
+            const stoppedMeetingId = event.payload?.meetingId;
+            if (stoppedMeetingId && stoppedMeetingId !== resolvedMeetingId)
+              return;
+            stopMeetingTranscription("manual").catch(() => {});
+          }),
+        );
+        addUnlisten(
+          listen("meetings:silence-stop", () => {
+            stopMeetingTranscription("silence").catch(() => {});
+          }),
+        );
+        addUnlisten(
+          listen("meetings:sleep-stop", () => {
+            stopMeetingTranscription("sleep").catch(() => {});
+          }),
+        );
+        addUnlisten(
+          listen("meetings:call-ended", () => {
+            stopMeetingTranscription("call-ended").catch(() => {});
+          }),
+        );
+
+        await invoke("recording_pill_show", {
+          meetingId: resolvedMeetingId,
+          mode: "meeting",
+        });
+
+        try {
+          await invoke("meeting_audio_start", {
+            meetingId: resolvedMeetingId,
+            locale: navigator.language || "en-US",
+          });
+        } catch (err) {
+          console.warn(
+            "[clips-popover] mic + system meeting audio failed, falling back to mic-only:",
+            err,
+          );
+          session.audioMode = "mic-only";
+          await invoke("native_speech_start", {
+            locale: navigator.language || "en-US",
+          });
+        }
+
+        await invoke("silence_detector_start", {
+          config: {
+            silenceThreshold: 0.05,
+            silenceMs: 15 * 60 * 1000,
+            callEndedMs: 2 * 60 * 1000,
+            watchSleep: true,
+            watchCallEnded: true,
+          },
+        }).catch(() => {});
+
+        if (payload.joinUrl && payload.reason !== "user") {
+          emit("meetings:open-join-url", {
+            joinUrl: payload.joinUrl,
+          }).catch(() => {});
+        }
+        emit("meetings:transcription-started", {
+          meetingId: resolvedMeetingId,
+        }).catch(() => {});
+      } catch (err) {
+        meetingTranscriptionRef.current = null;
+        await invoke("recording_pill_hide").catch(() => {});
+        const message =
+          err instanceof Error ? err.message : "Could not start notes.";
+        emit("meetings:transcription-error", {
+          meetingId,
+          error: message,
+        }).catch(() => {});
+      }
+    },
+    [
+      callClipsAction,
+      flushMeetingTranscript,
+      stopMeetingTranscription,
+    ],
+  );
+
+  useEffect(() => {
+    const unlisteners: Array<() => void> = [];
+    let stopped = false;
+    const track = (promise: Promise<() => void>) => {
+      promise
+        .then((unlisten) => {
+          if (stopped) {
+            unlisten();
+            return;
+          }
+          unlisteners.push(unlisten);
+        })
+        .catch(() => {});
+    };
+    track(
+      listen<MeetingTranscriptionPayload>(
+        "meetings:start-transcription",
+        (event) => {
+          startMeetingTranscription(event.payload).catch((err) => {
+            console.error("[clips-popover] start transcription failed:", err);
+          });
+        },
+      ),
+    );
+    return () => {
+      stopped = true;
+      unlisteners.forEach((unlisten) => {
+        try {
+          unlisten();
+        } catch {
+          // ignore
+        }
+      });
+      unlisteners.length = 0;
+    };
+  }, [startMeetingTranscription]);
 
   // OAuth (Google) opens in the system browser — the popover WebView can't
   // share a cookie jar with a separate Tauri WebviewWindow, and the old
@@ -3008,8 +3295,13 @@ function Setup({
   const inputRef = useRef<HTMLInputElement | null>(null);
   const featureConfig = useFeatureConfig();
   const voiceEnabled = featureConfig?.voiceEnabled !== false;
+  const meetingsEnabled = featureConfig?.meetingsEnabled !== false;
   const launchAtLoginEnabled = featureConfig?.launchAtLoginEnabled !== false;
   const autoHidePopoverEnabled = featureConfig?.autoHidePopoverEnabled === true;
+  const meetingTranscriptionMode: MeetingTranscriptionMode =
+    featureConfig?.meetingTranscriptionMode ?? "ask";
+  const showMeetingWidgetEnabled =
+    featureConfig?.showMeetingWidgetEnabled !== false;
   const [providerStatus, setProviderStatus] =
     useState<VoiceProviderStatus | null>(null);
   const [providerStatusLoading, setProviderStatusLoading] = useState(true);
@@ -3029,6 +3321,15 @@ function Setup({
     );
   }
 
+  function setMeetingsEnabled(enabled: boolean) {
+    if (!featureConfig) return;
+    invoke("set_feature_config", {
+      config: { ...featureConfig, meetingsEnabled: enabled },
+    }).catch((err) =>
+      console.error("[settings] set_feature_config failed", err),
+    );
+  }
+
   function setLaunchAtLoginEnabled(enabled: boolean) {
     if (!featureConfig) return;
     invoke("set_feature_config", {
@@ -3042,6 +3343,24 @@ function Setup({
     if (!featureConfig) return;
     invoke("set_feature_config", {
       config: { ...featureConfig, autoHidePopoverEnabled: enabled },
+    }).catch((err) =>
+      console.error("[settings] set_feature_config failed", err),
+    );
+  }
+
+  function setMeetingTranscriptionMode(mode: MeetingTranscriptionMode) {
+    if (!featureConfig) return;
+    invoke("set_feature_config", {
+      config: { ...featureConfig, meetingTranscriptionMode: mode },
+    }).catch((err) =>
+      console.error("[settings] set_feature_config failed", err),
+    );
+  }
+
+  function setShowMeetingWidgetEnabled(enabled: boolean) {
+    if (!featureConfig) return;
+    invoke("set_feature_config", {
+      config: { ...featureConfig, showMeetingWidgetEnabled: enabled },
     }).catch((err) =>
       console.error("[settings] set_feature_config failed", err),
     );
@@ -3307,6 +3626,64 @@ function Setup({
           />
         </div>
       </div>
+
+      <div className="setup-section">
+        <div className="setup-toggle-row">
+          <SettingLabel
+            label="Meeting notes"
+            hint="Use calendar meetings to show a notes widget and start live transcription."
+          />
+          <Switch
+            on={meetingsEnabled}
+            onChange={setMeetingsEnabled}
+            label="Enable meeting notes"
+          />
+        </div>
+      </div>
+
+      {meetingsEnabled ? (
+        <>
+          <div className="setup-section">
+            <SettingLabel
+              label="Meeting transcription"
+              hint="Choose whether Clips asks first, starts automatically, or waits for manual start."
+              htmlFor="meeting-transcription-mode"
+            />
+            <select
+              id="meeting-transcription-mode"
+              className="setup-select"
+              value={meetingTranscriptionMode}
+              onChange={(event) =>
+                setMeetingTranscriptionMode(
+                  event.target.value as MeetingTranscriptionMode,
+                )
+              }
+            >
+              <option value="ask">Ask at meeting time</option>
+              <option value="auto">Auto-start during meeting times</option>
+              <option value="manual">Manual only</option>
+            </select>
+            <p className="setup-hint">
+              Auto-start still shows the notes pill while transcription is
+              active.
+            </p>
+          </div>
+
+          <div className="setup-section">
+            <div className="setup-toggle-row">
+              <SettingLabel
+                label="Meeting widget"
+                hint="Show the on-screen meeting widget near calendar start times, even when macOS notifications are hidden."
+              />
+              <Switch
+                on={showMeetingWidgetEnabled}
+                onChange={setShowMeetingWidgetEnabled}
+                label="Show meeting widget"
+              />
+            </div>
+          </div>
+        </>
+      ) : null}
 
       <div className="setup-section">
         <SettingLabel

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -65,6 +65,24 @@ interface PendingNativeUpload {
 
 type PendingDesktopUpload = PendingNativeUpload | PendingBrowserRecordingUpload;
 
+type TranscriptSource = "mic" | "system";
+
+interface MeetingTranscriptionPayload {
+  meetingId: string;
+  joinUrl?: string | null;
+  reason?: "user" | "calendar-auto" | string;
+}
+
+interface MeetingTranscriptionSession {
+  meetingId: string;
+  recordingId: string;
+  lines: string[];
+  unlisten: Array<() => void>;
+  flushTimer: ReturnType<typeof setTimeout> | null;
+  stopping: boolean;
+  audioMode: "mic-system" | "mic-only";
+}
+
 type CaptureMode = "screen" | "screen-camera" | "camera";
 type CaptureSource = "full-screen" | "window";
 
@@ -528,6 +546,9 @@ export function App() {
   const signInInflightRef = useRef(false);
   // Stored so Cancel can stop the polling loop.
   const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const meetingTranscriptionRef = useRef<MeetingTranscriptionSession | null>(
+    null,
+  );
   const isRecording = recorder !== null;
   const voiceDictationEnabled = featureConfig?.voiceEnabled !== false;
   const fnShortcutEnabled =

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -1884,7 +1884,6 @@ export function App() {
 
       <ReadinessPanel
         mode={mode}
-        source={source}
         cameraOn={cameraOn}
         micOn={micOn}
         includeFnMonitoring={fnShortcutEnabled}
@@ -2012,29 +2011,6 @@ function permissionPaneLabel(pane: MacosPrivacyPane): string {
   }[pane];
 }
 
-function captureModeLabel(mode: CaptureMode, source: CaptureSource): string {
-  if (mode === "camera") return "Camera";
-  const base = source === "window" ? "Window" : "Full screen";
-  return mode === "screen-camera" ? `${base} + camera` : base;
-}
-
-function recordingSummaryParts({
-  mode,
-  source,
-  cameraOn,
-  micOn,
-}: {
-  mode: CaptureMode;
-  source: CaptureSource;
-  cameraOn: boolean;
-  micOn: boolean;
-}): string[] {
-  const parts = [captureModeLabel(mode, source)];
-  if (mode !== "screen") parts.push(cameraOn ? "Camera on" : "Camera off");
-  parts.push(micOn ? "Mic on" : "Mic off");
-  return parts;
-}
-
 type ReadinessItem = {
   label: string;
   detail: string;
@@ -2091,7 +2067,6 @@ function readinessItems({
 
 function ReadinessPanel({
   mode,
-  source,
   cameraOn,
   micOn,
   includeFnMonitoring,
@@ -2100,7 +2075,6 @@ function ReadinessPanel({
   onOpenPermission,
 }: {
   mode: CaptureMode;
-  source: CaptureSource;
   cameraOn: boolean;
   micOn: boolean;
   includeFnMonitoring: boolean;
@@ -2114,12 +2088,6 @@ function ReadinessPanel({
     micOn,
     includeFnMonitoring,
   });
-  const summary = recordingSummaryParts({
-    mode,
-    source,
-    cameraOn,
-    micOn,
-  }).join(" · ");
 
   return (
     <div className={`readiness ${open ? "readiness-open" : ""}`}>
@@ -2130,7 +2098,6 @@ function ReadinessPanel({
         onClick={() => onOpenChange(!open)}
       >
         <span className="readiness-title">Setup</span>
-        <span className="readiness-copy">{summary}</span>
         <span className="readiness-action">{open ? "Hide" : "Review"}</span>
       </button>
       {open ? (

--- a/templates/clips/desktop/src/app.tsx
+++ b/templates/clips/desktop/src/app.tsx
@@ -838,9 +838,7 @@ export function App() {
       const existing = meetingTranscriptionRef.current;
       if (existing && !existing.stopping) {
         if (existing.meetingId === meetingId) {
-          emit("meetings:transcription-started", { meetingId }).catch(
-            () => {},
-          );
+          emit("meetings:transcription-started", { meetingId }).catch(() => {});
           return;
         }
         await stopMeetingTranscription("replaced");
@@ -881,7 +879,10 @@ export function App() {
         const addUnlisten = (promise: Promise<() => void>) => {
           promise
             .then((unlisten) => {
-              if (meetingTranscriptionRef.current !== session || session.stopping) {
+              if (
+                meetingTranscriptionRef.current !== session ||
+                session.stopping
+              ) {
                 unlisten();
                 return;
               }
@@ -978,11 +979,7 @@ export function App() {
         }).catch(() => {});
       }
     },
-    [
-      callClipsAction,
-      flushMeetingTranscript,
-      stopMeetingTranscription,
-    ],
+    [callClipsAction, flushMeetingTranscript, stopMeetingTranscription],
   );
 
   useEffect(() => {

--- a/templates/clips/desktop/src/overlays/meeting-notification.tsx
+++ b/templates/clips/desktop/src/overlays/meeting-notification.tsx
@@ -110,18 +110,24 @@ export function MeetingNotification() {
       }),
     );
     trackListen(
-      listen<TranscriptionStatusPayload>("meetings:transcription-started", (ev) => {
-        if (ev.payload.meetingId !== dataRef.current?.meetingId) return;
-        dismiss();
-      }),
+      listen<TranscriptionStatusPayload>(
+        "meetings:transcription-started",
+        (ev) => {
+          if (ev.payload.meetingId !== dataRef.current?.meetingId) return;
+          dismiss();
+        },
+      ),
     );
     trackListen(
-      listen<TranscriptionStatusPayload>("meetings:transcription-error", (ev) => {
-        if (ev.payload.meetingId !== dataRef.current?.meetingId) return;
-        setPending(false);
-        setError(ev.payload.error || "Could not start notes.");
-        scheduleDismiss(15_000);
-      }),
+      listen<TranscriptionStatusPayload>(
+        "meetings:transcription-error",
+        (ev) => {
+          if (ev.payload.meetingId !== dataRef.current?.meetingId) return;
+          setPending(false);
+          setError(ev.payload.error || "Could not start notes.");
+          scheduleDismiss(15_000);
+        },
+      ),
     );
 
     return () => {

--- a/templates/clips/desktop/src/overlays/meeting-notification.tsx
+++ b/templates/clips/desktop/src/overlays/meeting-notification.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -11,71 +10,27 @@ interface NotificationData {
   subtitle: string;
   meetingId: string;
   joinUrl?: string | null;
+  autoStart?: boolean;
 }
 
 interface StartRecordingPayload {
   meetingId: string;
   joinUrl?: string | null;
+  reason?: string;
 }
 
-const STORAGE_KEY = "clips:server-url";
+interface TranscriptionStatusPayload {
+  meetingId: string;
+  error?: string;
+}
+
 const DEFAULT_DISMISS_MS = 30_000;
 const SNOOZE_MS = 5 * 60_000;
-
-function getServerUrl(): string | null {
-  try {
-    const v = localStorage.getItem(STORAGE_KEY);
-    if (v && v.trim()) return v.replace(/\/+$/, "");
-  } catch {
-    // ignore
-  }
-  return null;
-}
-
-/**
- * Call the start-meeting-recording action and surface a useful error if it
- * fails. Returns null on success, or a short user-visible error string on
- * failure (so the banner can render it).
- */
-async function callStartMeetingRecording(
-  meetingId: string,
-): Promise<{ error: string | null; meetingId?: string }> {
-  const base = getServerUrl();
-  if (!base) {
-    return { error: "No server configured" };
-  }
-  try {
-    const resp = await fetch(
-      `${base}/_agent-native/actions/start-meeting-recording`,
-      {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ meetingId }),
-      },
-    );
-    if (!resp.ok) {
-      const text = await resp.text().catch(() => "");
-      return {
-        error:
-          resp.status === 401
-            ? "Sign in to record meetings"
-            : `Couldn't start recording (${resp.status})${text ? `: ${text.slice(0, 120)}` : ""}`,
-      };
-    }
-    const payload = await resp.json().catch(() => null);
-    const result = payload?.result ?? payload;
-    return { error: null, meetingId: result?.meetingId ?? meetingId };
-  } catch (err) {
-    console.error("[clips-tray] start-meeting-recording fetch failed:", err);
-    return { error: "Network error — couldn't reach server" };
-  }
-}
 
 /**
  * Open a meeting join URL via the Tauri shell plugin. Centralized here so
  * both the notification's "Take Notes" and the watcher's
- * `meetings:start-recording` event use the same path.
+ * `meetings:start-transcription` event use the same path.
  */
 async function openJoinUrl(url: string | null | undefined): Promise<void> {
   if (!url) return;
@@ -91,14 +46,14 @@ async function openJoinUrl(url: string | null | undefined): Promise<void> {
  * Variants:
  *
  *   - Calendar event: solid left bar (green), meeting title, time,
- *     "Take Notes" + "Snooze 5 min" buttons.
+ *     "Start notes" + "Snooze 5 min" buttons.
  *   - Ad-hoc call: dashed left bar (slate), "Call detected", app name,
  *     same controls.
  *
  * Data arrives via Tauri event `meetings:show-notification`. Auto-dismisses
- * after 30s by default. Hover pauses the auto-dismiss timer. Errors from
- * `start-meeting-recording` surface inline beneath the title so the user
- * isn't left wondering why nothing happened.
+ * after 30s by default. Hover pauses the auto-dismiss timer. Errors from the
+ * persistent popover transcription session surface inline beneath the title
+ * so the user isn't left wondering why nothing happened.
  */
 export function MeetingNotification() {
   const [data, setData] = useState<NotificationData | null>(null);
@@ -137,35 +92,35 @@ export function MeetingNotification() {
       listen<NotificationData>("meetings:show-notification", (ev) => {
         setData(ev.payload);
         setError(null);
-        setPending(false);
+        setPending(!!ev.payload.autoStart);
         scheduleDismiss(DEFAULT_DISMISS_MS);
       }),
     );
 
-    // The Rust meetings_watcher (and the notifications module) fire
-    // `meetings:start-recording` when the user accepts a meeting reminder.
-    // Wire it directly to the start-meeting-recording action, surface any
-    // error, and open the join URL via tauri-plugin-shell.
+    // Legacy bridge: older Rust builds emitted `meetings:start-recording`.
+    // Re-route to the persistent popover-owned transcription session so this
+    // overlay can close without losing the transcript.
     trackListen(
       listen<StartRecordingPayload>("meetings:start-recording", (ev) => {
         const { meetingId, joinUrl } = ev.payload;
         if (!meetingId) return;
-        if (joinUrl) {
-          openJoinUrl(joinUrl);
-          // Keep the legacy event around for any other listeners that
-          // care about it (host integrations, analytics, etc.).
-          emit("meetings:open-join-url", { joinUrl }).catch(() => {});
-        }
-        callStartMeetingRecording(meetingId).then((result) => {
-          if (result.error) {
-            setError(result.error);
-            return;
-          }
-          invoke("recording_pill_show", {
-            meetingId: result.meetingId ?? meetingId,
-            mode: "meeting",
-          }).catch(() => {});
-        });
+        emit("meetings:start-transcription", { meetingId, joinUrl }).catch(
+          () => {},
+        );
+      }),
+    );
+    trackListen(
+      listen<TranscriptionStatusPayload>("meetings:transcription-started", (ev) => {
+        if (ev.payload.meetingId !== dataRef.current?.meetingId) return;
+        dismiss();
+      }),
+    );
+    trackListen(
+      listen<TranscriptionStatusPayload>("meetings:transcription-error", (ev) => {
+        if (ev.payload.meetingId !== dataRef.current?.meetingId) return;
+        setPending(false);
+        setError(ev.payload.error || "Could not start notes.");
+        scheduleDismiss(15_000);
       }),
     );
 
@@ -213,20 +168,14 @@ export function MeetingNotification() {
       openJoinUrl(data.joinUrl);
     }
     emit("meetings:take-notes", { meetingId: data.meetingId }).catch(() => {});
-    const result = await callStartMeetingRecording(data.meetingId);
-    setPending(false);
-    if (result.error) {
-      setError(result.error);
-      // Keep the banner up so the user can see the error — re-arm with a
-      // longer auto-dismiss so they have time to read it.
-      scheduleDismiss(15_000);
-      return;
-    }
-    invoke("recording_pill_show", {
-      meetingId: result.meetingId ?? data.meetingId,
-      mode: "meeting",
-    }).catch(() => {});
-    dismiss();
+    emit("meetings:start-transcription", {
+      meetingId: data.meetingId,
+      joinUrl: data.joinUrl,
+      reason: "user",
+    }).catch((err) => {
+      setPending(false);
+      setError((err as Error)?.message ?? "Could not start notes.");
+    });
   }
 
   function snooze() {
@@ -292,7 +241,7 @@ export function MeetingNotification() {
             disabled={pending}
             data-no-drag
           >
-            {pending ? "Starting…" : "Take Notes"}
+            {pending ? "Starting…" : "Start notes"}
           </button>
           <button
             className="meeting-notification-btn meeting-notification-btn-secondary"

--- a/templates/clips/desktop/src/overlays/onboarding.tsx
+++ b/templates/clips/desktop/src/overlays/onboarding.tsx
@@ -25,6 +25,9 @@ export function Onboarding() {
           meetingsEnabled: meetings,
           voiceEnabled: voice,
           launchAtLoginEnabled: true,
+          autoHidePopoverEnabled: false,
+          meetingTranscriptionMode: "ask",
+          showMeetingWidgetEnabled: true,
           onboardingComplete: true,
         },
       });

--- a/templates/clips/desktop/src/overlays/recording-pill.tsx
+++ b/templates/clips/desktop/src/overlays/recording-pill.tsx
@@ -259,6 +259,8 @@ export function RecordingPill() {
 
   const mm = String(Math.floor(elapsed / 60)).padStart(2, "0");
   const ss = String(elapsed % 60).padStart(2, "0");
+  const stopLabel =
+    ctx.mode === "meeting" ? "Stop transcription" : "Stop recording";
 
   return (
     <div className="flex h-full w-full items-stretch justify-stretch">
@@ -306,7 +308,7 @@ export function RecordingPill() {
             />
           )}
           <span className="ml-auto truncate text-[12px] text-zinc-300">
-            {ctx.mode === "meeting" ? "Meeting" : "Recording"}
+            {ctx.mode === "meeting" ? "Meeting notes" : "Recording"}
           </span>
           <button
             type="button"
@@ -314,8 +316,8 @@ export function RecordingPill() {
             disabled={stopping}
             data-no-drag
             className="ml-1 inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full bg-red-500 text-white hover:bg-red-400 disabled:cursor-not-allowed disabled:opacity-60"
-            aria-label="Stop recording"
-            title="Stop recording"
+            aria-label={stopLabel}
+            title={stopLabel}
           >
             <IconPlayerStopFilled size={14} />
           </button>
@@ -373,6 +375,7 @@ export function RecordingPill() {
                 disabled={stopping}
                 data-no-drag
                 className="ml-auto inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-full bg-red-500 px-3 text-[12px] font-medium text-white hover:bg-red-400 disabled:cursor-not-allowed disabled:opacity-60"
+                aria-label={stopLabel}
               >
                 <IconPlayerStopFilled size={14} />
                 Stop

--- a/templates/clips/desktop/src/shared/config.ts
+++ b/templates/clips/desktop/src/shared/config.ts
@@ -8,6 +8,8 @@ interface FeatureConfig {
   voiceEnabled: boolean;
   launchAtLoginEnabled: boolean;
   autoHidePopoverEnabled: boolean;
+  meetingTranscriptionMode: "manual" | "ask" | "auto";
+  showMeetingWidgetEnabled: boolean;
   onboardingComplete: boolean;
 }
 

--- a/templates/clips/desktop/src/styles.css
+++ b/templates/clips/desktop/src/styles.css
@@ -821,7 +821,7 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
 
 .readiness-summary {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
   width: 100%;
@@ -860,16 +860,6 @@ body[data-clips-route]:not([data-clips-route="popover"]) #root {
 
 .readiness-open .readiness-title {
   color: var(--fg);
-}
-
-.readiness-copy {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--fg-muted);
-  font-size: 12px;
-  line-height: 1.2;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .readiness-action {

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
-import type { Document } from "@shared/api";
+import type { Document, DocumentTreeNode } from "@shared/api";
 import {
   IconPlus,
   IconSearch,
@@ -127,6 +127,8 @@ export function DocumentSidebar({
   );
 
   const tree = buildDocumentTree(documents);
+  const privateTree = tree.filter((node) => node.visibility !== "org");
+  const organizationTree = tree.filter((node) => node.visibility === "org");
   const favorites = documents.filter((d) => d.isFavorite);
   const moveAvailability = useMemo(() => {
     const availability = new Map<string, MoveAvailability>();
@@ -188,6 +190,7 @@ export function DocumentSidebar({
         icon: null,
         position: 9999,
         isFavorite: false,
+        visibility: "private",
         createdAt: now,
         updatedAt: now,
       };
@@ -315,6 +318,27 @@ export function DocumentSidebar({
         d.title.toLowerCase().includes(searchQuery.toLowerCase()),
       )
     : null;
+
+  const renderDocumentTree = (nodes: DocumentTreeNode[]) =>
+    nodes.map((node) => (
+      <DocumentTreeItem
+        key={node.id}
+        node={node}
+        depth={0}
+        activeId={activeDocumentId}
+        expandedIds={expandedIds}
+        onToggleExpanded={handleToggleExpanded}
+        onSelect={(id) => {
+          navigateToDocument(id);
+          onNavigate?.();
+        }}
+        onCreateChild={(parentId) => handleCreatePage(parentId)}
+        onDelete={handleDelete}
+        onMove={handleMovePage}
+        moveAvailability={moveAvailability}
+        onToggleFavorite={handleToggleFavorite}
+      />
+    ));
 
   if (collapsed) {
     return (
@@ -489,10 +513,10 @@ export function DocumentSidebar({
                 </div>
               )}
 
-              {/* Page tree */}
+              {/* Private page tree */}
               <div>
                 <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                  Pages
+                  Private
                 </div>
                 {isLoading ? (
                   <div className="space-y-1 px-3 py-1">
@@ -509,43 +533,40 @@ export function DocumentSidebar({
                       </div>
                     ))}
                   </div>
-                ) : tree.length === 0 ? (
+                ) : privateTree.length === 0 ? (
                   <div className="px-3 py-4 text-sm text-muted-foreground text-center">
-                    No pages yet
+                    No private pages yet
                   </div>
                 ) : (
-                  tree.map((node) => (
-                    <DocumentTreeItem
-                      key={node.id}
-                      node={node}
-                      depth={0}
-                      activeId={activeDocumentId}
-                      expandedIds={expandedIds}
-                      onToggleExpanded={handleToggleExpanded}
-                      onSelect={(id) => {
-                        navigateToDocument(id);
-                        onNavigate?.();
-                      }}
-                      onCreateChild={(parentId) => handleCreatePage(parentId)}
-                      onDelete={handleDelete}
-                      onMove={handleMovePage}
-                      moveAvailability={moveAvailability}
-                      onToggleFavorite={handleToggleFavorite}
-                    />
-                  ))
+                  renderDocumentTree(privateTree)
                 )}
               </div>
+
+              {/* New page button — private pages are the default */}
+              <button
+                className="flex w-full items-center gap-2 rounded-md px-3 py-[5px] text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                onClick={() => handleCreatePage()}
+              >
+                <IconPlus size={14} className="shrink-0" />
+                <span>New page</span>
+              </button>
+
+              {!isLoading && (
+                <div className="mt-3">
+                  <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    Organization
+                  </div>
+                  {organizationTree.length === 0 ? (
+                    <div className="px-3 py-4 text-sm text-muted-foreground text-center">
+                      No organization pages yet
+                    </div>
+                  ) : (
+                    renderDocumentTree(organizationTree)
+                  )}
+                </div>
+              )}
             </>
           )}
-
-          {/* New page button — under the list */}
-          <button
-            className="flex w-full items-center gap-2 rounded-md px-3 py-[5px] text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-            onClick={() => handleCreatePage()}
-          >
-            <IconPlus size={14} className="shrink-0" />
-            <span>New page</span>
-          </button>
         </div>
       </ScrollArea>
 

--- a/templates/content/app/components/sidebar/DocumentSidebar.tsx
+++ b/templates/content/app/components/sidebar/DocumentSidebar.tsx
@@ -340,6 +340,16 @@ export function DocumentSidebar({
       />
     ));
 
+  const renderNewPageButton = () => (
+    <button
+      className="flex w-full items-center gap-2 rounded-md px-3 py-[5px] text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+      onClick={() => handleCreatePage()}
+    >
+      <IconPlus size={14} className="shrink-0" />
+      <span>New page</span>
+    </button>
+  );
+
   if (collapsed) {
     return (
       <div className="flex flex-col h-full w-12 border-r border-border bg-muted/30 items-center py-3 gap-1">
@@ -446,39 +456,44 @@ export function DocumentSidebar({
         <div className="py-2">
           {/* IconSearch results */}
           {filteredDocuments ? (
-            <div>
-              <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                Results
-              </div>
-              {filteredDocuments.length === 0 ? (
-                <div className="px-3 py-4 text-sm text-muted-foreground text-center">
-                  No pages found
+            <>
+              <div>
+                <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  Results
                 </div>
-              ) : (
-                filteredDocuments.map((doc) => (
-                  <button
-                    key={doc.id}
-                    className={cn(
-                      "w-full flex items-center gap-2 px-3 py-[5px] text-sm text-left rounded-md",
-                      doc.id === activeDocumentId
-                        ? "bg-accent text-accent-foreground"
-                        : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                    )}
-                    onClick={() => {
-                      navigateToDocument(doc.id);
-                      setIsSearching(false);
-                      setSearchQuery("");
-                      onNavigate?.();
-                    }}
-                  >
-                    <span className="flex-shrink-0 w-5 text-center">
-                      {doc.icon || <IconFileText size={14} />}
-                    </span>
-                    <span className="truncate">{doc.title || "Untitled"}</span>
-                  </button>
-                ))
-              )}
-            </div>
+                {filteredDocuments.length === 0 ? (
+                  <div className="px-3 py-4 text-sm text-muted-foreground text-center">
+                    No pages found
+                  </div>
+                ) : (
+                  filteredDocuments.map((doc) => (
+                    <button
+                      key={doc.id}
+                      className={cn(
+                        "w-full flex items-center gap-2 px-3 py-[5px] text-sm text-left rounded-md",
+                        doc.id === activeDocumentId
+                          ? "bg-accent text-accent-foreground"
+                          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                      )}
+                      onClick={() => {
+                        navigateToDocument(doc.id);
+                        setIsSearching(false);
+                        setSearchQuery("");
+                        onNavigate?.();
+                      }}
+                    >
+                      <span className="flex-shrink-0 w-5 text-center">
+                        {doc.icon || <IconFileText size={14} />}
+                      </span>
+                      <span className="truncate">
+                        {doc.title || "Untitled"}
+                      </span>
+                    </button>
+                  ))
+                )}
+              </div>
+              {renderNewPageButton()}
+            </>
           ) : (
             <>
               {/* Favorites */}
@@ -543,13 +558,7 @@ export function DocumentSidebar({
               </div>
 
               {/* New page button — private pages are the default */}
-              <button
-                className="flex w-full items-center gap-2 rounded-md px-3 py-[5px] text-sm text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                onClick={() => handleCreatePage()}
-              >
-                <IconPlus size={14} className="shrink-0" />
-                <span>New page</span>
-              </button>
+              {renderNewPageButton()}
 
               {!isLoading && (
                 <div className="mt-3">

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -215,14 +215,20 @@ async function deleteDeckFromAPI(id: string): Promise<void> {
 }
 
 async function createDeckOnAPI(deck: Deck): Promise<void> {
-  try {
-    await fetch(`${appBasePath()}/api/decks`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(deck),
-    });
-  } catch (err) {
-    console.error(`Failed to create deck ${deck.id}:`, err);
+  const res = await fetch(`${appBasePath()}/api/decks`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(deck),
+  });
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`;
+    try {
+      const body = (await res.json()) as { error?: string; message?: string };
+      message = body.error || body.message || message;
+    } catch {
+      // Keep the HTTP status fallback.
+    }
+    throw new Error(message);
   }
 }
 
@@ -552,9 +558,13 @@ export function DeckProvider({ children }: { children: ReactNode }) {
       // Save to API immediately (not debounced). Track as pending so the
       // poll doesn't wipe the optimistic deck before the POST completes.
       pendingCreateIdsRef.current.add(newDeck.id);
-      createDeckOnAPI(newDeck).finally(() => {
-        pendingCreateIdsRef.current.delete(newDeck.id);
-      });
+      createDeckOnAPI(newDeck)
+        .catch((err) => {
+          console.error(`Failed to create deck ${newDeck.id}:`, err);
+        })
+        .finally(() => {
+          pendingCreateIdsRef.current.delete(newDeck.id);
+        });
       setDecksWithHistory("Create deck", (prev) => [...prev, newDeck]);
       return newDeck;
     },

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -672,11 +672,20 @@ export default function DeckEditor() {
           </>
         )}
 
-        {isNewDeckGenerating && deck.slides.length === 0 && (
-          <GeneratingOverlay />
+        {showQuestionFlow && (
+          <QuestionFlow
+            questions={questionFlowData!.questions}
+            onSubmit={handleQuestionSubmit}
+            onSkip={handleQuestionSkip}
+            designSystem={deck.designSystemId ? designSystem : undefined}
+          />
         )}
 
-        {isNewDeckGenerating && deck.slides.length > 0 && (
+        {isNewDeckGenerating &&
+          deck.slides.length === 0 &&
+          !showQuestionFlow && <GeneratingOverlay />}
+
+        {isNewDeckGenerating && deck.slides.length > 0 && !showQuestionFlow && (
           <div className="pointer-events-none absolute left-1/2 top-3 z-30 -translate-x-1/2 rounded-lg border border-border bg-popover/95 px-3 py-2 text-sm text-popover-foreground shadow-lg backdrop-blur">
             <span className="font-medium">Building deck</span>
             <span className="ml-2 text-muted-foreground">
@@ -684,15 +693,6 @@ export default function DeckEditor() {
               added
             </span>
           </div>
-        )}
-
-        {showQuestionFlow && !isNewDeckGenerating && (
-          <QuestionFlow
-            questions={questionFlowData!.questions}
-            onSubmit={handleQuestionSubmit}
-            onSkip={handleQuestionSkip}
-            designSystem={deck.designSystemId ? designSystem : undefined}
-          />
         )}
 
         {!(isNewDeckGenerating && deck.slides.length === 0) &&

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -37,6 +37,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { toast } from "@/hooks/use-toast";
 
 const MAX_SOURCE_CONTEXT_CHARS = 60_000;
 const NEW_DECK_DRAFT_SCOPE = "slides-new-deck";
@@ -226,7 +227,6 @@ export default function Index() {
     });
     if (!deck) return;
     setNewDeckPromptOpen(false);
-    navigate(`/deck/${deck.id}?generating=1`);
 
     const trimmedPrompt = prompt.trim();
     const sourceForContext = truncateSourceForContext(trimmedPrompt);
@@ -283,7 +283,22 @@ export default function Index() {
       "Do NOT use create-deck (the deck already exists). Do NOT call db-schema, resource-read, or search-files.",
     ].join("\n");
 
-    await waitForDeckServerRow(deck.id);
+    const persisted = await waitForDeckServerRow(deck.id);
+    if (!persisted) {
+      try {
+        sessionStorage.setItem(PENDING_PROMPT_KEY, prompt);
+      } catch {}
+      deleteDeck(deck.id);
+      toast({
+        title: "Couldn't start deck generation",
+        description:
+          "The new deck did not finish saving, so the agent was not started against a missing deck. Your prompt was saved so you can try again.",
+      });
+      setShowNewDeckPrompt(true);
+      return;
+    }
+
+    navigate(`/deck/${deck.id}?generating=1`);
     agentSubmit(
       `Create deck: ${summarizePromptForChat(trimmedPrompt)}`,
       context,


### PR DESCRIPTION
## Summary

Seed PR for the next concurrent-agent batch. First commit redesigns the desktop shell's TabBar:

- Tabs are now compact 44px squares showing only the app icon, so more apps fit without scrolling
- `Tab` carries its app icon explicitly through `createTab`
- `ICON_MAP` adds `MessageCircle`, `Phone`, `Note`, `Microphone`, `CalendarTime`, `Photo` and swaps `GalleryHorizontal` → `IconPresentation`
- `shell.css` drops the label rule + flexible width and centers the icon in the fixed cell

Concurrent agent sweeps will land here as they arrive.

## Test plan

- [ ] Build, Lint, Test, Typecheck, Guard, Changeset all green
- [ ] Desktop shell renders icons-only tabs at 44px width
- [ ] All app icons map correctly via ICON_MAP