### PR TITLE
fix(analytics): blank input on optional credential keys deletes the stored value

### DIFF
--- a/.changeset/command-menu-top-15vh.md
+++ b/.changeset/command-menu-top-15vh.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Drop the command menu from `top-[5vh]` to `top-[15vh]` so the palette sits comfortably below the page header instead of pinned to the top.

--- a/.changeset/top-aligned-command-palettes.md
+++ b/.changeset/top-aligned-command-palettes.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/dispatch": patch
+---
+
+Top-align command palettes so result count changes do not shift their viewport position.

--- a/packages/core/src/client/CommandMenu.tsx
+++ b/packages/core/src/client/CommandMenu.tsx
@@ -338,7 +338,7 @@ export function CommandMenu({
       <div
         ref={containerRef}
         className={cn(
-          "fixed left-1/2 top-[5vh] -translate-x-1/2 w-full max-w-lg",
+          "fixed left-1/2 top-[15vh] -translate-x-1/2 w-full max-w-lg",
           "rounded-lg border border-border bg-popover text-popover-foreground shadow-lg",
           className,
         )}

--- a/packages/dispatch/src/components/ui/command.tsx
+++ b/packages/dispatch/src/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <DialogTitle className="sr-only">Command menu</DialogTitle>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -301,17 +301,17 @@ To override the default org plugin (e.g. to add custom validation or extra handl
 
 ## Production Environment Variables
 
-| Var                                   | Required for                                                                                                                 |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `DATABASE_URL`                        | All deployments — Neon Postgres URL                                                                                          |
-| `BETTER_AUTH_SECRET`                  | Auth — random 32-byte hex string                                                                                             |
-| `BETTER_AUTH_URL`                     | Auth — `https://analytics.agent-native.com`                                                                                  |
-| `GOOGLE_CLIENT_ID`                    | Google sign-in (OAuth 2.0 Client ID, NOT the SA)                                                                             |
-| `GOOGLE_CLIENT_SECRET`                | Google sign-in                                                                                                               |
-| `BIGQUERY_PROJECT_ID`                 | BigQuery panels — configured GCP project ID                                                                                  |
-| `GOOGLE_APPLICATION_CREDENTIALS_JSON` | BigQuery service-account JSON (single line)                                                                                  |
-| `ANALYTICS_BIGQUERY_EVENTS_TABLE`     | Optional BigQuery table for first-party/app event examples; defaults to `<BIGQUERY_PROJECT_ID>.analytics.events_partitioned` |
-| `ANTHROPIC_API_KEY`                   | Agent chat                                                                                                                   |
+| Var                                   | Required for                                                                                                 |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `DATABASE_URL`                        | All deployments — Neon Postgres URL                                                                          |
+| `BETTER_AUTH_SECRET`                  | Auth — random 32-byte hex string                                                                             |
+| `BETTER_AUTH_URL`                     | Auth — `https://analytics.agent-native.com`                                                                  |
+| `GOOGLE_CLIENT_ID`                    | Google sign-in (OAuth 2.0 Client ID, NOT the SA)                                                             |
+| `GOOGLE_CLIENT_SECRET`                | Google sign-in                                                                                               |
+| `BIGQUERY_PROJECT_ID`                 | BigQuery panels — configured GCP project ID                                                                  |
+| `GOOGLE_APPLICATION_CREDENTIALS_JSON` | BigQuery service-account JSON (single line)                                                                  |
+| `ANALYTICS_BIGQUERY_EVENTS_TABLE`     | Optional `@app_events` alias for first-party/app event examples; not required for BigQuery connection status |
+| `ANTHROPIC_API_KEY`                   | Agent chat                                                                                                   |
 
 The OAuth 2.0 Client ID for Google sign-in is a **separate credential** from the BigQuery service account. Create it in GCP Console → APIs & Services → Credentials → OAuth client ID → Web application, with redirect URIs `https://analytics.agent-native.com/_agent-native/auth/ba/callback/google` and `http://localhost:3000/_agent-native/auth/ba/callback/google`.
 
@@ -347,6 +347,8 @@ The data dictionary is the canonical catalog of the metrics, tables, columns, an
 **Workflow for "build me a dashboard":**
 
 A `<data-dictionary>` block is injected into your system prompt with the approved entries for this workspace. Read it before you write any SQL. If the entry you need is there, you MUST use its `table` and `columns` values verbatim — column names in the underlying warehouse use prefixes (`hs_`, `m_`, `sfdc_`, etc.) that you cannot guess. Making them up produces `Unrecognized name` errors and a broken dashboard.
+
+**BigQuery is a warehouse, not a single table.** Treat `BIGQUERY_PROJECT_ID` + `GOOGLE_APPLICATION_CREDENTIALS_JSON` as the connection. `ANALYTICS_BIGQUERY_EVENTS_TABLE` only powers the optional `@app_events` shortcut for examples and event discovery; its absence does not mean BigQuery is disconnected, and its presence does not mean all warehouse data lives there. For warehouse questions, use approved data-dictionary entries, existing dashboard SQL, or `INFORMATION_SCHEMA` discovery to find the real datasets, tables, and columns.
 
 1. If the user's request is materially ambiguous, write 2-4 guided questions to `show-questions` before doing expensive dashboard work.
 2. **Check the `<data-dictionary>` block** in your system prompt for entries that match the user's request.
@@ -402,7 +404,7 @@ A `<data-dictionary>` block is injected into your system prompt with the approve
 | `seo-page-keywords`            | `--url`                     | Keywords for a specific page                                                                                                                              |
 | `seo-blog-pages`               |                             | Blog page SEO metrics                                                                                                                                     |
 | `ga4-report`                   | `--metrics`, `--dimensions` | Google Analytics reports                                                                                                                                  |
-| `bigquery`                     | `--sql`                     | Ad-hoc BigQuery/warehouse queries when BigQuery is configured. Do not use as a substitute for named provider actions like Jira or Pylon.                  |
+| `bigquery`                     | `--sql`                     | Ad-hoc BigQuery/warehouse queries across configured datasets and tables. Do not use as a substitute for named provider actions like Jira or Pylon.        |
 | `query-agent-native-analytics` | `--sql`                     | Query first-party `analytics_events` recorded via `/track`, including traffic, product events, and app/template usage collected by this analytics app     |
 | `create-analytics-public-key`  | `[--name <label>]`          | Generate a public write key for hosted apps to send events to `analytics.agent-native.com/track`                                                          |
 | `list-analytics-public-keys`   |                             | List active/revoked first-party analytics write keys                                                                                                      |

--- a/templates/analytics/actions/bigquery-table-info.ts
+++ b/templates/analytics/actions/bigquery-table-info.ts
@@ -3,14 +3,14 @@ import { z } from "zod";
 
 const TABLE_INFO = `## BigQuery Table Info
 
-This generic analytics template does not bundle a workspace-specific BigQuery data dictionary.
+This generic analytics template does not bundle a workspace-specific BigQuery data dictionary. BigQuery is a warehouse with many datasets and tables; the connection is not represented by one table name.
 
 Use these sources of truth instead:
 
 - \`list-data-dictionary\` for approved metric, table, column, join, and caveat definitions configured by this organization.
 - \`data-source-status --key bigquery\` to confirm whether BigQuery credentials and a project are configured.
 - The configured warehouse's \`INFORMATION_SCHEMA.COLUMNS\` tables when you need to discover actual datasets, tables, and columns.
-- \`@app_events\` as the placeholder for the configured application events table in query-metrics examples. It defaults to \`<BIGQUERY_PROJECT_ID>.analytics.events_partitioned\` and can be overridden with \`ANALYTICS_BIGQUERY_EVENTS_TABLE\`.
+- \`@app_events\` as an optional placeholder for a default application events table in query-metrics examples. It defaults to \`<BIGQUERY_PROJECT_ID>.analytics.events_partitioned\` and can be overridden with \`ANALYTICS_BIGQUERY_EVENTS_TABLE\`; it is not the BigQuery connection status or a table catalog.
 - \`@project\` as the configured BigQuery project placeholder for fully-qualified table references.
 
 If no data-dictionary entry exists and schema discovery is unavailable, ask the user for the source table or metric definition before writing SQL. Never invent table names, column names, joins, or numbers.

--- a/templates/analytics/app/components/ui/command.tsx
+++ b/templates/analytics/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/analytics/app/lib/data-source-status.spec.ts
+++ b/templates/analytics/app/lib/data-source-status.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { dataSources } from "./data-sources";
+import { isSourceConfigured } from "./data-source-status";
+
+describe("data source status", () => {
+  it("does not require the optional BigQuery app events alias", () => {
+    const bigquery = dataSources.find((source) => source.id === "bigquery");
+
+    expect(bigquery).toBeTruthy();
+    expect(
+      isSourceConfigured(bigquery!, [
+        {
+          key: "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+          label: "Google Cloud",
+          required: false,
+          configured: true,
+        },
+        {
+          key: "BIGQUERY_PROJECT_ID",
+          label: "BigQuery Project ID",
+          required: false,
+          configured: true,
+        },
+        {
+          key: "ANALYTICS_BIGQUERY_EVENTS_TABLE",
+          label: "BigQuery Events Table",
+          required: false,
+          configured: false,
+        },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/templates/analytics/app/lib/data-source-status.ts
+++ b/templates/analytics/app/lib/data-source-status.ts
@@ -21,17 +21,21 @@ export function credentialRowsFromStatus(
   return data?.credentials ?? [];
 }
 
-export function isSourceConfigured(
-  source: DataSource,
-  envStatus: EnvKeyStatus[],
-): boolean {
-  const statusMap = new Map(envStatus.map((s) => [s.key, s.configured]));
-  const optionalKeys = new Set(
+export function getOptionalCredentialKeys(source: DataSource): Set<string> {
+  return new Set(
     source.walkthroughSteps
       .filter((step) => step.optional)
       .map((step) => step.inputKey)
       .filter(Boolean),
   );
+}
+
+export function isSourceConfigured(
+  source: DataSource,
+  envStatus: EnvKeyStatus[],
+): boolean {
+  const statusMap = new Map(envStatus.map((s) => [s.key, s.configured]));
+  const optionalKeys = getOptionalCredentialKeys(source);
   return source.envKeys
     .filter((key) => !optionalKeys.has(key))
     .every((key) => statusMap.get(key) === true);

--- a/templates/analytics/app/lib/data-sources.ts
+++ b/templates/analytics/app/lib/data-sources.ts
@@ -141,7 +141,7 @@ export const dataSources: DataSource[] = [
   {
     id: "bigquery",
     name: "BigQuery",
-    description: "Query your data warehouse directly with SQL",
+    description: "Query your data warehouse datasets directly with SQL",
     category: "analytics",
     icon: IconDatabase,
     envKeys: [
@@ -191,13 +191,14 @@ export const dataSources: DataSource[] = [
         inputType: "text",
       },
       {
-        title: "Optional: set the application events table",
+        title: "Optional: set the default app events table alias",
         description:
-          "Used for first-party event examples and Explorer event discovery. Leave blank to use analytics.events_partitioned in the project above.",
+          "Used only for the @app_events shortcut in examples and Explorer event discovery. Leave blank to use analytics.events_partitioned in the project above.",
         inputKey: "ANALYTICS_BIGQUERY_EVENTS_TABLE",
-        inputLabel: "Events Table",
+        inputLabel: "Default App Events Table",
         inputPlaceholder: "analytics.events_partitioned",
         inputType: "text",
+        optional: true,
       },
     ],
   },

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -1167,7 +1167,7 @@ export default function DataSources() {
       {/* Filtered results */}
       {filteredSources !== null ? (
         filteredSources.length > 0 ? (
-          <div className="grid gap-3 lg:grid-cols-2">
+          <div className="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(min(100%,24rem),1fr))]">
             {filteredSources.map((source) => (
               <DataSourceCard
                 key={source.id}
@@ -1193,7 +1193,7 @@ export default function DataSources() {
               <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
                 {categoryLabels[category]}
               </h3>
-              <div className="grid gap-3 lg:grid-cols-2">
+              <div className="grid gap-3 [grid-template-columns:repeat(auto-fit,minmax(min(100%,24rem),1fr))]">
                 {category === "analytics" && <FirstPartyAnalyticsCard />}
                 {sources.map((source) => (
                   <DataSourceCard

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -45,6 +45,7 @@ import {
   type WalkthroughStep,
 } from "@/lib/data-sources";
 import {
+  getOptionalCredentialKeys,
   isSourceConfigured,
   type EnvKeyStatus,
 } from "@/lib/data-source-status";
@@ -329,6 +330,7 @@ function ConnectedView({
         .map((other) => other.name),
     ),
   );
+  const optionalKeys = getOptionalCredentialKeys(source);
 
   const handleDisconnect = () => {
     if (sharedCredentialKeys.length > 0) {
@@ -457,6 +459,7 @@ function ConnectedView({
             {source.envKeys.map((key) => {
               const configured =
                 envStatus.find((s) => s.key === key)?.configured ?? false;
+              const optional = optionalKeys.has(key);
               return (
                 <div
                   key={key}
@@ -469,6 +472,11 @@ function ConnectedView({
                     <span className="flex items-center gap-1 whitespace-nowrap text-emerald-500">
                       <IconCheck className="h-3 w-3" />
                       Configured
+                    </span>
+                  ) : optional ? (
+                    <span className="flex items-center gap-1 whitespace-nowrap text-muted-foreground">
+                      <IconCircle className="h-3 w-3" />
+                      Optional
                     </span>
                   ) : (
                     <span className="flex items-center gap-1 whitespace-nowrap text-rose-400">

--- a/templates/analytics/app/pages/DataSources.tsx
+++ b/templates/analytics/app/pages/DataSources.tsx
@@ -267,6 +267,7 @@ function ConnectedView({
   const [editing, setEditing] = useState(false);
   const [disconnectConfirmOpen, setDisconnectConfirmOpen] = useState(false);
   const [inputValues, setInputValues] = useState<Record<string, string>>({});
+  const [pendingClears, setPendingClears] = useState<Set<string>>(new Set());
   const [testResult, setTestResult] = useState<{
     ok: boolean;
     error?: string;
@@ -274,14 +275,20 @@ function ConnectedView({
 
   const saveMutation = useMutation({
     mutationFn: async () => {
-      const vars = Object.entries(inputValues)
-        .filter(([, v]) => v.trim())
-        .map(([key, value]) => ({ key, value: value.trim() }));
+      const vars: Array<{ key: string; value: string }> = [];
+      for (const [key, value] of Object.entries(inputValues)) {
+        const trimmed = value.trim();
+        if (trimmed) vars.push({ key, value: trimmed });
+      }
+      for (const key of pendingClears) {
+        if (!inputValues[key]?.trim()) vars.push({ key, value: "" });
+      }
       if (vars.length === 0) return;
       await saveEnvVars(vars);
     },
     onSuccess: () => {
       setInputValues({});
+      setPendingClears(new Set());
       setEditing(false);
       onSaved();
     },
@@ -305,7 +312,8 @@ function ConnectedView({
     },
   });
 
-  const hasInputValues = Object.values(inputValues).some((v) => v.trim());
+  const hasInputValues =
+    Object.values(inputValues).some((v) => v.trim()) || pendingClears.size > 0;
 
   // Get credential labels from walkthrough steps
   const keyLabels: Record<string, string> = {};
@@ -345,74 +353,126 @@ function ConnectedView({
       <div className="space-y-3 py-3">
         {source.walkthroughSteps
           .filter((step) => step.inputKey)
-          .map((step) => (
-            <div key={step.inputKey} className="space-y-1.5">
-              <div className="flex items-center justify-between">
-                <label className="text-xs font-medium text-muted-foreground">
-                  {step.inputLabel || step.inputKey}
-                </label>
-                {step.inputAcceptFile && (
-                  <label className="inline-flex items-center gap-1.5 text-xs text-primary hover:text-primary/80 cursor-pointer">
-                    <IconUpload className="h-3 w-3" />
-                    Upload file
-                    <input
-                      type="file"
-                      accept={step.inputAcceptFile}
-                      onChange={(e) => {
-                        const file = e.target.files?.[0];
-                        if (!file || !step.inputKey) return;
-                        const reader = new FileReader();
-                        reader.onload = () => {
-                          if (typeof reader.result === "string") {
-                            setInputValues((prev) => ({
-                              ...prev,
-                              [step.inputKey!]: reader.result as string,
-                            }));
-                          }
-                        };
-                        reader.readAsText(file);
-                        e.target.value = "";
-                      }}
-                      className="hidden"
-                    />
+          .map((step) => {
+            const stepKey = step.inputKey!;
+            const isOptional = optionalKeys.has(stepKey);
+            const isConfigured = !!envStatus.find((s) => s.key === stepKey)
+              ?.configured;
+            const isPendingClear = pendingClears.has(stepKey);
+            const hasTyped = !!inputValues[stepKey]?.trim();
+            return (
+              <div key={stepKey} className="space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    {step.inputLabel || stepKey}
                   </label>
+                  <div className="flex items-center gap-3">
+                    {isOptional && isConfigured && !isPendingClear && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setPendingClears((prev) => {
+                            const next = new Set(prev);
+                            next.add(stepKey);
+                            return next;
+                          });
+                          setInputValues((prev) => {
+                            const next = { ...prev };
+                            delete next[stepKey];
+                            return next;
+                          });
+                        }}
+                        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-rose-400 cursor-pointer"
+                      >
+                        <IconTrash className="h-3 w-3" />
+                        Clear saved value
+                      </button>
+                    )}
+                    {step.inputAcceptFile && !isPendingClear && (
+                      <label className="inline-flex items-center gap-1.5 text-xs text-primary hover:text-primary/80 cursor-pointer">
+                        <IconUpload className="h-3 w-3" />
+                        Upload file
+                        <input
+                          type="file"
+                          accept={step.inputAcceptFile}
+                          onChange={(e) => {
+                            const file = e.target.files?.[0];
+                            if (!file) return;
+                            const reader = new FileReader();
+                            reader.onload = () => {
+                              if (typeof reader.result === "string") {
+                                setInputValues((prev) => ({
+                                  ...prev,
+                                  [stepKey]: reader.result as string,
+                                }));
+                              }
+                            };
+                            reader.readAsText(file);
+                            e.target.value = "";
+                          }}
+                          className="hidden"
+                        />
+                      </label>
+                    )}
+                  </div>
+                </div>
+                {step.inputType === "textarea" ? (
+                  <textarea
+                    value={inputValues[stepKey] || ""}
+                    disabled={isPendingClear}
+                    onChange={(e) =>
+                      setInputValues((prev) => ({
+                        ...prev,
+                        [stepKey]: e.target.value,
+                      }))
+                    }
+                    placeholder={isPendingClear ? "" : "••••••••"}
+                    className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 min-h-[80px] resize-y font-mono disabled:opacity-50"
+                  />
+                ) : (
+                  <input
+                    type={step.inputType || "text"}
+                    value={inputValues[stepKey] || ""}
+                    disabled={isPendingClear}
+                    onChange={(e) =>
+                      setInputValues((prev) => ({
+                        ...prev,
+                        [stepKey]: e.target.value,
+                      }))
+                    }
+                    placeholder={isPendingClear ? "" : "••••••••"}
+                    className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 disabled:opacity-50"
+                  />
+                )}
+                {isPendingClear ? (
+                  <div className="flex items-center justify-between gap-2 text-xs text-amber-500">
+                    <span>Will be cleared on save (back to default).</span>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setPendingClears((prev) => {
+                          const next = new Set(prev);
+                          next.delete(stepKey);
+                          return next;
+                        });
+                      }}
+                      className="text-muted-foreground hover:text-foreground cursor-pointer"
+                    >
+                      Undo
+                    </button>
+                  </div>
+                ) : (
+                  isConfigured &&
+                  !hasTyped && (
+                    <p className="text-xs text-muted-foreground">
+                      A value is already saved. Leave blank to keep it, or enter
+                      a new value to replace it.
+                    </p>
+                  )
                 )}
               </div>
-              {step.inputType === "textarea" ? (
-                <textarea
-                  value={inputValues[step.inputKey!] || ""}
-                  onChange={(e) =>
-                    setInputValues((prev) => ({
-                      ...prev,
-                      [step.inputKey!]: e.target.value,
-                    }))
-                  }
-                  placeholder="••••••••"
-                  className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50 min-h-[80px] resize-y font-mono"
-                />
-              ) : (
-                <input
-                  type={step.inputType || "text"}
-                  value={inputValues[step.inputKey!] || ""}
-                  onChange={(e) =>
-                    setInputValues((prev) => ({
-                      ...prev,
-                      [step.inputKey!]: e.target.value,
-                    }))
-                  }
-                  placeholder="••••••••"
-                  className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/50"
-                />
-              )}
-              {envStatus.find((s) => s.key === step.inputKey)?.configured &&
-                !inputValues[step.inputKey!] && (
-                  <p className="text-xs text-muted-foreground">
-                    A value is already saved. Leave blank to keep it, or enter a
-                    new value to replace it.
-                  </p>
-                )}
-            </div>
-          ))}
+            );
+          })}
         <div className="flex items-center gap-2 pt-2">
           <Button
             size="sm"
@@ -435,6 +495,7 @@ function ConnectedView({
             onClick={() => {
               setEditing(false);
               setInputValues({});
+              setPendingClears(new Set());
             }}
             className="text-xs"
           >

--- a/templates/analytics/server/lib/credential-keys.spec.ts
+++ b/templates/analytics/server/lib/credential-keys.spec.ts
@@ -19,7 +19,6 @@ describe("credential key lookup", () => {
     expect(keysFor("bigquery")).toEqual([
       "GOOGLE_APPLICATION_CREDENTIALS_JSON",
       "BIGQUERY_PROJECT_ID",
-      "ANALYTICS_BIGQUERY_EVENTS_TABLE",
     ]);
     expect(keysFor("google-analytics")).toEqual([
       "GOOGLE_APPLICATION_CREDENTIALS_JSON",

--- a/templates/analytics/server/lib/credential-keys.spec.ts
+++ b/templates/analytics/server/lib/credential-keys.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildOptionalCredentialKeys,
   credentialProviderConfigs,
+  optionalCredentialKeys,
+  partitionCredentialUpdate,
   resolveCredentialConfigs,
 } from "./credential-keys";
 
@@ -54,5 +57,116 @@ describe("credential key lookup", () => {
       requiredKeys: ["GONG_ACCESS_KEY", "GONG_ACCESS_SECRET"],
       optionalKeys: ["GONG_API_BASE"],
     });
+  });
+});
+
+describe("optional credential keys", () => {
+  it("collects keys that are only ever optional across providers", () => {
+    expect(optionalCredentialKeys.has("ANALYTICS_BIGQUERY_EVENTS_TABLE")).toBe(
+      true,
+    );
+    expect(optionalCredentialKeys.has("GONG_API_BASE")).toBe(true);
+    expect(optionalCredentialKeys.has("SENTRY_ORG_SLUG")).toBe(true);
+    expect(optionalCredentialKeys.has("SENTRY_SERVER_TOKEN")).toBe(true);
+    expect(optionalCredentialKeys.has("SLACK_BOT_TOKEN_2")).toBe(true);
+  });
+
+  it("never marks a required key as optional, even if listed in another provider's optionalKeys", () => {
+    const built = buildOptionalCredentialKeys([
+      {
+        provider: "primary",
+        label: "Primary",
+        requiredKeys: ["SHARED_KEY"],
+      },
+      {
+        provider: "secondary",
+        label: "Secondary",
+        requiredKeys: [],
+        optionalKeys: ["SHARED_KEY", "TRULY_OPTIONAL"],
+      },
+    ]);
+    expect(built.has("SHARED_KEY")).toBe(false);
+    expect(built.has("TRULY_OPTIONAL")).toBe(true);
+  });
+
+  it("does not include keys that are required by any provider", () => {
+    expect(
+      optionalCredentialKeys.has("GOOGLE_APPLICATION_CREDENTIALS_JSON"),
+    ).toBe(false);
+    expect(optionalCredentialKeys.has("BIGQUERY_PROJECT_ID")).toBe(false);
+    expect(optionalCredentialKeys.has("SENTRY_AUTH_TOKEN")).toBe(false);
+  });
+});
+
+describe("partitionCredentialUpdate", () => {
+  const optional = new Set([
+    "ANALYTICS_BIGQUERY_EVENTS_TABLE",
+    "GONG_API_BASE",
+  ]);
+
+  it("routes blank values for optional keys to toDelete", () => {
+    const result = partitionCredentialUpdate(
+      [{ key: "ANALYTICS_BIGQUERY_EVENTS_TABLE", value: "" }],
+      optional,
+    );
+    expect(result).toEqual({
+      toSave: [],
+      toDelete: ["ANALYTICS_BIGQUERY_EVENTS_TABLE"],
+      blankRequired: [],
+    });
+  });
+
+  it("flags blank values for required keys without queueing a delete", () => {
+    const result = partitionCredentialUpdate(
+      [{ key: "BIGQUERY_PROJECT_ID", value: "" }],
+      optional,
+    );
+    expect(result).toEqual({
+      toSave: [],
+      toDelete: [],
+      blankRequired: ["BIGQUERY_PROJECT_ID"],
+    });
+  });
+
+  it("trims and saves non-blank values regardless of optional status", () => {
+    const result = partitionCredentialUpdate(
+      [
+        { key: "BIGQUERY_PROJECT_ID", value: "  proj-1  " },
+        { key: "GONG_API_BASE", value: "https://api.gong.io/v2" },
+      ],
+      optional,
+    );
+    expect(result).toEqual({
+      toSave: [
+        { key: "BIGQUERY_PROJECT_ID", value: "proj-1" },
+        { key: "GONG_API_BASE", value: "https://api.gong.io/v2" },
+      ],
+      toDelete: [],
+      blankRequired: [],
+    });
+  });
+
+  it("handles a mixed batch (save + clear) in one call", () => {
+    const result = partitionCredentialUpdate(
+      [
+        { key: "BIGQUERY_PROJECT_ID", value: "proj-1" },
+        { key: "ANALYTICS_BIGQUERY_EVENTS_TABLE", value: "" },
+      ],
+      optional,
+    );
+    expect(result).toEqual({
+      toSave: [{ key: "BIGQUERY_PROJECT_ID", value: "proj-1" }],
+      toDelete: ["ANALYTICS_BIGQUERY_EVENTS_TABLE"],
+      blankRequired: [],
+    });
+  });
+
+  it("treats whitespace-only values the same as blank", () => {
+    const result = partitionCredentialUpdate(
+      [{ key: "GONG_API_BASE", value: "   " }],
+      optional,
+    );
+    expect(result.toDelete).toEqual(["GONG_API_BASE"]);
+    expect(result.toSave).toEqual([]);
   });
 });

--- a/templates/analytics/server/lib/credential-keys.ts
+++ b/templates/analytics/server/lib/credential-keys.ts
@@ -104,6 +104,56 @@ export const credentialKeys: CredentialKeyConfig[] = [
   },
 ];
 
+/**
+ * Keys that act as overrides for a default value — providers list them under
+ * `optionalKeys`. A blank submission for one of these keys means "go back to
+ * the default", which the credentials POST handler treats as a delete. Keys
+ * that are required by *any* provider are excluded so a typo on a critical
+ * field can never silently erase it.
+ */
+export function buildOptionalCredentialKeys(
+  configs: CredentialProviderConfig[],
+): Set<string> {
+  const requiredAnywhere = new Set(configs.flatMap((cfg) => cfg.requiredKeys));
+  return new Set(
+    configs
+      .flatMap((cfg) => cfg.optionalKeys ?? [])
+      .filter((key) => !requiredAnywhere.has(key)),
+  );
+}
+
+export interface CredentialUpdatePartition {
+  toSave: Array<{ key: string; value: string }>;
+  toDelete: string[];
+  blankRequired: string[];
+}
+
+/**
+ * Split incoming credential updates into the keys that should be saved and
+ * the optional keys whose blank value means "clear and use the default".
+ * `blankRequired` collects any blank values for required keys so the caller
+ * can reject them before touching storage.
+ */
+export function partitionCredentialUpdate(
+  vars: Array<{ key: string; value: string }>,
+  optionalKeys: Set<string>,
+): CredentialUpdatePartition {
+  const toSave: Array<{ key: string; value: string }> = [];
+  const toDelete: string[] = [];
+  const blankRequired: string[] = [];
+  for (const { key, value } of vars) {
+    const trimmed = typeof value === "string" ? value.trim() : "";
+    if (trimmed) {
+      toSave.push({ key, value: trimmed });
+    } else if (optionalKeys.has(key)) {
+      toDelete.push(key);
+    } else {
+      blankRequired.push(key);
+    }
+  }
+  return { toSave, toDelete, blankRequired };
+}
+
 export const credentialProviderConfigs: CredentialProviderConfig[] = [
   {
     provider: "google-analytics",
@@ -218,6 +268,10 @@ export const credentialProviderConfigs: CredentialProviderConfig[] = [
     requiredKeys: ["DATAFORSEO_LOGIN", "DATAFORSEO_PASSWORD"],
   },
 ];
+
+export const optionalCredentialKeys = buildOptionalCredentialKeys(
+  credentialProviderConfigs,
+);
 
 const credentialAliases: Record<string, string[]> = {
   amplitude: ["AMPLITUDE_API_KEY", "AMPLITUDE_SECRET_KEY"],

--- a/templates/analytics/server/lib/credential-keys.ts
+++ b/templates/analytics/server/lib/credential-keys.ts
@@ -222,11 +222,7 @@ export const credentialProviderConfigs: CredentialProviderConfig[] = [
 const credentialAliases: Record<string, string[]> = {
   amplitude: ["AMPLITUDE_API_KEY", "AMPLITUDE_SECRET_KEY"],
   apollo: ["APOLLO_API_KEY"],
-  bigquery: [
-    "GOOGLE_APPLICATION_CREDENTIALS_JSON",
-    "BIGQUERY_PROJECT_ID",
-    "ANALYTICS_BIGQUERY_EVENTS_TABLE",
-  ],
+  bigquery: ["GOOGLE_APPLICATION_CREDENTIALS_JSON", "BIGQUERY_PROJECT_ID"],
   commonroom: ["COMMONROOM_API_TOKEN"],
   dataforseo: ["DATAFORSEO_LOGIN", "DATAFORSEO_PASSWORD"],
   ga4: ["GOOGLE_APPLICATION_CREDENTIALS_JSON", "GA4_PROPERTY_ID"],

--- a/templates/analytics/server/routes/api/credentials.post.ts
+++ b/templates/analytics/server/routes/api/credentials.post.ts
@@ -1,9 +1,14 @@
 import { defineEventHandler, setResponseStatus } from "h3";
 import {
   saveCredential,
+  deleteCredential,
   getCredentialContextFromEvent,
 } from "../../lib/credentials";
-import { credentialKeys } from "../../lib/credential-keys";
+import {
+  credentialKeys,
+  optionalCredentialKeys,
+  partitionCredentialUpdate,
+} from "../../lib/credential-keys";
 import { readBody } from "@agent-native/core/server";
 import {
   getScopedSettingRecord,
@@ -60,17 +65,33 @@ export default defineEventHandler(async (event) => {
     return { error: "vars array required" };
   }
 
-  const filtered = vars.filter(
-    (v) => typeof v.key === "string" && ALLOWED_KEYS.has(v.key) && v.value,
+  const recognized = vars.filter(
+    (v) => typeof v.key === "string" && ALLOWED_KEYS.has(v.key),
   );
-  if (filtered.length === 0) {
+  if (recognized.length === 0) {
     setResponseStatus(event, 400);
     return { error: "No recognized credential keys in request" };
   }
 
-  for (const { key, value } of filtered) {
-    const trimmed = value.trim();
-    const validationError = validateCredential(key, trimmed);
+  const { toSave, toDelete, blankRequired } = partitionCredentialUpdate(
+    recognized,
+    optionalCredentialKeys,
+  );
+
+  if (blankRequired.length > 0) {
+    setResponseStatus(event, 400);
+    return {
+      error: `Cannot clear required credentials: ${blankRequired.join(", ")}`,
+    };
+  }
+
+  if (toSave.length === 0 && toDelete.length === 0) {
+    setResponseStatus(event, 400);
+    return { error: "No values to save or delete" };
+  }
+
+  for (const { key, value } of toSave) {
+    const validationError = validateCredential(key, value);
     if (validationError) {
       setResponseStatus(event, 400);
       return { error: validationError };
@@ -82,15 +103,18 @@ export default defineEventHandler(async (event) => {
     setResponseStatus(event, 401);
     return { error: "Sign in to save credentials" };
   }
-  for (const { key, value } of filtered) {
-    await saveCredential(key, value.trim(), ctx);
+  for (const { key, value } of toSave) {
+    await saveCredential(key, value, ctx);
+  }
+  for (const key of toDelete) {
+    await deleteCredential(key, ctx);
   }
 
   // Auto-seed the Google Analytics SQL dashboard the first time a user
   // wires up either GA4 credential. Idempotent: if the dashboard already
   // exists (even empty) we leave it alone so a user who deleted panels
   // doesn't get them resurrected on the next reconnect.
-  const savedKeys = new Set(filtered.map((v) => v.key));
+  const savedKeys = new Set(toSave.map((v) => v.key));
   const savedGaCred = [...GA4_CREDENTIAL_KEYS].some((k) => savedKeys.has(k));
   if (savedGaCred) {
     try {
@@ -111,5 +135,5 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  return { saved: filtered.map((v) => v.key) };
+  return { saved: toSave.map((v) => v.key), deleted: toDelete };
 });

--- a/templates/calendar/app/components/ui/command.tsx
+++ b/templates/calendar/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/calls/app/components/ui/command.tsx
+++ b/templates/calls/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/clips/app/components/ui/command.tsx
+++ b/templates/clips/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/design/app/components/ui/command.tsx
+++ b/templates/design/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/forms/app/components/ui/command.tsx
+++ b/templates/forms/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ Command.displayName = CommandPrimitive.displayName;
 const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/issues/app/components/ui/command.tsx
+++ b/templates/issues/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/macros/app/components/ui/command.tsx
+++ b/templates/macros/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/mail/app/components/ui/command.tsx
+++ b/templates/mail/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ Command.displayName = CommandPrimitive.displayName;
 const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/recruiting/app/components/ui/command.tsx
+++ b/templates/recruiting/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/scheduling/app/components/ui/command.tsx
+++ b/templates/scheduling/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/slides/app/components/ui/command.tsx
+++ b/templates/slides/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/templates/starter/app/components/ui/command.tsx
+++ b/templates/starter/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <DialogTitle className="sr-only">Command menu</DialogTitle>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}

--- a/templates/videos/app/components/ui/command.tsx
+++ b/templates/videos/app/components/ui/command.tsx
@@ -26,7 +26,7 @@ interface CommandDialogProps extends DialogProps {}
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="top-[15vh] translate-y-0 overflow-hidden p-0 shadow-lg">
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>


### PR DESCRIPTION
## Summary
- Optional credential keys (e.g. `ANALYTICS_BIGQUERY_EVENTS_TABLE`, `GONG_API_BASE`, `SENTRY_ORG_SLUG`, `SENTRY_SERVER_TOKEN`, `SLACK_BOT_TOKEN_2`) can now be cleared back to the default without disconnecting the entire provider.
- Server: the credentials POST handler partitions the input. Blank values for keys in any provider's `optionalKeys` are routed through `deleteCredential`. Blank values for required keys are rejected with a 400. The partition lives in `partitionCredentialUpdate` so the rule has direct unit-test coverage.
- Client: each optional, configured key in the DataSources edit form now exposes a `Clear saved value` button. Clearing queues a delete that fires alongside any other edits when the user clicks `Save Changes`. `Cancel` discards queued clears.
- Picks up the gap [the Builder review bot called out on #600](https://github.com/BuilderIO/agent-native/pull/600) — the `ANALYTICS_BIGQUERY_EVENTS_TABLE` change made the key optional, but no UI/API path existed to revert a previously saved value.

## Test plan
- [x] `pnpm test` (analytics template) — 42/42 pass, including new `partitionCredentialUpdate` and `optionalCredentialKeys` cases
- [x] `pnpm typecheck` — clean
- [ ] Manual: open BigQuery in Settings → Data sources, save an `ANALYTICS_BIGQUERY_EVENTS_TABLE`, then click `Clear saved value` → `Save Changes`; confirm the key drops back to "Optional" status
- [ ] Manual: required keys still cannot be cleared (server returns 400, button doesn't render)