### PR TITLE
fix(core): show formatted missing-credential error text in chat adapter + concurrent sweeps

### DIFF
--- a/.changeset/brave-upload-filters.md
+++ b/.changeset/brave-upload-filters.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Broaden composer upload filters so Markdown, JSON, CSV, DOCX, and PPTX reference files are selectable in native file pickers.

--- a/.changeset/buffer-final-guard-text.md
+++ b/.changeset/buffer-final-guard-text.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Buffer streamed assistant text until the final-response guard approves it, so rejected answers never flash before the corrective retry. Removes the `clear` event the UI used to swallow.

--- a/.changeset/chat-embed-clarity.md
+++ b/.changeset/chat-embed-clarity.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Improve assistant chat embed previews and sub-agent task card labels.

--- a/.changeset/clear-analytics-guard-loop.md
+++ b/.changeset/clear-analytics-guard-loop.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Buffer guarded final-answer text until validation passes and clear stale chat activity when corrective retries discard partial output.
+Clear stale chat activity when corrective agent retries discard partial output.

--- a/.changeset/clear-analytics-guard-loop.md
+++ b/.changeset/clear-analytics-guard-loop.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Clear stale chat activity when corrective agent retries discard partial output.
+Buffer guarded final-answer text until validation passes and clear stale chat activity when corrective retries discard partial output.

--- a/.changeset/clear-analytics-guard-loop.md
+++ b/.changeset/clear-analytics-guard-loop.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Clear stale chat activity when corrective agent retries discard partial output.

--- a/.changeset/iframe-embed-header.md
+++ b/.changeset/iframe-embed-header.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add Preview header bar to IframeEmbed showing the embed's title above the iframe.

--- a/.changeset/libsql-native-serverless.md
+++ b/.changeset/libsql-native-serverless.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Include installed libsql native packages in Node serverless bundles so hosted apps do not fail loading local SQLite/libsql fallbacks.

--- a/.changeset/sqlite-better-sqlite3-fallback.md
+++ b/.changeset/sqlite-better-sqlite3-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use better-sqlite3 for local SQLite file URLs and `@libsql/client/web` for remote libsql/Turso URLs so serverless bundles no longer depend on libsql's platform-specific native packages. The deploy bundler still copies any installed `@libsql/<platform>` natives into Netlify/Vercel/Lambda outputs as a safety net.

--- a/.changeset/steady-agent-feedback.md
+++ b/.changeset/steady-agent-feedback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Bundle agent chat feedback controls with the main client entry so missing lazy chunks cannot crash the agent panel.

--- a/.changeset/visible-chat-auth-errors.md
+++ b/.changeset/visible-chat-auth-errors.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Show visible assistant error text for chat authentication failures instead of blank messages.

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1235,6 +1235,49 @@ describe("runAgentLoop", () => {
     );
   });
 
+  it("flushes guarded final-answer text after the guard accepts it", async () => {
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield { type: "text-delta", text: "Grounded answer." };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "Grounded answer." }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {},
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+      finalResponseGuard: () => null,
+    });
+
+    expect(events).toContainEqual({
+      type: "text",
+      text: "Grounded answer.",
+    });
+    expect(events.at(-1)).toEqual({ type: "done" });
+  });
+
   it("uses the final-response guard fallback after one failed corrective retry", async () => {
     let streamCalls = 0;
     const engine: AgentEngine = {

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1216,7 +1216,10 @@ describe("runAgentLoop", () => {
 
     expect(streamCalls).toBe(3);
     expect(guard).toHaveBeenCalledTimes(2);
-    expect(events).toContainEqual({ type: "clear" });
+    expect(events).not.toContainEqual({
+      type: "text",
+      text: "Looks up and to the right.",
+    });
     expect(events).toContainEqual({
       type: "tool_start",
       tool: "query-data",
@@ -1275,7 +1278,8 @@ describe("runAgentLoop", () => {
     });
 
     expect(streamCalls).toBe(2);
-    expect(events.filter((event) => event.type === "clear")).toHaveLength(2);
+    expect(events).not.toContainEqual({ type: "text", text: "fake answer" });
+    expect(events).not.toContainEqual({ type: "text", text: "still fake" });
     expect(events).toContainEqual({
       type: "text",
       text: "I stopped because no real data-source query ran.",

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1104,6 +1104,7 @@ export async function runAgentLoop(opts: {
     actions,
   );
   const duplicateReadOnlyToolCalls = new Map<string, number>();
+  const bufferTextUntilFinalGuard = Boolean(opts.finalResponseGuard);
   let finalGuardRetries = 0;
   let iterations = 0;
   while (true) {
@@ -1114,6 +1115,7 @@ export async function runAgentLoop(opts: {
     }
 
     let assistantContent: EngineContentPart[] | undefined;
+    let bufferedAssistantText = "";
     const toolCallErrors = new Map<
       string,
       { name: string; input: unknown; error: string }
@@ -1121,6 +1123,7 @@ export async function runAgentLoop(opts: {
 
     for (let retry = 0; ; retry++) {
       assistantContent = undefined;
+      bufferedAssistantText = "";
       toolCallErrors.clear();
       try {
         const streamOpts = {
@@ -1158,7 +1161,11 @@ export async function runAgentLoop(opts: {
 
         for await (const event of eventStream) {
           if (event.type === "text-delta") {
-            send({ type: "text", text: event.text });
+            if (bufferTextUntilFinalGuard) {
+              bufferedAssistantText += event.text;
+            } else {
+              send({ type: "text", text: event.text });
+            }
           } else if (event.type === "thinking-delta") {
             thinkingBuffer += event.text;
             // Thinking deltas are not forwarded to the SSE client yet —
@@ -1264,6 +1271,12 @@ export async function runAgentLoop(opts: {
       (p): p is import("./engine/types.js").EngineToolCallPart =>
         p.type === "tool-call",
     );
+    const flushBufferedAssistantText = () => {
+      if (!bufferTextUntilFinalGuard) return;
+      const text =
+        bufferedAssistantText || collectTextParts(assistantContentForHistory);
+      if (text) send({ type: "text", text });
+    };
 
     if (toolCallParts.length === 0) {
       const guard = opts.finalResponseGuard
@@ -1281,7 +1294,6 @@ export async function runAgentLoop(opts: {
           typeof guard === "string" ? guard : guard.retryMessage;
         const fallbackMessage =
           typeof guard === "string" ? guard : guard.fallbackMessage;
-        send({ type: "clear" });
         if (finalGuardRetries < 1) {
           finalGuardRetries += 1;
           messages.push({
@@ -1291,9 +1303,13 @@ export async function runAgentLoop(opts: {
           continue;
         }
         send({ type: "text", text: fallbackMessage ?? retryMessage });
+      } else {
+        flushBufferedAssistantText();
       }
       break;
     }
+
+    flushBufferedAssistantText();
 
     let requestedActionStop: { message: string; errorCode?: string } | null =
       null;

--- a/packages/core/src/client/AgentTaskCard.tsx
+++ b/packages/core/src/client/AgentTaskCard.tsx
@@ -163,13 +163,30 @@ export function AgentTaskCard({
   const isComplete = status === "completed";
   const isError = status === "errored";
 
+  const taskTitle = description.trim() || "Task";
+  const currentStepText = currentStep.trim();
+  const statusLabel = isRunning ? "Running" : isError ? "Error" : "Done";
+  const statusClassName = cn(
+    "inline-flex h-5 shrink-0 items-center gap-1 rounded-md px-1.5 text-[10px] font-medium",
+    isError
+      ? "bg-destructive/10 text-destructive"
+      : isComplete
+        ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+        : "bg-muted text-muted-foreground",
+  );
+
   const displayText = isComplete && summary ? summary : preview;
   const hasContent = displayText.length > 0;
+  const emptyMessage = isRunning
+    ? "Waiting for updates"
+    : isError
+      ? "No error details yet"
+      : "No summary available";
 
   return (
     <div
       className={cn(
-        "my-2 rounded-lg border overflow-hidden transition-colors",
+        "my-2 overflow-hidden rounded-lg border bg-background/50 transition-colors",
         isError
           ? "border-destructive/30"
           : isComplete
@@ -178,35 +195,31 @@ export function AgentTaskCard({
       )}
     >
       {/* Header */}
-      <div
-        className="flex items-center gap-2 px-3 py-2.5 cursor-pointer select-none hover:bg-muted/50"
+      <button
+        type="button"
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-muted/45"
         onClick={() => setExpanded(!expanded)}
       >
-        <span className="shrink-0">
+        <span className="inline-flex h-5 shrink-0 items-center gap-1 rounded-md border border-border/60 bg-background/70 px-1.5 text-[10px] font-medium text-muted-foreground">
+          <IconSubtask className="h-3 w-3" />
+          Sub-agent
+        </span>
+
+        <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+          {taskTitle}
+        </span>
+
+        <span className={statusClassName}>
           {isRunning ? (
-            <IconLoader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+            <IconLoader2 className="h-3 w-3 animate-spin" />
           ) : isError ? (
-            <IconAlertCircle className="h-3.5 w-3.5 text-destructive" />
+            <IconAlertCircle className="h-3 w-3" />
           ) : (
-            <IconCheck className="h-3.5 w-3.5 text-emerald-500" />
+            <IconCheck className="h-3 w-3" />
           )}
+          {statusLabel}
         </span>
-
-        <IconSubtask className="h-3.5 w-3.5 text-muted-foreground/60 shrink-0" />
-
-        <span className="text-xs font-medium truncate min-w-0 flex-1">
-          {description}
-        </span>
-
-        {currentStep && isRunning && (
-          <span className="text-[10px] text-muted-foreground/70 truncate max-w-[180px] shrink-0">
-            {currentStep}
-          </span>
-        )}
-
-        {isComplete && (
-          <span className="text-[10px] text-emerald-500/70 shrink-0">Done</span>
-        )}
 
         <IconChevronRight
           className={cn(
@@ -214,14 +227,21 @@ export function AgentTaskCard({
             expanded && "rotate-90",
           )}
         />
-      </div>
+      </button>
+
+      {expanded && isRunning && currentStepText && (
+        <div className="flex gap-1.5 border-t border-border/60 px-3 py-1.5 text-[11px] text-muted-foreground">
+          <span className="shrink-0 font-medium text-foreground/70">Now:</span>
+          <span className="min-w-0 break-words">{currentStepText}</span>
+        </div>
+      )}
 
       {/* Preview content */}
       {expanded && hasContent && (
-        <div className="px-3 pb-2">
+        <div className="px-3 pb-2 pt-1">
           <div
             ref={previewRef}
-            className="rounded-md bg-muted/30 px-3 py-2 text-xs text-muted-foreground break-words max-h-48 overflow-y-auto agent-markdown prose prose-sm prose-invert max-w-none"
+            className="agent-markdown prose prose-sm prose-invert max-h-48 max-w-none overflow-y-auto break-words rounded-md border border-border/50 bg-muted/25 px-3 py-2 text-xs text-muted-foreground"
           >
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
               {displayText.length > 800
@@ -234,19 +254,15 @@ export function AgentTaskCard({
 
       {/* Footer with Open button */}
       {expanded && (
-        <div className="flex items-center justify-between px-3 pb-2">
-          {isRunning && !hasContent && (
-            <span className="text-[10px] text-muted-foreground/50">
-              Working...
-            </span>
-          )}
-          {!isRunning && !hasContent && <span />}
-          {hasContent && <span />}
+        <div className="flex items-center justify-between gap-2 px-3 pb-2">
+          <span className="min-w-0 flex-1 truncate text-[10px] text-muted-foreground/60">
+            {!hasContent ? emptyMessage : ""}
+          </span>
           <button
             onClick={handleOpen}
-            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted"
+            className="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
           >
-            Open
+            Open thread
             <IconExternalLink className="h-3 w-3" />
           </button>
         </div>

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -64,6 +64,7 @@ import { IframeEmbed, parseEmbedBody } from "./IframeEmbed.js";
 import { useDevMode } from "./use-dev-mode.js";
 import { agentNativePath } from "./api-path.js";
 import { BUILDER_SPACE_SETTINGS_URL } from "./error-format.js";
+import { ThumbsFeedback } from "./observability/ThumbsFeedback.js";
 import {
   TiptapComposer,
   type TiptapComposerHandle,
@@ -106,12 +107,6 @@ import {
   IconRefresh,
   IconPlayerPlay,
 } from "@tabler/icons-react";
-
-const ThumbsFeedbackLazy = React.lazy(() =>
-  import("./observability/ThumbsFeedback.js").then((m) => ({
-    default: m.ThumbsFeedback,
-  })),
-);
 
 class BinaryDocumentAttachmentAdapter implements AttachmentAdapter {
   public accept = "application/pdf,.pdf";
@@ -1623,23 +1618,21 @@ function AssistantMessage() {
               Restoring...
             </span>
           ) : (
-            <React.Suspense fallback={null}>
-              <ThumbsFeedbackLazy
-                threadId={cpCtx?.threadId ?? ""}
-                runId={(() => {
-                  const meta = messageRuntime.getState().metadata as
-                    | { custom?: { runId?: unknown }; runId?: unknown }
-                    | undefined;
-                  return (
-                    (typeof meta?.custom?.runId === "string" &&
-                      meta.custom.runId) ||
-                    (typeof meta?.runId === "string" && meta.runId) ||
-                    ""
-                  );
-                })()}
-                messageSeq={thread.messages.findIndex((m) => m.id === msg.id)}
-              />
-            </React.Suspense>
+            <ThumbsFeedback
+              threadId={cpCtx?.threadId ?? ""}
+              runId={(() => {
+                const meta = messageRuntime.getState().metadata as
+                  | { custom?: { runId?: unknown }; runId?: unknown }
+                  | undefined;
+                return (
+                  (typeof meta?.custom?.runId === "string" &&
+                    meta.custom.runId) ||
+                  (typeof meta?.runId === "string" && meta.runId) ||
+                  ""
+                );
+              })()}
+              messageSeq={thread.messages.findIndex((m) => m.id === msg.id)}
+            />
           )}
         </div>
       )}

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -3137,6 +3137,18 @@ const AssistantChatInner = forwardRef<
   }, [tabId]);
 
   useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { tabId?: string };
+      if (tabId && detail?.tabId && detail.tabId !== tabId) return;
+      setActivityLabel(null);
+      setActivitySteps([]);
+    };
+    window.addEventListener("agent-chat:activity-clear", handler);
+    return () =>
+      window.removeEventListener("agent-chat:activity-clear", handler);
+  }, [tabId]);
+
+  useEffect(() => {
     if (!showRunningInUI) {
       setActivityLabel(null);
       setActivitySteps([]);

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -28,7 +28,6 @@ import type {
 } from "@assistant-ui/react";
 import {
   SimpleImageAttachmentAdapter,
-  SimpleTextAttachmentAdapter,
   CompositeAttachmentAdapter,
 } from "@assistant-ui/react";
 import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
@@ -43,6 +42,7 @@ import {
   readSSEStreamRaw,
 } from "./sse-event-processor.js";
 import { cn } from "./utils.js";
+import { TextAttachmentAdapter } from "./composer/attachment-accept.js";
 import { AgentTaskCard } from "./AgentTaskCard.js";
 import { ConnectBuilderCard } from "./ConnectBuilderCard.js";
 import { useBuilderConnectFlow } from "./settings/useBuilderStatus.js";
@@ -3868,7 +3868,7 @@ export const AssistantChat = forwardRef<
       new CompositeAttachmentAdapter([
         new SimpleImageAttachmentAdapter(),
         new BinaryDocumentAttachmentAdapter(),
-        new SimpleTextAttachmentAdapter(),
+        new TextAttachmentAdapter(),
       ]),
     [],
   );

--- a/packages/core/src/client/IframeEmbed.tsx
+++ b/packages/core/src/client/IframeEmbed.tsx
@@ -84,6 +84,7 @@ export function IframeEmbed({ src, aspect, title, height }: IframeEmbedProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const resolvedAspect =
     aspect && ALLOWED_ASPECTS.has(aspect) ? aspect : "16/9";
+  const displayTitle = title?.trim() || "Embedded content";
   const paddingBottom = useMemo(
     () => aspectToPaddingBottom(resolvedAspect),
     [resolvedAspect],
@@ -117,25 +118,34 @@ export function IframeEmbed({ src, aspect, title, height }: IframeEmbedProps) {
     : { paddingBottom };
 
   return (
-    <div
-      className={cn(
-        "my-2 rounded-lg border border-border overflow-hidden bg-muted/20 relative w-full",
-      )}
-      style={style}
-    >
-      {!loaded && (
-        <div className="absolute inset-0 animate-pulse bg-muted/40" />
-      )}
-      <iframe
-        ref={iframeRef}
-        src={src}
-        title={title || "Embedded content"}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-        referrerPolicy="same-origin"
-        loading="lazy"
-        onLoad={() => setLoaded(true)}
-        className="absolute inset-0 w-full h-full border-0 bg-transparent"
-      />
+    <div className="my-2 w-full overflow-hidden rounded-lg border border-border bg-background/60">
+      <div className="flex min-h-8 items-center gap-2 border-b border-border bg-muted/30 px-3 py-1.5">
+        <span className="shrink-0 text-[10px] font-medium uppercase text-muted-foreground">
+          Preview
+        </span>
+        <span aria-hidden="true" className="h-3 w-px shrink-0 bg-border" />
+        <span
+          className="min-w-0 flex-1 truncate text-xs font-medium text-foreground"
+          title={displayTitle}
+        >
+          {displayTitle}
+        </span>
+      </div>
+      <div className="relative w-full bg-muted/20" style={style}>
+        {!loaded && (
+          <div className="absolute inset-0 animate-pulse bg-muted/40" />
+        )}
+        <iframe
+          ref={iframeRef}
+          src={src}
+          title={displayTitle}
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          referrerPolicy="same-origin"
+          loading="lazy"
+          onLoad={() => setLoaded(true)}
+          className="absolute inset-0 h-full w-full border-0 bg-transparent"
+        />
+      </div>
     </div>
   );
 }

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -530,6 +530,47 @@ describe("createAgentChatAdapter", () => {
     );
   });
 
+  it("surfaces missing-credential HTTP responses instead of yielding a blank assistant message", async () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse(
+        {
+          error: "No LLM provider is connected",
+          errorCode: "missing_credentials",
+        },
+        500,
+      ),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const adapter = createAgentChatAdapter({
+      apiUrl: "/_agent-native/agent-chat",
+      tabId: "chat-missing-credentials",
+    });
+
+    const results = await drain(
+      adapter.run({
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "show my upcoming events" }],
+          },
+        ],
+        abortSignal: new AbortController().signal,
+      } as any),
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "agent-chat:missing-api-key" }),
+    );
+    expect(results[0]).toEqual({
+      content: [{ type: "text", text: "Error: No LLM provider is connected" }],
+      status: { type: "incomplete", reason: "error" },
+    });
+  });
+
   it("treats authentication failures as auth errors, not AI setup", async () => {
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -611,6 +611,15 @@ describe("createAgentChatAdapter", () => {
       } as any),
     );
 
+    expect(results[0]).toEqual({
+      content: [
+        {
+          type: "text",
+          text: "Error: Authentication required. Sign in again to use chat.",
+        },
+      ],
+      status: { type: "incomplete", reason: "error" },
+    });
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "agent-chat:auth-error",
@@ -654,7 +663,7 @@ describe("createAgentChatAdapter", () => {
       threadId: "thread-invalid-token",
     });
 
-    await drain(
+    const results = await drain(
       adapter.run({
         messages: [
           {
@@ -666,6 +675,15 @@ describe("createAgentChatAdapter", () => {
       } as any),
     );
 
+    expect(results[0]).toEqual({
+      content: [
+        {
+          type: "text",
+          text: "Error: Authentication required. Sign in again to use chat.",
+        },
+      ],
+      status: { type: "incomplete", reason: "error" },
+    });
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "agent-chat:auth-error",

--- a/packages/core/src/client/agent-chat-adapter.spec.ts
+++ b/packages/core/src/client/agent-chat-adapter.spec.ts
@@ -599,7 +599,7 @@ describe("createAgentChatAdapter", () => {
       tabId: "chat-auth",
     });
 
-    await drain(
+    const results = await drain(
       adapter.run({
         messages: [
           {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -10,7 +10,7 @@ import {
   readSSEStream,
 } from "./sse-event-processor.js";
 import { agentNativePath } from "./api-path.js";
-import { normalizeChatError } from "./error-format.js";
+import { formatChatErrorText, normalizeChatError } from "./error-format.js";
 import { captureError } from "./analytics.js";
 import { unwrapAttachmentEnvelope } from "./composer/pasted-text.js";
 import type { ReasoningEffort } from "../shared/reasoning-effort.js";
@@ -529,6 +529,30 @@ function isMissingCredentialMessage(message: string): boolean {
     msg.includes("no llm provider") ||
     msg.includes("llm provider is connected")
   );
+}
+
+function missingCredentialErrorText(message: string): string {
+  try {
+    const parsed = JSON.parse(message) as {
+      error?: unknown;
+      message?: unknown;
+      upgradeUrl?: unknown;
+      errorCode?: unknown;
+    };
+    const raw =
+      typeof parsed.error === "string"
+        ? parsed.error
+        : typeof parsed.message === "string"
+          ? parsed.message
+          : message;
+    return formatChatErrorText(
+      raw,
+      typeof parsed.upgradeUrl === "string" ? parsed.upgradeUrl : undefined,
+      typeof parsed.errorCode === "string" ? parsed.errorCode : undefined,
+    );
+  } catch {
+    return formatChatErrorText(message);
+  }
 }
 
 /**
@@ -1129,7 +1153,10 @@ export function createAgentChatAdapter(options?: {
                       new Event("agent-chat:missing-api-key"),
                     );
                   }
-                  content.push({ type: "text", text: "" });
+                  content.push({
+                    type: "text",
+                    text: missingCredentialErrorText(body),
+                  });
                   yield {
                     content: [...content],
                     status: {
@@ -1269,7 +1296,10 @@ export function createAgentChatAdapter(options?: {
               if (typeof window !== "undefined") {
                 window.dispatchEvent(new Event("agent-chat:missing-api-key"));
               }
-              content.push({ type: "text", text: "" });
+              content.push({
+                type: "text",
+                text: missingCredentialErrorText(errMsg),
+              });
               yield {
                 content: [...content],
                 status: {

--- a/packages/core/src/client/agent-chat-adapter.ts
+++ b/packages/core/src/client/agent-chat-adapter.ts
@@ -509,6 +509,34 @@ function authErrorReasonFromMessage(
     : "auth-required";
 }
 
+function authErrorText(
+  reason: "auth-required" | "session-expired",
+  message?: string,
+): string {
+  const fallback =
+    reason === "session-expired"
+      ? "Your chat session expired. Refresh chat and sign in again to continue."
+      : "Authentication required. Sign in again to use chat.";
+
+  if (!message) return formatChatErrorText(fallback);
+
+  try {
+    const parsed = JSON.parse(message) as {
+      error?: unknown;
+      message?: unknown;
+    };
+    const raw =
+      typeof parsed.error === "string"
+        ? parsed.error
+        : typeof parsed.message === "string"
+          ? parsed.message
+          : undefined;
+    return formatChatErrorText(raw || fallback);
+  } catch {
+    return formatChatErrorText(message || fallback);
+  }
+}
+
 function safeAgentNativePath(path: string): string {
   try {
     return agentNativePath(path);
@@ -1100,7 +1128,10 @@ export function createAgentChatAdapter(options?: {
                   continue;
                 }
                 dispatchAuthError("auth-required");
-                content.push({ type: "text", text: "" });
+                content.push({
+                  type: "text",
+                  text: authErrorText("auth-required"),
+                });
                 yield {
                   content: [...content],
                   status: {
@@ -1118,7 +1149,10 @@ export function createAgentChatAdapter(options?: {
                   continue;
                 }
                 dispatchAuthError("session-expired");
-                content.push({ type: "text", text: "" });
+                content.push({
+                  type: "text",
+                  text: authErrorText("session-expired"),
+                });
                 yield {
                   content: [...content],
                   status: {
@@ -1136,8 +1170,12 @@ export function createAgentChatAdapter(options?: {
                   if (await tryRecoverAuthOnce()) {
                     continue;
                   }
-                  dispatchAuthError(authErrorReasonFromMessage(body));
-                  content.push({ type: "text", text: "" });
+                  const reason = authErrorReasonFromMessage(body);
+                  dispatchAuthError(reason);
+                  content.push({
+                    type: "text",
+                    text: authErrorText(reason, body),
+                  });
                   yield {
                     content: [...content],
                     status: {
@@ -1279,8 +1317,12 @@ export function createAgentChatAdapter(options?: {
               if (await tryRecoverAuthOnce()) {
                 continue;
               }
-              dispatchAuthError(authErrorReasonFromMessage(errMsg));
-              content.push({ type: "text", text: "" });
+              const reason = authErrorReasonFromMessage(errMsg);
+              dispatchAuthError(reason);
+              content.push({
+                type: "text",
+                text: authErrorText(reason, errMsg),
+              });
               yield {
                 content: [...content],
                 status: {

--- a/packages/core/src/client/composer/ComposerPlusMenu.tsx
+++ b/packages/core/src/client/composer/ComposerPlusMenu.tsx
@@ -76,7 +76,8 @@ function UploadOnlyAttachButton() {
           </button>
         </TooltipTrigger>
         <TooltipContent>
-          Upload image, PDF, text, Markdown, JSON, CSV, HTML, CSS, or XML
+          Upload image, PDF, PPTX, DOCX, text, Markdown, JSON, CSV, HTML, CSS,
+          or XML
         </TooltipContent>
       </Tooltip>
     </>

--- a/packages/core/src/client/composer/PromptComposer.tsx
+++ b/packages/core/src/client/composer/PromptComposer.tsx
@@ -17,7 +17,6 @@ import type {
 import {
   CompositeAttachmentAdapter,
   SimpleImageAttachmentAdapter,
-  SimpleTextAttachmentAdapter,
 } from "@assistant-ui/react";
 import { IconX } from "@tabler/icons-react";
 import { cn } from "../utils.js";
@@ -27,6 +26,10 @@ import { useChatModels } from "../use-chat-models.js";
 import type { ReasoningEffort } from "../../shared/reasoning-effort.js";
 import { isPastedTextAttachmentName } from "./pasted-text.js";
 import { PastedTextChip } from "./PastedTextChip.js";
+import {
+  PROMPT_DOCUMENT_ATTACHMENT_ACCEPT,
+  TextAttachmentAdapter,
+} from "./attachment-accept.js";
 
 const MAX_INLINE_TEXT_FILE_CHARS = 60_000;
 
@@ -81,13 +84,12 @@ const NOOP_ADAPTER: ChatModelAdapter = {
 };
 
 /**
- * Local clone of AssistantChat's BinaryDocumentAttachmentAdapter so PDFs and
- * PPTX files can be attached without dragging the whole assistant chat module
- * into bundles that just want a prompt popover.
+ * Local binary document adapter so reference PDFs, decks, and docs can be
+ * attached without dragging the whole assistant chat module into bundles that
+ * just want a prompt popover.
  */
 class BinaryDocumentAttachmentAdapter implements AttachmentAdapter {
-  public accept =
-    "application/pdf,application/vnd.openxmlformats-officedocument.presentationml.presentation,.pdf,.pptx";
+  public accept = PROMPT_DOCUMENT_ATTACHMENT_ACCEPT;
 
   public async add(state: { file: File }): Promise<PendingAttachment> {
     return {
@@ -118,7 +120,9 @@ class BinaryDocumentAttachmentAdapter implements AttachmentAdapter {
 function isInlineableTextFile(file: File): boolean {
   if (file.type.startsWith("text/")) return true;
   if (file.type === "application/json") return true;
-  return /\.(txt|md|markdown|csv|json|yaml|yml)$/i.test(file.name);
+  return /\.(txt|md|markdown|csv|json|yaml|yml|html?|css|xml)$/i.test(
+    file.name,
+  );
 }
 
 function formatInlineTextFile(name: string, text: string): string {
@@ -364,7 +368,7 @@ export function PromptComposer(props: PromptComposerProps) {
       new CompositeAttachmentAdapter([
         new SimpleImageAttachmentAdapter(),
         new BinaryDocumentAttachmentAdapter(),
-        new SimpleTextAttachmentAdapter(),
+        new TextAttachmentAdapter(),
       ]),
     [],
   );

--- a/packages/core/src/client/composer/attachment-accept.ts
+++ b/packages/core/src/client/composer/attachment-accept.ts
@@ -1,0 +1,38 @@
+import { SimpleTextAttachmentAdapter } from "@assistant-ui/react";
+
+export const PROMPT_DOCUMENT_ATTACHMENT_ACCEPT = [
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".pdf",
+  ".pptx",
+  ".docx",
+].join(",");
+
+export const TEXT_ATTACHMENT_ACCEPT = [
+  "text/plain",
+  "text/html",
+  "text/markdown",
+  "text/csv",
+  "text/xml",
+  "text/json",
+  "text/css",
+  "text/yaml",
+  "application/json",
+  "application/x-yaml",
+  ".txt",
+  ".md",
+  ".markdown",
+  ".csv",
+  ".json",
+  ".html",
+  ".htm",
+  ".css",
+  ".xml",
+  ".yaml",
+  ".yml",
+].join(",");
+
+export class TextAttachmentAdapter extends SimpleTextAttachmentAdapter {
+  public accept = TEXT_ATTACHMENT_ACCEPT;
+}

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -426,6 +426,47 @@ describe("SSE event processor error classification", () => {
     );
   });
 
+  it("clears visible activity when the server clears a corrective draft", async () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent {
+        type: string;
+        detail: unknown;
+
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+    );
+
+    await drain(
+      readSSEStream(
+        eventStream([
+          {
+            type: "activity",
+            label: "Preparing data-source-status action",
+            tool: "data-source-status",
+          },
+          { type: "clear" },
+          { type: "done" },
+        ]),
+        [],
+        { value: 0 },
+        "tab-clear",
+      ),
+    );
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent-chat:activity-clear",
+        detail: { tabId: "tab-clear" },
+      }),
+    );
+  });
+
   it("dispatches visible activity for tool starts", async () => {
     const dispatchEvent = vi.fn();
     vi.stubGlobal("window", { dispatchEvent });

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -176,6 +176,15 @@ function isMissingCredentialText(message: string, errorCode?: string): boolean {
   );
 }
 
+function dispatchActivityClear(tabId: string | undefined) {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent("agent-chat:activity-clear", {
+      detail: { tabId },
+    }),
+  );
+}
+
 /**
  * Process a single SSE event and update the content accumulator.
  * Returns: "continue" to keep going, "done" to stop, or a yield-ready result.
@@ -202,6 +211,7 @@ export function processEvent(
   if (ev.type === "clear") {
     // Server is retrying — discard partial text/tool output from the failed attempt
     content.length = 0;
+    dispatchActivityClear(tabId);
     return { action: "continue" };
   }
 

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -4,9 +4,9 @@
  * Detects the database backend from the environment (D1, Postgres, or SQLite/libsql)
  * and returns a unified `DbExec` interface that all core stores use.
  *
- * Imports for postgres and @libsql/client are lazy (dynamic import) so this
- * module can be loaded in any runtime (Node.js, Cloudflare Workers, edge)
- * without failing on missing native deps.
+ * Imports for postgres, better-sqlite3, and @libsql/client/web are lazy
+ * (dynamic import) so this module can be loaded in any runtime (Node.js,
+ * Cloudflare Workers, edge) without failing on missing native deps.
  */
 import path from "path";
 
@@ -53,6 +53,43 @@ export function getDatabaseAuthToken(): string | undefined {
     if (prefixed) return prefixed;
   }
   return process.env.DATABASE_AUTH_TOKEN;
+}
+
+export function isLocalSqliteUrl(url: string): boolean {
+  return url === "" || url.startsWith("file:") || !url.includes("://");
+}
+
+export async function prepareLocalSqliteUrl(url: string): Promise<string> {
+  if (!url.startsWith("file:")) return url;
+
+  // On serverless runtimes (Netlify, AWS Lambda) the working directory is
+  // read-only. Detect this and redirect local SQLite to /tmp which IS writable
+  // (ephemeral per invocation, but the server stays alive for the request).
+  const isServerless =
+    !!process.env.NETLIFY ||
+    !!process.env.AWS_LAMBDA_FUNCTION_NAME ||
+    !!process.env.LAMBDA_TASK_ROOT;
+  try {
+    const fs = await import("fs");
+    if (isServerless && url === "file:./data/app.db") {
+      fs.mkdirSync("/tmp/data", { recursive: true });
+      return "file:///tmp/data/app.db";
+    }
+    fs.mkdirSync(path.join(process.cwd(), "data"), { recursive: true });
+  } catch {
+    // Edge runtime — no filesystem.
+  }
+  return url;
+}
+
+export function sqliteFilenameFromUrl(url: string): string {
+  if (url.startsWith("file://")) {
+    return decodeURIComponent(new URL(url).pathname);
+  }
+  if (url.startsWith("file:")) {
+    return url.slice("file:".length) || ":memory:";
+  }
+  return url || "./data/app.db";
 }
 
 // ---------------------------------------------------------------------------
@@ -291,6 +328,7 @@ export async function retryOnConnectionError<T>(
 let _exec: DbExec | undefined;
 let _pgPool: any;
 let _neonPool: any;
+let _sqlite: any;
 let _initPromise: Promise<void> | undefined;
 
 async function initClient(): Promise<void> {
@@ -420,43 +458,43 @@ async function initClient(): Promise<void> {
     return;
   }
 
-  // SQLite / libsql (default)
-  if (url.startsWith("file:")) {
-    // On serverless runtimes (Netlify, AWS Lambda) the working directory is
-    // read-only. Detect this and redirect local SQLite to /tmp which IS
-    // writable (ephemeral per invocation, but the server stays alive for the
-    // duration of the request).
-    const isServerless =
-      !!process.env.NETLIFY ||
-      !!process.env.AWS_LAMBDA_FUNCTION_NAME ||
-      !!process.env.LAMBDA_TASK_ROOT;
-    try {
-      const fs = await import("fs");
-      if (isServerless && url === "file:./data/app.db") {
-        fs.mkdirSync("/tmp/data", { recursive: true });
-        url = "file:///tmp/data/app.db";
-      } else {
-        fs.mkdirSync(path.join(process.cwd(), "data"), { recursive: true });
-      }
-    } catch {
-      // Edge runtime — no filesystem
-    }
+  // SQLite / libsql (default). Local file databases use better-sqlite3 so
+  // serverless bundles do not need libsql's platform-specific native package.
+  if (isLocalSqliteUrl(url)) {
+    url = await prepareLocalSqliteUrl(
+      url.startsWith("file:") ? url : `file:${url}`,
+    );
+    const { default: Database } = await import("better-sqlite3");
+    _sqlite = new Database(sqliteFilenameFromUrl(url));
+    _sqlite.pragma("busy_timeout = 10000");
+    _sqlite.pragma("journal_mode = WAL");
+
+    _exec = {
+      async execute(sql) {
+        const rawSql = typeof sql === "string" ? sql : sql.sql;
+        const args = typeof sql === "string" ? [] : sql.args || [];
+        const stmt = _sqlite.prepare(rawSql);
+        if (stmt.reader) {
+          return {
+            rows: stmt.all(...args),
+            rowsAffected: 0,
+          };
+        }
+        const result = stmt.run(...args);
+        return {
+          rows: [],
+          rowsAffected: result.changes ?? 0,
+        };
+      },
+    };
+    return;
   }
 
-  const { createClient } = await import("@libsql/client");
+  const { createClient } = await import("@libsql/client/web");
   const client = createClient({
     url,
     authToken: getDatabaseAuthToken(),
   });
-
-  // Enable WAL mode and set busy timeout for local SQLite.
-  // Retries handle SQLITE_BUSY_RECOVERY (stale WAL from a previous crash/HMR restart).
-  if (url.startsWith("file:") || url.endsWith(".db")) {
-    await retrySqliteBusy(async () => {
-      await client.execute("PRAGMA busy_timeout = 10000");
-      await client.execute("PRAGMA journal_mode = WAL");
-    });
-  }
 
   _exec = {
     async execute(sql) {
@@ -521,6 +559,10 @@ export async function closeDbExec(): Promise<void> {
   if (_neonPool) {
     await _neonPool.end();
     _neonPool = undefined;
+  }
+  if (_sqlite) {
+    _sqlite.close();
+    _sqlite = undefined;
   }
   _exec = undefined;
   _initPromise = undefined;

--- a/packages/core/src/db/create-get-db.ts
+++ b/packages/core/src/db/create-get-db.ts
@@ -1,6 +1,13 @@
 import { drizzle as drizzleD1 } from "drizzle-orm/d1";
 import type { LibSQLDatabase } from "drizzle-orm/libsql";
-import { getDialect, getDatabaseUrl, getDatabaseAuthToken } from "./client.js";
+import {
+  getDialect,
+  getDatabaseUrl,
+  getDatabaseAuthToken,
+  isLocalSqliteUrl,
+  prepareLocalSqliteUrl,
+  sqliteFilenameFromUrl,
+} from "./client.js";
 
 // Lazy driver loaders — cached promises so dynamic import only runs once.
 let _pgDrizzle: Promise<{ drizzle: any; postgres: any }> | undefined;
@@ -48,14 +55,30 @@ export function isNeonUrl(url: string): boolean {
   return /\.neon\.tech([:/?]|$)/.test(url);
 }
 
-let _libsqlDrizzle: Promise<{ drizzle: any }> | undefined;
-function getLibsqlDrizzle() {
-  if (!_libsqlDrizzle) {
-    _libsqlDrizzle = import("drizzle-orm/libsql").then((mod) => ({
+let _libsqlWebDrizzle: Promise<{ drizzle: any }> | undefined;
+function getLibsqlWebDrizzle() {
+  if (!_libsqlWebDrizzle) {
+    _libsqlWebDrizzle = import("drizzle-orm/libsql/web").then((mod) => ({
       drizzle: mod.drizzle,
     }));
   }
-  return _libsqlDrizzle;
+  return _libsqlWebDrizzle;
+}
+
+let _betterSqliteDrizzle:
+  | Promise<{ drizzle: any; Database: any }>
+  | undefined;
+function getBetterSqliteDrizzle() {
+  if (!_betterSqliteDrizzle) {
+    _betterSqliteDrizzle = Promise.all([
+      import("drizzle-orm/better-sqlite3"),
+      import("better-sqlite3"),
+    ]).then(([drizzleMod, sqliteMod]) => ({
+      drizzle: drizzleMod.drizzle,
+      Database: sqliteMod.default,
+    }));
+  }
+  return _betterSqliteDrizzle;
 }
 
 export function createGetDb<T extends Record<string, unknown>>(schema: T) {
@@ -96,8 +119,17 @@ export function createGetDb<T extends Record<string, unknown>>(schema: T) {
           _db = drizzle(client, { schema });
         });
       }
+    } else if (isLocalSqliteUrl(url)) {
+      _dbReady = Promise.all([
+        prepareLocalSqliteUrl(url.startsWith("file:") ? url : `file:${url}`),
+        getBetterSqliteDrizzle(),
+      ]).then(([sqliteUrl, { drizzle, Database }]) => {
+        const sqlite = new Database(sqliteFilenameFromUrl(sqliteUrl));
+        sqlite.pragma("journal_mode = WAL");
+        _db = drizzle(sqlite, { schema });
+      });
     } else {
-      _dbReady = getLibsqlDrizzle().then(({ drizzle }) => {
+      _dbReady = getLibsqlWebDrizzle().then(({ drizzle }) => {
         _db = drizzle({
           connection: { url, authToken: getDatabaseAuthToken() },
           schema,

--- a/packages/core/src/db/create-get-db.ts
+++ b/packages/core/src/db/create-get-db.ts
@@ -65,9 +65,7 @@ function getLibsqlWebDrizzle() {
   return _libsqlWebDrizzle;
 }
 
-let _betterSqliteDrizzle:
-  | Promise<{ drizzle: any; Database: any }>
-  | undefined;
+let _betterSqliteDrizzle: Promise<{ drizzle: any; Database: any }> | undefined;
 function getBetterSqliteDrizzle() {
   if (!_betterSqliteDrizzle) {
     _betterSqliteDrizzle = Promise.all([

--- a/packages/core/src/deploy/build.ts
+++ b/packages/core/src/deploy/build.ts
@@ -945,6 +945,78 @@ function copyDir(src: string, dest: string) {
   }
 }
 
+const LIBSQL_NATIVE_PACKAGE_NAMES = [
+  "darwin-arm64",
+  "darwin-x64",
+  "linux-arm-gnueabihf",
+  "linux-arm-musleabihf",
+  "linux-arm64-gnu",
+  "linux-arm64-musl",
+  "linux-x64-gnu",
+  "linux-x64-musl",
+  "win32-x64-msvc",
+];
+
+function nodeModulesAncestors(startDir: string): string[] {
+  const dirs: string[] = [];
+  let current = path.resolve(startDir);
+  while (true) {
+    const candidate = path.join(current, "node_modules");
+    if (fs.existsSync(candidate)) dirs.push(candidate);
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return dirs;
+}
+
+function findInstalledLibsqlNativePackage(
+  nodeModulesRoots: string[],
+  packageName: string,
+): string | null {
+  for (const root of nodeModulesRoots) {
+    const direct = path.join(root, "@libsql", packageName);
+    if (fs.existsSync(path.join(direct, "index.node"))) return direct;
+
+    const pnpmRoot = path.join(root, ".pnpm");
+    if (!fs.existsSync(pnpmRoot)) continue;
+    const pnpmPrefix = `@libsql+${packageName}@`;
+    for (const entry of fs.readdirSync(pnpmRoot)) {
+      if (!entry.startsWith(pnpmPrefix)) continue;
+      const nested = path.join(
+        pnpmRoot,
+        entry,
+        "node_modules",
+        "@libsql",
+        packageName,
+      );
+      if (fs.existsSync(path.join(nested, "index.node"))) return nested;
+    }
+  }
+  return null;
+}
+
+function copyInstalledLibsqlNativePackages(serverDir: string | undefined) {
+  if (!serverDir || !fs.existsSync(serverDir)) return;
+  const nodeModulesRoots = nodeModulesAncestors(cwd);
+  const destScopeDir = path.join(serverDir, "node_modules", "@libsql");
+  let copied = 0;
+
+  for (const packageName of LIBSQL_NATIVE_PACKAGE_NAMES) {
+    const src = findInstalledLibsqlNativePackage(nodeModulesRoots, packageName);
+    if (!src) continue;
+
+    copyDir(src, path.join(destScopeDir, packageName));
+    copied += 1;
+  }
+
+  if (copied > 0) {
+    console.log(
+      `[deploy] Copied ${copied} installed libsql native package(s) into the server bundle.`,
+    );
+  }
+}
+
 /**
  * Create stub directories for dangling platform-specific optional dependency
  * symlinks in the pnpm store.
@@ -1199,6 +1271,10 @@ export default bundle;
     console.log(
       `[deploy] Copied client assets to ${path.relative(cwd, publicOutputDir)}`,
     );
+  }
+
+  if (preset === "netlify" || preset === "vercel" || preset === "aws-lambda") {
+    copyInstalledLibsqlNativePackages(nitro.options.output.serverDir);
   }
 
   // Resolve remaining bare npm imports by bundling them into _libs/.

--- a/packages/core/src/scripts/db/exec.ts
+++ b/packages/core/src/scripts/db/exec.ts
@@ -15,8 +15,7 @@
  */
 
 import path from "path";
-import { createClient } from "@libsql/client";
-import { getDatabaseUrl, getDatabaseAuthToken } from "../../db/client.js";
+import { getDatabaseUrl } from "../../db/client.js";
 import { parseArgs, fail } from "../utils.js";
 import {
   buildScopingPostgres,
@@ -24,6 +23,7 @@ import {
   type ScopingContext,
 } from "./scoping.js";
 import { assertNoSensitiveFrameworkTables } from "./safety.js";
+import { createSqliteScriptClient } from "./sqlite-client.js";
 
 function isPostgresUrl(url: string): boolean {
   return url.startsWith("postgres://") || url.startsWith("postgresql://");
@@ -692,10 +692,7 @@ Options:
   }
 
   // libsql / SQLite path
-  const client = createClient({
-    url,
-    authToken: getDatabaseAuthToken(),
-  });
+  const client = await createSqliteScriptClient(url);
 
   try {
     // Set up user-scoped temp views in production

--- a/packages/core/src/scripts/db/parameterized.spec.ts
+++ b/packages/core/src/scripts/db/parameterized.spec.ts
@@ -8,8 +8,8 @@ describe("db scripts parameterized SQL", () => {
   });
 
   function mockSqliteClient(executeImpl: ReturnType<typeof vi.fn>) {
-    vi.doMock("@libsql/client", () => ({
-      createClient: () => ({
+    vi.doMock("./sqlite-client.js", () => ({
+      createSqliteScriptClient: async () => ({
         execute: executeImpl,
         close: vi.fn(),
       }),

--- a/packages/core/src/scripts/db/patch.ts
+++ b/packages/core/src/scripts/db/patch.ts
@@ -48,11 +48,11 @@
  */
 
 import path from "path";
-import { createClient } from "@libsql/client";
-import { getDatabaseUrl, getDatabaseAuthToken } from "../../db/client.js";
+import { getDatabaseUrl } from "../../db/client.js";
 import { parseArgs, fail } from "../utils.js";
 import { assertNoSensitiveFrameworkTables } from "./safety.js";
 import { buildScopingPostgres, buildScopingSqlite } from "./scoping.js";
+import { createSqliteScriptClient } from "./sqlite-client.js";
 
 interface TextEdit {
   find: string;
@@ -626,10 +626,7 @@ async function runPostgres(opts: RunOpts): Promise<void> {
 // ─── SQLite / libSQL path ───────────────────────────────────────────────────
 
 async function runSqlite(opts: RunOpts): Promise<void> {
-  const client = createClient({
-    url: opts.url,
-    authToken: getDatabaseAuthToken(),
-  });
+  const client = await createSqliteScriptClient(opts.url);
   try {
     const scoping = await buildScopingSqlite(client);
     for (const stmt of scoping.setup) {

--- a/packages/core/src/scripts/db/query.ts
+++ b/packages/core/src/scripts/db/query.ts
@@ -13,11 +13,11 @@
  */
 
 import path from "path";
-import { createClient } from "@libsql/client";
-import { getDatabaseUrl, getDatabaseAuthToken } from "../../db/client.js";
+import { getDatabaseUrl } from "../../db/client.js";
 import { parseArgs, fail } from "../utils.js";
 import { assertNoSensitiveFrameworkTables } from "./safety.js";
 import { buildScopingPostgres, buildScopingSqlite } from "./scoping.js";
+import { createSqliteScriptClient } from "./sqlite-client.js";
 
 function isPostgresUrl(url: string): boolean {
   return url.startsWith("postgres://") || url.startsWith("postgresql://");
@@ -267,10 +267,7 @@ Options:
   }
 
   // libsql / SQLite path
-  const client = createClient({
-    url,
-    authToken: getDatabaseAuthToken(),
-  });
+  const client = await createSqliteScriptClient(url);
 
   try {
     // Set up user-scoped temp views in production

--- a/packages/core/src/scripts/db/schema.ts
+++ b/packages/core/src/scripts/db/schema.ts
@@ -10,9 +10,12 @@
  */
 
 import path from "path";
-import { createClient, type Client } from "@libsql/client";
-import { getDatabaseUrl, getDatabaseAuthToken } from "../../db/client.js";
+import { getDatabaseUrl } from "../../db/client.js";
 import { parseArgs, fail } from "../utils.js";
+import {
+  createSqliteScriptClient,
+  type SqliteScriptClient,
+} from "./sqlite-client.js";
 
 interface ColumnInfo {
   name: string;
@@ -54,7 +57,7 @@ function databaseLabel(url: string): string {
  * Execute a PRAGMA query and return the rows as plain objects.
  */
 async function pragma(
-  client: Client,
+  client: SqliteScriptClient,
   pragmaQuery: string,
 ): Promise<Record<string, unknown>[]> {
   const result = await client.execute(pragmaQuery);
@@ -251,10 +254,7 @@ Options:
   }
 
   // SQLite / libsql path
-  const client = createClient({
-    url,
-    authToken: getDatabaseAuthToken(),
-  });
+  const client = await createSqliteScriptClient(url);
 
   try {
     const tablesResult = await client.execute(

--- a/packages/core/src/scripts/db/sqlite-client.ts
+++ b/packages/core/src/scripts/db/sqlite-client.ts
@@ -1,0 +1,78 @@
+import {
+  getDatabaseAuthToken,
+  isLocalSqliteUrl,
+  prepareLocalSqliteUrl,
+  sqliteFilenameFromUrl,
+} from "../../db/client.js";
+
+export interface SqliteScriptResult {
+  rows: any[];
+  columns: string[];
+  rowsAffected: number;
+  lastInsertRowid?: bigint | number;
+}
+
+export interface SqliteScriptClient {
+  execute(
+    stmtOrSql: string | { sql: string; args?: any[] },
+  ): Promise<SqliteScriptResult>;
+  close(): void | Promise<void>;
+}
+
+function sqliteRowsToLibsqlShape(rows: Record<string, unknown>[]) {
+  const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
+  return {
+    rows: rows.map((row) => {
+      const values = columns.map((column) => row[column]) as any[];
+      return Object.assign(values, row);
+    }),
+    columns,
+  };
+}
+
+export async function createSqliteScriptClient(
+  url: string,
+): Promise<SqliteScriptClient> {
+  if (isLocalSqliteUrl(url)) {
+    const sqliteUrl = await prepareLocalSqliteUrl(
+      url.startsWith("file:") ? url : `file:${url}`,
+    );
+    const { default: Database } = await import("better-sqlite3");
+    const sqlite = new Database(sqliteFilenameFromUrl(sqliteUrl));
+    sqlite.pragma("busy_timeout = 10000");
+    sqlite.pragma("journal_mode = WAL");
+
+    return {
+      async execute(stmtOrSql) {
+        const sql =
+          typeof stmtOrSql === "string" ? stmtOrSql : stmtOrSql.sql;
+        const args =
+          typeof stmtOrSql === "string" ? [] : (stmtOrSql.args ?? []);
+        const stmt = sqlite.prepare(sql);
+        if (stmt.reader) {
+          return {
+            ...sqliteRowsToLibsqlShape(stmt.all(...args)),
+            rowsAffected: 0,
+          };
+        }
+        const result = stmt.run(...args);
+        return {
+          rows: [],
+          columns: [],
+          rowsAffected: result.changes ?? 0,
+          lastInsertRowid: result.lastInsertRowid,
+        };
+      },
+      close() {
+        sqlite.close();
+      },
+    };
+  }
+
+  const { createClient } = await import("@libsql/client/web");
+  const client = createClient({
+    url,
+    authToken: getDatabaseAuthToken(),
+  });
+  return client as unknown as SqliteScriptClient;
+}

--- a/packages/core/src/scripts/db/sqlite-client.ts
+++ b/packages/core/src/scripts/db/sqlite-client.ts
@@ -19,10 +19,11 @@ export interface SqliteScriptClient {
   close(): void | Promise<void>;
 }
 
-function sqliteRowsToLibsqlShape(rows: Record<string, unknown>[]) {
-  const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
+function sqliteRowsToLibsqlShape(rows: unknown[]) {
+  const records = rows as Record<string, unknown>[];
+  const columns = records.length > 0 ? Object.keys(records[0]) : [];
   return {
-    rows: rows.map((row) => {
+    rows: records.map((row) => {
       const values = columns.map((column) => row[column]) as any[];
       return Object.assign(values, row);
     }),
@@ -44,8 +45,7 @@ export async function createSqliteScriptClient(
 
     return {
       async execute(stmtOrSql) {
-        const sql =
-          typeof stmtOrSql === "string" ? stmtOrSql : stmtOrSql.sql;
+        const sql = typeof stmtOrSql === "string" ? stmtOrSql : stmtOrSql.sql;
         const args =
           typeof stmtOrSql === "string" ? [] : (stmtOrSql.args ?? []);
         const stmt = sqlite.prepare(sql);

--- a/packages/core/src/server/better-auth-instance.ts
+++ b/packages/core/src/server/better-auth-instance.ts
@@ -880,10 +880,11 @@ async function buildDatabaseConfig(
     });
   }
 
-  // Remote libsql (Turso)
-  const { createClient } = await import("@libsql/client");
+  // Remote libsql (Turso). Use the web client to avoid serverless bundles
+  // depending on libsql's platform-specific native packages.
+  const { createClient } = await import("@libsql/client/web");
   const client = createClient({ url, authToken: getDatabaseAuthToken() });
-  const { drizzle } = await import("drizzle-orm/libsql");
+  const { drizzle } = await import("drizzle-orm/libsql/web");
   const db = drizzle(client, { schema: sqliteAuthSchema });
   const { drizzleAdapter } = await import("better-auth/adapters/drizzle");
   return drizzleAdapter(db, {

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -1,12 +1,12 @@
 # Analytics — Agent Guide
 
-You are the AI assistant for this analytics dashboard app. You can query data, build dashboards, and answer questions from multiple data sources. When a user asks a data question, query real data first, then present the answer directly in chat.
+You are the AI assistant for this analytics dashboard app. You can query data, build dashboards, and answer questions from multiple data sources. When a user asks a data question, query real data first, then present the answer directly in chat. When the user asks for workflow setup, recurring jobs, code/UI fixes, settings help, planning, or explanation, handle that request normally without forcing a data-source check.
 
 This is an **agent-native** app built with `@agent-native/core`.
 
 ## DATA INTEGRITY — NON-NEGOTIABLE
 
-**Never fabricate, estimate, or invent data. This is the most important rule for this agent.**
+**Never fabricate, estimate, or invent data. This rule applies to analytics results, source records, and derived metrics; it does not mean every non-data task needs a data-source action.**
 
 Every raw number, record, sequence ID, quote, or underlying value you present MUST originate from an actual tool call that succeeded. Derived metrics (totals, averages, rates, percentages, distributions) computed from real query results are fine — but you may not invent the underlying data they are derived from.
 
@@ -25,9 +25,11 @@ Every raw number, record, sequence ID, quote, or underlying value you present MU
 - Say "here's what the data shows" when you haven't actually queried it
 - Silently fall back to made-up values when a query fails
 
-**Correct response when data is unavailable:**
+**Correct response when data is unavailable and the user asked for a result:**
 
 > "I can't retrieve this data right now — [specific reason, e.g. 'BigQuery credentials are not configured' or 'the HubSpot connection returned an error']. Once that's resolved, I can run this query and show you real results."
+
+It is also fine to ask a concise clarifying question or provide a plan for how you would query the data, as long as you do not present numbers or source-record conclusions as facts.
 
 **Why this matters:** Users make business decisions based on the data you present. Fabricated data is not a helpful approximation — it is actively harmful. Admitting "I can't get that right now" is always the right answer when you cannot query the actual source.
 
@@ -35,7 +37,7 @@ Every raw number, record, sequence ID, quote, or underlying value you present MU
 
 Use configured data sources and actions. The generic analytics template can include provider actions even when a deployment has not connected credentials, granted permissions, or provided a warehouse schema for that provider.
 
-When source availability is unclear, call `data-source-status` and inspect existing dashboards, data-dictionary entries, and user/org resources before choosing a source. If multiple configured sources could answer the question, ask one concise clarification.
+When source availability is unclear for a data request, call `data-source-status` and inspect existing dashboards, data-dictionary entries, and user/org resources before choosing a source. If multiple configured sources could answer the question, ask one concise clarification. Do not call `data-source-status` just because the user is on an analytics screen; first decide whether the user actually asked for analytics data.
 
 When the user names a data source or tool, that source is authoritative for the turn. If they ask for Jira, Pylon, HubSpot, Gong, Slack, Sentry, GA4, or another provider by name, call that provider's action first and report its real result or unavailable/error state. Do not substitute BigQuery for a named provider unless the user explicitly asks for the warehouse copy, or the named provider is unavailable and the user chooses a fallback. `data-source-status --key <provider>` accepts provider aliases such as `jira`, `pylon`, `bigquery`, `hubspot`, `gong`, and `slack`.
 

--- a/templates/analytics/server/lib/real-data-actions.spec.ts
+++ b/templates/analytics/server/lib/real-data-actions.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   hasDataQueryAttempt,
+  isSafeNoDataAnalyticsResponse,
   looksLikeAnalyticsDataRequest,
   stripInjectedAnalyticsGuardContext,
 } from "./real-data-actions";
@@ -75,5 +76,37 @@ describe("analytics data request classification", () => {
     expect(looksLikeAnalyticsDataRequest("fix the dashboard layout")).toBe(
       false,
     );
+  });
+
+  it("does not classify generic chat/message bug reports as data requests", () => {
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "the chat keeps typing long messages that disappear",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("safe no-data analytics responses", () => {
+  it("allows explicit unavailable-source answers without forcing another retry", () => {
+    expect(
+      isSafeNoDataAnalyticsResponse(
+        "I can't retrieve this data right now because BigQuery credentials are not configured.",
+      ),
+    ).toBe(true);
+  });
+
+  it("allows clarification questions without unsupported result claims", () => {
+    expect(
+      isSafeNoDataAnalyticsResponse(
+        "Which data source should I use for signups: GA4 or BigQuery?",
+      ),
+    ).toBe(true);
+  });
+
+  it("blocks unsupported metric claims", () => {
+    expect(
+      isSafeNoDataAnalyticsResponse("The data shows 42 signups last week."),
+    ).toBe(false);
   });
 });

--- a/templates/analytics/server/lib/real-data-actions.spec.ts
+++ b/templates/analytics/server/lib/real-data-actions.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { hasDataQueryAttempt } from "./real-data-actions";
+import {
+  hasDataQueryAttempt,
+  looksLikeAnalyticsDataRequest,
+  stripInjectedAnalyticsGuardContext,
+} from "./real-data-actions";
 
 describe("real data action classification", () => {
   it("treats unstructured source records as real analytics evidence", () => {
@@ -23,5 +27,53 @@ describe("real data action classification", () => {
     expect(hasDataQueryAttempt([{ name: "data-source-status" }])).toBe(false);
     expect(hasDataQueryAttempt([{ name: "save-analysis" }])).toBe(false);
     expect(hasDataQueryAttempt([{ name: "generate-chart" }])).toBe(false);
+  });
+});
+
+describe("analytics data request classification", () => {
+  it("ignores framework-injected screen context when classifying the user ask", () => {
+    const text =
+      "i want a recurring job this is the .yml file\n\n" +
+      "<current-screen>\n" +
+      "Onboarding Progress\nCustomers in onboarding status\nMetrics dashboard\n" +
+      "</current-screen>";
+
+    expect(stripInjectedAnalyticsGuardContext(text)).toBe(
+      "i want a recurring job this is the .yml file",
+    );
+    expect(looksLikeAnalyticsDataRequest(text)).toBe(false);
+  });
+
+  it("does not treat GitHub Actions workflow migrations as analytics requests", () => {
+    const text =
+      '<attachment name="workflow.yml">\n' +
+      "on:\n  schedule:\n    - cron: '0 12 * * *'\n" +
+      "jobs:\n  post-message:\n    steps:\n      - run: pnpm script\n" +
+      "</attachment>\n\n" +
+      "I have a GitHub action from a previous repo and wanted to create a recurring job based on this .yml file.";
+
+    expect(looksLikeAnalyticsDataRequest(text)).toBe(false);
+  });
+
+  it("still recognizes real analytics questions after stripping context", () => {
+    const text =
+      "How many signups came from paid traffic last week?\n\n" +
+      "<current-screen>\nSettings page\n</current-screen>";
+
+    expect(looksLikeAnalyticsDataRequest(text)).toBe(true);
+  });
+
+  it("respects explicit real-data markers", () => {
+    expect(
+      looksLikeAnalyticsDataRequest(
+        "REAL_DATA_REQUIRED: analyze Slack messages for onboarding objections",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps non-data app maintenance requests out of the guard", () => {
+    expect(looksLikeAnalyticsDataRequest("fix the dashboard layout")).toBe(
+      false,
+    );
   });
 });

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -1,5 +1,15 @@
 export const REAL_DATA_REQUIRED_MARKER = "REAL_DATA_REQUIRED";
 
+const INJECTED_CONTEXT_BLOCKS = [
+  "current-screen",
+  "current-url",
+  "available-files",
+  "available-skills",
+  "available-agents",
+  "available-jobs",
+  "plan-mode-note",
+];
+
 export const DATA_QUERY_ACTIONS = new Set([
   "amplitude-events",
   "apollo-search",
@@ -62,6 +72,65 @@ function isMcpDataSourceTool(name: string): boolean {
   if (!name.startsWith("mcp__")) return false;
   const normalized = name.toLowerCase();
   return MCP_DATA_SOURCE_TOKENS.some((token) => normalized.includes(token));
+}
+
+export function stripInjectedAnalyticsGuardContext(text: string): string {
+  let requestText = text;
+  for (const tag of INJECTED_CONTEXT_BLOCKS) {
+    requestText = requestText.replace(
+      new RegExp(`\\n*<${tag}>[\\s\\S]*?<\\/${tag}>`, "gi"),
+      "",
+    );
+  }
+  return requestText.trim();
+}
+
+function looksLikeWorkflowOrAutomationRequest(lower: string): boolean {
+  const hasWorkflowArtifact =
+    /\b(github actions?|ya?ml|cron|scheduled job|recurring job|pnpm script)\b|\.(?:ya?ml)\b/.test(
+      lower,
+    );
+  const hasCreationIntent =
+    /\b(want|need|create|make|set up|setup|add|migrate|move|port|convert|turn|translate|recreate|build)\b/.test(
+      lower,
+    );
+  const hasAutomationTarget =
+    /\b(recurring job|scheduled job|job|automation|automations|workflow|workflows|cron)\b/.test(
+      lower,
+    );
+
+  return (
+    /\brecurring job\b/.test(lower) ||
+    (hasWorkflowArtifact && hasCreationIntent) ||
+    (hasCreationIntent &&
+      hasAutomationTarget &&
+      /\bgithub actions?\b/.test(lower))
+  );
+}
+
+export function looksLikeAnalyticsDataRequest(text: string): boolean {
+  const requestText = stripInjectedAnalyticsGuardContext(text);
+  const lower = requestText.toLowerCase();
+  if (!lower) return false;
+  if (lower.includes(REAL_DATA_REQUIRED_MARKER.toLowerCase())) return true;
+  if (looksLikeWorkflowOrAutomationRequest(lower)) return false;
+  if (
+    /\b(open|navigate|go to|rename|delete|share|favorite|unfavorite)\b/.test(
+      lower,
+    )
+  ) {
+    return false;
+  }
+  if (
+    /\b(fix|bug|layout|style|component|route|code|source code|integration|connect|configure|settings)\b/.test(
+      lower,
+    )
+  ) {
+    return false;
+  }
+  return /\b(analy[sz]e|analysis|dashboard|panel|metric|metrics|count|total|trend|breakdown|conversion|funnel|revenue|traffic|pageviews?|signups?|events?|users?|sessions?|retention|churn|pipeline|deals?|calls?|transcripts?|messages?|sentiment|themes?|objections?)\b/.test(
+    lower,
+  );
 }
 
 export function hasDataQueryAttempt(

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -108,6 +108,17 @@ function looksLikeWorkflowOrAutomationRequest(lower: string): boolean {
   );
 }
 
+const ANALYTICS_RESULT_TERMS =
+  /\b(conversion|conversions|funnel|revenue|traffic|pageviews?|signups?|events?|active users?|sessions?|retention|churn|pipeline|deals?|calls?|transcripts?|sentiment|themes?|objections?|cohorts?|segments?|accounts?|customers?|tickets?|issues?|leads?|opportunities|mrr|arr|ctr|cvr|cac|ltv)\b/;
+
+const ANALYTICS_INTENT_TERMS =
+  /\b(analy[sz]e|measure|calculate|query|report|summari[sz]e|break ?down|compare|rank|segment|forecast|trend|count|total|average|median|percent(?:age)?|rate|top|bottom|highest|lowest|how many|how much|what (?:is|are|was|were)|which|why)\b/;
+
+const ARTIFACT_TERMS = /\b(analysis|dashboard|panel|chart|metric|metrics)\b/;
+
+const ARTIFACT_DATA_INTENT =
+  /\b(build|create|make|show|visuali[sz]e|plot|chart|query|calculate|report)\b/;
+
 export function looksLikeAnalyticsDataRequest(text: string): boolean {
   const requestText = stripInjectedAnalyticsGuardContext(text);
   const lower = requestText.toLowerCase();
@@ -128,9 +139,30 @@ export function looksLikeAnalyticsDataRequest(text: string): boolean {
   ) {
     return false;
   }
-  return /\b(analy[sz]e|analysis|dashboard|panel|metric|metrics|count|total|trend|breakdown|conversion|funnel|revenue|traffic|pageviews?|signups?|events?|users?|sessions?|retention|churn|pipeline|deals?|calls?|transcripts?|messages?|sentiment|themes?|objections?)\b/.test(
-    lower,
+
+  if (ANALYTICS_RESULT_TERMS.test(lower)) return true;
+  if (ANALYTICS_INTENT_TERMS.test(lower) && /\b(data|source|table|sql)\b/.test(lower)) {
+    return true;
+  }
+  return (
+    ARTIFACT_TERMS.test(lower) &&
+    ARTIFACT_DATA_INTENT.test(lower) &&
+    ANALYTICS_RESULT_TERMS.test(lower)
   );
+}
+
+const UNSUPPORTED_RESULT_CLAIM =
+  /(?:\b\d[\d,.]*(?:\.\d+)?\s*(?:%|percent|users?|customers?|accounts?|sessions?|events?|deals?|tickets?|issues?|calls?|messages?|signups?|pageviews?)\b|\$\s*\d|\b(?:data|query|results?)\s+(?:shows?|showed|indicates?|returned|found)\b|\b(?:i found|the top|the bottom|highest|lowest|increased|decreased|grew|declined|converted|churned|retained|averaged|total(?:ed)?|count(?:ed)?)\b)/i;
+
+const SAFE_NO_DATA_RESPONSE =
+  /\b(?:i can't|i cannot|can't retrieve|cannot retrieve|couldn't retrieve|unable to retrieve|don't have access|do not have access|not configured|missing credentials?|need (?:a|the)? ?data source|need to know which source|which source|which data source|clarify|can you|once (?:that'?s|it is) (?:connected|configured|available)|no data source|without a successful|before (?:i|we) can (?:calculate|report|answer|analyze)|i need to query)\b/i;
+
+export function isSafeNoDataAnalyticsResponse(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  if (UNSUPPORTED_RESULT_CLAIM.test(trimmed)) return false;
+  if (SAFE_NO_DATA_RESPONSE.test(trimmed)) return true;
+  return /\?\s*$/.test(trimmed) && !UNSUPPORTED_RESULT_CLAIM.test(trimmed);
 }
 
 export function hasDataQueryAttempt(

--- a/templates/analytics/server/lib/real-data-actions.ts
+++ b/templates/analytics/server/lib/real-data-actions.ts
@@ -141,7 +141,10 @@ export function looksLikeAnalyticsDataRequest(text: string): boolean {
   }
 
   if (ANALYTICS_RESULT_TERMS.test(lower)) return true;
-  if (ANALYTICS_INTENT_TERMS.test(lower) && /\b(data|source|table|sql)\b/.test(lower)) {
+  if (
+    ANALYTICS_INTENT_TERMS.test(lower) &&
+    /\b(data|source|table|sql)\b/.test(lower)
+  ) {
     return true;
   }
   return (

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -11,6 +11,7 @@ import {
 } from "../lib/scoped-settings";
 import {
   hasDataQueryAttempt,
+  isSafeNoDataAnalyticsResponse,
   looksLikeAnalyticsDataRequest,
 } from "../lib/real-data-actions";
 
@@ -36,12 +37,13 @@ function realDataFinalGuard(context: AgentLoopFinalResponseGuardContext) {
   const userText = latestUserText(context.messages ?? []);
   if (!looksLikeAnalyticsDataRequest(userText)) return null;
   if (hasDataQueryAttempt(context.toolResults)) return null;
+  if (isSafeNoDataAnalyticsResponse(context.text)) return null;
 
   return {
     retryMessage:
-      "This analytics request requires real evidence before the answer can be final. Run at least one data-source action or connected provider MCP tool now. If the user named a source or tool (for example Jira, Pylon, HubSpot, Gong, Slack, Sentry, GA4, or BigQuery), use that named provider first; for HubSpot, use `hubspot-records` or a HubSpot MCP search tool for contacts/companies/tickets/general CRM records and `hubspot-deals`/`hubspot-metrics` for pipeline metrics. Do not substitute BigQuery for provider-specific data unless the user explicitly asks for a warehouse copy. Structured tables and unstructured records such as HubSpot CRM records, Pylon tickets, Jira issues, Gong calls/transcripts, and Slack messages all count as real evidence. `data-source-status`, `list-data-dictionary`, `update-dashboard`, `save-analysis`, and `generate-chart` do not count. If no source can answer, call the most relevant named source action/tool and report its exact unavailable/error result instead of inventing data.",
+      "This looks like an analytics result request, but no real source query ran. If you are making data claims, run one relevant data-source action or connected provider MCP tool now and answer from that result. If the right response is a clarification, plan, or explicit unavailable/credentials-missing message with no metrics or source-record claims, finalize that directly instead.",
     fallbackMessage:
-      "I stopped before finalizing because this analytics request requires real source evidence, and no data-source action or connected provider tool ran. I won't invent analytics results.",
+      "I can't provide a grounded analytics result yet because no real data-source query ran successfully. Tell me which source to use or connect the missing source, and I'll run it before giving numbers or source-record conclusions.",
   };
 }
 
@@ -98,6 +100,7 @@ export default createAgentChatPlugin({
     // having credentials or workspace-specific schemas configured.
     const sourceGuidance =
       "<data-source-guidance>\n" +
+      "Apply real-data requirements only when presenting analytics results, source records, or derived metrics. Do not call data-source tools for workflow migration, recurring-job setup, UI/code fixes, settings help, conceptual planning, or other non-data tasks unless the user explicitly asks for data. " +
       "Use configured data sources and actions only. Call `data-source-status` when you need to know which providers are connected, and treat provider actions as unavailable for analysis if they return missing credentials, permission, syntax, quota, or network errors. " +
       "When the user names a provider or tool such as Jira, Pylon, HubSpot, Gong, Slack, Sentry, GA4, or BigQuery, that named source is authoritative for the turn: check that provider and call its action or connected MCP tool first. For HubSpot, call `hubspot-records` or a HubSpot MCP search tool for contacts, companies, tickets, or broad CRM lookup; call `hubspot-deals`, `hubspot-metrics`, or `hubspot-pipelines` for deal pipeline analysis. Do not substitute BigQuery for Pylon, Jira, HubSpot, or another provider unless the user explicitly asks for the warehouse copy or the named provider is unavailable and the user chooses a fallback. " +
       "When the user refers to the current analysis, this analysis, this project, or asks to spin off, adapt, modify, or reuse a saved analysis, call `view-screen` first and use the returned analysis details; if an analysis id or @mention is provided, call `get-analysis` before responding. " +
@@ -105,7 +108,7 @@ export default createAgentChatPlugin({
       "For ordinary ad-hoc data questions, answer the explicit question after the first relevant successful query or bounded evidence batch instead of continuing into suggested follow-up investigations. " +
       "Unstructured source records are valid analytics evidence: Pylon tickets, Jira issues, Gong calls/transcripts, Slack messages, and similar text records may be coded for themes, mention counts, sentiment, objections, and qualitative patterns as long as the answer states the inspected sample size and does not imply unsupported statistical certainty. " +
       "For schema questions, prefer data-dictionary entries and configured warehouse schemas over assumptions. " +
-      "Never substitute fabricated numbers for a failed query or unavailable provider.\n" +
+      "Never substitute fabricated numbers for a failed query or unavailable provider. It is fine to ask a clarifying question, provide a plan, or say exactly which source is unavailable as long as you do not present metrics or source-record conclusions without evidence.\n" +
       "</data-source-guidance>";
 
     try {

--- a/templates/analytics/server/plugins/agent-chat.ts
+++ b/templates/analytics/server/plugins/agent-chat.ts
@@ -11,7 +11,7 @@ import {
 } from "../lib/scoped-settings";
 import {
   hasDataQueryAttempt,
-  REAL_DATA_REQUIRED_MARKER,
+  looksLikeAnalyticsDataRequest,
 } from "../lib/real-data-actions";
 
 const SQL_DASHBOARD_PREFIX = "sql-dashboard-";
@@ -30,28 +30,6 @@ function latestUserText(
     if (text.trim()) return text;
   }
   return "";
-}
-
-function looksLikeAnalyticsDataRequest(text: string): boolean {
-  const lower = text.toLowerCase();
-  if (lower.includes(REAL_DATA_REQUIRED_MARKER.toLowerCase())) return true;
-  if (
-    /\b(open|navigate|go to|rename|delete|share|favorite|unfavorite)\b/.test(
-      lower,
-    )
-  ) {
-    return false;
-  }
-  if (
-    /\b(fix|bug|layout|style|component|route|code|source code|integration|connect|configure|settings)\b/.test(
-      lower,
-    )
-  ) {
-    return false;
-  }
-  return /\b(analy[sz]e|analysis|dashboard|panel|metric|metrics|count|total|trend|breakdown|conversion|funnel|revenue|traffic|pageviews?|signups?|events?|users?|sessions?|retention|churn|pipeline|deals?|calls?|transcripts?|messages?|sentiment|themes?|objections?)\b/.test(
-    lower,
-  );
 }
 
 function realDataFinalGuard(context: AgentLoopFinalResponseGuardContext) {

--- a/templates/calendar/actions/db-connect.ts
+++ b/templates/calendar/actions/db-connect.ts
@@ -38,7 +38,7 @@ export default defineAction({
     const maskedUrl = url.replace(/\/\/.*@/, "//***@");
 
     try {
-      const { createClient } = await import("@libsql/client");
+      const { createClient } = await import("@libsql/client/web");
       const client = createClient({ url, authToken: token || undefined });
       await client.execute("SELECT 1");
     } catch (err: any) {

--- a/templates/calendar/actions/db-status.ts
+++ b/templates/calendar/actions/db-status.ts
@@ -1,4 +1,5 @@
 import { defineAction } from "@agent-native/core";
+import { getDbExec } from "@agent-native/core/db";
 import { z } from "zod";
 
 export default defineAction({
@@ -10,15 +11,11 @@ export default defineAction({
     const isLocal = url.startsWith("file:");
 
     try {
-      const { createClient } = await import("@libsql/client");
-      const client = createClient({
-        url,
-        authToken: process.env.DATABASE_AUTH_TOKEN,
-      });
+      const db = getDbExec();
 
-      await client.execute("SELECT 1");
+      await db.execute("SELECT 1");
 
-      const result = await client.execute(
+      const result = await db.execute(
         "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE '__%' ORDER BY name",
       );
       const tables = result.rows.map((r) => r.name as string);

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -440,15 +440,15 @@ Scripts use `readAppState()` / `writeAppState()` from `@agent-native/core/applic
 
 ### Reading & Searching
 
-| Action              | Args                                                                                               | Purpose                                       |
-| ------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| `view-screen`       | `[--full]`                                                                                         | See what the user is looking at right now     |
-| `view-composer`     | `[--id=<draft-id>]`                                                                                | See all open compose drafts                   |
-| `get-mail-settings` | none                                                                                               | Read signature and writing style              |
-| `list-emails`       | `--view <inbox\|unread\|starred\|sent\|...> --q <term> [--account <email>] [--includeCounts=true]` | List and search emails (uses Gmail via API)   |
-| `search-emails`     | `--q <term> [--view <name>] [--account <email>] [--includeCounts=true]`                            | Search emails across all views (requires --q) |
-| `get-email`         | `--id <email-id>`                                                                                  | Get a single email by ID                      |
-| `get-thread`        | `--id <thread-id> [--compact]`                                                                     | Get all messages in a thread                  |
+| Action                | Args                                                                                               | Purpose                                       |
+| --------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `view-screen`         | `[--full]`                                                                                         | See what the user is looking at right now     |
+| `view-composer`       | `[--id=<draft-id>]`                                                                                | See all open compose drafts                   |
+| `get-mail-settings`   | none                                                                                               | Read signature and writing style              |
+| `list-emails`         | `--view <inbox\|unread\|starred\|sent\|...> --q <term> [--account <email>] [--includeCounts=true]` | List and search emails (uses Gmail via API)   |
+| `search-emails`       | `--q <term> [--view <name>] [--account <email>] [--includeCounts=true]`                            | Search emails across all views (requires --q) |
+| `get-email`           | `--id <email-id>`                                                                                  | Get a single email by ID                      |
+| `get-thread`          | `--id <thread-id> [--compact]`                                                                     | Get all messages in a thread                  |
 | `get-hubspot-contact` | `--email <email>`                                                                                  | Look up HubSpot contact, deals, and tickets   |
 
 ### Actions

--- a/templates/mail/AGENTS.md
+++ b/templates/mail/AGENTS.md
@@ -43,6 +43,37 @@ title: Q3 Budget Proposal
 ```
 ````
 
+## Actionable Inbox Triage
+
+When the user asks to summarize, triage, prioritize, catch up on, or find emails that need replies, make the response actionable instead of just descriptive.
+
+Use this shape by default:
+
+1. **Needs attention / likely replies** — emails where the user probably owes a response, decision, approval, scheduling answer, customer follow-up, or sensitive acknowledgement.
+2. **Follow-up tasks** — action items implied by the emails, even when the right next step is not a reply.
+3. **FYI / no action** — important context the user may want to know, but no obvious response needed.
+
+For every item in the first two groups, include:
+
+- Sender and subject.
+- Why it matters in one short sentence.
+- The concrete next action.
+- A direct app link using the route `/<view>/<threadId>` (for example `[Open email](/inbox/abc123)`). Use the current view from `view-screen` when available; otherwise default to `inbox`.
+
+For the top one to three most important threads, also include an inline `embed` preview immediately next to the sentence that references it. Keep the embed cap from the Inline Previews section.
+
+After the triage, ask a specific follow-up question that moves the workflow forward, such as:
+
+> Want me to draft replies for the urgent ones, turn the follow-ups into a checklist, or archive the FYIs?
+
+When the user asks for help prioritizing and writing responses, create or update compose drafts for the selected urgent threads instead of only describing what you would write. Use `get-mail-settings` first, then `manage-draft --action=create --mode=reply --replyToId=<message-id> --replyToThreadId=<thread-id> ...` for each draft. Never send unless the user explicitly asks to send.
+
+For sales, customer, PG, support, or account follow-up, enrich the top candidates with CRM context when possible:
+
+- Run `pnpm action get-hubspot-contact --email=<sender-email>` for the sender or relevant customer contact.
+- Use HubSpot context to raise priority when there are open deals, tickets, lifecycle stage signals, or recent account activity.
+- If HubSpot is not configured or the contact is not found, continue with Gmail-only triage and mention no CRM signal only when it affects the recommendation.
+
 ## Resources
 
 Resources are SQL-backed persistent files for storing notes, learnings, and context. They replace the old `LEARNINGS.md` file approach — resources are stored in the database, not the filesystem.
@@ -263,6 +294,7 @@ Common operations:
 - **Create/edit drafts:** `pnpm action manage-draft --action=create --to=... --subject=... --body=...`
 - **Navigate UI:** `pnpm action navigate --view=inbox` or `--threadId=...`
 - **Search:** `pnpm action search-emails --q=term`
+- **Check CRM context:** `pnpm action get-hubspot-contact --email=<sender@example.com>`
 
 See the full Scripts section below for all available scripts and arguments.
 
@@ -417,6 +449,7 @@ Scripts use `readAppState()` / `writeAppState()` from `@agent-native/core/applic
 | `search-emails`     | `--q <term> [--view <name>] [--account <email>] [--includeCounts=true]`                            | Search emails across all views (requires --q) |
 | `get-email`         | `--id <email-id>`                                                                                  | Get a single email by ID                      |
 | `get-thread`        | `--id <thread-id> [--compact]`                                                                     | Get all messages in a thread                  |
+| `get-hubspot-contact` | `--email <email>`                                                                                  | Look up HubSpot contact, deals, and tickets   |
 
 ### Actions
 

--- a/templates/mail/actions/get-hubspot-contact.ts
+++ b/templates/mail/actions/get-hubspot-contact.ts
@@ -1,0 +1,40 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import { resolveOwnerEmail } from "./helpers.js";
+import {
+  getHubSpotApiKey,
+  HubSpotLookupError,
+  lookupHubSpotContact,
+} from "../server/lib/hubspot.js";
+
+export default defineAction({
+  description:
+    "Look up HubSpot CRM context for an email address, including contact details, associated deals, and associated tickets.",
+  schema: z.object({
+    email: z
+      .string()
+      .trim()
+      .min(1)
+      .describe("Email address of the contact to look up in HubSpot."),
+  }),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async ({ email }) => {
+    const ownerEmail = await resolveOwnerEmail();
+    const apiKey = await getHubSpotApiKey(ownerEmail);
+
+    if (!apiKey) {
+      return { error: "HubSpot API key not configured" };
+    }
+
+    try {
+      return await lookupHubSpotContact(apiKey, email);
+    } catch (error) {
+      if (error instanceof HubSpotLookupError) {
+        return { error: error.message };
+      }
+
+      return { error: "Failed to reach HubSpot API" };
+    }
+  },
+});

--- a/templates/mail/server/handlers/hubspot.ts
+++ b/templates/mail/server/handlers/hubspot.ts
@@ -4,8 +4,12 @@ import {
   setResponseStatus,
   type H3Event,
 } from "h3";
-import { appStateGet } from "@agent-native/core/application-state";
 import { getSession } from "@agent-native/core/server";
+import {
+  getHubSpotApiKey,
+  HubSpotLookupError,
+  lookupHubSpotContact,
+} from "../lib/hubspot.js";
 
 async function getSessionId(event: H3Event): Promise<string> {
   const session = await getSession(event);
@@ -15,8 +19,7 @@ async function getSessionId(event: H3Event): Promise<string> {
 
 async function getHubSpotKey(event: H3Event): Promise<string | undefined> {
   const sessionId = await getSessionId(event);
-  const data = await appStateGet(sessionId, "hubspot");
-  return (data as any)?.apiKey || undefined;
+  return getHubSpotApiKey(sessionId);
 }
 
 // GET /api/hubspot/contact?email=...
@@ -35,164 +38,13 @@ export const hubspotContactLookup = defineEventHandler(
     }
 
     try {
-      // Search for contact by email
-      const searchRes = await fetch(
-        "https://api.hubapi.com/crm/v3/objects/contacts/search",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${apiKey}`,
-          },
-          body: JSON.stringify({
-            filterGroups: [
-              {
-                filters: [
-                  { propertyName: "email", operator: "EQ", value: email },
-                ],
-              },
-            ],
-            properties: [
-              "firstname",
-              "lastname",
-              "email",
-              "phone",
-              "company",
-              "jobtitle",
-              "lifecyclestage",
-              "hs_lead_status",
-              "lastmodifieddate",
-              "createdate",
-              "hubspot_owner_id",
-            ],
-          }),
-        },
-      );
-
-      if (!searchRes.ok) {
-        setResponseStatus(event, searchRes.status);
-        return { error: `HubSpot API error: ${searchRes.status}` };
+      return await lookupHubSpotContact(apiKey, email);
+    } catch (error) {
+      if (error instanceof HubSpotLookupError) {
+        setResponseStatus(event, error.statusCode);
+        return { error: error.message };
       }
 
-      const searchData = await searchRes.json();
-      const contact = searchData.results?.[0] || null;
-      if (!contact) {
-        return null;
-      }
-
-      // Fetch associated deals
-      let deals: any[] = [];
-      try {
-        const dealsRes = await fetch(
-          `https://api.hubapi.com/crm/v3/objects/contacts/${contact.id}/associations/deals`,
-          {
-            headers: { Authorization: `Bearer ${apiKey}` },
-          },
-        );
-        if (dealsRes.ok) {
-          const dealsData = await dealsRes.json();
-          const dealIds = (dealsData.results || [])
-            .slice(0, 5)
-            .map((d: any) => d.id);
-          if (dealIds.length > 0) {
-            const batchRes = await fetch(
-              "https://api.hubapi.com/crm/v3/objects/deals/batch/read",
-              {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                  Authorization: `Bearer ${apiKey}`,
-                },
-                body: JSON.stringify({
-                  inputs: dealIds.map((id: string) => ({ id })),
-                  properties: [
-                    "dealname",
-                    "amount",
-                    "dealstage",
-                    "closedate",
-                    "pipeline",
-                  ],
-                }),
-              },
-            );
-            if (batchRes.ok) {
-              const batchData = await batchRes.json();
-              deals = (batchData.results || []).map((d: any) => ({
-                id: d.id,
-                name: d.properties?.dealname,
-                amount: d.properties?.amount,
-                stage: d.properties?.dealstage,
-                closeDate: d.properties?.closedate,
-              }));
-            }
-          }
-        }
-      } catch {}
-
-      // Fetch associated tickets
-      let tickets: any[] = [];
-      try {
-        const ticketsRes = await fetch(
-          `https://api.hubapi.com/crm/v3/objects/contacts/${contact.id}/associations/tickets`,
-          {
-            headers: { Authorization: `Bearer ${apiKey}` },
-          },
-        );
-        if (ticketsRes.ok) {
-          const ticketsData = await ticketsRes.json();
-          const ticketIds = (ticketsData.results || [])
-            .slice(0, 5)
-            .map((t: any) => t.id);
-          if (ticketIds.length > 0) {
-            const batchRes = await fetch(
-              "https://api.hubapi.com/crm/v3/objects/tickets/batch/read",
-              {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                  Authorization: `Bearer ${apiKey}`,
-                },
-                body: JSON.stringify({
-                  inputs: ticketIds.map((id: string) => ({ id })),
-                  properties: [
-                    "subject",
-                    "hs_pipeline_stage",
-                    "hs_ticket_priority",
-                    "createdate",
-                  ],
-                }),
-              },
-            );
-            if (batchRes.ok) {
-              const batchData = await batchRes.json();
-              tickets = (batchData.results || []).map((t: any) => ({
-                id: t.id,
-                subject: t.properties?.subject,
-                stage: t.properties?.hs_pipeline_stage,
-                priority: t.properties?.hs_ticket_priority,
-                created: t.properties?.createdate,
-              }));
-            }
-          }
-        }
-      } catch {}
-
-      return {
-        id: contact.id,
-        firstName: contact.properties?.firstname,
-        lastName: contact.properties?.lastname,
-        email: contact.properties?.email,
-        phone: contact.properties?.phone,
-        company: contact.properties?.company,
-        title: contact.properties?.jobtitle,
-        lifecycleStage: contact.properties?.lifecyclestage,
-        leadStatus: contact.properties?.hs_lead_status,
-        lastModified: contact.properties?.lastmodifieddate,
-        created: contact.properties?.createdate,
-        deals,
-        tickets,
-      };
-    } catch {
       setResponseStatus(event, 500);
       return { error: "Failed to reach HubSpot API" };
     }

--- a/templates/mail/server/lib/hubspot.ts
+++ b/templates/mail/server/lib/hubspot.ts
@@ -1,0 +1,251 @@
+import { appStateGet } from "@agent-native/core/application-state";
+
+const HUBSPOT_BASE_URL = "https://api.hubapi.com";
+
+const CONTACT_PROPERTIES = [
+  "firstname",
+  "lastname",
+  "email",
+  "phone",
+  "company",
+  "jobtitle",
+  "lifecyclestage",
+  "hs_lead_status",
+  "lastmodifieddate",
+  "createdate",
+  "hubspot_owner_id",
+];
+
+const DEAL_PROPERTIES = [
+  "dealname",
+  "amount",
+  "dealstage",
+  "closedate",
+  "pipeline",
+];
+
+const TICKET_PROPERTIES = [
+  "subject",
+  "hs_pipeline_stage",
+  "hs_ticket_priority",
+  "createdate",
+];
+
+type HubSpotRecord = {
+  id: string;
+  properties?: Record<string, string | undefined>;
+};
+
+type HubSpotSearchResponse = {
+  results?: HubSpotRecord[];
+};
+
+type HubSpotAssociationsResponse = {
+  results?: Array<{ id: string }>;
+};
+
+export type HubSpotDeal = {
+  id: string;
+  name?: string;
+  amount?: string;
+  stage?: string;
+  closeDate?: string;
+};
+
+export type HubSpotTicket = {
+  id: string;
+  subject?: string;
+  stage?: string;
+  priority?: string;
+  created?: string;
+};
+
+export type HubSpotContact = {
+  id: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  company?: string;
+  title?: string;
+  lifecycleStage?: string;
+  leadStatus?: string;
+  lastModified?: string;
+  created?: string;
+  deals: HubSpotDeal[];
+  tickets: HubSpotTicket[];
+};
+
+export class HubSpotLookupError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message);
+    this.name = "HubSpotLookupError";
+  }
+}
+
+export async function getHubSpotApiKey(
+  sessionId: string,
+): Promise<string | undefined> {
+  const data = await appStateGet(sessionId, "hubspot");
+  const apiKey = (data as { apiKey?: unknown } | undefined)?.apiKey;
+  return typeof apiKey === "string" && apiKey.length > 0 ? apiKey : undefined;
+}
+
+function hubSpotHeaders(apiKey: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json()) as T;
+}
+
+async function readAssociatedObjectIds(
+  apiKey: string,
+  contactId: string,
+  objectType: "deals" | "tickets",
+): Promise<string[]> {
+  const response = await fetch(
+    `${HUBSPOT_BASE_URL}/crm/v3/objects/contacts/${contactId}/associations/${objectType}`,
+    {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    },
+  );
+
+  if (!response.ok) return [];
+
+  const data = await readJson<HubSpotAssociationsResponse>(response);
+  return (data.results || []).slice(0, 5).map((item) => item.id);
+}
+
+async function readAssociatedDeals(
+  apiKey: string,
+  contactId: string,
+): Promise<HubSpotDeal[]> {
+  try {
+    const dealIds = await readAssociatedObjectIds(apiKey, contactId, "deals");
+    if (dealIds.length === 0) return [];
+
+    const response = await fetch(
+      `${HUBSPOT_BASE_URL}/crm/v3/objects/deals/batch/read`,
+      {
+        method: "POST",
+        headers: hubSpotHeaders(apiKey),
+        body: JSON.stringify({
+          inputs: dealIds.map((id) => ({ id })),
+          properties: DEAL_PROPERTIES,
+        }),
+      },
+    );
+
+    if (!response.ok) return [];
+
+    const data = await readJson<HubSpotSearchResponse>(response);
+    return (data.results || []).map((deal) => ({
+      id: deal.id,
+      name: deal.properties?.dealname,
+      amount: deal.properties?.amount,
+      stage: deal.properties?.dealstage,
+      closeDate: deal.properties?.closedate,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function readAssociatedTickets(
+  apiKey: string,
+  contactId: string,
+): Promise<HubSpotTicket[]> {
+  try {
+    const ticketIds = await readAssociatedObjectIds(
+      apiKey,
+      contactId,
+      "tickets",
+    );
+    if (ticketIds.length === 0) return [];
+
+    const response = await fetch(
+      `${HUBSPOT_BASE_URL}/crm/v3/objects/tickets/batch/read`,
+      {
+        method: "POST",
+        headers: hubSpotHeaders(apiKey),
+        body: JSON.stringify({
+          inputs: ticketIds.map((id) => ({ id })),
+          properties: TICKET_PROPERTIES,
+        }),
+      },
+    );
+
+    if (!response.ok) return [];
+
+    const data = await readJson<HubSpotSearchResponse>(response);
+    return (data.results || []).map((ticket) => ({
+      id: ticket.id,
+      subject: ticket.properties?.subject,
+      stage: ticket.properties?.hs_pipeline_stage,
+      priority: ticket.properties?.hs_ticket_priority,
+      created: ticket.properties?.createdate,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export async function lookupHubSpotContact(
+  apiKey: string,
+  email: string,
+): Promise<HubSpotContact | null> {
+  const searchResponse = await fetch(
+    `${HUBSPOT_BASE_URL}/crm/v3/objects/contacts/search`,
+    {
+      method: "POST",
+      headers: hubSpotHeaders(apiKey),
+      body: JSON.stringify({
+        filterGroups: [
+          {
+            filters: [{ propertyName: "email", operator: "EQ", value: email }],
+          },
+        ],
+        properties: CONTACT_PROPERTIES,
+      }),
+    },
+  );
+
+  if (!searchResponse.ok) {
+    throw new HubSpotLookupError(
+      `HubSpot API error: ${searchResponse.status}`,
+      searchResponse.status,
+    );
+  }
+
+  const searchData = await readJson<HubSpotSearchResponse>(searchResponse);
+  const contact = searchData.results?.[0] || null;
+  if (!contact) return null;
+
+  const [deals, tickets] = await Promise.all([
+    readAssociatedDeals(apiKey, contact.id),
+    readAssociatedTickets(apiKey, contact.id),
+  ]);
+
+  return {
+    id: contact.id,
+    firstName: contact.properties?.firstname,
+    lastName: contact.properties?.lastname,
+    email: contact.properties?.email,
+    phone: contact.properties?.phone,
+    company: contact.properties?.company,
+    title: contact.properties?.jobtitle,
+    lifecycleStage: contact.properties?.lifecyclestage,
+    leadStatus: contact.properties?.hs_lead_status,
+    lastModified: contact.properties?.lastmodifieddate,
+    created: contact.properties?.createdate,
+    deals,
+    tickets,
+  };
+}

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -80,7 +80,8 @@ function describeUploadedFilesForAgent(
     "",
     "File handling rules:",
     `- PPTX files: call \`import-pptx --filePath "<path>" --deckId ${deckId}\` when the user wants the deck/slides imported, or to extract slide source from a presentation.`,
-    `- PDF, DOCX, and text-like files: call \`import-file --filePath "<path>" --format auto --deckId ${deckId}\` and use the returned content as source material.`,
+    `- PDF and DOCX files: call \`import-file --filePath "<path>" --format auto --deckId ${deckId}\` and use the returned content as source material.`,
+    "- Text-like files: use the uploaded-text-file blocks already included in the prompt; do not call import-file for them.",
     "- Image files: treat them as visual/reference assets only; do not claim to have processed a PPTX/PDF/DOCX unless the relevant import action succeeds.",
   ].join("\n");
 }

--- a/templates/slides/app/components/editor/QuestionFlow.tsx
+++ b/templates/slides/app/components/editor/QuestionFlow.tsx
@@ -11,6 +11,10 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import type { DesignSystemData, QuestionFlowQuestion } from "@shared/api";
+import {
+  SLIDES_REFERENCE_FILE_ACCEPT,
+  SLIDES_REFERENCE_FILE_LABEL,
+} from "@shared/upload-types";
 
 interface QuestionFlowProps {
   questions: QuestionFlowQuestion[];
@@ -436,14 +440,14 @@ function FileDropZone({
             <input
               type="file"
               multiple
-              accept="image/*,.pdf,.pptx,.docx"
+              accept={SLIDES_REFERENCE_FILE_ACCEPT}
               onChange={handleFileInput}
               className="hidden"
             />
           </label>
         </p>
         <p className="mt-1 text-[10px] text-muted-foreground/70">
-          Images, PDFs, PPTX, DOCX
+          {SLIDES_REFERENCE_FILE_LABEL}
         </p>
       </div>
 

--- a/templates/slides/app/pages/Index.tsx
+++ b/templates/slides/app/pages/Index.tsx
@@ -81,7 +81,8 @@ function describeUploadedFilesForAgent(
     "",
     "File handling rules:",
     `- PPTX files: call \`import-pptx --filePath "<path>" --deckId ${deckId}\` before adding or editing slides.`,
-    `- PDF, DOCX, and text-like files: call \`import-file --filePath "<path>" --format auto --deckId ${deckId}\` and use the returned content as source material.`,
+    `- PDF and DOCX files: call \`import-file --filePath "<path>" --format auto --deckId ${deckId}\` and use the returned content as source material.`,
+    "- Text-like files: use the uploaded-text-file blocks already included in the prompt; do not call import-file for them.",
     "- Image files: treat them as visual/reference assets only; do not claim to have processed a PPTX/PDF/DOCX unless the relevant import action succeeds.",
   ].join("\n");
 }

--- a/templates/slides/server/handlers/uploads.ts
+++ b/templates/slides/server/handlers/uploads.ts
@@ -8,22 +8,12 @@ import fs from "fs";
 import crypto from "crypto";
 import { nanoid } from "nanoid";
 import { getSession } from "@agent-native/core/server";
+import {
+  SLIDES_REFERENCE_FILE_ERROR_LABEL,
+  isSlidesReferenceFileExtension,
+} from "../../shared/upload-types";
 
 const UPLOADS_ROOT = path.join(process.cwd(), "data", "uploads");
-const ALLOWED_EXTENSIONS = new Set([
-  ".pptx",
-  ".docx",
-  ".pdf",
-  ".txt",
-  ".md",
-  ".csv",
-  ".json",
-  ".png",
-  ".jpg",
-  ".jpeg",
-  ".webp",
-  ".gif",
-]);
 
 function tenantUploadDir(email: string): string {
   const key = crypto
@@ -36,7 +26,7 @@ function tenantUploadDir(email: string): string {
 
 function safeFilename(originalName: string): string | null {
   const ext = path.extname(originalName).toLowerCase();
-  if (!ALLOWED_EXTENSIONS.has(ext)) return null;
+  if (!isSlidesReferenceFileExtension(ext)) return null;
   // Filename uniqueness comes from nanoid (~21 chars, ~126 bits of entropy),
   // not `Date.now()` — second-resolution timestamps are guessable and let
   // someone with the per-tenant URL prefix probe the upload window. The
@@ -117,7 +107,7 @@ export const uploadFiles = defineEventHandler(async (event) => {
         const filename = safeFilename(originalName);
         if (!filename) {
           throw new Error(
-            "Unsupported file type. Allowed: pptx, docx, pdf, text, JSON, CSV, and raster images.",
+            `Unsupported file type. Allowed: ${SLIDES_REFERENCE_FILE_ERROR_LABEL}.`,
           );
         }
         const ext = path.extname(filename).toLowerCase();

--- a/templates/slides/shared/upload-types.ts
+++ b/templates/slides/shared/upload-types.ts
@@ -1,0 +1,30 @@
+export const SLIDES_REFERENCE_FILE_EXTENSIONS = [
+  ".pptx",
+  ".docx",
+  ".pdf",
+  ".txt",
+  ".md",
+  ".markdown",
+  ".csv",
+  ".json",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".webp",
+  ".gif",
+] as const;
+
+export const SLIDES_REFERENCE_FILE_ACCEPT =
+  SLIDES_REFERENCE_FILE_EXTENSIONS.join(",");
+
+export const SLIDES_REFERENCE_FILE_LABEL =
+  "PPTX, DOCX, PDF, text, Markdown, JSON, CSV, and images";
+
+export const SLIDES_REFERENCE_FILE_ERROR_LABEL =
+  "pptx, docx, pdf, text, Markdown, JSON, CSV, and raster images";
+
+export function isSlidesReferenceFileExtension(ext: string): boolean {
+  return SLIDES_REFERENCE_FILE_EXTENSIONS.includes(
+    ext.toLowerCase() as (typeof SLIDES_REFERENCE_FILE_EXTENSIONS)[number],
+  );
+}


### PR DESCRIPTION
## Summary

Seed PR for the next concurrent-agent batch. First commit fills in the assistant message body with formatted error text (via `formatChatErrorText`) on the missing-credential SSE path in `agent-chat-adapter`, instead of emitting an empty `text` part. Covers both the initial POST and the auto-continue retry path. Concurrent agent sweeps will land here as they arrive.

## Test plan

- [ ] Build, Lint, Test, Typecheck, Guard, Changeset all green
- [ ] Missing-key responses surface "Error: No LLM provider is connected" in the assistant message instead of an empty bubble