### PR TITLE
fix(core/cli): scaffold pinpoint package for slides and videos workspace apps

### DIFF
--- a/.changeset/scaffold-pinpoint-required.md
+++ b/.changeset/scaffold-pinpoint-required.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix workspace scaffolds of `slides` and `videos` failing with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` for `@agent-native/pinpoint`. Both templates depend on pinpoint but were not declaring it in `requiredPackages`, so it never got copied into `packages/pinpoint` and the `workspace:*` reference could not resolve.

--- a/packages/core/src/cli/templates-meta.ts
+++ b/packages/core/src/cli/templates-meta.ts
@@ -86,6 +86,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8086,
     prodUrl: "https://slides.agent-native.com",
     defaultMode: "prod",
+    requiredPackages: ["pinpoint"],
     core: true,
   },
   {
@@ -98,6 +99,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8087,
     prodUrl: "https://videos.agent-native.com",
     defaultMode: "prod",
+    requiredPackages: ["pinpoint"],
   },
   {
     name: "analytics",

--- a/packages/shared-app-config/templates.ts
+++ b/packages/shared-app-config/templates.ts
@@ -94,6 +94,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8086,
     prodUrl: "https://slides.agent-native.com",
     defaultMode: "prod",
+    requiredPackages: ["pinpoint"],
     core: true,
   },
   {
@@ -106,6 +107,7 @@ export const TEMPLATES: TemplateMeta[] = [
     devPort: 8087,
     prodUrl: "https://videos.agent-native.com",
     defaultMode: "prod",
+    requiredPackages: ["pinpoint"],
   },
   {
     name: "clips",


### PR DESCRIPTION
## Summary
  - `slides` and `videos` template scaffolds fail with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` for `@agent-native/pinpoint` when created as workspace apps.
  - Both templates depend on `@agent-native/pinpoint: workspace:*` in their `package.json`, but neither declared `pinpoint` in `requiredPackages` in
  `templates-meta.ts`. The workspace scaffolder (`workspacify.ts`) only copies packages listed in `requiredPackages` into `packages/`, so the `workspace:*` ref was
  unresolvable.
  - Adds `requiredPackages: ["pinpoint"]` to both entries. `design` already had this set, which is why design-only workspaces never hit the bug.

  ## Repro
  ```bash
  agent-native create my-app   # pick slides (without design)
  cd my-app && pnpm install
  # ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  @agent-native/pinpoint