### PR TITLE
fix(desktop-release): use prerelease tag for auto versions + bump desktop-app to 0.1.7

### DIFF
--- a/.changeset/workspace-dev-dark-mode.md
+++ b/.changeset/workspace-dev-dark-mode.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Workspace dev gateway pages (loading + index) now respect `prefers-color-scheme` and render in dark mode when the user's OS is set to dark.

--- a/.changeset/workspace-oauth-origin-precedence.md
+++ b/.changeset/workspace-oauth-origin-precedence.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Prefer the public auth origin (`APP_URL` / `BETTER_AUTH_URL` / `WORKSPACE_OAUTH_ORIGIN`) over the workspace gateway URL when resolving Google OAuth redirect URIs, on both server and client. Filter out loopback gateway origins so dev workspaces don't accidentally redirect to localhost in production. The workspace dev runner forwards the resolved origin to per-app processes via `VITE_WORKSPACE_OAUTH_ORIGIN`.

--- a/.github/workflows/clips-desktop-release.yml
+++ b/.github/workflows/clips-desktop-release.yml
@@ -29,6 +29,12 @@ jobs:
   build-tauri:
     strategy:
       fail-fast: false
+      # Serialize so the two jobs can't race to create the draft release at
+      # the same time — when both call tauri-action concurrently, one job's
+      # bundles + latest.json get orphaned (clips-v0.1.74 lost its macOS
+      # assets this way, leaving the manifest Windows-only and breaking the
+      # Tauri updater on macOS clients).
+      max-parallel: 1
       matrix:
         include:
           - os: macos-latest

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -37,7 +37,10 @@ jobs:
             echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "push" ]; then
             BASE=$(node -p "require('./packages/desktop-app/package.json').version")
-            echo "version=${BASE}+${AUTO_VERSION_SUFFIX}" >> "$GITHUB_OUTPUT"
+            # Use a prerelease tag (-N) not build metadata (+N): npm version
+            # silently strips +metadata when writing package.json, which would
+            # cause every run to collide on the same release tag and assets.
+            echo "version=${BASE}-${AUTO_VERSION_SUFFIX}" >> "$GITHUB_OUTPUT"
           else
             echo "version=$(node -p "require('./packages/desktop-app/package.json').version")" >> "$GITHUB_OUTPUT"
           fi

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -64,6 +64,28 @@ describe("workspace dev startup", () => {
     expect(fake.startedApps()).toEqual(["dispatch", "starter", "todo"]);
   });
 
+  it("passes the public workspace OAuth origin separately from the local gateway", async () => {
+    tmpDir = makeWorkspace(["dispatch"]);
+    const fake = fakeSpawn();
+    handle = runWorkspaceDev({
+      root: tmpDir,
+      env: {
+        ...testEnv(),
+        APP_URL: "https://workspace.example.test/dispatch",
+      },
+      spawnProcess: fake.spawnProcess,
+      openBrowser: false,
+    });
+    await handle.ready;
+
+    const env = fake.calls()[0]?.options?.env;
+    expect(env?.WORKSPACE_GATEWAY_URL).toMatch(/^http:\/\/127\.0\.0\.1:/);
+    expect(env?.VITE_WORKSPACE_GATEWAY_URL).toBe(env?.WORKSPACE_GATEWAY_URL);
+    expect(env?.VITE_WORKSPACE_OAUTH_ORIGIN).toBe(
+      "https://workspace.example.test",
+    );
+  });
+
   it("uses the root list as fallback when Dispatch is absent", async () => {
     tmpDir = makeWorkspace(["starter"]);
     const fake = fakeSpawn();
@@ -308,6 +330,7 @@ function fakeSpawn(): {
   calls: () => Array<{
     command: string;
     args: string[];
+    options?: { env?: NodeJS.ProcessEnv };
     child: ChildProcess & EventEmitter;
   }>;
   startedApps: () => string[];
@@ -315,22 +338,34 @@ function fakeSpawn(): {
   const calls: Array<{
     command: string;
     args: string[];
+    options?: { env?: NodeJS.ProcessEnv };
     child: ChildProcess & EventEmitter;
   }> = [];
-  const spawnProcess = vi.fn((command: string, args: string[]) => {
-    const child = new EventEmitter() as ChildProcess;
-    child.stdout = new EventEmitter() as ChildProcess["stdout"];
-    child.stderr = new EventEmitter() as ChildProcess["stderr"];
-    child.killed = false;
-    child.kill = vi.fn(() => {
-      child.killed = true;
-      child.emit("exit", 0, null);
-      return true;
-    }) as ChildProcess["kill"];
-    child.unref = vi.fn() as ChildProcess["unref"];
-    calls.push({ command, args, child: child as ChildProcess & EventEmitter });
-    return child;
-  }) as unknown as typeof spawn;
+  const spawnProcess = vi.fn(
+    (
+      command: string,
+      args: string[],
+      options?: { env?: NodeJS.ProcessEnv },
+    ) => {
+      const child = new EventEmitter() as ChildProcess;
+      child.stdout = new EventEmitter() as ChildProcess["stdout"];
+      child.stderr = new EventEmitter() as ChildProcess["stderr"];
+      child.killed = false;
+      child.kill = vi.fn(() => {
+        child.killed = true;
+        child.emit("exit", 0, null);
+        return true;
+      }) as ChildProcess["kill"];
+      child.unref = vi.fn() as ChildProcess["unref"];
+      calls.push({
+        command,
+        args,
+        options,
+        child: child as ChildProcess & EventEmitter,
+      });
+      return child;
+    },
+  ) as unknown as typeof spawn;
 
   return {
     spawnProcess,

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -238,12 +238,15 @@ function renderStartingApp(app: WorkspaceApp): string {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="refresh" content="1" />
     <title>Starting ${escapedName}</title>
+    <meta name="color-scheme" content="light dark" />
     <style>
-      body { min-height: 100vh; margin: 0; display: grid; place-items: center; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #fafafa; color: #171717; }
+      :root { --bg: #fafafa; --fg: #171717; --muted: #737373; --bar-bg: #e5e5e5; --bar-fill: #171717; }
+      @media (prefers-color-scheme: dark) { :root { --bg: #0a0a0a; --fg: #fafafa; --muted: #a3a3a3; --bar-bg: #262626; --bar-fill: #fafafa; } }
+      body { min-height: 100vh; margin: 0; display: grid; place-items: center; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: var(--bg); color: var(--fg); }
       main { width: min(420px, calc(100vw - 48px)); }
-      .bar { height: 3px; overflow: hidden; border-radius: 999px; background: #e5e5e5; }
-      .bar::before { content: ""; display: block; height: 100%; width: 42%; border-radius: inherit; background: #171717; animation: load 1s ease-in-out infinite; }
-      p { color: #737373; }
+      .bar { height: 3px; overflow: hidden; border-radius: 999px; background: var(--bar-bg); }
+      .bar::before { content: ""; display: block; height: 100%; width: 42%; border-radius: inherit; background: var(--bar-fill); animation: load 1s ease-in-out infinite; }
+      p { color: var(--muted); }
       @keyframes load { 0% { transform: translateX(-105%); } 100% { transform: translateX(245%); } }
     </style>
     <script>setTimeout(() => window.location.reload(), 900);</script>
@@ -282,13 +285,16 @@ function renderIndex(apps: WorkspaceApp[]): string {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Agent-Native Workspace</title>
+    <meta name="color-scheme" content="light dark" />
     <style>
-      body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; padding: 32px; background: #fafafa; color: #171717; }
+      :root { --bg: #fafafa; --fg: #171717; --muted: #737373; --card-bg: #ffffff; --card-border: #d4d4d4; }
+      @media (prefers-color-scheme: dark) { :root { --bg: #0a0a0a; --fg: #fafafa; --muted: #a3a3a3; --card-bg: #171717; --card-border: #262626; } }
+      body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; padding: 32px; background: var(--bg); color: var(--fg); }
       main { max-width: 760px; margin: 0 auto; }
       a { color: inherit; text-decoration: none; }
       .grid { display: grid; gap: 12px; margin-top: 20px; }
-      .card { display: flex; justify-content: space-between; border: 1px solid #d4d4d4; border-radius: 8px; padding: 14px 16px; background: white; }
-      .muted { color: #737373; }
+      .card { display: flex; justify-content: space-between; border: 1px solid var(--card-border); border-radius: 8px; padding: 14px 16px; background: var(--card-bg); }
+      .muted { color: var(--muted); }
     </style>
   </head>
   <body>

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -53,6 +53,28 @@ const DEFAULT_APP_PORT_START = 8100;
 const PROXY_READY_RETRY_DELAY_MS = 250;
 const APP_RESTART_MAX_DELAY_MS = 10_000;
 
+function normalizeOrigin(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function workspaceOAuthOrigin(
+  env: NodeJS.ProcessEnv,
+  gatewayUrl: string,
+): string | undefined {
+  return (
+    normalizeOrigin(env.VITE_WORKSPACE_OAUTH_ORIGIN) ||
+    normalizeOrigin(env.WORKSPACE_OAUTH_ORIGIN) ||
+    normalizeOrigin(env.APP_URL) ||
+    normalizeOrigin(env.BETTER_AUTH_URL) ||
+    normalizeOrigin(gatewayUrl)
+  );
+}
+
 export function isWorkspaceWatcherLimitError(
   err: Pick<NodeJS.ErrnoException, "code">,
 ): boolean {
@@ -444,6 +466,7 @@ export function runWorkspaceDev(
         APP_BASE_PATH: basePath,
         VITE_AGENT_NATIVE_WORKSPACE: "1",
         VITE_APP_BASE_PATH: basePath,
+        VITE_WORKSPACE_OAUTH_ORIGIN: workspaceOAuthOrigin(env, gatewayUrl),
         VITE_WORKSPACE_GATEWAY_URL: gatewayUrl,
         PORT: String(app.port),
         WORKSPACE_GATEWAY_URL: gatewayUrl,

--- a/packages/core/src/client/api-path.spec.ts
+++ b/packages/core/src/client/api-path.spec.ts
@@ -81,10 +81,7 @@ describe("oauthRedirectUri", () => {
       "VITE_WORKSPACE_OAUTH_ORIGIN",
       "https://workspace.example/dispatch",
     );
-    vi.stubEnv(
-      "VITE_WORKSPACE_GATEWAY_URL",
-      "http://127.0.0.1:8080",
-    );
+    vi.stubEnv("VITE_WORKSPACE_GATEWAY_URL", "http://127.0.0.1:8080");
     vi.stubGlobal("window", {
       location: {
         origin:

--- a/packages/core/src/client/api-path.spec.ts
+++ b/packages/core/src/client/api-path.spec.ts
@@ -75,7 +75,30 @@ describe("oauthRedirectUri", () => {
     );
   });
 
-  it("uses the configured workspace gateway origin in workspace mode", () => {
+  it("uses the configured workspace OAuth origin in workspace mode", () => {
+    vi.stubEnv("VITE_AGENT_NATIVE_WORKSPACE", "1");
+    vi.stubEnv(
+      "VITE_WORKSPACE_OAUTH_ORIGIN",
+      "https://workspace.example/dispatch",
+    );
+    vi.stubEnv(
+      "VITE_WORKSPACE_GATEWAY_URL",
+      "http://127.0.0.1:8080",
+    );
+    vi.stubGlobal("window", {
+      location: {
+        origin:
+          "https://940ebc5a83164aa6a37dde445e494f3a-thunder-handle-xmq6tgfy.builderio.xyz",
+        pathname: "/dispatch/_agent-native/google/auth-url",
+      },
+    });
+
+    expect(oauthRedirectUri("/_agent-native/google/callback")).toBe(
+      "https://workspace.example/_agent-native/google/callback",
+    );
+  });
+
+  it("falls back to a public workspace gateway origin in workspace mode", () => {
     vi.stubEnv("VITE_AGENT_NATIVE_WORKSPACE", "1");
     vi.stubEnv(
       "VITE_WORKSPACE_GATEWAY_URL",

--- a/packages/core/src/client/frame.ts
+++ b/packages/core/src/client/frame.ts
@@ -130,8 +130,14 @@ function runtimeEnvValue(name: string): string | boolean | undefined {
     : undefined;
 }
 
-function workspaceGatewayOrigin(): string | null {
+function workspaceOAuthOrigin(): string | null {
   const raw =
+    runtimeEnvValue("VITE_WORKSPACE_OAUTH_ORIGIN") ||
+    runtimeEnvValue("WORKSPACE_OAUTH_ORIGIN") ||
+    runtimeEnvValue("VITE_APP_URL") ||
+    runtimeEnvValue("APP_URL") ||
+    runtimeEnvValue("VITE_BETTER_AUTH_URL") ||
+    runtimeEnvValue("BETTER_AUTH_URL") ||
     runtimeEnvValue("VITE_WORKSPACE_GATEWAY_URL") ||
     runtimeEnvValue("WORKSPACE_GATEWAY_URL");
   if (typeof raw !== "string" || !raw) return null;
@@ -164,10 +170,10 @@ export function oauthRedirectUri(callbackPath: string): string {
   const path = shouldUseWorkspaceCallbackRelay(normalized)
     ? normalized
     : agentNativePath(normalized);
-  const gatewayOrigin = shouldUseWorkspaceCallbackRelay(normalized)
-    ? workspaceGatewayOrigin()
+  const oauthOrigin = shouldUseWorkspaceCallbackRelay(normalized)
+    ? workspaceOAuthOrigin()
     : null;
-  const origin = gatewayOrigin ?? getCallbackOrigin();
+  const origin = oauthOrigin ?? getCallbackOrigin();
   return `${origin}${path}`;
 }
 

--- a/packages/core/src/deploy/workspace-deploy.spec.ts
+++ b/packages/core/src/deploy/workspace-deploy.spec.ts
@@ -8,7 +8,9 @@ import { runWorkspaceDeploy } from "./workspace-deploy.js";
 
 let tmpDir: string;
 let previousAppBasePath: string | undefined;
+let previousAppUrl: string | undefined;
 let previousA2ASecret: string | undefined;
+let previousBetterAuthUrl: string | undefined;
 let previousCfPages: string | undefined;
 let previousDatabaseUrl: string | undefined;
 let previousUnpooledDatabaseUrl: string | undefined;
@@ -17,6 +19,10 @@ let previousNetlifyLocal: string | undefined;
 let previousNitroPreset: string | undefined;
 let previousVercel: string | undefined;
 let previousViteAppBasePath: string | undefined;
+let previousViteWorkspaceGatewayUrl: string | undefined;
+let previousViteWorkspaceOAuthOrigin: string | undefined;
+let previousWorkspaceGatewayUrl: string | undefined;
+let previousWorkspaceOAuthOrigin: string | undefined;
 let previousWorkspaceAppsJson: string | undefined;
 let execFile: ReturnType<typeof vi.fn>;
 
@@ -35,7 +41,9 @@ beforeEach(() => {
     return Buffer.from("");
   }) as typeof execFileSync);
   previousAppBasePath = process.env.APP_BASE_PATH;
+  previousAppUrl = process.env.APP_URL;
   previousA2ASecret = process.env.A2A_SECRET;
+  previousBetterAuthUrl = process.env.BETTER_AUTH_URL;
   previousCfPages = process.env.CF_PAGES;
   previousDatabaseUrl = process.env.DATABASE_URL;
   previousUnpooledDatabaseUrl = process.env.NETLIFY_DATABASE_URL_UNPOOLED;
@@ -44,9 +52,15 @@ beforeEach(() => {
   previousNitroPreset = process.env.NITRO_PRESET;
   previousVercel = process.env.VERCEL;
   previousViteAppBasePath = process.env.VITE_APP_BASE_PATH;
+  previousViteWorkspaceGatewayUrl = process.env.VITE_WORKSPACE_GATEWAY_URL;
+  previousViteWorkspaceOAuthOrigin = process.env.VITE_WORKSPACE_OAUTH_ORIGIN;
+  previousWorkspaceGatewayUrl = process.env.WORKSPACE_GATEWAY_URL;
+  previousWorkspaceOAuthOrigin = process.env.WORKSPACE_OAUTH_ORIGIN;
   previousWorkspaceAppsJson = process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
   delete process.env.APP_BASE_PATH;
+  delete process.env.APP_URL;
   delete process.env.A2A_SECRET;
+  delete process.env.BETTER_AUTH_URL;
   delete process.env.CF_PAGES;
   delete process.env.DATABASE_URL;
   delete process.env.NETLIFY_DATABASE_URL_UNPOOLED;
@@ -55,12 +69,18 @@ beforeEach(() => {
   delete process.env.NITRO_PRESET;
   delete process.env.VERCEL;
   delete process.env.VITE_APP_BASE_PATH;
+  delete process.env.VITE_WORKSPACE_GATEWAY_URL;
+  delete process.env.VITE_WORKSPACE_OAUTH_ORIGIN;
+  delete process.env.WORKSPACE_GATEWAY_URL;
+  delete process.env.WORKSPACE_OAUTH_ORIGIN;
   delete process.env.AGENT_NATIVE_WORKSPACE_APPS_JSON;
 });
 
 afterEach(() => {
   restoreEnv("APP_BASE_PATH", previousAppBasePath);
+  restoreEnv("APP_URL", previousAppUrl);
   restoreEnv("A2A_SECRET", previousA2ASecret);
+  restoreEnv("BETTER_AUTH_URL", previousBetterAuthUrl);
   restoreEnv("CF_PAGES", previousCfPages);
   restoreEnv("DATABASE_URL", previousDatabaseUrl);
   restoreEnv("NETLIFY_DATABASE_URL_UNPOOLED", previousUnpooledDatabaseUrl);
@@ -69,6 +89,10 @@ afterEach(() => {
   restoreEnv("NITRO_PRESET", previousNitroPreset);
   restoreEnv("VERCEL", previousVercel);
   restoreEnv("VITE_APP_BASE_PATH", previousViteAppBasePath);
+  restoreEnv("VITE_WORKSPACE_GATEWAY_URL", previousViteWorkspaceGatewayUrl);
+  restoreEnv("VITE_WORKSPACE_OAUTH_ORIGIN", previousViteWorkspaceOAuthOrigin);
+  restoreEnv("WORKSPACE_GATEWAY_URL", previousWorkspaceGatewayUrl);
+  restoreEnv("WORKSPACE_OAUTH_ORIGIN", previousWorkspaceOAuthOrigin);
   restoreEnv("AGENT_NATIVE_WORKSPACE_APPS_JSON", previousWorkspaceAppsJson);
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
@@ -702,6 +726,9 @@ describe("workspace deploy", () => {
     });
 
     const dispatchCall = buildCallForApp("dispatch");
+    expect(dispatchCall?.env?.VITE_WORKSPACE_OAUTH_ORIGIN).toBe(
+      "https://workspace.example.test",
+    );
     expect(
       JSON.parse(dispatchCall?.env?.AGENT_NATIVE_WORKSPACE_APPS_JSON ?? "[]"),
     ).toEqual([

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -188,6 +188,7 @@ function buildOneApp(
   const appDir = path.join(workspaceRoot, "apps", app);
   const workspaceGatewayUrl =
     process.env.VITE_WORKSPACE_GATEWAY_URL || workspaceBaseUrl();
+  const workspaceOAuthUrl = workspaceOAuthOrigin(workspaceGatewayUrl);
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     NITRO_PRESET: preset,
@@ -200,6 +201,9 @@ function buildOneApp(
           WORKSPACE_GATEWAY_URL:
             process.env.WORKSPACE_GATEWAY_URL || workspaceGatewayUrl,
           VITE_WORKSPACE_GATEWAY_URL: workspaceGatewayUrl,
+          ...(workspaceOAuthUrl
+            ? { VITE_WORKSPACE_OAUTH_ORIGIN: workspaceOAuthUrl }
+            : {}),
         }
       : {}),
     [WORKSPACE_APPS_ENV_KEY]: JSON.stringify(workspaceApps),
@@ -905,6 +909,29 @@ function workspaceBaseUrl(): string | null {
     process.env.DEPLOY_URL ||
     process.env.BETTER_AUTH_URL ||
     null
+  );
+}
+
+function normalizeOrigin(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function workspaceOAuthOrigin(
+  workspaceGatewayUrl: string | null,
+): string | undefined {
+  return (
+    normalizeOrigin(process.env.VITE_WORKSPACE_OAUTH_ORIGIN) ||
+    normalizeOrigin(process.env.WORKSPACE_OAUTH_ORIGIN) ||
+    normalizeOrigin(process.env.APP_URL) ||
+    normalizeOrigin(process.env.BETTER_AUTH_URL) ||
+    normalizeOrigin(process.env.URL) ||
+    normalizeOrigin(process.env.DEPLOY_URL) ||
+    normalizeOrigin(workspaceGatewayUrl)
   );
 }
 

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1646,10 +1646,11 @@ describe("server/auth", () => {
       );
     });
 
-    it("uses the configured workspace gateway instead of loopback for workspace OAuth redirects", async () => {
+    it("uses the configured public app URL instead of the local workspace gateway for workspace OAuth redirects", async () => {
       vi.stubEnv("APP_BASE_PATH", "/dispatch");
       vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
-      vi.stubEnv("WORKSPACE_GATEWAY_URL", "https://agent-workspace.builder.io");
+      vi.stubEnv("APP_URL", "https://agent-workspace.builder.io");
+      vi.stubEnv("WORKSPACE_GATEWAY_URL", "http://127.0.0.1:8080");
       const { resolveOAuthRedirectUri } = await import("./google-oauth.js");
       const event = createMockEvent({
         path: "/_agent-native/google/auth-url",
@@ -1665,10 +1666,29 @@ describe("server/auth", () => {
       );
     });
 
-    it("uses the configured workspace gateway instead of Builder preview hosts for workspace OAuth redirects", async () => {
+    it("uses a public workspace gateway when no app URL is configured", async () => {
       vi.stubEnv("APP_BASE_PATH", "/dispatch");
       vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
       vi.stubEnv("WORKSPACE_GATEWAY_URL", "https://agent-workspace.builder.io");
+      const { resolveOAuthRedirectUri } = await import("./google-oauth.js");
+      const event = createMockEvent({
+        path: "/_agent-native/google/auth-url",
+        headers: {
+          host: "940ebc5a83164aa6a37dde445e494f3a-thunder-handle-xmq6tgfy.builderio.xyz",
+          "x-forwarded-proto": "https",
+        },
+      });
+
+      expect(resolveOAuthRedirectUri(event)).toBe(
+        "https://agent-workspace.builder.io/_agent-native/google/callback",
+      );
+    });
+
+    it("uses the configured public app URL instead of Builder preview hosts for workspace OAuth redirects", async () => {
+      vi.stubEnv("APP_BASE_PATH", "/dispatch");
+      vi.stubEnv("AGENT_NATIVE_WORKSPACE", "1");
+      vi.stubEnv("APP_URL", "https://agent-workspace.builder.io");
+      vi.stubEnv("WORKSPACE_GATEWAY_URL", "http://127.0.0.1:8080");
       const { resolveOAuthRedirectUri } = await import("./google-oauth.js");
       const event = createMockEvent({
         path: "/_agent-native/google/auth-url",

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -127,10 +127,15 @@ function firstConfiguredOrigin(): string | undefined {
 }
 
 function getWorkspaceCallbackOrigin(): string | undefined {
-  return (
-    normalizeOrigin(process.env.WORKSPACE_GATEWAY_URL) ??
-    firstConfiguredOrigin()
-  );
+  const publicAuthOrigin =
+    normalizeOrigin(process.env.APP_URL) ??
+    normalizeOrigin(process.env.BETTER_AUTH_URL);
+  if (publicAuthOrigin) return publicAuthOrigin;
+
+  const gatewayOrigin = normalizeOrigin(process.env.WORKSPACE_GATEWAY_URL);
+  if (gatewayOrigin && !isLoopbackOrigin(gatewayOrigin)) return gatewayOrigin;
+
+  return firstConfiguredOrigin();
 }
 
 function isLoopbackHost(host: string | undefined): boolean {
@@ -143,6 +148,15 @@ function isLoopbackHost(host: string | undefined): boolean {
       parsed.hostname === "::1" ||
       parsed.hostname === "[::1]"
     );
+  } catch {
+    return false;
+  }
+}
+
+function isLoopbackOrigin(origin: string | undefined): boolean {
+  if (!origin) return false;
+  try {
+    return isLoopbackHost(new URL(origin).host);
   } catch {
     return false;
   }

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/desktop-app",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/mobile-app/babel.config.js
+++ b/packages/mobile-app/babel.config.js
@@ -1,0 +1,8 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: [
+      ["babel-preset-expo", { unstable_transformImportMeta: true }],
+    ],
+  };
+};

--- a/packages/mobile-app/babel.config.js
+++ b/packages/mobile-app/babel.config.js
@@ -1,8 +1,6 @@
 module.exports = function (api) {
   api.cache(true);
   return {
-    presets: [
-      ["babel-preset-expo", { unstable_transformImportMeta: true }],
-    ],
+    presets: [["babel-preset-expo", { unstable_transformImportMeta: true }]],
   };
 };

--- a/packages/mobile-app/package.json
+++ b/packages/mobile-app/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
+    "babel-preset-expo": "^55.0.18",
     "typescript": "^6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,6 +776,9 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      babel-preset-expo:
+        specifier: ^55.0.18
+        version: 55.0.18(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.17)(react-refresh@0.14.2)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/scripts/dev-lazy.ts
+++ b/scripts/dev-lazy.ts
@@ -236,12 +236,15 @@ function renderStartingApp(app: TemplateApp): string {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta http-equiv="refresh" content="1" />
     <title>Starting ${escapedName}</title>
+    <meta name="color-scheme" content="light dark" />
     <style>
-      body { min-height: 100vh; margin: 0; display: grid; place-items: center; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #fafafa; color: #171717; }
+      :root { --bg: #fafafa; --fg: #171717; --muted: #737373; --bar-bg: #e5e5e5; --bar-fill: #171717; }
+      @media (prefers-color-scheme: dark) { :root { --bg: #0a0a0a; --fg: #fafafa; --muted: #a3a3a3; --bar-bg: #262626; --bar-fill: #fafafa; } }
+      body { min-height: 100vh; margin: 0; display: grid; place-items: center; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: var(--bg); color: var(--fg); }
       main { width: min(420px, calc(100vw - 48px)); }
-      .bar { height: 3px; overflow: hidden; border-radius: 999px; background: #e5e5e5; }
-      .bar::before { content: ""; display: block; height: 100%; width: 42%; border-radius: inherit; background: #171717; animation: load 1s ease-in-out infinite; }
-      p { color: #737373; }
+      .bar { height: 3px; overflow: hidden; border-radius: 999px; background: var(--bar-bg); }
+      .bar::before { content: ""; display: block; height: 100%; width: 42%; border-radius: inherit; background: var(--bar-fill); animation: load 1s ease-in-out infinite; }
+      p { color: var(--muted); }
       @keyframes load { 0% { transform: translateX(-105%); } 100% { transform: translateX(245%); } }
     </style>
     <script>setTimeout(() => window.location.reload(), 900);</script>
@@ -263,13 +266,16 @@ function renderIndex(): string {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Agent-Native Templates</title>
+    <meta name="color-scheme" content="light dark" />
     <style>
-      body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; padding: 32px; background: #fafafa; color: #171717; }
+      :root { --bg: #fafafa; --fg: #171717; --muted: #737373; --card-bg: #ffffff; --card-border: #d4d4d4; }
+      @media (prefers-color-scheme: dark) { :root { --bg: #0a0a0a; --fg: #fafafa; --muted: #a3a3a3; --card-bg: #171717; --card-border: #262626; } }
+      body { font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; padding: 32px; background: var(--bg); color: var(--fg); }
       main { max-width: 760px; margin: 0 auto; }
       a { color: inherit; text-decoration: none; }
       .grid { display: grid; gap: 12px; margin-top: 20px; }
-      .card { display: flex; justify-content: space-between; gap: 16px; border: 1px solid #d4d4d4; border-radius: 8px; padding: 14px 16px; background: white; }
-      .muted { color: #737373; }
+      .card { display: flex; justify-content: space-between; gap: 16px; border: 1px solid var(--card-border); border-radius: 8px; padding: 14px 16px; background: var(--card-bg); }
+      .muted { color: var(--muted); }
     </style>
   </head>
   <body>

--- a/templates/clips/server/routes/api/clips-updater.json.get.ts
+++ b/templates/clips/server/routes/api/clips-updater.json.get.ts
@@ -14,6 +14,16 @@ const GITHUB_MANIFEST_URL =
   "https://github.com/BuilderIO/agent-native/releases/download/clips-latest/clips-latest.json";
 const CACHE_TTL_MS = 5 * 60_000;
 
+// Tauri throws a red-banner error if the requesting client's target triple is
+// missing from `platforms`. We ship Universal-macOS + Windows, so the manifest
+// must always carry both — if upstream is missing either, fall back to inert
+// so no client sees a hard error.
+const REQUIRED_PLATFORM_KEYS = [
+  "darwin-aarch64",
+  "darwin-x86_64",
+  "windows-x86_64",
+];
+
 const INERT_PLATFORM = {
   url: "https://clips.agent-native.com/download",
   signature: "updates-disabled",
@@ -52,6 +62,13 @@ function isManifestLike(value: unknown): value is Record<string, unknown> {
   return !!obj.platforms && typeof obj.platforms === "object";
 }
 
+function hasAllRequiredPlatforms(value: unknown): boolean {
+  if (!isManifestLike(value)) return false;
+  const platforms = value.platforms as Record<string, unknown> | undefined;
+  if (!platforms || typeof platforms !== "object") return false;
+  return REQUIRED_PLATFORM_KEYS.every((k) => k in platforms);
+}
+
 async function fetchSignedManifest(): Promise<unknown> {
   const res = await fetch(GITHUB_MANIFEST_URL, {
     headers: {
@@ -63,6 +80,14 @@ async function fetchSignedManifest(): Promise<unknown> {
   if (!res.ok) throw new Error(`GitHub updater manifest ${res.status}`);
   const json = (await res.json()) as unknown;
   if (!isManifestLike(json)) throw new Error("Invalid updater manifest");
+  if (!hasAllRequiredPlatforms(json)) {
+    const present = Object.keys(
+      (json as { platforms?: Record<string, unknown> }).platforms ?? {},
+    );
+    throw new Error(
+      `Updater manifest missing required platforms; got [${present.join(", ")}]`,
+    );
+  }
   return json;
 }
 


### PR DESCRIPTION
## Summary

The desktop-release workflow's auto-version branch was producing `<base>+<sha>` build-metadata tags, but `npm version` silently strips `+metadata` when it writes `package.json`. Every push therefore collided on the same release tag and clobbered earlier release assets. Switch to a `-N` prerelease suffix (SemVer-compliant + npm-stable) and bump `@agent-native/desktop-app` to `0.1.7` for the next release.

## Test plan

- [ ] Push lands `cf2a4b7bc` on the auto-version path; the desktop-release workflow tag now uses `-<sha>` instead of `+<sha>`
- [ ] Confirm npm version no longer drops the suffix
- [ ] CI gate green: Build, Lint, Test, Typecheck, Guard, Changeset