### PR TITLE
feat(core,analytics): builder-desktop OAuth fix + SSE activity trail + extensions hovercard + DataSources kebab

### DIFF
--- a/.changeset/fix-builder-desktop-google-auth.md
+++ b/.changeset/fix-builder-desktop-google-auth.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Use redirect sign-in inside Builder.io desktop and harden Builder Google popup opening.

--- a/.changeset/tidy-extension-hovercard.md
+++ b/.changeset/tidy-extension-hovercard.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Move the extensions sidebar explainer from a click popover to an interactive hovercard.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -111,6 +111,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@neondatabase/serverless": "^1.1.0",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -107,6 +107,9 @@ import {
   IconRefresh,
   IconPlayerPlay,
   IconClipboardList,
+  IconSearch,
+  IconArrowsMaximize,
+  IconArrowsMinimize,
 } from "@tabler/icons-react";
 
 class BinaryDocumentAttachmentAdapter implements AttachmentAdapter {
@@ -318,6 +321,11 @@ const markdownStyles = `
 .dark .agent-markdown-shiki pre { background: var(--shiki-dark-bg); color: var(--shiki-dark); }
 .dark .agent-markdown-shiki pre span { color: var(--shiki-dark); background: var(--shiki-dark-bg); }
 @media (prefers-color-scheme: dark) { :root:not(.light) .agent-markdown-shiki pre { background: var(--shiki-dark-bg); color: var(--shiki-dark); } :root:not(.light) .agent-markdown-shiki pre span { color: var(--shiki-dark); background: var(--shiki-dark-bg); } }
+.agent-tool-code .agent-markdown-shiki { margin: 0; border-radius: 0; min-width: max-content; }
+.agent-tool-code .agent-markdown-shiki pre { padding: 0.75rem; border: 0; background: transparent; }
+.agent-tool-code .agent-markdown-shiki pre span { background: transparent; }
+.agent-tool-code pre { margin: 0; min-width: max-content; padding: 0.75rem; background: transparent; color: inherit; }
+.agent-tool-code mark { border-radius: 0.1875rem; background: rgba(245, 158, 11, 0.25); color: inherit; }
 .agent-markdown hr { border: none; border-top: 1px solid hsl(var(--border, 0 0% 20%)); margin: 0.75em 0; }
 .agent-markdown a { text-decoration: underline; text-underline-offset: 2px; }
 .agent-markdown a.agent-markdown-cta { text-decoration: none; }
@@ -596,6 +604,7 @@ function loadHighlighter(): Promise<ShikiHighlighter> {
           import("shiki/langs/shellscript.mjs"),
           import("shiki/langs/python.mjs"),
           import("shiki/langs/yaml.mjs"),
+          import("shiki/langs/sql.mjs"),
         ],
         engine: createOnigurumaEngine(import("shiki/wasm")),
       }) as unknown as Promise<ShikiHighlighter>;
@@ -623,6 +632,8 @@ const LANG_ALIASES: Record<string, string> = {
   py: "python",
   yml: "yaml",
   md: "markdown",
+  bq: "sql",
+  bigquery: "sql",
 };
 
 function HighlightedCodeBlock({ code, lang }: { code: string; lang: string }) {
@@ -890,6 +901,13 @@ const ChatRunningContext = React.createContext(false);
 // assistant-ui hooks here.
 
 type ToolDetailSection = "input" | "result";
+type ToolDetailPayload = {
+  section: ToolDetailSection;
+  title: string;
+  text: string;
+  copyText: string;
+  lang: string;
+};
 
 function stringifyToolValue(value: unknown, pretty = false): string {
   if (typeof value === "string") return value;
@@ -911,21 +929,303 @@ function toolArgsPreview(args: Record<string, unknown>): string {
     .join(", ");
 }
 
-function toolArgsDisplayText(args: Record<string, unknown>): string {
-  const entries = Object.entries(args);
-  if (entries.length === 1) {
-    const [key, value] = entries[0]!;
-    return `${key}=\n${stringifyToolValue(value, true)}`;
-  }
-  return JSON.stringify(args, null, 2);
+function looksLikeSql(text: string): boolean {
+  return /^\s*(select|with|insert|update|delete|merge|create|alter|drop|explain|declare|begin)\b/i.test(
+    text,
+  );
 }
 
-function toolArgsCopyText(args: Record<string, unknown>): string {
-  const entries = Object.entries(args);
-  if (entries.length === 1 && typeof entries[0]![1] === "string") {
-    return entries[0]![1] as string;
+function parseJsonText(text: string): unknown | null {
+  const trimmed = text.trim();
+  if (!trimmed || !/^[{[]/.test(trimmed)) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
   }
-  return JSON.stringify(args, null, 2);
+}
+
+function inferToolTextLanguage(
+  text: string,
+  key?: string,
+  toolName?: string,
+): string {
+  const keyName = (key ?? "").toLowerCase();
+  const tool = (toolName ?? "").toLowerCase();
+  if (
+    keyName === "sql" ||
+    keyName.endsWith("sql") ||
+    keyName === "query" ||
+    tool.includes("bigquery") ||
+    tool.includes("db-query") ||
+    looksLikeSql(text)
+  ) {
+    return "sql";
+  }
+  return parseJsonText(text) ? "json" : "text";
+}
+
+function formatToolTextValue(
+  value: unknown,
+  key?: string,
+  toolName?: string,
+): { text: string; lang: string } {
+  if (typeof value === "string") {
+    const parsed = parseJsonText(value);
+    if (parsed) {
+      return { text: JSON.stringify(parsed, null, 2), lang: "json" };
+    }
+    return {
+      text: value,
+      lang: inferToolTextLanguage(value, key, toolName),
+    };
+  }
+  return { text: stringifyToolValue(value, true), lang: "json" };
+}
+
+function toolInputPayload(
+  toolName: string,
+  args: Record<string, unknown>,
+): ToolDetailPayload | null {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return null;
+  if (entries.length === 1) {
+    const [key, value] = entries[0]!;
+    const formatted = formatToolTextValue(value, key, toolName);
+    const normalizedKey = key.toLowerCase();
+    const keyLabel =
+      normalizedKey === "sql" || normalizedKey.endsWith("sql") ? "SQL" : key;
+    return {
+      section: "input",
+      title: `Input - ${keyLabel}`,
+      text: formatted.text,
+      copyText:
+        typeof value === "string" ? value : stringifyToolValue(value, true),
+      lang: formatted.lang,
+    };
+  }
+  return {
+    section: "input",
+    title: "Input",
+    text: JSON.stringify(args, null, 2),
+    copyText: JSON.stringify(args, null, 2),
+    lang: "json",
+  };
+}
+
+function toolResultPayload(
+  result: string | undefined,
+): ToolDetailPayload | null {
+  if (result === undefined) return null;
+  const formatted = formatToolTextValue(result);
+  return {
+    section: "result",
+    title: "Result",
+    text: formatted.text,
+    copyText: result,
+    lang: formatted.lang,
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function countTextMatches(text: string, query: string): number {
+  const needle = query.trim();
+  if (!needle) return 0;
+  return Array.from(text.matchAll(new RegExp(escapeRegExp(needle), "gi")))
+    .length;
+}
+
+function renderHighlightedSearchText(
+  text: string,
+  query: string,
+): React.ReactNode {
+  const needle = query.trim();
+  if (!needle) return text;
+  const regex = new RegExp(escapeRegExp(needle), "gi");
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text))) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    parts.push(<mark key={`${match.index}-${match[0]}`}>{match[0]}</mark>);
+    lastIndex = match.index + match[0].length;
+    if (match[0].length === 0) regex.lastIndex += 1;
+  }
+  if (lastIndex < text.length) parts.push(text.slice(lastIndex));
+  return parts;
+}
+
+function ToolDetailViewer({ payload }: { payload: ToolDetailPayload }) {
+  const [expanded, setExpanded] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [copied, setCopied] = useState(false);
+  const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const matchCount = useMemo(
+    () => countTextMatches(payload.text, search),
+    [payload.text, search],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (copyResetRef.current) clearTimeout(copyResetRef.current);
+    };
+  }, []);
+
+  const copyValue = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(payload.copyText);
+      setCopied(true);
+      if (copyResetRef.current) clearTimeout(copyResetRef.current);
+      copyResetRef.current = setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // Clipboard failures should not interrupt chat rendering.
+    }
+  }, [payload.copyText]);
+
+  return (
+    <div className="rounded-md border border-border/50 bg-background/60">
+      <div className="flex min-h-9 flex-wrap items-center gap-2 border-b border-border/50 px-2.5 py-1.5">
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate text-[11px] font-medium text-foreground/85">
+              {payload.title}
+            </span>
+            {payload.lang !== "text" && (
+              <span className="shrink-0 rounded border border-border/60 px-1 py-0.5 font-mono text-[9px] uppercase leading-none text-muted-foreground">
+                {payload.lang}
+              </span>
+            )}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setSearchOpen((v) => !v)}
+          aria-label={`Search ${payload.title.toLowerCase()}`}
+          aria-pressed={searchOpen}
+          className={cn(
+            "inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground",
+            searchOpen && "bg-accent text-foreground",
+          )}
+        >
+          <IconSearch size={12} />
+        </button>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-label={expanded ? "Shrink code viewer" : "Expand code viewer"}
+          aria-pressed={expanded}
+          className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          {expanded ? (
+            <IconArrowsMinimize size={12} />
+          ) : (
+            <IconArrowsMaximize size={12} />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={copyValue}
+          className="inline-flex h-6 items-center gap-1 rounded-md px-1.5 font-sans text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+      {searchOpen && (
+        <div className="flex items-center gap-2 border-b border-border/50 px-2.5 py-2">
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Find"
+            className="h-7 min-w-0 flex-1 rounded-md border border-border bg-background px-2 text-xs text-foreground outline-none placeholder:text-muted-foreground focus:ring-1 focus:ring-ring"
+          />
+          <span className="shrink-0 text-[11px] text-muted-foreground">
+            {search.trim() ? matchCount : ""}
+          </span>
+        </div>
+      )}
+      <div
+        className={cn(
+          "agent-tool-code overflow-auto font-mono text-[11px] leading-relaxed text-foreground",
+          expanded ? "max-h-[70vh]" : "max-h-72",
+        )}
+      >
+        {search.trim() ? (
+          <pre>
+            <code>{renderHighlightedSearchText(payload.text, search)}</code>
+          </pre>
+        ) : (
+          <HighlightedCodeBlock code={payload.text} lang={payload.lang} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function activityTrailFromMetadata(message: unknown): ActivityStep[] {
+  const meta = (message as { metadata?: unknown })?.metadata as
+    | {
+        custom?: { activityTrail?: unknown };
+        activityTrail?: unknown;
+      }
+    | undefined;
+  const raw = meta?.custom?.activityTrail ?? meta?.activityTrail;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item, index): ActivityStep | null => {
+      if (!item || typeof item !== "object") return null;
+      const label = (item as { label?: unknown }).label;
+      const tool = (item as { tool?: unknown }).tool;
+      if (typeof label !== "string" || !label.trim()) return null;
+      return {
+        id: `trail-${index}-${label}`,
+        label: label.trim(),
+        ...(typeof tool === "string" && tool.trim()
+          ? { tool: tool.trim() }
+          : {}),
+      };
+    })
+    .filter((item): item is ActivityStep => item !== null);
+}
+
+function RunActivityTrail({ steps }: { steps: ActivityStep[] }) {
+  const [open, setOpen] = useState(false);
+  if (steps.length === 0) return null;
+  const visibleSteps = steps.slice(-6);
+  return (
+    <div className="mt-1.5">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+      >
+        <IconChevronDown
+          size={12}
+          className={cn("transition-transform", open && "rotate-180")}
+        />
+        Steps
+      </button>
+      {open && (
+        <div className="mt-1 rounded-md border border-border/60 bg-muted/25 px-2.5 py-2 text-[11px] text-muted-foreground">
+          <div className="space-y-1">
+            {visibleSteps.map((step) => (
+              <div key={step.id} className="flex min-w-0 items-center gap-2">
+                <IconCheck className="h-3 w-3 shrink-0 text-emerald-500" />
+                <span className="truncate">{step.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 function ToolCallDisplay({
@@ -944,10 +1244,6 @@ function ToolCallDisplay({
   const streamRef = useRef<HTMLDivElement>(null);
   const isAgentCall = toolName.startsWith("agent:");
   const [expanded, setExpanded] = useState(isAgentCall);
-  const [copiedSection, setCopiedSection] = useState<ToolDetailSection | null>(
-    null,
-  );
-  const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const agentName = isAgentCall ? toolName.slice(6) : null;
   const isAgentError = isAgentCall && result === "Error calling agent";
   const agentStreamText = isAgentCall ? (argsText ?? "") : "";
@@ -960,26 +1256,6 @@ function ToolCallDisplay({
       streamRef.current.scrollTop = streamRef.current.scrollHeight;
     }
   }, [agentStreamText, isAgentCall, isRunning]);
-
-  useEffect(() => {
-    return () => {
-      if (copyResetRef.current) clearTimeout(copyResetRef.current);
-    };
-  }, []);
-
-  const copyToolDetail = useCallback(
-    async (section: ToolDetailSection, text: string) => {
-      try {
-        await navigator.clipboard.writeText(text);
-        setCopiedSection(section);
-        if (copyResetRef.current) clearTimeout(copyResetRef.current);
-        copyResetRef.current = setTimeout(() => setCopiedSection(null), 1200);
-      } catch {
-        // Clipboard failures should not interrupt chat rendering.
-      }
-    },
-    [],
-  );
 
   // Render connect-builder as ConnectBuilderCard once the result is available
   if (toolName === "connect-builder" && result) {
@@ -1042,10 +1318,8 @@ function ToolCallDisplay({
   }
 
   const argsStr = isAgentCall ? "" : toolArgsPreview(args);
-  const inputDisplay = hasArgs ? toolArgsDisplayText(args) : "";
-  const inputCopy = hasArgs ? toolArgsCopyText(args) : "";
-  const resultDisplay =
-    result !== undefined ? stringifyToolValue(result, true) : "";
+  const inputPayload = hasArgs ? toolInputPayload(toolName, args) : null;
+  const resultPayload = toolResultPayload(result);
 
   const displayName = isAgentCall
     ? isRunning
@@ -1111,42 +1385,8 @@ function ToolCallDisplay({
       )}
       {isExpanded && !isAgentCall && (hasArgs || result !== undefined) && (
         <div className="mt-1 space-y-2 rounded-md bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
-          {hasArgs && (
-            <div>
-              <div className="mb-1 flex items-center justify-between gap-2">
-                <span className="font-medium text-foreground/80">Input</span>
-                <button
-                  type="button"
-                  onClick={() => copyToolDetail("input", inputCopy)}
-                  className="inline-flex h-6 items-center gap-1 rounded-md px-1.5 font-sans text-[11px] text-muted-foreground hover:bg-background/80 hover:text-foreground"
-                >
-                  <IconCopy size={12} />
-                  {copiedSection === "input" ? "Copied" : "Copy"}
-                </button>
-              </div>
-              <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/50 bg-background/60 p-2 font-mono text-[11px] leading-relaxed">
-                {inputDisplay}
-              </pre>
-            </div>
-          )}
-          {result !== undefined && (
-            <div>
-              <div className="mb-1 flex items-center justify-between gap-2">
-                <span className="font-medium text-foreground/80">Result</span>
-                <button
-                  type="button"
-                  onClick={() => copyToolDetail("result", resultDisplay)}
-                  className="inline-flex h-6 items-center gap-1 rounded-md px-1.5 font-sans text-[11px] text-muted-foreground hover:bg-background/80 hover:text-foreground"
-                >
-                  <IconCopy size={12} />
-                  {copiedSection === "result" ? "Copied" : "Copy"}
-                </button>
-              </div>
-              <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/50 bg-background/60 p-2 font-mono text-[11px] leading-relaxed">
-                {resultDisplay}
-              </pre>
-            </div>
-          )}
+          {inputPayload && <ToolDetailViewer payload={inputPayload} />}
+          {resultPayload && <ToolDetailViewer payload={resultPayload} />}
         </div>
       )}
     </div>
@@ -1626,6 +1866,7 @@ function AssistantMessage() {
   const chatRunning = React.useContext(ChatRunningContext);
   const msg = messageRuntime.getState();
   const timestamp = formatMessageTimestamp(msg.createdAt);
+  const activityTrail = activityTrailFromMetadata(msg);
   const isLast =
     thread.messages.length > 0 &&
     thread.messages[thread.messages.length - 1].id === msg.id;
@@ -1698,6 +1939,9 @@ function AssistantMessage() {
           }}
         />
       </div>
+      {isComplete && activityTrail.length > 0 && (
+        <RunActivityTrail steps={activityTrail} />
+      )}
       {isComplete && (
         <div className="mt-1 flex items-center justify-between">
           <div className="flex min-w-0 items-center gap-2">
@@ -2053,6 +2297,23 @@ function isBuilderReconnectRunError(info: RunErrorInfo): boolean {
   );
 }
 
+function isProviderQueryRunError(info: RunErrorInfo): boolean {
+  const text = [info.errorCode, info.message, info.details]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+  return (
+    text.includes("bigquery") ||
+    text.includes("sql") ||
+    text.includes("query") ||
+    text.includes("schema") ||
+    text.includes("syntax") ||
+    text.includes("unknown column") ||
+    text.includes("unknown table") ||
+    text.includes("type mismatch")
+  );
+}
+
 function getMessageText(message: unknown): string {
   const msg = (message as { message?: unknown })?.message ?? message;
   const content = (msg as { content?: unknown })?.content;
@@ -2083,6 +2344,9 @@ function RunErrorRecoveryCard({
   const [copied, setCopied] = useState(false);
   const canRecover = info.recoverable === true;
   const shouldShowBuilderReconnect = isBuilderReconnectRunError(info);
+  const isQueryError = isProviderQueryRunError(info);
+  const copyLabel =
+    info.runId || info.errorCode || info.details ? "Copy debug" : "Copy";
   const copyDetails = useCallback(() => {
     const text = [
       info.message,
@@ -2183,7 +2447,7 @@ function RunErrorRecoveryCard({
               className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-background px-3 text-xs font-medium text-foreground hover:bg-accent"
             >
               <IconRefresh size={13} />
-              Retry
+              {isQueryError ? "Diagnose and retry" : "Retry"}
             </button>
           </>
         )}
@@ -2205,7 +2469,7 @@ function RunErrorRecoveryCard({
           className="ml-auto inline-flex h-8 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium text-muted-foreground hover:bg-background/80 hover:text-foreground"
         >
           {copied ? <IconCheck size={13} /> : <IconCopy size={13} />}
-          {copied ? "Copied" : "Copy"}
+          {copied ? "Copied" : copyLabel}
         </button>
       </div>
     </div>

--- a/packages/core/src/client/components/ui/hover-card.tsx
+++ b/packages/core/src/client/components/ui/hover-card.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
+
+import { cn } from "../../utils.js";
+
+const HoverCard = HoverCardPrimitive.Root;
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger;
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
+));
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
+
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
+++ b/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
@@ -10,6 +10,7 @@ import {
   IconStarFilled,
   IconTrash,
   IconDots,
+  IconInfoCircle,
   IconPencil,
   IconGripVertical,
   IconTool,
@@ -22,6 +23,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "../components/ui/popover.js";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "../components/ui/hover-card.js";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -409,50 +415,63 @@ export function ExtensionsSidebarSection() {
             extensionsOpen && sortedTools.length > 0 && "mb-1",
           )}
         >
-          <Popover>
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                className="flex min-w-0 flex-1 items-center gap-3 px-3 py-1.5 pr-24 text-left"
-                aria-label="About extensions"
+          <button
+            type="button"
+            onClick={toggleExtensionsOpen}
+            className="absolute inset-0 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={
+              extensionsOpen ? "Collapse extensions" : "Expand extensions"
+            }
+            aria-expanded={extensionsOpen}
+          />
+          <div className="pointer-events-none relative z-10 flex min-w-0 flex-1 items-center gap-3 px-3 py-1.5 pr-24">
+            <IconTool className="h-4 w-4 shrink-0" />
+            <span className="min-w-0 whitespace-nowrap">Extensions</span>
+            <HoverCard openDelay={250} closeDelay={120}>
+              <HoverCardTrigger asChild>
+                <button
+                  type="button"
+                  className="pointer-events-auto -ml-1 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/45 transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  aria-label="About extensions"
+                >
+                  <IconInfoCircle className="h-3.5 w-3.5" />
+                </button>
+              </HoverCardTrigger>
+              <HoverCardContent
+                side="right"
+                align="start"
+                sideOffset={8}
+                className="w-72 space-y-3 p-3"
               >
-                <IconTool className="h-4 w-4 shrink-0" />
-                <span className="min-w-0 whitespace-nowrap">Extensions</span>
-              </button>
-            </PopoverTrigger>
-            <PopoverContent
-              side="right"
-              align="start"
-              className="w-72 space-y-3 p-3"
-            >
-              <div>
-                <p className="text-sm font-semibold text-foreground">
-                  Extensions
-                </p>
-                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                  Build small sandboxed apps that can read app data, call
-                  actions, and save their own state.
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <Link
-                  to="/extensions"
-                  className="inline-flex h-8 items-center rounded-md border px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
-                >
-                  Open extensions
-                </Link>
-                <a
-                  href="https://agent-native.com/docs/extensions"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex h-8 items-center rounded-md px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                >
-                  Learn more
-                </a>
-              </div>
-            </PopoverContent>
-          </Popover>
-          <div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center">
+                <div>
+                  <p className="text-sm font-semibold text-foreground">
+                    Extensions
+                  </p>
+                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                    Build small sandboxed apps that can read app data, call
+                    actions, and save their own state.
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Link
+                    to="/extensions"
+                    className="inline-flex h-8 items-center rounded-md border px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-accent"
+                  >
+                    Open extensions
+                  </Link>
+                  <a
+                    href="https://agent-native.com/docs/extensions"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex h-8 items-center rounded-md px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  >
+                    Learn more
+                  </a>
+                </div>
+              </HoverCardContent>
+            </HoverCard>
+          </div>
+          <div className="absolute right-1 top-1/2 z-20 flex -translate-y-1/2 items-center">
             <ExtensionSortMenu
               value={sortModeState}
               onChange={setExtensionSortMode}

--- a/packages/core/src/client/sse-event-processor.spec.ts
+++ b/packages/core/src/client/sse-event-processor.spec.ts
@@ -413,7 +413,21 @@ describe("SSE event processor error classification", () => {
       ),
     );
 
-    expect(results).toEqual([{ content: [] }]);
+    expect(results).toEqual([
+      {
+        content: [],
+        metadata: {
+          custom: {
+            activityTrail: [
+              {
+                label: "Preparing create-document action",
+                tool: "create-document",
+              },
+            ],
+          },
+        },
+      },
+    ]);
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "agent-chat:activity",
@@ -506,6 +520,16 @@ describe("SSE event processor error classification", () => {
           toolName: "create-document",
         }),
       ],
+      metadata: {
+        custom: {
+          activityTrail: [
+            {
+              label: "Running create-document",
+              tool: "create-document",
+            },
+          ],
+        },
+      },
     });
     expect(dispatchEvent).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/core/src/client/sse-event-processor.ts
+++ b/packages/core/src/client/sse-event-processor.ts
@@ -64,6 +64,23 @@ export class AgentAutoContinueSignal extends Error {
 
 export const SSE_NO_PROGRESS_TIMEOUT_MS = 75_000;
 
+type ActivityTrailEntry = { label: string; tool?: string };
+
+function appendActivityTrail(
+  trail: ActivityTrailEntry[],
+  next: ActivityTrailEntry,
+) {
+  const label = next.label.trim();
+  if (!label) return;
+  const tool = next.tool?.trim();
+  const last = trail[trail.length - 1];
+  if (last?.label === label && last.tool === tool) return;
+  trail.push({ label, ...(tool ? { tool } : {}) });
+  if (trail.length > 8) {
+    trail.splice(0, trail.length - 8);
+  }
+}
+
 async function readChunkWithProgressTimeout(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   lastMeaningfulEventAt: number,
@@ -526,16 +543,17 @@ export async function* readSSEStream(
   const decoder = new TextDecoder();
   let buf = "";
   let lastMeaningfulEventAt = Date.now();
+  const activityTrail: ActivityTrailEntry[] = [];
 
-  const withRunId = (r: ChatModelRunResult): ChatModelRunResult => {
-    if (!runId) return r;
+  const withStreamMetadata = (r: ChatModelRunResult): ChatModelRunResult => {
+    if (!runId && activityTrail.length === 0) return r;
     const metadata = (r.metadata ?? {}) as Record<string, unknown>;
     const custom =
       metadata.custom && typeof metadata.custom === "object"
         ? (metadata.custom as Record<string, unknown>)
         : {};
     const runError =
-      custom.runError && typeof custom.runError === "object"
+      runId && custom.runError && typeof custom.runError === "object"
         ? {
             ...(custom.runError as Record<string, unknown>),
             runId,
@@ -545,7 +563,14 @@ export async function* readSSEStream(
       ...r,
       metadata: {
         ...metadata,
-        custom: { ...custom, runId, ...(runError ? { runError } : {}) },
+        custom: {
+          ...custom,
+          ...(runId ? { runId } : {}),
+          ...(runError ? { runError } : {}),
+          ...(activityTrail.length > 0
+            ? { activityTrail: [...activityTrail] }
+            : {}),
+        },
       },
     };
   };
@@ -582,6 +607,21 @@ export async function* readSSEStream(
           onSeq(ev.seq);
         }
 
+        if (ev.type === "clear") {
+          activityTrail.length = 0;
+        } else if (ev.type === "activity") {
+          appendActivityTrail(activityTrail, {
+            label: ev.label ?? "Working",
+            ...(ev.tool ? { tool: ev.tool } : {}),
+          });
+        } else if (ev.type === "tool_start") {
+          const tool = ev.tool ?? "unknown";
+          appendActivityTrail(activityTrail, {
+            label: `Running ${tool}`,
+            tool,
+          });
+        }
+
         const { action, result, autoContinue } = processEvent(
           ev,
           content,
@@ -589,7 +629,7 @@ export async function* readSSEStream(
           tabId,
         );
 
-        if (result) yield withRunId(result);
+        if (result) yield withStreamMetadata(result);
         if (action === "auto_continue") {
           throw new AgentAutoContinueSignal(
             autoContinue ?? { reason: "stream_ended" },

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1267,10 +1267,18 @@ describe("server/auth", () => {
       expect(html).toContain("params.set('desktop', '1')");
       expect(html).toContain("params.set('flow_id', flowId)");
       expect(html).toContain("params.set('redirect', '1')");
-      expect(html).toContain("window.open(url, '_blank'");
+      expect(html).toContain("__anIsBuilderDesktop()");
+      expect(html).toContain(
+        "if (__anIsBuilderPreview() && !__anIsBuilderDesktop())",
+      );
+      expect(html).toContain(
+        "window.open('', '_blank', 'width=640,height=760')",
+      );
+      expect(html).toContain("popup.location.href = url");
       expect(html).toContain("__anOpenOAuthUrl(data.url)");
       expect(html).toContain("window.location.href = url");
       expect(html).not.toContain("window.open(data.url");
+      expect(html).not.toContain("noopener,noreferrer,width=640,height=760");
       expect(html).not.toContain("Waiting for sign-in");
     });
 
@@ -1287,6 +1295,14 @@ describe("server/auth", () => {
       expect(loginHtml).toContain(
         "__anSetOAuthDebug('Google popup opened; waiting for callback', flowId)",
       );
+      expect(loginHtml).toContain("__anIsBuilderDesktop()");
+      expect(loginHtml).toContain(
+        "if (__anIsBuilderPreview() && !__anIsBuilderDesktop())",
+      );
+      expect(loginHtml).toContain(
+        "window.open('', '_blank', 'width=640,height=760')",
+      );
+      expect(loginHtml).toContain("popup.location.href = url");
       expect(loginHtml).toContain(
         "Google popup was blocked. Allow popups for this site",
       );

--- a/packages/core/src/server/google-auth-plugin.ts
+++ b/packages/core/src/server/google-auth-plugin.ts
@@ -98,6 +98,14 @@ const GOOGLE_LOGIN_HTML = `<!DOCTYPE html>
       return false;
     }
   }
+  function __anIsBuilderDesktop() {
+    try {
+      var ua = navigator.userAgent || '';
+      return ua.indexOf('Electron') !== -1 && ua.indexOf('AgentNativeDesktop') === -1;
+    } catch(e) {
+      return false;
+    }
+  }
   var __anOAuthPollTimer = null;
   var __anOAuthPollCount = 0;
   function __anNewOAuthFlowId() {
@@ -179,9 +187,17 @@ const GOOGLE_LOGIN_HTML = `<!DOCTYPE html>
     try { sessionStorage.setItem('__an_signin', '1'); } catch(e) {}
     __anSetOAuthDebug('Opening Google sign-in popup', flowId);
     try {
-      var popup = window.open(url, '_blank', 'noopener,noreferrer,width=640,height=760');
+      var popup = window.open('', '_blank', 'width=640,height=760');
       if (!popup) {
         __anShowOAuthError(err, btn, 'Google popup was blocked. Allow popups for this site and try again (flow ' + __anFlowDebugId(flowId) + ').');
+        return;
+      }
+      try { popup.opener = null; } catch(e) {}
+      try {
+        popup.location.href = url;
+      } catch(e) {
+        try { popup.close(); } catch(closeErr) {}
+        __anShowOAuthError(err, btn, 'Could not navigate Google popup for flow ' + __anFlowDebugId(flowId) + ': ' + (e && e.message ? e.message : 'unknown error'));
         return;
       }
       __anSetOAuthDebug('Google popup opened; waiting for callback', flowId);
@@ -201,7 +217,7 @@ const GOOGLE_LOGIN_HTML = `<!DOCTYPE html>
     var ret = window.location.pathname + window.location.search;
     btn.disabled = true;
     err.classList.remove('show');
-    if (__anIsBuilderPreview()) {
+    if (__anIsBuilderPreview() && !__anIsBuilderDesktop()) {
       __anStartBuilderOAuth(ret, btn, err);
       return;
     }

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -908,6 +908,14 @@ ${
         return false;
       }
     }
+    function __anIsBuilderDesktop() {
+      try {
+        var ua = navigator.userAgent || '';
+        return ua.indexOf('Electron') !== -1 && ua.indexOf('AgentNativeDesktop') === -1;
+      } catch(e) {
+        return false;
+      }
+    }
     var __anOAuthPollTimer = null;
     var __anOAuthPollCount = 0;
     function __anNewOAuthFlowId() {
@@ -989,9 +997,17 @@ ${
       try { sessionStorage.setItem('__an_signin', '1'); } catch(e) {}
       __anSetOAuthDebug('Opening Google sign-in popup', flowId);
       try {
-        var popup = window.open(url, '_blank', 'noopener,noreferrer,width=640,height=760');
+        var popup = window.open('', '_blank', 'width=640,height=760');
         if (!popup) {
           __anShowOAuthError(err, btn, 'Google popup was blocked. Allow popups for this site and try again (flow ' + __anFlowDebugId(flowId) + ').');
+          return;
+        }
+        try { popup.opener = null; } catch(e) {}
+        try {
+          popup.location.href = url;
+        } catch(e) {
+          try { popup.close(); } catch(closeErr) {}
+          __anShowOAuthError(err, btn, 'Could not navigate Google popup for flow ' + __anFlowDebugId(flowId) + ': ' + (e && e.message ? e.message : 'unknown error'));
           return;
         }
         __anSetOAuthDebug('Google popup opened; waiting for callback', flowId);
@@ -1479,7 +1495,7 @@ ${
     var ret = __anGetReturnPath();
     btn.disabled = true;
     err.classList.remove('show');
-    if (__anIsBuilderPreview()) {
+    if (__anIsBuilderPreview() && !__anIsBuilderDesktop()) {
       __anStartBuilderOAuth(ret, btn, err);
       return;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-hover-card':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -34,6 +34,7 @@ import {
   IconPlus,
   IconKey,
   IconCopy,
+  IconDotsVertical,
 } from "@tabler/icons-react";
 import { getIdToken } from "@/lib/auth";
 import {
@@ -59,6 +60,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface AnalyticsPublicKeyRow {
   id: string;
@@ -443,90 +451,95 @@ function ConnectedView({
 
   return (
     <>
-      <div className="space-y-3 py-3">
-        {/* Credential summary */}
-        <div className="space-y-2">
-          {source.envKeys.map((key) => {
-            const configured =
-              envStatus.find((s) => s.key === key)?.configured ?? false;
-            return (
-              <div
-                key={key}
-                className="flex items-center justify-between text-xs"
-              >
-                <span className="text-muted-foreground">
-                  {keyLabels[key] || key}
-                </span>
-                {configured ? (
-                  <span className="text-emerald-500 flex items-center gap-1">
-                    <IconCheck className="h-3 w-3" />
-                    Configured
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1 space-y-2">
+            {source.envKeys.map((key) => {
+              const configured =
+                envStatus.find((s) => s.key === key)?.configured ?? false;
+              return (
+                <div
+                  key={key}
+                  className="flex items-center justify-between gap-4 text-xs"
+                >
+                  <span className="text-muted-foreground">
+                    {keyLabels[key] || key}
                   </span>
-                ) : (
-                  <span className="text-rose-400 flex items-center gap-1">
-                    <IconAlertCircle className="h-3 w-3" />
-                    Missing
-                  </span>
-                )}
-              </div>
-            );
-          })}
-        </div>
+                  {configured ? (
+                    <span className="flex items-center gap-1 whitespace-nowrap text-emerald-500">
+                      <IconCheck className="h-3 w-3" />
+                      Configured
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1 whitespace-nowrap text-rose-400">
+                      <IconAlertCircle className="h-3 w-3" />
+                      Missing
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
 
-        {/* Actions */}
-        <div className="flex flex-wrap items-center gap-2 pt-2 border-t border-border/30">
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => {
-              setTestResult(null);
-              testMutation.mutate();
-            }}
-            disabled={testMutation.isPending}
-            className="text-xs"
-          >
-            {testMutation.isPending ? (
-              <>
-                <IconLoader2 className="h-3 w-3 animate-spin mr-1.5" />
-                Testing...
-              </>
-            ) : (
-              "Test Connection"
-            )}
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() => setEditing(true)}
-            className="text-xs"
-          >
-            <IconPencil className="h-3 w-3 mr-1.5" />
-            Edit
-          </Button>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={handleDisconnect}
-            disabled={disconnectMutation.isPending}
-            className="text-xs text-destructive hover:text-destructive"
-          >
-            {disconnectMutation.isPending ? (
-              <IconLoader2 className="h-3 w-3 animate-spin mr-1.5" />
-            ) : (
-              <IconTrash className="h-3 w-3 mr-1.5" />
-            )}
-            Disconnect
-          </Button>
-          {source.docsUrl && (
-            <a
-              href={source.docsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-muted-foreground hover:text-primary flex items-center gap-1 ml-auto"
-            >
-              Docs <IconExternalLink className="h-3 w-3" />
-            </a>
-          )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="-mr-1 -mt-1 h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+                aria-label={`${source.name} actions`}
+              >
+                <IconDotsVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuItem
+                onSelect={() => {
+                  setTestResult(null);
+                  testMutation.mutate();
+                }}
+                disabled={testMutation.isPending}
+              >
+                {testMutation.isPending ? (
+                  <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <IconCheck className="mr-2 h-4 w-4" />
+                )}
+                {testMutation.isPending ? "Testing..." : "Test connection"}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setEditing(true)}>
+                <IconPencil className="mr-2 h-4 w-4" />
+                Edit credentials
+              </DropdownMenuItem>
+              {source.docsUrl && (
+                <DropdownMenuItem asChild>
+                  <a
+                    href={source.docsUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <IconExternalLink className="mr-2 h-4 w-4" />
+                    Open docs
+                  </a>
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={handleDisconnect}
+                disabled={disconnectMutation.isPending}
+                className="text-destructive focus:text-destructive"
+              >
+                {disconnectMutation.isPending ? (
+                  <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <IconTrash className="mr-2 h-4 w-4" />
+                )}
+                {disconnectMutation.isPending
+                  ? "Disconnecting..."
+                  : "Disconnect"}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
         {testResult && (
@@ -621,9 +634,9 @@ function DataSourceCard({
     <Card className="bg-card border-border/50">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full text-left"
+        className="w-full rounded-t-lg text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
       >
-        <CardHeader className="pb-3">
+        <CardHeader className="p-5">
           <div className="flex items-center justify-between gap-6">
             <div className="flex items-center gap-3">
               <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
@@ -663,7 +676,7 @@ function DataSourceCard({
       </button>
 
       {expanded && (
-        <CardContent className="pt-0 border-t border-border/50">
+        <CardContent className="border-t border-border/50 px-5 py-4">
           {connected ? (
             <ConnectedView
               source={source}
@@ -673,7 +686,7 @@ function DataSourceCard({
           ) : (
             <>
               {/* Step progress */}
-              <div className="flex items-center gap-1.5 py-3">
+              <div className="flex items-center gap-1.5 pb-3">
                 {source.walkthroughSteps.map((_, i) => (
                   <button
                     key={i}
@@ -729,7 +742,7 @@ function DataSourceCard({
                   : true;
                 const canAdvance = !stepKey || step.optional || stepFilled;
                 return (
-                  <div className="flex items-center gap-2 pt-2 pb-4">
+                  <div className="flex items-center gap-2 pb-4 pt-1">
                     {currentStep > 0 && (
                       <Button
                         size="sm"
@@ -761,7 +774,7 @@ function DataSourceCard({
                 );
               })()}
 
-              <div className="flex items-center gap-2 pt-4 border-t border-border/30">
+              <div className="flex items-center gap-2 border-t border-border/30 pt-3">
                 {hasInputValues && (
                   <Button
                     size="sm"
@@ -919,9 +932,9 @@ function FirstPartyAnalyticsCard() {
     <Card className="bg-card border-border/50">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full text-left"
+        className="w-full rounded-t-lg text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
       >
-        <CardHeader className="pb-3">
+        <CardHeader className="p-5">
           <div className="flex items-center justify-between gap-6">
             <div className="flex items-center gap-3">
               <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
@@ -962,8 +975,8 @@ function FirstPartyAnalyticsCard() {
       </button>
 
       {expanded && (
-        <CardContent className="pt-0 border-t border-border/50">
-          <div className="space-y-4 pt-3">
+        <CardContent className="border-t border-border/50 px-5 py-4">
+          <div className="space-y-4">
             <div className="grid gap-2 rounded-md border border-border/50 bg-muted/20 p-3 text-xs">
               <div className="flex items-center justify-between gap-3">
                 <span className="text-muted-foreground">Endpoint</span>
@@ -1058,23 +1071,32 @@ function FirstPartyAnalyticsCard() {
                           : " never used"}
                       </div>
                     </div>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        revokeKey.mutate({ id: key.id });
-                      }}
-                      disabled={revokeKey.isPending}
-                      className="text-xs text-destructive hover:text-destructive"
-                    >
-                      {revokeKey.isPending ? (
-                        <IconLoader2 className="h-3 w-3 animate-spin mr-1.5" />
-                      ) : (
-                        <IconTrash className="h-3 w-3 mr-1.5" />
-                      )}
-                      Revoke
-                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-8 w-8 shrink-0 text-muted-foreground hover:text-foreground"
+                          aria-label={`${key.name} key actions`}
+                        >
+                          <IconDotsVertical className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="w-36">
+                        <DropdownMenuItem
+                          onSelect={() => revokeKey.mutate({ id: key.id })}
+                          disabled={revokeKey.isPending}
+                          className="text-destructive focus:text-destructive"
+                        >
+                          {revokeKey.isPending ? (
+                            <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />
+                          ) : (
+                            <IconTrash className="mr-2 h-4 w-4" />
+                          )}
+                          {revokeKey.isPending ? "Revoking..." : "Revoke"}
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## Summary

- **Builder.io desktop OAuth**: detect Electron-without-AgentNativeDesktop UA (the Builder.io desktop preview) and skip the Builder redirect-loop sign-in path; use the standard popup flow instead. Both popup-opening sites now open an empty `about:blank` window and set `popup.location.href` separately so URL navigation doesn't race with window allocation.
- **SSE activity trail**: rolling 8-entry label+tool history stamped onto every assistant chunk's `metadata.custom.activityTrail`. Clears on `clear`, appends on `activity` / `tool_start`. Spec coverage.
- **AssistantChat tool detail**: shiki highlighting now loads the sql grammar (with `bq` / `bigquery` aliases), inline search over input/result code, and a fullscreen viewer.
- **Extensions sidebar hovercard**: replaces the click-popover explainer with a Radix HoverCard. New `components/ui/hover-card.tsx` primitive + `@radix-ui/react-hover-card` dep.
- **Analytics DataSources**: connected source rows get a proper kebab menu (`DropdownMenu`) for actions instead of inline buttons.

## Test plan

- [ ] `pnpm run prep` clean
- [ ] In Builder Desktop, sign in with Google — confirms popup flow opens, redeems flow id, and lands the user back signed in
- [ ] Run a long agent turn and confirm assistant chunks carry an `activityTrail` with the last 8 messages
- [ ] Hover the Extensions row in the sidebar — confirms the hovercard opens with the explainer + Open / Learn more links
- [ ] Open analytics Data Sources — confirms each connected source has a `⋯` kebab with the same actions that used to live inline