### PR TITLE
fix(core/ssr): wrap React Router loaders in runWithRequestContext

### DIFF
--- a/.changeset/core-thread-data-attachment-dedupe.md
+++ b/.changeset/core-thread-data-attachment-dedupe.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+fix(thread persist): every user message was getting duplicated in `chat_threads` because the runtime export (assistant-ui's `saveThreadData`) wrote `attachments: []` while the server-side `persistSubmittedUserMessage` → `buildUserMessage` path omitted the field entirely. The fingerprint used to dedupe in `messageIdentityKeys` couldn't see them as the same message — `[]` and `undefined` hashed differently. Now normalize the attachments slot through `normalizeAttachmentIdentity` (which collapses both shapes to `undefined`) so duplicates merge instead of stacking up as `client_user → assistant → server_user` triples.

--- a/.changeset/ssr-loader-request-context.md
+++ b/.changeset/ssr-loader-request-context.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Wrap SSR loaders in `runWithRequestContext` so React Router loaders see the signed-in user via `getRequestUserEmail()` / `accessFilter()`. Fixes a bug where the slides "Presentation link" 404'd for shared admins and even for the deck owner unless visibility was made public.

--- a/.changeset/ssr-loader-request-context.md
+++ b/.changeset/ssr-loader-request-context.md
@@ -2,4 +2,8 @@
 "@agent-native/core": patch
 ---
 
-Wrap SSR loaders in `runWithRequestContext` so React Router loaders see the signed-in user via `getRequestUserEmail()` / `accessFilter()`. Fixes a bug where the slides "Presentation link" 404'd for shared admins and even for the deck owner unless visibility was made public.
+Mirror Google Slides' sharing behavior in the framework `ShareButton` and SSR runtime:
+
+- Wrap SSR loaders in `runWithRequestContext` so React Router loaders see the signed-in user via `getRequestUserEmail()` / `accessFilter()`. Fixes a bug where shared admins (and even owners) hit 404 on access-controlled SSR routes unless visibility was set to public.
+- `ShareButton` now supports an optional `secondaryShareUrl` (with `secondaryShareUrlLabel` / `secondaryShareUrlDescription`) so a resource can expose two copyable URLs — e.g. an editor link and a read-only / presentation link — in the same share dialog.
+- `shareUrlRequiresPublic` (and the related `shareUrlUnavailableDescription`) is now a no-op and deprecated. Access is enforced on the resource itself, not the URL shape, matching Google Slides — copying a link no longer requires flipping visibility to public.

--- a/packages/core/src/agent/thread-data-builder.spec.ts
+++ b/packages/core/src/agent/thread-data-builder.spec.ts
@@ -322,6 +322,48 @@ describe("mergeThreadDataForClientSave", () => {
     expect(merged.messages).toEqual(existing.messages);
   });
 
+  it("dedupes a client-save user message against the server's submittedRunId copy of the same prompt", () => {
+    // The runtime's saveThreadData PUT sends the runtime export, which
+    // assigns every user message `attachments: []`. The server's
+    // `persistSubmittedUserMessage` → `buildUserMessage` writes the same
+    // logical message but omits `attachments` entirely. Without
+    // attachment normalization in `messageIdentityKeys`, the merge sees
+    // them as different fingerprints and keeps both, producing a duplicate
+    // user-message row per turn (observed on slides prod: every turn
+    // ended up as `client_user → assistant → server_user`).
+    const existing = {
+      messages: [
+        {
+          message: {
+            id: "server-user-run-2026-05-10",
+            role: "user",
+            content: [{ type: "text", text: "make me a deck about pumpkins" }],
+            metadata: { custom: { submittedRunId: "run-2026-05-10" } },
+          },
+          parentId: null,
+        },
+      ],
+    };
+    const incoming = {
+      messages: [
+        {
+          message: {
+            id: "client-runtime-id",
+            role: "user",
+            content: [{ type: "text", text: "make me a deck about pumpkins" }],
+            attachments: [],
+            metadata: { custom: {} },
+          },
+          parentId: null,
+        },
+      ],
+    };
+
+    const merged = mergeThreadDataForClientSave(existing, incoming);
+
+    expect(merged.messages).toHaveLength(1);
+  });
+
   it("keeps a terminal server message over a stale same-run partial", () => {
     const existing = {
       messages: [

--- a/packages/core/src/agent/thread-data-builder.ts
+++ b/packages/core/src/agent/thread-data-builder.ts
@@ -236,7 +236,7 @@ function isTerminalAssistantStatus(status: unknown): boolean {
 }
 
 function normalizeAttachmentIdentity(attachments: unknown): unknown {
-  if (!Array.isArray(attachments)) return undefined;
+  if (!Array.isArray(attachments) || attachments.length === 0) return undefined;
   return attachments.map((att: any) => ({
     type: att?.type,
     name: att?.name,
@@ -252,12 +252,23 @@ function messageIdentityKeys(message: any): string[] {
   const runId = getMessageRunId(message);
   if (runId) keys.push(`run:${runId}`);
 
+  // Normalize attachments through `normalizeAttachmentIdentity` so an
+  // explicit empty `[]` (assistant-ui's default for messages with no
+  // attachments) and an omitted/undefined `attachments` field hash to the
+  // same fingerprint. Without this, every user message ended up duplicated
+  // in `chat_threads`: one copy from `saveThreadData` (runtime export
+  // includes `attachments: []`) and one from `persistSubmittedUserMessage`
+  // → `buildUserMessage` (omits the field entirely). The merge couldn't
+  // dedupe them because their fingerprints differed by exactly one
+  // `[]` vs `undefined`. (Repro on slides prod: every user turn produced
+  // a `client_user → assistant → server_user` triple instead of a
+  // `user → assistant` pair.)
   try {
     keys.push(
       `fingerprint:${JSON.stringify({
         role: message?.role,
         content: message?.content,
-        attachments: message?.attachments,
+        attachments: normalizeAttachmentIdentity(message?.attachments),
       })}`,
     );
   } catch {

--- a/packages/core/src/client/sharing/ShareButton.spec.tsx
+++ b/packages/core/src/client/sharing/ShareButton.spec.tsx
@@ -137,69 +137,17 @@ describe("ShareButton", () => {
     );
   });
 
-  it("requires public visibility before copying a public-only link", async () => {
-    const writeText = vi.fn(async () => undefined);
-    Object.defineProperty(navigator, "clipboard", {
-      value: { writeText },
-      configurable: true,
-    });
-
+  it("shows the copy action for share URLs regardless of visibility", async () => {
+    // Mirrors Google Slides: the copy button is always live. Access is
+    // enforced when the recipient opens the URL, not by hiding the link in
+    // the share dialog.
     await act(async () => {
       root.render(
         <QueryClientProvider client={queryClient}>
           <ShareButton
             resourceType="deck"
             resourceId="deck-1"
-            resourceTitle="Launch deck"
-            shareUrl="https://slides.agent-native.com/p/deck-1"
-            shareUrlRequiresPublic
-          />
-        </QueryClientProvider>,
-      );
-    });
-
-    const makePublicAndCopy = Array.from(
-      container.querySelectorAll("button"),
-    ).find((button) => button.textContent === "Make public and copy");
-    if (!makePublicAndCopy) throw new Error("Make public button not found");
-
-    const linkInput = container.querySelector(
-      'input[value="Link available after general access is Public"]',
-    );
-    expect(linkInput).toBeTruthy();
-
-    await act(async () => {
-      makePublicAndCopy.click();
-    });
-
-    expect(otherMutate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resourceType: "deck",
-        resourceId: "deck-1",
-        visibility: "public",
-      }),
-      expect.any(Object),
-    );
-    expect(writeText).not.toHaveBeenCalled();
-  });
-
-  it("shows the copy action for public public-only links", async () => {
-    sharesData.current = {
-      ownerEmail: "owner@example.com",
-      orgId: null,
-      visibility: "public",
-      role: "owner",
-      shares: [],
-    };
-
-    await act(async () => {
-      root.render(
-        <QueryClientProvider client={queryClient}>
-          <ShareButton
-            resourceType="deck"
-            resourceId="deck-1"
-            shareUrl="https://slides.agent-native.com/p/deck-1"
-            shareUrlRequiresPublic
+            shareUrl="https://slides.agent-native.com/deck/deck-1"
           />
         </QueryClientProvider>,
       );
@@ -210,5 +158,32 @@ describe("ShareButton", () => {
         (button) => button.textContent === "Copy",
       ),
     ).toBe(true);
+  });
+
+  it("renders both primary and secondary share URLs", async () => {
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ShareButton
+            resourceType="deck"
+            resourceId="deck-1"
+            shareUrl="https://slides.agent-native.com/deck/deck-1"
+            shareUrlLabel="Editor link"
+            secondaryShareUrl="https://slides.agent-native.com/p/deck-1"
+            secondaryShareUrlLabel="Presentation link"
+          />
+        </QueryClientProvider>,
+      );
+    });
+
+    const inputs = Array.from(container.querySelectorAll("input"));
+    const editorInput = inputs.find(
+      (i) => i.value === "https://slides.agent-native.com/deck/deck-1",
+    );
+    const presentationInput = inputs.find(
+      (i) => i.value === "https://slides.agent-native.com/p/deck-1",
+    );
+    expect(editorInput).toBeTruthy();
+    expect(presentationInput).toBeTruthy();
   });
 });

--- a/packages/core/src/client/sharing/ShareButton.tsx
+++ b/packages/core/src/client/sharing/ShareButton.tsx
@@ -37,15 +37,28 @@ export interface ShareButtonProps {
    *  button next to an iframe use this to disable the iframe's pointer events
    *  while the popover is open, so popover hover/clicks aren't swallowed. */
   onOpenChange?: (open: boolean) => void;
-  /** Optional public/share URL shown as a copyable link in the popover. */
+  /** Optional public/share URL shown as a copyable link in the popover.
+   *  This is treated as the primary "Copy link" target — same convention
+   *  as Google Docs' Share dialog, which copies the editor URL. */
   shareUrl?: string;
-  /** Optional label for the copyable link section. */
+  /** Optional label for the primary copyable link section. */
   shareUrlLabel?: string;
-  /** Optional helper text for the copyable link section. */
+  /** Optional helper text for the primary copyable link section. */
   shareUrlDescription?: ReactNode;
-  /** When true, the share URL is only copyable after visibility is public. */
+  /** Optional secondary copyable link (e.g. a presentation / read-only
+   *  surface for the same resource). Anyone with at least viewer access
+   *  can open it — access is enforced on the resource itself, not the
+   *  URL shape, so we never gate this behind visibility. */
+  secondaryShareUrl?: string;
+  /** Optional label for the secondary copyable link. */
+  secondaryShareUrlLabel?: string;
+  /** Optional helper text for the secondary copyable link. */
+  secondaryShareUrlDescription?: ReactNode;
+  /** @deprecated No longer enforced — access is checked on the resource,
+   *  not the URL shape, mirroring Google Slides. Kept for callsite
+   *  compatibility; the prop is now a no-op. */
   shareUrlRequiresPublic?: boolean;
-  /** Optional helper text shown when the share URL requires public visibility. */
+  /** @deprecated See `shareUrlRequiresPublic`. No longer rendered. */
   shareUrlUnavailableDescription?: ReactNode;
   /** Optional template-specific copy for the visibility picker. */
   visibilityCopy?: Partial<
@@ -683,20 +696,14 @@ function SharePanel(
           value={props.shareUrl}
           label={props.shareUrlLabel}
           description={props.shareUrlDescription}
-          unavailable={props.shareUrlRequiresPublic && visibility !== "public"}
-          unavailableDescription={
-            props.shareUrlUnavailableDescription ??
-            (canManage
-              ? "Make general access public before copying this link."
-              : "This link is not public. Ask an owner or admin to make it public.")
-          }
-          unavailableActionLabel={
-            canManage ? "Make public and copy" : "Not public"
-          }
-          unavailableActionBusyLabel="Making public..."
-          onUnavailableAction={
-            canManage ? () => onVisibilityChange("public") : undefined
-          }
+        />
+      ) : null}
+
+      {props.secondaryShareUrl ? (
+        <CopyLinkField
+          value={props.secondaryShareUrl}
+          label={props.secondaryShareUrlLabel}
+          description={props.secondaryShareUrlDescription}
         />
       ) : null}
 
@@ -717,23 +724,12 @@ function CopyLinkField({
   value,
   label = "Share link",
   description,
-  unavailable = false,
-  unavailableDescription,
-  unavailableActionLabel = "Unavailable",
-  unavailableActionBusyLabel = "Working...",
-  onUnavailableAction,
 }: {
   value: string;
   label?: string;
   description?: ReactNode;
-  unavailable?: boolean;
-  unavailableDescription?: ReactNode;
-  unavailableActionLabel?: string;
-  unavailableActionBusyLabel?: string;
-  onUnavailableAction?: () => Promise<void> | void;
 }) {
   const [copied, setCopied] = useState(false);
-  const [busy, setBusy] = useState(false);
   const resetRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => {
@@ -742,41 +738,16 @@ function CopyLinkField({
     };
   }, []);
 
-  const markCopied = () => {
-    setCopied(true);
-    if (resetRef.current) clearTimeout(resetRef.current);
-    resetRef.current = setTimeout(() => setCopied(false), 1400);
-  };
-
-  const copyValue = async () => {
-    await navigator.clipboard.writeText(value);
-    markCopied();
-  };
-
   const handleCopy = async () => {
     try {
-      await copyValue();
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      if (resetRef.current) clearTimeout(resetRef.current);
+      resetRef.current = setTimeout(() => setCopied(false), 1400);
     } catch {
       setCopied(false);
     }
   };
-
-  const handleUnavailableAction = async () => {
-    if (!onUnavailableAction) return;
-    setBusy(true);
-    try {
-      await onUnavailableAction();
-      await copyValue();
-    } catch {
-      setCopied(false);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const inputValue = unavailable
-    ? "Link available after general access is Public"
-    : value;
 
   return (
     <div className="mb-4">
@@ -784,39 +755,20 @@ function CopyLinkField({
       {description ? (
         <div className="mb-2 text-xs text-muted-foreground">{description}</div>
       ) : null}
-      {unavailable && unavailableDescription ? (
-        <div className="mb-2 rounded-md border border-border bg-muted/35 px-3 py-2 text-xs text-muted-foreground">
-          {unavailableDescription}
-        </div>
-      ) : null}
       <div className="flex min-w-0 items-center gap-2">
         <input
           readOnly
-          disabled={unavailable}
-          value={inputValue}
-          aria-disabled={unavailable}
-          className={cn(
-            "h-9 min-w-0 flex-1 rounded-md border border-input px-3 text-sm text-muted-foreground outline-none",
-            unavailable ? "cursor-not-allowed bg-muted/40" : "bg-background",
-          )}
-          onFocus={(event) => {
-            if (!unavailable) event.currentTarget.select();
-          }}
+          value={value}
+          className="h-9 min-w-0 flex-1 rounded-md border border-input bg-background px-3 text-sm text-muted-foreground outline-none"
+          onFocus={(event) => event.currentTarget.select()}
         />
         <button
           type="button"
-          onClick={unavailable ? handleUnavailableAction : handleCopy}
-          disabled={unavailable && !onUnavailableAction}
+          onClick={handleCopy}
           className="inline-flex h-9 shrink-0 items-center gap-2 rounded-md border border-input bg-background px-3 text-sm font-medium text-foreground hover:bg-accent"
         >
           {copied ? <IconCheck size={15} /> : <IconCopy size={15} />}
-          {busy
-            ? unavailableActionBusyLabel
-            : unavailable
-              ? unavailableActionLabel
-              : copied
-                ? "Copied"
-                : "Copy"}
+          {copied ? "Copied" : "Copy"}
         </button>
       </div>
     </div>

--- a/packages/core/src/server/ssr-handler.ts
+++ b/packages/core/src/server/ssr-handler.ts
@@ -16,8 +16,24 @@
  * the unknown scheme — silently 302'ing every request to "/".
  */
 import { createRequestHandler } from "react-router";
-import { defineEventHandler } from "h3";
+import { defineEventHandler, type H3Event } from "h3";
 import { getSentryClientConfigScript } from "./sentry-config.js";
+import { getSession } from "./auth.js";
+import { runWithRequestContext } from "./request-context.js";
+
+/**
+ * Read the active org for a request without forcing every template to bundle
+ * the org module. Mirrors what `core-routes-plugin` does for action handlers.
+ */
+async function readOrgIdForEvent(event: H3Event): Promise<string | undefined> {
+  try {
+    const { getOrgContext } = await import("../org/context.js");
+    const ctx = await getOrgContext(event);
+    return ctx?.orgId ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 function normalizeAppBasePath(value: string | undefined): string {
   if (!value || value === "/") return "";
@@ -188,13 +204,31 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
     }
     try {
       const request = requestWithPathname(event.req as Request, p, basePath);
+      // Pin the active session onto the async request context so React Router
+      // loaders that call `getRequestUserEmail()` / `accessFilter()` see the
+      // signed-in user. Without this, SSR loaders fall through to the
+      // unauthenticated branch even when the user is logged in — which broke
+      // shared-deck "Presentation link" access for non-public decks.
+      let session: Awaited<ReturnType<typeof getSession>> | null = null;
+      try {
+        session = await getSession(event);
+      } catch {
+        // Auth lookup failures must not break SSR; treat as unauthenticated.
+      }
+      const orgId = session?.email ? await readOrgIdForEvent(event) : undefined;
+      const ctx = {
+        userEmail: session?.email ?? undefined,
+        orgId,
+      };
       if (request.method === "HEAD") {
         const getRequest = new Request(request.url, {
           method: "GET",
           headers: request.headers,
           signal: request.signal,
         });
-        const response = await handler(getRequest);
+        const response = await runWithRequestContext(ctx, () =>
+          handler(getRequest),
+        );
         return await rewriteMountedResponse(
           new Response(null, {
             status: response.status,
@@ -204,7 +238,10 @@ export function createH3SSRHandler(getBuild: () => Promise<unknown> | unknown) {
           basePath,
         );
       }
-      return await rewriteMountedResponse(await handler(request), basePath);
+      return await rewriteMountedResponse(
+        await runWithRequestContext(ctx, () => handler(request)),
+        basePath,
+      );
     } catch (err) {
       // Log the full stack server-side, but never leak it to the client.
       // Stack traces expose file paths, library versions, and code structure

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -203,8 +203,7 @@ body {
     background var(--ease);
 }
 
-.tab:hover .tab-close,
-.tab--active .tab-close {
+.tab:hover .tab-close {
   opacity: 0.5;
 }
 

--- a/templates/content/app/components/editor/LinkHoverPreview.tsx
+++ b/templates/content/app/components/editor/LinkHoverPreview.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useRef, forwardRef } from "react";
-import { IconUnlink, IconExternalLink } from "@tabler/icons-react";
+import { useEffect, useState, useRef } from "react";
+import { IconUnlink, IconExternalLink, IconPencil } from "@tabler/icons-react";
 import type { Editor } from "@tiptap/react";
 import {
   Tooltip,
@@ -21,6 +21,8 @@ export function LinkHoverPreview({
     rect: DOMRect;
     pos: number;
   } | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [editUrl, setEditUrl] = useState("");
 
   const hoverTimer = useRef<NodeJS.Timeout>(undefined);
   const leaveTimer = useRef<NodeJS.Timeout>(undefined);
@@ -28,6 +30,7 @@ export function LinkHoverPreview({
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
+      if (editing) return;
       const target = e.target as HTMLElement;
       const link = target.closest("a.notion-link") as HTMLAnchorElement;
 
@@ -68,6 +71,7 @@ export function LinkHoverPreview({
     };
 
     const handleMouseLeave = () => {
+      if (editing) return;
       clearTimeout(hoverTimer.current);
       leaveTimer.current = setTimeout(() => {
         setHoveredLink(null);
@@ -84,7 +88,7 @@ export function LinkHoverPreview({
       clearTimeout(hoverTimer.current);
       clearTimeout(leaveTimer.current);
     };
-  }, [editor, hoveredLink]);
+  }, [editor, hoveredLink, editing]);
 
   const handleRemoveLink = () => {
     if (hoveredLink && hoveredLink.pos >= 0) {
@@ -96,6 +100,35 @@ export function LinkHoverPreview({
         .run();
       setHoveredLink(null);
     }
+  };
+
+  const handleStartEdit = () => {
+    if (!hoveredLink) return;
+    setEditUrl(hoveredLink.url);
+    setEditing(true);
+  };
+
+  const handleCancelEdit = () => {
+    setEditing(false);
+    setEditUrl("");
+    setHoveredLink(null);
+  };
+
+  const handleApplyEdit = () => {
+    if (!hoveredLink || hoveredLink.pos < 0) return;
+    const next = editUrl.trim();
+    const chain = editor
+      .chain()
+      .setTextSelection(hoveredLink.pos)
+      .extendMarkRange("link");
+    if (next) {
+      chain.setLink({ href: next }).run();
+    } else {
+      chain.unsetLink().run();
+    }
+    setEditing(false);
+    setEditUrl("");
+    setHoveredLink(null);
   };
 
   if (!hoveredLink) return null;
@@ -112,6 +145,7 @@ export function LinkHoverPreview({
     <div
       ref={previewRef}
       onMouseLeave={() => {
+        if (editing) return;
         leaveTimer.current = setTimeout(() => {
           setHoveredLink(null);
           leaveTimer.current = undefined;
@@ -129,42 +163,84 @@ export function LinkHoverPreview({
       }}
       className="w-72 rounded-lg border bg-popover text-popover-foreground shadow-md overflow-hidden animate-in fade-in-0 zoom-in-95"
     >
-      <div className="flex items-center gap-2 p-2">
-        <a
-          href={hoveredLink.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex-1 text-xs text-blue-500 hover:underline truncate"
-        >
-          {domain}
-        </a>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <a
-              href={hoveredLink.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-muted-foreground hover:text-foreground p-1 rounded hover:bg-accent"
-            >
-              <IconExternalLink className="h-3.5 w-3.5" />
-            </a>
-          </TooltipTrigger>
-          <TooltipContent>Open link</TooltipContent>
-        </Tooltip>
-        {editable ? (
+      {editing ? (
+        <div className="flex items-center gap-1 p-1.5">
+          <input
+            autoFocus
+            type="url"
+            value={editUrl}
+            onChange={(e) => setEditUrl(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleApplyEdit();
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                handleCancelEdit();
+              }
+            }}
+            placeholder="Paste link..."
+            className="flex-1 bg-transparent border-none outline-none text-xs px-2 py-1 placeholder:text-muted-foreground"
+          />
+          <button
+            onClick={handleApplyEdit}
+            className="text-xs font-medium text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 px-2 py-1 cursor-pointer"
+          >
+            Apply
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 p-2">
+          <a
+            href={hoveredLink.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex-1 text-xs text-blue-600 dark:text-blue-400 hover:underline truncate"
+          >
+            {domain}
+          </a>
           <Tooltip>
             <TooltipTrigger asChild>
-              <button
-                onClick={handleRemoveLink}
-                className="text-muted-foreground hover:text-destructive p-1 rounded hover:bg-destructive/10"
+              <a
+                href={hoveredLink.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground hover:text-foreground p-1 rounded hover:bg-accent cursor-pointer"
               >
-                <IconUnlink className="h-3.5 w-3.5" />
-              </button>
+                <IconExternalLink className="h-3.5 w-3.5" />
+              </a>
             </TooltipTrigger>
-            <TooltipContent>Remove link</TooltipContent>
+            <TooltipContent>Open link</TooltipContent>
           </Tooltip>
-        ) : null}
-      </div>
+          {editable ? (
+            <>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={handleStartEdit}
+                    className="text-muted-foreground hover:text-foreground p-1 rounded hover:bg-accent cursor-pointer"
+                  >
+                    <IconPencil className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Edit link</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={handleRemoveLink}
+                    className="text-muted-foreground hover:text-destructive p-1 rounded hover:bg-destructive/10 cursor-pointer"
+                  >
+                    <IconUnlink className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Remove link</TooltipContent>
+              </Tooltip>
+            </>
+          ) : null}
+        </div>
+      )}
     </div>
   );
 }

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { getDb, schema } from "../server/db/index.js";
 import { assertAccess } from "@agent-native/core/sharing";
 import { notifyClients } from "../server/handlers/decks.js";
+import { normalizeSlidePadding } from "../app/lib/normalize-slide-padding.js";
 
 // In-process serialization per deckId. `add-slide` is intentionally advertised
 // as a sequential write, but the lock still protects against accidental
@@ -87,7 +88,10 @@ export default defineAction({
         `slide-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const newSlide: any = { id: newSlideId, content };
+      const newSlide: any = {
+        id: newSlideId,
+        content: normalizeSlidePadding(content),
+      };
       if (layout) newSlide.layout = layout;
       if (notes) newSlide.notes = notes;
 

--- a/templates/slides/actions/create-deck.ts
+++ b/templates/slides/actions/create-deck.ts
@@ -11,6 +11,7 @@ import {
 import { notifyClients } from "../server/handlers/decks.js";
 import { ASPECT_RATIO_VALUES } from "../shared/aspect-ratios.js";
 import { getDeckUrl } from "./_app-url.js";
+import { normalizeSlidePadding } from "../app/lib/normalize-slide-padding.js";
 
 const SlideSchema = z.object({
   id: z.string().describe("Unique slide ID, e.g. 'slide-1'"),
@@ -67,9 +68,20 @@ export default defineAction({
       .describe("Optional design system ID to link to the deck"),
   }),
   http: false,
-  run: async ({ title, slides, deckId, aspectRatio, designSystemId }) => {
+  run: async ({
+    title,
+    slides: rawSlides,
+    deckId,
+    aspectRatio,
+    designSystemId,
+  }) => {
     const db = getDb();
     const now = new Date().toISOString();
+
+    const slides = rawSlides.map((s) => ({
+      ...s,
+      content: normalizeSlidePadding(s.content),
+    }));
 
     if (deckId) {
       if (designSystemId) {

--- a/templates/slides/actions/update-slide.ts
+++ b/templates/slides/actions/update-slide.ts
@@ -10,6 +10,8 @@ import { z } from "zod";
 import { notifyClients } from "../server/handlers/decks.js";
 import "../server/db/index.js"; // ensure registerShareableResource runs
 
+import { normalizeSlidePadding } from "../app/lib/normalize-slide-padding.js";
+
 async function findCollabOrigin(): Promise<string | null> {
   const tryOrigins = [
     process.env.ORIGIN,
@@ -130,7 +132,7 @@ export default defineAction({
     let findFound = true;
 
     if (fullContent) {
-      slide.content = fullContent;
+      slide.content = normalizeSlidePadding(fullContent);
       applied = true;
     } else if (find) {
       const idx = (slide.content as string).indexOf(find);

--- a/templates/slides/app/__tests__/public-deck-route.test.ts
+++ b/templates/slides/app/__tests__/public-deck-route.test.ts
@@ -25,6 +25,7 @@ vi.mock("@agent-native/core/sharing", () => ({
 
 vi.mock("drizzle-orm", () => ({
   and: (...conditions: unknown[]) => ({ and: conditions }),
+  or: (...conditions: unknown[]) => ({ or: conditions }),
   eq: (column: unknown, value: unknown) => ({ column, value }),
 }));
 
@@ -57,7 +58,7 @@ describe("public deck route", () => {
     mockGetRequestUserEmail.mockReturnValue(undefined);
   });
 
-  it("serves a public deck without speaker notes", async () => {
+  it("serves a public deck for anonymous viewers without speaker notes", async () => {
     resultQueue.current = [publicDeckRows()];
 
     const result = await loader(requestFor());
@@ -73,6 +74,7 @@ describe("public deck route", () => {
         background: "#111",
       },
     ]);
+    // Anonymous viewers only see decks with visibility = "public".
     expect(where).toHaveBeenCalledWith({
       and: [
         { column: "id_col", value: "deck-1" },
@@ -81,32 +83,33 @@ describe("public deck route", () => {
     });
   });
 
-  it("redirects signed-in viewers with access to the editor", async () => {
+  it("renders the presentation for signed-in viewers with share access", async () => {
     mockGetRequestUserEmail.mockReturnValue("viewer@example.com");
-    resultQueue.current = [[{ id: "deck-1" }]];
-
-    try {
-      await loader(requestFor());
-      throw new Error("Expected redirect");
-    } catch (error) {
-      expect(error).toBeInstanceOf(Response);
-      const response = error as Response;
-      expect(response.status).toBe(302);
-      expect(response.headers.get("Location")).toBe("/deck/deck-1");
-    }
-  });
-
-  it("keeps signed-in public-link-only viewers on the read-only route", async () => {
-    mockGetRequestUserEmail.mockReturnValue("viewer@example.com");
-    resultQueue.current = [[], publicDeckRows()];
+    resultQueue.current = [publicDeckRows()];
 
     const result = await loader(requestFor());
 
+    // Mirrors Google Slides: shared users open the presentation directly
+    // instead of being bounced to the editor.
     expect(result.deck?.title).toBe("Launch review");
-    expect(result.deck?.slides[0]?.notes).toBe("");
+    // Signed-in viewers query unions accessFilter and visibility=public.
+    expect(where).toHaveBeenCalledWith({
+      and: [
+        { column: "id_col", value: "deck-1" },
+        {
+          or: ["access_filter", { column: "visibility_col", value: "public" }],
+        },
+      ],
+    });
   });
 
-  it("404s when the deck is not public", async () => {
+  it("404s when the deck is private and the viewer has no access", async () => {
+    mockGetRequestUserEmail.mockReturnValue("viewer@example.com");
+    resultQueue.current = [[]];
+    await expect(loader(requestFor())).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("404s anonymous visitors when the deck is not public", async () => {
     await expect(loader(requestFor())).rejects.toMatchObject({ status: 404 });
   });
 });

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -69,6 +69,10 @@ interface EditorToolbarProps {
   deck: Deck;
   deckId: string;
   deckTitle: string;
+  /** When false, the user is a viewer — render the editor shell with all
+   *  edit affordances disabled, matching Google Slides' viewer experience.
+   *  Defaults to true for backward compatibility. */
+  canEdit?: boolean;
   onTitleChange: (title: string) => void;
   activeTab: "visual" | "code";
   onTabChange: (tab: "visual" | "code") => void;
@@ -249,8 +253,17 @@ export default function EditorToolbar({
   aspectRatio,
   onSetAspectRatio,
   designSystemTitle,
+  canEdit = true,
 }: EditorToolbarProps) {
-  const shareUrl =
+  // Mirror Google Slides: the share dialog exposes both the editor URL
+  // (primary) and the presentation URL (secondary). Access is enforced on
+  // the deck, not the URL shape — anyone with at least viewer access can
+  // open either link.
+  const editorUrl =
+    typeof window === "undefined"
+      ? `/deck/${deckId}`
+      : `${window.location.origin}${appPath(`/deck/${deckId}`)}`;
+  const presentationUrl =
     typeof window === "undefined"
       ? `/p/${deckId}`
       : `${window.location.origin}${appPath(`/p/${deckId}`)}`;
@@ -407,8 +420,15 @@ export default function EditorToolbar({
       {/* Spacer */}
       <div className="flex-1 min-w-2" />
 
+      {/* "View only" badge — mirrors Google Slides' viewer chrome */}
+      {!canEdit && (
+        <span className="flex-shrink-0 inline-flex items-center gap-1 rounded-full border border-border bg-muted/50 px-2.5 py-1 text-xs font-medium text-muted-foreground">
+          View only
+        </span>
+      )}
+
       {/* Slide settings cog menu */}
-      {currentSlide && onUpdateSlide && (
+      {canEdit && currentSlide && onUpdateSlide && (
         <>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -662,178 +682,187 @@ graph TD
       )}
 
       {/* Slide tools palette — animations, tweaks, draw, comment-pin all live
-       * inside one popover so the toolbar doesn't drown in icons. */}
-      {(onToggleAnimations ||
-        onToggleTweaks ||
-        onToggleDrawMode ||
-        onTogglePinMode) && (
-        <>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                ref={toolsRef}
-                onClick={() => {
-                  closeAll();
-                  setToolsOpen(!toolsOpen);
-                }}
-                className={`relative p-1.5 rounded cursor-pointer flex-shrink-0 ${
-                  anyToolActive || toolsOpen
-                    ? "bg-accent text-foreground"
-                    : "text-muted-foreground hover:text-foreground/70 hover:bg-accent"
-                }`}
-                aria-label="Slide tools"
-              >
-                <IconWand className="w-4 h-4" />
-                {anyToolActive && !toolsOpen && (
-                  <span className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-[#609FF8]" />
+       * inside one popover so the toolbar doesn't drown in icons. Hidden in
+       * view-only mode since none of these affordances apply. */}
+      {canEdit &&
+        (onToggleAnimations ||
+          onToggleTweaks ||
+          onToggleDrawMode ||
+          onTogglePinMode) && (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  ref={toolsRef}
+                  onClick={() => {
+                    closeAll();
+                    setToolsOpen(!toolsOpen);
+                  }}
+                  className={`relative p-1.5 rounded cursor-pointer flex-shrink-0 ${
+                    anyToolActive || toolsOpen
+                      ? "bg-accent text-foreground"
+                      : "text-muted-foreground hover:text-foreground/70 hover:bg-accent"
+                  }`}
+                  aria-label="Slide tools"
+                >
+                  <IconWand className="w-4 h-4" />
+                  {anyToolActive && !toolsOpen && (
+                    <span className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-[#609FF8]" />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Slide tools</TooltipContent>
+            </Tooltip>
+            <ToolbarPopover
+              open={toolsOpen}
+              anchorRef={toolsRef}
+              onClose={() => setToolsOpen(false)}
+              width={200}
+            >
+              <div className="py-1.5">
+                {currentSlide && onToggleAnimations && (
+                  <button
+                    onClick={() => {
+                      onToggleAnimations();
+                      setToolsOpen(false);
+                    }}
+                    className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
+                      animationsOpen
+                        ? "text-[#609FF8] bg-accent/50"
+                        : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                    }`}
+                  >
+                    <IconBolt className="w-3.5 h-3.5" />
+                    Element animations
+                  </button>
                 )}
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Slide tools</TooltipContent>
-          </Tooltip>
-          <ToolbarPopover
-            open={toolsOpen}
-            anchorRef={toolsRef}
-            onClose={() => setToolsOpen(false)}
-            width={200}
-          >
-            <div className="py-1.5">
-              {currentSlide && onToggleAnimations && (
-                <button
-                  onClick={() => {
-                    onToggleAnimations();
-                    setToolsOpen(false);
-                  }}
-                  className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
-                    animationsOpen
-                      ? "text-[#609FF8] bg-accent/50"
-                      : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                  }`}
-                >
-                  <IconBolt className="w-3.5 h-3.5" />
-                  Element animations
-                </button>
-              )}
-              {onToggleTweaks && (
-                <button
-                  onClick={() => {
-                    onToggleTweaks();
-                    setToolsOpen(false);
-                  }}
-                  className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
-                    tweaksOpen
-                      ? "text-foreground bg-accent/50"
-                      : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                  }`}
-                >
-                  <IconAdjustments className="w-3.5 h-3.5" />
-                  Tweaks
-                </button>
-              )}
-              {onToggleDrawMode && (
-                <button
-                  onClick={() => {
-                    onToggleDrawMode();
-                    setToolsOpen(false);
-                  }}
-                  data-toolbar-draw-button
-                  className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
-                    drawMode
-                      ? "text-foreground bg-accent/50"
-                      : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                  }`}
-                >
-                  <IconPencilPlus className="w-3.5 h-3.5" />
-                  Draw on slide
-                </button>
-              )}
-              {onTogglePinMode && (
-                <button
-                  onClick={() => {
-                    onTogglePinMode();
-                    setToolsOpen(false);
-                  }}
-                  data-toolbar-pin-button
-                  className={`flex items-start gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
-                    pinMode
-                      ? "text-foreground bg-accent/50"
-                      : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                  }`}
-                >
-                  <IconPin className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
-                  <span className="flex flex-col items-start min-w-0">
-                    <span>Pin comments</span>
-                    <span className="text-[10px] text-muted-foreground/80 leading-tight mt-0.5">
-                      Click spots on the slide to queue several edits, then send
-                      them all at once.
+                {onToggleTweaks && (
+                  <button
+                    onClick={() => {
+                      onToggleTweaks();
+                      setToolsOpen(false);
+                    }}
+                    className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
+                      tweaksOpen
+                        ? "text-foreground bg-accent/50"
+                        : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                    }`}
+                  >
+                    <IconAdjustments className="w-3.5 h-3.5" />
+                    Tweaks
+                  </button>
+                )}
+                {onToggleDrawMode && (
+                  <button
+                    onClick={() => {
+                      onToggleDrawMode();
+                      setToolsOpen(false);
+                    }}
+                    data-toolbar-draw-button
+                    className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
+                      drawMode
+                        ? "text-foreground bg-accent/50"
+                        : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                    }`}
+                  >
+                    <IconPencilPlus className="w-3.5 h-3.5" />
+                    Draw on slide
+                  </button>
+                )}
+                {onTogglePinMode && (
+                  <button
+                    onClick={() => {
+                      onTogglePinMode();
+                      setToolsOpen(false);
+                    }}
+                    data-toolbar-pin-button
+                    className={`flex items-start gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
+                      pinMode
+                        ? "text-foreground bg-accent/50"
+                        : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                    }`}
+                  >
+                    <IconPin className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+                    <span className="flex flex-col items-start min-w-0">
+                      <span>Pin comments</span>
+                      <span className="text-[10px] text-muted-foreground/80 leading-tight mt-0.5">
+                        Click spots on the slide to queue several edits, then
+                        send them all at once.
+                      </span>
                     </span>
-                  </span>
+                  </button>
+                )}
+              </div>
+            </ToolbarPopover>
+          </>
+        )}
+
+      {/* Edit-only cluster — undo/redo + edit-mode tabs */}
+      {canEdit && (
+        <>
+          {/* Separator */}
+          <div className="w-px h-5 bg-accent flex-shrink-0 hidden sm:block" />
+
+          {/* Undo/Redo */}
+          <div className="flex items-center flex-shrink-0">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onUndo}
+                  disabled={!canUndo}
+                  className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent disabled:opacity-20 transition-colors"
+                  aria-label="Undo"
+                >
+                  <IconArrowBackUp className="w-3.5 h-3.5 text-muted-foreground" />
                 </button>
-              )}
-            </div>
-          </ToolbarPopover>
+              </TooltipTrigger>
+              <TooltipContent>Undo ({shortcutLabel("cmd+z")})</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onRedo}
+                  disabled={!canRedo}
+                  className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent disabled:opacity-20 transition-colors"
+                  aria-label="Redo"
+                >
+                  <IconArrowForwardUp className="w-3.5 h-3.5 text-muted-foreground" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Redo ({shortcutLabel("cmd+shift+z")})
+              </TooltipContent>
+            </Tooltip>
+          </div>
+
+          {/* Separator */}
+          <div className="w-px h-5 bg-accent flex-shrink-0 hidden sm:block" />
+
+          {/* Edit mode tabs */}
+          <div className="flex items-center rounded-md border border-border overflow-hidden flex-shrink-0">
+            <button
+              onClick={() => onTabChange("visual")}
+              className={`px-3 py-2 sm:py-1.5 text-xs font-medium transition-colors ${
+                activeTab === "visual"
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:text-muted-foreground"
+              }`}
+            >
+              Preview
+            </button>
+            <button
+              onClick={() => onTabChange("code")}
+              className={`px-3 py-2 sm:py-1.5 text-xs font-medium transition-colors ${
+                activeTab === "code"
+                  ? "bg-accent text-foreground"
+                  : "text-muted-foreground hover:text-muted-foreground"
+              }`}
+            >
+              Code
+            </button>
+          </div>
         </>
       )}
-
-      {/* Separator */}
-      <div className="w-px h-5 bg-accent flex-shrink-0 hidden sm:block" />
-
-      {/* Undo/Redo */}
-      <div className="flex items-center flex-shrink-0">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={onUndo}
-              disabled={!canUndo}
-              className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent disabled:opacity-20 transition-colors"
-              aria-label="Undo"
-            >
-              <IconArrowBackUp className="w-3.5 h-3.5 text-muted-foreground" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Undo ({shortcutLabel("cmd+z")})</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={onRedo}
-              disabled={!canRedo}
-              className="p-2.5 sm:p-1.5 rounded-md hover:bg-accent disabled:opacity-20 transition-colors"
-              aria-label="Redo"
-            >
-              <IconArrowForwardUp className="w-3.5 h-3.5 text-muted-foreground" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent>Redo ({shortcutLabel("cmd+shift+z")})</TooltipContent>
-        </Tooltip>
-      </div>
-
-      {/* Separator */}
-      <div className="w-px h-5 bg-accent flex-shrink-0 hidden sm:block" />
-
-      {/* Edit mode tabs */}
-      <div className="flex items-center rounded-md border border-border overflow-hidden flex-shrink-0">
-        <button
-          onClick={() => onTabChange("visual")}
-          className={`px-3 py-2 sm:py-1.5 text-xs font-medium transition-colors ${
-            activeTab === "visual"
-              ? "bg-accent text-foreground"
-              : "text-muted-foreground hover:text-muted-foreground"
-          }`}
-        >
-          Preview
-        </button>
-        <button
-          onClick={() => onTabChange("code")}
-          className={`px-3 py-2 sm:py-1.5 text-xs font-medium transition-colors ${
-            activeTab === "code"
-              ? "bg-accent text-foreground"
-              : "text-muted-foreground hover:text-muted-foreground"
-          }`}
-        >
-          Code
-        </button>
-      </div>
 
       {/* Presence avatars — shared PresenceBar (agent + collaborators) */}
       <PresenceBar
@@ -892,11 +921,12 @@ graph TD
           resourceType="deck"
           resourceId={deckId}
           resourceTitle={deckTitle}
-          shareUrl={shareUrl}
-          shareUrlLabel="Presentation link"
-          shareUrlDescription="Read-only presentation view for anyone with public access."
-          shareUrlRequiresPublic
-          shareUrlUnavailableDescription="This link opens only after general access is Public. Keep the deck private to invite specific people instead."
+          shareUrl={editorUrl}
+          shareUrlLabel="Editor link"
+          shareUrlDescription="Opens the deck in the editor. Anyone with access can use this link."
+          secondaryShareUrl={presentationUrl}
+          secondaryShareUrlLabel="Presentation link"
+          secondaryShareUrlDescription="Opens directly in fullscreen presentation mode."
         />
       </div>
       {/* Present button — matches Share trigger height (h-9) */}

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -178,6 +178,10 @@ function stripBuilderIds(html: string): string {
 interface SlideEditorProps {
   slide: Slide;
   onUpdateSlide: (updates: Partial<Omit<Slide, "id">>) => void;
+  /** When true, all inline-edit affordances are disabled — the slide is
+   *  navigable but contentEditable / image overlays don't activate.
+   *  Mirrors Google Slides' viewer experience. */
+  readOnly?: boolean;
   activeTab: "visual" | "code";
   onGenerateImage: () => void;
   onOpenAssetLibrary: (replaceSrc: string) => void;
@@ -329,6 +333,7 @@ function syncSelectionToAppState(
 export default function SlideEditor({
   slide,
   onUpdateSlide,
+  readOnly = false,
   activeTab,
   onGenerateImage,
   onOpenAssetLibrary,
@@ -983,6 +988,10 @@ export default function SlideEditor({
 
   const handleSlideDoubleClick = useCallback(
     (e: ReactMouseEvent) => {
+      // Viewers see the slide but can't enter edit mode — matches Google
+      // Slides' viewer experience.
+      if (readOnly) return;
+
       const target = e.target as HTMLElement;
 
       // For images / placeholders, show overlay
@@ -1008,7 +1017,7 @@ export default function SlideEditor({
       e.stopPropagation();
       enterInlineEdit(block);
     },
-    [showImageOverlay, enterInlineEdit, isHtmlSlide],
+    [showImageOverlay, enterInlineEdit, isHtmlSlide, readOnly],
   );
 
   const slideElementSelected = !!selectedImg || !!editingEl;

--- a/templates/slides/app/hooks/use-deck-role.ts
+++ b/templates/slides/app/hooks/use-deck-role.ts
@@ -1,0 +1,34 @@
+import { useActionQuery } from "@agent-native/core/client";
+
+type Role = "viewer" | "editor" | "admin";
+
+interface SharesResponse {
+  ownerEmail: string | null;
+  role?: "owner" | Role;
+  visibility: "private" | "org" | "public" | null;
+  shares: unknown[];
+}
+
+/**
+ * Resolve the signed-in user's role on a deck. Mirrors Google Slides:
+ * `Viewer` = no edit affordances, but the editor shell is still navigable;
+ * any other role (Owner / Editor / Admin) gets full editing.
+ *
+ * Returns `canEdit = true` while the role is still loading so that owners
+ * never see a flash of view-only chrome on first paint.
+ */
+export function useDeckRole(deckId: string | undefined): {
+  role: SharesResponse["role"] | undefined;
+  canEdit: boolean;
+  isLoading: boolean;
+} {
+  const query = useActionQuery<SharesResponse>(
+    "list-resource-shares",
+    { resourceType: "deck", resourceId: deckId ?? "" } as any,
+    { enabled: Boolean(deckId) } as any,
+  );
+  const role = query.data?.role;
+  const canEdit =
+    role === undefined ? true : role === "owner" || role !== "viewer";
+  return { role, canEdit, isLoading: query.isLoading };
+}

--- a/templates/slides/app/lib/normalize-slide-padding.test.ts
+++ b/templates/slides/app/lib/normalize-slide-padding.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSlidePadding } from "./normalize-slide-padding";
+
+describe("normalizeSlidePadding", () => {
+  it("forces 80px 110px when the agent dropped the second arg", () => {
+    const html =
+      '<div class="fmd-slide" style="padding: 80px; display: flex;"><h1>Hi</h1></div>';
+    expect(normalizeSlidePadding(html)).toBe(
+      '<div class="fmd-slide" style="padding: 80px 110px; display: flex;"><h1>Hi</h1></div>',
+    );
+  });
+
+  it("forces 80px 110px when horizontal value drifted smaller", () => {
+    const html =
+      '<div class="fmd-slide" style="padding: 80px 60px; font-family: Poppins;"></div>';
+    expect(normalizeSlidePadding(html)).toContain("padding: 80px 110px");
+    expect(normalizeSlidePadding(html)).toContain("font-family: Poppins");
+  });
+
+  it("adds the declaration if missing", () => {
+    const html =
+      '<div class="fmd-slide" style="display: flex; font-family: Poppins;"></div>';
+    expect(normalizeSlidePadding(html)).toBe(
+      '<div class="fmd-slide" style="padding: 80px 110px; display: flex; font-family: Poppins;"></div>',
+    );
+  });
+
+  it("only normalizes the outer fmd-slide wrapper, not inner divs", () => {
+    const html =
+      '<div class="fmd-slide" style="padding: 80px;"><div style="padding: 12px 24px;">x</div></div>';
+    const out = normalizeSlidePadding(html);
+    expect(out).toContain('class="fmd-slide" style="padding: 80px 110px;"');
+    expect(out).toContain('<div style="padding: 12px 24px;">');
+  });
+
+  it("is a no-op when the wrapper class is missing", () => {
+    const html = '<div style="padding: 80px;"></div>';
+    expect(normalizeSlidePadding(html)).toBe(html);
+  });
+});

--- a/templates/slides/app/lib/normalize-slide-padding.ts
+++ b/templates/slides/app/lib/normalize-slide-padding.ts
@@ -1,0 +1,28 @@
+/**
+ * Force the canonical `padding: 80px 110px` on the outer `.fmd-slide` wrapper
+ * when the agent supplies slide HTML. Models drift on numeric values during
+ * regeneration — most often dropping the second padding arg, which collapses
+ * horizontal padding from 110px to 80px and looks like the right margin
+ * shrunk. AGENTS.md treats `80px 110px` as canonical for every layout, so we
+ * normalize server-side rather than trusting the model's output.
+ */
+export function normalizeSlidePadding(html: string): string {
+  if (!html.includes('class="fmd-slide"')) return html;
+
+  return html.replace(
+    /(<div\b[^>]*\bclass="fmd-slide"[^>]*\bstyle=")([^"]*)(")/,
+    (_match, before, style, after) => {
+      const hasPadding = /(?:^|;)\s*padding\s*:/i.test(style);
+      let nextStyle: string;
+      if (hasPadding) {
+        nextStyle = style.replace(
+          /(^|;)\s*padding\s*:\s*[^;]*/i,
+          `$1${style.startsWith("padding") ? "" : " "}padding: 80px 110px`,
+        );
+      } else {
+        nextStyle = `padding: 80px 110px;${style.startsWith(" ") ? "" : " "}${style}`;
+      }
+      return `${before}${nextStyle}${after}`;
+    },
+  );
+}

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -46,6 +46,7 @@ import {
   useGuidedQuestionFlow,
 } from "@agent-native/core/client";
 import { useDeckPresence } from "@/hooks/use-deck-presence";
+import { useDeckRole } from "@/hooks/use-deck-role";
 import { useSlideComments } from "@/hooks/use-slide-comments";
 import { SlideCommentsPanel } from "@/components/comments/SlideCommentsPanel";
 import { AnimationsPanel } from "@/components/editor/AnimationsPanel";
@@ -125,6 +126,10 @@ export default function DeckEditor() {
 
   const deck = getDeck(id || "");
   const slideCount = deck?.slides.length ?? 0;
+  // Mirror Google Slides: viewers see the editor shell with edit affordances
+  // disabled (rather than a separate "viewer" route). Owners/Editors/Admins
+  // get the full editor.
+  const { canEdit } = useDeckRole(id);
   const isNewDeckGenerating = shouldShowNewDeckGeneratingOverlay({
     generating,
     isNewDeckCreation: wasNewDeckCreation.current,
@@ -542,6 +547,7 @@ export default function DeckEditor() {
         deck={deck}
         deckId={id}
         deckTitle={deck.title}
+        canEdit={canEdit}
         onTitleChange={(title) => updateDeck(id, { title })}
         activeTab={activeTab}
         onTabChange={setActiveTab}
@@ -699,6 +705,7 @@ export default function DeckEditor() {
           currentSlide && (
             <SlideEditor
               slide={currentSlide}
+              readOnly={!canEdit}
               onUpdateSlide={(updates) =>
                 updateSlide(id, currentSlide.id, updates)
               }

--- a/templates/slides/app/routes/p.$id.tsx
+++ b/templates/slides/app/routes/p.$id.tsx
@@ -1,9 +1,9 @@
 import SharedPresentation from "@/pages/SharedPresentation";
 import { Spinner } from "@/components/ui/spinner";
 import type { SharedDeckResponse } from "@shared/api";
-import { and, eq } from "drizzle-orm";
+import { and, eq, or } from "drizzle-orm";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
-import { redirect, useLoaderData } from "react-router";
+import { useLoaderData } from "react-router";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { accessFilter } from "@agent-native/core/sharing";
 import { getDb, schema } from "../../server/db";
@@ -50,20 +50,23 @@ export async function loader({
   const id = params.id;
   if (!id) throw new Response("Not found", { status: 404 });
 
+  // Mirror Google Slides: access is checked on the deck, not on the URL shape.
+  // `/p/<id>` (presentation) and `/deck/<id>` (editor) share the same access
+  // rules. Anyone with at least viewer access — owner, explicit share grant,
+  // org visibility for an org member, or public visibility — can open the
+  // presentation. Earlier behavior gated `/p/<id>` on `visibility = "public"`,
+  // which 404'd shared admins and broke the share-link copy flow.
   const db = getDb();
-  if (getRequestUserEmail()) {
-    const [directAccess] = await db
-      .select({ id: schema.decks.id })
-      .from(schema.decks)
-      .where(
-        and(
-          eq(schema.decks.id, id),
+  const userEmail = getRequestUserEmail();
+  const where = userEmail
+    ? and(
+        eq(schema.decks.id, id),
+        or(
           accessFilter(schema.decks, schema.deckShares),
+          eq(schema.decks.visibility, "public"),
         ),
       )
-      .limit(1);
-    if (directAccess) throw redirect(`/deck/${id}`);
-  }
+    : and(eq(schema.decks.id, id), eq(schema.decks.visibility, "public"));
 
   const [deck] = await db
     .select({
@@ -71,7 +74,7 @@ export async function loader({
       data: schema.decks.data,
     })
     .from(schema.decks)
-    .where(and(eq(schema.decks.id, id), eq(schema.decks.visibility, "public")))
+    .where(where)
     .limit(1);
 
   if (!deck) throw new Response("Not found", { status: 404 });


### PR DESCRIPTION
## Summary

SSR loaders that call `getRequestUserEmail()` / `accessFilter()` were seeing the unauthenticated branch even when the user was logged in, because `runWithRequestContext` only auto-runs for auto-mounted action handlers — not for the React Router request handler. The slides "Presentation link" 404'd for shared admins and even for the deck owner unless the deck was public.

The SSR handler now reads the session via `getSession(event)` and the active org via a lazy-imported `getOrgContext`, then runs the React Router handler (both GET and HEAD paths) inside `runWithRequestContext({ userEmail, orgId }, …)`. Auth-lookup failures fall through to the unauthenticated branch — never break SSR.

## Test plan

- [ ] CI green on `updates-296`
- [ ] Builder review pass
- [ ] Manual: a non-public shared slides deck loads via the Presentation link for an admin who isn't the owner
- [ ] Manual: same link still 404s for an unauthenticated visitor / a user who isn't shared on the deck

🤖 Generated with [Claude Code](https://claude.com/claude-code)