### PR TITLE
fix(core,dispatch,analytics): UX polish + analytics dashboard archive support

### DIFF
--- a/.changeset/agent-chat-stuck-detector.md
+++ b/.changeset/agent-chat-stuck-detector.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": minor
+---
+
+Surface a user-visible "this chat looks stuck" affordance when an agent run goes silent. The server now tracks a durable `last_progress_at` timestamp on every emitted event (distinct from the process-liveness `heartbeat_at`); `/runs/active` returns it; and a new `useRunStuckDetection` hook + `RunStuckBanner` component poll it from the client. After 90s without progress — past the adapter's 75s no-progress reconnect — the banner appears with Retry / Cancel buttons. `MultiTabAssistantChat` wires this in by default, with Retry sending a continuation prompt via the existing chat handle. `trackEvent` calls fire on stuck-detected, retry, and cancel so we can finally see the long tail of stuck-chat incidents in analytics instead of relying on user reports.

--- a/.changeset/chat-sidebar-instant-paint.md
+++ b/.changeset/chat-sidebar-instant-paint.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Make the chat sidebar paint the composer immediately on open instead of blocking behind a `GET /threads` (+ optional `POST /threads`) round-trip. `useChatThreads` now seeds an optimistic active thread synchronously on mount — either from localStorage or a freshly-generated UUID — and persists it server-side in the background. For new chats the empty/composer state is visible on first render; for existing chats the header and composer render immediately while the per-thread restore skeleton stays scoped to the message area.

--- a/.changeset/chat-sidebar-instant-paint.md
+++ b/.changeset/chat-sidebar-instant-paint.md
@@ -2,4 +2,4 @@
 "@agent-native/core": patch
 ---
 
-Make the chat sidebar paint the composer immediately on open instead of blocking behind a `GET /threads` (+ optional `POST /threads`) round-trip. `useChatThreads` now seeds an optimistic active thread synchronously on mount — either from localStorage or a freshly-generated UUID — and persists it server-side in the background. For new chats the empty/composer state is visible on first render; for existing chats the header and composer render immediately while the per-thread restore skeleton stays scoped to the message area.
+Make the chat sidebar paint instantly on open instead of blocking behind network round-trips. `useChatThreads` now seeds an optimistic active thread synchronously on mount — either from localStorage or a freshly-generated UUID — and persists it server-side in the background. For existing chats, every save also writes the thread data to a localStorage cache, and `AssistantChat` hydrates from that cache synchronously so the message bubbles paint on first commit; the server fetch still runs in the background to refresh, and is skipped as a no-op when the server data is identical to the cache.

--- a/.changeset/composer-plus-menu-extension-label.md
+++ b/.changeset/composer-plus-menu-extension-label.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Composer + menu now reads "Create Extension" (was "Create Tool") and "Schedule Task" (was "Scheduled Task") to match the imperative tense of the other menu items.

--- a/.changeset/dispatch-overview-section-spacing.md
+++ b/.changeset/dispatch-overview-section-spacing.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Increase vertical spacing between sections on Dispatch pages so section headings (Getting started, At a glance, Operations detail, etc.) read as distinct groups instead of running together.

--- a/.changeset/unavailable-coming-soon.md
+++ b/.changeset/unavailable-coming-soon.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Reword waitlisted Builder Cloud Agents UI from "unavailable" to "coming soon" in the connect card and code-required dialog.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "dev:all": "node scripts/dev-all.ts",
     "dev:all:desktop": "node scripts/dev-all.ts --desktop",
     "dev:lazy": "node scripts/dev-lazy.ts",
-    "dev:lazy:desktop": "node scripts/dev-lazy.ts --desktop --no-open",
+    "dev:lazy:desktop": "node scripts/dev-lazy.ts --desktop",
     "dev:docs": "pnpm --filter @agent-native/docs dev",
     "dev:electron": "node scripts/dev-electron.ts",
     "dev:electron:apps": "node scripts/dev-electron.ts --apps"

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -609,11 +609,12 @@ describe("run manager soft timeout", () => {
       startedAt: Date.now() - 1000,
       heartbeatAt: Date.now() - 1000,
       completedAt: Date.now() - 500,
+      lastProgressAt: Date.now() - 800,
     });
 
     const result = await getActiveRunForThreadAsync("thread-recent");
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       runId: "run-recent-completed",
       threadId: "thread-recent",
       status: "completed",
@@ -634,6 +635,7 @@ describe("run manager soft timeout", () => {
       startedAt: completedAt - 5_000,
       heartbeatAt: null,
       completedAt,
+      lastProgressAt: null,
     });
 
     const result = await getActiveRunForThreadAsync("thread-old");
@@ -655,6 +657,7 @@ describe("run manager soft timeout", () => {
       startedAt,
       heartbeatAt: Date.now() - 5_000,
       completedAt: Date.now() - 2_000,
+      lastProgressAt: Date.now() - 5_000,
     });
 
     const result = await getActiveRunForThreadAsync("thread-long");
@@ -676,6 +679,7 @@ describe("run manager soft timeout", () => {
       startedAt: Date.now() - TERMINAL_RUN_RECONNECT_WINDOW_MS - 120_000,
       heartbeatAt: Date.now() - 3_000,
       completedAt: null,
+      lastProgressAt: null,
     });
 
     const result = await getActiveRunForThreadAsync("thread-legacy");
@@ -694,6 +698,7 @@ describe("run manager soft timeout", () => {
       startedAt: Date.now() - 1000,
       heartbeatAt: null,
       completedAt: Date.now() - 500,
+      lastProgressAt: null,
     });
 
     const result = await getActiveRunForThreadAsync("thread-errored");

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -13,6 +13,7 @@ vi.mock("./run-store.js", () => ({
   getRunByThread: vi.fn(() => Promise.resolve(null)),
   cleanupOldRuns: vi.fn(() => Promise.resolve()),
   updateRunHeartbeat: vi.fn(() => Promise.resolve()),
+  bumpRunProgress: vi.fn(() => Promise.resolve()),
   reapIfStale: vi.fn(() => Promise.resolve(null)),
 }));
 

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -744,13 +744,17 @@ export function getActiveRunForThread(threadId: string): ActiveRun | null {
  * Used by the /runs/active endpoint.
  *
  * Returns `heartbeatAt` so the client can independently decide a run is
- * dead even before the server-side stale reap has fired.
+ * dead even before the server-side stale reap has fired. Returns
+ * `lastProgressAt` so the client-side stuck-detector can show a
+ * user-visible "this chat looks stuck" affordance when a run is alive
+ * (heartbeating) but not actually emitting events.
  */
 export async function getActiveRunForThreadAsync(threadId: string): Promise<{
   runId: string;
   threadId: string;
   status: string;
   heartbeatAt: number;
+  lastProgressAt: number | null;
 } | null> {
   // Check memory first — return both running AND recently-completed runs
   // that still have events in memory. This allows sub-agent tabs to replay
@@ -764,6 +768,12 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
       // In-memory means this isolate is the producer. By definition, the
       // heartbeat is fresh as of "now" — the client can trust this.
       heartbeatAt: Date.now(),
+      // For an in-memory run we don't have a separate "last event emit"
+      // timestamp tracked in JS — the SQL bump is throttled per-second.
+      // Read it back from SQL on demand. For the common case the SQL row
+      // is well under 1s old; if it isn't, the stuck-detector will pick
+      // it up on the next poll cycle.
+      lastProgressAt: await fetchLastProgressAt(memRun.runId),
     };
   }
   // Fall back to SQL — also surface recently terminated runs so the client
@@ -787,6 +797,7 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
         threadId: sqlRun.threadId,
         status: sqlRun.status,
         heartbeatAt: sqlRun.heartbeatAt ?? sqlRun.startedAt,
+        lastProgressAt: sqlRun.lastProgressAt,
       };
     }
     if (sqlRun.status === "completed" || sqlRun.status === "errored") {
@@ -810,12 +821,29 @@ export async function getActiveRunForThreadAsync(threadId: string): Promise<{
         threadId: sqlRun.threadId,
         status: sqlRun.status,
         heartbeatAt: sqlRun.heartbeatAt ?? sqlRun.startedAt,
+        lastProgressAt: sqlRun.lastProgressAt,
       };
     }
   } catch {
     // SQL error — fall through
   }
   return null;
+}
+
+async function fetchLastProgressAt(runId: string): Promise<number | null> {
+  try {
+    const run = await getRunById(runId);
+    if (!run) return null;
+    // `getRunById` returns a narrow projection today; ask for the row via
+    // the thread lookup which carries last_progress_at.
+    const byThread = await getRunByThread(run.threadId, {
+      includeTerminal: true,
+    });
+    if (byThread && byThread.id === runId) return byThread.lastProgressAt;
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 /** Get a run by ID */

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -12,6 +12,7 @@ import {
   getRunByThread,
   cleanupOldRuns,
   updateRunHeartbeat,
+  bumpRunProgress,
   reapIfStale,
 } from "./run-store.js";
 
@@ -180,6 +181,18 @@ export function startRun(
   // overwritten by a late row stuck at status='running'.
   const insertRunPromise = insertRun(runId, threadId).catch(() => {});
 
+  // Throttle the durable progress timestamp to at most once per second so
+  // a chatty token-by-token stream doesn't translate into one DB write per
+  // chunk. The stuck-detector threshold is on the order of tens of seconds,
+  // so 1s resolution is plenty.
+  let lastProgressBumpAt = 0;
+  const bumpProgressIfDue = () => {
+    const now = Date.now();
+    if (now - lastProgressBumpAt < 1000) return;
+    lastProgressBumpAt = now;
+    bumpRunProgress(runId).catch(() => {});
+  };
+
   // Periodic SQL abort check interval (for cross-isolate abort on Workers)
   let lastAbortCheck = Date.now() - 3000;
   const checkSqlAbort = () => {
@@ -268,6 +281,12 @@ export function startRun(
         run.subscribers.delete(subscriber);
       }
     }
+
+    // Bump the durable progress timestamp. Distinct from the heartbeat:
+    // heartbeat = "process is up", progress = "real work is happening." The
+    // gap between them is what the client-side stuck-detector reads to tell
+    // a hung run from a healthy one.
+    bumpProgressIfDue();
 
     // Persist event to SQL. Ordinary streaming events are fire-and-forget, but
     // terminal events are awaited before final status is persisted so reconnects

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -37,7 +37,8 @@ async function ensureRunTables(): Promise<void> {
           abort_reason TEXT,
           started_at ${intType()} NOT NULL,
           completed_at ${intType()},
-          heartbeat_at ${intType()}
+          heartbeat_at ${intType()},
+          last_progress_at ${intType()}
         )
       `);
       // Backfill heartbeat_at on older deployments.
@@ -66,6 +67,23 @@ async function ensureRunTables(): Promise<void> {
       } catch {
         // Column already exists — ignore
       }
+      // Backfill last_progress_at — this is distinct from heartbeat_at.
+      // heartbeat_at = "the producer process is alive" (bumped on a timer).
+      // last_progress_at = "the agent is actually emitting events" (bumped on
+      // each emit). The gap between them is the stuck-detector signal.
+      try {
+        if (isPostgres()) {
+          await client.execute(
+            `ALTER TABLE agent_runs ADD COLUMN IF NOT EXISTS last_progress_at ${intType()}`,
+          );
+        } else {
+          await client.execute(
+            `ALTER TABLE agent_runs ADD COLUMN last_progress_at ${intType()}`,
+          );
+        }
+      } catch {
+        // Column already exists — ignore
+      }
       await client.execute(`
         CREATE TABLE IF NOT EXISTS agent_run_events (
           run_id TEXT NOT NULL,
@@ -84,8 +102,8 @@ export async function insertRun(id: string, threadId: string): Promise<void> {
   const client = getDbExec();
   const now = Date.now();
   await client.execute({
-    sql: `INSERT INTO agent_runs (id, thread_id, status, started_at, heartbeat_at) VALUES (?, ?, 'running', ?, ?)`,
-    args: [id, threadId, now, now],
+    sql: `INSERT INTO agent_runs (id, thread_id, status, started_at, heartbeat_at, last_progress_at) VALUES (?, ?, 'running', ?, ?, ?)`,
+    args: [id, threadId, now, now, now],
   });
 }
 
@@ -95,6 +113,21 @@ export async function updateRunHeartbeat(runId: string): Promise<void> {
   const client = getDbExec();
   await client.execute({
     sql: `UPDATE agent_runs SET heartbeat_at = ? WHERE id = ?`,
+    args: [Date.now(), runId],
+  });
+}
+
+/**
+ * Bump `last_progress_at` — call this whenever the agent actually emits an
+ * event (token, tool call, message). Distinct from `heartbeat_at` so the
+ * stuck-detector can tell "process alive but nothing happening" from
+ * "process dead." Callers should throttle (run-manager debounces to ~1/s).
+ */
+export async function bumpRunProgress(runId: string): Promise<void> {
+  await ensureRunTables();
+  const client = getDbExec();
+  await client.execute({
+    sql: `UPDATE agent_runs SET last_progress_at = ? WHERE id = ?`,
     args: [Date.now(), runId],
   });
 }
@@ -239,12 +272,13 @@ export async function getRunByThread(
   startedAt: number;
   heartbeatAt: number | null;
   completedAt: number | null;
+  lastProgressAt: number | null;
 } | null> {
   await ensureRunTables();
   const client = getDbExec();
   const sql = options?.includeTerminal
-    ? `SELECT id, thread_id, status, started_at, heartbeat_at, completed_at FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`
-    : `SELECT id, thread_id, status, started_at, heartbeat_at, completed_at FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`;
+    ? `SELECT id, thread_id, status, started_at, heartbeat_at, completed_at, last_progress_at FROM agent_runs WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`
+    : `SELECT id, thread_id, status, started_at, heartbeat_at, completed_at, last_progress_at FROM agent_runs WHERE thread_id = ? AND status = 'running' ORDER BY started_at DESC LIMIT 1`;
   const { rows } = await client.execute({ sql, args: [threadId] });
   if (rows.length === 0) return null;
   const r = rows[0] as {
@@ -254,6 +288,7 @@ export async function getRunByThread(
     started_at: number | string;
     heartbeat_at: number | string | null;
     completed_at: number | string | null;
+    last_progress_at: number | string | null;
   };
   return {
     id: r.id,
@@ -262,6 +297,8 @@ export async function getRunByThread(
     startedAt: Number(r.started_at),
     heartbeatAt: r.heartbeat_at == null ? null : Number(r.heartbeat_at),
     completedAt: r.completed_at == null ? null : Number(r.completed_at),
+    lastProgressAt:
+      r.last_progress_at == null ? null : Number(r.last_progress_at),
   };
 }
 

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2,6 +2,7 @@ import React, {
   useState,
   useRef,
   useEffect,
+  useLayoutEffect,
   useCallback,
   useMemo,
   forwardRef,
@@ -63,6 +64,7 @@ import {
 import { IframeEmbed, parseEmbedBody } from "./IframeEmbed.js";
 import { useDevMode } from "./use-dev-mode.js";
 import { agentNativePath } from "./api-path.js";
+import { getThreadCacheKey } from "./use-chat-threads.js";
 import { BUILDER_SPACE_SETTINGS_URL } from "./error-format.js";
 import { ThumbsFeedback } from "./observability/ThumbsFeedback.js";
 import {
@@ -2974,7 +2976,21 @@ const AssistantChatInner = forwardRef<
 
   // ─── Chat persistence ──────────────────────────────────────────────
   const hasRestoredRef = useRef(false);
-  const [isRestoring, setIsRestoring] = useState(!!threadId && !isNewThread);
+  // Cached thread data from a prior session, read synchronously so existing
+  // chats can paint their messages on first commit instead of after the server
+  // round-trip. The server fetch still runs to refresh with the latest.
+  const [cachedThreadData] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
+    if (!threadId || isNewThread) return null;
+    try {
+      return localStorage.getItem(getThreadCacheKey(threadId));
+    } catch {
+      return null;
+    }
+  });
+  const [isRestoring, setIsRestoring] = useState(
+    !!threadId && !isNewThread && !cachedThreadData,
+  );
   const onSaveThreadRef = useRef(onSaveThread);
   onSaveThreadRef.current = onSaveThread;
   const onGenerateTitleRef = useRef(onGenerateTitle);

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -3230,6 +3230,21 @@ const AssistantChatInner = forwardRef<
       }
     }, [apiUrl, refreshThreadFromServer, startReconnectToRun, threadId]);
 
+  // Hydrate from the localStorage cache synchronously so the message bubbles
+  // paint on the first commit instead of after the server round-trip. The
+  // server fetch below still runs to refresh with the latest content.
+  const hydratedFromCacheRef = useRef(false);
+  useLayoutEffect(() => {
+    if (hydratedFromCacheRef.current) return;
+    if (!cachedThreadData) return;
+    hydratedFromCacheRef.current = true;
+    try {
+      importThreadData(cachedThreadData, { markTitleGenerated: true });
+    } catch {
+      // Corrupt cache entry — ignore and let the server fetch repopulate.
+    }
+  }, [cachedThreadData, importThreadData]);
+
   // Restore messages from server on mount (when threadId is set)
   useEffect(() => {
     if (hasRestoredRef.current) return;
@@ -3245,7 +3260,12 @@ const AssistantChatInner = forwardRef<
           if (!res.ok) return;
           const data = await res.json();
           if (data.threadData) {
-            importThreadData(data.threadData, { markTitleGenerated: true });
+            // Skip the re-import if the server data matches what we already
+            // hydrated from cache — avoids a second runtime.import that would
+            // briefly flicker the message list.
+            if (data.threadData !== cachedThreadData) {
+              importThreadData(data.threadData, { markTitleGenerated: true });
+            }
           }
           // Also skip title generation if thread already has a title
           if (data.title) {
@@ -3282,6 +3302,7 @@ const AssistantChatInner = forwardRef<
     threadRuntime,
     importThreadData,
     reconnectActiveRunForThread,
+    cachedThreadData,
   ]);
 
   // If assistant-ui stops the local runtime while the background server run is

--- a/packages/core/src/client/ConnectBuilderCard.tsx
+++ b/packages/core/src/client/ConnectBuilderCard.tsx
@@ -181,7 +181,7 @@ export function ConnectBuilderCard({
   } else if (showWaitlist) {
     title = waitlistJoined
       ? "You're on the waitlist"
-      : "Builder Cloud Agents unavailable";
+      : "Builder Cloud Agents coming soon";
     subtitle = waitlistJoined ? (
       <>
         We'll let you know when Builder Cloud Agents are available for this

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -15,6 +15,7 @@ import {
 } from "./components/ui/tooltip.js";
 import { useChatThreads, type ChatThreadSummary } from "./use-chat-threads.js";
 import { agentNativePath } from "./api-path.js";
+import { RunStuckBanner } from "./RunStuckBanner.js";
 import { DEFAULT_MODEL } from "../agent/default-model.js";
 import {
   getReasoningEffortOptionsForModel,
@@ -1543,12 +1544,22 @@ export function MultiTabAssistantChat({
             return (
               <div
                 key={tabId}
-                className="flex-1 min-h-0"
+                className="flex-1 min-h-0 flex-col"
                 style={{
                   display:
                     contentHidden || tabId !== activeThreadId ? "none" : "flex",
                 }}
               >
+                <RunStuckBanner
+                  threadId={tabId}
+                  apiUrl={apiUrl}
+                  onRetry={() => {
+                    const handle = chatRefs.current.get(tabId);
+                    handle?.sendMessage(
+                      "Continue from where you left off and finish my last request. Do not repeat completed work.",
+                    );
+                  }}
+                />
                 <AssistantChat
                   {...props}
                   ref={(handle) => {

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -408,6 +408,7 @@ export function MultiTabAssistantChat({
     generateTitle,
     searchThreads,
     refreshThreads,
+    isNewThread,
   } = useChatThreads(apiUrl, storageKey);
 
   // Namespace all localStorage keys by storageKey when provided (for per-app isolation in frame)
@@ -772,11 +773,14 @@ export function MultiTabAssistantChat({
     }
   }, [activeThreadId]);
 
-  // Ensure at least one tab is always open — auto-create if sidebar is empty
+  // Ensure at least one tab is always open — auto-create if sidebar is empty.
+  // Skipped when an active thread already exists (e.g. the hook generated an
+  // optimistic id for a brand-new session); the activeThreadId effect above
+  // adds it to openTabIds without spinning up a duplicate thread.
   const autoCreatingRef = useRef(false);
   useEffect(() => {
     if (isLoading || autoCreatingRef.current) return;
-    if (openTabIds.length === 0) {
+    if (openTabIds.length === 0 && !activeThreadId) {
       autoCreatingRef.current = true;
       createThread().then((id) => {
         autoCreatingRef.current = false;
@@ -786,7 +790,7 @@ export function MultiTabAssistantChat({
         }
       });
     }
-  }, [isLoading, openTabIds, createThread]);
+  }, [isLoading, openTabIds, activeThreadId, createThread]);
 
   // Focus the composer when switching tabs
   useEffect(() => {
@@ -1309,7 +1313,11 @@ export function MultiTabAssistantChat({
     tabCount: openTabIds.length,
   };
 
-  if (isLoading) {
+  // No full-shell skeleton: the hook seeds an optimistic activeThreadId
+  // synchronously so the chat shell + composer can paint on first render.
+  // Per-thread restore (existing chats with history) shows its own message-area
+  // skeleton inside AssistantChat — header and composer stay visible.
+  if (isLoading && !activeThreadId) {
     return (
       <ChatSkeleton
         header={renderHeader?.(headerProps)}
@@ -1553,7 +1561,9 @@ export function MultiTabAssistantChat({
                   threadId={tabId}
                   tabId={tabId}
                   apiUrl={apiUrl}
-                  isNewThread={newThreadIds.current.has(tabId)}
+                  isNewThread={
+                    newThreadIds.current.has(tabId) || isNewThread(tabId)
+                  }
                   onMessageCountChange={(count) =>
                     setMessageCounts((prev) =>
                       prev[tabId] === count

--- a/packages/core/src/client/RunStuckBanner.tsx
+++ b/packages/core/src/client/RunStuckBanner.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useRef, useState } from "react";
+import { IconAlertTriangle, IconLoader2 } from "@tabler/icons-react";
+import {
+  useRunStuckDetection,
+  useAbortRun,
+  type RunStuckState,
+} from "./use-run-stuck-detection.js";
+import { trackEvent } from "./analytics.js";
+import { cn } from "./utils.js";
+
+/**
+ * Surface a user-visible affordance when a chat run hasn't emitted any
+ * events for an unusually long time. The adapter's silent reconnect logic
+ * keeps trying in the background; this banner is the fallback when those
+ * attempts haven't restored progress and the user is staring at a frozen
+ * spinner.
+ */
+export interface RunStuckBannerProps {
+  /** The thread to monitor. Pass null/undefined to disable. */
+  threadId: string | null | undefined;
+  /** API base path. Default `/_agent-native/agent-chat`. */
+  apiUrl?: string;
+  /**
+   * Threshold above which an in-flight run is considered stuck.
+   * Defaults to 90s (after the adapter's 75s no-progress reconnect
+   * has had a chance to recover).
+   */
+  stuckThresholdMs?: number;
+  /**
+   * Called when the user clicks Retry. Implementations should re-prompt
+   * the agent (typically via `chatHandle.sendMessage(...)`) — the banner
+   * itself only handles aborting the prior run.
+   */
+  onRetry?: (runId: string) => void;
+  /**
+   * Called whenever the stuck state transitions. Useful for surfacing
+   * observability events (Sentry, PostHog) at the call site.
+   */
+  onStuckStateChange?: (state: RunStuckState) => void;
+  /** Extra class on the outer container. */
+  className?: string;
+}
+
+export function RunStuckBanner({
+  threadId,
+  apiUrl,
+  stuckThresholdMs,
+  onRetry,
+  onStuckStateChange,
+  className,
+}: RunStuckBannerProps) {
+  const state = useRunStuckDetection({ threadId, stuckThresholdMs, apiUrl });
+  const abortRun = useAbortRun(apiUrl);
+  const [busy, setBusy] = useState<"none" | "cancel" | "retry">("none");
+
+  const lastReportedRef = useRef<{
+    isStuck: boolean;
+    runId: string | null;
+  }>({ isStuck: false, runId: null });
+  useEffect(() => {
+    const last = lastReportedRef.current;
+    if (last.isStuck === state.isStuck && last.runId === state.runId) return;
+    lastReportedRef.current = { isStuck: state.isStuck, runId: state.runId };
+    onStuckStateChange?.(state);
+    if (state.isStuck && state.runId) {
+      trackEvent("agent_chat_stuck_detected", {
+        runId: state.runId,
+        threadId: threadId ?? null,
+        stuckSinceMs: state.stuckSinceMs ?? null,
+        stuckSinceSec:
+          state.stuckSinceMs != null
+            ? Math.floor(state.stuckSinceMs / 1000)
+            : null,
+        runStatus: state.status,
+      });
+    }
+  }, [state, onStuckStateChange, threadId]);
+
+  // Reset the busy spinner once the underlying run has flipped away from
+  // running — no need to keep showing a stale "Retrying…" indicator.
+  useEffect(() => {
+    if (state.status !== "running") {
+      setBusy("none");
+    }
+  }, [state.status]);
+
+  if (!state.isStuck || !state.runId) return null;
+
+  const handleCancel = async () => {
+    if (!state.runId || busy !== "none") return;
+    setBusy("cancel");
+    trackEvent("agent_chat_stuck_cancel", {
+      runId: state.runId,
+      threadId: threadId ?? null,
+      stuckSinceMs: state.stuckSinceMs ?? null,
+    });
+    await abortRun(state.runId, "user_stuck_cancel");
+  };
+
+  const handleRetry = async () => {
+    if (!state.runId || busy !== "none") return;
+    setBusy("retry");
+    trackEvent("agent_chat_stuck_retry", {
+      runId: state.runId,
+      threadId: threadId ?? null,
+      stuckSinceMs: state.stuckSinceMs ?? null,
+    });
+    const aborted = await abortRun(state.runId, "user_stuck_retry");
+    if (aborted) onRetry?.(aborted);
+  };
+
+  const stuckSeconds =
+    state.stuckSinceMs != null ? Math.floor(state.stuckSinceMs / 1000) : null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "mx-3 mt-2 flex items-start gap-2.5 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-xs text-foreground",
+        className,
+      )}
+    >
+      <IconAlertTriangle
+        size={16}
+        className="mt-0.5 shrink-0 text-amber-500"
+        aria-hidden="true"
+      />
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <div className="leading-snug">
+          <span className="font-medium">This chat looks stuck.</span>{" "}
+          <span className="text-muted-foreground">
+            No progress
+            {stuckSeconds != null ? ` for ${stuckSeconds}s` : ""}. The agent
+            may have hit a server timeout or lost its connection.
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={handleRetry}
+            disabled={busy !== "none"}
+            className="inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-md bg-foreground px-2.5 text-[11px] font-medium text-background transition-colors hover:bg-foreground/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {busy === "retry" ? (
+              <IconLoader2
+                size={12}
+                className="animate-spin"
+                aria-hidden="true"
+              />
+            ) : null}
+            Retry
+          </button>
+          <button
+            type="button"
+            onClick={handleCancel}
+            disabled={busy !== "none"}
+            className="inline-flex h-7 cursor-pointer items-center gap-1.5 rounded-md border border-border bg-background px-2.5 text-[11px] font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {busy === "cancel" ? (
+              <IconLoader2
+                size={12}
+                className="animate-spin"
+                aria-hidden="true"
+              />
+            ) : null}
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/core/src/client/RunStuckBanner.tsx
+++ b/packages/core/src/client/RunStuckBanner.tsx
@@ -131,8 +131,8 @@ export function RunStuckBanner({
           <span className="font-medium">This chat looks stuck.</span>{" "}
           <span className="text-muted-foreground">
             No progress
-            {stuckSeconds != null ? ` for ${stuckSeconds}s` : ""}. The agent
-            may have hit a server timeout or lost its connection.
+            {stuckSeconds != null ? ` for ${stuckSeconds}s` : ""}. The agent may
+            have hit a server timeout or lost its connection.
           </span>
         </div>
         <div className="flex flex-wrap items-center gap-2">

--- a/packages/core/src/client/components/CodeRequiredDialog.tsx
+++ b/packages/core/src/client/components/CodeRequiredDialog.tsx
@@ -216,14 +216,14 @@ export function CodeRequiredDialog({
               </div>
               <div style={s.optionText}>
                 <span style={s.optionTitle}>
-                  Builder Cloud Agents unavailable
+                  Builder Cloud Agents coming soon
                 </span>
                 <span style={s.optionDesc}>
                   You don't have access yet. Use the desktop app or your local
                   clone for this code change.
                 </span>
               </div>
-              <span style={s.badge}>Unavailable</span>
+              <span style={s.badge}>Coming soon</span>
             </div>
           ) : (
             <a

--- a/packages/core/src/client/composer/ComposerPlusMenu.tsx
+++ b/packages/core/src/client/composer/ComposerPlusMenu.tsx
@@ -36,10 +36,10 @@ import {
 interface ComposerPlusMenuProps {
   onSelectMode?: (mode: ComposerMode) => void;
   /**
-   * "full" (default): full + menu with Upload File, Create Skill, Scheduled Task,
-   * Automation, Tool, MCP Server. "upload-only": clicking + opens the file
+   * "full" (default): full + menu with Upload File, Create Skill, Schedule Task,
+   * Automation, Extension, MCP Server. "upload-only": clicking + opens the file
    * picker directly — no popover, no other modes. Use for prompt popovers
-   * (create tool, create deck, create dashboard, etc.) where the only thing
+   * (create extension, create deck, create dashboard, etc.) where the only thing
    * to attach is a file.
    */
   mode?: "full" | "upload-only";
@@ -251,7 +251,7 @@ function ComposerPlusMenuFull({
     },
     {
       icon: <IconClock className="h-3.5 w-3.5" />,
-      label: "Scheduled Task",
+      label: "Schedule Task",
       desc: "Run something on a schedule",
       action: () => {
         onSelectMode?.("job");
@@ -269,8 +269,8 @@ function ComposerPlusMenuFull({
     },
     {
       icon: <IconTool className="h-3.5 w-3.5" />,
-      label: "Create Tool",
-      desc: "Build an interactive mini app",
+      label: "Create Extension",
+      desc: "Build a mini app extension",
       action: () => {
         onSelectMode?.("extension");
         setOpen(false);

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -126,7 +126,7 @@ After creating, update the shared AGENTS.md resource to reference the new skill 
 Keep the skill concise (under 500 lines) and actionable.`,
   },
   job: {
-    label: "Scheduled Task",
+    label: "Schedule Task",
     icon: IconClock,
     placeholder: "Describe what should happen and when...",
     messagePrefix: "Create a recurring job: ",

--- a/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
+++ b/packages/core/src/client/extensions/ExtensionsSidebarSection.tsx
@@ -431,7 +431,7 @@ export function ExtensionsSidebarSection() {
               <HoverCardTrigger asChild>
                 <button
                   type="button"
-                  className="pointer-events-auto -ml-1 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/45 transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="pointer-events-auto inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/45 transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   aria-label="About extensions"
                 >
                   <IconInfoCircle className="h-3.5 w-3.5" />

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -72,6 +72,16 @@ export {
   type MultiTabAssistantChatProps,
   type MultiTabAssistantChatHeaderProps,
 } from "./MultiTabAssistantChat.js";
+export {
+  RunStuckBanner,
+  type RunStuckBannerProps,
+} from "./RunStuckBanner.js";
+export {
+  useRunStuckDetection,
+  useAbortRun,
+  type RunStuckState,
+  type UseRunStuckDetectionOptions,
+} from "./use-run-stuck-detection.js";
 export { createAgentChatAdapter } from "./agent-chat-adapter.js";
 export {
   PromptComposer,

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -72,10 +72,7 @@ export {
   type MultiTabAssistantChatProps,
   type MultiTabAssistantChatHeaderProps,
 } from "./MultiTabAssistantChat.js";
-export {
-  RunStuckBanner,
-  type RunStuckBannerProps,
-} from "./RunStuckBanner.js";
+export { RunStuckBanner, type RunStuckBannerProps } from "./RunStuckBanner.js";
 export {
   useRunStuckDetection,
   useAbortRun,

--- a/packages/core/src/client/resources/ResourcesPanel.tsx
+++ b/packages/core/src/client/resources/ResourcesPanel.tsx
@@ -475,7 +475,7 @@ The result should be a reusable agent profile, not a one-off task response.`,
     },
     {
       icon: <IconClock className="h-3.5 w-3.5" />,
-      label: "Scheduled Task",
+      label: "Schedule Task",
       desc: "Run something on a schedule",
       action: () => setView("job"),
     },
@@ -616,7 +616,7 @@ The result should be a reusable agent profile, not a one-off task response.`,
         {view === "job" && (
           <div className="p-3">
             <label className="mb-1 block text-[11px] font-semibold text-foreground">
-              Scheduled Task
+              Schedule Task
             </label>
             <p className="mb-2 text-[10px] text-muted-foreground/60 leading-relaxed">
               Describe what should happen and when.

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -22,6 +22,16 @@ export interface ChatThreadData {
 }
 
 const ACTIVE_THREAD_KEY = "agent-chat-active-thread";
+const THREAD_DATA_CACHE_PREFIX = "agent-chat-thread-cache:";
+
+/**
+ * Key for the per-thread message cache in localStorage. AssistantChat reads
+ * this synchronously on mount so existing chats can hydrate from cache and
+ * paint immediately, then refreshes from the server in the background.
+ */
+export function getThreadCacheKey(threadId: string): string {
+  return `${THREAD_DATA_CACHE_PREFIX}${threadId}`;
+}
 
 export function useChatThreads(
   apiUrl = agentNativePath("/_agent-native/agent-chat"),
@@ -192,6 +202,9 @@ export function useChatThreads(
           method: "DELETE",
         });
       } catch {}
+      try {
+        localStorage.removeItem(getThreadCacheKey(id));
+      } catch {}
       setThreads((prev) => {
         const next = prev.filter((t) => t.id !== id);
         if (id === activeThreadId) {
@@ -219,6 +232,12 @@ export function useChatThreads(
         messageCount?: number;
       },
     ) => {
+      // Cache locally so the next mount of this thread can hydrate
+      // synchronously and skip the per-message restore skeleton. Quota errors
+      // (5–10MB cap) are swallowed — the thread just falls back to fetching.
+      try {
+        localStorage.setItem(getThreadCacheKey(id), data.threadData);
+      } catch {}
       try {
         await fetch(`${apiUrl}/threads/${encodeURIComponent(id)}`, {
           method: "PUT",

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -31,15 +31,32 @@ export function useChatThreads(
     ? `${ACTIVE_THREAD_KEY}:${storageKey}`
     : ACTIVE_THREAD_KEY;
   const [threads, setThreads] = useState<ChatThreadSummary[]>([]);
+
+  // IDs we generated client-side this session — consumers use this to know
+  // whether to skip the per-thread restore skeleton. Tracked by ref instead
+  // of state because the consumer reads it inside the render path and we
+  // never need to re-render when the set changes.
+  const newlyCreatedRef = useRef<Set<string>>(new Set());
+
   const [activeThreadId, setActiveThreadId] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null;
     try {
-      return localStorage.getItem(activeThreadKey);
-    } catch {
-      return null;
+      const saved = localStorage.getItem(activeThreadKey);
+      if (saved) return saved;
+    } catch {}
+    // No saved thread — generate one synchronously so the chat shell + composer
+    // can paint on first render instead of after a network round-trip.
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+      const id = crypto.randomUUID();
+      newlyCreatedRef.current.add(id);
+      return id;
     }
+    return null;
   });
   const [isLoading, setIsLoading] = useState(true);
   const fetchedRef = useRef(false);
+  const activeThreadIdRef = useRef(activeThreadId);
+  activeThreadIdRef.current = activeThreadId;
 
   // Persist active thread ID
   useEffect(() => {
@@ -57,47 +74,27 @@ export function useChatThreads(
       const res = await fetch(`${apiUrl}/threads`);
       if (!res.ok) return;
       const data = await res.json();
-      setThreads(data.threads ?? []);
+      setThreads((prev) => {
+        const loaded = (data.threads ?? []) as ChatThreadSummary[];
+        // Preserve any optimistic threads we've created this session that
+        // haven't shown up in the server list yet (POST still in-flight).
+        const loadedIds = new Set(loaded.map((t) => t.id));
+        const optimisticOnly = prev.filter(
+          (t) => newlyCreatedRef.current.has(t.id) && !loadedIds.has(t.id),
+        );
+        return [...optimisticOnly, ...loaded];
+      });
       return data.threads as ChatThreadSummary[];
     } catch {
       return undefined;
     }
   }, [apiUrl]);
 
-  // Initial load
-  useEffect(() => {
-    if (fetchedRef.current) return;
-    fetchedRef.current = true;
-
-    (async () => {
-      setIsLoading(true);
-      const loadedThreads = await fetchThreads();
-
-      if (loadedThreads && loadedThreads.length > 0) {
-        // If the saved active thread still exists, keep it. Otherwise use the most recent.
-        const savedId = activeThreadId;
-        if (!savedId || !loadedThreads.find((t) => t.id === savedId)) {
-          setActiveThreadId(loadedThreads[0].id);
-        }
-      } else {
-        // No threads — create the first one
-        try {
-          const res = await fetch(`${apiUrl}/threads`, { method: "POST" });
-          if (res.ok) {
-            const thread = await res.json();
-            setThreads([thread]);
-            setActiveThreadId(thread.id);
-          }
-        } catch {}
-      }
-      setIsLoading(false);
-    })();
-  }, [fetchThreads, apiUrl, activeThreadId]);
-
-  const createThread = useCallback(
-    (preferredId?: string): Promise<string | null> => {
-      // Generate ID client-side for instant UI response
-      const id = preferredId || crypto.randomUUID();
+  // Persist a client-generated thread to the server in the background.
+  // Optimistically adds it to the local thread list so callers can render
+  // immediately; rolls back on failure.
+  const persistNewThread = useCallback(
+    (id: string) => {
       const now = Date.now();
       const optimistic: ChatThreadSummary = {
         id,
@@ -107,10 +104,9 @@ export function useChatThreads(
         createdAt: now,
         updatedAt: now,
       };
-      setThreads((prev) => [optimistic, ...prev]);
-      setActiveThreadId(id);
-
-      // Persist to server in the background
+      setThreads((prev) =>
+        prev.some((t) => t.id === id) ? prev : [optimistic, ...prev],
+      );
       fetch(`${apiUrl}/threads`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -129,15 +125,60 @@ export function useChatThreads(
           );
         })
         .catch(() => {
-          // If server fails, remove the optimistic thread instead of leaving a
-          // phantom active tab that disappears on the next refresh.
           setThreads((prev) => prev.filter((t) => t.id !== id));
+          newlyCreatedRef.current.delete(id);
           setActiveThreadId((current) => (current === id ? null : current));
         });
-
-      return Promise.resolve(id);
     },
     [apiUrl],
+  );
+
+  // Initial load. Runs in the background — does NOT gate the consumer's
+  // first paint. The composer renders against the optimistic active thread
+  // we set up in useState above; this fetch just populates the history list
+  // and reconciles a stale saved active id.
+  useEffect(() => {
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
+
+    // Persist any thread we optimistically created during the initial render.
+    for (const id of newlyCreatedRef.current) {
+      persistNewThread(id);
+    }
+
+    (async () => {
+      const loadedThreads = await fetchThreads();
+      if (loadedThreads && loadedThreads.length > 0) {
+        const savedId = activeThreadIdRef.current;
+        // If the saved active thread isn't on the server (and isn't one we
+        // just created client-side), fall back to the most recent.
+        if (
+          savedId &&
+          !newlyCreatedRef.current.has(savedId) &&
+          !loadedThreads.find((t) => t.id === savedId)
+        ) {
+          setActiveThreadId(loadedThreads[0].id);
+        }
+      }
+      setIsLoading(false);
+    })();
+  }, [fetchThreads, persistNewThread]);
+
+  const createThread = useCallback(
+    (preferredId?: string): Promise<string | null> => {
+      // Generate ID client-side for instant UI response
+      const id = preferredId || crypto.randomUUID();
+      newlyCreatedRef.current.add(id);
+      setActiveThreadId(id);
+      persistNewThread(id);
+      return Promise.resolve(id);
+    },
+    [persistNewThread],
+  );
+
+  const isNewThread = useCallback(
+    (id: string) => newlyCreatedRef.current.has(id),
+    [],
   );
 
   const switchThread = useCallback((id: string) => {
@@ -302,5 +343,6 @@ export function useChatThreads(
     generateTitle,
     searchThreads,
     refreshThreads,
+    isNewThread,
   };
 }

--- a/packages/core/src/client/use-run-stuck-detection.ts
+++ b/packages/core/src/client/use-run-stuck-detection.ts
@@ -95,9 +95,9 @@ export function useRunStuckDetection({
             lastProgressAt != null ? Date.now() - lastProgressAt : null;
           const isStuck = Boolean(
             data.active &&
-              data.status === "running" &&
-              stuckSinceMs != null &&
-              stuckSinceMs > stuckThresholdMs,
+            data.status === "running" &&
+            stuckSinceMs != null &&
+            stuckSinceMs > stuckThresholdMs,
           );
           setState({
             isStuck,

--- a/packages/core/src/client/use-run-stuck-detection.ts
+++ b/packages/core/src/client/use-run-stuck-detection.ts
@@ -1,0 +1,168 @@
+import { useEffect, useState, useCallback } from "react";
+import { agentNativePath } from "./api-path.js";
+
+/**
+ * Per-thread chat run health, derived from the durable `last_progress_at`
+ * timestamp on the server. Drives the user-visible "this chat looks stuck"
+ * affordance — distinct from the silent reconnect logic in
+ * `agent-chat-adapter.ts`, which keeps trying in the background. When
+ * automatic recovery isn't making progress (for whatever reason), this
+ * hook surfaces a Retry / Cancel button to the user instead of leaving
+ * them staring at a frozen spinner.
+ */
+export interface RunStuckState {
+  /** True when an active run hasn't emitted an event for `stuckThresholdMs`. */
+  isStuck: boolean;
+  /** ID of the active run, or null when nothing is in flight. */
+  runId: string | null;
+  /** Server-side run status ("running" / "completed" / "errored" / etc.). */
+  status: string | null;
+  /** Server timestamp (ms) of the last emitted event, or null if none yet. */
+  lastProgressAt: number | null;
+  /** Milliseconds since `lastProgressAt`, or null. */
+  stuckSinceMs: number | null;
+  /** Server timestamp (ms) of the last process-alive heartbeat. */
+  heartbeatAt: number | null;
+}
+
+export interface UseRunStuckDetectionOptions {
+  /** The thread to monitor. Pass null/undefined to disable polling. */
+  threadId: string | null | undefined;
+  /**
+   * Threshold above which an in-flight run is considered stuck. The default
+   * sits comfortably above the adapter's 75s no-progress reconnect — by then
+   * automatic recovery has already had its chance.
+   */
+  stuckThresholdMs?: number;
+  /** Poll interval. Default 5_000ms. */
+  pollIntervalMs?: number;
+  /** API base path. Default `/_agent-native/agent-chat`. */
+  apiUrl?: string;
+}
+
+const DEFAULT_STUCK_THRESHOLD_MS = 90_000;
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const IDLE_BACKOFF_INTERVAL_MS = 15_000;
+
+interface ActiveRunResponse {
+  active: boolean;
+  runId?: string;
+  status?: string;
+  heartbeatAt: number | null;
+  lastProgressAt?: number | null;
+}
+
+const EMPTY_STATE: RunStuckState = {
+  isStuck: false,
+  runId: null,
+  status: null,
+  lastProgressAt: null,
+  stuckSinceMs: null,
+  heartbeatAt: null,
+};
+
+export function useRunStuckDetection({
+  threadId,
+  stuckThresholdMs = DEFAULT_STUCK_THRESHOLD_MS,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  apiUrl,
+}: UseRunStuckDetectionOptions): RunStuckState {
+  const [state, setState] = useState<RunStuckState>(EMPTY_STATE);
+
+  useEffect(() => {
+    // Reset on every thread change so the previous thread's stuck banner
+    // doesn't bleed onto the new one before the first poll completes.
+    setState(EMPTY_STATE);
+    if (!threadId) return;
+
+    const base = apiUrl ?? agentNativePath("/_agent-native/agent-chat");
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      if (cancelled) return;
+      let nextDelay = pollIntervalMs;
+      try {
+        const res = await fetch(
+          `${base}/runs/active?threadId=${encodeURIComponent(threadId)}`,
+          { credentials: "same-origin" },
+        );
+        if (cancelled) return;
+        if (res.ok) {
+          const data = (await res.json()) as ActiveRunResponse;
+          const lastProgressAt = data.lastProgressAt ?? null;
+          const stuckSinceMs =
+            lastProgressAt != null ? Date.now() - lastProgressAt : null;
+          const isStuck = Boolean(
+            data.active &&
+              data.status === "running" &&
+              stuckSinceMs != null &&
+              stuckSinceMs > stuckThresholdMs,
+          );
+          setState({
+            isStuck,
+            runId: data.runId ?? null,
+            status: data.status ?? null,
+            lastProgressAt,
+            stuckSinceMs,
+            heartbeatAt: data.heartbeatAt ?? null,
+          });
+          // Back off polling when nothing is in flight — there's no point
+          // hammering the endpoint while the chat is idle. We still poll
+          // occasionally so a fresh run started in another tab is picked up.
+          if (!data.active || data.status !== "running") {
+            nextDelay = IDLE_BACKOFF_INTERVAL_MS;
+          }
+        }
+      } catch {
+        // Network blip — leave previous state. Next tick will retry.
+      }
+      if (!cancelled) {
+        timer = setTimeout(poll, nextDelay);
+      }
+    };
+
+    // Stagger the first poll so a freshly-started run isn't immediately
+    // classified as stuck before the server has had a chance to record
+    // any progress events.
+    timer = setTimeout(poll, 2_000);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [threadId, stuckThresholdMs, pollIntervalMs, apiUrl]);
+
+  return state;
+}
+
+/**
+ * POST `/runs/:id/abort` so the server flips the run to "aborted" and the
+ * adapter's reconnect loop exits cleanly. Returns the run id that was
+ * aborted (or null on failure) so callers can correlate observability
+ * events. Best-effort — failures are swallowed, since the user's intent
+ * is already captured locally.
+ */
+export function useAbortRun(apiUrl?: string) {
+  return useCallback(
+    async (runId: string, reason: string = "user"): Promise<string | null> => {
+      const base = apiUrl ?? agentNativePath("/_agent-native/agent-chat");
+      try {
+        const res = await fetch(
+          `${base}/runs/${encodeURIComponent(runId)}/abort`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "same-origin",
+            body: JSON.stringify({ reason }),
+          },
+        );
+        if (!res.ok) return null;
+        return runId;
+      } catch {
+        return null;
+      }
+    },
+    [apiUrl],
+  );
+}

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -4695,6 +4695,7 @@ Non-code requests are still fine on this surface — read data, navigate the UI,
                 threadId,
                 status: "idle",
                 heartbeatAt: null,
+                lastProgressAt: null,
               };
             }
 
@@ -4704,6 +4705,7 @@ Non-code requests are still fine on this surface — read data, navigate the UI,
               threadId: run.threadId,
               status: run.status,
               heartbeatAt: run.heartbeatAt,
+              lastProgressAt: run.lastProgressAt,
             };
           }
 

--- a/packages/dispatch/src/components/layout/Layout.tsx
+++ b/packages/dispatch/src/components/layout/Layout.tsx
@@ -382,7 +382,7 @@ export function Layout({
       <InvitationBanner />
       <main className="flex-1 overflow-y-auto">
         {showHeader ? (
-          <div className="mx-auto max-w-7xl space-y-5 px-4 py-6 sm:px-6">
+          <div className="mx-auto max-w-7xl space-y-10 px-4 py-6 sm:px-6">
             {children}
           </div>
         ) : (

--- a/scripts/dev-lazy.ts
+++ b/scripts/dev-lazy.ts
@@ -65,7 +65,8 @@ Options:
   --all                Expose every template in packages/shared-app-config
   --desktop            Also start the local frame and Electron desktop app
   --eager              Start every exposed template immediately
-  --no-open            Do not open the gateway URL in the browser
+  --open               Open the gateway URL in the browser on ready
+  --no-open            (legacy / no-op — auto-open is off by default)
   --no-kill            Do not kill stale processes on gateway/template ports
   --dry-run            Print ports and commands without spawning
   -h, --help           Show this help message
@@ -155,6 +156,7 @@ const isHeadlessEnv =
   !!process.env.CODESPACES ||
   !!process.env.GITPOD_WORKSPACE_ID;
 const shouldOpen =
+  (hasFlag("--open") || process.env.WORKSPACE_OPEN === "1") &&
   !hasFlag("--no-open") &&
   process.env.WORKSPACE_NO_OPEN !== "1" &&
   !isHeadlessEnv;

--- a/templates/analytics/.agents/skills/dashboard-management/SKILL.md
+++ b/templates/analytics/.agents/skills/dashboard-management/SKILL.md
@@ -44,10 +44,12 @@ When the user asks for a dashboard:
 
 1. Read the injected `<data-dictionary>` block first. If relevant entries exist, use their `table`, `columns`, `queryTemplate`, and gotchas verbatim.
 2. If a metric is not documented, do not guess column names. Ask for the table/columns or introspect the provider schema, then propose a dictionary entry with `save-data-dictionary-entry`.
-3. Build a complete `SqlDashboardConfig` with `name` and `panels`.
-4. Every panel needs `id`, `title`, `source`, `chartType`, `width`, and `sql`.
+3. Build a complete `SqlDashboardConfig` with `name` and `panels`. Optionally set top-level `columns` (1–6, default 2) to control how many grid columns the panels before any section use.
+4. Every panel needs `id`, `title`, `source`, `chartType`, `width`, and `sql`. `width` is the number of grid columns the panel spans (1..6, clamped to the active section's column count). Section panels skip `source` and `sql` and may set their own `columns` (1–6) to override the dashboard default for the panels following the section.
 5. Persist with `update-dashboard`, not raw SQL or settings writes.
 6. Navigate to it with `pnpm action navigate --view=adhoc --dashboardId=<id>`.
+
+Layout is always **1 column on screens narrower than `md`** (panels stack), then expands to the configured column count from `md` and up. So picking 3 or 4 columns is fine — the renderer keeps mobile/narrow layouts readable automatically.
 
 ```bash
 pnpm action update-dashboard --dashboardId weekly-metrics --config '<full json>'

--- a/templates/analytics/.agents/skills/dashboard-management/SKILL.md
+++ b/templates/analytics/.agents/skills/dashboard-management/SKILL.md
@@ -114,6 +114,19 @@ pnpm action update-dashboard --dashboardId weekly-metrics --config '<full json>'
 
 After a mutation, navigate to the dashboard if the user is elsewhere. The app syncs through the framework's polling/query invalidation path.
 
+## Archiving vs deleting
+
+Dashboards have a soft-delete state. The default user-facing destructive action is **Archive** (recoverable). Hard delete still exists, but lives behind a "Delete permanently" confirm in both the page header and the sidebar dropdown — and in the agent surface, behind the older `delete-dashboard` action. Archived rows stay in the `dashboards` table with `archived_at` set, are hidden from the default sidebar list, and remain accessible by id (so deep links in chat history keep working) until explicitly purged.
+
+```bash
+# Archive
+pnpm action archive-dashboard --id weekly-metrics
+# Restore
+pnpm action archive-dashboard --id weekly-metrics --archived false
+```
+
+Default the agent to archive when the user says "delete" / "remove" / "get rid of" a dashboard. Reach for hard delete only when the user explicitly says "permanently", "for good", or similar. List queries default to active rows only — use `?archived=1` on `/api/sql-dashboards` (or the `archived: 'all' | 'archived' | 'active'` option on `listDashboards`) to see archived rows.
+
 ## Sharing
 
 Dashboards are private by default. Use the framework sharing actions:

--- a/templates/analytics/.agents/skills/dashboard-management/SKILL.md
+++ b/templates/analytics/.agents/skills/dashboard-management/SKILL.md
@@ -64,6 +64,9 @@ The save path dry-runs BigQuery panels before persisting. If validation returns 
 {
   "name": "Weekly Metrics",
   "description": "Core product and acquisition metrics",
+  // Default grid columns for panels before any section. 1–6, default 2.
+  // The grid is always 1 column on small screens and expands at `md:`.
+  "columns": 3,
   "filters": [
     { "id": "date", "type": "date-range", "label": "Date Range", "default": "30d" }
   ],
@@ -71,6 +74,12 @@ The save path dry-runs BigQuery panels before persisting. If validation returns 
     "EVENTS": "`my_project.analytics.events`"
   },
   "panels": [
+    // 3 metric cards sit side-by-side at md+ thanks to the dashboard's "columns": 3.
+    { "id": "kpi-clicks", "title": "Clicks", "source": "first-party", "chartType": "metric", "width": 1, "sql": "SELECT COUNT(*) AS value FROM analytics_events WHERE event_name = 'click'" },
+    { "id": "kpi-signups", "title": "Signups", "source": "first-party", "chartType": "metric", "width": 1, "sql": "SELECT COUNT(*) AS value FROM analytics_events WHERE event_name = 'signup'" },
+    { "id": "kpi-active", "title": "Active users", "source": "first-party", "chartType": "metric", "width": 1, "sql": "SELECT COUNT(DISTINCT user_id) AS value FROM analytics_events" },
+    // Section header switches the grid to 2 columns for the panels below it.
+    { "id": "trends", "title": "Trends", "chartType": "section", "width": 1, "columns": 2 },
     {
       "id": "events",
       "title": "Events",

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -488,7 +488,7 @@ title: Weekly signups
 ```
 ````
 
-The `SqlPanel` shape is the same one used by `update-dashboard` (see `app/pages/adhoc/sql-dashboard/types.ts`). Required fields: `id`, `title`, `sql`, `source` (`"bigquery" | "ga4" | "amplitude" | "first-party"`), `chartType` (`"line" | "area" | "bar" | "metric" | "table" | "pie"`), `width` (`1` or `2`). Optional `config` for axis keys, formatting, pivots, color palettes, stacking, and `legend`. Chart legends render automatically; set `config.legend=false` only when the user asks to hide them.
+The `SqlPanel` shape is the same one used by `update-dashboard` (see `app/pages/adhoc/sql-dashboard/types.ts`). Required fields: `id`, `title`, `sql`, `source` (`"bigquery" | "ga4" | "amplitude" | "first-party"`), `chartType` (`"line" | "area" | "bar" | "metric" | "table" | "pie"`), `width` (1..6 — number of grid columns to span; clamped to the active section's column count). Optional `config` for axis keys, formatting, pivots, color palettes, stacking, and `legend`. Chart legends render automatically; set `config.legend=false` only when the user asks to hide them. The dashboard always renders 1 column on screens narrower than `md` and expands to the configured column count from `md` and up — set the dashboard-level `columns` (1..6, default 2) for the panels before any section, and use a `chartType: "section"` panel with its own `columns` to switch the grid for the panels that follow it.
 
 Keep the JSON compact — URLs are capped around 4KB. If the SQL is long, persist it as a saved dashboard panel instead and link to that dashboard.
 

--- a/templates/analytics/AGENTS.md
+++ b/templates/analytics/AGENTS.md
@@ -278,6 +278,8 @@ Read (`/api/sql-dashboards/:id`, `/api/analyses/:id`) admits rows the current us
 
 **Storage.** Dashboards and analyses now live in SQL (`dashboards`, `analyses`, `dashboard_shares`, `analysis_shares`, `dashboard_views`). Legacy settings-KV keys (`u:<email>:dashboard-*`, `u:<email>:sql-dashboard-*`, `o:<orgId>:sql-dashboard-*`, `adhoc-analysis-*`) are read as a fallback on first access and copied into SQL automatically — existing dashboards are preserved. See `server/lib/dashboards-store.ts` for the exact migration policy.
 
+**Archive.** `dashboards.archived_at` is a soft-delete timestamp. The default `listDashboards`/`/api/sql-dashboards` response hides archived rows; pass `?archived=1` (or `archived: 'archived' | 'all'` to the store) to surface them. Hard delete still removes a row entirely. Prefer archive for ordinary destructive flows so users can restore from the sidebar's Archived section.
+
 ## Organizations & Team
 
 This template supports multi-org deployments using the framework-provided org module. The schema (`organizations`, `org_members`, `org_invitations`) lives in `@agent-native/core/org` — there is no template-side schema file. Users sign in with Google, create or get invited to an org, and dashboards remember the org context they were created in while staying private until explicitly shared.
@@ -460,6 +462,8 @@ pnpm action commonroom-members --query="enterprise" --limit=10
 | "Build me a dashboard for X"         | If ambiguous, use guided questions; then `list-data-dictionary --search=X` FIRST and compose from entries                                                                    |
 | "Document this metric"               | `save-data-dictionary-entry --metric="…" --definition="…" …`                                                                                                                 |
 | "Populate the data dictionary"       | Ask where definitions live, fetch them, loop over `save-data-dictionary-entry`                                                                                               |
+| "Delete / remove this dashboard"     | `archive-dashboard --id <id>` (soft, recoverable). Use a hard delete only if the user says "permanently" / "for good".                                                       |
+| "Restore / unarchive this dashboard" | `archive-dashboard --id <id> --archived false`                                                                                                                               |
 
 **Key principle**: When asked a question, don't say "check the dashboard" — actually query the data, get results, and present the answer directly in chat with tables and/or charts.
 

--- a/templates/analytics/actions/archive-dashboard.ts
+++ b/templates/analytics/actions/archive-dashboard.ts
@@ -1,0 +1,56 @@
+import { defineAction } from "@agent-native/core";
+import {
+  getRequestUserEmail,
+  getRequestOrgId,
+} from "@agent-native/core/server";
+import { z } from "zod";
+import {
+  archiveDashboard,
+  unarchiveDashboard,
+} from "../server/lib/dashboards-store";
+
+function resolveScope() {
+  const orgId = getRequestOrgId() || null;
+  const email = getRequestUserEmail();
+  if (!email) throw new Error("no authenticated user");
+  return { orgId, email };
+}
+
+export default defineAction({
+  description:
+    "Archive (soft-delete) or restore a saved dashboard by ID. Archived dashboards " +
+    "stay in the database but are hidden from the default sidebar list. They can be " +
+    "restored from the sidebar's Archived section or by re-running this action with " +
+    "`archived: false`. Use this instead of `delete-dashboard` when the user might " +
+    "want the dashboard back later — only use a hard delete when the user explicitly " +
+    "asks to remove a dashboard permanently.",
+  schema: z.object({
+    id: z.string().describe("The dashboard ID"),
+    archived: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe(
+        "true = archive (default), false = restore an archived dashboard",
+      ),
+  }),
+  run: async (args) => {
+    const ctx = resolveScope();
+    const dash = args.archived
+      ? await archiveDashboard(args.id, ctx)
+      : await unarchiveDashboard(args.id, ctx);
+    if (!dash) {
+      throw new Error(
+        `Dashboard "${args.id}" not found (or you don't have access).`,
+      );
+    }
+    return {
+      id: dash.id,
+      name: dash.title,
+      archivedAt: dash.archivedAt,
+      message: args.archived
+        ? `Dashboard "${dash.title}" archived. Restore via the sidebar's Archived section, or run archive-dashboard with archived:false.`
+        : `Dashboard "${dash.title}" restored.`,
+    };
+  },
+});

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -275,7 +275,11 @@ function validateDashboardConfig(
     if (!isSection && !validSources.has(p.source as string)) {
       return `panel[${i}].source must be 'bigquery', 'ga4', 'amplitude', or 'first-party' (got '${p.source}'). source selects the backend — put the table name in sql, not here.`;
     }
-    if (isSection && p.columns !== undefined && !isValidColumnCount(p.columns)) {
+    if (
+      isSection &&
+      p.columns !== undefined &&
+      !isValidColumnCount(p.columns)
+    ) {
       return `panel[${i}].columns must be an integer between 1 and 6 (only valid on section panels)`;
     }
   }

--- a/templates/analytics/actions/update-dashboard.ts
+++ b/templates/analytics/actions/update-dashboard.ts
@@ -242,6 +242,12 @@ function validateDashboardConfig(
     return "config.panels must be an array (use [] for an empty dashboard)";
   }
   const validSources = new Set(["bigquery", "ga4", "amplitude", "first-party"]);
+  const isValidColumnCount = (v: unknown): v is number =>
+    typeof v === "number" &&
+    Number.isFinite(v) &&
+    v >= 1 &&
+    v <= 6 &&
+    Math.floor(v) === v;
   for (let i = 0; i < panels.length; i++) {
     const p = panels[i] as Record<string, unknown> | null;
     if (!p || typeof p !== "object") {
@@ -257,7 +263,9 @@ function validateDashboardConfig(
     for (const field of required) {
       const v = p[field];
       if (field === "width") {
-        if (v !== 1 && v !== 2) return `panel[${i}].width must be 1 or 2`;
+        if (!isValidColumnCount(v)) {
+          return `panel[${i}].width must be an integer between 1 and 6 (number of grid columns to span)`;
+        }
         continue;
       }
       if (typeof v !== "string" || v.trim().length === 0) {
@@ -267,6 +275,12 @@ function validateDashboardConfig(
     if (!isSection && !validSources.has(p.source as string)) {
       return `panel[${i}].source must be 'bigquery', 'ga4', 'amplitude', or 'first-party' (got '${p.source}'). source selects the backend — put the table name in sql, not here.`;
     }
+    if (isSection && p.columns !== undefined && !isValidColumnCount(p.columns)) {
+      return `panel[${i}].columns must be an integer between 1 and 6 (only valid on section panels)`;
+    }
+  }
+  if (config.columns !== undefined && !isValidColumnCount(config.columns)) {
+    return "config.columns must be an integer between 1 and 6";
   }
   return null;
 }

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -212,7 +212,7 @@ function SidebarSectionSortMenu({
             </button>
           </DropdownMenuTrigger>
         </TooltipTrigger>
-        <TooltipContent>{`${label} sort`}</TooltipContent>
+        <TooltipContent side="right">{`${label} sort`}</TooltipContent>
       </Tooltip>
       <DropdownMenuContent side="right" align="start" className="w-44">
         <DropdownMenuLabel className="text-xs">Sort by</DropdownMenuLabel>
@@ -657,7 +657,7 @@ function SortableDashboardItem({
                           />
                         </button>
                       </TooltipTrigger>
-                      <TooltipContent>
+                      <TooltipContent side="right">
                         {favoriteIds.has(`view:${d.id}:${sv.id}`)
                           ? "Unfavorite"
                           : "Favorite"}
@@ -677,7 +677,7 @@ function SortableDashboardItem({
                             </button>
                           </PopoverTrigger>
                         </TooltipTrigger>
-                        <TooltipContent>{`Delete ${sv.name}`}</TooltipContent>
+                        <TooltipContent side="right">{`Delete ${sv.name}`}</TooltipContent>
                       </Tooltip>
                       <PopoverContent
                         className="w-56 p-3"
@@ -763,7 +763,7 @@ function ArchivedDashboardRow({
             <IconArchiveOff className="h-3 w-3" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Restore</TooltipContent>
+        <TooltipContent side="right">Restore</TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger asChild>
@@ -776,7 +776,7 @@ function ArchivedDashboardRow({
             <IconTrash className="h-3 w-3" />
           </button>
         </TooltipTrigger>
-        <TooltipContent>Delete permanently</TooltipContent>
+        <TooltipContent side="right">Delete permanently</TooltipContent>
       </Tooltip>
       <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <AlertDialogContent>

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -24,6 +24,8 @@ import {
   IconUsers,
   IconReportAnalytics,
   IconSearch,
+  IconArchive,
+  IconArchiveOff,
 } from "@tabler/icons-react";
 import { getIdToken } from "@/lib/auth";
 import {
@@ -40,6 +42,7 @@ type SidebarDashboard = {
   name: string;
   subviews?: DashboardSubview[];
   source: "static" | "sql";
+  archivedAt?: string | null;
 };
 import {
   Tooltip,
@@ -62,6 +65,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { OrgSwitcher } from "@agent-native/core/client/org";
 import {
@@ -243,6 +256,8 @@ function SortableRow({
   onToggleFavorite,
   onDelete,
   onRename,
+  onArchive,
+  archived,
   children,
 }: {
   id: string;
@@ -254,6 +269,11 @@ function SortableRow({
   onToggleFavorite: (key: string) => void;
   onDelete: () => Promise<void> | void;
   onRename: (name: string) => Promise<void> | void;
+  /** When provided, the menu shows Archive/Restore as the primary destructive
+   *  action and Delete becomes a confirm-gated "Delete permanently". When
+   *  omitted, Delete fires immediately with no confirm (analyses behavior). */
+  onArchive?: (action: "archive" | "restore") => Promise<void> | void;
+  archived?: boolean;
   children?: React.ReactNode;
 }) {
   const {
@@ -272,6 +292,7 @@ function SortableRow({
   };
   const isFav = favoriteIds.has(favoriteKey);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(name);
 
@@ -300,6 +321,7 @@ function SortableRow({
 
   const runDelete = useCallback(async () => {
     setMenuOpen(false);
+    setConfirmDeleteOpen(false);
     try {
       await onDelete();
     } catch (e) {
@@ -310,6 +332,23 @@ function SortableRow({
       );
     }
   }, [name, onDelete]);
+
+  const runArchive = useCallback(
+    async (action: "archive" | "restore") => {
+      setMenuOpen(false);
+      if (!onArchive) return;
+      try {
+        await onArchive(action);
+      } catch (e) {
+        toast.error(
+          e instanceof Error
+            ? `Couldn't ${action} ${name}: ${e.message}`
+            : `Couldn't ${action} ${name}`,
+        );
+      }
+    },
+    [name, onArchive],
+  );
 
   return (
     <div ref={setNodeRef} style={style} className="group/item relative min-w-0">
@@ -392,7 +431,7 @@ function SortableRow({
               </TooltipTrigger>
               <TooltipContent>{`${name} actions`}</TooltipContent>
             </Tooltip>
-            <DropdownMenuContent side="right" align="start" className="w-36">
+            <DropdownMenuContent side="right" align="start" className="w-44">
               <DropdownMenuItem
                 onSelect={() => {
                   setRenameValue(name);
@@ -402,21 +441,84 @@ function SortableRow({
                 <IconPencil className="mr-2 h-3.5 w-3.5" />
                 Rename
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={(event) => {
-                  event.preventDefault();
-                  void runDelete();
-                }}
-                className="text-destructive focus:text-destructive"
-              >
-                <IconTrash className="mr-2 h-3.5 w-3.5" />
-                Delete
-              </DropdownMenuItem>
+              {onArchive ? (
+                <>
+                  {archived ? (
+                    <DropdownMenuItem
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        void runArchive("restore");
+                      }}
+                    >
+                      <IconArchiveOff className="mr-2 h-3.5 w-3.5" />
+                      Restore
+                    </DropdownMenuItem>
+                  ) : (
+                    <DropdownMenuItem
+                      onSelect={(event) => {
+                        event.preventDefault();
+                        void runArchive("archive");
+                      }}
+                    >
+                      <IconArchive className="mr-2 h-3.5 w-3.5" />
+                      Archive
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      setMenuOpen(false);
+                      setConfirmDeleteOpen(true);
+                    }}
+                    className="text-destructive focus:text-destructive"
+                  >
+                    <IconTrash className="mr-2 h-3.5 w-3.5" />
+                    Delete permanently
+                  </DropdownMenuItem>
+                </>
+              ) : (
+                <DropdownMenuItem
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    void runDelete();
+                  }}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <IconTrash className="mr-2 h-3.5 w-3.5" />
+                  Delete
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
       </div>
       {children}
+      {onArchive && (
+        <AlertDialog
+          open={confirmDeleteOpen}
+          onOpenChange={setConfirmDeleteOpen}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete permanently?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This permanently deletes &ldquo;{name}&rdquo; and cannot be
+                undone. To keep it recoverable, choose Archive instead.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => void runDelete()}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Delete permanently
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
     </div>
   );
 }
@@ -431,6 +533,7 @@ function SortableDashboardItem({
   onToggleFavorite,
   onDelete,
   onRename,
+  onArchive,
   views,
 }: {
   d: SidebarDashboard;
@@ -440,6 +543,10 @@ function SortableDashboardItem({
   onToggleFavorite: (id: string) => void;
   onDelete: (d: SidebarDashboard) => Promise<void>;
   onRename: (d: SidebarDashboard, name: string) => Promise<void>;
+  onArchive?: (
+    d: SidebarDashboard,
+    action: "archive" | "restore",
+  ) => Promise<void>;
   views?: DashboardView[];
 }) {
   const href = `/adhoc/${d.id}`;
@@ -490,6 +597,8 @@ function SortableDashboardItem({
       onToggleFavorite={onToggleFavorite}
       onDelete={() => onDelete(d)}
       onRename={(name) => onRename(d, name)}
+      onArchive={onArchive ? (action) => onArchive(d, action) : undefined}
+      archived={!!d.archivedAt}
     >
       {isActive && allSubviews.length > 0 && (
         <div className="ml-6 mt-0.5 space-y-0.5">
@@ -624,6 +733,76 @@ function SortableDashboardItem({
   );
 }
 
+// --- Archived dashboard row: simple non-sortable row with Restore + Delete ---
+
+function ArchivedDashboardRow({
+  dashboard,
+  onRestore,
+  onDelete,
+}: {
+  dashboard: SqlDashboardListItem;
+  onRestore: () => Promise<void> | void;
+  onDelete: () => Promise<void> | void;
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  return (
+    <div className="group/archived flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-muted-foreground/70 hover:bg-sidebar-accent/40">
+      <span className="min-w-0 flex-1 truncate" title={dashboard.name}>
+        {dashboard.name}
+      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => void onRestore()}
+            className="shrink-0 rounded p-0.5 opacity-0 transition-colors hover:text-primary group-hover/archived:opacity-100"
+            aria-label={`Restore ${dashboard.name}`}
+          >
+            <IconArchiveOff className="h-3 w-3" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Restore</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(true)}
+            className="shrink-0 rounded p-0.5 opacity-0 transition-colors hover:text-destructive group-hover/archived:opacity-100"
+            aria-label={`Delete ${dashboard.name} permanently`}
+          >
+            <IconTrash className="h-3 w-3" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Delete permanently</TooltipContent>
+      </Tooltip>
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete permanently?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently deletes &ldquo;{dashboard.name}&rdquo; and cannot
+              be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setConfirmOpen(false);
+                void onDelete();
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete permanently
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
 // Analyses reuse SortableRow directly — no wrapper component needed.
 
 const ANALYSIS_ORDER_KEY = "analysis-order";
@@ -687,9 +866,21 @@ function setStaticDashboardRenames(renames: Record<string, string>): void {
   }
 }
 
-async function fetchSqlDashboards(): Promise<{ id: string; name: string }[]> {
+type SqlDashboardListItem = {
+  id: string;
+  name: string;
+  archivedAt: string | null;
+};
+
+async function fetchSqlDashboardsByArchived(
+  archived: "active" | "archived",
+): Promise<SqlDashboardListItem[]> {
   const token = await getIdToken();
-  const res = await fetch(appApiPath("/api/sql-dashboards"), {
+  const url =
+    archived === "archived"
+      ? "/api/sql-dashboards?archived=1"
+      : "/api/sql-dashboards";
+  const res = await fetch(appApiPath(url), {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
   if (!res.ok) return [];
@@ -702,8 +893,13 @@ async function fetchSqlDashboards(): Promise<{ id: string; name: string }[]> {
         typeof d.name === "string" && d.name.trim().length > 0
           ? d.name
           : "Untitled dashboard",
+      archivedAt: typeof d.archivedAt === "string" ? d.archivedAt : null,
     }));
 }
+
+const fetchSqlDashboards = () => fetchSqlDashboardsByArchived("active");
+const fetchArchivedSqlDashboards = () =>
+  fetchSqlDashboardsByArchived("archived");
 
 async function fetchSidebarAnalyses(): Promise<{ id: string; name: string }[]> {
   const token = await getIdToken();
@@ -846,6 +1042,14 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       staleTime: 30_000,
     });
 
+  const { data: archivedDashboards = [] } = useQuery({
+    queryKey: ["sql-dashboards-archived-sidebar"],
+    queryFn: fetchArchivedSqlDashboards,
+    staleTime: 30_000,
+  });
+
+  const [archivedOpen, setArchivedOpen] = useState(false);
+
   const { data: analysesList = [], isLoading: analysesLoading } = useQuery({
     queryKey: ["analyses-sidebar"],
     queryFn: fetchSidebarAnalyses,
@@ -860,12 +1064,12 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       return applyOrder(analysesList, analysisOrderState);
     }
     return [...analysesList].sort((a, b) => {
-      const aPop = popularityOf(popularity, "analysis", a.id);
-      const bPop = popularityOf(popularity, "analysis", b.id);
-      if (aPop !== bPop) return bPop - aPop;
       const aFav = favoriteIds.has(`analysis:${a.id}`) ? 0 : 1;
       const bFav = favoriteIds.has(`analysis:${b.id}`) ? 0 : 1;
       if (aFav !== bFav) return aFav - bFav;
+      const aPop = popularityOf(popularity, "analysis", a.id);
+      const bPop = popularityOf(popularity, "analysis", b.id);
+      if (aPop !== bPop) return bPop - aPop;
       return a.name.localeCompare(b.name);
     });
   }, [
@@ -908,6 +1112,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       id: d.id,
       name: d.name,
       source: "sql",
+      archivedAt: d.archivedAt,
     }));
     const all = [...staticItems, ...sqlItems];
     if (dashboardSortMode === "alphabetical") {
@@ -917,12 +1122,12 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
       return applyOrder(all, dashboardOrderState);
     }
     return [...all].sort((a, b) => {
-      const aPop = popularityOf(popularity, "dashboard", a.id);
-      const bPop = popularityOf(popularity, "dashboard", b.id);
-      if (aPop !== bPop) return bPop - aPop;
       const aFav = favoriteIds.has(a.id) ? 0 : 1;
       const bFav = favoriteIds.has(b.id) ? 0 : 1;
       if (aFav !== bFav) return aFav - bFav;
+      const aPop = popularityOf(popularity, "dashboard", a.id);
+      const bPop = popularityOf(popularity, "dashboard", b.id);
+      if (aPop !== bPop) return bPop - aPop;
       return a.name.localeCompare(b.name);
     });
   }, [
@@ -950,15 +1155,20 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
         setHiddenIds(getHiddenDashboards());
         return;
       }
-      // Optimistic: remove from the sidebar query cache immediately so the
+      // Optimistic: remove from both sidebar query caches immediately so the
       // row disappears without waiting for the DELETE round-trip. Snapshot
-      // the prior value so we can roll back on failure.
-      const queryKey = ["sql-dashboards-sidebar"] as const;
-      const prev =
-        queryClient.getQueryData<{ id: string; name: string }[]>(queryKey);
-      queryClient.setQueryData<{ id: string; name: string }[]>(
-        queryKey,
-        (old) => (old ?? []).filter((item) => item.id !== d.id),
+      // the prior values so we can roll back on failure.
+      const activeKey = ["sql-dashboards-sidebar"] as const;
+      const archivedKey = ["sql-dashboards-archived-sidebar"] as const;
+      const prevActive =
+        queryClient.getQueryData<SqlDashboardListItem[]>(activeKey);
+      const prevArchived =
+        queryClient.getQueryData<SqlDashboardListItem[]>(archivedKey);
+      queryClient.setQueryData<SqlDashboardListItem[]>(activeKey, (old) =>
+        (old ?? []).filter((item) => item.id !== d.id),
+      );
+      queryClient.setQueryData<SqlDashboardListItem[]>(archivedKey, (old) =>
+        (old ?? []).filter((item) => item.id !== d.id),
       );
       try {
         const token = await getIdToken();
@@ -969,9 +1179,73 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
         if (!res.ok) {
           throw new Error(`Delete failed: ${res.status}`);
         }
-        queryClient.invalidateQueries({ queryKey });
+        queryClient.invalidateQueries({ queryKey: activeKey });
+        queryClient.invalidateQueries({ queryKey: archivedKey });
       } catch (err) {
-        if (prev) queryClient.setQueryData(queryKey, prev);
+        if (prevActive) queryClient.setQueryData(activeKey, prevActive);
+        if (prevArchived) queryClient.setQueryData(archivedKey, prevArchived);
+        throw err;
+      }
+    },
+    [queryClient],
+  );
+
+  const handleDashboardArchive = useCallback(
+    async (d: SidebarDashboard, action: "archive" | "restore") => {
+      if (d.source === "static") {
+        // Static dashboards can only be hidden, not archived; route to delete
+        // (which calls hideDashboard for static items).
+        if (action === "archive") {
+          hideDashboard(d.id);
+          setHiddenIds(getHiddenDashboards());
+        }
+        return;
+      }
+      const activeKey = ["sql-dashboards-sidebar"] as const;
+      const archivedKey = ["sql-dashboards-archived-sidebar"] as const;
+      const prevActive =
+        queryClient.getQueryData<SqlDashboardListItem[]>(activeKey);
+      const prevArchived =
+        queryClient.getQueryData<SqlDashboardListItem[]>(archivedKey);
+      // Optimistic move between the two lists.
+      if (action === "archive") {
+        queryClient.setQueryData<SqlDashboardListItem[]>(activeKey, (old) =>
+          (old ?? []).filter((item) => item.id !== d.id),
+        );
+        queryClient.setQueryData<SqlDashboardListItem[]>(archivedKey, (old) => [
+          ...(old ?? []),
+          { id: d.id, name: d.name, archivedAt: new Date().toISOString() },
+        ]);
+      } else {
+        queryClient.setQueryData<SqlDashboardListItem[]>(archivedKey, (old) =>
+          (old ?? []).filter((item) => item.id !== d.id),
+        );
+        queryClient.setQueryData<SqlDashboardListItem[]>(activeKey, (old) => [
+          ...(old ?? []),
+          { id: d.id, name: d.name, archivedAt: null },
+        ]);
+      }
+      try {
+        const token = await getIdToken();
+        const path =
+          action === "archive"
+            ? `/api/sql-dashboards/${d.id}/archive`
+            : `/api/sql-dashboards/${d.id}/unarchive`;
+        const res = await fetch(appApiPath(path), {
+          method: "POST",
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!res.ok) throw new Error(`${action} failed: ${res.status}`);
+        queryClient.invalidateQueries({ queryKey: activeKey });
+        queryClient.invalidateQueries({ queryKey: archivedKey });
+        toast.success(
+          action === "archive"
+            ? `Archived "${d.name}"`
+            : `Restored "${d.name}"`,
+        );
+      } catch (err) {
+        if (prevActive) queryClient.setQueryData(activeKey, prevActive);
+        if (prevArchived) queryClient.setQueryData(archivedKey, prevArchived);
         throw err;
       }
     },
@@ -1288,6 +1562,7 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
                       onToggleFavorite={toggleFavorite}
                       onDelete={handleDashboardDelete}
                       onRename={handleDashboardRename}
+                      onArchive={handleDashboardArchive}
                       views={allViewsMap[d.id]}
                     />
                   ))}
@@ -1315,6 +1590,56 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
                         />
                       </div>
                     ))}
+                  {archivedDashboards.length > 0 && (
+                    <div className="pt-1">
+                      <button
+                        type="button"
+                        onClick={() => setArchivedOpen((v) => !v)}
+                        className="flex w-full items-center gap-1.5 rounded-md px-3 py-1 text-[11px] text-muted-foreground/70 hover:text-primary"
+                        aria-expanded={archivedOpen}
+                      >
+                        <IconChevronDown
+                          className={cn(
+                            "h-3 w-3 shrink-0 transition-transform",
+                            !archivedOpen && "-rotate-90",
+                          )}
+                        />
+                        <IconArchive className="h-3 w-3 shrink-0" />
+                        <span className="truncate">
+                          Archived ({archivedDashboards.length})
+                        </span>
+                      </button>
+                      {archivedOpen && (
+                        <div className="ml-2 mt-0.5 space-y-0.5">
+                          {archivedDashboards.map((d) => (
+                            <ArchivedDashboardRow
+                              key={d.id}
+                              dashboard={d}
+                              onRestore={() =>
+                                handleDashboardArchive(
+                                  {
+                                    id: d.id,
+                                    name: d.name,
+                                    source: "sql",
+                                    archivedAt: d.archivedAt,
+                                  },
+                                  "restore",
+                                )
+                              }
+                              onDelete={() =>
+                                handleDashboardDelete({
+                                  id: d.id,
+                                  name: d.name,
+                                  source: "sql",
+                                  archivedAt: d.archivedAt,
+                                })
+                              }
+                            />
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
                   <NewDashboardDialog />
                 </div>
               </SortableContext>

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -394,7 +394,7 @@ function SortableRow({
                 <span className="block truncate">{name}</span>
               </Link>
             </TooltipTrigger>
-            <TooltipContent>{name}</TooltipContent>
+            <TooltipContent side="right">{name}</TooltipContent>
           </Tooltip>
         )}
         <div className="pointer-events-none absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-100 transition-opacity md:opacity-0 md:group-hover/item:opacity-100 md:group-focus-within/item:opacity-100">
@@ -414,7 +414,9 @@ function SortableRow({
                 <IconStar className={cn("h-3 w-3", isFav && "fill-current")} />
               </button>
             </TooltipTrigger>
-            <TooltipContent>{isFav ? "Unfavorite" : "Favorite"}</TooltipContent>
+            <TooltipContent side="right">
+              {isFav ? "Unfavorite" : "Favorite"}
+            </TooltipContent>
           </Tooltip>
           <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
             <Tooltip>
@@ -429,7 +431,7 @@ function SortableRow({
                   </button>
                 </DropdownMenuTrigger>
               </TooltipTrigger>
-              <TooltipContent>{`${name} actions`}</TooltipContent>
+              <TooltipContent side="right">{`${name} actions`}</TooltipContent>
             </Tooltip>
             <DropdownMenuContent side="right" align="start" className="w-44">
               <DropdownMenuItem

--- a/templates/analytics/app/components/ui/tooltip.tsx
+++ b/templates/analytics/app/components/ui/tooltip.tsx
@@ -13,15 +13,17 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className,
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 

--- a/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
@@ -31,7 +31,18 @@ import {
   IconArrowsMinimize,
   IconPencil,
   IconExternalLink,
+  IconArchive,
+  IconArchiveOff,
+  IconDots,
 } from "@tabler/icons-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { toast } from "sonner";
 import {
   PresenceBar,
   useCollaborativeDoc,
@@ -100,13 +111,24 @@ async function fetchWithAuth(url: string, options?: RequestInit) {
   });
 }
 
+type FetchedExplorerDashboard = {
+  data: ExplorerDashboardData;
+  archivedAt: string | null;
+};
+
 async function fetchDashboard(
   id: string,
-): Promise<ExplorerDashboardData | null> {
+): Promise<FetchedExplorerDashboard | null> {
   const res = await fetchWithAuth(`/api/explorer-dashboards/${id}`);
   if (!res.ok) return null;
   const data = await res.json();
-  return { name: data.name ?? "Untitled Dashboard", charts: data.charts ?? [] };
+  return {
+    data: {
+      name: data.name ?? "Untitled Dashboard",
+      charts: data.charts ?? [],
+    },
+    archivedAt: typeof data.archivedAt === "string" ? data.archivedAt : null,
+  };
 }
 
 async function saveDashboard(id: string, data: ExplorerDashboardData) {
@@ -134,10 +156,12 @@ export default function ExplorerDashboardPage() {
   const [dashboard, setDashboard] = useState<ExplorerDashboardData | null>(
     null,
   );
+  const [archivedAt, setArchivedAt] = useState<string | null>(null);
   const [editingName, setEditingName] = useState(false);
   const [nameInput, setNameInput] = useState("");
   const [addChartOpen, setAddChartOpen] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   // ── Collaborative editing ──────────────────────────────────────────
   const { session } = useSession();
@@ -211,13 +235,47 @@ export default function ExplorerDashboardPage() {
     if (!dashboardId) return;
     fetchDashboard(dashboardId).then((d) => {
       if (d) {
-        setDashboard(d);
+        setDashboard(d.data);
+        setArchivedAt(d.archivedAt);
       } else {
         setDashboard({ name: "Untitled Dashboard", charts: [] });
+        setArchivedAt(null);
       }
       setLoaded(true);
     });
   }, [dashboardId]);
+
+  const handleArchiveToggle = useCallback(
+    async (action: "archive" | "restore") => {
+      if (!dashboardId) return;
+      const path =
+        action === "archive"
+          ? `/api/explorer-dashboards/${dashboardId}/archive`
+          : `/api/explorer-dashboards/${dashboardId}/unarchive`;
+      try {
+        const res = await fetchWithAuth(path, { method: "POST" });
+        if (!res.ok) throw new Error(`${action} failed (${res.status})`);
+        queryClient.invalidateQueries({
+          queryKey: ["explorer-dashboards-sidebar"],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ["explorer-dashboards-palette"],
+        });
+        if (action === "archive") {
+          toast.success(`Archived "${dashboard?.name ?? "dashboard"}"`);
+          navigate("/adhoc/explorer");
+        } else {
+          setArchivedAt(null);
+          toast.success(`Restored "${dashboard?.name ?? "dashboard"}"`);
+        }
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : `Couldn't ${action} dashboard`,
+        );
+      }
+    },
+    [dashboardId, queryClient, navigate, dashboard?.name],
+  );
 
   const persist = useCallback(
     (updated: ExplorerDashboardData) => {
@@ -381,27 +439,83 @@ export default function ExplorerDashboardPage() {
             <IconPlus className="h-4 w-4 mr-1" />
             Add Chart
           </Button>
-          <AlertDialog>
+          {archivedAt ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <AlertDialogTrigger asChild>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => handleArchiveToggle("restore")}
+                >
+                  <IconArchiveOff className="h-4 w-4 mr-1.5" />
+                  Restore
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>This dashboard is archived</TooltipContent>
+            </Tooltip>
+          ) : null}
+          <DropdownMenu>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
                   <Button
                     size="sm"
                     variant="ghost"
                     className="text-muted-foreground hover:text-foreground"
+                    aria-label="Dashboard actions"
                   >
-                    <IconTrash className="h-4 w-4" />
+                    <IconDots className="h-4 w-4" />
                   </Button>
-                </AlertDialogTrigger>
+                </DropdownMenuTrigger>
               </TooltipTrigger>
-              <TooltipContent>Delete dashboard</TooltipContent>
+              <TooltipContent>More actions</TooltipContent>
             </Tooltip>
+            <DropdownMenuContent align="end" className="w-44">
+              {archivedAt ? (
+                <DropdownMenuItem
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    void handleArchiveToggle("restore");
+                  }}
+                >
+                  <IconArchiveOff className="mr-2 h-3.5 w-3.5" />
+                  Restore
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    void handleArchiveToggle("archive");
+                  }}
+                >
+                  <IconArchive className="mr-2 h-3.5 w-3.5" />
+                  Archive
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault();
+                  setConfirmDeleteOpen(true);
+                }}
+                className="text-destructive focus:text-destructive"
+              >
+                <IconTrash className="mr-2 h-3.5 w-3.5" />
+                Delete permanently
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <AlertDialog
+            open={confirmDeleteOpen}
+            onOpenChange={setConfirmDeleteOpen}
+          >
             <AlertDialogContent>
               <AlertDialogHeader>
-                <AlertDialogTitle>Delete dashboard?</AlertDialogTitle>
+                <AlertDialogTitle>Delete permanently?</AlertDialogTitle>
                 <AlertDialogDescription>
-                  This will permanently delete &ldquo;{dashboard.name}&rdquo;.
-                  This action cannot be undone.
+                  This permanently deletes &ldquo;{dashboard.name}&rdquo; and
+                  cannot be undone. To keep it recoverable, choose Archive
+                  instead.
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
@@ -425,10 +539,12 @@ export default function ExplorerDashboardPage() {
                     queryClient.invalidateQueries({
                       queryKey: ["explorer-dashboards-palette"],
                     });
+                    setConfirmDeleteOpen(false);
                     navigate("/adhoc/explorer");
                   }}
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                 >
-                  Delete
+                  Delete permanently
                 </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
@@ -31,7 +31,15 @@ import {
   IconLoader2,
 } from "@tabler/icons-react";
 import { canFormatPanelSql, formatPanelSql } from "@/lib/format-sql";
-import type { ChartType, DataSourceType, SqlPanel } from "./types";
+import {
+  clampDashboardColumns,
+  clampPanelWidth,
+  DEFAULT_DASHBOARD_COLUMNS,
+  MAX_DASHBOARD_COLUMNS,
+  type ChartType,
+  type DataSourceType,
+  type SqlPanel,
+} from "./types";
 
 const CHART_TYPES: { value: ChartType; label: string }[] = [
   { value: "line", label: "Line" },
@@ -63,7 +71,10 @@ export interface PanelFormValues {
   title: string;
   chartType: ChartType;
   source: DataSourceType;
-  width: 1 | 2;
+  width: number;
+  /** Section panels only: number of grid columns the panels following this
+   *  section should use. Ignored when `chartType` is not `"section"`. */
+  columns: number;
   sql: string;
   description: string;
 }
@@ -75,6 +86,7 @@ function panelToForm(panel: SqlPanel | null): PanelFormValues {
       chartType: "line",
       source: "bigquery",
       width: 1,
+      columns: DEFAULT_DASHBOARD_COLUMNS,
       sql: "",
       description: "",
     };
@@ -83,7 +95,8 @@ function panelToForm(panel: SqlPanel | null): PanelFormValues {
     title: panel.title,
     chartType: panel.chartType,
     source: panel.source,
-    width: panel.width,
+    width: clampPanelWidth(panel.width, MAX_DASHBOARD_COLUMNS),
+    columns: clampDashboardColumns(panel.columns ?? DEFAULT_DASHBOARD_COLUMNS),
     sql: panel.sql,
     description: panel.config?.description ?? "",
   };
@@ -102,13 +115,19 @@ function formToPanel(
   } else {
     delete config.description;
   }
+  const isSection = form.chartType === "section";
   return {
     id,
     title: form.title.trim() || "Untitled panel",
     sql: form.sql,
     source: form.source,
     chartType: form.chartType,
-    width: form.width,
+    width: clampPanelWidth(form.width, MAX_DASHBOARD_COLUMNS),
+    ...(isSection
+      ? { columns: clampDashboardColumns(form.columns) }
+      : existing?.columns !== undefined
+        ? { columns: existing.columns }
+        : null),
     config: Object.keys(config).length > 0 ? config : undefined,
   };
 }
@@ -206,7 +225,7 @@ function PanelEditorContent({
         `If no source can answer, report the exact unavailable/error result instead of saving a panel with guessed schema or metrics. ` +
         `Use the \`update-dashboard\` action with ops=[{op:'insert', path:'/panels/-', value: <panel>}] ` +
         `to append, or an appropriate index to place the panel in the right spot. ` +
-        `Panel shape: { id (unique slug), title, sql, source ('bigquery'|'ga4'|'amplitude'|'first-party'), chartType ('line'|'area'|'bar'|'metric'|'table'|'pie'), width (1 half | 2 full), config? }. ` +
+        `Panel shape: { id (unique slug), title, sql, source ('bigquery'|'ga4'|'amplitude'|'first-party'), chartType ('line'|'area'|'bar'|'metric'|'table'|'pie'|'section'), width (number of grid columns to span, 1..6), columns? (section panels only — 1..6 grid columns for the panels following this section), config? }. ` +
         `For amplitude panels, sql is a JSON descriptor: {"event":"event name","groupBy":"property","days":30}. ` +
         `For first-party panels, sql is read-only SQL over analytics_events only; use source 'first-party' and do not call db-query for this datasource. ` +
         `Config is optional: { xKey, yKey, yKeys, yFormatter ('number'|'currency'|'percent'), description, columns, pivot, limit, color, colors, stacked, legend }. ` +
@@ -289,24 +308,57 @@ function PanelEditorContent({
         </div>
 
         <div className="grid gap-1.5">
-          <Label>Width</Label>
-          <ToggleGroup
-            type="single"
-            value={String(form.width)}
-            onValueChange={(v) => {
-              if (v === "1" || v === "2") {
-                setForm((f) => ({ ...f, width: Number(v) as 1 | 2 }));
-              }
-            }}
-            className="justify-start h-9"
-          >
-            <ToggleGroupItem value="1" className="h-9 px-3 text-xs">
-              Half
-            </ToggleGroupItem>
-            <ToggleGroupItem value="2" className="h-9 px-3 text-xs">
-              Full
-            </ToggleGroupItem>
-          </ToggleGroup>
+          <Label>{form.chartType === "section" ? "Section columns" : "Span"}</Label>
+          {form.chartType === "section" ? (
+            <ToggleGroup
+              type="single"
+              value={String(form.columns)}
+              onValueChange={(v) => {
+                if (!v) return;
+                const next = clampDashboardColumns(Number(v));
+                setForm((f) => ({ ...f, columns: next }));
+              }}
+              className="justify-start h-9"
+            >
+              {Array.from({ length: MAX_DASHBOARD_COLUMNS }, (_, i) => i + 1).map(
+                (n) => (
+                  <ToggleGroupItem
+                    key={n}
+                    value={String(n)}
+                    className="h-9 w-9 px-0 text-xs"
+                  >
+                    {n}
+                  </ToggleGroupItem>
+                ),
+              )}
+            </ToggleGroup>
+          ) : (
+            <ToggleGroup
+              type="single"
+              value={String(form.width)}
+              onValueChange={(v) => {
+                if (!v) return;
+                const next = clampPanelWidth(
+                  Number(v),
+                  MAX_DASHBOARD_COLUMNS,
+                );
+                setForm((f) => ({ ...f, width: next }));
+              }}
+              className="justify-start h-9"
+            >
+              {Array.from({ length: MAX_DASHBOARD_COLUMNS }, (_, i) => i + 1).map(
+                (n) => (
+                  <ToggleGroupItem
+                    key={n}
+                    value={String(n)}
+                    className="h-9 w-9 px-0 text-xs"
+                  >
+                    {n}
+                  </ToggleGroupItem>
+                ),
+              )}
+            </ToggleGroup>
+          )}
         </div>
       </div>
 

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/PanelEditorDialog.tsx
@@ -308,7 +308,9 @@ function PanelEditorContent({
         </div>
 
         <div className="grid gap-1.5">
-          <Label>{form.chartType === "section" ? "Section columns" : "Span"}</Label>
+          <Label>
+            {form.chartType === "section" ? "Section columns" : "Span"}
+          </Label>
           {form.chartType === "section" ? (
             <ToggleGroup
               type="single"
@@ -320,17 +322,18 @@ function PanelEditorContent({
               }}
               className="justify-start h-9"
             >
-              {Array.from({ length: MAX_DASHBOARD_COLUMNS }, (_, i) => i + 1).map(
-                (n) => (
-                  <ToggleGroupItem
-                    key={n}
-                    value={String(n)}
-                    className="h-9 w-9 px-0 text-xs"
-                  >
-                    {n}
-                  </ToggleGroupItem>
-                ),
-              )}
+              {Array.from(
+                { length: MAX_DASHBOARD_COLUMNS },
+                (_, i) => i + 1,
+              ).map((n) => (
+                <ToggleGroupItem
+                  key={n}
+                  value={String(n)}
+                  className="h-9 w-9 px-0 text-xs"
+                >
+                  {n}
+                </ToggleGroupItem>
+              ))}
             </ToggleGroup>
           ) : (
             <ToggleGroup
@@ -338,25 +341,23 @@ function PanelEditorContent({
               value={String(form.width)}
               onValueChange={(v) => {
                 if (!v) return;
-                const next = clampPanelWidth(
-                  Number(v),
-                  MAX_DASHBOARD_COLUMNS,
-                );
+                const next = clampPanelWidth(Number(v), MAX_DASHBOARD_COLUMNS);
                 setForm((f) => ({ ...f, width: next }));
               }}
               className="justify-start h-9"
             >
-              {Array.from({ length: MAX_DASHBOARD_COLUMNS }, (_, i) => i + 1).map(
-                (n) => (
-                  <ToggleGroupItem
-                    key={n}
-                    value={String(n)}
-                    className="h-9 w-9 px-0 text-xs"
-                  >
-                    {n}
-                  </ToggleGroupItem>
-                ),
-              )}
+              {Array.from(
+                { length: MAX_DASHBOARD_COLUMNS },
+                (_, i) => i + 1,
+              ).map((n) => (
+                <ToggleGroupItem
+                  key={n}
+                  value={String(n)}
+                  className="h-9 w-9 px-0 text-xs"
+                >
+                  {n}
+                </ToggleGroupItem>
+              ))}
             </ToggleGroup>
           )}
         </div>

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/SqlChartCard.tsx
@@ -42,7 +42,13 @@ interface SqlChartCardProps {
   panel: SqlPanel;
   resolvedSql?: string;
   onRemove: () => void;
-  onToggleWidth: () => void;
+  /** Toggle between "span 1 column" and "span all columns of the current
+   *  section". Optional because section panels never expose this control. */
+  onToggleWidth?: () => void;
+  /** Number of columns in the section this panel currently lives in. Used to
+   *  decide the toggle label / icon: when the panel already spans the full
+   *  row, we offer to shrink; otherwise we offer to expand. */
+  gridColumns?: number;
   onEdit?: () => void;
   /** Persist a SQL-only edit from the inline View SQL popover. Should throw on
    *  validation failure so the popover can stay open and surface the error. */
@@ -54,6 +60,7 @@ export function SqlChartCard({
   resolvedSql,
   onRemove,
   onToggleWidth,
+  gridColumns,
   onEdit,
   onSaveSql,
 }: SqlChartCardProps) {
@@ -223,14 +230,21 @@ export function SqlChartCard({
                     </DropdownMenuItem>
                   </ViewSqlPopover>
                 )}
-                <DropdownMenuItem onSelect={onToggleWidth}>
-                  {panel.width === 2 ? (
-                    <IconArrowsMinimize className="h-4 w-4 mr-2" />
-                  ) : (
-                    <IconArrowsMaximize className="h-4 w-4 mr-2" />
-                  )}
-                  {panel.width === 2 ? "Half width" : "Full width"}
-                </DropdownMenuItem>
+                {onToggleWidth && (gridColumns ?? 2) > 1 && (
+                  <DropdownMenuItem onSelect={onToggleWidth}>
+                    {panel.width >= (gridColumns ?? 2) ? (
+                      <>
+                        <IconArrowsMinimize className="h-4 w-4 mr-2" />
+                        Span 1 column
+                      </>
+                    ) : (
+                      <>
+                        <IconArrowsMaximize className="h-4 w-4 mr-2" />
+                        Span full row
+                      </>
+                    )}
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuSeparator />
                 {onEdit && (
                   <DropdownMenuItem onSelect={() => onEdit()}>

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -1,4 +1,11 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import {
+  Fragment,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+} from "react";
 import { useSearchParams, useParams, useNavigate } from "react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -24,7 +31,21 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { IconPencil, IconPlus, IconTrash } from "@tabler/icons-react";
+import {
+  IconArchive,
+  IconArchiveOff,
+  IconDots,
+  IconPencil,
+  IconPlus,
+  IconTrash,
+} from "@tabler/icons-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   ShareButton,
   PresenceBar,
@@ -47,7 +68,13 @@ import {
 import { interpolate } from "./interpolate";
 import { AddPanelPopover, PanelEditorDialog } from "./PanelEditorDialog";
 import { ViewsMenu } from "./ViewsMenu";
-import type { SqlDashboardConfig, SqlPanel } from "./types";
+import {
+  clampDashboardColumns,
+  clampPanelWidth,
+  DEFAULT_DASHBOARD_COLUMNS,
+  type SqlDashboardConfig,
+  type SqlPanel,
+} from "./types";
 import { useUserPref } from "@/hooks/use-user-pref";
 import { useDashboardViews } from "@/hooks/use-dashboard-views";
 import { incrementItemView } from "@/lib/item-popularity";
@@ -86,16 +113,24 @@ async function fetchWithAuth(url: string, options?: RequestInit) {
   });
 }
 
-async function fetchDashboard(id: string): Promise<SqlDashboardConfig | null> {
+type FetchedDashboard = {
+  config: SqlDashboardConfig;
+  archivedAt: string | null;
+};
+
+async function fetchDashboard(id: string): Promise<FetchedDashboard | null> {
   const res = await fetchWithAuth(`/api/sql-dashboards/${id}`);
   if (!res.ok) return null;
   const data = await res.json();
   return {
-    name: data.name ?? "Untitled Dashboard",
-    description: data.description,
-    filters: data.filters,
-    variables: data.variables,
-    panels: data.panels ?? [],
+    config: {
+      name: data.name ?? "Untitled Dashboard",
+      description: data.description,
+      filters: data.filters,
+      variables: data.variables,
+      panels: data.panels ?? [],
+    },
+    archivedAt: typeof data.archivedAt === "string" ? data.archivedAt : null,
   };
 }
 
@@ -129,11 +164,13 @@ export default function SqlDashboardPage() {
   const dashboardId = searchParams.get("id") || routeId;
 
   const [dashboard, setDashboard] = useState<SqlDashboardConfig | null>(null);
+  const [archivedAt, setArchivedAt] = useState<string | null>(null);
   const [editingName, setEditingName] = useState(false);
   const [nameInput, setNameInput] = useState("");
   const [editingDescription, setEditingDescription] = useState(false);
   const [descriptionInput, setDescriptionInput] = useState("");
   const [loaded, setLoaded] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const viewedDashboardIdRef = useRef<string | null>(null);
 
   const dashboardQuery = useQuery({
@@ -243,18 +280,21 @@ export default function SqlDashboardPage() {
     appliedSaved.current = false;
     setLoaded(false);
     setDashboard(null);
+    setArchivedAt(null);
     if (!dashboardId) setLoaded(true);
   }, [dashboardId]);
 
   useEffect(() => {
     if (!dashboardId || !dashboardQuery.isSuccess) return;
-    const next = dashboardQuery.data ?? {
+    const fetched = dashboardQuery.data;
+    const next = fetched?.config ?? {
       name: "Untitled Dashboard",
       panels: [],
     };
     setDashboard(next);
+    setArchivedAt(fetched?.archivedAt ?? null);
     setLoaded(true);
-    if (dashboardQuery.data && viewedDashboardIdRef.current !== dashboardId) {
+    if (fetched && viewedDashboardIdRef.current !== dashboardId) {
       viewedDashboardIdRef.current = dashboardId;
       incrementItemView("dashboard", dashboardId);
     }
@@ -411,13 +451,16 @@ export default function SqlDashboardPage() {
   );
 
   const toggleWidth = useCallback(
-    (panelId: string) => {
+    (panelId: string, gridColumns: number) => {
       if (!dashboard) return;
+      const max = clampDashboardColumns(gridColumns);
       persist({
         ...dashboard,
-        panels: dashboard.panels.map((p) =>
-          p.id === panelId ? { ...p, width: p.width === 1 ? 2 : 1 } : p,
-        ),
+        panels: dashboard.panels.map((p) => {
+          if (p.id !== panelId) return p;
+          const current = clampPanelWidth(p.width, max);
+          return { ...p, width: current >= max ? 1 : max };
+        }),
       });
     },
     [dashboard, persist],
@@ -553,18 +596,104 @@ export default function SqlDashboardPage() {
     return dashboard.panels.filter((p) => !p.tab || p.tab === activeTab);
   }, [dashboard, activeTab]);
 
+  // Group panels into "section blocks": each section starts a new block whose
+  // grid uses the section's `columns` (falling back to the dashboard default).
+  // Panels before any section go in an initial unsectioned block.
+  const dashboardColumns = clampDashboardColumns(
+    dashboard?.columns ?? DEFAULT_DASHBOARD_COLUMNS,
+  );
+  const panelGroups = useMemo(() => {
+    const groups: Array<{
+      key: string;
+      section: SqlPanel | null;
+      panels: SqlPanel[];
+      columns: number;
+    }> = [];
+    let current: {
+      key: string;
+      section: SqlPanel | null;
+      panels: SqlPanel[];
+      columns: number;
+    } = {
+      key: "intro",
+      section: null,
+      panels: [],
+      columns: dashboardColumns,
+    };
+    for (const panel of visiblePanels) {
+      if (panel.chartType === "section") {
+        if (current.section || current.panels.length > 0) groups.push(current);
+        current = {
+          key: panel.id,
+          section: panel,
+          panels: [],
+          columns: clampDashboardColumns(panel.columns ?? dashboardColumns),
+        };
+      } else {
+        current.panels.push(panel);
+      }
+    }
+    if (current.section || current.panels.length > 0) groups.push(current);
+    return groups;
+  }, [visiblePanels, dashboardColumns]);
+
   const handleDelete = useCallback(async () => {
     if (!dashboardId) return;
     await fetchWithAuth(`/api/sql-dashboards/${dashboardId}`, {
       method: "DELETE",
     });
     queryClient.invalidateQueries({ queryKey: ["sql-dashboards-sidebar"] });
+    queryClient.invalidateQueries({
+      queryKey: ["sql-dashboards-archived-sidebar"],
+    });
     queryClient.invalidateQueries({ queryKey: ["sql-dashboards-palette"] });
     queryClient.invalidateQueries({
       queryKey: ["data", "sql-dashboard", dashboardId],
     });
     navigate("/");
   }, [dashboardId, queryClient, navigate]);
+
+  const handleArchiveToggle = useCallback(
+    async (action: "archive" | "restore") => {
+      if (!dashboardId) return;
+      const path =
+        action === "archive"
+          ? `/api/sql-dashboards/${dashboardId}/archive`
+          : `/api/sql-dashboards/${dashboardId}/unarchive`;
+      try {
+        const res = await fetchWithAuth(path, { method: "POST" });
+        if (!res.ok) {
+          let msg = `${action} failed (${res.status})`;
+          try {
+            const body = await res.json();
+            if (body?.error) msg = body.error;
+          } catch {
+            // non-JSON body — keep generic message
+          }
+          throw new Error(msg);
+        }
+        queryClient.invalidateQueries({ queryKey: ["sql-dashboards-sidebar"] });
+        queryClient.invalidateQueries({
+          queryKey: ["sql-dashboards-archived-sidebar"],
+        });
+        queryClient.invalidateQueries({
+          queryKey: ["data", "sql-dashboard", dashboardId],
+        });
+        if (action === "archive") {
+          toast.success(`Archived "${dashboard?.name ?? "dashboard"}"`);
+          navigate("/");
+        } else {
+          setArchivedAt(null);
+          toast.success(`Restored "${dashboard?.name ?? "dashboard"}"`);
+        }
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : `Couldn't ${action} dashboard`,
+        );
+      }
+    },
+    [dashboardId, queryClient, navigate, dashboard?.name],
+  );
 
   const handleSaveView = useCallback(
     async (name: string, filters: Record<string, string>) => {
@@ -637,34 +766,92 @@ export default function SqlDashboardPage() {
             Add panel
           </Button>
         </AddPanelPopover>
-        <AlertDialog>
+        {archivedAt ? (
           <Tooltip>
             <TooltipTrigger asChild>
-              <AlertDialogTrigger asChild>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => handleArchiveToggle("restore")}
+              >
+                <IconArchiveOff className="h-4 w-4 mr-1.5" />
+                Restore
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>This dashboard is archived</TooltipContent>
+          </Tooltip>
+        ) : null}
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
                 <Button
                   size="sm"
                   variant="ghost"
                   className="text-muted-foreground hover:text-foreground"
-                  aria-label="Delete dashboard"
+                  aria-label="Dashboard actions"
                 >
-                  <IconTrash className="h-4 w-4" />
+                  <IconDots className="h-4 w-4" />
                 </Button>
-              </AlertDialogTrigger>
+              </DropdownMenuTrigger>
             </TooltipTrigger>
-            <TooltipContent>Delete dashboard</TooltipContent>
+            <TooltipContent>More actions</TooltipContent>
           </Tooltip>
+          <DropdownMenuContent align="end" className="w-44">
+            {archivedAt ? (
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault();
+                  void handleArchiveToggle("restore");
+                }}
+              >
+                <IconArchiveOff className="mr-2 h-3.5 w-3.5" />
+                Restore
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault();
+                  void handleArchiveToggle("archive");
+                }}
+              >
+                <IconArchive className="mr-2 h-3.5 w-3.5" />
+                Archive
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault();
+                setConfirmDeleteOpen(true);
+              }}
+              className="text-destructive focus:text-destructive"
+            >
+              <IconTrash className="mr-2 h-3.5 w-3.5" />
+              Delete permanently
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <AlertDialog
+          open={confirmDeleteOpen}
+          onOpenChange={setConfirmDeleteOpen}
+        >
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>Delete dashboard?</AlertDialogTitle>
+              <AlertDialogTitle>Delete permanently?</AlertDialogTitle>
               <AlertDialogDescription>
-                This will permanently delete &ldquo;{dashboard?.name}&rdquo;.
-                This action cannot be undone.
+                This permanently deletes &ldquo;{dashboard?.name}&rdquo; and
+                cannot be undone. To keep it recoverable, choose Archive
+                instead.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction onClick={handleDelete}>
-                Delete
+              <AlertDialogAction
+                onClick={handleDelete}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                Delete permanently
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
@@ -790,63 +977,131 @@ export default function SqlDashboardPage() {
             items={visiblePanels.map((p) => p.id)}
             strategy={rectSortingStrategy}
           >
-            <div className="grid auto-rows-auto grid-cols-1 items-stretch gap-4 md:grid-cols-2">
-              {visiblePanels.map((panel) => {
-                const resolved = panel.config?.description
-                  ? {
-                      ...panel,
-                      config: {
-                        ...panel.config,
-                        description: interpolate(
-                          panel.config.description,
-                          vars,
-                        ),
-                      },
-                    }
-                  : panel;
-                const remoteEditor = remoteEditingPanels.get(panel.id);
-                const isSection = panel.chartType === "section";
-                const isFullWidth = panel.width === 2;
+            <div className="flex flex-col gap-4">
+              {panelGroups.map((group) => {
+                const renderPanelCell = (panel: SqlPanel) => {
+                  const resolved = panel.config?.description
+                    ? {
+                        ...panel,
+                        config: {
+                          ...panel.config,
+                          description: interpolate(
+                            panel.config.description,
+                            vars,
+                          ),
+                        },
+                      }
+                    : panel;
+                  const remoteEditor = remoteEditingPanels.get(panel.id);
+                  const span = clampPanelWidth(panel.width, group.columns);
+                  return (
+                    <div
+                      key={panel.id}
+                      className="relative h-full md:[grid-column:span_var(--panel-span)/span_var(--panel-span)]"
+                      style={
+                        {
+                          "--panel-span": span,
+                          ...(remoteEditor
+                            ? {
+                                outline: `2px solid ${remoteEditor.color}`,
+                                outlineOffset: 2,
+                                borderRadius: 8,
+                              }
+                            : null),
+                        } as React.CSSProperties
+                      }
+                    >
+                      {remoteEditor && (
+                        <span
+                          className="absolute -top-2.5 left-3 px-1.5 text-[10px] font-medium rounded z-10"
+                          style={{
+                            backgroundColor: remoteEditor.color,
+                            color: "#fff",
+                          }}
+                        >
+                          {remoteEditor.name}
+                        </span>
+                      )}
+                      <SqlChartCard
+                        panel={resolved}
+                        resolvedSql={interpolate(panel.sql, vars)}
+                        onRemove={() => removePanel(panel.id)}
+                        onToggleWidth={() =>
+                          toggleWidth(panel.id, group.columns)
+                        }
+                        onEdit={() => openEditPanel(panel)}
+                        onSaveSql={(sql) =>
+                          handleSavePanel({ ...panel, sql })
+                        }
+                      />
+                    </div>
+                  );
+                };
+
+                const renderSection = (section: SqlPanel) => {
+                  const remoteEditor = remoteEditingPanels.get(section.id);
+                  const resolved = section.config?.description
+                    ? {
+                        ...section,
+                        config: {
+                          ...section.config,
+                          description: interpolate(
+                            section.config.description,
+                            vars,
+                          ),
+                        },
+                      }
+                    : section;
+                  return (
+                    <div
+                      className="relative"
+                      style={
+                        remoteEditor
+                          ? {
+                              outline: `2px solid ${remoteEditor.color}`,
+                              outlineOffset: 2,
+                              borderRadius: 8,
+                            }
+                          : undefined
+                      }
+                    >
+                      {remoteEditor && (
+                        <span
+                          className="absolute -top-2.5 left-3 px-1.5 text-[10px] font-medium rounded z-10"
+                          style={{
+                            backgroundColor: remoteEditor.color,
+                            color: "#fff",
+                          }}
+                        >
+                          {remoteEditor.name}
+                        </span>
+                      )}
+                      <SqlChartCard
+                        panel={resolved}
+                        resolvedSql=""
+                        onRemove={() => removePanel(section.id)}
+                        onEdit={() => openEditPanel(section)}
+                      />
+                    </div>
+                  );
+                };
+
                 return (
-                  <div
-                    key={panel.id}
-                    className={
-                      isSection
-                        ? "relative md:col-span-2"
-                        : isFullWidth
-                          ? "relative h-full md:col-span-2"
-                          : "relative h-full"
-                    }
-                    style={
-                      remoteEditor
-                        ? {
-                            outline: `2px solid ${remoteEditor.color}`,
-                            outlineOffset: 2,
-                            borderRadius: 8,
-                          }
-                        : undefined
-                    }
-                  >
-                    {remoteEditor && (
-                      <span
-                        className="absolute -top-2.5 left-3 px-1.5 text-[10px] font-medium rounded z-10"
-                        style={{
-                          backgroundColor: remoteEditor.color,
-                          color: "#fff",
-                        }}
+                  <Fragment key={group.key}>
+                    {group.section && renderSection(group.section)}
+                    {group.panels.length > 0 && (
+                      <div
+                        className="grid auto-rows-auto grid-cols-1 items-stretch gap-4 md:[grid-template-columns:repeat(var(--dash-cols),minmax(0,1fr))]"
+                        style={
+                          {
+                            "--dash-cols": group.columns,
+                          } as React.CSSProperties
+                        }
                       >
-                        {remoteEditor.name}
-                      </span>
+                        {group.panels.map(renderPanelCell)}
+                      </div>
                     )}
-                    <SqlChartCard
-                      panel={resolved}
-                      resolvedSql={interpolate(panel.sql, vars)}
-                      onRemove={() => removePanel(panel.id)}
-                      onToggleWidth={() => toggleWidth(panel.id)}
-                      onEdit={() => openEditPanel(panel)}
-                      onSaveSql={(sql) => handleSavePanel({ ...panel, sql })}
-                    />
-                  </div>
+                  </Fragment>
                 );
               })}
             </div>

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -1025,6 +1025,7 @@ export default function SqlDashboardPage() {
                       <SqlChartCard
                         panel={resolved}
                         resolvedSql={interpolate(panel.sql, vars)}
+                        gridColumns={group.columns}
                         onRemove={() => removePanel(panel.id)}
                         onToggleWidth={() =>
                           toggleWidth(panel.id, group.columns)

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -998,7 +998,7 @@ export default function SqlDashboardPage() {
                   return (
                     <div
                       key={panel.id}
-                      className="relative h-full md:[grid-column:span_var(--panel-span)/span_var(--panel-span)]"
+                      className="relative h-full md:[grid-column:span_var(--panel-span)]"
                       style={
                         {
                           "--panel-span": span,

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -1031,9 +1031,7 @@ export default function SqlDashboardPage() {
                           toggleWidth(panel.id, group.columns)
                         }
                         onEdit={() => openEditPanel(panel)}
-                        onSaveSql={(sql) =>
-                          handleSavePanel({ ...panel, sql })
-                        }
+                        onSaveSql={(sql) => handleSavePanel({ ...panel, sql })}
                       />
                     </div>
                   );

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -128,6 +128,7 @@ async function fetchDashboard(id: string): Promise<FetchedDashboard | null> {
       description: data.description,
       filters: data.filters,
       variables: data.variables,
+      columns: typeof data.columns === "number" ? data.columns : undefined,
       panels: data.panels ?? [],
     },
     archivedAt: typeof data.archivedAt === "string" ? data.archivedAt : null,

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/types.ts
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/types.ts
@@ -79,7 +79,19 @@ export interface SqlPanel {
   sql: string;
   source: DataSourceType;
   chartType: ChartType;
-  width: 1 | 2;
+  /**
+   * How many grid columns this panel spans. Defaults to 1. The renderer
+   * clamps to the active section's column count, so a `width: 4` panel in a
+   * 2-column section still spans the full row. Sections always span every
+   * column regardless of this value.
+   */
+  width: number;
+  /**
+   * Section panels only: number of columns the panels following this section
+   * (until the next section) should be laid out in. Falls back to the
+   * dashboard-level `columns`, then to 2.
+   */
+  columns?: number;
   config?: SqlPanelConfig;
   /**
    * Optional tab assignment. When any panel in a dashboard declares a `tab`,
@@ -96,5 +108,38 @@ export interface SqlDashboardConfig {
   description?: string;
   filters?: DashboardFilter[];
   variables?: Record<string, string>;
+  /**
+   * Default column count for panels that appear before any section. Sections
+   * can override this via their own `columns`. Always 1 column on screens
+   * narrower than the `md` breakpoint. Defaults to 2.
+   */
+  columns?: number;
   panels: SqlPanel[];
+}
+
+/**
+ * Lower / upper bounds for the per-section column count. Keep in sync with
+ * the validators in `actions/update-dashboard.ts` and
+ * `server/handlers/sql-dashboards.ts`.
+ */
+export const MIN_DASHBOARD_COLUMNS = 1;
+export const MAX_DASHBOARD_COLUMNS = 6;
+export const DEFAULT_DASHBOARD_COLUMNS = 2;
+
+export function clampDashboardColumns(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_DASHBOARD_COLUMNS;
+  }
+  const integer = Math.floor(value);
+  if (integer < MIN_DASHBOARD_COLUMNS) return MIN_DASHBOARD_COLUMNS;
+  if (integer > MAX_DASHBOARD_COLUMNS) return MAX_DASHBOARD_COLUMNS;
+  return integer;
+}
+
+export function clampPanelWidth(value: unknown, gridColumns: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 1;
+  const integer = Math.floor(value);
+  if (integer < 1) return 1;
+  if (integer > gridColumns) return gridColumns;
+  return integer;
 }

--- a/templates/analytics/app/routes/chart.tsx
+++ b/templates/analytics/app/routes/chart.tsx
@@ -49,9 +49,10 @@ function decodePanel(raw: string): SqlPanel | { error: string } {
       sql: p.sql,
       source: p.source as SqlPanel["source"],
       chartType: p.chartType as SqlPanel["chartType"],
-      width: (p.width === 1 || p.width === 2
-        ? p.width
-        : 2) as SqlPanel["width"],
+      width:
+        typeof p.width === "number" && Number.isFinite(p.width) && p.width >= 1
+          ? Math.floor(p.width)
+          : 1,
       config: (p.config && typeof p.config === "object"
         ? p.config
         : undefined) as SqlPanel["config"],

--- a/templates/analytics/server/db/schema.ts
+++ b/templates/analytics/server/db/schema.ts
@@ -24,6 +24,9 @@ export const dashboards = table("dashboards", {
   config: text("config").notNull(),
   createdAt: text("created_at").notNull().default(now()),
   updatedAt: text("updated_at").notNull().default(now()),
+  /** Archive timestamp. Null = active. Archived rows are hidden from
+   *  default list responses but remain accessible by id and can be restored. */
+  archivedAt: text("archived_at"),
   ...ownableColumns(),
 });
 

--- a/templates/analytics/server/handlers/explorer-dashboards.ts
+++ b/templates/analytics/server/handlers/explorer-dashboards.ts
@@ -1,4 +1,9 @@
-import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
+import {
+  defineEventHandler,
+  getQuery,
+  getRouterParam,
+  setResponseStatus,
+} from "h3";
 import { readBody } from "@agent-native/core/server";
 import { getOrgContext } from "@agent-native/core/org";
 import {
@@ -6,6 +11,9 @@ import {
   listDashboards,
   upsertDashboard,
   removeDashboard,
+  archiveDashboard,
+  unarchiveDashboard,
+  type DashboardArchiveFilter,
 } from "../lib/dashboards-store";
 
 async function ctxFromEvent(event: any) {
@@ -13,16 +21,25 @@ async function ctxFromEvent(event: any) {
   return { email: ctx.email, orgId: ctx.orgId ?? null };
 }
 
+function parseArchivedFilter(raw: unknown): DashboardArchiveFilter {
+  if (raw === "1" || raw === "true" || raw === "only" || raw === "archived")
+    return "archived";
+  if (raw === "all") return "all";
+  return "active";
+}
+
 export const listExplorerDashboards = defineEventHandler(async (event) => {
   try {
     const ctx = await ctxFromEvent(event);
-    const rows = await listDashboards(ctx, { kind: "explorer" });
+    const archived = parseArchivedFilter(getQuery(event).archived);
+    const rows = await listDashboards(ctx, { kind: "explorer", archived });
     const dashboards = rows.map((d) => ({
       id: d.id,
       ...(d.config as Record<string, unknown>),
       ownerEmail: d.ownerEmail,
       orgId: d.orgId,
       visibility: d.visibility,
+      archivedAt: d.archivedAt,
     }));
     return { dashboards };
   } catch (err: any) {
@@ -50,6 +67,7 @@ export const getExplorerDashboard = defineEventHandler(async (event) => {
       ownerEmail: dash.ownerEmail,
       orgId: dash.orgId,
       visibility: dash.visibility,
+      archivedAt: dash.archivedAt,
     };
   } catch (err: any) {
     const status = err?.statusCode ?? 500;
@@ -86,6 +104,48 @@ export const deleteExplorerDashboard = defineEventHandler(async (event) => {
     const ctx = await ctxFromEvent(event);
     await removeDashboard(id, ctx);
     return { id, success: true };
+  } catch (err: any) {
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
+    return { error: err.message };
+  }
+});
+
+export const archiveExplorerDashboard = defineEventHandler(async (event) => {
+  const id = getRouterParam(event, "id");
+  if (!id) {
+    setResponseStatus(event, 400);
+    return { error: "Missing dashboard id" };
+  }
+  try {
+    const ctx = await ctxFromEvent(event);
+    const dash = await archiveDashboard(id, ctx);
+    if (!dash) {
+      setResponseStatus(event, 404);
+      return { error: "Dashboard not found" };
+    }
+    return { id, archivedAt: dash.archivedAt, success: true };
+  } catch (err: any) {
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
+    return { error: err.message };
+  }
+});
+
+export const unarchiveExplorerDashboard = defineEventHandler(async (event) => {
+  const id = getRouterParam(event, "id");
+  if (!id) {
+    setResponseStatus(event, 400);
+    return { error: "Missing dashboard id" };
+  }
+  try {
+    const ctx = await ctxFromEvent(event);
+    const dash = await unarchiveDashboard(id, ctx);
+    if (!dash) {
+      setResponseStatus(event, 404);
+      return { error: "Dashboard not found" };
+    }
+    return { id, archivedAt: dash.archivedAt, success: true };
   } catch (err: any) {
     const status = err?.statusCode ?? 500;
     setResponseStatus(event, status);

--- a/templates/analytics/server/handlers/sql-dashboards.ts
+++ b/templates/analytics/server/handlers/sql-dashboards.ts
@@ -358,9 +358,37 @@ function validateDashboardConfig(
       if (!isSection && !validSources.has(p.source as string)) {
         return `panel[${i}].source must be 'bigquery', 'ga4', 'amplitude', or 'first-party' (got '${p.source}'). The table name belongs in the panel's sql, not in source — source selects the backend, not the table.`;
       }
-      if (p.width !== 1 && p.width !== 2) {
-        return `panel[${i}].width must be 1 or 2`;
+      if (
+        typeof p.width !== "number" ||
+        !Number.isFinite(p.width) ||
+        p.width < 1 ||
+        p.width > 6 ||
+        Math.floor(p.width) !== p.width
+      ) {
+        return `panel[${i}].width must be an integer between 1 and 6 (number of grid columns to span)`;
       }
+      if (isSection && p.columns !== undefined) {
+        if (
+          typeof p.columns !== "number" ||
+          !Number.isFinite(p.columns) ||
+          p.columns < 1 ||
+          p.columns > 6 ||
+          Math.floor(p.columns) !== p.columns
+        ) {
+          return `panel[${i}].columns must be an integer between 1 and 6 (only valid on section panels)`;
+        }
+      }
+    }
+  }
+  if (config.columns !== undefined) {
+    if (
+      typeof config.columns !== "number" ||
+      !Number.isFinite(config.columns) ||
+      config.columns < 1 ||
+      config.columns > 6 ||
+      Math.floor(config.columns) !== config.columns
+    ) {
+      return "config.columns must be an integer between 1 and 6";
     }
   }
   return null;

--- a/templates/analytics/server/handlers/sql-dashboards.ts
+++ b/templates/analytics/server/handlers/sql-dashboards.ts
@@ -1,4 +1,9 @@
-import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
+import {
+  defineEventHandler,
+  getQuery,
+  getRouterParam,
+  setResponseStatus,
+} from "h3";
 import { readBody } from "@agent-native/core/server";
 import { getOrgContext } from "@agent-native/core/org";
 import { runApiHandlerWithContext } from "../lib/credentials";
@@ -7,6 +12,9 @@ import {
   listDashboards,
   upsertDashboard,
   removeDashboard,
+  archiveDashboard,
+  unarchiveDashboard,
+  type DashboardArchiveFilter,
 } from "../lib/dashboards-store";
 import { dryRunQuery } from "../lib/bigquery";
 import { interpolate } from "../../app/pages/adhoc/sql-dashboard/interpolate";
@@ -76,16 +84,25 @@ function buildDryRunVars(
   return vars;
 }
 
+function parseArchivedFilter(raw: unknown): DashboardArchiveFilter {
+  if (raw === "1" || raw === "true" || raw === "only" || raw === "archived")
+    return "archived";
+  if (raw === "all") return "all";
+  return "active";
+}
+
 export const listSqlDashboards = defineEventHandler(async (event) => {
   try {
     const ctx = await ctxFromEvent(event);
-    const rows = await listDashboards(ctx, { kind: "sql" });
+    const archived = parseArchivedFilter(getQuery(event).archived);
+    const rows = await listDashboards(ctx, { kind: "sql", archived });
     const dashboards = rows.map((d) => ({
       id: d.id,
       ...(d.config as Record<string, unknown>),
       ownerEmail: d.ownerEmail,
       orgId: d.orgId,
       visibility: d.visibility,
+      archivedAt: d.archivedAt,
     }));
     return { dashboards };
   } catch (err: any) {
@@ -113,6 +130,7 @@ export const getSqlDashboard = defineEventHandler(async (event) => {
       ownerEmail: dash.ownerEmail,
       orgId: dash.orgId,
       visibility: dash.visibility,
+      archivedAt: dash.archivedAt,
     };
   } catch (err: any) {
     const status = err?.statusCode ?? 500;
@@ -358,6 +376,48 @@ export const deleteSqlDashboard = defineEventHandler(async (event) => {
     const ctx = await ctxFromEvent(event);
     await removeDashboard(id, ctx);
     return { id, success: true };
+  } catch (err: any) {
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
+    return { error: err.message };
+  }
+});
+
+export const archiveSqlDashboard = defineEventHandler(async (event) => {
+  const id = getRouterParam(event, "id");
+  if (!id) {
+    setResponseStatus(event, 400);
+    return { error: "Missing dashboard id" };
+  }
+  try {
+    const ctx = await ctxFromEvent(event);
+    const dash = await archiveDashboard(id, ctx);
+    if (!dash) {
+      setResponseStatus(event, 404);
+      return { error: "Dashboard not found" };
+    }
+    return { id, archivedAt: dash.archivedAt, success: true };
+  } catch (err: any) {
+    const status = err?.statusCode ?? 500;
+    setResponseStatus(event, status);
+    return { error: err.message };
+  }
+});
+
+export const unarchiveSqlDashboard = defineEventHandler(async (event) => {
+  const id = getRouterParam(event, "id");
+  if (!id) {
+    setResponseStatus(event, 400);
+    return { error: "Missing dashboard id" };
+  }
+  try {
+    const ctx = await ctxFromEvent(event);
+    const dash = await unarchiveDashboard(id, ctx);
+    if (!dash) {
+      setResponseStatus(event, 404);
+      return { error: "Dashboard not found" };
+    }
+    return { id, archivedAt: dash.archivedAt, success: true };
   } catch (err: any) {
     const status = err?.statusCode ?? 500;
     setResponseStatus(event, status);

--- a/templates/analytics/server/lib/dashboards-store.ts
+++ b/templates/analytics/server/lib/dashboards-store.ts
@@ -12,7 +12,7 @@
  * - `o:<orgId>:sql-dashboard-{id}` → kind='sql',      owner=caller, visibility='org'
  * - `adhoc-analysis-{id}`          → owner=caller,   legacy visibility from its source key
  */
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
 import {
   accessFilter,
   assertAccess,
@@ -40,7 +40,11 @@ export interface DashboardRecord {
   visibility: "private" | "org" | "public";
   createdAt: string;
   updatedAt: string;
+  /** ISO timestamp set when the dashboard is archived. Null = active. */
+  archivedAt: string | null;
 }
+
+export type DashboardArchiveFilter = "active" | "archived" | "all";
 
 export interface AnalysisRecord {
   id: string;
@@ -121,6 +125,7 @@ function rowToDashboard(row: any): DashboardRecord {
     visibility: row.visibility,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    archivedAt: row.archivedAt ?? null,
   };
 }
 
@@ -251,28 +256,42 @@ export async function getDashboard(
   );
 }
 
-/** List dashboards visible to the caller. Union of SQL rows + not-yet-migrated legacy keys. */
+/**
+ * List dashboards visible to the caller. Union of SQL rows + not-yet-migrated
+ * legacy keys.
+ *
+ * `archived` controls whether archived rows are included:
+ *   - `"active"` (default): hide archived rows
+ *   - `"archived"`: only archived rows
+ *   - `"all"`: both
+ *
+ * Legacy settings rows have no archive concept, so they are treated as active.
+ */
 export async function listDashboards(
   ctx: AccessCtx,
-  filter?: { kind?: DashboardKind },
+  filter?: { kind?: DashboardKind; archived?: DashboardArchiveFilter },
 ): Promise<DashboardRecord[]> {
   const db = getDb() as any;
-  const where = filter?.kind
-    ? and(
-        eq(schema.dashboards.kind, filter.kind),
-        accessFilter(schema.dashboards, schema.dashboardShares, {
-          userEmail: ctx.email,
-          orgId: ctx.orgId ?? undefined,
-        }),
-      )
-    : accessFilter(schema.dashboards, schema.dashboardShares, {
-        userEmail: ctx.email,
-        orgId: ctx.orgId ?? undefined,
-      });
+  const archived = filter?.archived ?? "active";
+  const conditions: any[] = [
+    accessFilter(schema.dashboards, schema.dashboardShares, {
+      userEmail: ctx.email,
+      orgId: ctx.orgId ?? undefined,
+    }),
+  ];
+  if (filter?.kind) conditions.push(eq(schema.dashboards.kind, filter.kind));
+  if (archived === "active")
+    conditions.push(isNull(schema.dashboards.archivedAt));
+  else if (archived === "archived")
+    conditions.push(isNotNull(schema.dashboards.archivedAt));
+  const where = conditions.length === 1 ? conditions[0] : and(...conditions);
   const rows = await db.select().from(schema.dashboards).where(where);
   const out: DashboardRecord[] = rows.map(rowToDashboard);
   const seen = new Set(out.map((r) => r.id));
   // Legacy: scan settings once and surface anything not yet migrated.
+  // Archived state doesn't exist in legacy rows, so skip the legacy scan
+  // entirely when the caller wants archived-only.
+  if (archived === "archived") return out;
   try {
     const all = await getAllSettings();
     for (const [key, value] of Object.entries(all)) {
@@ -362,6 +381,77 @@ export async function upsertDashboard(
     .where(eq(schema.dashboards.id, id));
   // Notify any sibling tabs (sidebar list, command palette, dashboard view)
   // so create/update propagate just like delete and the legacy-migration path.
+  const dashboard = rowToDashboard(row);
+  recordScopedChange(
+    "dashboards",
+    "change",
+    dashboard.id,
+    dashboard.ownerEmail,
+    dashboard.orgId,
+    dashboard.visibility,
+  );
+  return dashboard;
+}
+
+/**
+ * Archive a dashboard (soft-delete). Requires editor. The row stays in the
+ * dashboards table with `archived_at` set, so it disappears from the default
+ * sidebar list but remains accessible by id and can be restored.
+ */
+export async function archiveDashboard(
+  id: string,
+  ctx: AccessCtx,
+): Promise<DashboardRecord | null> {
+  const existing = await getDashboard(id, ctx);
+  if (!existing) return null;
+  if (existing.archivedAt) return existing;
+  await assertAccess("dashboard", id, "editor", {
+    userEmail: ctx.email,
+    orgId: ctx.orgId ?? undefined,
+  });
+  const db = getDb() as any;
+  const now = nowIso();
+  await db
+    .update(schema.dashboards)
+    .set({ archivedAt: now, updatedAt: now })
+    .where(eq(schema.dashboards.id, id));
+  const [row] = await db
+    .select()
+    .from(schema.dashboards)
+    .where(eq(schema.dashboards.id, id));
+  const dashboard = rowToDashboard(row);
+  recordScopedChange(
+    "dashboards",
+    "change",
+    dashboard.id,
+    dashboard.ownerEmail,
+    dashboard.orgId,
+    dashboard.visibility,
+  );
+  return dashboard;
+}
+
+/** Restore an archived dashboard. Requires editor. No-op if already active. */
+export async function unarchiveDashboard(
+  id: string,
+  ctx: AccessCtx,
+): Promise<DashboardRecord | null> {
+  const existing = await getDashboard(id, ctx);
+  if (!existing) return null;
+  if (!existing.archivedAt) return existing;
+  await assertAccess("dashboard", id, "editor", {
+    userEmail: ctx.email,
+    orgId: ctx.orgId ?? undefined,
+  });
+  const db = getDb() as any;
+  await db
+    .update(schema.dashboards)
+    .set({ archivedAt: null, updatedAt: nowIso() })
+    .where(eq(schema.dashboards.id, id));
+  const [row] = await db
+    .select()
+    .from(schema.dashboards)
+    .where(eq(schema.dashboards.id, id));
   const dashboard = rowToDashboard(row);
   recordScopedChange(
     "dashboards",

--- a/templates/analytics/server/lib/dashboards-store.ts
+++ b/templates/analytics/server/lib/dashboards-store.ts
@@ -174,6 +174,9 @@ async function migrateDashboardFromSettings(
       updatedAt,
     })
     .onConflictDoNothing();
+  // guard:allow-unscoped — read-after-write of the row just inserted above
+  // with ownerEmail from ctx; eq(id) is sufficient because we know the id we
+  // just wrote and onConflictDoNothing leaves any pre-existing row untouched.
   const [row] = await db
     .select()
     .from(schema.dashboards)
@@ -732,6 +735,10 @@ export async function upsertAnalysis(
       visibility: "private",
     });
   }
+  // guard:allow-unscoped — read-after-write of the analysis row just upserted
+  // above with ownerEmail from ctx; the upsert path already gated access via
+  // assertAccess earlier in this function for the update branch, and the
+  // insert branch sets ownerEmail = ctx.email, so eq(id) is sufficient.
   const [row] = await db
     .select()
     .from(schema.analyses)

--- a/templates/analytics/server/plugins/db.ts
+++ b/templates/analytics/server/plugins/db.ts
@@ -165,6 +165,14 @@ export default runMigrations(
       version: 18,
       sql: `ALTER TABLE analytics_events ADD COLUMN IF NOT EXISTS signed_in TEXT`,
     },
+    {
+      version: 19,
+      sql: `ALTER TABLE dashboards ADD COLUMN IF NOT EXISTS archived_at TEXT`,
+    },
+    {
+      version: 20,
+      sql: `CREATE INDEX IF NOT EXISTS dashboards_archived_at_idx ON dashboards (archived_at)`,
+    },
   ],
   { table: "analytics_migrations" },
 );

--- a/templates/analytics/server/routes/api/explorer-dashboards/[id]/archive.post.ts
+++ b/templates/analytics/server/routes/api/explorer-dashboards/[id]/archive.post.ts
@@ -1,0 +1,1 @@
+export { archiveExplorerDashboard as default } from "../../../../handlers/explorer-dashboards";

--- a/templates/analytics/server/routes/api/explorer-dashboards/[id]/unarchive.post.ts
+++ b/templates/analytics/server/routes/api/explorer-dashboards/[id]/unarchive.post.ts
@@ -1,0 +1,1 @@
+export { unarchiveExplorerDashboard as default } from "../../../../handlers/explorer-dashboards";

--- a/templates/analytics/server/routes/api/sql-dashboards/[id]/archive.post.ts
+++ b/templates/analytics/server/routes/api/sql-dashboards/[id]/archive.post.ts
@@ -1,0 +1,1 @@
+export { archiveSqlDashboard as default } from "../../../../handlers/sql-dashboards";

--- a/templates/analytics/server/routes/api/sql-dashboards/[id]/unarchive.post.ts
+++ b/templates/analytics/server/routes/api/sql-dashboards/[id]/unarchive.post.ts
@@ -1,0 +1,1 @@
+export { unarchiveSqlDashboard as default } from "../../../../handlers/sql-dashboards";


### PR DESCRIPTION
## Summary

Concurrent-agent sweep on a fresh branch — four self-documented changesets plus a new analytics archive feature:

- **core/chat-sidebar** — paint composer immediately on open instead of blocking behind GET/POST `/threads`; seed an optimistic active thread from localStorage or a fresh UUID synchronously on mount and persist server-side in the background. New chats see the empty composer on first render; existing chats render header + composer immediately while the per-thread restore skeleton stays scoped to messages.
- **core/composer-plus-menu** — _"Create Extension"_ (was Create Tool) and _"Schedule Task"_ (was Scheduled Task) for imperative-tense parity with the rest of the menu.
- **core/ConnectBuilderCard + CodeRequiredDialog** — _"coming soon"_ instead of _"unavailable"_ for waitlisted Builder Cloud Agents.
- **dispatch** — increased vertical spacing between Overview sections (Getting started / At a glance / Operations detail) so headings read as distinct groups.
- **analytics dashboard archive** — new `archive-dashboard` agent action plus per-id `archive` / `unarchive` routes for explorer + sql dashboards, schema additions, sidebar + index page wiring, and a `dashboard-management` SKILL update.

## Test plan

- [ ] `pnpm prep` (Build, Lint, Test, Typecheck, Guard, Changeset)
- [ ] Open the chat sidebar with no thread cached — composer paints immediately, no spinner blocking input
- [ ] Archive an analytics dashboard from the agent (`archive-dashboard --id ...`) and via the new HTTP route; confirm sidebar updates
- [ ] Visit Dispatch overview — section headings read distinct