### PR TITLE
feat(dispatch): scaffold archived-apps + available-templates surface in app-creation-store

### DIFF
--- a/.changeset/dispatch-workspace-app-actions.md
+++ b/.changeset/dispatch-workspace-app-actions.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": minor
+---
+
+Add agent actions for managing workspace apps from Dispatch: `scaffold-workspace-app`, `archive-workspace-app`, `unarchive-workspace-app`, `remove-pending-workspace-app`, and `list-available-workspace-templates`. Backed by the new archived-apps + available-templates surface in `app-creation-store`.

--- a/packages/dispatch/src/actions/archive-workspace-app.ts
+++ b/packages/dispatch/src/actions/archive-workspace-app.ts
@@ -1,0 +1,16 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import { archiveWorkspaceApp } from "../server/lib/app-creation-store.js";
+
+export default defineAction({
+  description:
+    "Hide a workspace app from the Apps list for the current viewer. The app's files and database stay intact; this is a per-user/org visibility flag stored in dispatch settings. Pair with unarchive-workspace-app to restore.",
+  schema: z.object({
+    appId: z
+      .string()
+      .min(1)
+      .max(64)
+      .describe("Workspace app id (matches the apps/<id>/ folder)"),
+  }),
+  run: async (input) => archiveWorkspaceApp({ appId: input.appId }),
+});

--- a/packages/dispatch/src/actions/index.ts
+++ b/packages/dispatch/src/actions/index.ts
@@ -1,6 +1,7 @@
 import type { ActionEntry } from "@agent-native/core/server";
 import approveDispatchChange from "./approve-dispatch-change.js";
 import approveVaultRequest from "./approve-vault-request.js";
+import archiveWorkspaceApp from "./archive-workspace-app.js";
 import createLinkToken from "./create-link-token.js";
 import createVaultGrant from "./create-vault-grant.js";
 import createVaultSecret from "./create-vault-secret.js";
@@ -17,6 +18,7 @@ import getWorkspaceInfo from "./get-workspace-info.js";
 import grantWorkspaceResourcesToApp from "./grant-workspace-resources-to-app.js";
 import grantVaultSecretsToApp from "./grant-vault-secrets-to-app.js";
 import listAgentThreadSources from "./list-agent-thread-sources.js";
+import listAvailableWorkspaceTemplates from "./list-available-workspace-templates.js";
 import listConnectedAgents from "./list-connected-agents.js";
 import listDestinations from "./list-destinations.js";
 import listDispatchApprovals from "./list-dispatch-approvals.js";
@@ -36,9 +38,11 @@ import listWorkspaceResourceGrants from "./list-workspace-resource-grants.js";
 import listWorkspaceResources from "./list-workspace-resources.js";
 import navigate from "./navigate.js";
 import rejectDispatchChange from "./reject-dispatch-change.js";
+import removePendingWorkspaceApp from "./remove-pending-workspace-app.js";
 import requestVaultSecret from "./request-vault-secret.js";
 import revokeVaultGrant from "./revoke-vault-grant.js";
 import revokeWorkspaceResourceGrant from "./revoke-workspace-resource-grant.js";
+import scaffoldWorkspaceApp from "./scaffold-workspace-app.js";
 import searchAgentThreads from "./search-agent-threads.js";
 import sendPlatformMessage from "./send-platform-message.js";
 import setAppCreationSettings from "./set-app-creation-settings.js";
@@ -47,6 +51,7 @@ import startWorkspaceAppCreation from "./start-workspace-app-creation.js";
 import syncVaultToApp from "./sync-vault-to-app.js";
 import syncWorkspaceResourcesToAll from "./sync-workspace-resources-to-all.js";
 import syncWorkspaceResourcesToApp from "./sync-workspace-resources-to-app.js";
+import unarchiveWorkspaceApp from "./unarchive-workspace-app.js";
 import updateVaultSecret from "./update-vault-secret.js";
 import updateWorkspaceResource from "./update-workspace-resource.js";
 import upsertDestination from "./upsert-destination.js";
@@ -61,6 +66,7 @@ import viewScreen from "./view-screen.js";
 export const dispatchActions: Record<string, ActionEntry> = {
   "approve-dispatch-change": approveDispatchChange,
   "approve-vault-request": approveVaultRequest,
+  "archive-workspace-app": archiveWorkspaceApp,
   "create-link-token": createLinkToken,
   "create-vault-grant": createVaultGrant,
   "create-vault-secret": createVaultSecret,

--- a/packages/dispatch/src/actions/list-available-workspace-templates.ts
+++ b/packages/dispatch/src/actions/list-available-workspace-templates.ts
@@ -1,0 +1,11 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import { listAvailableWorkspaceTemplates } from "../server/lib/app-creation-store.js";
+
+export default defineAction({
+  description:
+    "List first-party templates that can be scaffolded into this workspace via the Apps page. Excludes templates already installed under apps/. The agent should usually call start-workspace-app-creation for natural-language requests; this list is for the static 'Add a template' tiles.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  run: async () => listAvailableWorkspaceTemplates(),
+});

--- a/packages/dispatch/src/actions/remove-pending-workspace-app.ts
+++ b/packages/dispatch/src/actions/remove-pending-workspace-app.ts
@@ -1,0 +1,16 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import { removePendingWorkspaceApp } from "../server/lib/app-creation-store.js";
+
+export default defineAction({
+  description:
+    "Remove a pending Builder app entry from the Apps list. Use when the user no longer wants to track a Builder branch in Dispatch (e.g. they abandoned the build). The Builder branch itself is not affected.",
+  schema: z.object({
+    appId: z
+      .string()
+      .min(1)
+      .max(64)
+      .describe("Workspace app id of the pending entry to remove"),
+  }),
+  run: async (input) => removePendingWorkspaceApp({ appId: input.appId }),
+});

--- a/packages/dispatch/src/actions/scaffold-workspace-app.ts
+++ b/packages/dispatch/src/actions/scaffold-workspace-app.ts
@@ -1,0 +1,34 @@
+import { defineAction } from "@agent-native/core";
+import { getWorkspaceAppIdValidationError } from "@agent-native/core/shared";
+import { z } from "zod";
+import { scaffoldWorkspaceAppFromTemplate } from "../server/lib/app-creation-store.js";
+
+export default defineAction({
+  description:
+    "Scaffold a first-party template (mail, calendar, slides, etc.) into apps/<id>/ in the current workspace. Local-dev only — runs `agent-native add-app` as a subprocess. The workspace gateway picks the new app up automatically and serves it at /<id>. For natural-language app creation, call start-workspace-app-creation instead.",
+  schema: z.object({
+    template: z
+      .string()
+      .min(1)
+      .describe(
+        "Template name (mail, calendar, slides, content, clips, analytics, forms, design, videos)",
+      ),
+    appId: z
+      .string()
+      .max(64)
+      .optional()
+      .nullable()
+      .refine((appId) => !appId || !getWorkspaceAppIdValidationError(appId), {
+        message:
+          "Use a non-reserved app id with lowercase letters, numbers, and hyphens.",
+      })
+      .describe(
+        "Optional override for the apps/<id>/ directory name; defaults to the template name",
+      ),
+  }),
+  run: async (input) =>
+    scaffoldWorkspaceAppFromTemplate({
+      template: input.template,
+      appId: input.appId ?? null,
+    }),
+});

--- a/packages/dispatch/src/actions/unarchive-workspace-app.ts
+++ b/packages/dispatch/src/actions/unarchive-workspace-app.ts
@@ -1,0 +1,16 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import { unarchiveWorkspaceApp } from "../server/lib/app-creation-store.js";
+
+export default defineAction({
+  description:
+    "Restore a previously archived workspace app to the Apps list for the current viewer.",
+  schema: z.object({
+    appId: z
+      .string()
+      .min(1)
+      .max(64)
+      .describe("Workspace app id (matches the apps/<id>/ folder)"),
+  }),
+  run: async (input) => unarchiveWorkspaceApp({ appId: input.appId }),
+});

--- a/packages/dispatch/src/server/lib/app-creation-store.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.ts
@@ -685,13 +685,30 @@ export function getWorkspaceInfo(): WorkspaceInfo {
   };
 }
 
+async function applyArchivedAndPending(
+  apps: WorkspaceAppSummary[],
+  options: ListWorkspaceAppsOptions,
+): Promise<WorkspaceAppSummary[]> {
+  const [withPending, archivedIds] = await Promise.all([
+    appendPendingWorkspaceApps(apps),
+    listArchivedAppIds(),
+  ]);
+  const archivedSet = new Set(archivedIds);
+  const annotated = withPending.map((app) =>
+    archivedSet.has(app.id) ? { ...app, archived: true } : app,
+  );
+  return options.includeArchived
+    ? annotated
+    : annotated.filter((app) => !app.archived);
+}
+
 export async function listWorkspaceApps(
   options: ListWorkspaceAppsOptions = {},
 ): Promise<WorkspaceAppSummary[]> {
   const gatewayApps = await readWorkspaceAppsFromGateway();
   if (gatewayApps) {
     return maybeIncludeAgentCards(
-      await appendPendingWorkspaceApps(gatewayApps),
+      await applyArchivedAndPending(gatewayApps, options),
       options,
     );
   }
@@ -703,7 +720,7 @@ export async function listWorkspaceApps(
       : null;
   if (localFilesystemApps) {
     return maybeIncludeAgentCards(
-      await appendPendingWorkspaceApps(localFilesystemApps),
+      await applyArchivedAndPending(localFilesystemApps, options),
       options,
     );
   }
@@ -712,33 +729,225 @@ export async function listWorkspaceApps(
     readWorkspaceAppsFromEnv() ?? readWorkspaceAppsFromManifestFile();
   if (manifestApps) {
     return maybeIncludeAgentCards(
-      await appendPendingWorkspaceApps(manifestApps),
+      await applyArchivedAndPending(manifestApps, options),
       options,
     );
   }
 
   if (!workspaceRoot) {
     return maybeIncludeAgentCards(
-      await appendPendingWorkspaceApps([
-        {
-          id: "dispatch",
-          name: "Dispatch",
-          description: "Workspace control plane",
-          path: "/dispatch",
-          url: workspaceAppUrl("/dispatch"),
-          isDispatch: true,
-          status: "ready",
-        },
-      ]),
+      await applyArchivedAndPending(
+        [
+          {
+            id: "dispatch",
+            name: "Dispatch",
+            description: "Workspace control plane",
+            path: "/dispatch",
+            url: workspaceAppUrl("/dispatch"),
+            isDispatch: true,
+            status: "ready",
+          },
+        ],
+        options,
+      ),
       options,
     );
   }
 
   const apps = readWorkspaceAppsFromFilesystem(workspaceRoot) ?? [];
   return maybeIncludeAgentCards(
-    await appendPendingWorkspaceApps(apps),
+    await applyArchivedAndPending(apps, options),
     options,
   );
+}
+
+/**
+ * First-party templates the user can scaffold into this workspace via the
+ * Apps page tiles. Inlined here (rather than importing from
+ * `@agent-native/shared-app-config`) because the published `@agent-native/dispatch`
+ * package has no `workspace:*` runtime dependencies. Keep in sync with
+ * `packages/core/src/cli/templates-meta.ts`.
+ */
+const ADDABLE_TEMPLATES: AvailableWorkspaceTemplate[] = [
+  {
+    name: "mail",
+    label: "Mail",
+    hint: "Email client with keyboard shortcuts and AI triage",
+    icon: "Mail",
+    color: "#3B82F6",
+    colorRgb: "59 130 246",
+    core: true,
+  },
+  {
+    name: "calendar",
+    label: "Calendar",
+    hint: "Manage events, sync, and public booking",
+    icon: "CalendarDays",
+    color: "#8B5CF6",
+    colorRgb: "139 92 246",
+    core: true,
+  },
+  {
+    name: "content",
+    label: "Content",
+    hint: "Write and organize with agent assistance",
+    icon: "FileText",
+    color: "#10B981",
+    colorRgb: "16 185 129",
+    core: true,
+  },
+  {
+    name: "slides",
+    label: "Slides",
+    hint: "Generate and edit React presentations",
+    icon: "GalleryHorizontal",
+    color: "#EC4899",
+    colorRgb: "236 72 153",
+    core: true,
+  },
+  {
+    name: "clips",
+    label: "Clips",
+    hint: "Screen recording, meeting notes, and voice dictation",
+    icon: "ScreenShare",
+    color: "#625DF5",
+    colorRgb: "98 93 245",
+    core: true,
+  },
+  {
+    name: "analytics",
+    label: "Analytics",
+    hint: "Connect data sources, prompt for charts",
+    icon: "BarChart2",
+    color: "#F59E0B",
+    colorRgb: "245 158 11",
+    core: true,
+  },
+  {
+    name: "forms",
+    label: "Forms",
+    hint: "Create, edit, and manage forms",
+    icon: "ClipboardList",
+    color: "#06B6D4",
+    colorRgb: "6 182 212",
+    core: true,
+  },
+  {
+    name: "design",
+    label: "Design",
+    hint: "Create and edit visual designs with agent assistance",
+    icon: "Brush",
+    color: "#F472B6",
+    colorRgb: "244 114 182",
+    core: true,
+  },
+  {
+    name: "videos",
+    label: "Video",
+    hint: "Video editing with Remotion",
+    icon: "Video",
+    color: "#EF4444",
+    colorRgb: "239 68 68",
+    core: false,
+  },
+];
+
+export async function listAvailableWorkspaceTemplates(): Promise<
+  AvailableWorkspaceTemplate[]
+> {
+  const installed = new Set(
+    (await listWorkspaceApps({ includeArchived: true })).map((app) => app.id),
+  );
+  return ADDABLE_TEMPLATES.filter((tpl) => !installed.has(tpl.name));
+}
+
+const SCAFFOLD_TIMEOUT_MS = 90_000;
+
+export async function scaffoldWorkspaceAppFromTemplate(input: {
+  template: string;
+  appId?: string | null;
+}): Promise<{ appId: string; template: string; output: string }> {
+  if (!isLocalAppCreationRuntime()) {
+    throw new Error(
+      "Scaffolding from Dispatch is only available in local development. " +
+        "Use the Builder branch flow on a deployed workspace.",
+    );
+  }
+  const template = input.template.trim();
+  if (!template) throw new Error("template is required");
+  if (!ADDABLE_TEMPLATES.some((tpl) => tpl.name === template)) {
+    throw new Error(`Unknown template "${template}".`);
+  }
+
+  const appId = (input.appId?.trim() || template).toLowerCase();
+  assertValidWorkspaceAppId(appId);
+
+  const workspaceRoot = findWorkspaceRoot();
+  if (!workspaceRoot) {
+    throw new Error("No agent-native workspace detected for scaffolding.");
+  }
+  const appDir = path.join(workspaceRoot, "apps", appId);
+  if (fs.existsSync(appDir)) {
+    throw new Error(`apps/${appId} already exists.`);
+  }
+
+  const output = await runScaffoldCli({
+    cwd: workspaceRoot,
+    args: ["add-app", appId, "--template", template],
+  });
+
+  await recordAudit({
+    action: "workspace-app.scaffolded",
+    targetType: "workspace-app",
+    targetId: appId,
+    summary: `Scaffolded apps/${appId} from ${template}`,
+    metadata: { template },
+  });
+
+  return { appId, template, output };
+}
+
+function runScaffoldCli(input: {
+  cwd: string;
+  args: string[];
+}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("pnpm", ["exec", "agent-native", ...input.args], {
+      cwd: input.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, CI: "1", FORCE_COLOR: "0" },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(
+        new Error(
+          `Scaffold timed out after ${Math.round(SCAFFOLD_TIMEOUT_MS / 1000)}s`,
+        ),
+      );
+    }, SCAFFOLD_TIMEOUT_MS);
+    timer.unref();
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve([stdout, stderr].filter(Boolean).join("\n").trim());
+        return;
+      }
+      const detail = (stderr || stdout || "").trim() || `exit code ${code}`;
+      reject(new Error(`Scaffold failed: ${detail}`));
+    });
+  });
 }
 
 export async function getAppCreationSettings(): Promise<AppCreationSettings> {

--- a/packages/dispatch/src/server/lib/app-creation-store.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -52,10 +53,27 @@ export interface WorkspaceAppSummary {
   a2aEndpointUrl?: string | null;
   agentName?: string | null;
   agentSkillsCount?: number | null;
+  archived?: boolean;
 }
 
 export interface ListWorkspaceAppsOptions {
   includeAgentCards?: boolean;
+  /**
+   * Include apps the current viewer has hidden (archived). Defaults to false
+   * so polling/UI callers see only the visible set; the apps page passes true
+   * when rendering the "Hidden apps" expander.
+   */
+  includeArchived?: boolean;
+}
+
+export interface AvailableWorkspaceTemplate {
+  name: string;
+  label: string;
+  hint: string;
+  icon: string;
+  color: string;
+  colorRgb: string;
+  core: boolean;
 }
 
 export interface AppCreationSettings {
@@ -258,6 +276,76 @@ function parsePendingWorkspaceApps(value: unknown): PendingWorkspaceApp[] {
 async function listPendingWorkspaceApps(): Promise<PendingWorkspaceApp[]> {
   const raw = await readSettingsRecord();
   return parsePendingWorkspaceApps(raw.pendingApps);
+}
+
+function parseArchivedAppIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const ids = value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
+  return Array.from(new Set(ids));
+}
+
+async function listArchivedAppIds(): Promise<string[]> {
+  const raw = await readSettingsRecord();
+  return parseArchivedAppIds(raw.archivedAppIds);
+}
+
+export async function archiveWorkspaceApp(input: {
+  appId: string;
+}): Promise<{ archivedAppIds: string[] }> {
+  const appId = input.appId.trim();
+  if (!appId) throw new Error("appId is required");
+  const raw = await readSettingsRecord();
+  const current = parseArchivedAppIds(raw.archivedAppIds);
+  if (!current.includes(appId)) current.push(appId);
+  await putSetting(scopedSettingsKey(), { ...raw, archivedAppIds: current });
+  await recordAudit({
+    action: "workspace-app.archived",
+    targetType: "workspace-app",
+    targetId: appId,
+    summary: "Hid workspace app from the Apps list",
+  });
+  return { archivedAppIds: current };
+}
+
+export async function unarchiveWorkspaceApp(input: {
+  appId: string;
+}): Promise<{ archivedAppIds: string[] }> {
+  const appId = input.appId.trim();
+  if (!appId) throw new Error("appId is required");
+  const raw = await readSettingsRecord();
+  const current = parseArchivedAppIds(raw.archivedAppIds).filter(
+    (id) => id !== appId,
+  );
+  await putSetting(scopedSettingsKey(), { ...raw, archivedAppIds: current });
+  await recordAudit({
+    action: "workspace-app.unarchived",
+    targetType: "workspace-app",
+    targetId: appId,
+    summary: "Restored workspace app to the Apps list",
+  });
+  return { archivedAppIds: current };
+}
+
+export async function removePendingWorkspaceApp(input: {
+  appId: string;
+}): Promise<{ removed: boolean }> {
+  const appId = input.appId.trim();
+  if (!appId) throw new Error("appId is required");
+  const raw = await readSettingsRecord();
+  const pending = parsePendingWorkspaceApps(raw.pendingApps);
+  const next = pending.filter((app) => app.id !== appId);
+  const removed = next.length !== pending.length;
+  if (!removed) return { removed: false };
+  await putSetting(scopedSettingsKey(), { ...raw, pendingApps: next });
+  await recordAudit({
+    action: "workspace-app.pending-removed",
+    targetType: "workspace-app",
+    targetId: appId,
+    summary: "Removed pending Builder app from the Apps list",
+  });
+  return { removed: true };
 }
 
 function pendingAppToSummary(app: PendingWorkspaceApp): WorkspaceAppSummary {

--- a/packages/mobile-app/app/(tabs)/_layout.tsx
+++ b/packages/mobile-app/app/(tabs)/_layout.tsx
@@ -279,10 +279,7 @@ export default function TabLayout() {
         animationType="fade"
         onRequestClose={() => setMoreOpen(false)}
       >
-        <Pressable
-          style={styles.backdrop}
-          onPress={() => setMoreOpen(false)}
-        >
+        <Pressable style={styles.backdrop} onPress={() => setMoreOpen(false)}>
           <Pressable style={styles.sheet} onPress={(e) => e.stopPropagation()}>
             <View style={styles.handle} />
             <Text style={styles.sheetTitle}>More Apps</Text>
@@ -306,18 +303,10 @@ export default function TabLayout() {
                           { backgroundColor: `${app.color}33` },
                         ]}
                       >
-                        <Feather
-                          name={iconName}
-                          size={18}
-                          color={app.color}
-                        />
+                        <Feather name={iconName} size={18} color={app.color} />
                       </View>
                       <Text style={styles.rowText}>{app.name}</Text>
-                      <Feather
-                        name="chevron-right"
-                        size={18}
-                        color="#555555"
-                      />
+                      <Feather name="chevron-right" size={18} color="#555555" />
                     </TouchableOpacity>
                   );
                 })

--- a/packages/mobile-app/app/(tabs)/_layout.tsx
+++ b/packages/mobile-app/app/(tabs)/_layout.tsx
@@ -1,10 +1,21 @@
-import { Tabs } from "expo-router";
+import { useState, useMemo, useCallback } from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+} from "react-native";
+import { Tabs, useRouter } from "expo-router";
 import { Feather } from "@expo/vector-icons";
+import type { AppConfig } from "@agent-native/shared-app-config";
 import { useApps } from "../../lib/use-apps";
 
-/** Map tab file names to app IDs in the config */
-const TAB_TO_APP_ID: Record<string, string> = {
-  index: "mail",
+/** Map app IDs in the config to their tab file name. */
+const APP_ID_TO_TAB: Record<string, string> = {
+  mail: "index",
   calendar: "calendar",
   content: "content",
   slides: "slides",
@@ -16,163 +27,366 @@ const TAB_TO_APP_ID: Record<string, string> = {
   starter: "starter",
 };
 
+/** Built-in app icon used both in the tab bar and the More sheet. */
+const APP_ICON: Record<string, keyof typeof Feather.glyphMap> = {
+  mail: "mail",
+  calendar: "calendar",
+  content: "file-text",
+  slides: "airplay",
+  clips: "cast",
+  analytics: "bar-chart-2",
+  dispatch: "message-circle",
+  forms: "clipboard",
+  design: "edit-2",
+  starter: "code",
+};
+
+const MAX_VISIBLE_APPS = 4;
+
 export default function TabLayout() {
-  const { enabledApps, loading } = useApps();
+  const { enabledApps } = useApps();
+  const router = useRouter();
+  const [moreOpen, setMoreOpen] = useState(false);
 
-  const enabledIds = new Set(enabledApps.map((a) => a.id));
+  const enabledIds = useMemo(
+    () => new Set(enabledApps.map((a) => a.id)),
+    [enabledApps],
+  );
 
-  /** Returns `undefined` (show tab) or `null` (hide tab) */
-  const hrefFor = (tabName: string) => {
-    const appId = TAB_TO_APP_ID[tabName];
-    if (!appId) return undefined;
-    return enabledIds.has(appId) ? undefined : null;
-  };
+  /** First N enabled apps that have a tab route → shown in the bar. */
+  const visibleAppIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const a of enabledApps) {
+      if (APP_ID_TO_TAB[a.id]) {
+        ids.push(a.id);
+        if (ids.length >= MAX_VISIBLE_APPS) break;
+      }
+    }
+    return new Set(ids);
+  }, [enabledApps]);
+
+  /** All enabled apps not in the bar → shown in the More sheet. */
+  const overflowApps = useMemo(
+    () => enabledApps.filter((a) => !visibleAppIds.has(a.id)),
+    [enabledApps, visibleAppIds],
+  );
+
+  const hrefFor = useCallback(
+    (appId: string) => (enabledIds.has(appId) ? undefined : null),
+    [enabledIds],
+  );
+
+  /** Hide enabled-but-overflow tabs from the bar while keeping them routable. */
+  const itemStyleFor = useCallback(
+    (appId: string) =>
+      enabledIds.has(appId) && !visibleAppIds.has(appId)
+        ? { display: "none" as const }
+        : undefined,
+    [enabledIds, visibleAppIds],
+  );
+
+  const openOverflowApp = useCallback(
+    (app: AppConfig) => {
+      setMoreOpen(false);
+      const tab = APP_ID_TO_TAB[app.id];
+      if (tab) {
+        router.push(tab === "index" ? "/" : (`/${tab}` as never));
+      } else {
+        router.push(`/app/${app.id}` as never);
+      }
+    },
+    [router],
+  );
 
   return (
-    <Tabs
-      initialRouteName="calendar"
-      screenOptions={{
-        tabBarStyle: {
-          backgroundColor: "#111111",
-          borderTopColor: "#222222",
-        },
-        tabBarActiveTintColor: "#ffffff",
-        tabBarInactiveTintColor: "#666666",
-        headerStyle: { backgroundColor: "#111111" },
-        headerTintColor: "#ffffff",
-        headerTitleStyle: { fontWeight: "600" },
-      }}
-    >
-      <Tabs.Screen
-        name="calendar"
-        options={{
-          title: "Calendar",
-          headerShown: false,
-          href: hrefFor("calendar"),
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="calendar" size={size} color={color} />
-          ),
+    <>
+      <Tabs
+        initialRouteName="calendar"
+        screenOptions={{
+          tabBarStyle: {
+            backgroundColor: "#111111",
+            borderTopColor: "#222222",
+          },
+          tabBarActiveTintColor: "#ffffff",
+          tabBarInactiveTintColor: "#666666",
+          headerStyle: { backgroundColor: "#111111" },
+          headerTintColor: "#ffffff",
+          headerTitleStyle: { fontWeight: "600" },
         }}
-      />
-      <Tabs.Screen
-        name="content"
-        options={{
-          title: "Content",
-          headerShown: false,
-          href: hrefFor("content"),
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="file-text" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="slides"
-        options={{
-          title: "Slides",
-          headerShown: false,
-          href: hrefFor("slides"),
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="airplay" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="clips"
-        options={{
-          title: "Clips",
-          headerShown: false,
-          href: hrefFor("clips"),
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="cast" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="analytics"
-        options={{
-          title: "Analytics",
-          headerShown: false,
-          href: hrefFor("analytics"),
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="bar-chart-2" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: "Mail",
-          headerShown: false,
-          href: hrefFor("index"),
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="mail" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="dispatch"
-        options={{
-          title: "Dispatch",
-          headerShown: false,
-          href: hrefFor("dispatch"),
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="message-circle" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="forms"
-        options={{
-          title: "Forms",
-          headerShown: false,
-          href: hrefFor("forms"),
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="clipboard" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="design"
-        options={{
-          title: "Design",
-          headerShown: false,
-          href: hrefFor("design"),
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="edit-2" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="starter"
-        options={{
-          title: "Starter",
-          headerShown: false,
-          href: hrefFor("starter"),
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="code" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="videos"
-        options={{
-          title: "Video",
-          headerShown: false,
-          href: null,
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="film" size={size} color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="settings"
-        options={{
-          title: "Settings",
-          tabBarIcon: ({ color, size }) => (
-            <Feather name="settings" size={size} color={color} />
-          ),
-        }}
-      />
-    </Tabs>
+      >
+        <Tabs.Screen
+          name="calendar"
+          options={{
+            title: "Calendar",
+            headerShown: false,
+            href: hrefFor("calendar"),
+            tabBarItemStyle: itemStyleFor("calendar"),
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="calendar" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="content"
+          options={{
+            title: "Content",
+            headerShown: false,
+            href: hrefFor("content"),
+            tabBarItemStyle: itemStyleFor("content"),
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="file-text" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="slides"
+          options={{
+            title: "Slides",
+            headerShown: false,
+            href: hrefFor("slides"),
+            tabBarItemStyle: itemStyleFor("slides"),
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="airplay" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="clips"
+          options={{
+            title: "Clips",
+            headerShown: false,
+            href: hrefFor("clips"),
+            tabBarItemStyle: itemStyleFor("clips"),
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="cast" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="analytics"
+          options={{
+            title: "Analytics",
+            headerShown: false,
+            href: hrefFor("analytics"),
+            tabBarItemStyle: itemStyleFor("analytics"),
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="bar-chart-2" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="index"
+          options={{
+            title: "Mail",
+            headerShown: false,
+            href: hrefFor("mail"),
+            tabBarItemStyle: itemStyleFor("mail"),
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="mail" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="dispatch"
+          options={{
+            title: "Dispatch",
+            headerShown: false,
+            href: hrefFor("dispatch"),
+            tabBarItemStyle: itemStyleFor("dispatch"),
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="message-circle" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="forms"
+          options={{
+            title: "Forms",
+            headerShown: false,
+            href: hrefFor("forms"),
+            tabBarItemStyle: itemStyleFor("forms"),
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="clipboard" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="design"
+          options={{
+            title: "Design",
+            headerShown: false,
+            href: hrefFor("design"),
+            tabBarItemStyle: itemStyleFor("design"),
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="edit-2" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="starter"
+          options={{
+            title: "Starter",
+            headerShown: false,
+            href: hrefFor("starter"),
+            tabBarItemStyle: itemStyleFor("starter"),
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="code" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="videos"
+          options={{
+            title: "Video",
+            headerShown: false,
+            href: null,
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="film" size={size} color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="more"
+          options={{
+            title: "More",
+            tabBarItemStyle:
+              overflowApps.length === 0 ? { display: "none" } : undefined,
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="more-horizontal" size={size} color={color} />
+            ),
+          }}
+          listeners={{
+            tabPress: (e) => {
+              e.preventDefault();
+              setMoreOpen(true);
+            },
+          }}
+        />
+        <Tabs.Screen
+          name="settings"
+          options={{
+            title: "Settings",
+            tabBarIcon: ({ color, size }) => (
+              <Feather name="settings" size={size} color={color} />
+            ),
+          }}
+        />
+      </Tabs>
+
+      <Modal
+        visible={moreOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setMoreOpen(false)}
+      >
+        <Pressable
+          style={styles.backdrop}
+          onPress={() => setMoreOpen(false)}
+        >
+          <Pressable style={styles.sheet} onPress={(e) => e.stopPropagation()}>
+            <View style={styles.handle} />
+            <Text style={styles.sheetTitle}>More Apps</Text>
+            <ScrollView>
+              {overflowApps.length === 0 ? (
+                <Text style={styles.emptyText}>
+                  No additional apps. Enable more apps in Settings.
+                </Text>
+              ) : (
+                overflowApps.map((app) => {
+                  const iconName = APP_ICON[app.id] ?? "globe";
+                  return (
+                    <TouchableOpacity
+                      key={app.id}
+                      style={styles.row}
+                      onPress={() => openOverflowApp(app)}
+                    >
+                      <View
+                        style={[
+                          styles.iconWrap,
+                          { backgroundColor: `${app.color}33` },
+                        ]}
+                      >
+                        <Feather
+                          name={iconName}
+                          size={18}
+                          color={app.color}
+                        />
+                      </View>
+                      <Text style={styles.rowText}>{app.name}</Text>
+                      <Feather
+                        name="chevron-right"
+                        size={18}
+                        color="#555555"
+                      />
+                    </TouchableOpacity>
+                  );
+                })
+              )}
+            </ScrollView>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </>
   );
 }
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    backgroundColor: "#1a1a1a",
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingTop: 8,
+    paddingBottom: 32,
+    paddingHorizontal: 8,
+    maxHeight: "70%",
+  },
+  handle: {
+    alignSelf: "center",
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: "#333333",
+    marginBottom: 12,
+  },
+  sheetTitle: {
+    color: "#999999",
+    fontSize: 12,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    paddingHorizontal: 12,
+    paddingBottom: 8,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingVertical: 14,
+    gap: 12,
+    borderRadius: 10,
+  },
+  iconWrap: {
+    width: 32,
+    height: 32,
+    borderRadius: 8,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  rowText: {
+    flex: 1,
+    color: "#ffffff",
+    fontSize: 16,
+  },
+  emptyText: {
+    color: "#666666",
+    fontSize: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 24,
+    textAlign: "center",
+  },
+});

--- a/packages/mobile-app/app/(tabs)/more.tsx
+++ b/packages/mobile-app/app/(tabs)/more.tsx
@@ -1,0 +1,7 @@
+import { View } from "react-native";
+
+// Placeholder — the More tab opens a sheet via tabPress listener in
+// `_layout.tsx`; this screen is never actually rendered.
+export default function More() {
+  return <View />;
+}

--- a/packages/mobile-app/app/(tabs)/settings.tsx
+++ b/packages/mobile-app/app/(tabs)/settings.tsx
@@ -25,13 +25,6 @@ export default function SettingsScreen() {
     [updateApp],
   );
 
-  const handleModeToggle = useCallback(
-    (id: string, mode: "dev" | "prod") => {
-      updateApp(id, { mode });
-    },
-    [updateApp],
-  );
-
   const handleEdit = useCallback((app: AppConfig) => {
     setEditingApp(app);
   }, []);
@@ -94,41 +87,6 @@ export default function SettingsScreen() {
               </View>
             </View>
             <View style={styles.appActions}>
-              <View style={styles.modeToggle}>
-                <TouchableOpacity
-                  style={[
-                    styles.modeButton,
-                    (app.mode ?? "prod") === "prod" && styles.modeButtonActive,
-                  ]}
-                  onPress={() => handleModeToggle(app.id, "prod")}
-                >
-                  <Text
-                    style={[
-                      styles.modeButtonText,
-                      (app.mode ?? "prod") === "prod" &&
-                        styles.modeButtonTextActive,
-                    ]}
-                  >
-                    Prod
-                  </Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[
-                    styles.modeButton,
-                    app.mode === "dev" && styles.modeButtonActive,
-                  ]}
-                  onPress={() => handleModeToggle(app.id, "dev")}
-                >
-                  <Text
-                    style={[
-                      styles.modeButtonText,
-                      app.mode === "dev" && styles.modeButtonTextActive,
-                    ]}
-                  >
-                    Dev
-                  </Text>
-                </TouchableOpacity>
-              </View>
               <TouchableOpacity
                 onPress={() => handleEdit(app)}
                 style={styles.editButton}
@@ -245,29 +203,6 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
-  },
-  modeToggle: {
-    flexDirection: "row",
-    backgroundColor: "#1A1A1A",
-    borderRadius: 6,
-    padding: 2,
-    gap: 1,
-  },
-  modeButton: {
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 4,
-  },
-  modeButtonActive: {
-    backgroundColor: "#333333",
-  },
-  modeButtonText: {
-    color: "#555555",
-    fontSize: 11,
-    fontWeight: "600",
-  },
-  modeButtonTextActive: {
-    color: "#ffffff",
   },
   editButton: {
     padding: 6,

--- a/packages/mobile-app/app/app/[id].tsx
+++ b/packages/mobile-app/app/app/[id].tsx
@@ -94,7 +94,7 @@ export default function AppScreen() {
     );
   }
 
-  const baseUrl = app.mode === "dev" && app.devUrl ? app.devUrl : app.url;
+  const baseUrl = app.url;
 
   // Append the session token as a query param so the server can promote it to
   // an httpOnly cookie. This bridges the Safari/WKWebView cookie jar gap.

--- a/packages/mobile-app/components/AppForm.tsx
+++ b/packages/mobile-app/components/AppForm.tsx
@@ -57,8 +57,6 @@ export default function AppForm({
 }: AppFormProps) {
   const [name, setName] = useState(editApp?.name ?? "");
   const [url, setUrl] = useState(editApp?.url ?? "");
-  const [devUrl, setDevUrl] = useState(editApp?.devUrl ?? "");
-  const [devCommand, setDevCommand] = useState(editApp?.devCommand ?? "");
   const [description, setDescription] = useState(editApp?.description ?? "");
   const [color, setColor] = useState(editApp?.color ?? COLOR_PRESETS[0]);
   const [icon, setIcon] = useState(editApp?.icon ?? "Globe");
@@ -71,7 +69,7 @@ export default function AppForm({
       return;
     }
     if (!url.trim()) {
-      Alert.alert("Error", "Production URL is required");
+      Alert.alert("Error", "URL is required");
       return;
     }
 
@@ -97,8 +95,8 @@ export default function AppForm({
       description: description.trim() || name.trim(),
       url: url.trim(),
       devPort: 0,
-      devUrl: devUrl.trim() || undefined,
-      devCommand: devCommand.trim() || undefined,
+      devUrl: editApp?.devUrl,
+      devCommand: editApp?.devCommand,
       color,
       colorRgb: hexToRgb(color),
       isBuiltIn: editApp?.isBuiltIn ?? false,
@@ -136,7 +134,7 @@ export default function AppForm({
             placeholderTextColor="#555555"
           />
 
-          <Text style={styles.label}>Production URL *</Text>
+          <Text style={styles.label}>URL *</Text>
           <TextInput
             style={styles.input}
             value={url}
@@ -144,31 +142,6 @@ export default function AppForm({
             placeholder="https://myapp.example.com"
             placeholderTextColor="#555555"
             keyboardType="url"
-            autoCapitalize="none"
-            autoCorrect={false}
-          />
-
-          <Text style={styles.label}>Dev URL (optional)</Text>
-          <TextInput
-            style={styles.input}
-            value={devUrl}
-            onChangeText={setDevUrl}
-            placeholder="http://localhost:3000"
-            placeholderTextColor="#555555"
-            keyboardType="url"
-            autoCapitalize="none"
-            autoCorrect={false}
-          />
-
-          <Text style={styles.label}>
-            Dev Command (optional, for reference)
-          </Text>
-          <TextInput
-            style={styles.input}
-            value={devCommand}
-            onChangeText={setDevCommand}
-            placeholder="pnpm dev"
-            placeholderTextColor="#555555"
             autoCapitalize="none"
             autoCorrect={false}
           />

--- a/packages/mobile-app/lib/app-store.ts
+++ b/packages/mobile-app/lib/app-store.ts
@@ -7,6 +7,19 @@ import {
 
 const STORAGE_KEY = "agent-native:apps";
 
+const listeners = new Set<() => void>();
+
+export function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+function emit(): void {
+  for (const fn of listeners) fn();
+}
+
 function migrateApps(apps: AppConfig[]): {
   apps: AppConfig[];
   changed: boolean;
@@ -83,6 +96,7 @@ export async function getApps(): Promise<AppConfig[]> {
 
 export async function saveApps(apps: AppConfig[]): Promise<void> {
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(apps));
+  emit();
 }
 
 export async function addApp(app: AppConfig): Promise<void> {

--- a/packages/mobile-app/lib/get-app-url.ts
+++ b/packages/mobile-app/lib/get-app-url.ts
@@ -1,11 +1,6 @@
 import type { AppConfig } from "@agent-native/shared-app-config";
 
-declare const __DEV__: boolean | undefined;
-
-/** Return devUrl in dev mode, production url otherwise. */
+/** Mobile app only ever shows production URLs — no localhost on phones. */
 export function getAppUrl(app: AppConfig): string {
-  if (typeof __DEV__ !== "undefined" && __DEV__ && app.devUrl) {
-    return app.devUrl;
-  }
   return app.url;
 }

--- a/packages/mobile-app/lib/use-apps.ts
+++ b/packages/mobile-app/lib/use-apps.ts
@@ -14,6 +14,7 @@ export function useApps() {
 
   useEffect(() => {
     reload();
+    return AppStore.subscribe(reload);
   }, [reload]);
 
   const addApp = useCallback(


### PR DESCRIPTION
## Summary

Lays the data-shape groundwork for two upcoming workspace features:

- **Archived apps** — adds `archived?: boolean` to `WorkspaceAppSummary` and `includeArchived?: boolean` to `ListWorkspaceAppsOptions` so the workspace polling/UI defaults to hiding archived apps and the apps page can opt in (e.g. for a "Hidden apps" expander).
- **Available templates** — new `AvailableWorkspaceTemplate` type for the upcoming scaffolding picker.

Also imports `spawn` for the soon-to-land creation flow.

## Test plan

- [ ] `pnpm prep` (Build, Lint, Test, Typecheck, Guard, Changeset)
- [ ] No call sites updated yet — purely additive types