### PR TITLE
fix(core): tighten extensions empty-state copy

### DIFF
--- a/.changeset/extensions-empty-state-copy.md
+++ b/.changeset/extensions-empty-state-copy.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Tighten the extensions empty-state copy ("Describe a small app and the agent will build it.").

--- a/packages/core/src/client/extensions/ExtensionsListPage.tsx
+++ b/packages/core/src/client/extensions/ExtensionsListPage.tsx
@@ -210,7 +210,7 @@ export function ExtensionsListPage() {
                     Create your first extension
                   </p>
                   <p className="mx-auto max-w-sm text-sm text-muted-foreground">
-                    Describe the small app you want and the agent will build it.
+                    Describe a small app and the agent will build it.
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Tightens the extensions empty-state subtitle from _"Describe the small app you want and the agent will build it."_ to _"Describe a small app and the agent will build it."_ — clearer, less throat-clearing, same intent.

## Test plan

- [ ] Visit any template's extensions page with no extensions yet
- [ ] Confirm the new subtitle reads naturally
- [ ] CI: Build, Lint, Test, Typecheck, Guard, Changeset green