### PR TITLE
core: Builder desktop OAuth bridge + composer image lightbox; dispatch skeletons; design rename

### DIFF
--- a/.changeset/agent-reaper-retry-and-capture.md
+++ b/.changeset/agent-reaper-retry-and-capture.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Agent run-store: stop the bug that caused the user-facing `run_terminal_event_missing` error from happening in the first place. The reaper paths (`reapIfStale`, `reapAllStaleRuns`, `cleanupOldRuns`, `markRunAborted`) used to call `appendTerminalRunEvent(...).catch(() => {})`, silently dropping transient SQL errors and stranding reconnecting clients with bare `status='errored'` rows. They now go through `safeAppendTerminalRunEvent` — one retry after a 100ms backoff, then a structured `captureError` to Sentry on persistent failure. `cleanupOldRuns` also broadens its terminal-event-append SELECT to cover the 24h-age UPDATE in addition to the heartbeat-stale one (an old run with a somehow-fresh heartbeat would previously be flipped to `errored` without a terminal event).

--- a/.changeset/builder-local-oauth-return.md
+++ b/.changeset/builder-local-oauth-return.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Return Builder desktop Google sign-in to the local workspace gateway and bridge the OAuth session back with `_session`.

--- a/.changeset/chat-history-active-thread-merge.md
+++ b/.changeset/chat-history-active-thread-merge.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Stop chat history from "reverting" mid-conversation: `useChatThreads.fetchThreads` now reconciles per-thread instead of replacing wholesale, so a server fetch that arrives a few hundred ms behind a fresh local update no longer rolls the recent-chats list back to older timestamps. The active thread is also kept visible in the History popover (and highlighted as `Active`) even when its `messageCount` is still zero, so a brand-new chat doesn't appear to vanish from the list right after opening.

--- a/.changeset/chat-no-empty-thread-rows.md
+++ b/.changeset/chat-no-empty-thread-rows.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-fix(chat): stop creating empty `chat_threads` rows for users who never send a message. The client used to optimistically `POST /_agent-native/agent-chat/threads` on mount and on every "+" click, which inflated the table with rows that had `message_count=0` and zero linked `agent_runs` (one user's account had 112 such ghost rows out of 127 total). The server already creates the row idempotently when the user actually sends — `persistSubmittedUserMessage` → `createThread` — so the client now only adds the thread to its local list and skips the POST. The threads table reflects real conversations only.

--- a/.changeset/chat-no-empty-thread-rows.md
+++ b/.changeset/chat-no-empty-thread-rows.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+fix(chat): stop creating empty `chat_threads` rows for users who never send a message. The client used to optimistically `POST /_agent-native/agent-chat/threads` on mount and on every "+" click, which inflated the table with rows that had `message_count=0` and zero linked `agent_runs` (one user's account had 112 such ghost rows out of 127 total). The server already creates the row idempotently when the user actually sends — `persistSubmittedUserMessage` → `createThread` — so the client now only adds the thread to its local list and skips the POST. The threads table reflects real conversations only.

--- a/.changeset/chat-no-ghost-rows-and-stale-thread-recover.md
+++ b/.changeset/chat-no-ghost-rows-and-stale-thread-recover.md
@@ -1,0 +1,12 @@
+---
+"@agent-native/core": patch
+---
+
+fix(chat): stop creating empty `chat_threads` rows on every page mount + recover from stale active threads
+
+Two related fixes that together prevent `chat_threads` from filling up with ghost rows and prevent users from getting stuck on an active id the server doesn't know about:
+
+- `useChatThreads` no longer optimistically `POST`s `/_agent-native/agent-chat/threads` when synthesizing a thread id for the composer. The previous flow inserted an empty `chat_threads` row (`message_count=0`, no linked `agent_runs`) on every page mount and every "+" click, even when the user never sent a message. The agent run's server-side `persistSubmittedUserMessage` already creates the row idempotently the moment the user sends, so the client just adds the thread to local state. Rows now land in `chat_threads` only when there's a real conversation behind them.
+- When the saved active thread id isn't on the server AND wasn't created locally this session, the hook now drops the user on the most-recent real thread instead of leaving them on a stale composer that the server has no record of. The `newlyCreatedRef` check disambiguates: only optimistic-this-session ids stay active; ids from a previous session whose row was cleaned up get swapped out.
+
+Per-thread merge in `fetchThreads` (already shipped) keeps in-flight optimistic threads visible until the server learns about them, so the chat list still shows the user's current thread without flicker.

--- a/.changeset/composer-image-preview-lightbox.md
+++ b/.changeset/composer-image-preview-lightbox.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Click an attached image in the prompt composer to open a fullscreen preview (Esc or click-outside to close). The thumbnail's X button still removes the attachment.

--- a/.changeset/composer-image-preview-lightbox.md
+++ b/.changeset/composer-image-preview-lightbox.md
@@ -2,4 +2,7 @@
 "@agent-native/core": patch
 ---
 
-Click an attached image in the prompt composer to open a fullscreen preview (Esc or click-outside to close). The thumbnail's X button still removes the attachment.
+Two small UI primitives:
+
+- Prompt composer: click an attached image to open a fullscreen preview (Esc / click-outside to close). The thumbnail's X button still removes.
+- Agent sidebar: new `window.dispatchEvent(new Event("agent-panel:close"))` event mirrors the existing `agent-panel:open` so apps can collapse the sidebar programmatically (used by the design template's Edit mode to free up canvas space).

--- a/.changeset/core-stale-run-friendly-replay.md
+++ b/.changeset/core-stale-run-friendly-replay.md
@@ -1,5 +1,0 @@
----
-"@agent-native/core": patch
----
-
-fix(agent): SSE reconnects to a run that's marked `errored` in SQL but has no terminal event in the event stream now replay the same friendly stale-run message reapers send (`"The agent stopped before it could finish…"`) instead of a bare `run_terminal_event_missing` debug string. The terminal event is also persisted idempotently via the new `ensureTerminalRunEvent` helper, so future reconnects replay it from SQL on the normal path rather than regenerating it.

--- a/.changeset/core-stale-run-friendly-replay.md
+++ b/.changeset/core-stale-run-friendly-replay.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+fix(agent): SSE reconnects to a run that's marked `errored` in SQL but has no terminal event in the event stream now replay the same friendly stale-run message reapers send (`"The agent stopped before it could finish…"`) instead of a bare `run_terminal_event_missing` debug string. The terminal event is also persisted idempotently via the new `ensureTerminalRunEvent` helper, so future reconnects replay it from SQL on the normal path rather than regenerating it.

--- a/.changeset/dispatch-skeleton-loading-states.md
+++ b/.changeset/dispatch-skeleton-loading-states.md
@@ -1,0 +1,16 @@
+---
+"@agent-native/dispatch": patch
+---
+
+fix(dispatch): replace inline "Loading..." text with skeleton placeholders
+
+Six dispatch loading states were rendering the literal string "Loading..." (or "Loading…", "Loading app status...") instead of skeleton placeholders. This made the UI feel cheap and inconsistent with the rest of the framework.
+
+Now using `<Skeleton>` placeholders shaped like the content that's about to render in:
+
+- `approval.tsx` — full-page approval preview card (was: centered "Loading...")
+- `overview.tsx` — Recent activity list under Operations detail (was: small "Loading..." next to the section header)
+- `vault.tsx` — Secrets tab count badge and the empty list area (was: inline "Loading...")
+- `workspace.tsx` — Workspace Resources count and tab list area (was: inline "Loading...")
+- `apps.$appId.tsx` — Workspace app detail card (was: "Loading app status...")
+- `app-keys-popover.tsx` — App-keys grant popover list (was: "Loading…")

--- a/.changeset/dispatch-skeleton-loading-states.md
+++ b/.changeset/dispatch-skeleton-loading-states.md
@@ -2,7 +2,7 @@
 "@agent-native/dispatch": patch
 ---
 
-fix(dispatch): replace inline "Loading..." text with skeleton placeholders
+fix(dispatch): replace inline "Loading..." with skeletons + stop `/dispatch/dispatch` redirect loop
 
 Six dispatch loading states were rendering the literal string "Loading..." (or "Loading…", "Loading app status...") instead of skeleton placeholders. This made the UI feel cheap and inconsistent with the rest of the framework.
 
@@ -14,3 +14,5 @@ Now using `<Skeleton>` placeholders shaped like the content that's about to rend
 - `workspace.tsx` — Workspace Resources count and tab list area (was: inline "Loading...")
 - `apps.$appId.tsx` — Workspace app detail card (was: "Loading app status...")
 - `app-keys-popover.tsx` — App-keys grant popover list (was: "Loading…")
+
+Also fixes a redirect loop on `/dispatch/dispatch` (the catch-all hit when something tries to navigate to dispatch from inside dispatch). The catch-all loader resolved the dispatch entry from the workspace manifest and redirected to `app.path` (`/dispatch`), but `useActionQuery`'s 2s poll re-fired the `window.location.assign(href)` effect each tick, leaving the page stuck on a "Loading…" state with the URL refreshing forever. Both `loader` and the new `clientLoader` now short-circuit to `appPath("/overview")` when `appId === "dispatch"`, and the component renders `<Navigate replace>` for the same case so SPA navigations resolve immediately.

--- a/.changeset/run-terminal-event-missing-friendly.md
+++ b/.changeset/run-terminal-event-missing-friendly.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Agent SSE reconnect: replace the cryptic `run_terminal_event_missing` error with the friendlier stale-run message, and persist it back to SQL so future reconnects replay the proper terminal event instead of regenerating it. This path triggers when an `agent_runs` row was flipped to `errored` but the terminal event write was lost (e.g. a reaper's `appendTerminalRunEvent(...).catch(() => {})` swallowed a transient DB error). The user-facing situation is identical to a stale-run reap, so the UI now shows "The agent stopped before it could finish" with `recoverable: true` (offering retry) instead of the debug-string error.

--- a/packages/core/src/agent/run-manager.spec.ts
+++ b/packages/core/src/agent/run-manager.spec.ts
@@ -15,6 +15,16 @@ vi.mock("./run-store.js", () => ({
   updateRunHeartbeat: vi.fn(() => Promise.resolve()),
   bumpRunProgress: vi.fn(() => Promise.resolve()),
   reapIfStale: vi.fn(() => Promise.resolve(null)),
+  ensureTerminalRunEvent: vi.fn(() => Promise.resolve()),
+  STALE_RUN_ERROR_EVENT: {
+    type: "error",
+    error:
+      "The agent stopped before it could finish. It may have hit a server timeout or the worker may have been interrupted.",
+    errorCode: "stale_run",
+    recoverable: true,
+    details:
+      "The run heartbeat stopped while the run was still marked running. Partial output and tool calls were preserved when available.",
+  },
 }));
 
 import {
@@ -37,6 +47,7 @@ import {
   getRunEventsSince,
   markRunAborted,
   updateRunStatus,
+  ensureTerminalRunEvent,
 } from "./run-store.js";
 import { registerErrorCaptureProvider } from "../server/capture-error.js";
 
@@ -710,7 +721,7 @@ describe("run manager soft timeout", () => {
     });
   });
 
-  it("synthesizes an explicit error for errored SQL runs missing terminal events", async () => {
+  it("synthesizes a friendly stale-run error for errored SQL runs missing terminal events and heals SQL", async () => {
     vi.mocked(getRunById).mockResolvedValue({
       id: "run-sql-errored",
       threadId: "thread-sql-errored",
@@ -718,6 +729,7 @@ describe("run manager soft timeout", () => {
       startedAt: Date.now(),
     });
     vi.mocked(getRunEventsSince).mockResolvedValue([]);
+    vi.mocked(ensureTerminalRunEvent).mockClear();
 
     const stream = subscribeToRun("run-sql-errored", 0);
     expect(stream).not.toBeNull();
@@ -733,6 +745,41 @@ describe("run manager soft timeout", () => {
 
     const output = chunks.join("");
     expect(output).toContain('"type":"error"');
-    expect(output).toContain('"errorCode":"run_terminal_event_missing"');
+    expect(output).toContain('"errorCode":"stale_run"');
+    expect(output).toContain('"recoverable":true');
+    // Self-heal: persist the synthesized terminal event back to SQL so future
+    // reconnects replay it normally instead of regenerating it each time.
+    expect(ensureTerminalRunEvent).toHaveBeenCalledWith(
+      "run-sql-errored",
+      expect.objectContaining({ errorCode: "stale_run" }),
+    );
+  });
+
+  it("still streams the synthesized stale-run error when persistence to SQL fails", async () => {
+    vi.mocked(getRunById).mockResolvedValue({
+      id: "run-sql-errored-persist-fail",
+      threadId: "thread-persist-fail",
+      status: "errored",
+      startedAt: Date.now(),
+    });
+    vi.mocked(getRunEventsSince).mockResolvedValue([]);
+    vi.mocked(ensureTerminalRunEvent).mockRejectedValueOnce(
+      new Error("DB unavailable"),
+    );
+
+    const stream = subscribeToRun("run-sql-errored-persist-fail", 0);
+    expect(stream).not.toBeNull();
+    const reader = stream!.getReader();
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+
+    for (let i = 0; i < 5; i++) {
+      const next = await reader.read();
+      if (next.done) break;
+      chunks.push(decoder.decode(next.value));
+    }
+
+    const output = chunks.join("");
+    expect(output).toContain('"errorCode":"stale_run"');
   });
 });

--- a/packages/core/src/agent/run-manager.ts
+++ b/packages/core/src/agent/run-manager.ts
@@ -14,6 +14,8 @@ import {
   updateRunHeartbeat,
   bumpRunProgress,
   reapIfStale,
+  ensureTerminalRunEvent,
+  STALE_RUN_ERROR_EVENT,
 } from "./run-store.js";
 
 export interface ActiveRun {
@@ -668,16 +670,23 @@ function subscribeFromSQL(
                   return;
                 }
               } else if (run?.status === "errored") {
+                // The run row was flipped to `errored` but no terminal event
+                // was ever persisted — almost always means a reaper's silent
+                // `appendTerminalRunEvent(...).catch(() => {})` swallowed a
+                // transient DB error, so the user-facing situation is the
+                // same as a stale-run reap. Send the friendly event AND try
+                // to persist it so future reconnects replay it from SQL
+                // rather than regenerating it (the user used to see a bare
+                // "run_terminal_event_missing" debug string here).
+                await ensureTerminalRunEvent(
+                  runId,
+                  STALE_RUN_ERROR_EVENT,
+                ).catch(() => {});
                 try {
                   controller.enqueue(
                     encoder.encode(
                       `data: ${JSON.stringify({
-                        type: "error",
-                        error:
-                          "Agent run ended before its final error event was persisted.",
-                        errorCode: "run_terminal_event_missing",
-                        details:
-                          "The persisted run status is errored, but no terminal SSE event was available during reconnect.",
+                        ...STALE_RUN_ERROR_EVENT,
                         seq: lastSeq,
                       })}\n\n`,
                     ),

--- a/packages/core/src/agent/run-store.spec.ts
+++ b/packages/core/src/agent/run-store.spec.ts
@@ -7,6 +7,8 @@ interface ExecCall {
 
 const execCalls: ExecCall[] = [];
 let latestEventRows: Array<{ seq: number; event_data: string }> = [];
+let staleSelectRows: Array<{ id: string }> = [];
+let insertEventBehavior: () => void = () => {};
 
 const mockDb = {
   execute: vi.fn(async (sql: string | { sql: string; args?: unknown[] }) => {
@@ -17,6 +19,13 @@ const mockDb = {
     if (/SELECT seq, event_data FROM agent_run_events/i.test(rawSql)) {
       return { rows: latestEventRows, rowsAffected: 0 };
     }
+    if (/SELECT id FROM agent_runs[\s\S]*status = 'running'/i.test(rawSql)) {
+      return { rows: staleSelectRows, rowsAffected: 0 };
+    }
+    if (/INSERT INTO agent_run_events/i.test(rawSql)) {
+      insertEventBehavior();
+      return { rows: [], rowsAffected: 1 };
+    }
 
     return {
       rows: [],
@@ -25,18 +34,27 @@ const mockDb = {
   }),
 };
 
+const mockCaptureError = vi.fn();
+
 vi.mock("../db/client.js", () => ({
   getDbExec: () => mockDb,
   intType: () => "INTEGER",
   isPostgres: () => false,
 }));
 
-const { markRunAborted } = await import("./run-store.js");
+vi.mock("../server/capture-error.js", () => ({
+  captureError: mockCaptureError,
+}));
+
+const { markRunAborted, reapIfStale, cleanupOldRuns } =
+  await import("./run-store.js");
 
 describe("run store", () => {
   beforeEach(() => {
     execCalls.length = 0;
     latestEventRows = [];
+    staleSelectRows = [];
+    insertEventBehavior = () => {};
     vi.clearAllMocks();
   });
 
@@ -72,5 +90,67 @@ describe("run store", () => {
       /INSERT INTO agent_run_events/i.test(call.sql),
     );
     expect(eventInserts).toHaveLength(0);
+  });
+
+  it("retries a failed terminal-event insert before giving up", async () => {
+    let attempts = 0;
+    insertEventBehavior = () => {
+      attempts++;
+      if (attempts === 1) throw new Error("transient SQL blip");
+    };
+
+    await markRunAborted("run-retry-success");
+
+    expect(attempts).toBe(2);
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+
+  it("captures to Sentry when the terminal-event retry also fails", async () => {
+    insertEventBehavior = () => {
+      throw new Error("DB unavailable");
+    };
+
+    await markRunAborted("run-retry-fail");
+
+    expect(mockCaptureError).toHaveBeenCalledTimes(1);
+    const [err, ctx] = mockCaptureError.mock.calls[0];
+    expect((err as Error).message).toBe("DB unavailable");
+    expect(ctx?.tags?.operation).toBe("append-terminal-event");
+    expect(ctx?.tags?.source).toBe("mark-aborted");
+    expect(ctx?.extra?.runId).toBe("run-retry-fail");
+  });
+
+  it("appends a terminal event for runs reaped by reapIfStale", async () => {
+    await reapIfStale("run-stale");
+
+    const insert = execCalls.find((call) =>
+      /INSERT INTO agent_run_events/i.test(call.sql),
+    );
+    expect(insert?.args[0]).toBe("run-stale");
+    const eventJson = insert?.args[2] as string;
+    expect(eventJson).toContain('"errorCode":"stale_run"');
+  });
+
+  it("cleanupOldRuns SELECTs both heartbeat-stale AND age-stale rows for terminal-event append", async () => {
+    staleSelectRows = [{ id: "old-but-heartbeating-run" }];
+
+    await cleanupOldRuns(24 * 60 * 60 * 1000);
+
+    // The broadened SELECT — both predicates in one query — is what catches
+    // a 24h-old row whose heartbeat somehow stayed fresh. The older
+    // heartbeat-only SELECT would have left it without a terminal event.
+    const select = execCalls.find(
+      (call) =>
+        /SELECT id FROM agent_runs/i.test(call.sql) &&
+        /COALESCE\(heartbeat_at, started_at\) < \?/.test(call.sql) &&
+        /OR started_at < \?/.test(call.sql),
+    );
+    expect(select).toBeDefined();
+
+    const insert = execCalls.find((call) =>
+      /INSERT INTO agent_run_events/i.test(call.sql),
+    );
+    expect(insert?.args[0]).toBe("old-but-heartbeating-run");
+    expect(insert?.args[2] as string).toContain('"errorCode":"stale_run"');
   });
 });

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -15,7 +15,7 @@ let _initPromise: Promise<void> | undefined;
  */
 export const RUN_STALE_MS = 6_000;
 
-const STALE_RUN_ERROR_EVENT = {
+export const STALE_RUN_ERROR_EVENT = {
   type: "error",
   error:
     "The agent stopped before it could finish. It may have hit a server timeout or the worker may have been interrupted.",
@@ -385,6 +385,23 @@ export async function cleanupOldRuns(olderThanMs: number): Promise<void> {
     sql: `DELETE FROM agent_runs WHERE status != 'running' AND completed_at < ?`,
     args: [cutoff],
   });
+}
+
+/**
+ * Idempotently append a terminal event to a run's event stream. No-op if the
+ * stream already ends in a terminal event. Used by reapers AND by SSE
+ * reconnect paths that discover an `errored` run row with no terminal event
+ * (e.g. an earlier reaper's silent `.catch(() => {})` swallowed the append).
+ *
+ * Persisting from the reconnect path is what keeps the system self-healing:
+ * subsequent reconnects replay the proper terminal event from SQL instead of
+ * synthesizing a fresh one each time.
+ */
+export async function ensureTerminalRunEvent(
+  runId: string,
+  event: Record<string, unknown>,
+): Promise<void> {
+  return appendTerminalRunEvent(runId, event);
 }
 
 async function appendTerminalRunEvent(

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -4,6 +4,7 @@
  * reliable reconnection after page refreshes.
  */
 import { getDbExec, intType, isPostgres } from "../db/client.js";
+import { captureError } from "../server/capture-error.js";
 
 let _initPromise: Promise<void> | undefined;
 
@@ -154,7 +155,11 @@ export async function reapIfStale(
   });
   const reaped = (rowsAffected ?? 0) > 0;
   if (reaped) {
-    await appendTerminalRunEvent(runId, STALE_RUN_ERROR_EVENT).catch(() => {});
+    await safeAppendTerminalRunEvent(
+      runId,
+      STALE_RUN_ERROR_EVENT,
+      "reap-if-stale",
+    );
   }
   return reaped;
 }
@@ -181,7 +186,7 @@ export async function markRunAborted(
     sql: `UPDATE agent_runs SET status = 'aborted', abort_reason = ?, completed_at = ? WHERE id = ?`,
     args: [reason ?? "user", Date.now(), runId],
   });
-  await appendTerminalRunEvent(runId, { type: "done" }).catch(() => {});
+  await safeAppendTerminalRunEvent(runId, { type: "done" }, "mark-aborted");
 }
 
 export async function isRunAborted(runId: string): Promise<boolean> {
@@ -334,7 +339,11 @@ export async function reapAllStaleRuns(): Promise<number> {
   for (const row of stale.rows) {
     const id = (row as { id?: unknown }).id;
     if (typeof id === "string") {
-      await appendTerminalRunEvent(id, STALE_RUN_ERROR_EVENT).catch(() => {});
+      await safeAppendTerminalRunEvent(
+        id,
+        STALE_RUN_ERROR_EVENT,
+        "reap-all-stale",
+      );
     }
   }
   return rowsAffected ?? 0;
@@ -348,13 +357,19 @@ export async function cleanupOldRuns(olderThanMs: number): Promise<void> {
   const client = getDbExec();
   const cutoff = Date.now() - olderThanMs;
   // Expire stale running rows on the absolute-age threshold — safety net
-  // for runs that never received a heartbeat (very old deployments).
+  // for runs that never received a heartbeat (very old deployments). The
+  // SELECT covers BOTH UPDATE conditions so the terminal-event-append loop
+  // below catches every row we're about to flip — a 24h-old row with a
+  // somehow-fresh heartbeat would slip past a heartbeat-only SELECT.
   const heartbeatCutoff = Date.now() - RUN_STALE_MS;
   const stale = await client.execute({
     sql: `SELECT id FROM agent_runs
           WHERE status = 'running'
-            AND COALESCE(heartbeat_at, started_at) < ?`,
-    args: [heartbeatCutoff],
+            AND (
+              COALESCE(heartbeat_at, started_at) < ?
+              OR started_at < ?
+            )`,
+    args: [heartbeatCutoff, cutoff],
   });
   await client.execute({
     sql: `UPDATE agent_runs SET status = 'errored', completed_at = ? WHERE status = 'running' AND started_at < ?`,
@@ -371,7 +386,11 @@ export async function cleanupOldRuns(olderThanMs: number): Promise<void> {
   for (const row of stale.rows) {
     const id = (row as { id?: unknown }).id;
     if (typeof id === "string") {
-      await appendTerminalRunEvent(id, STALE_RUN_ERROR_EVENT).catch(() => {});
+      await safeAppendTerminalRunEvent(
+        id,
+        STALE_RUN_ERROR_EVENT,
+        "cleanup-old-runs",
+      );
     }
   }
   // Delete events for old non-running runs
@@ -402,6 +421,50 @@ export async function ensureTerminalRunEvent(
   event: Record<string, unknown>,
 ): Promise<void> {
   return appendTerminalRunEvent(runId, event);
+}
+
+/**
+ * Append a terminal run event, retrying once on failure and reporting to
+ * Sentry if both attempts fail. Background reaper paths can't surface errors
+ * to a user, but they MUST eventually persist a terminal event — losing it
+ * leaves reconnecting clients staring at a bare `status='errored'` row with
+ * no payload to render. The previous `.catch(() => {})` callsites silently
+ * dropped transient SQL blips and produced exactly that bug. Never throws.
+ */
+async function safeAppendTerminalRunEvent(
+  runId: string,
+  event: Record<string, unknown>,
+  source: string,
+): Promise<void> {
+  let firstError: unknown;
+  try {
+    await appendTerminalRunEvent(runId, event);
+    return;
+  } catch (err) {
+    firstError = err;
+  }
+  // Brief backoff — most "transient" SQL failures (connection blip, lock
+  // contention) clear within a couple hundred ms.
+  await new Promise<void>((resolve) => setTimeout(resolve, 100));
+  try {
+    await appendTerminalRunEvent(runId, event);
+  } catch (retryErr) {
+    captureError(retryErr, {
+      tags: {
+        component: "agent-run-store",
+        operation: "append-terminal-event",
+        source,
+      },
+      extra: {
+        runId,
+        eventType: typeof event.type === "string" ? event.type : "(unknown)",
+        firstError:
+          firstError instanceof Error
+            ? firstError.message
+            : String(firstError),
+      },
+    });
+  }
 }
 
 async function appendTerminalRunEvent(

--- a/packages/core/src/agent/run-store.ts
+++ b/packages/core/src/agent/run-store.ts
@@ -459,9 +459,7 @@ async function safeAppendTerminalRunEvent(
         runId,
         eventType: typeof event.type === "string" ? event.type : "(unknown)",
         firstError:
-          firstError instanceof Error
-            ? firstError.message
-            : String(firstError),
+          firstError instanceof Error ? firstError.message : String(firstError),
       },
     });
   }

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1798,11 +1798,23 @@ export function AgentSidebar({
         setOpenPersisted(true);
       }
     };
+    const closeHandler = () => {
+      if (frameCodeMode && window.parent !== window) {
+        window.parent.postMessage(
+          { type: "agentNative.toggleSidebar", data: { open: false } },
+          parentFrameTargetOrigin(),
+        );
+      } else {
+        setOpenPersisted(false);
+      }
+    };
     window.addEventListener("agent-panel:toggle", toggleHandler);
     window.addEventListener("agent-panel:open", openHandler);
+    window.addEventListener("agent-panel:close", closeHandler);
     return () => {
       window.removeEventListener("agent-panel:toggle", toggleHandler);
       window.removeEventListener("agent-panel:open", openHandler);
+      window.removeEventListener("agent-panel:close", closeHandler);
     };
   }, [setOpenPersisted, frameCodeMode]);
 

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -149,12 +149,14 @@ function ChatSkeleton({
 function HistoryPopover({
   threads,
   openTabIds,
+  activeThreadId,
   onSelect,
   onClose,
   onSearch,
 }: {
   threads: ChatThreadSummary[];
   openTabIds: Set<string>;
+  activeThreadId: string | null;
   onSelect: (id: string) => void;
   onClose: () => void;
   onSearch?: (query: string) => Promise<ChatThreadSummary[]>;
@@ -208,10 +210,18 @@ function HistoryPopover({
     };
   }, [search, onSearch]);
 
-  const visibleThreads = threads.filter((t) => t.messageCount > 0);
+  // Hide empty threads from the history list — except the currently-active
+  // one. The active thread always belongs in the list so the user can see
+  // they're in it (the previous filter dropped a brand-new chat the user
+  // had just opened, making them think their chat had vanished).
+  const visibleThreads = threads.filter(
+    (t) => t.messageCount > 0 || t.id === activeThreadId,
+  );
 
   const filtered = search.trim()
-    ? (searchResults ?? visibleThreads).filter((t) => t.messageCount > 0)
+    ? (searchResults ?? visibleThreads).filter(
+        (t) => t.messageCount > 0 || t.id === activeThreadId,
+      )
     : visibleThreads;
 
   const formatTime = (ts: number) => {
@@ -251,32 +261,40 @@ function HistoryPopover({
               {search ? "No matching chats" : "No chats yet"}
             </div>
           ) : (
-            filtered.map((thread) => (
-              <button
-                key={thread.id}
-                onClick={() => {
-                  onSelect(thread.id);
-                  onClose();
-                }}
-                className="w-full px-3 py-2 text-left hover:bg-accent/50"
-              >
-                <div className="flex items-baseline justify-between gap-2">
-                  <span className="text-xs font-medium text-foreground truncate">
-                    {thread.title || thread.preview || "Chat"}
-                  </span>
-                  <span className="text-[10px] text-muted-foreground shrink-0">
-                    {openTabIds.has(thread.id)
-                      ? "Open"
-                      : formatTime(thread.updatedAt)}
-                  </span>
-                </div>
-                {thread.preview && thread.title !== thread.preview && (
-                  <div className="text-[11px] text-muted-foreground truncate mt-0.5">
-                    {thread.preview}
+            filtered.map((thread) => {
+              const isActive = thread.id === activeThreadId;
+              return (
+                <button
+                  key={thread.id}
+                  onClick={() => {
+                    onSelect(thread.id);
+                    onClose();
+                  }}
+                  className={cn(
+                    "w-full px-3 py-2 text-left hover:bg-accent/50",
+                    isActive && "bg-accent/30",
+                  )}
+                >
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="text-xs font-medium text-foreground truncate">
+                      {thread.title || thread.preview || "Chat"}
+                    </span>
+                    <span className="text-[10px] text-muted-foreground shrink-0">
+                      {isActive
+                        ? "Active"
+                        : openTabIds.has(thread.id)
+                          ? "Open"
+                          : formatTime(thread.updatedAt)}
+                    </span>
                   </div>
-                )}
-              </button>
-            ))
+                  {thread.preview && thread.title !== thread.preview && (
+                    <div className="text-[11px] text-muted-foreground truncate mt-0.5">
+                      {thread.preview}
+                    </div>
+                  )}
+                </button>
+              );
+            })
           )}
         </div>
       </div>
@@ -1522,6 +1540,7 @@ export function MultiTabAssistantChat({
           <HistoryPopover
             threads={threads}
             openTabIds={new Set(openTabIds)}
+            activeThreadId={activeThreadId}
             onSelect={openFromHistory}
             onClose={() => setShowHistory(false)}
             onSearch={searchThreads}

--- a/packages/core/src/client/composer/PromptComposer.tsx
+++ b/packages/core/src/client/composer/PromptComposer.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, type Ref } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Ref,
+} from "react";
 import {
   AssistantRuntimeProvider,
   ComposerPrimitive,
@@ -149,6 +156,52 @@ function getImageSrc(attachment: Attachment): string | null {
   return imagePart && "image" in imagePart ? imagePart.image : null;
 }
 
+function ImagePreviewLightbox({
+  src,
+  alt,
+  onClose,
+}: {
+  src: string;
+  alt: string;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handler);
+      document.body.style.overflow = "";
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Image preview"
+      onClick={onClose}
+      className="fixed inset-0 z-[300] flex items-center justify-center bg-black/80 p-6 cursor-zoom-out"
+    >
+      <img
+        src={src}
+        alt={alt}
+        onClick={(e) => e.stopPropagation()}
+        className="max-h-full max-w-full object-contain rounded-md shadow-2xl cursor-default"
+      />
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close preview"
+        className="absolute right-4 top-4 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border border-white/30 bg-black/40 text-white hover:bg-black/60"
+      >
+        <IconX className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
 function AttachmentChip({
   attachment,
   onRemove,
@@ -157,6 +210,7 @@ function AttachmentChip({
   onRemove: (id: string) => void;
 }) {
   const src = useMemo(() => getImageSrc(attachment), [attachment]);
+  const [previewOpen, setPreviewOpen] = useState(false);
   useEffect(
     () => () => {
       if (src?.startsWith("blob:")) URL.revokeObjectURL(src);
@@ -170,21 +224,46 @@ function AttachmentChip({
 
   if (src) {
     return (
-      <div className="group relative flex h-16 min-w-16 max-w-28 items-center justify-center overflow-hidden rounded-lg border border-border/70 bg-muted/50">
-        <img
-          src={src}
-          alt={attachment.name}
-          className="max-h-full max-w-full object-contain p-1"
-        />
+      <>
         <button
           type="button"
-          onClick={() => onRemove(attachment.id)}
-          aria-label={`Remove ${attachment.name}`}
-          className="absolute right-1 top-1 flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border border-border/60 bg-background/90 text-muted-foreground hover:text-foreground"
+          onClick={() => setPreviewOpen(true)}
+          aria-label={`Preview ${attachment.name}`}
+          className="group relative flex h-16 min-w-16 max-w-28 cursor-zoom-in items-center justify-center overflow-hidden rounded-lg border border-border/70 bg-muted/50"
         >
-          <IconX className="h-3 w-3" />
+          <img
+            src={src}
+            alt={attachment.name}
+            className="max-h-full max-w-full object-contain p-1"
+          />
+          <span
+            role="button"
+            tabIndex={0}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove(attachment.id);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.stopPropagation();
+                onRemove(attachment.id);
+              }
+            }}
+            aria-label={`Remove ${attachment.name}`}
+            className="absolute right-1 top-1 flex h-5 w-5 cursor-pointer items-center justify-center rounded-full border border-border/60 bg-background/90 text-muted-foreground hover:text-foreground"
+          >
+            <IconX className="h-3 w-3" />
+          </span>
         </button>
-      </div>
+        {previewOpen ? (
+          <ImagePreviewLightbox
+            src={src}
+            alt={attachment.name}
+            onClose={() => setPreviewOpen(false)}
+          />
+        ) : null}
+      </>
     );
   }
 

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -74,13 +74,32 @@ export function useChatThreads(
       const data = await res.json();
       setThreads((prev) => {
         const loaded = (data.threads ?? []) as ChatThreadSummary[];
+        const loadedIds = new Set(loaded.map((t) => t.id));
         // Preserve any optimistic threads we've created this session that
         // haven't shown up in the server list yet (POST still in-flight).
-        const loadedIds = new Set(loaded.map((t) => t.id));
         const optimisticOnly = prev.filter(
           (t) => newlyCreatedRef.current.has(t.id) && !loadedIds.has(t.id),
         );
-        return [...optimisticOnly, ...loaded];
+        // Reconcile each server thread against our local copy. If the local
+        // copy has a newer updatedAt or higher messageCount, keep those
+        // fields — the server probably hasn't observed the user's latest
+        // send yet, and naively replacing makes the recent-chats list
+        // visibly jump back to older timestamps right after a send.
+        const merged = loaded.map((server) => {
+          const local = prev.find((t) => t.id === server.id);
+          if (!local) return server;
+          const next = { ...server };
+          if (local.updatedAt > server.updatedAt) {
+            next.updatedAt = local.updatedAt;
+          }
+          if (local.messageCount > server.messageCount) {
+            next.messageCount = local.messageCount;
+            if (local.preview) next.preview = local.preview;
+            if (local.title) next.title = local.title;
+          }
+          return next;
+        });
+        return [...optimisticOnly, ...merged];
       });
       return data.threads as ChatThreadSummary[];
     } catch {

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -33,16 +33,19 @@ export function useChatThreads(
   const [threads, setThreads] = useState<ChatThreadSummary[]>([]);
 
   // IDs we generated client-side this session — consumers use this to know
-  // whether to skip the per-thread restore skeleton. Tracked by ref instead
-  // of state because the consumer reads it inside the render path and we
-  // never need to re-render when the set changes.
+  // whether to skip the per-thread restore skeleton, and we use it to
+  // protect the optimistic-only thread from being yanked out of local
+  // state when the server's threads list (which never sees it) loads.
   const newlyCreatedRef = useRef<Set<string>>(new Set());
 
   // Restore the saved active thread synchronously on mount so the chat shell
   // can paint immediately. We do NOT synthesize a fresh UUID here when no
-  // saved id exists — that races with the agent run's server-side thread
-  // create and was producing ghost threads that disappeared from history.
-  // First-time users see the brief loading state while threads load.
+  // saved id exists — that flow was creating empty `chat_threads` rows on
+  // every page load via the optimistic POST, even if the user never chatted.
+  // (Steve's account had 127 threads; 112 had message_count=0 and zero
+  // agent_runs — pure ghosts.) When localStorage is empty, the initial
+  // useEffect picks the most-recent server thread, or synthesizes a brand
+  // new id only when there are no server threads at all.
   const [activeThreadId, setActiveThreadId] = useState<string | null>(() => {
     if (typeof window === "undefined") return null;
     try {
@@ -76,7 +79,9 @@ export function useChatThreads(
         const loaded = (data.threads ?? []) as ChatThreadSummary[];
         const loadedIds = new Set(loaded.map((t) => t.id));
         // Preserve any optimistic threads we've created this session that
-        // haven't shown up in the server list yet (POST still in-flight).
+        // haven't shown up in the server list yet — the server only learns
+        // about a thread when the user actually sends a message and the
+        // agent run's `persistSubmittedUserMessage` writes the row.
         const optimisticOnly = prev.filter(
           (t) => newlyCreatedRef.current.has(t.id) && !loadedIds.has(t.id),
         );
@@ -107,53 +112,39 @@ export function useChatThreads(
     }
   }, [apiUrl]);
 
-  // Persist a client-generated thread to the server in the background.
-  // Optimistically adds it to the local thread list so callers can render
-  // immediately. POST /threads is idempotent server-side (returns the
-  // existing thread on UNIQUE conflict instead of 500), so client retries
-  // and races with the agent run's `persistSubmittedUserMessage` no longer
-  // wipe a freshly-created thread out of local state.
-  const persistNewThread = useCallback(
-    (id: string) => {
-      const now = Date.now();
-      const optimistic: ChatThreadSummary = {
-        id,
-        title: "",
-        preview: "",
-        messageCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      };
-      setThreads((prev) =>
-        prev.some((t) => t.id === id) ? prev : [optimistic, ...prev],
-      );
-      fetch(`${apiUrl}/threads`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id }),
-      })
-        .then(async (res) => {
-          if (!res.ok) return;
-          const created = (await res
-            .json()
-            .catch(() => null)) as ChatThreadSummary | null;
-          if (!created) return;
-          setThreads((prev) =>
-            prev.map((thread) => (thread.id === id ? created : thread)),
-          );
-        })
-        .catch(() => {
-          // Network blip — keep the optimistic row and let the next
-          // fetchThreads reconcile. Don't yank the thread out of local
-          // state: the agent's onRunPrepared will (idempotently) create
-          // it server-side anyway and we don't want to drop the user's
-          // active conversation just because POST /threads was flaky.
-        });
-    },
-    [apiUrl],
-  );
+  // Add a client-generated thread to the local list optimistically.
+  //
+  // Critically, this does NOT `POST /threads` to the server — that path was
+  // creating an empty row in `chat_threads` (message_count=0, no
+  // agent_runs) on every page mount and every "+" click. The server
+  // already creates the row idempotently the moment the user actually
+  // sends their first message (`persistSubmittedUserMessage` →
+  // `createThread`), so the client doesn't need to pre-create it. This
+  // makes the threads table reflect real conversations only.
+  const addOptimisticThread = useCallback((id: string) => {
+    const now = Date.now();
+    const optimistic: ChatThreadSummary = {
+      id,
+      title: "",
+      preview: "",
+      messageCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    setThreads((prev) =>
+      prev.some((t) => t.id === id) ? prev : [optimistic, ...prev],
+    );
+  }, []);
 
-  // Initial load.
+  // Initial load: load threads from server. If the saved active thread
+  // exists on the server (or was just created client-side this session),
+  // keep it. If localStorage points at a thread the server doesn't know
+  // about and we didn't create it locally this session, the saved id is
+  // either a stale ghost or an in-flight thread the server hasn't observed
+  // yet — we still keep it (don't auto-swap to most-recent), because
+  // swapping mid-conversation is exactly the "reverts to a chat from an
+  // hour ago" symptom users were reporting. Once the user sends a message,
+  // the server creates the row and the next refresh reconciles.
   useEffect(() => {
     if (fetchedRef.current) return;
     fetchedRef.current = true;
@@ -162,41 +153,40 @@ export function useChatThreads(
       setIsLoading(true);
       const loadedThreads = await fetchThreads();
 
-      if (loadedThreads && loadedThreads.length > 0) {
-        const savedId = activeThreadIdRef.current;
-        // If the saved active thread isn't on the server, fall back to the
-        // most recent so the user lands on real history instead of a ghost.
-        if (!savedId || !loadedThreads.find((t) => t.id === savedId)) {
+      const savedId = activeThreadIdRef.current;
+      if (!savedId) {
+        if (loadedThreads && loadedThreads.length > 0) {
+          // First-ever session for this user (no saved id) but they have
+          // existing chats — drop them on the most recent.
           setActiveThreadId(loadedThreads[0].id);
-        }
-      } else if (!activeThreadIdRef.current) {
-        // No threads on server and no saved active id — create a fresh one
-        // so the composer has something to send into. This matches the
-        // pre-instant-paint behavior.
-        try {
-          const res = await fetch(`${apiUrl}/threads`, { method: "POST" });
-          if (res.ok) {
-            const thread = (await res.json()) as ChatThreadSummary;
-            newlyCreatedRef.current.add(thread.id);
-            setThreads([thread]);
-            setActiveThreadId(thread.id);
+        } else {
+          // Brand new — synthesize a local id so the composer has a target.
+          // No POST: the server will create the row when the user sends.
+          if (typeof crypto !== "undefined" && crypto.randomUUID) {
+            const id = crypto.randomUUID();
+            newlyCreatedRef.current.add(id);
+            addOptimisticThread(id);
+            setActiveThreadId(id);
           }
-        } catch {}
+        }
       }
       setIsLoading(false);
     })();
-  }, [fetchThreads, apiUrl]);
+  }, [fetchThreads, addOptimisticThread]);
 
   const createThread = useCallback(
     (preferredId?: string): Promise<string | null> => {
-      // Generate ID client-side for instant UI response
+      // Generate ID client-side for instant UI response. No POST — the
+      // server creates the row when the user actually sends a message,
+      // which prevents accumulation of empty thread rows when the user
+      // clicks "+" but never chats.
       const id = preferredId || crypto.randomUUID();
       newlyCreatedRef.current.add(id);
+      addOptimisticThread(id);
       setActiveThreadId(id);
-      persistNewThread(id);
       return Promise.resolve(id);
     },
-    [persistNewThread],
+    [addOptimisticThread],
   );
 
   const isNewThread = useCallback(
@@ -248,22 +238,40 @@ export function useChatThreads(
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(data),
         });
-        // Update local thread list metadata
-        setThreads((prev) =>
-          prev.map((t) =>
-            t.id === id
-              ? {
-                  ...t,
-                  title: data.title,
-                  preview: data.preview,
-                  ...(data.messageCount != null && {
-                    messageCount: data.messageCount,
-                  }),
-                  updatedAt: Date.now(),
-                }
-              : t,
-          ),
-        );
+        // Update local thread list metadata. If the thread isn't in our
+        // local list yet (an optimistic-only thread that the server just
+        // created via persistSubmittedUserMessage), add it so HistoryPopover
+        // can show it once it has messages.
+        setThreads((prev) => {
+          const exists = prev.some((t) => t.id === id);
+          if (exists) {
+            return prev.map((t) =>
+              t.id === id
+                ? {
+                    ...t,
+                    title: data.title,
+                    preview: data.preview,
+                    ...(data.messageCount != null && {
+                      messageCount: data.messageCount,
+                    }),
+                    updatedAt: Date.now(),
+                  }
+                : t,
+            );
+          }
+          const now = Date.now();
+          return [
+            {
+              id,
+              title: data.title,
+              preview: data.preview,
+              messageCount: data.messageCount ?? 0,
+              createdAt: now,
+              updatedAt: now,
+            },
+            ...prev,
+          ];
+        });
       } catch {}
     },
     [apiUrl],

--- a/packages/core/src/client/use-chat-threads.ts
+++ b/packages/core/src/client/use-chat-threads.ts
@@ -136,15 +136,20 @@ export function useChatThreads(
     );
   }, []);
 
-  // Initial load: load threads from server. If the saved active thread
-  // exists on the server (or was just created client-side this session),
-  // keep it. If localStorage points at a thread the server doesn't know
-  // about and we didn't create it locally this session, the saved id is
-  // either a stale ghost or an in-flight thread the server hasn't observed
-  // yet — we still keep it (don't auto-swap to most-recent), because
-  // swapping mid-conversation is exactly the "reverts to a chat from an
-  // hour ago" symptom users were reporting. Once the user sends a message,
-  // the server creates the row and the next refresh reconciles.
+  // Initial load: load threads from server, then reconcile against the
+  // saved active thread.
+  //
+  // - savedId in loadedThreads → keep it (user's last conversation).
+  // - savedId in newlyCreatedRef (we just created it this session) → keep
+  //   it; the server hasn't seen it yet because there's no POST anymore,
+  //   the row gets written when the user sends a message.
+  // - savedId is set but neither on the server nor newly created here →
+  //   it's a stale id from a previous session whose row no longer exists
+  //   (was a ghost cleaned up, or the user emptied their account, etc.).
+  //   Drop them on the most-recent real thread instead of leaving them
+  //   staring at a 404'd composer.
+  // - No savedId, no server threads → synthesize a fresh local id (no
+  //   POST; server creates the row on first message).
   useEffect(() => {
     if (fetchedRef.current) return;
     fetchedRef.current = true;
@@ -152,22 +157,26 @@ export function useChatThreads(
     (async () => {
       setIsLoading(true);
       const loadedThreads = await fetchThreads();
-
       const savedId = activeThreadIdRef.current;
-      if (!savedId) {
-        if (loadedThreads && loadedThreads.length > 0) {
-          // First-ever session for this user (no saved id) but they have
-          // existing chats — drop them on the most recent.
+
+      if (loadedThreads && loadedThreads.length > 0) {
+        if (
+          savedId &&
+          !newlyCreatedRef.current.has(savedId) &&
+          !loadedThreads.find((t) => t.id === savedId)
+        ) {
           setActiveThreadId(loadedThreads[0].id);
-        } else {
-          // Brand new — synthesize a local id so the composer has a target.
-          // No POST: the server will create the row when the user sends.
-          if (typeof crypto !== "undefined" && crypto.randomUUID) {
-            const id = crypto.randomUUID();
-            newlyCreatedRef.current.add(id);
-            addOptimisticThread(id);
-            setActiveThreadId(id);
-          }
+        } else if (!savedId) {
+          setActiveThreadId(loadedThreads[0].id);
+        }
+      } else if (!savedId) {
+        // Brand new user — synthesize a local id so the composer has a
+        // target. No POST: the server creates the row on first send.
+        if (typeof crypto !== "undefined" && crypto.randomUUID) {
+          const id = crypto.randomUUID();
+          newlyCreatedRef.current.add(id);
+          addOptimisticThread(id);
+          setActiveThreadId(id);
         }
       }
       setIsLoading(false);

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1157,6 +1157,38 @@ describe("server/auth", () => {
     });
   });
 
+  describe("OAuth return URLs", () => {
+    it("allows the configured local workspace gateway but rejects other absolute returns", async () => {
+      vi.stubEnv("WORKSPACE_GATEWAY_URL", "http://127.0.0.1:8080/");
+      const { safeOAuthReturnUrl } = await import("./oauth-return-url.js");
+
+      expect(safeOAuthReturnUrl("http://127.0.0.1:8080/dispatch")).toBe(
+        "http://127.0.0.1:8080/dispatch",
+      );
+      expect(safeOAuthReturnUrl("/todo")).toBe("/todo");
+      expect(safeOAuthReturnUrl("https://evil.example/todo")).toBe("/");
+      expect(safeOAuthReturnUrl("http://127.0.0.1:9090/dispatch")).toBe("/");
+    });
+
+    it("can bridge a hosted OAuth session back to the local workspace gateway", async () => {
+      vi.stubEnv("WORKSPACE_GATEWAY_URL", "http://127.0.0.1:8080/");
+      const { appendSessionToOAuthReturnUrl } =
+        await import("./oauth-return-url.js");
+
+      expect(
+        appendSessionToOAuthReturnUrl(
+          "http://127.0.0.1:8080/dispatch?builder.preview=interact",
+          "session-token",
+        ),
+      ).toBe(
+        "http://127.0.0.1:8080/dispatch?builder.preview=interact&_session=session-token",
+      );
+      expect(appendSessionToOAuthReturnUrl("/dispatch", "session-token")).toBe(
+        "/dispatch",
+      );
+    });
+  });
+
   describe("OAuth state returnUrl round-trip", () => {
     beforeEach(() => {
       vi.stubEnv("GOOGLE_CLIENT_SECRET", "test-signing-key-do-not-use");
@@ -1253,6 +1285,7 @@ describe("server/auth", () => {
       expect(html).toContain(
         'var __AN_PUBLIC_OAUTH_ORIGIN = "https://agent-workspace.builder.io";',
       );
+      expect(html).toContain('var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = "";');
       expect(html).toContain("__anStartPopupOAuth(ret, btn, err)");
       expect(html).toContain(
         "__anPath('/_agent-native/auth/desktop-exchange')",
@@ -1278,8 +1311,9 @@ describe("server/auth", () => {
       expect(html).toContain(
         "__anSetOAuthDebug('Opening Google sign-in redirect')",
       );
+      expect(html).toContain("function __anOAuthReturnTarget(ret)");
       expect(html).toContain(
-        "__anOpenOAuthUrl(__anAuthPath('/_agent-native/google/auth-url') + '?' + params.toString())",
+        "params.set('return', __anOAuthReturnTarget(ret))",
       );
       expect(html).toContain(
         "window.open('', '_blank', 'width=640,height=760')",
@@ -1305,6 +1339,9 @@ describe("server/auth", () => {
       expect(loginHtml).toContain(
         'var __AN_PUBLIC_OAUTH_ORIGIN = "https://agent-workspace.builder.io";',
       );
+      expect(loginHtml).toContain(
+        'var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = "";',
+      );
       expect(loginHtml).toContain('id="debug"');
       expect(loginHtml).toContain(
         "__anSetOAuthDebug('Google popup opened; waiting for callback', flowId)",
@@ -1316,8 +1353,9 @@ describe("server/auth", () => {
       expect(loginHtml).toContain(
         "__anSetOAuthDebug('Opening Google sign-in redirect')",
       );
+      expect(loginHtml).toContain("function __anOAuthReturnTarget(ret)");
       expect(loginHtml).toContain(
-        "__anOpenOAuthUrl(__anAuthPath('/_agent-native/google/auth-url') + '?' + params.toString())",
+        "params.set('return', __anOAuthReturnTarget(ret))",
       );
       expect(loginHtml).toContain(
         "window.open('', '_blank', 'width=640,height=760')",
@@ -1624,6 +1662,25 @@ describe("server/auth", () => {
       expect(typeof response === "string" || response === "").toBe(true);
       expect(event.res.status).toBe(302);
       expect(event.res.headers.get("Location")).toBe("/dashboard");
+    });
+
+    it("bridges hosted OAuth completion back to the local workspace gateway", async () => {
+      vi.stubEnv("WORKSPACE_GATEWAY_URL", "http://127.0.0.1:8080/");
+      const { oauthCallbackResponse } = await import("./google-oauth.js");
+      const event = createMockEvent();
+      const response = await Promise.resolve(
+        oauthCallbackResponse(event, "steve@example.com", {
+          sessionToken: "token-1",
+          returnUrl: "http://127.0.0.1:8080/dispatch",
+        }),
+      );
+
+      expect(typeof response === "string" || response === "").toBe(true);
+      expect(event.res.status).toBe(302);
+      expect(event.res.headers.get("Location")).toBe(
+        "http://127.0.0.1:8080/dispatch?_session=token-1",
+      );
+      expect(event.res.headers.get("Referrer-Policy")).toBe("no-referrer");
     });
   });
 

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -85,6 +85,7 @@ import {
   resolveOAuthRedirectUri,
   isAllowedOAuthRedirectUri,
 } from "./google-oauth.js";
+import { safeOAuthReturnUrl } from "./oauth-return-url.js";
 import { captureAuthError } from "./sentry.js";
 import { extractOAuthStateAppId } from "../shared/oauth-state.js";
 import { isValidWorkspaceAppIdFormat } from "../shared/workspace-app-id.js";
@@ -301,6 +302,15 @@ function oauthDebugUrlPath(value: unknown): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function isBuilderOAuthRequest(event: H3Event): boolean {
+  const userAgent = getHeader(event, "user-agent") || "";
+  const referer = getHeader(event, "referer") || "";
+  return (
+    /Electron/i.test(userAgent) ||
+    /builder\.(io|my)|builderio\.(xyz|dev)/i.test(referer)
+  );
 }
 
 function logGoogleOAuthDebug(
@@ -1750,7 +1760,11 @@ async function mountBetterAuthRoutes(
         // small for the common case.
         const returnQuery = q.return;
         const validated =
-          typeof returnQuery === "string" ? safeReturnPath(returnQuery) : "/";
+          typeof returnQuery === "string"
+            ? safeOAuthReturnUrl(returnQuery, {
+                allowDefaultLoopback: isBuilderOAuthRequest(event),
+              })
+            : "/";
         const returnUrl = validated !== "/" ? validated : undefined;
         const state = encodeOAuthState({
           redirectUri,

--- a/packages/core/src/server/google-auth-plugin.ts
+++ b/packages/core/src/server/google-auth-plugin.ts
@@ -1,5 +1,6 @@
 import { createAuthPlugin } from "./auth-plugin.js";
 import { getPublicOAuthOrigin } from "./oauth-public-origin.js";
+import { getWorkspaceGatewayReturnOrigin } from "./oauth-return-url.js";
 import {
   resolveGoogleAuthMode,
   type GoogleAuthMode,
@@ -20,6 +21,7 @@ export interface GoogleAuthPluginOptions {
 
 function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
   const publicOAuthOrigin = getPublicOAuthOrigin();
+  const workspaceGatewayReturnOrigin = getWorkspaceGatewayReturnOrigin();
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -100,6 +102,7 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
     return __anBasePath() + path;
   }
   var __AN_PUBLIC_OAUTH_ORIGIN = ${JSON.stringify(publicOAuthOrigin)};
+  var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = ${JSON.stringify(workspaceGatewayReturnOrigin)};
   var __AN_GOOGLE_AUTH_MODE = ${JSON.stringify(googleAuthMode)};
   function __anConfiguredOAuthOrigin() {
     if (!__AN_PUBLIC_OAUTH_ORIGIN) return '';
@@ -113,6 +116,42 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
   function __anAuthPath(path) {
     var origin = __anIsBuilderPreview() ? __anConfiguredOAuthOrigin() : '';
     return origin ? origin + path : __anPath(path);
+  }
+  function __anWorkspaceGatewayReturnOrigin() {
+    if (__AN_WORKSPACE_GATEWAY_RETURN_ORIGIN) return __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN;
+    return __anIsBuilderDesktop() ? 'http://127.0.0.1:8080' : '';
+  }
+  function __anNormalizeWorkspaceReturnPath(ret) {
+    try {
+      var url = new URL(ret || '/', window.location.origin);
+      var path = url.pathname || '/';
+      if (path === '/dispatch/dispatch') {
+        path = '/dispatch';
+      } else if (path.indexOf('/dispatch/') === 0) {
+        var rest = path.slice('/dispatch/'.length);
+        var first = rest.split('/')[0];
+        var dispatchRoutes = {
+          overview: true, apps: true, metrics: true, vault: true,
+          integrations: true, messaging: true, workspace: true,
+          agents: true, destinations: true, identities: true,
+          approvals: true, audit: true, team: true, 'thread-debug': true,
+          'new-app': true
+        };
+        if (first === 'dispatch') {
+          path = '/dispatch' + rest.slice(first.length);
+        } else if (first && !dispatchRoutes[first]) {
+          path = '/' + rest;
+        }
+      }
+      return path + url.search + url.hash;
+    } catch(e) {
+      return ret || '/';
+    }
+  }
+  function __anOAuthReturnTarget(ret) {
+    var path = __anNormalizeWorkspaceReturnPath(ret);
+    var origin = __anWorkspaceGatewayReturnOrigin();
+    return origin ? origin + path : path;
   }
   function __anIsBuilderPreview() {
     try {
@@ -265,7 +304,7 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
     }
     if (__anIsBuilderPreview()) {
       var params = new URLSearchParams();
-      if (ret) params.set('return', ret);
+      if (ret) params.set('return', __anOAuthReturnTarget(ret));
       params.set('redirect', '1');
       __anSetOAuthDebug('Opening Google sign-in redirect');
       __anOpenOAuthUrl(__anAuthPath('/_agent-native/google/auth-url') + '?' + params.toString());

--- a/packages/core/src/server/google-oauth.ts
+++ b/packages/core/src/server/google-oauth.ts
@@ -19,11 +19,11 @@ import {
   addSession,
   getSession,
   getSessionMaxAge,
-  safeReturnPath,
   setFrameworkSessionCookie,
 } from "./auth.js";
 import { getAppName } from "./app-name.js";
 import { writeDesktopSso } from "./desktop-sso.js";
+import { appendSessionToOAuthReturnUrl } from "./oauth-return-url.js";
 
 // ─── Platform Detection ─────────────────────────────────────────────────────
 
@@ -770,13 +770,17 @@ export function oauthCallbackResponse(
       </script></body></html>`);
   }
 
-  // Web: redirect to the requested return path (validated same-origin) or
-  // "/" if no return was supplied / the return failed validation. Returning
-  // an empty string body keeps h3's `prepareResponseBody` → `FastResponse`
-  // path, which merges the prepared event headers (Location + any cookies
-  // set via `setCookie(event, ...)`).
+  // Web: redirect to the requested return target. Path-only returns stay
+  // same-origin; Builder desktop workspace returns may point back to the
+  // local loopback gateway and carry the short-lived `_session` bridge so
+  // the local app can promote the newly created hosted OAuth session.
   setResponseStatus(event, 302);
-  setResponseHeader(event, "Location", safeReturnPath(opts.returnUrl));
+  setResponseHeader(
+    event,
+    "Location",
+    appendSessionToOAuthReturnUrl(opts.returnUrl, opts.sessionToken),
+  );
+  setResponseHeader(event, "Referrer-Policy", "no-referrer");
   return "";
 }
 

--- a/packages/core/src/server/oauth-return-url.ts
+++ b/packages/core/src/server/oauth-return-url.ts
@@ -1,0 +1,80 @@
+function normalizeOrigin(raw: string | undefined): string {
+  if (!raw) return "";
+  try {
+    return new URL(raw).origin;
+  } catch {
+    return "";
+  }
+}
+
+function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const hostname = new URL(origin).hostname;
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "[::1]"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function getWorkspaceGatewayReturnOrigin(): string {
+  for (const raw of [
+    process.env.WORKSPACE_GATEWAY_URL,
+    process.env.VITE_WORKSPACE_GATEWAY_URL,
+  ]) {
+    const origin = normalizeOrigin(raw);
+    if (origin && isLoopbackOrigin(origin)) return origin;
+  }
+  return "";
+}
+
+function allowedOAuthReturnOrigins(allowDefaultLoopback: boolean): Set<string> {
+  const out = new Set<string>();
+  const configured = getWorkspaceGatewayReturnOrigin();
+  if (configured) out.add(configured);
+  if (allowDefaultLoopback) out.add("http://127.0.0.1:8080");
+  return out;
+}
+
+export function safeOAuthReturnUrl(
+  raw: string | null | undefined,
+  opts: { allowDefaultLoopback?: boolean } = {},
+): string {
+  if (!raw) return "/";
+  if (/[\x00-\x1f]/.test(raw)) return "/";
+  try {
+    const parsed = new URL(raw, "http://safe-base.invalid");
+    if (parsed.origin === "http://safe-base.invalid") {
+      return parsed.pathname + parsed.search + parsed.hash;
+    }
+    const allowedOrigins = allowedOAuthReturnOrigins(
+      opts.allowDefaultLoopback === true,
+    );
+    if (allowedOrigins.has(parsed.origin)) {
+      return parsed.toString();
+    }
+  } catch {
+    return "/";
+  }
+  return "/";
+}
+
+export function appendSessionToOAuthReturnUrl(
+  raw: string | null | undefined,
+  sessionToken: string | undefined,
+): string {
+  const safe = safeOAuthReturnUrl(raw, { allowDefaultLoopback: true });
+  if (!sessionToken) return safe;
+  try {
+    const parsed = new URL(safe);
+    if (!allowedOAuthReturnOrigins(true).has(parsed.origin)) return safe;
+    parsed.searchParams.set("_session", sessionToken);
+    return parsed.toString();
+  } catch {
+    return safe;
+  }
+}

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -51,11 +51,25 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain(
       'var __AN_PUBLIC_OAUTH_ORIGIN = "https://agent-workspace.builder.io";',
     );
+    expect(html).toContain('var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = "";');
     expect(html).toContain(
       "__anSetOAuthDebug('Opening Google sign-in redirect')",
     );
+    expect(html).toContain("function __anOAuthReturnTarget(ret)");
+    expect(html).toContain("params.set('return', __anOAuthReturnTarget(ret))");
+  });
+
+  it("embeds the local workspace gateway return origin when configured", () => {
+    vi.stubEnv("WORKSPACE_GATEWAY_URL", "http://127.0.0.1:8080/");
+    vi.stubEnv("GOOGLE_CLIENT_ID", "google-client-id");
+    vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-client-secret");
+
+    const html = getOnboardingHtml();
+
     expect(html).toContain(
-      "__anOpenOAuthUrl(__anAuthPath('/_agent-native/google/auth-url') + '?' + params.toString())",
+      'var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = "http://127.0.0.1:8080";',
     );
+    expect(html).toContain("function __anNormalizeWorkspaceReturnPath(ret)");
+    expect(html).toContain("path === '/dispatch/dispatch'");
   });
 });

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -12,6 +12,7 @@ import {
   resolveGoogleAuthMode,
   type GoogleAuthMode,
 } from "./google-auth-mode.js";
+import { getWorkspaceGatewayReturnOrigin } from "./oauth-return-url.js";
 
 function hasGoogleOAuth(): boolean {
   return !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
@@ -91,6 +92,7 @@ export function getOnboardingHtml(opts: OnboardingHtmlOptions = {}): string {
     process.env.VITE_APP_BASE_PATH || process.env.APP_BASE_PATH,
   );
   const publicOAuthOrigin = getPublicOAuthOrigin();
+  const workspaceGatewayReturnOrigin = getWorkspaceGatewayReturnOrigin();
   const googleAuthMode = resolveGoogleAuthMode(opts.googleAuthMode);
 
   const marketing = opts.marketing;
@@ -904,6 +906,7 @@ ${
       return __anBasePath() + path;
     }
     var __AN_PUBLIC_OAUTH_ORIGIN = ${JSON.stringify(publicOAuthOrigin)};
+    var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = ${JSON.stringify(workspaceGatewayReturnOrigin)};
     var __AN_GOOGLE_AUTH_MODE = ${JSON.stringify(googleAuthMode)};
     function __anConfiguredOAuthOrigin() {
       if (!__AN_PUBLIC_OAUTH_ORIGIN) return '';
@@ -917,6 +920,42 @@ ${
     function __anAuthPath(path) {
       var origin = __anIsBuilderPreview() ? __anConfiguredOAuthOrigin() : '';
       return origin ? origin + path : __anPath(path);
+    }
+    function __anWorkspaceGatewayReturnOrigin() {
+      if (__AN_WORKSPACE_GATEWAY_RETURN_ORIGIN) return __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN;
+      return __anIsBuilderDesktop() ? 'http://127.0.0.1:8080' : '';
+    }
+    function __anNormalizeWorkspaceReturnPath(ret) {
+      try {
+        var url = new URL(ret || '/', window.location.origin);
+        var path = url.pathname || '/';
+        if (path === '/dispatch/dispatch') {
+          path = '/dispatch';
+        } else if (path.indexOf('/dispatch/') === 0) {
+          var rest = path.slice('/dispatch/'.length);
+          var first = rest.split('/')[0];
+          var dispatchRoutes = {
+            overview: true, apps: true, metrics: true, vault: true,
+            integrations: true, messaging: true, workspace: true,
+            agents: true, destinations: true, identities: true,
+            approvals: true, audit: true, team: true, 'thread-debug': true,
+            'new-app': true
+          };
+          if (first === 'dispatch') {
+            path = '/dispatch' + rest.slice(first.length);
+          } else if (first && !dispatchRoutes[first]) {
+            path = '/' + rest;
+          }
+        }
+        return path + url.search + url.hash;
+      } catch(e) {
+        return ret || '/';
+      }
+    }
+    function __anOAuthReturnTarget(ret) {
+      var path = __anNormalizeWorkspaceReturnPath(ret);
+      var origin = __anWorkspaceGatewayReturnOrigin();
+      return origin ? origin + path : path;
     }
     function __anGetReturnPath() {
       try {
@@ -1546,7 +1585,7 @@ ${
     }
     if (__anIsBuilderPreview()) {
       var params = new URLSearchParams();
-      if (ret) params.set('return', ret);
+      if (ret) params.set('return', __anOAuthReturnTarget(ret));
       params.set('redirect', '1');
       __anSetOAuthDebug('Opening Google sign-in redirect');
       __anOpenOAuthUrl(__anAuthPath('/_agent-native/google/auth-url') + '?' + params.toString());

--- a/packages/dispatch/src/components/app-keys-popover.tsx
+++ b/packages/dispatch/src/components/app-keys-popover.tsx
@@ -13,6 +13,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 
 interface VaultSecret {
   id: string;
@@ -180,7 +181,20 @@ function AppKeysPanel({ appId, appName }: { appId: string; appName: string }) {
 
       <div className="max-h-[320px] space-y-1.5 overflow-y-auto rounded-md border border-border bg-card p-1.5">
         {isLoading ? (
-          <p className="px-3 py-3 text-xs text-muted-foreground">Loading…</p>
+          <div className="space-y-1.5 p-1.5">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div
+                key={index}
+                className="flex items-start gap-3 rounded-md px-2.5 py-2"
+              >
+                <Skeleton className="mt-0.5 h-4 w-4 shrink-0 rounded" />
+                <div className="flex-1 space-y-1.5">
+                  <Skeleton className="h-3 w-1/2" />
+                  <Skeleton className="h-3 w-3/4" />
+                </div>
+              </div>
+            ))}
+          </div>
         ) : typedSecrets.length === 0 ? (
           <p className="rounded-md border border-dashed border-border px-3 py-3 text-xs text-muted-foreground">
             No vault keys yet. Add one from the Vault page.

--- a/packages/dispatch/src/routes/pages/$appId.tsx
+++ b/packages/dispatch/src/routes/pages/$appId.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import {
   Link,
+  Navigate,
   redirect,
   useParams,
   type LoaderFunctionArgs,
@@ -47,16 +48,34 @@ export function meta() {
  * OAuth callbackURL, so Google sign-in completes back at /dispatch/todo
  * and looks broken. This route fixes both the post-creation navigation
  * and the OAuth round-trip from a single place.
+ *
+ * `appId === "dispatch"` short-circuit: when the segment matches Dispatch
+ * itself (e.g. `/dispatch/dispatch`), we go straight to the overview rather
+ * than chaining through `/dispatch` (which polled `useActionQuery` re-fired
+ * `window.location.assign` against and looped forever in production).
  */
+function dispatchSelfRedirect(appId: string | undefined): string | null {
+  if (appId === "dispatch") return appPath("/overview");
+  return null;
+}
+
 export function loader({ params }: LoaderFunctionArgs) {
   const appId = params.appId;
   if (!appId) return null;
+  const selfTarget = dispatchSelfRedirect(appId);
+  if (selfTarget) throw redirect(selfTarget);
   const apps = loadWorkspaceAppsManifest();
   if (!apps) return null;
   const app = apps.find((entry) => entry?.id === appId);
   const target =
     app?.path && app.path.startsWith("/") ? app.path : app ? `/${appId}` : null;
   if (target) throw redirect(target);
+  return null;
+}
+
+export function clientLoader({ params }: LoaderFunctionArgs) {
+  const selfTarget = dispatchSelfRedirect(params.appId);
+  if (selfTarget) throw redirect(selfTarget);
   return null;
 }
 
@@ -73,11 +92,17 @@ export default function WorkspaceAppCatchAllRoute() {
     [appId, apps],
   );
   const href = app ? workspaceAppHref(app) : null;
+  const isSelfReference = appId === "dispatch";
 
   useEffect(() => {
+    if (isSelfReference) return;
     if (!app || app.status === "pending" || !href) return;
     window.location.assign(href);
-  }, [app, href]);
+  }, [app, href, isSelfReference]);
+
+  if (isSelfReference) {
+    return <Navigate to={appPath("/overview")} replace />;
+  }
 
   if ((isLoading && !app) || (app && app.status !== "pending" && href)) {
     return (

--- a/packages/dispatch/src/routes/pages/approval.tsx
+++ b/packages/dispatch/src/routes/pages/approval.tsx
@@ -9,6 +9,7 @@ import {
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   IconCheck,
   IconX,
@@ -98,9 +99,38 @@ export default function ApprovalPreviewRoute() {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-background p-6">
-        <div className="w-full max-w-md rounded-2xl border bg-card p-6 text-center">
-          <p className="text-sm text-muted-foreground">Loading...</p>
+      <div className="flex min-h-screen items-start justify-center bg-background p-6">
+        <div className="w-full max-w-md space-y-4">
+          <div className="rounded-2xl border bg-card p-5">
+            <div className="flex items-start gap-3">
+              <Skeleton className="h-9 w-9 shrink-0 rounded-xl" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-5 w-20 rounded-full" />
+                </div>
+                <Skeleton className="h-3 w-32" />
+              </div>
+            </div>
+            <div className="mt-4 space-y-2 rounded-xl border bg-muted/30 px-4 py-3">
+              <div className="flex justify-between gap-4">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-3 w-24" />
+              </div>
+              <div className="flex justify-between gap-4">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-3 w-28" />
+              </div>
+              <div className="flex justify-between gap-4">
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-3 w-32" />
+              </div>
+            </div>
+            <div className="mt-4 flex gap-2">
+              <Skeleton className="h-8 flex-1 rounded-md" />
+              <Skeleton className="h-8 flex-1 rounded-md" />
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/packages/dispatch/src/routes/pages/apps.$appId.tsx
+++ b/packages/dispatch/src/routes/pages/apps.$appId.tsx
@@ -9,6 +9,7 @@ import {
 import { DispatchShell } from "@/components/dispatch-shell";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   workspaceAppHref,
   type WorkspaceAppSummary,
@@ -53,7 +54,11 @@ export default function WorkspaceAppRoute() {
         </Button>
 
         {isLoading && !app ? (
-          <p className="text-sm text-muted-foreground">Loading app status...</p>
+          <div className="space-y-3">
+            <Skeleton className="h-5 w-48" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
         ) : !app ? (
           <div className="space-y-3">
             <h2 className="text-base font-semibold text-foreground">

--- a/packages/dispatch/src/routes/pages/overview.tsx
+++ b/packages/dispatch/src/routes/pages/overview.tsx
@@ -131,6 +131,60 @@ function AppCardSkeleton() {
   );
 }
 
+interface RecentAuditEvent {
+  id: string;
+  summary: string;
+  actor: string;
+  createdAt: string;
+}
+
+function RecentActivityList({
+  isLoading,
+  events,
+}: {
+  isLoading: boolean;
+  events: RecentAuditEvent[];
+}) {
+  if (isLoading && events.length === 0) {
+    return (
+      <div className="mt-4 space-y-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div
+            key={index}
+            className="rounded-xl border bg-muted/30 px-4 py-3 space-y-2"
+          >
+            <Skeleton className="h-4 w-3/5" />
+            <Skeleton className="h-3 w-2/5" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+  if (events.length === 0) {
+    return (
+      <div className="mt-4 space-y-3">
+        <div className="rounded-xl border border-dashed px-4 py-6 text-sm text-muted-foreground">
+          No activity yet.
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="mt-4 space-y-3">
+      {events.map((event) => (
+        <div key={event.id} className="rounded-xl border bg-muted/30 px-4 py-3">
+          <div className="text-sm font-medium text-foreground">
+            {event.summary}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {event.actor} · {new Date(event.createdAt).toLocaleString()}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function WorkspaceAppsSection({
   apps,
   isLoading,
@@ -625,33 +679,11 @@ export default function OverviewRoute() {
                 <h2 className="text-lg font-semibold text-foreground">
                   Recent activity
                 </h2>
-                {isLoading && (
-                  <span className="text-xs text-muted-foreground">
-                    Loading...
-                  </span>
-                )}
               </div>
-              <div className="mt-4 space-y-3">
-                {(data?.recentAudit || []).map((event) => (
-                  <div
-                    key={event.id}
-                    className="rounded-xl border bg-muted/30 px-4 py-3"
-                  >
-                    <div className="text-sm font-medium text-foreground">
-                      {event.summary}
-                    </div>
-                    <div className="mt-1 text-xs text-muted-foreground">
-                      {event.actor} ·{" "}
-                      {new Date(event.createdAt).toLocaleString()}
-                    </div>
-                  </div>
-                ))}
-                {!isLoading && (data?.recentAudit?.length || 0) === 0 && (
-                  <div className="rounded-xl border border-dashed px-4 py-6 text-sm text-muted-foreground">
-                    No activity yet.
-                  </div>
-                )}
-              </div>
+              <RecentActivityList
+                isLoading={isLoading}
+                events={data?.recentAudit ?? []}
+              />
             </section>
 
             <section className="rounded-2xl border bg-card p-5">

--- a/packages/dispatch/src/routes/pages/vault.tsx
+++ b/packages/dispatch/src/routes/pages/vault.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const PROVIDERS = [
   "google",
@@ -549,22 +550,34 @@ export default function VaultRoute() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <IconKey size={16} />
-              <span>
-                {secretsLoading
-                  ? "Loading..."
-                  : `${secrets?.length || 0} secret${(secrets?.length || 0) !== 1 ? "s" : ""}`}
-              </span>
+              {secretsLoading ? (
+                <Skeleton className="h-4 w-20" />
+              ) : (
+                <span>
+                  {`${secrets?.length || 0} secret${(secrets?.length || 0) !== 1 ? "s" : ""}`}
+                </span>
+              )}
             </div>
             <AddSecretDialog />
           </div>
 
-          {(secrets || []).map((secret: any) => (
-            <SecretRow
-              key={secret.id}
-              secret={secret}
-              grants={grantsBySecret[secret.id] || []}
-            />
-          ))}
+          {secretsLoading && (secrets ?? []).length === 0
+            ? Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="rounded-2xl border bg-card px-5 py-4 space-y-2"
+                >
+                  <Skeleton className="h-4 w-1/3" />
+                  <Skeleton className="h-3 w-2/3" />
+                </div>
+              ))
+            : (secrets || []).map((secret: any) => (
+                <SecretRow
+                  key={secret.id}
+                  secret={secret}
+                  grants={grantsBySecret[secret.id] || []}
+                />
+              ))}
 
           {!secretsLoading && (secrets?.length || 0) === 0 && (
             <div className="rounded-2xl border border-dashed px-6 py-12 text-center">

--- a/packages/dispatch/src/routes/pages/workspace.tsx
+++ b/packages/dispatch/src/routes/pages/workspace.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export function meta() {
   return [{ title: "Workspace Resources — Dispatch" }];
@@ -528,6 +529,21 @@ export default function WorkspaceRoute() {
     items: any[];
     emptyText: string;
   }) {
+    if (isLoading && (resources ?? []).length === 0) {
+      return (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div
+              key={index}
+              className="rounded-2xl border bg-card px-5 py-4 space-y-2"
+            >
+              <Skeleton className="h-4 w-1/3" />
+              <Skeleton className="h-3 w-2/3" />
+            </div>
+          ))}
+        </div>
+      );
+    }
     if (items.length === 0) {
       return (
         <div className="rounded-2xl border border-dashed px-6 py-12 text-center text-sm text-muted-foreground">
@@ -555,9 +571,11 @@ export default function WorkspaceRoute() {
     >
       <div className="flex items-center justify-between">
         <div className="text-sm text-muted-foreground">
-          {isLoading
-            ? "Loading..."
-            : `${resources?.length || 0} resource${(resources?.length || 0) !== 1 ? "s" : ""}`}
+          {isLoading ? (
+            <Skeleton className="h-4 w-24" />
+          ) : (
+            `${resources?.length || 0} resource${(resources?.length || 0) !== 1 ? "s" : ""}`
+          )}
         </div>
         <div className="flex gap-2">
           <Button

--- a/templates/calendar/app/components/layout/Sidebar.tsx
+++ b/templates/calendar/app/components/layout/Sidebar.tsx
@@ -766,24 +766,33 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                           >
                             {person.name || person.email}
                           </span>
-                          <div className="flex items-center opacity-0 group-hover:opacity-100">
-                            <button
-                              type="button"
-                              onClick={() =>
-                                toggleHiddenCalendar("people", person.email)
-                              }
-                              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground"
-                            >
-                              {isHiddenCalendar("people", person.email) ? (
-                                <IconEyeOff className="h-3 w-3" />
-                              ) : (
-                                <IconEye className="h-3 w-3" />
-                              )}
-                            </button>
+                          <div className="flex items-center">
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    toggleHiddenCalendar("people", person.email)
+                                  }
+                                  className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground group-hover:text-muted-foreground/80"
+                                >
+                                  {isHiddenCalendar("people", person.email) ? (
+                                    <IconEyeOff className="h-3 w-3" />
+                                  ) : (
+                                    <IconEye className="h-3 w-3" />
+                                  )}
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent side="right">
+                                {isHiddenCalendar("people", person.email)
+                                  ? "Show calendar"
+                                  : "Hide calendar"}
+                              </TooltipContent>
+                            </Tooltip>
                             <button
                               type="button"
                               onClick={() => removePerson.mutate(person.email)}
-                              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground"
+                              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/60 opacity-0 hover:text-foreground group-hover:opacity-100"
                             >
                               <IconX className="h-3 w-3" />
                             </button>
@@ -851,24 +860,33 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                           >
                             {cal.name}
                           </span>
-                          <div className="flex items-center opacity-0 group-hover:opacity-100">
-                            <button
-                              type="button"
-                              onClick={() =>
-                                toggleHiddenCalendar("external", cal.id)
-                              }
-                              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground"
-                            >
-                              {isHiddenCalendar("external", cal.id) ? (
-                                <IconEyeOff className="h-3 w-3" />
-                              ) : (
-                                <IconEye className="h-3 w-3" />
-                              )}
-                            </button>
+                          <div className="flex items-center">
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    toggleHiddenCalendar("external", cal.id)
+                                  }
+                                  className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/40 hover:text-foreground group-hover:text-muted-foreground/80"
+                                >
+                                  {isHiddenCalendar("external", cal.id) ? (
+                                    <IconEyeOff className="h-3 w-3" />
+                                  ) : (
+                                    <IconEye className="h-3 w-3" />
+                                  )}
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent side="right">
+                                {isHiddenCalendar("external", cal.id)
+                                  ? "Show calendar"
+                                  : "Hide calendar"}
+                              </TooltipContent>
+                            </Tooltip>
                             <button
                               type="button"
                               onClick={() => removeExternal.mutate(cal.id)}
-                              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground"
+                              className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground/60 opacity-0 hover:text-foreground group-hover:opacity-100"
                             >
                               <IconX className="h-3 w-3" />
                             </button>

--- a/templates/design/actions/list-designs.ts
+++ b/templates/design/actions/list-designs.ts
@@ -1,8 +1,13 @@
 import { defineAction } from "@agent-native/core";
 import { z } from "zod";
-import { desc } from "drizzle-orm";
+import { desc, inArray } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import { accessFilter } from "@agent-native/core/sharing";
+
+// Truncate preview HTML so the listing payload stays reasonable. The home
+// screen only needs enough HTML to render a recognizable thumbnail; full
+// content loads on demand when the user opens an editor.
+const PREVIEW_MAX_BYTES = 50_000;
 
 export default defineAction({
   description:
@@ -14,6 +19,12 @@ export default defineAction({
       .optional()
       .describe(
         "Set to 'true' for compact output (id, title, projectType only)",
+      ),
+    includePreview: z
+      .enum(["true", "false"])
+      .optional()
+      .describe(
+        "Set to 'true' to include a truncated `previewHtml` field per design (the index.html content). Used by the homepage to render thumbnails.",
       ),
   }),
   readOnly: true,
@@ -30,6 +41,43 @@ export default defineAction({
       return { count: 0, designs: [] };
     }
 
+    // Look up one preview per design when requested. We pick the shortest
+    // HTML file so the response stays small and the chosen file is more
+    // likely to be the entry point (`index.html`) rather than a heavy
+    // multi-page sub-screen. Falls back to the first HTML file we find.
+    const previews = new Map<string, string>();
+    if (args.includePreview === "true" && args.compact !== "true") {
+      const ids = rows.map((r) => r.id);
+      const fileRows = await db
+        .select({
+          designId: schema.designFiles.designId,
+          filename: schema.designFiles.filename,
+          content: schema.designFiles.content,
+          fileType: schema.designFiles.fileType,
+        })
+        .from(schema.designFiles)
+        .where(inArray(schema.designFiles.designId, ids));
+
+      const byDesign = new Map<string, typeof fileRows>();
+      for (const f of fileRows) {
+        if (f.fileType !== "html") continue;
+        const list = byDesign.get(f.designId);
+        if (list) list.push(f);
+        else byDesign.set(f.designId, [f]);
+      }
+
+      for (const [designId, files] of byDesign) {
+        const indexFile =
+          files.find((f) => f.filename === "index.html") ?? files[0];
+        if (!indexFile?.content) continue;
+        const trimmed =
+          indexFile.content.length > PREVIEW_MAX_BYTES
+            ? indexFile.content.slice(0, PREVIEW_MAX_BYTES)
+            : indexFile.content;
+        previews.set(designId, trimmed);
+      }
+    }
+
     const items = rows.map((row) => {
       if (args.compact === "true") {
         return {
@@ -38,7 +86,7 @@ export default defineAction({
           projectType: row.projectType,
         };
       }
-      return {
+      const base = {
         id: row.id,
         title: row.title,
         description: row.description,
@@ -48,6 +96,10 @@ export default defineAction({
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
       };
+      if (args.includePreview === "true") {
+        return { ...base, previewHtml: previews.get(row.id) ?? null };
+      }
+      return base;
     });
 
     return { count: items.length, designs: items };

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -330,9 +330,13 @@ export function DesignCanvas({
   // CanvasCommentPins can absolutely-position themselves on top of the
   // iframe. The pin component anchors to `.design-canvas-iframe-wrapper`
   // via canvasSelector.
+  //
+  // The wrapper carries a faint outline + soft shadow so the frame edge is
+  // visible even when the design's background matches the canvas dot-grid
+  // (e.g. both dark). Without this, a dark design dissolves into the canvas.
   const iframeElement = (
     <div
-      className="design-canvas-iframe-wrapper relative inline-block"
+      className="design-canvas-iframe-wrapper relative inline-block ring-1 ring-border/60 shadow-[0_0_0_1px_rgba(0,0,0,0.04),0_8px_24px_-12px_rgba(0,0,0,0.45)]"
       style={{
         width: iframeWidth,
         height: deviceFrame === "none" ? "100%" : (iframeHeight ?? undefined),

--- a/templates/design/app/components/design/EditPanel.tsx
+++ b/templates/design/app/components/design/EditPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { IconPointer } from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -407,6 +408,21 @@ function PageProperties({
 
   return (
     <div className="space-y-4">
+      {/* Lead with a clear CTA so users discover the much richer per-element
+          panel. Without this it's easy to mistake the 3 page-level fields for
+          "the entire editor" — the cause of the "controls too limited"
+          feedback. */}
+      <div className="rounded-lg border border-border/70 bg-accent/30 p-3 text-xs text-muted-foreground/90 leading-relaxed">
+        <p className="font-medium text-foreground/85 mb-1 flex items-center gap-1.5">
+          <IconPointer className="w-3.5 h-3.5" />
+          Click any element on the canvas
+        </p>
+        <p>
+          Edit typography, spacing, sizing, borders and fill for whatever you
+          select. Page defaults below.
+        </p>
+      </div>
+
       <SectionTitle>Page</SectionTitle>
       <ColorInput
         label="Background"

--- a/templates/design/app/components/design/EditPanel.tsx
+++ b/templates/design/app/components/design/EditPanel.tsx
@@ -19,25 +19,55 @@ interface EditPanelProps {
   onStyleChange: (property: string, value: string) => void;
 }
 
-/** Compact input row: label + text input */
+/**
+ * Normalize a CSS length-ish value typed by the user. If the input is bare
+ * digits (e.g. "32" or "32.5"), append the default unit so it parses as a
+ * valid CSS length. Lets users type "32" and get the expected "32px" when
+ * the field is committed.
+ */
+function normalizeLengthValue(raw: string, defaultUnit: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) return `${trimmed}${defaultUnit}`;
+  return trimmed;
+}
+
+/** Compact input row: label + text input.
+ *
+ * For CSS length fields (font-size, padding, width, etc.) pass `defaultUnit`
+ * so the change is committed on blur/Enter and a bare number auto-appends the
+ * unit. Without that, intermediate keystrokes apply invalid CSS — typing "32"
+ * for a font-size silently fails because "32" alone isn't a valid length, and
+ * it never reaches "32px" because every keystroke re-applies the broken
+ * value.
+ */
 function PropInput({
   label,
   value,
   onChange,
   placeholder,
   type = "text",
+  defaultUnit,
 }: {
   label: string;
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
   type?: string;
+  defaultUnit?: string;
 }) {
   const [draft, setDraft] = useState(value);
 
   useEffect(() => {
     setDraft(value);
   }, [value]);
+
+  const commit = () => {
+    if (defaultUnit === undefined) return;
+    const next = normalizeLengthValue(draft, defaultUnit);
+    if (next !== draft) setDraft(next);
+    if (next !== value) onChange(next);
+  };
 
   return (
     <div className="flex items-center gap-2">
@@ -49,7 +79,19 @@ function PropInput({
         value={draft}
         onChange={(e) => {
           setDraft(e.target.value);
-          onChange(e.target.value);
+          // For length fields, defer the live update until blur/Enter so that
+          // invalid intermediate strings ("3", "32", "32p") don't get applied
+          // and discarded by the browser. Free-text fields (without
+          // defaultUnit) keep the responsive live-update behavior.
+          if (defaultUnit === undefined) onChange(e.target.value);
+        }}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+            (e.currentTarget as HTMLInputElement).blur();
+          }
         }}
         placeholder={placeholder}
         className="h-7 text-xs"
@@ -209,6 +251,46 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   );
 }
 
+function FourSideCell({
+  side,
+  placeholder,
+  value,
+  onChange,
+}: {
+  side: string;
+  placeholder: string;
+  value: string;
+  onChange: (side: string, value: string) => void;
+}) {
+  const [draft, setDraft] = useState(value);
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
+  const commit = () => {
+    const next = normalizeLengthValue(draft, "px");
+    if (next !== draft) setDraft(next);
+    if (next !== value) onChange(side, next);
+  };
+
+  return (
+    <Input
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          commit();
+          (e.currentTarget as HTMLInputElement).blur();
+        }
+      }}
+      placeholder={placeholder}
+      className="h-7 text-xs text-center"
+    />
+  );
+}
+
 function FourSideInput({
   label,
   values,
@@ -222,29 +304,29 @@ function FourSideInput({
     <div className="space-y-1.5">
       <Label className="text-xs text-muted-foreground">{label}</Label>
       <div className="grid grid-cols-4 gap-1">
-        <Input
-          value={values.top}
-          onChange={(e) => onChange("Top", e.target.value)}
+        <FourSideCell
+          side="Top"
           placeholder="T"
-          className="h-7 text-xs text-center"
+          value={values.top}
+          onChange={onChange}
         />
-        <Input
-          value={values.right}
-          onChange={(e) => onChange("Right", e.target.value)}
+        <FourSideCell
+          side="Right"
           placeholder="R"
-          className="h-7 text-xs text-center"
+          value={values.right}
+          onChange={onChange}
         />
-        <Input
-          value={values.bottom}
-          onChange={(e) => onChange("Bottom", e.target.value)}
+        <FourSideCell
+          side="Bottom"
           placeholder="B"
-          className="h-7 text-xs text-center"
+          value={values.bottom}
+          onChange={onChange}
         />
-        <Input
-          value={values.left}
-          onChange={(e) => onChange("Left", e.target.value)}
+        <FourSideCell
+          side="Left"
           placeholder="L"
-          className="h-7 text-xs text-center"
+          value={values.left}
+          onChange={onChange}
         />
       </div>
     </div>
@@ -342,6 +424,7 @@ function PageProperties({
         value={styles.fontSize || "16px"}
         onChange={(v) => onStyleChange("fontSize", v)}
         placeholder="16px"
+        defaultUnit="px"
       />
     </div>
   );
@@ -371,6 +454,7 @@ function TextProperties({
         value={styles.fontSize || ""}
         onChange={(v) => onStyleChange("fontSize", v)}
         placeholder="16px"
+        defaultUnit="px"
       />
       <PropSelect
         label="Weight"
@@ -400,6 +484,7 @@ function TextProperties({
         value={styles.letterSpacing || ""}
         onChange={(v) => onStyleChange("letterSpacing", v)}
         placeholder="0px"
+        defaultUnit="px"
       />
     </div>
   );
@@ -441,6 +526,7 @@ function FlexProperties({
         value={styles.gap || ""}
         onChange={(v) => onStyleChange("gap", v)}
         placeholder="0px"
+        defaultUnit="px"
       />
     </div>
   );
@@ -478,12 +564,14 @@ function ElementProperties({
         value={styles.width || ""}
         onChange={(v) => onStyleChange("width", v)}
         placeholder="auto"
+        defaultUnit="px"
       />
       <PropInput
         label="Height"
         value={styles.height || ""}
         onChange={(v) => onStyleChange("height", v)}
         placeholder="auto"
+        defaultUnit="px"
       />
       <PropSlider
         label="Opacity"
@@ -527,6 +615,7 @@ function ElementProperties({
         value={styles.borderWidth || "0"}
         onChange={(v) => onStyleChange("borderWidth", v)}
         placeholder="0px"
+        defaultUnit="px"
       />
       <ColorInput
         label="Color"
@@ -538,6 +627,7 @@ function ElementProperties({
         value={styles.borderRadius || "0"}
         onChange={(v) => onStyleChange("borderRadius", v)}
         placeholder="0px"
+        defaultUnit="px"
       />
 
       <Separator />

--- a/templates/design/app/components/visual-editor/DrawOverlay.tsx
+++ b/templates/design/app/components/visual-editor/DrawOverlay.tsx
@@ -11,10 +11,12 @@ import { useState, useRef, useCallback, useEffect } from "react";
 import {
   IconEraser,
   IconArrowBackUp,
+  IconArrowForwardUp,
   IconSend,
   IconCursorText,
   IconX,
 } from "@tabler/icons-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -97,6 +99,10 @@ export function DrawOverlay({ visible, onSend, onClose }: DrawOverlayProps) {
   const [lineWidth, setLineWidth] = useState(LINE_WIDTHS[1].value);
   const [strokes, setStrokes] = useState<Stroke[]>([]);
   const [textAnnotations, setTextAnnotations] = useState<DrawAnnotation[]>([]);
+  // Redo stack. Pushing here happens via undo(); a fresh stroke clears it
+  // (standard editor convention — once you draw something new, the redo
+  // history is no longer reachable).
+  const [redoStrokes, setRedoStrokes] = useState<Stroke[]>([]);
   const [currentStroke, setCurrentStroke] = useState<Point[] | null>(null);
   const [textMode, setTextMode] = useState(false);
   const [textInput, setTextInput] = useState<{
@@ -112,6 +118,7 @@ export function DrawOverlay({ visible, onSend, onClose }: DrawOverlayProps) {
     if (!visible) {
       setStrokes([]);
       setTextAnnotations([]);
+      setRedoStrokes([]);
       setCurrentStroke(null);
       setTextInput(null);
       setInstruction("");
@@ -187,14 +194,50 @@ export function DrawOverlay({ visible, onSend, onClose }: DrawOverlayProps) {
           lineWidth,
         },
       ]);
+      setRedoStrokes([]);
     }
     setCurrentStroke(null);
   }, [currentStroke, color, lineWidth]);
 
-  const undo = () => setStrokes((prev) => prev.slice(0, -1));
+  const undo = () => {
+    setStrokes((prev) => {
+      if (prev.length === 0) return prev;
+      const last = prev[prev.length - 1];
+      setRedoStrokes((stack) => [...stack, last]);
+      return prev.slice(0, -1);
+    });
+  };
+
+  const redo = () => {
+    setRedoStrokes((stack) => {
+      if (stack.length === 0) return stack;
+      const top = stack[stack.length - 1];
+      setStrokes((prev) => [...prev, top]);
+      return stack.slice(0, -1);
+    });
+  };
+
   const clear = () => {
+    if (strokes.length === 0 && textAnnotations.length === 0) return;
+    // Snapshot for the toast's Undo. Using a toast (instead of an AlertDialog
+    // confirm) keeps Clear a single click for users who know what they want,
+    // while still letting an accidental click be recovered for the toast's
+    // lifetime.
+    const prevStrokes = strokes;
+    const prevTexts = textAnnotations;
     setStrokes([]);
     setTextAnnotations([]);
+    setRedoStrokes([]);
+    toast("Cleared all annotations", {
+      action: {
+        label: "Undo",
+        onClick: () => {
+          setStrokes(prevStrokes);
+          setTextAnnotations(prevTexts);
+        },
+      },
+      duration: 6000,
+    });
   };
 
   const commitTextAnnotation = () => {
@@ -396,6 +439,20 @@ export function DrawOverlay({ visible, onSend, onClose }: DrawOverlayProps) {
             </button>
           </TooltipTrigger>
           <TooltipContent>Undo stroke</TooltipContent>
+        </Tooltip>
+
+        {/* Redo */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={redo}
+              disabled={redoStrokes.length === 0}
+              className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:cursor-default disabled:opacity-30"
+            >
+              <IconArrowForwardUp className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Redo stroke</TooltipContent>
         </Tooltip>
 
         {/* Clear all */}

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -710,6 +710,11 @@ export default function DesignEditor() {
     });
   }, []);
 
+  // Track whether we auto-collapsed the agent sidebar on entering Edit mode
+  // so we can restore it on exit. We only restore when we were the ones who
+  // closed it — if the user had it closed already, leave it closed.
+  const sidebarCollapsedByEditModeRef = useRef(false);
+
   const handleModeChange = useCallback(
     (next: EditorMode) => {
       if (next === "draw" && (!activeFile || viewMode === "overview")) return;
@@ -726,6 +731,24 @@ export default function DesignEditor() {
       } else {
         setDrawMode(false);
         if (next === "edit") setPinMode(false);
+      }
+
+      // Auto-collapse the agent sidebar when entering Edit so the EditPanel
+      // and canvas have the screen to themselves. Restore it on the way out
+      // — but only if we collapsed it. Read localStorage to check current
+      // state at entry; AgentPanel writes it synchronously on every toggle.
+      if (next === "edit") {
+        let isOpen = false;
+        try {
+          isOpen = localStorage.getItem("agent-native-sidebar-open") === "true";
+        } catch {}
+        if (isOpen) {
+          window.dispatchEvent(new Event("agent-panel:close"));
+          sidebarCollapsedByEditModeRef.current = true;
+        }
+      } else if (sidebarCollapsedByEditModeRef.current) {
+        window.dispatchEvent(new Event("agent-panel:open"));
+        sidebarCollapsedByEditModeRef.current = false;
       }
     },
     [activeFile, viewMode],

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -19,6 +19,7 @@ import {
   IconPin,
   IconDownload,
   IconCode,
+  IconRefresh,
 } from "@tabler/icons-react";
 import {
   useActionQuery,
@@ -34,9 +35,11 @@ import {
   type CollabUser,
   type PromptComposerSubmitOptions,
 } from "@agent-native/core/client";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -169,9 +172,12 @@ function isDesignData(
 export default function DesignEditor() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   // Editor state
   const [mode, setMode] = useState<EditorMode>("comment");
+  const [titleEditing, setTitleEditing] = useState(false);
+  const [titleDraft, setTitleDraft] = useState("");
   const [zoom, setZoom] = useState(100);
   const [deviceFrame, setDeviceFrame] = useState<DeviceFrameType>("none");
   const [viewMode, setViewMode] = useState<"single" | "overview">("single");
@@ -201,6 +207,16 @@ export default function DesignEditor() {
     hasFreshPendingGeneration(id),
   );
   const [generationIssue, setGenerationIssue] = useState<string | null>(null);
+  // When generation stalls we keep the original prompt + files around so the
+  // user can retry with one click instead of re-typing. Cleared as soon as the
+  // user kicks off a new run (retry or fresh prompt).
+  const [retryablePrompt, setRetryablePrompt] = useState<{
+    prompt: string;
+    files: UploadedFile[];
+    model?: PromptComposerSubmitOptions["model"];
+    engine?: PromptComposerSubmitOptions["engine"];
+    effort?: PromptComposerSubmitOptions["effort"];
+  } | null>(null);
   const generationOutputReadyRef = useRef(false);
   const generationCompleteTimerRef = useRef<number | null>(null);
   const clearGenerationCompleteTimer = useCallback(() => {
@@ -212,6 +228,19 @@ export default function DesignEditor() {
   const staleToastShownRef = useRef(false);
   const markGenerationStale = useCallback(() => {
     clearGenerationCompleteTimer();
+    // Capture the original prompt before clearing so the user can retry without
+    // re-typing it. The full pending payload (model/engine/effort) is preserved
+    // so the retry runs with identical settings.
+    const pending = readPendingGeneration(id);
+    if (pending?.prompt) {
+      setRetryablePrompt({
+        prompt: pending.prompt,
+        files: Array.isArray(pending.files) ? pending.files : [],
+        model: pending.model,
+        engine: pending.engine,
+        effort: pending.effort,
+      });
+    }
     clearPendingGeneration(id);
     setHasPendingGeneration(false);
     setGenerationIssue(
@@ -331,6 +360,7 @@ export default function DesignEditor() {
   }, [id, hasPendingGeneration, markGenerationStale]);
 
   const updateFileMutation = useActionMutation("update-file");
+  const updateDesignMutation = useActionMutation("update-design");
   const createCodingHandoffMutation = useActionMutation(
     "export-coding-handoff",
   );
@@ -368,6 +398,36 @@ export default function DesignEditor() {
   }, []);
 
   const design = isDesignData(designResult) ? designResult : null;
+
+  const commitTitleEdit = useCallback(() => {
+    setTitleEditing(false);
+    if (!id) return;
+    const next = titleDraft.trim();
+    if (!next || next === design?.title) return;
+
+    queryClient.setQueryData(["action", "get-design", { id }], (old: any) => {
+      if (!old || typeof old !== "object") return old;
+      return { ...old, title: next };
+    });
+    queryClient.setQueryData(
+      ["action", "list-designs", undefined],
+      (old: any) => {
+        if (!old) return old;
+        return {
+          ...old,
+          designs: (old.designs ?? []).map((d: any) =>
+            d.id === id ? { ...d, title: next } : d,
+          ),
+        };
+      },
+    );
+
+    updateDesignMutation.mutate({ id, title: next } as any, {
+      onError: () => {
+        queryClient.invalidateQueries({ queryKey: ["action", "get-design"] });
+      },
+    });
+  }, [id, titleDraft, design?.title, updateDesignMutation, queryClient]);
 
   const files = design?.files ?? [];
 
@@ -709,6 +769,43 @@ export default function DesignEditor() {
     setDrawMode(false);
   }, [activeFile, pinMode, viewMode]);
 
+  const handleRetryGeneration = useCallback(() => {
+    if (!id || !design || !retryablePrompt) return;
+    const fileContext = formatUploadedFileContext(retryablePrompt.files);
+    const context = [
+      `The user has design "${id}" (title: "${design.title}") open and wants to fill it with design files.`,
+      `User request: "${retryablePrompt.prompt}"`,
+      fileContext,
+      "",
+      "(Retrying — the previous attempt did not complete.)",
+      `Use the \`generate-design --designId="${id}"\` action with one or more files (index.html, etc.). The design already exists — DO NOT call create-design.`,
+      "Each file's content must be complete, self-contained HTML with Alpine.js + Tailwind via CDN. HTML templates are in your AGENTS.md.",
+    ].join("\n");
+    clearGenerationCompleteTimer();
+    setGenerationIssue(null);
+    const runTabId = agentSubmit(
+      `Generate design for "${design.title}": ${retryablePrompt.prompt}`,
+      context,
+      {
+        model: retryablePrompt.model,
+        engine: retryablePrompt.engine,
+        effort: retryablePrompt.effort,
+      },
+    );
+    patchPendingGeneration(id, {
+      prompt: retryablePrompt.prompt,
+      files: retryablePrompt.files,
+      title: design.title,
+      model: retryablePrompt.model,
+      engine: retryablePrompt.engine,
+      effort: retryablePrompt.effort,
+      runTabId,
+      startedAt: Date.now(),
+    });
+    setHasPendingGeneration(true);
+    setRetryablePrompt(null);
+  }, [id, design, retryablePrompt, agentSubmit, clearGenerationCompleteTimer]);
+
   const handleCopyCodingHandoff = useCallback(() => {
     if (!id) return;
     createCodingHandoffMutation.mutate(
@@ -792,9 +889,36 @@ export default function DesignEditor() {
           >
             <IconArrowLeft className="w-4 h-4" />
           </Link>
-          <span className="text-sm font-medium text-foreground/90 truncate max-w-[200px]">
-            {design.title}
-          </span>
+          {titleEditing ? (
+            <Input
+              autoFocus
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onBlur={commitTitleEdit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  commitTitleEdit();
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  setTitleEditing(false);
+                }
+              }}
+              className="h-7 w-[240px] text-sm"
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                setTitleDraft(design.title);
+                setTitleEditing(true);
+              }}
+              title="Click to rename"
+              className="text-sm font-medium text-foreground/90 truncate max-w-[240px] cursor-text rounded px-1 -mx-1 hover:bg-accent/50 text-left"
+            >
+              {design.title}
+            </button>
+          )}
           <Badge variant="secondary" className="text-[10px]">
             {design.projectType}
           </Badge>
@@ -1178,16 +1302,36 @@ export default function DesignEditor() {
                     {generationIssue ??
                       "No files yet. Ask the agent to generate a design."}
                   </p>
-                  <Button
-                    ref={generateBtnRef}
-                    variant="outline"
-                    size="sm"
-                    className="cursor-pointer"
-                    onClick={() => setShowPrompt(true)}
-                  >
-                    <IconPlus className="w-3.5 h-3.5" />
-                    Generate Design
-                  </Button>
+                  {retryablePrompt ? (
+                    <p className="text-xs text-muted-foreground/70 mb-4 max-w-sm mx-auto italic">
+                      "{retryablePrompt.prompt}"
+                    </p>
+                  ) : null}
+                  <div className="flex items-center justify-center gap-2">
+                    {retryablePrompt ? (
+                      <Button
+                        size="sm"
+                        className="cursor-pointer"
+                        onClick={handleRetryGeneration}
+                      >
+                        <IconRefresh className="w-3.5 h-3.5" />
+                        Try again
+                      </Button>
+                    ) : null}
+                    <Button
+                      ref={generateBtnRef}
+                      variant={retryablePrompt ? "ghost" : "outline"}
+                      size="sm"
+                      className="cursor-pointer"
+                      onClick={() => {
+                        setRetryablePrompt(null);
+                        setShowPrompt(true);
+                      }}
+                    >
+                      <IconPlus className="w-3.5 h-3.5" />
+                      {retryablePrompt ? "New prompt" : "Generate Design"}
+                    </Button>
+                  </div>
                 </>
               )}
             </div>

--- a/templates/design/app/pages/Index.tsx
+++ b/templates/design/app/pages/Index.tsx
@@ -12,6 +12,7 @@ import {
   IconCopy,
   IconCode,
   IconX,
+  IconPencil,
 } from "@tabler/icons-react";
 import { useActionQuery, useActionMutation } from "@agent-native/core/client";
 import { useQueryClient } from "@tanstack/react-query";
@@ -74,6 +75,8 @@ export default function Index() {
     () => new Set(),
   );
   const [showNewPrompt, setShowNewPrompt] = useState(false);
+  const [renameId, setRenameId] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState("");
 
   const anchorElRef = useRef<HTMLElement | null>(null);
   const anchorRef = useRef<HTMLElement | null>(null);
@@ -88,6 +91,7 @@ export default function Index() {
   const createMutation = useActionMutation("create-design");
   const deleteMutation = useActionMutation("delete-design");
   const duplicateMutation = useActionMutation("duplicate-design");
+  const updateMutation = useActionMutation("update-design");
 
   const designs = designsData?.designs ?? [];
 
@@ -209,13 +213,10 @@ export default function Index() {
       files: UploadedFile[],
       options: PromptComposerSubmitOptions,
     ) => {
-      // Derive a title from the prompt — first line / first ~60 chars
-      const derivedTitle =
-        prompt
-          .split("\n")[0]
-          ?.trim()
-          .replace(/[.!?]+$/, "")
-          .slice(0, 60) || "New Design";
+      // Derive a short title from the prompt — first line, ~40 chars max,
+      // word-boundary truncated. The full prompt still drives generation;
+      // the title is just a label, so longer is worse.
+      const derivedTitle = derivePromptTitle(prompt);
 
       const { id, title } = createDesign(derivedTitle);
 
@@ -297,6 +298,37 @@ export default function Index() {
     },
     [duplicateMutation, queryClient, navigate],
   );
+
+  const startRename = useCallback((design: Design) => {
+    setRenameId(design.id);
+    setRenameDraft(design.title);
+  }, []);
+
+  const commitRename = useCallback(() => {
+    if (!renameId) return;
+    const id = renameId;
+    const next = renameDraft.trim();
+    setRenameId(null);
+    if (!next) return;
+
+    queryClient.setQueryData(
+      ["action", "list-designs", undefined],
+      (old: any) => ({
+        count: old?.count ?? 0,
+        designs: (old?.designs ?? []).map((d: Design) =>
+          d.id === id ? { ...d, title: next } : d,
+        ),
+      }),
+    );
+
+    updateMutation.mutate({ id, title: next } as any, {
+      onError: () => {
+        queryClient.invalidateQueries({
+          queryKey: ["action", "list-designs"],
+        });
+      },
+    });
+  }, [renameId, renameDraft, queryClient, updateMutation]);
 
   const projectTypeBadge = (type: ProjectType) => {
     const labels: Record<ProjectType, string> = {
@@ -513,6 +545,13 @@ export default function Index() {
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
                               <DropdownMenuItem
+                                onClick={() => startRename(design)}
+                                className="cursor-pointer"
+                              >
+                                <IconPencil className="w-3.5 h-3.5 mr-2" />
+                                Rename
+                              </DropdownMenuItem>
+                              <DropdownMenuItem
                                 onClick={() => handleDuplicate(design.id)}
                                 className="cursor-pointer"
                               >
@@ -592,8 +631,69 @@ export default function Index() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Rename Dialog */}
+      <AlertDialog
+        open={!!renameId}
+        onOpenChange={(open) => {
+          if (!open) setRenameId(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Rename design</AlertDialogTitle>
+          </AlertDialogHeader>
+          <Input
+            value={renameDraft}
+            onChange={(e) => setRenameDraft(e.target.value)}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                commitRename();
+              }
+            }}
+            placeholder="Design name"
+            className="h-9 text-sm"
+          />
+          <AlertDialogFooter>
+            <AlertDialogCancel className="cursor-pointer">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={commitRename}
+              disabled={!renameDraft.trim()}
+              className="cursor-pointer"
+            >
+              Save
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
+}
+
+/**
+ * Derive a short, friendly title from a prompt. The full prompt still drives
+ * generation — the title is just a label that shows up in the editor header
+ * and the design card, so longer is worse.
+ *
+ * Strategy: take the first line, strip trailing punctuation, then truncate
+ * at the nearest word boundary near 40 chars (with an ellipsis when cut).
+ */
+function derivePromptTitle(prompt: string): string {
+  const firstLine = prompt
+    .split("\n")[0]
+    ?.trim()
+    .replace(/[.!?]+$/, "");
+  if (!firstLine) return "Untitled Design";
+  const MAX = 40;
+  if (firstLine.length <= MAX) return firstLine;
+  const slice = firstLine.slice(0, MAX);
+  const lastSpace = slice.lastIndexOf(" ");
+  const trimmed = lastSpace > 20 ? slice.slice(0, lastSpace) : slice;
+  return `${trimmed.trim()}…`;
 }
 
 function LoadingSkeleton() {

--- a/templates/design/app/pages/Index.tsx
+++ b/templates/design/app/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { useNavigate, Link } from "react-router";
 import { nanoid } from "nanoid";
 import {
@@ -62,6 +62,9 @@ interface Design {
   designSystemId?: string | null;
   createdAt?: string;
   updatedAt?: string;
+  /** Preview HTML for the thumbnail. Only present when the list query asks
+   *  for `includePreview: 'true'`. Truncated server-side. */
+  previewHtml?: string | null;
 }
 
 export default function Index() {
@@ -86,7 +89,7 @@ export default function Index() {
   const { data: designsData, isLoading } = useActionQuery<{
     count: number;
     designs: Design[];
-  }>("list-designs");
+  }>("list-designs", { includePreview: "true" });
 
   const createMutation = useActionMutation("create-design");
   const deleteMutation = useActionMutation("delete-design");
@@ -166,7 +169,7 @@ export default function Index() {
 
       // Optimistic update
       queryClient.setQueryData(
-        ["action", "list-designs", undefined],
+        ["action", "list-designs", { includePreview: "true" }],
         (old: any) => {
           const newDesign: Design = {
             id,
@@ -234,7 +237,7 @@ export default function Index() {
 
     // Optimistic update
     queryClient.setQueryData(
-      ["action", "list-designs", undefined],
+      ["action", "list-designs", { includePreview: "true" }],
       (old: any) => ({
         count: Math.max((old?.count ?? 1) - 1, 0),
         designs: (old?.designs ?? []).filter((d: Design) => d.id !== id),
@@ -259,7 +262,7 @@ export default function Index() {
     const idsToDelete = new Set(ids);
 
     queryClient.setQueryData(
-      ["action", "list-designs", undefined],
+      ["action", "list-designs", { includePreview: "true" }],
       (old: any) => ({
         count: Math.max(
           (old?.count ?? (old?.designs ?? []).length) - ids.length,
@@ -312,7 +315,7 @@ export default function Index() {
     if (!next) return;
 
     queryClient.setQueryData(
-      ["action", "list-designs", undefined],
+      ["action", "list-designs", { includePreview: "true" }],
       (old: any) => ({
         count: old?.count ?? 0,
         designs: (old?.designs ?? []).map((d: Design) =>
@@ -391,7 +394,10 @@ export default function Index() {
         {isLoading ? (
           <LoadingSkeleton />
         ) : designs.length === 0 ? (
-          <EmptyState onCreateDesign={openNewDesign} />
+          <EmptyState
+            onCreateDesign={openNewDesign}
+            onStarterPrompt={(prompt) => handleSubmitPrompt(prompt, [], {})}
+          />
         ) : (
           <>
             {isSelectionMode ? (
@@ -473,9 +479,7 @@ export default function Index() {
                 const isSelected = selectedDesignIds.has(design.id);
                 const cardContent = (
                   <>
-                    <div className="aspect-video bg-muted/50 flex items-center justify-center">
-                      <IconCode className="w-8 h-8 text-muted-foreground/40" />
-                    </div>
+                    <DesignThumbnail html={design.previewHtml ?? null} />
                     <div className="p-4">
                       <div className="flex items-center gap-2 mb-1">
                         <h3 className="font-medium text-sm text-foreground/90 truncate flex-1">
@@ -696,6 +700,72 @@ function derivePromptTitle(prompt: string): string {
   return `${trimmed.trim()}…`;
 }
 
+/**
+ * Render the design's index.html as a non-interactive thumbnail. The iframe
+ * renders at a fixed natural size (so designs that assume a desktop viewport
+ * still look right) and is then scaled to fill the card via a transform.
+ *
+ * The size is recomputed via ResizeObserver so the same component works in
+ * 1, 2, 3 and 4-column grid layouts. We use a sandboxed iframe with the same
+ * settings as DesignCanvas (allow-scripts + allow-same-origin) so Tailwind
+ * CDN + Alpine.js can run.
+ */
+function DesignThumbnail({ html }: { html: string | null }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(0.25);
+
+  // Designs are generated for a desktop-ish viewport. Render at 1280×720 then
+  // shrink — close enough to 16:10 for the aspect-video card without leaving
+  // a sliver of letterbox at the bottom.
+  const NATURAL_WIDTH = 1280;
+  const NATURAL_HEIGHT = 720;
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => {
+      const w = el.clientWidth;
+      if (w > 0) setScale(w / NATURAL_WIDTH);
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  if (!html) {
+    return (
+      <div className="aspect-video bg-muted/50 flex items-center justify-center">
+        <IconCode className="w-8 h-8 text-muted-foreground/40" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="aspect-video relative overflow-hidden bg-white"
+    >
+      <iframe
+        srcDoc={html}
+        sandbox="allow-scripts allow-same-origin"
+        loading="lazy"
+        tabIndex={-1}
+        aria-hidden
+        title="Design preview"
+        style={{
+          width: `${NATURAL_WIDTH}px`,
+          height: `${NATURAL_HEIGHT}px`,
+          transform: `scale(${scale})`,
+          transformOrigin: "top left",
+          border: 0,
+          pointerEvents: "none",
+        }}
+      />
+    </div>
+  );
+}
+
 function LoadingSkeleton() {
   return (
     <>
@@ -717,10 +787,40 @@ function LoadingSkeleton() {
   );
 }
 
+// Starter prompt chips shown on the empty home state. Each one is a fully
+// formed prompt that the user can run with one click instead of staring at
+// an empty composer. Keep these distinct enough that the four results would
+// all look meaningfully different — same approach as Phase 2 variant
+// generation in the design agent.
+const STARTER_PROMPTS: { label: string; prompt: string }[] = [
+  {
+    label: "SaaS landing page",
+    prompt:
+      "A modern SaaS landing page with a dark theme, hero section, three feature cards, and a final CTA section.",
+  },
+  {
+    label: "Dashboard",
+    prompt:
+      "A clean analytics dashboard with a sidebar nav, four KPI tiles, a chart, and a recent-activity table.",
+  },
+  {
+    label: "Mobile app",
+    prompt:
+      "A mobile app prototype shown on a phone frame, with a tab bar at the bottom and three list cards on the home screen.",
+  },
+  {
+    label: "Pricing page",
+    prompt:
+      "A three-tier pricing page with a monthly/annual toggle, feature checklists, and a highlighted recommended tier.",
+  },
+];
+
 function EmptyState({
   onCreateDesign,
+  onStarterPrompt,
 }: {
   onCreateDesign: (e: React.MouseEvent<HTMLElement>) => void;
+  onStarterPrompt: (prompt: string) => void;
 }) {
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center">
@@ -730,11 +830,23 @@ function EmptyState({
       <h2 className="text-xl font-semibold text-foreground mb-2">
         Create your first design
       </h2>
-      <p className="text-sm text-muted-foreground max-w-sm mb-8 leading-relaxed">
-        Build interactive prototypes and design artifacts with AI-powered
-        generation and a visual editor.
+      <p className="text-sm text-muted-foreground max-w-sm mb-6 leading-relaxed">
+        Pick a starting point or write your own prompt.
       </p>
+      <div className="flex flex-wrap items-center justify-center gap-2 max-w-md mb-6">
+        {STARTER_PROMPTS.map((s) => (
+          <button
+            key={s.label}
+            type="button"
+            onClick={() => onStarterPrompt(s.prompt)}
+            className="cursor-pointer rounded-full border border-border bg-card px-3 py-1.5 text-xs text-foreground/80 hover:border-foreground/30 hover:text-foreground/95 transition-colors"
+          >
+            {s.label}
+          </button>
+        ))}
+      </div>
       <Button
+        variant="outline"
         onClick={(e: React.MouseEvent<HTMLButtonElement>) =>
           onCreateDesign(e as React.MouseEvent<HTMLElement>)
         }

--- a/templates/dispatch/app/routes/$appId.tsx
+++ b/templates/dispatch/app/routes/$appId.tsx
@@ -1,4 +1,5 @@
 export {
+  clientLoader,
   default,
   loader,
   meta,

--- a/templates/slides/actions/view-screen.ts
+++ b/templates/slides/actions/view-screen.ts
@@ -61,7 +61,9 @@ export default defineAction({
       );
       lines.push(`deckTitle: ${rows[0].title ?? deck?.title ?? "(untitled)"}`);
       lines.push(`slideCount: ${slides.length}`);
-      lines.push(`currentSlideIndex: ${slideIndex}`);
+      lines.push(
+        `currentSlideIndex: ${slideIndex}   (0-based; the user's UI shows this as "slide ${slideIndex + 1} of ${slides.length}" — use the 1-based number when talking to them)`,
+      );
       if (currentSlide) {
         lines.push(
           `currentSlideId: ${currentSlide.id}   ← use this for update-slide --slideId`,

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -754,14 +754,20 @@ graph TD
                     setToolsOpen(false);
                   }}
                   data-toolbar-pin-button
-                  className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
+                  className={`flex items-start gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
                     pinMode
                       ? "text-foreground bg-accent/50"
                       : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
                   }`}
                 >
-                  <IconPin className="w-3.5 h-3.5" />
-                  Drop comment pin
+                  <IconPin className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+                  <span className="flex flex-col items-start min-w-0">
+                    <span>Pin comments</span>
+                    <span className="text-[10px] text-muted-foreground/80 leading-tight mt-0.5">
+                      Click spots on the slide to queue several edits, then send
+                      them all at once.
+                    </span>
+                  </span>
                 </button>
               )}
             </div>

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -1217,6 +1217,7 @@ export default function SlideEditor({
         }}
       />
       <CanvasCommentPins
+        key={slideId || slide.id}
         active={!!pinMode}
         onClose={() => onExitPinMode?.()}
         canvasSelector="[data-main-slide-canvas='true'] .slide-content"

--- a/templates/slides/app/components/visual-editor/CanvasCommentPins.tsx
+++ b/templates/slides/app/components/visual-editor/CanvasCommentPins.tsx
@@ -76,16 +76,29 @@ export function CanvasCommentPins({
     setActivePinId(null);
   }, [contextId]);
 
-  // Find the canvas container the pins overlay
+  // Find the canvas container the pins overlay. The canvas can take a few
+  // frames to land in the DOM after a slide change — retry until we find
+  // it so the click handler isn't permanently stuck on a stale (or null)
+  // ref when the user navigates between slides with pin mode active.
   useEffect(() => {
     if (!active) return;
+    let cancelled = false;
+    let attempts = 0;
     const findCanvas = () => {
+      if (cancelled) return;
       const el = document.querySelector(canvasSelector) as HTMLElement | null;
-      if (el) containerRef.current = el;
+      if (el) {
+        containerRef.current = el;
+        return;
+      }
+      if (attempts++ < 30) {
+        setTimeout(findCanvas, 50);
+      }
     };
     findCanvas();
-    const t = setTimeout(findCanvas, 50);
-    return () => clearTimeout(t);
+    return () => {
+      cancelled = true;
+    };
   }, [active, canvasSelector, contextId]);
 
   // Click handler — drops a pin where the user clicks the canvas

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -388,7 +388,18 @@ export function DeckProvider({ children }: { children: ReactNode }) {
         // Also re-fetch the currently-open deck so agent-added slides show up.
         // The list endpoint may not include full slide contents, and SSE can
         // miss events if the client reconnects between broadcasts.
-        if (currentOpenId && !pending.has(currentOpenId)) {
+        //
+        // Skip the refetch if a save is pending or in flight — the server's
+        // copy might be a few hundred ms behind the local edits the user is
+        // mid-typing, and overwriting wholesale would briefly revert their
+        // characters before the next save lands. The next poll tick (after
+        // saves settle) catches up.
+        if (
+          currentOpenId &&
+          !pending.has(currentOpenId) &&
+          !pendingSaves.has(currentOpenId) &&
+          !inFlightSaves.has(currentOpenId)
+        ) {
           try {
             const res = await fetch(
               `${appBasePath()}/api/decks/${currentOpenId}`,
@@ -469,6 +480,14 @@ export function DeckProvider({ children }: { children: ReactNode }) {
           lastExternalUpdateRef.current = Date.now();
           setDecks((prev) => prev.filter((d) => d.id !== data.deckId));
         } else if (data.type === "deck-changed" && data.deckId) {
+          // Skip if a save for this deck is pending or in flight — this
+          // event is most likely the echo of our own write and the server
+          // copy may be a few hundred ms behind what the user just typed.
+          // Polling and the next save's response will bring the canonical
+          // state once the local burst settles.
+          if (pendingSaves.has(data.deckId) || inFlightSaves.has(data.deckId)) {
+            return;
+          }
           // Refetch the changed deck from the API
           const res = await fetch(`${appBasePath()}/api/decks/${data.deckId}`);
           if (!res.ok) return;

--- a/templates/slides/app/hooks/use-navigation-state.ts
+++ b/templates/slides/app/hooks/use-navigation-state.ts
@@ -28,6 +28,18 @@ export function useNavigationState() {
       if (path.endsWith("/present")) {
         state.view = "present";
       }
+      // The deck editor stores the active slide as a 1-based ?slide=N URL
+      // param. Convert to a 0-based index for the agent so view-screen can
+      // pick the correct slide; without this, the agent always thought the
+      // user was on slide 1 (off-by-one vs. the toolbar's "6 of 10").
+      const params = new URLSearchParams(location.search);
+      const slideParam = params.get("slide");
+      if (slideParam) {
+        const oneBased = parseInt(slideParam, 10);
+        if (Number.isFinite(oneBased) && oneBased >= 1) {
+          state.slideIndex = oneBased - 1;
+        }
+      }
     } else if (path.startsWith("/settings")) {
       state.view = "settings";
     } else if (path.startsWith("/share/")) {
@@ -43,7 +55,7 @@ export function useNavigationState() {
       },
       body: JSON.stringify(state),
     }).catch(() => {});
-  }, [location.pathname]);
+  }, [location.pathname, location.search]);
 
   // Listen for navigate commands from agent
   const { data: navCommand } = useQuery({

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -365,37 +365,46 @@ export default function DeckEditor() {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!deck || !id || !activeSlideId) return;
-      // Don't intercept if user is typing in an input/textarea/contenteditable
-      // OR if a slide element is selected (image/text element selection state
-      // is owned by SlideEditor — we shouldn't blast the whole slide just
-      // because the user clicked an image then hit Delete).
-      const target = e.target as HTMLElement;
-      if (
-        target.tagName === "INPUT" ||
-        target.tagName === "TEXTAREA" ||
-        target.isContentEditable
-      )
-        return;
+      if (e.key !== "Delete" && e.key !== "Backspace") return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      // Don't intercept while the user is in an annotation mode (pin / draw)
+      // — they are clearly composing, not navigating slides.
+      if (pinMode || drawMode) return;
+      // Bail if the focused element OR the event target is editable, lives
+      // inside the agent sidebar, lives inside a pin popover, or is a slide
+      // element selection. Walking ancestors instead of relying on tagName
+      // alone catches Tiptap (contenteditable), portaled popovers, and
+      // shadcn wrappers that re-route focus.
+      const isInsideSafeZone = (el: Element | null) => {
+        if (!el) return false;
+        if (el instanceof HTMLInputElement) return true;
+        if (el instanceof HTMLTextAreaElement) return true;
+        if (el instanceof HTMLElement) {
+          if (el.isContentEditable) return true;
+          if (el.closest("[contenteditable='true']")) return true;
+          if (el.closest("input, textarea, [role='textbox']")) return true;
+          if (el.closest("[data-pin-popover]")) return true;
+          if (el.closest(".agent-panel-root")) return true;
+        }
+        return false;
+      };
+      const target = e.target as Element | null;
+      if (isInsideSafeZone(target)) return;
+      if (isInsideSafeZone(document.activeElement)) return;
       // Skip if the SlideEditor reports an element is selected (image, text
       // block, or builder-id selector). Slide-level delete is reserved for
       // when the canvas itself has focus.
       if (document.querySelector("[data-slide-element-selected='true']"))
         return;
-      if (
-        (e.key === "Delete" || e.key === "Backspace") &&
-        !e.metaKey &&
-        !e.ctrlKey
-      ) {
-        if (deck.slides.length <= 1) return; // don't delete last slide
-        const idx = deck.slides.findIndex((s) => s.id === activeSlideId);
-        const nextSlide = deck.slides[idx + 1] || deck.slides[idx - 1];
-        deleteSlideWithUndo(id, activeSlideId);
-        if (nextSlide) setActiveSlideId(nextSlide.id);
-      }
+      if (deck.slides.length <= 1) return; // don't delete last slide
+      const idx = deck.slides.findIndex((s) => s.id === activeSlideId);
+      const nextSlide = deck.slides[idx + 1] || deck.slides[idx - 1];
+      deleteSlideWithUndo(id, activeSlideId);
+      if (nextSlide) setActiveSlideId(nextSlide.id);
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [deck, id, activeSlideId, deleteSlideWithUndo]);
+  }, [deck, id, activeSlideId, deleteSlideWithUndo, pinMode, drawMode]);
 
   // Resolve the active slide from URL/deck state. Imports replace slide IDs, so
   // keep this valid after deck contents change instead of only on first load.


### PR DESCRIPTION
## Summary

- **core/auth**: Bridge Builder desktop Google sign-in back to the local workspace gateway. New `oauth-return-url.ts` helpers compute where the OAuth round-trip should bounce; the login HTML, Better Auth bootstrap, and standalone Google plugin all route through them. Spec coverage in `auth.spec.ts` + `onboarding-html.spec.ts`.
- **core/PromptComposer**: Click an attached image thumbnail to open a fullscreen lightbox (Esc / click-outside to close). The X button still removes the attachment.
- **dispatch**: Replace six `"Loading..."` strings with shadcn `Skeleton` placeholders shaped like the content (approval, overview, vault, workspace, apps.$appId, app-keys-popover).
- **calendar/Sidebar**: Per-person eye-toggle in the Other People list now has tooltips and is permanently visible (subtle until hover) instead of hidden behind hover-to-discover.
- **design**: Inline-editable design title on the Index list (pencil affordance + `update-design` mutation + word-boundary `derivePromptTitle` so derived titles are short and readable). EditPanel + DrawOverlay + DesignCanvas polish for the in-canvas edit flow.

## Test plan

- [ ] CI green on `updates-293` (lint, test, typecheck, build, scaffold E2E, guard, changeset)
- [ ] Builder review pass
- [ ] Manual: Builder desktop Google sign-in completes back inside the local workspace gateway
- [ ] Manual: composer image attachment opens fullscreen on click; X still removes; Esc closes lightbox
- [ ] Manual: dispatch loading states render skeletons instead of "Loading..." strings
- [ ] Manual: calendar Sidebar eye-toggle is visible at rest and shows tooltip on hover
- [ ] Manual: design Index inline rename, IconPencil shows + saves via update-design

🤖 Generated with [Claude Code](https://claude.com/claude-code)