### PR TITLE
feat(mail): drag-drop attachments + optimistic sent hydration + signature image stripping

### DIFF
--- a/.changeset/empty-response-fallback.md
+++ b/.changeset/empty-response-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Surface a visible "model returned an empty response" message when an engine ends a turn with reasoning-only content and zero output text (e.g. OpenAI gpt-5+ Responses runs where reasoning consumes the entire output-token budget). Previously the SSE stream finished cleanly with no text, producing a silent empty assistant bubble.

--- a/.changeset/prepare-request-hook.md
+++ b/.changeset/prepare-request-hook.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add an optional `prepareRequest` hook on `ProductionAgentOptions` and `AgentChatPluginOptions` so templates can normalize the inbound chat request — materialize uploaded attachments into per-template file handles, rewrite the message, or append non-visible instructions — between owner resolution and system/context assembly. Re-export `AgentChatAttachment` from the core entry points so templates can type the hook's payload.

--- a/.changeset/slides-chat-attachment-prepare.md
+++ b/.changeset/slides-chat-attachment-prepare.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Add a server-side agent chat request preparation hook for templates to materialize uploaded attachments before a run starts.

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -15,6 +15,7 @@ export {
   type AgentMessage,
   type AgentChatRequest,
   type AgentChatEvent,
+  type AgentChatAttachment,
   type AgentChatReference,
   type MentionProvider,
   type MentionProviderItem,

--- a/packages/core/src/agent/production-agent.spec.ts
+++ b/packages/core/src/agent/production-agent.spec.ts
@@ -1330,6 +1330,91 @@ describe("runAgentLoop", () => {
     expect(events.at(-1)).toEqual({ type: "done" });
   });
 
+  it("surfaces a fallback message when the engine ends with no text or tool calls", async () => {
+    // Mirrors OpenAI Responses gpt-5+ producing reasoning-only content with
+    // zero `output_text` items: the engine still emits a clean `end_turn`
+    // stop, but parts contains only thinking. Without the fallback the run
+    // would render as a silent empty assistant bubble.
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: true,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield { type: "thinking-delta", text: "thinking out loud..." };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "thinking" as const, text: "thinking out loud..." }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {},
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    const textEvents = events.filter((e) => e.type === "text");
+    expect(textEvents).toHaveLength(1);
+    expect(textEvents[0].text).toMatch(/empty response/i);
+    expect(textEvents[0].text).toMatch(/different model/i);
+  });
+
+  it("does not surface the empty-response fallback when text was streamed", async () => {
+    const engine: AgentEngine = {
+      name: "test",
+      label: "Test",
+      defaultModel: "test-model",
+      supportedModels: ["test-model"],
+      capabilities: {
+        thinking: false,
+        promptCaching: false,
+        vision: false,
+        computerUse: false,
+        parallelToolCalls: false,
+      },
+      async *stream(): AsyncIterable<EngineEvent> {
+        yield { type: "text-delta", text: "Real answer." };
+        yield {
+          type: "assistant-content",
+          parts: [{ type: "text" as const, text: "Real answer." }],
+        };
+        yield { type: "stop", reason: "end_turn" };
+      },
+    };
+    const events: any[] = [];
+
+    await runAgentLoop({
+      engine,
+      model: "test-model",
+      systemPrompt: "system",
+      tools: [],
+      messages: [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      actions: {},
+      send: (event) => events.push(event),
+      signal: new AbortController().signal,
+    });
+
+    const textEvents = events.filter((e) => e.type === "text");
+    expect(textEvents).toHaveLength(1);
+    expect(textEvents[0].text).toBe("Real answer.");
+  });
+
   it("does not retry Builder gateway timeouts inside one serverless run", async () => {
     let streamCalls = 0;
     const engine: AgentEngine = {

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -452,6 +452,36 @@ export interface ProductionAgentOptions {
     message: string;
     attachments?: AgentChatAttachment[];
   }) => void | Promise<void>;
+  /**
+   * Optional per-template request normalizer. Runs after owner resolution and
+   * before system/context assembly so templates can materialize uploaded chat
+   * attachments or append app-specific, non-visible instructions.
+   */
+  prepareRequest?: (details: {
+    event: any;
+    ownerEmail: string | null;
+    message: string;
+    displayMessage?: string;
+    attachments: AgentChatAttachment[];
+    references: AgentChatReference[];
+    threadId?: string;
+    internalContinuation?: boolean;
+    mode: AgentExecutionMode;
+  }) =>
+    | void
+    | {
+        message?: string;
+        displayMessage?: string;
+        attachments?: AgentChatAttachment[];
+      }
+    | Promise<
+        | void
+        | {
+            message?: string;
+            displayMessage?: string;
+            attachments?: AgentChatAttachment[];
+          }
+      >;
   /** Optional per-app agent run chunk budget in milliseconds. Defaults to
    *  AGENT_RUN_SOFT_TIMEOUT_MS when set, otherwise no framework-imposed
    *  timeout. When reached, the client receives an internal auto-continuation
@@ -1632,14 +1662,41 @@ export function createProductionAgentHandler(
       setResponseStatus(event, 400);
       return { error: "message is required" };
     }
-    const requestMessage = hasMessageText
+    let requestMessage = hasMessageText
       ? message
       : "Use the attached context.";
+    let requestAttachments = Array.isArray(attachments) ? attachments : [];
+    let requestDisplayMessage = displayMessage;
 
     // Resolve owner first so we can look up a per-owner API key. Users
     // who bring their own key use their key for this request (durable
     // across serverless cold starts via the settings table).
     const ownerEmail = await resolveAgentOwnerEmail(options, event);
+    const preparedRequest = await options.prepareRequest?.({
+      event,
+      ownerEmail,
+      message: requestMessage,
+      displayMessage: requestDisplayMessage,
+      attachments: requestAttachments,
+      references,
+      threadId,
+      internalContinuation: Boolean(internalContinuation),
+      mode: requestMode,
+    });
+    if (preparedRequest) {
+      if (
+        typeof preparedRequest.message === "string" &&
+        preparedRequest.message.trim().length > 0
+      ) {
+        requestMessage = preparedRequest.message;
+      }
+      if (typeof preparedRequest.displayMessage === "string") {
+        requestDisplayMessage = preparedRequest.displayMessage;
+      }
+      if (Array.isArray(preparedRequest.attachments)) {
+        requestAttachments = preparedRequest.attachments;
+      }
+    }
 
     // When a per-request engine override is specified, resolve the API key
     // for that provider instead of the global active engine's provider.
@@ -1976,7 +2033,7 @@ export function createProductionAgentHandler(
 
     const userContent = buildUserContentWithAttachments({
       text: enrichedMessage + screenContext + filesContext + planModeAgentNote,
-      attachments,
+      attachments: requestAttachments,
     });
 
     const historyMessages =
@@ -2012,14 +2069,15 @@ export function createProductionAgentHandler(
     const runId = generateRunId();
     if (options.onRunPrepared && !internalContinuation) {
       const messageToPersist =
-        typeof displayMessage === "string" && displayMessage.trim().length > 0
-          ? displayMessage
+        typeof requestDisplayMessage === "string" &&
+        requestDisplayMessage.trim().length > 0
+          ? requestDisplayMessage
           : requestMessage;
       await options.onRunPrepared({
         runId,
         threadId,
         message: messageToPersist,
-        attachments: Array.isArray(attachments) ? attachments : [],
+        attachments: requestAttachments,
       });
     }
     startRun(

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -1289,6 +1289,7 @@ export async function runAgentLoop(opts: {
             retryCount: finalGuardRetries,
           })
         : null;
+      let guardEmittedFallback = false;
       if (guard) {
         const retryMessage =
           typeof guard === "string" ? guard : guard.retryMessage;
@@ -1303,8 +1304,25 @@ export async function runAgentLoop(opts: {
           continue;
         }
         send({ type: "text", text: fallbackMessage ?? retryMessage });
+        guardEmittedFallback = true;
       } else {
         flushBufferedAssistantText();
+      }
+      // Some providers (notably OpenAI Responses for gpt-5+) can stream a
+      // successful turn that contains only reasoning content and zero output
+      // text — typically when reasoning consumes the entire output-token
+      // budget. Without a final text part the SSE stream still ends with a
+      // clean `done`, which renders as a totally empty assistant bubble.
+      // Surface a plain-language error so the user knows what happened.
+      if (
+        !guardEmittedFallback &&
+        collectTextParts(assistantContentForHistory).trim().length === 0 &&
+        bufferedAssistantText.trim().length === 0
+      ) {
+        send({
+          type: "text",
+          text: "The model returned an empty response. This usually means reasoning used the full output-token budget. Try again, or pick a different model from the model menu.",
+        });
       }
       break;
     }

--- a/packages/core/src/agent/production-agent.ts
+++ b/packages/core/src/agent/production-agent.ts
@@ -474,14 +474,11 @@ export interface ProductionAgentOptions {
         displayMessage?: string;
         attachments?: AgentChatAttachment[];
       }
-    | Promise<
-        | void
-        | {
-            message?: string;
-            displayMessage?: string;
-            attachments?: AgentChatAttachment[];
-          }
-      >;
+    | Promise<void | {
+        message?: string;
+        displayMessage?: string;
+        attachments?: AgentChatAttachment[];
+      }>;
   /** Optional per-app agent run chunk budget in milliseconds. Defaults to
    *  AGENT_RUN_SOFT_TIMEOUT_MS when set, otherwise no framework-imposed
    *  timeout. When reached, the client receives an internal auto-continuation
@@ -1662,9 +1659,7 @@ export function createProductionAgentHandler(
       setResponseStatus(event, 400);
       return { error: "message is required" };
     }
-    let requestMessage = hasMessageText
-      ? message
-      : "Use the attached context.";
+    let requestMessage = hasMessageText ? message : "Use the attached context.";
     let requestAttachments = Array.isArray(attachments) ? attachments : [];
     let requestDisplayMessage = displayMessage;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export {
   type AgentMessage,
   type AgentChatRequest,
   type AgentChatEvent,
+  type AgentChatAttachment,
   DEFAULT_MODEL,
 } from "./agent/index.js";
 export {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1440,14 +1440,11 @@ export interface AgentChatPluginOptions {
         displayMessage?: string;
         attachments?: AgentChatAttachment[];
       }
-    | Promise<
-        | void
-        | {
-            message?: string;
-            displayMessage?: string;
-            attachments?: AgentChatAttachment[];
-          }
-      >;
+    | Promise<void | {
+        message?: string;
+        displayMessage?: string;
+        attachments?: AgentChatAttachment[];
+      }>;
   /**
    * Use ONLY the template's `systemPrompt` and the actions list — skip the
    * framework prompt wrapper, resource loading (AGENTS.md/LEARNINGS.md/

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -34,6 +34,7 @@ import { DEFAULT_ANTHROPIC_MODEL } from "../agent/default-model.js";
 import type {
   AgentChatAttachment,
   AgentChatEvent,
+  AgentChatReference,
   ActionTool,
   MentionProvider,
   MentionProviderItem,
@@ -1417,6 +1418,36 @@ export interface AgentChatPluginOptions {
    * real data-source tool calls for analytics requests.
    */
   finalResponseGuard?: import("../agent/production-agent.js").AgentLoopFinalResponseGuard;
+  /**
+   * Optional per-template request normalizer. Runs after authentication and
+   * before the model sees the message, so apps can translate chat attachments
+   * into template-native file handles while preserving the user's visible text.
+   */
+  prepareRequest?: (details: {
+    event: any;
+    ownerEmail: string | null;
+    message: string;
+    displayMessage?: string;
+    attachments: AgentChatAttachment[];
+    references: AgentChatReference[];
+    threadId?: string;
+    internalContinuation?: boolean;
+    mode: "act" | "plan";
+  }) =>
+    | void
+    | {
+        message?: string;
+        displayMessage?: string;
+        attachments?: AgentChatAttachment[];
+      }
+    | Promise<
+        | void
+        | {
+            message?: string;
+            displayMessage?: string;
+            attachments?: AgentChatAttachment[];
+          }
+      >;
   /**
    * Use ONLY the template's `systemPrompt` and the actions list — skip the
    * framework prompt wrapper, resource loading (AGENTS.md/LEARNINGS.md/
@@ -3715,6 +3746,7 @@ export function createAgentChatPlugin(
         apiKey: options?.apiKey,
         runSoftTimeoutMs: options?.runSoftTimeoutMs,
         finalResponseGuard: options?.finalResponseGuard,
+        prepareRequest: options?.prepareRequest,
         skipFilesContext: leanPrompt,
         onEngineResolved: (engine, model) => {
           const runCtx = ensureRequestRunContext();
@@ -3757,6 +3789,7 @@ export function createAgentChatPlugin(
               apiKey: options?.apiKey,
               runSoftTimeoutMs: options?.runSoftTimeoutMs,
               finalResponseGuard: options?.finalResponseGuard,
+              prepareRequest: options?.prepareRequest,
               skipFilesContext: true,
               onEngineResolved: (engine, model) => {
                 const runCtx = ensureRequestRunContext();
@@ -3854,6 +3887,7 @@ export function createAgentChatPlugin(
           apiKey: options?.apiKey,
           runSoftTimeoutMs: options?.runSoftTimeoutMs,
           finalResponseGuard: options?.finalResponseGuard,
+          prepareRequest: options?.prepareRequest,
           skipFilesContext: leanPrompt,
           onEngineResolved: (engine, model) => {
             const runCtx = ensureRequestRunContext();

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -34,6 +34,7 @@ export {
   type AgentMessage,
   type AgentChatRequest,
   type AgentChatEvent,
+  type AgentChatAttachment,
   type AgentChatReference,
   type MentionProvider,
   type MentionProviderItem,

--- a/templates/mail/actions/get-mail-settings.ts
+++ b/templates/mail/actions/get-mail-settings.ts
@@ -3,12 +3,13 @@ import { getRequestUserEmail } from "@agent-native/core/server";
 import { getUserSetting } from "@agent-native/core/settings";
 import { z } from "zod";
 import type { UserSettings } from "../shared/types.js";
+import { normalizeSignature } from "../shared/signature.js";
 
 function normalize(settings: Partial<UserSettings> | undefined, email: string) {
   return {
     name: settings?.name ?? "",
     email: settings?.email || email,
-    signature: settings?.signature ?? "",
+    signature: normalizeSignature(settings?.signature),
     writingStyle: settings?.writingStyle ?? "",
   };
 }

--- a/templates/mail/actions/import-gmail-signature.ts
+++ b/templates/mail/actions/import-gmail-signature.ts
@@ -32,7 +32,7 @@ async function readGmailSignature(accessToken: string, account: string) {
 
 export default defineAction({
   description:
-    "Import the user's configured Gmail signature into Mail drafting settings. Converts Gmail's HTML signature into compose-friendly Markdown while preserving links and safe images when possible.",
+    "Import the user's configured Gmail signature into Mail drafting settings. Converts Gmail's HTML signature into compose-friendly Markdown while preserving text and links.",
   schema: z.object({
     account: z
       .string()

--- a/templates/mail/actions/send-email.ts
+++ b/templates/mail/actions/send-email.ts
@@ -7,6 +7,7 @@ import {
   gmailSendMessage,
   googleFetch,
 } from "../server/lib/google-api.js";
+import { invalidateListCacheForOwner } from "../server/lib/google-auth.js";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
 import { emit } from "@agent-native/core/event-bus";
@@ -424,6 +425,7 @@ export default defineAction({
 
     try {
       const sent = await gmailSendMessage(selectedToken, raw, threadId);
+      invalidateListCacheForOwner(ownerEmail);
       if (tracking && sent?.id) {
         await persistTracking({
           pixelToken: tracking.pixelToken,

--- a/templates/mail/actions/update-mail-settings.ts
+++ b/templates/mail/actions/update-mail-settings.ts
@@ -3,6 +3,7 @@ import { getRequestUserEmail } from "@agent-native/core/server";
 import { getUserSetting, putUserSetting } from "@agent-native/core/settings";
 import { z } from "zod";
 import type { UserSettings } from "../shared/types.js";
+import { normalizeSignature } from "../shared/signature.js";
 
 const settingsSchema = z.object({
   name: z.string().optional().describe("Display name for local fallback mail"),
@@ -30,7 +31,9 @@ export default defineAction({
 
     const updates: Partial<UserSettings> = {};
     if (args.name !== undefined) updates.name = args.name.trim();
-    if (args.signature !== undefined) updates.signature = args.signature.trim();
+    if (args.signature !== undefined) {
+      updates.signature = normalizeSignature(args.signature);
+    }
     if (args.writingStyle !== undefined) {
       updates.writingStyle = args.writingStyle.trim();
     }

--- a/templates/mail/app/components/email/ComposeModal.tsx
+++ b/templates/mail/app/components/email/ComposeModal.tsx
@@ -48,8 +48,7 @@ import { toast } from "sonner";
 import type { ComposeState } from "@shared/types";
 import { RecipientInput } from "./RecipientInput";
 import { ComposeEditor, type ComposeEditorHandle } from "./ComposeEditor";
-import { openFilePicker, uploadFile } from "@/lib/upload";
-import type { ComposeAttachment } from "@shared/types";
+import { openFilePicker, uploadFiles } from "@/lib/upload";
 import { useAccountFilter } from "@/hooks/use-account-filter";
 import { canUseAgentGenerate } from "@/lib/agent-generate";
 import { AttachmentStrip } from "./AttachmentStrip";
@@ -417,25 +416,36 @@ export function ComposeModal({
     setGenerateOpen(false);
   };
 
-  const handleAttach = async () => {
-    if (!activeId || !activeDraft) return;
-    const file = await openFilePicker("*/*");
-    if (!file) return;
+  const handleAttachFiles = async (files: File[]) => {
+    if (!activeId || !activeDraft || files.length === 0) return;
     try {
-      const result = await uploadFile(file);
-      const attachment: ComposeAttachment = {
-        id: result.filename,
-        filename: result.filename,
-        originalName: result.originalName,
-        mimeType: result.mimeType,
-        size: result.size,
-        url: result.url,
-      };
+      const attachments = await uploadFiles(files);
       const existing = activeDraft.attachments ?? [];
-      onUpdate(activeId, { attachments: [...existing, attachment] });
+      onUpdate(activeId, { attachments: [...existing, ...attachments] });
     } catch {
       toast.error("Failed to attach file");
     }
+  };
+
+  const handleAttach = async () => {
+    const file = await openFilePicker("*/*");
+    if (!file) return;
+    await handleAttachFiles([file]);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!Array.from(e.dataTransfer.types).includes("Files")) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    const files = Array.from(e.dataTransfer.files ?? []);
+    if (files.length === 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    void handleAttachFiles(files);
   };
 
   const handleRemoveAttachment = (attachmentId: string) => {
@@ -474,6 +484,8 @@ export function ComposeModal({
       )}
       style={composeStyle}
       onKeyDown={handleKeyDown}
+      onDragOverCapture={handleDragOver}
+      onDropCapture={handleDrop}
     >
       {/* Title bar with inline tabs */}
       <div className="flex h-11 shrink-0 items-center sm:rounded-t-xl px-2 gap-0">

--- a/templates/mail/app/components/email/InlineReplyComposer.tsx
+++ b/templates/mail/app/components/email/InlineReplyComposer.tsx
@@ -39,14 +39,10 @@ import { expandAliasTokens } from "@/lib/alias-utils";
 import { appApiPath } from "@/lib/api-path";
 import { useAgentChatGenerating } from "@agent-native/core";
 import { toast } from "sonner";
-import type {
-  ComposeState,
-  EmailMessage,
-  ComposeAttachment,
-} from "@shared/types";
+import type { ComposeState, EmailMessage } from "@shared/types";
 import { RecipientInput } from "./RecipientInput";
 import { ComposeEditor, type ComposeEditorHandle } from "./ComposeEditor";
-import { openFilePicker, uploadFile } from "@/lib/upload";
+import { openFilePicker, uploadFiles } from "@/lib/upload";
 import { canUseAgentGenerate } from "@/lib/agent-generate";
 import { AttachmentStrip } from "./AttachmentStrip";
 
@@ -291,24 +287,36 @@ export const InlineReplyComposer = forwardRef<
     setGenerateOpen(false);
   };
 
-  const handleAttach = async () => {
-    const file = await openFilePicker("*/*");
-    if (!file) return;
+  const handleAttachFiles = async (files: File[]) => {
+    if (files.length === 0) return;
     try {
-      const result = await uploadFile(file);
-      const attachment: ComposeAttachment = {
-        id: result.filename,
-        filename: result.filename,
-        originalName: result.originalName,
-        mimeType: result.mimeType,
-        size: result.size,
-        url: result.url,
-      };
+      const attachments = await uploadFiles(files);
       const existing = draft.attachments ?? [];
-      onUpdate(draft.id, { attachments: [...existing, attachment] });
+      onUpdate(draft.id, { attachments: [...existing, ...attachments] });
     } catch {
       toast.error("Failed to attach file");
     }
+  };
+
+  const handleAttach = async () => {
+    const file = await openFilePicker("*/*");
+    if (!file) return;
+    await handleAttachFiles([file]);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    if (!Array.from(e.dataTransfer.types).includes("Files")) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    const files = Array.from(e.dataTransfer.files ?? []);
+    if (files.length === 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    void handleAttachFiles(files);
   };
 
   const handleRemoveAttachment = (attachmentId: string) => {
@@ -323,6 +331,8 @@ export const InlineReplyComposer = forwardRef<
       ref={composerRef}
       className="rounded-lg bg-card dark:bg-[hsl(220,5%,10%)] overflow-hidden"
       onKeyDown={handleKeyDown}
+      onDragOverCapture={handleDragOver}
+      onDropCapture={handleDrop}
     >
       {/* Header */}
       {draft.mode === "forward" ? (

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -70,6 +70,66 @@ function makeTempId(prefix: string) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+const RECENT_SENT_DURATION = 2 * 60_000;
+const recentSentMessages = new Map<
+  string,
+  { message: EmailMessage; timestamp: number }
+>();
+
+function messageThreadKey(message: EmailMessage): string {
+  return message.threadId || message.id;
+}
+
+function rememberRecentSentEmail(message: EmailMessage) {
+  recentSentMessages.set(message.id, { message, timestamp: Date.now() });
+}
+
+function replaceRecentSentEmail(tempId: string, message: EmailMessage) {
+  recentSentMessages.delete(tempId);
+  rememberRecentSentEmail(message);
+}
+
+function forgetRecentSentEmail(id: string) {
+  recentSentMessages.delete(id);
+}
+
+function applyRecentSentEmails(
+  emails: EmailMessage[],
+  view: string,
+  search?: string,
+  label?: string,
+): EmailMessage[] {
+  if (search || label || (view !== "sent" && view !== "all")) return emails;
+  if (recentSentMessages.size === 0) return emails;
+
+  const now = Date.now();
+  const recent = Array.from(recentSentMessages.values())
+    .filter(({ timestamp }) => {
+      if (now - timestamp <= RECENT_SENT_DURATION) return true;
+      return false;
+    })
+    .map(({ message }) => message);
+
+  for (const [id, { timestamp }] of recentSentMessages) {
+    if (now - timestamp > RECENT_SENT_DURATION) {
+      recentSentMessages.delete(id);
+    }
+  }
+
+  if (recent.length === 0) return emails;
+
+  const recentThreadKeys = new Set(recent.map(messageThreadKey));
+  const recentIds = new Set(recent.map((message) => message.id));
+  return [
+    ...recent,
+    ...emails.filter(
+      (message) =>
+        !recentIds.has(message.id) &&
+        !recentThreadKeys.has(messageThreadKey(message)),
+    ),
+  ].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
+
 // Delay cache invalidation for mutations with optimistic updates.
 // Gmail's search index has eventual consistency — if we refetch immediately
 // after archiving/trashing, the email may still appear in `in:inbox` results,
@@ -274,6 +334,68 @@ export function flattenInfiniteEmails(
   return data?.pages.flatMap((p) => p.emails) ?? [];
 }
 
+function isRecentSentListKey(key: readonly unknown[]): boolean {
+  return (
+    key[0] === "emails" &&
+    (key[1] === "sent" || key[1] === "all") &&
+    key[2] == null &&
+    key[3] == null
+  );
+}
+
+function getRecentSentListSnapshots(qc: ReturnType<typeof useQueryClient>) {
+  return qc
+    .getQueriesData<InfiniteEmails>({ queryKey: ["emails"] })
+    .filter(([key]) => isRecentSentListKey(key));
+}
+
+function upsertEmailInInfiniteList(
+  old: InfiniteEmails | undefined,
+  message: EmailMessage,
+): InfiniteEmails | undefined {
+  if (!old || old.pages.length === 0) return old;
+
+  const threadKey = messageThreadKey(message);
+  return {
+    ...old,
+    pages: old.pages.map((page, index) => {
+      const emails = page.emails.filter(
+        (existing) =>
+          existing.id !== message.id &&
+          messageThreadKey(existing) !== threadKey,
+      );
+      if (index !== 0) return { ...page, emails };
+      return {
+        ...page,
+        emails: [message, ...emails].sort(
+          (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+        ),
+      };
+    }),
+  };
+}
+
+function replaceEmailInInfiniteList(
+  old: InfiniteEmails | undefined,
+  tempId: string,
+  message: EmailMessage,
+): InfiniteEmails | undefined {
+  if (!old) return old;
+  let replaced = false;
+  const next = {
+    ...old,
+    pages: old.pages.map((page) => ({
+      ...page,
+      emails: page.emails.map((existing) => {
+        if (existing.id !== tempId) return existing;
+        replaced = true;
+        return message;
+      }),
+    })),
+  };
+  return replaced ? next : upsertEmailInInfiniteList(old, message);
+}
+
 // ─── Emails ──────────────────────────────────────────────────────────────────
 
 interface EmailsPage {
@@ -332,8 +454,9 @@ export function useEmails(
   const data = useMemo(() => {
     if (!q.data) return undefined;
     const all = q.data.pages.flatMap((p: EmailsPage) => p.emails);
-    return applyOverrides(search ? all : filterSuppressed(all, view));
-  }, [q.data, search, view]);
+    const visible = applyOverrides(search ? all : filterSuppressed(all, view));
+    return applyRecentSentEmails(visible, view, search, label);
+  }, [q.data, search, view, label]);
 
   return {
     data,
@@ -760,8 +883,9 @@ export function useSendEmail() {
         data.replyToId ||
         makeTempId("thread");
 
-      // Snapshot pre-send thread state so onError can roll back.
+      // Snapshot pre-send state so onError can roll back.
       const previousThread = getCachedThread(threadId);
+      const previousLists = getRecentSentListSnapshots(qc);
 
       // Reuse the optimistic message that addOptimisticReply may have
       // already inserted, rather than double-adding.
@@ -769,17 +893,11 @@ export function useSendEmail() {
       const existingOptimistic = existingMessages.find(
         (m) => m.id.startsWith("sent-") && m.isSent,
       );
+      const rollbackThread = existingOptimistic
+        ? existingMessages.filter((m) => m.id !== existingOptimistic.id)
+        : previousThread;
 
-      if (existingOptimistic) {
-        return {
-          previousThread,
-          optimisticMessage: existingOptimistic,
-          threadId,
-        };
-      }
-
-      // No prior optimistic message (e.g. sent from ComposeModal) — add one
-      const optimisticMessage: EmailMessage = {
+      const optimisticMessage: EmailMessage = existingOptimistic ?? {
         id: makeTempId("sent"),
         threadId,
         from: {
@@ -814,17 +932,35 @@ export function useSendEmail() {
         ...(data.accountEmail ? { accountEmail: data.accountEmail } : {}),
       };
 
-      setCachedThread(
-        threadId,
-        [...existingMessages, optimisticMessage].sort(
-          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
-        ),
-      );
+      if (!existingOptimistic) {
+        setCachedThread(
+          threadId,
+          [...existingMessages, optimisticMessage].sort(
+            (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+          ),
+        );
+      }
 
-      return { previousThread, optimisticMessage, threadId };
+      rememberRecentSentEmail(optimisticMessage);
+      for (const [key] of previousLists) {
+        qc.setQueryData<InfiniteEmails>(key, (old) =>
+          upsertEmailInInfiniteList(old, optimisticMessage),
+        );
+      }
+
+      return {
+        previousThread: rollbackThread,
+        optimisticMessage,
+        threadId,
+        previousLists,
+      };
     },
     onError: (_err, _vars, context) => {
       if (!context) return;
+      forgetRecentSentEmail(context.optimisticMessage.id);
+      context.previousLists.forEach(([key, data]) =>
+        qc.setQueryData(key, data),
+      );
       if (context.previousThread) {
         setCachedThread(context.threadId, context.previousThread);
       } else {
@@ -848,6 +984,16 @@ export function useSendEmail() {
         threadId,
         labelIds: result.labelIds?.map((id) => id.toLowerCase()) || ["sent"],
       };
+      replaceRecentSentEmail(context.optimisticMessage.id, replacement);
+      for (const [key] of getRecentSentListSnapshots(qc)) {
+        qc.setQueryData<InfiniteEmails>(key, (old) =>
+          replaceEmailInInfiniteList(
+            old,
+            context.optimisticMessage.id,
+            replacement,
+          ),
+        );
+      }
       const hasOptimistic = current.some(
         (message) => message.id === context.optimisticMessage.id,
       );

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -103,17 +103,44 @@ function applyRecentSentEmails(
   if (recentSentMessages.size === 0) return emails;
 
   const now = Date.now();
-  const recent = Array.from(recentSentMessages.values())
-    .filter(({ timestamp }) => {
-      if (now - timestamp <= RECENT_SENT_DURATION) return true;
-      return false;
-    })
-    .map(({ message }) => message);
-
   for (const [id, { timestamp }] of recentSentMessages) {
     if (now - timestamp > RECENT_SENT_DURATION) {
       recentSentMessages.delete(id);
     }
+  }
+  if (recentSentMessages.size === 0) return emails;
+
+  // Index server rows by message id and thread key so we can drop optimistic
+  // overlays once the server confirms the same message, or once the server
+  // reports a fresher message in the same thread (reply arrived, user
+  // archived/trashed, etc.).
+  const serverIds = new Set(emails.map((message) => message.id));
+  const newestByThread = new Map<string, number>();
+  for (const message of emails) {
+    const key = messageThreadKey(message);
+    const ts = new Date(message.date).getTime();
+    const existing = newestByThread.get(key);
+    if (existing === undefined || ts > existing) {
+      newestByThread.set(key, ts);
+    }
+  }
+
+  const recent: EmailMessage[] = [];
+  for (const [id, { message }] of recentSentMessages) {
+    if (serverIds.has(message.id)) {
+      recentSentMessages.delete(id);
+      continue;
+    }
+    const threadKey = messageThreadKey(message);
+    const serverNewest = newestByThread.get(threadKey);
+    const optimisticTs = new Date(message.date).getTime();
+    if (serverNewest !== undefined && serverNewest >= optimisticTs) {
+      // Server has a row at least as fresh as our optimistic copy — let it
+      // win so we don't mask a reply or archive that landed during the TTL.
+      recentSentMessages.delete(id);
+      continue;
+    }
+    recent.push(message);
   }
 
   if (recent.length === 0) return emails;

--- a/templates/mail/app/lib/upload.ts
+++ b/templates/mail/app/lib/upload.ts
@@ -1,4 +1,5 @@
 import { appApiPath } from "@/lib/api-path";
+import type { ComposeAttachment } from "@shared/types";
 
 export interface UploadResult {
   url: string;
@@ -21,6 +22,27 @@ export async function uploadFile(file: File): Promise<UploadResult> {
     throw new Error(`Upload failed: ${resp.statusText}`);
   }
   return resp.json();
+}
+
+export function uploadResultToAttachment(
+  result: UploadResult,
+): ComposeAttachment {
+  return {
+    id: result.filename,
+    filename: result.filename,
+    originalName: result.originalName,
+    mimeType: result.mimeType,
+    size: result.size,
+    url: result.url,
+  };
+}
+
+export async function uploadFiles(files: File[]): Promise<ComposeAttachment[]> {
+  const uploaded: ComposeAttachment[] = [];
+  for (const file of files) {
+    uploaded.push(uploadResultToAttachment(await uploadFile(file)));
+  }
+  return uploaded;
 }
 
 export function openFilePicker(accept: string): Promise<File | null> {

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -71,6 +71,7 @@ import {
   buildRawEmail as buildOutgoingRawEmail,
   resolveComposeAttachments,
 } from "../lib/outgoing-email.js";
+import { normalizeSignature } from "../../shared/signature.js";
 import { getAppProductionUrl } from "@agent-native/core/server";
 import { isBlockedToolUrl } from "@agent-native/core/tools/url-safety";
 
@@ -348,6 +349,7 @@ async function readSettings(email: string): Promise<UserSettings> {
       ...DEFAULT_SETTINGS,
       ...(data as any),
       email: (data as any).email || email,
+      signature: normalizeSignature((data as any).signature),
     } as UserSettings;
   }
   return { ...DEFAULT_SETTINGS, email };
@@ -1505,6 +1507,7 @@ export const sendEmail = defineEventHandler(async (event: H3Event) => {
         if (sent.threadId) {
           invalidateThreadCache(email, sent.threadId);
         }
+        invalidateListCacheForOwner(email);
 
         // Track contact frequency for all recipients
         const allRecipients = [to, cc, bcc]
@@ -2400,7 +2403,13 @@ export const updateSettings = defineEventHandler(async (event: H3Event) => {
   const email = await userEmail(event);
   const current = await readSettings(email);
   const body = await readBody(event);
-  const updated = { ...current, ...body };
+  const updated = {
+    ...current,
+    ...body,
+    ...(body.signature !== undefined
+      ? { signature: normalizeSignature(body.signature) }
+      : {}),
+  };
   await putUserSetting(
     email,
     "mail-settings",

--- a/templates/mail/shared/gmail-signature.test.ts
+++ b/templates/mail/shared/gmail-signature.test.ts
@@ -10,12 +10,12 @@ describe("htmlSignatureToMarkdown", () => {
     ).toBe("Steve\n\n[Website](https://example.com/)");
   });
 
-  it("keeps safe images when Gmail signatures include logos", () => {
+  it("drops image assets from Gmail signatures", () => {
     expect(
       htmlSignatureToMarkdown(
-        '<div><img src="https://example.com/logo.png" alt="Acme"></div>',
+        '<div>Steve</div><div><a href="https://example.com"><img src="https://example.com/logo.png" alt="Acme"></a></div>',
       ),
-    ).toBe("![Acme](https://example.com/logo.png)");
+    ).toBe("Steve");
   });
 
   it("drops unsafe URLs", () => {

--- a/templates/mail/shared/gmail-signature.ts
+++ b/templates/mail/shared/gmail-signature.ts
@@ -45,19 +45,14 @@ export function htmlSignatureToMarkdown(html: string): string {
     .replace(/<style[\s\S]*?<\/style>/gi, "");
 
   next = next.replace(/<br\s*\/?>/gi, "\n");
-  next = next.replace(/<img\b[^>]*>/gi, (tag) => {
-    const src = safeUrl(attr(tag, "src"));
-    if (!src) return "";
-    const alt = attr(tag, "alt") ?? "";
-    return `![${alt.replace(/]/g, "\\]")}](${normalizeMarkdownUrl(src)})`;
-  });
+  next = next.replace(/<img\b[^>]*>/gi, "");
   next = next.replace(
     /<a\b[^>]*href\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)[^>]*>([\s\S]*?)<\/a>/gi,
     (match, label) => {
       const href = safeUrl(attr(match, "href"), true);
       if (!href) return label;
       const text = cleanMarkdown(label.replace(/<[^>]+>/g, ""));
-      if (!text) return href;
+      if (!text) return "";
       return `[${text.replace(/]/g, "\\]")}](${normalizeMarkdownUrl(href)})`;
     },
   );

--- a/templates/mail/shared/signature.test.ts
+++ b/templates/mail/shared/signature.test.ts
@@ -34,4 +34,15 @@ describe("appendSignatureToBody", () => {
       "Hi Alice\n\nSteve",
     );
   });
+
+  it("strips images whose alt text contains brackets", () => {
+    const signature = "Steve\n![Image [1]](https://example.com/logo.png)";
+    expect(normalizeSignature(signature)).toBe("Steve");
+  });
+
+  it("strips linked-image logos without leaving an empty link", () => {
+    const signature =
+      "Steve\n[![Logo](https://example.com/logo.png)](https://example.com)";
+    expect(normalizeSignature(signature)).toBe("Steve");
+  });
 });

--- a/templates/mail/shared/signature.test.ts
+++ b/templates/mail/shared/signature.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { appendSignatureToBody } from "./signature";
+import { appendSignatureToBody, normalizeSignature } from "./signature";
 
 describe("appendSignatureToBody", () => {
   it("appends a configured signature to a new draft", () => {
@@ -25,5 +25,13 @@ describe("appendSignatureToBody", () => {
 
   it("leaves body unchanged when signature is blank", () => {
     expect(appendSignatureToBody("Hi Alice", "   ")).toBe("Hi Alice");
+  });
+
+  it("strips image markdown from signatures before appending", () => {
+    const signature = "Steve\n![Logo](https://example.com/logo.png)";
+    expect(normalizeSignature(signature)).toBe("Steve");
+    expect(appendSignatureToBody("Hi Alice", signature)).toBe(
+      "Hi Alice\n\nSteve",
+    );
   });
 });

--- a/templates/mail/shared/signature.ts
+++ b/templates/mail/shared/signature.ts
@@ -14,7 +14,16 @@ function splitQuotedContent(body: string): [string, string] {
 }
 
 export function normalizeSignature(signature?: string | null): string {
-  return (signature ?? "").trim();
+  return stripSignatureImages(signature ?? "").trim();
+}
+
+export function stripSignatureImages(signature: string): string {
+  return signature
+    .replace(/!\[[^\]\n]*\]\((?:https?:\/\/|data:image\/)[^\)\n]+\)/gi, "")
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/g, ""))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n");
 }
 
 export function appendSignatureToBody(

--- a/templates/mail/shared/signature.ts
+++ b/templates/mail/shared/signature.ts
@@ -19,7 +19,11 @@ export function normalizeSignature(signature?: string | null): string {
 
 export function stripSignatureImages(signature: string): string {
   return signature
-    .replace(/!\[[^\]\n]*\]\((?:https?:\/\/|data:image\/)[^\)\n]+\)/gi, "")
+    .replace(
+      /\[!\[[\s\S]*?\]\((?:https?:\/\/|data:image\/)[^)]*\)\]\([^)]*\)/gi,
+      "",
+    )
+    .replace(/!\[[\s\S]*?\]\((?:https?:\/\/|data:image\/)[^)]*\)/gi, "")
     .split("\n")
     .map((line) => line.replace(/[ \t]+$/g, ""))
     .join("\n")

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -32,6 +32,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { toast } from "@/hooks/use-toast";
 
 interface EditorSidebarProps {
   slides: Slide[];
@@ -330,9 +331,21 @@ function AddSlidePopover({
             method: "POST",
             body: formData,
           });
-          if (res.ok) uploaded = (await res.json()) as UploadedFile[];
-        } catch {
-          /* silent */
+          if (!res.ok) {
+            const data = await res.json().catch(() => null);
+            throw new Error(data?.error || "Upload failed");
+          }
+          uploaded = (await res.json()) as UploadedFile[];
+        } catch (error) {
+          toast({
+            title: "Upload failed",
+            description:
+              error instanceof Error
+                ? error.message
+                : "Could not upload the attached file.",
+            variant: "destructive",
+          });
+          return;
         }
       }
 

--- a/templates/slides/app/components/editor/ExportMenu.test.tsx
+++ b/templates/slides/app/components/editor/ExportMenu.test.tsx
@@ -58,12 +58,14 @@ beforeEach(() => {
   vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:pptx");
   vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
   const realSetTimeout = window.setTimeout.bind(window);
-  vi.spyOn(window, "setTimeout").mockImplementation(
-    ((handler: TimerHandler, timeout?: number, ...args: any[]) => {
-      if (timeout === 60_000) return 1;
-      return realSetTimeout(handler, timeout, ...args);
-    }) as typeof window.setTimeout,
-  );
+  vi.spyOn(window, "setTimeout").mockImplementation(((
+    handler: TimerHandler,
+    timeout?: number,
+    ...args: any[]
+  ) => {
+    if (timeout === 60_000) return 1;
+    return realSetTimeout(handler, timeout, ...args);
+  }) as typeof window.setTimeout);
   vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
     () => undefined,
   );

--- a/templates/slides/app/components/editor/ExportMenu.test.tsx
+++ b/templates/slides/app/components/editor/ExportMenu.test.tsx
@@ -57,6 +57,13 @@ beforeEach(() => {
   }) as typeof fetch;
   vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:pptx");
   vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+  const realSetTimeout = window.setTimeout.bind(window);
+  vi.spyOn(window, "setTimeout").mockImplementation(
+    ((handler: TimerHandler, timeout?: number, ...args: any[]) => {
+      if (timeout === 60_000) return 1;
+      return realSetTimeout(handler, timeout, ...args);
+    }) as typeof window.setTimeout,
+  );
   vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
     () => undefined,
   );
@@ -91,6 +98,11 @@ describe("<ExportMenu>", () => {
       "export-google-slides",
     );
     expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(window.setTimeout).toHaveBeenCalledWith(
+      expect.any(Function),
+      60_000,
+    );
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
     expect(window.open).toHaveBeenCalledWith(
       "https://docs.google.com/presentation/u/0/?usp=import",
       "_blank",

--- a/templates/slides/app/components/editor/ExportMenu.tsx
+++ b/templates/slides/app/components/editor/ExportMenu.tsx
@@ -55,7 +55,7 @@ export function ExportMenu({
     document.body.appendChild(a);
     a.click();
     a.remove();
-    URL.revokeObjectURL(url);
+    window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
   };
 
   const filenameFromDisposition = (value: string | null) => {

--- a/templates/slides/app/components/editor/PromptDialog.tsx
+++ b/templates/slides/app/components/editor/PromptDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
 import { appBasePath, PromptComposer } from "@agent-native/core/client";
 import { GoogleDocImportHint } from "./GoogleDocImportHint";
+import { toast } from "@/hooks/use-toast";
 
 export interface UploadedFile {
   path: string;
@@ -116,7 +117,10 @@ export default function PromptPopover({
           method: "POST",
           body: formData,
         });
-        if (!res.ok) return [];
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          throw new Error(data?.error || "Upload failed");
+        }
         return (await res.json()) as UploadedFile[];
       } finally {
         setUploading(false);
@@ -127,11 +131,22 @@ export default function PromptPopover({
 
   const handleSubmit = useCallback(
     async (text: string, files: File[]) => {
-      const uploaded = await uploadFiles(files);
-      const enrichedText = [text.trim(), googleDocContext]
-        .filter(Boolean)
-        .join("\n\n");
-      onSubmit(enrichedText, uploaded);
+      try {
+        const uploaded = await uploadFiles(files);
+        const enrichedText = [text.trim(), googleDocContext]
+          .filter(Boolean)
+          .join("\n\n");
+        onSubmit(enrichedText, uploaded);
+      } catch (error) {
+        toast({
+          title: "Upload failed",
+          description:
+            error instanceof Error
+              ? error.message
+              : "Could not upload the attached file.",
+          variant: "destructive",
+        });
+      }
     },
     [googleDocContext, onSubmit, uploadFiles],
   );

--- a/templates/slides/server/handlers/uploads.ts
+++ b/templates/slides/server/handlers/uploads.ts
@@ -5,23 +5,20 @@ import {
 } from "h3";
 import path from "path";
 import fs from "fs";
-import crypto from "crypto";
 import { nanoid } from "nanoid";
 import { getSession } from "@agent-native/core/server";
+import { tenantUploadDir } from "../lib/tenant-files.js";
 import {
   SLIDES_REFERENCE_FILE_ERROR_LABEL,
   isSlidesReferenceFileExtension,
 } from "../../shared/upload-types";
 
-const UPLOADS_ROOT = path.join(process.cwd(), "data", "uploads");
-
-function tenantUploadDir(email: string): string {
-  const key = crypto
-    .createHash("sha256")
-    .update(email.trim().toLowerCase())
-    .digest("hex")
-    .slice(0, 24);
-  return path.join(UPLOADS_ROOT, key);
+export interface UploadedReferenceFile {
+  path: string;
+  originalName: string;
+  filename: string;
+  type: string;
+  size: number;
 }
 
 function safeFilename(originalName: string): string | null {
@@ -67,6 +64,43 @@ function hasExpectedSignature(ext: string, data: Uint8Array): boolean {
   return !data.subarray(0, 4096).includes(0);
 }
 
+function pathForAgent(absPath: string): string {
+  const relative = path.relative(process.cwd(), absPath);
+  if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+    return relative.split(path.sep).join("/");
+  }
+  return absPath;
+}
+
+export async function saveUploadedReferenceFile(args: {
+  email: string;
+  originalName: string;
+  data: Uint8Array;
+  type?: string;
+}): Promise<UploadedReferenceFile> {
+  const filename = safeFilename(args.originalName);
+  if (!filename) {
+    throw new Error(
+      `Unsupported file type. Allowed: ${SLIDES_REFERENCE_FILE_ERROR_LABEL}.`,
+    );
+  }
+  const ext = path.extname(filename).toLowerCase();
+  if (!hasExpectedSignature(ext, args.data)) {
+    throw new Error(`File contents do not match ${ext} upload type`);
+  }
+  const uploadDir = tenantUploadDir(args.email);
+  await fs.promises.mkdir(uploadDir, { recursive: true });
+  const destPath = path.join(uploadDir, filename);
+  await fs.promises.writeFile(destPath, args.data);
+  return {
+    path: pathForAgent(destPath),
+    originalName: args.originalName,
+    filename,
+    type: args.type || "application/octet-stream",
+    size: args.data.length,
+  };
+}
+
 // Upload one or more files
 export const uploadFiles = defineEventHandler(async (event) => {
   const session = await getSession(event).catch(() => null);
@@ -103,31 +137,12 @@ export const uploadFiles = defineEventHandler(async (event) => {
   try {
     results = await Promise.all(
       fileParts.map(async (part) => {
-        const originalName = part.filename || "upload";
-        const filename = safeFilename(originalName);
-        if (!filename) {
-          throw new Error(
-            `Unsupported file type. Allowed: ${SLIDES_REFERENCE_FILE_ERROR_LABEL}.`,
-          );
-        }
-        const ext = path.extname(filename).toLowerCase();
-        if (!hasExpectedSignature(ext, part.data)) {
-          throw new Error(`File contents do not match ${ext} upload type`);
-        }
-        const uploadDir = tenantUploadDir(session.email);
-        await fs.promises.mkdir(uploadDir, { recursive: true });
-        const destPath = path.join(uploadDir, filename);
-        await fs.promises.writeFile(destPath, part.data);
-        return {
-          path: path
-            .relative(process.cwd(), destPath)
-            .split(path.sep)
-            .join("/"),
-          originalName,
-          filename,
-          type: part.type || "application/octet-stream",
-          size: part.data.length,
-        };
+        return saveUploadedReferenceFile({
+          email: session.email,
+          originalName: part.filename || "upload",
+          data: part.data,
+          type: part.type,
+        });
       }),
     );
   } catch (err) {

--- a/templates/slides/server/plugins/agent-chat.ts
+++ b/templates/slides/server/plugins/agent-chat.ts
@@ -1,16 +1,121 @@
 import {
   createAgentChatPlugin,
   loadActionsFromStaticRegistry,
+  type AgentChatAttachment,
 } from "@agent-native/core/server";
 import actionsRegistry from "../../.generated/actions-registry.js";
 import { getOrgContext } from "@agent-native/core/org";
+import path from "path";
+import { saveUploadedReferenceFile } from "../handlers/uploads.js";
+import { isSlidesReferenceFileExtension } from "../../shared/upload-types.js";
 import "../register-secrets.js";
+
+const MAX_CHAT_UPLOAD_BYTES = 50 * 1024 * 1024;
+
+function decodeDataUrl(data: string | undefined): {
+  bytes: Buffer;
+  contentType: string;
+} | null {
+  const match = data?.match(/^data:([^;,]+);base64,(.*)$/s);
+  if (!match) return null;
+  return {
+    contentType: match[1] || "application/octet-stream",
+    bytes: Buffer.from(match[2], "base64"),
+  };
+}
+
+async function prepareSlidesChatAttachments(args: {
+  ownerEmail: string | null;
+  message: string;
+  attachments: AgentChatAttachment[];
+}): Promise<{ message?: string } | void> {
+  if (!args.ownerEmail || args.attachments.length === 0) return;
+
+  const uploaded: Array<{
+    originalName: string;
+    path: string;
+    type: string;
+    size: number;
+  }> = [];
+  const failed: Array<{ name: string; reason: string }> = [];
+
+  for (const attachment of args.attachments) {
+    if (attachment.type !== "file" || !attachment.data) continue;
+    const ext = path.extname(attachment.name).toLowerCase();
+    if (!isSlidesReferenceFileExtension(ext)) continue;
+
+    const decoded = decodeDataUrl(attachment.data);
+    if (!decoded) continue;
+    if (decoded.bytes.length > MAX_CHAT_UPLOAD_BYTES) {
+      failed.push({
+        name: attachment.name,
+        reason: "file is larger than the 50 MB upload limit",
+      });
+      continue;
+    }
+
+    try {
+      uploaded.push(
+        await saveUploadedReferenceFile({
+          email: args.ownerEmail,
+          originalName: attachment.name,
+          data: decoded.bytes,
+          type: attachment.contentType || decoded.contentType,
+        }),
+      );
+    } catch (error) {
+      failed.push({
+        name: attachment.name,
+        reason: error instanceof Error ? error.message : "upload failed",
+      });
+    }
+  }
+
+  if (uploaded.length === 0 && failed.length === 0) return;
+
+  const fileList = uploaded
+    .map(
+      (file) =>
+        `- ${file.originalName} (${file.type}, ${(file.size / 1024).toFixed(1)}KB) at path: ${file.path}`,
+    )
+    .join("\n");
+  const failureList = failed
+    .map((file) => `- ${file.name}: ${file.reason}`)
+    .join("\n");
+  const attachmentContext = [
+    "<slides-chat-attachments>",
+    uploaded.length > 0
+      ? [
+          "The user attached file(s) in chat. They have been saved as real server upload paths that Slides import actions can read:",
+          fileList,
+          "",
+          "File handling rules:",
+          "- PPTX files: call `import-pptx --filePath \"<path>\"` to create or replace a deck from the presentation.",
+          "- PDF and DOCX files: call `import-file --filePath \"<path>\" --format auto` and use the returned content as source material before creating slides.",
+          "- Do not say no PDF/PPTX/DOCX was attached when a matching saved path is listed here.",
+        ].join("\n")
+      : "",
+    failed.length > 0
+      ? [
+          "Some attached file(s) could not be saved to Slides upload storage:",
+          failureList,
+          "The binary attachment is still present in the chat request; use it directly if the model supports it, otherwise report the save error exactly.",
+        ].join("\n")
+      : "",
+    "</slides-chat-attachments>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return { message: `${args.message}\n\n${attachmentContext}` };
+}
 
 export default createAgentChatPlugin({
   appId: "slides",
   actions: loadActionsFromStaticRegistry(actionsRegistry),
   runSoftTimeoutMs: 240_000,
   resolveOrgId: async (event) => (await getOrgContext(event)).orgId,
+  prepareRequest: prepareSlidesChatAttachments,
   mentionProviders: async () => {
     const { getDb } = await import("../db/index.js");
     const { decks, deckShares } = await import("../db/schema.js");

--- a/templates/slides/server/plugins/agent-chat.ts
+++ b/templates/slides/server/plugins/agent-chat.ts
@@ -90,8 +90,8 @@ async function prepareSlidesChatAttachments(args: {
           fileList,
           "",
           "File handling rules:",
-          "- PPTX files: call `import-pptx --filePath \"<path>\"` to create or replace a deck from the presentation.",
-          "- PDF and DOCX files: call `import-file --filePath \"<path>\" --format auto` and use the returned content as source material before creating slides.",
+          '- PPTX files: call `import-pptx --filePath "<path>"` to create or replace a deck from the presentation.',
+          '- PDF and DOCX files: call `import-file --filePath "<path>" --format auto` and use the returned content as source material before creating slides.',
           "- Do not say no PDF/PPTX/DOCX was attached when a matching saved path is listed here.",
         ].join("\n")
       : "",


### PR DESCRIPTION
## Summary

- Compose modal + inline reply now accept files via drag-and-drop, using a shared multi-file upload helper.
- Sent emails appear in sent/all lists immediately for 2 minutes via an in-memory recent map, so users don't see the message vanish while Gmail's index catches up.
- Signatures (both stored and imported from Gmail HTML) drop image refs entirely to avoid inline tracking pixels and bare-URL anchor fallbacks.

## Test plan

- [ ] `pnpm run prep` clean
- [ ] Drop a file onto the compose modal — confirms it attaches without opening the picker
- [ ] Send an email — confirm it appears at the top of the sent / all lists immediately and stays there for ~2 min before Gmail catches up
- [ ] Import a Gmail signature with an inline image — verify the markdown signature has no `![alt](src)` reference