### PR TITLE
credential reconnect cleanup, slides presentation fit, dev-lazy tray, analytics polish

### DIFF
--- a/.agents/skills/adding-a-feature/SKILL.md
+++ b/.agents/skills/adding-a-feature/SKILL.md
@@ -23,6 +23,25 @@ When you add a new feature, work through these four areas in order:
 
 Build the user-facing interface — a page, component, dialog, or route. Use `useActionQuery` and `useActionMutation` from `@agent-native/core/client` to call actions for data fetching and mutations — you rarely need custom `/api/` routes.
 
+**Auto-refresh on agent writes is non-negotiable** — when the agent mutates data, the UI must reflect the change without a manual refresh. There are two paths, and you must pick the right one:
+
+- **`useActionQuery` / `useActionMutation`** — covered automatically. The framework's `useDbSync` invalidates `["action"]` on every change event, so every `useActionQuery` hook refetches on agent activity. No extra wiring required. **Prefer this path.**
+- **Raw `useQuery` with custom keys** — needs explicit wiring. Fold `useChangeVersions([<source>, "action"])` from `@agent-native/core/client` into the `queryKey` and set `placeholderData: (prev) => prev`. The `action` source is the reliable signal (the agent runner emits it after every successful tool call); the resource-specific source (`"dashboards"`, `"analyses"`, `"settings"`, etc.) is bonus when emitted. Without this wiring, agent writes will be invisible until manual refresh — that breaks the framework's #1 promise.
+
+  ```tsx
+  import { useChangeVersions } from "@agent-native/core/client";
+  import { useQuery } from "@tanstack/react-query";
+
+  const v = useChangeVersions(["dashboards", "action"]);
+  useQuery({
+    queryKey: ["dashboard", id, v],
+    queryFn: () => fetchDashboard(id),
+    placeholderData: (prev) => prev, // no flicker on refetch
+  });
+  ```
+
+  See the `real-time-sync` skill for the full pattern and source catalog.
+
 ### 2. Action
 
 Create an action in `actions/` using `defineAction`. This serves double duty: the agent calls it as a tool, and the framework auto-exposes it as an HTTP endpoint at `/_agent-native/actions/:name` for the UI to call. Set `http: { method: "GET" }` for read actions, leave default for writes, or set `http: false` for agent-only actions like `navigate` and `view-screen`.

--- a/.changeset/builder-reconnect-clears-stale-credentials.md
+++ b/.changeset/builder-reconnect-clears-stale-credentials.md
@@ -1,0 +1,14 @@
+---
+"@agent-native/core": patch
+---
+
+Builder reconnect now clears stale credentials before writing the new connection, so reconnecting with a different Builder space actually takes effect.
+
+`writeBuilderCredentials` previously upserted each new key but left stale rows in place. Two failure modes:
+
+- Reconnecting with a Builder space that doesn't carry every optional field (e.g. no `orgName`/`orgKind`/`userId`) left the previous connection's metadata behind at the target scope, so the gateway saw a mix of new and old credentials.
+- When a user's first connect wrote at user scope (member or no-org) and a later reconnect wrote at org scope (now owner/admin), the old user-scope row still won resolution — user scope beats org scope by design — so the chat kept using the old Builder space's credentials even though the UI showed the new connection.
+
+Fix: before writing, delete all five `BUILDER_*` keys at the target scope, and when writing at org scope also delete the writer's user-scope rows. The org-scope row is intentionally left alone when writing at user scope so a single user's personal override doesn't blow away the team's shared connection.
+
+Reported as "I signed in again with my Builder space not my own one and still telling me I need to upgrade" on 2026-05-11.

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -143,6 +143,86 @@ describe("writeBuilderCredentials", () => {
       "BUILDER_USER_ID",
     ]);
   });
+
+  it("clears stale optional keys at target scope before writing the new connection", async () => {
+    // Reconnecting with a Builder space that doesn't carry orgName/orgKind
+    // must not leave the previous connection's metadata in place.
+    await writeBuilderCredentials(
+      "owner@b.com",
+      { privateKey: "pk2", publicKey: "pub2" },
+      { orgId: "builder_io", role: "owner" },
+    );
+    const deleteCalls = mockDeleteAppSecret.mock.calls.map((c) => c[0]);
+    const orgDeletes = deleteCalls.filter(
+      (c) => c.scope === "org" && c.scopeId === "builder_io",
+    );
+    expect(orgDeletes.map((c) => c.key).sort()).toEqual([
+      "BUILDER_ORG_KIND",
+      "BUILDER_ORG_NAME",
+      "BUILDER_PRIVATE_KEY",
+      "BUILDER_PUBLIC_KEY",
+      "BUILDER_USER_ID",
+    ]);
+  });
+
+  it("clears the writer's user-scope override when writing at org scope so the new connection wins resolution", async () => {
+    // Without this, a user who previously connected as a member (writing
+    // at user scope) and is now an admin/owner reconnecting (writing at
+    // org scope) would still see their stale personal credentials win on
+    // the next chat call — `resolveScopedBuilderCredential` checks user
+    // scope before org scope by design.
+    await writeBuilderCredentials(
+      "owner@b.com",
+      { privateKey: "pk-new", publicKey: "pub-new" },
+      { orgId: "builder_io", role: "owner" },
+    );
+    const userDeletes = mockDeleteAppSecret.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c.scope === "user" && c.scopeId === "owner@b.com");
+    expect(userDeletes.map((c) => c.key).sort()).toEqual([
+      "BUILDER_ORG_KIND",
+      "BUILDER_ORG_NAME",
+      "BUILDER_PRIVATE_KEY",
+      "BUILDER_PUBLIC_KEY",
+      "BUILDER_USER_ID",
+    ]);
+  });
+
+  it("does NOT touch the org-scope row when writing at user scope (other org members still need it)", async () => {
+    await writeBuilderCredentials(
+      "member@b.com",
+      { privateKey: "pk", publicKey: "pub" },
+      { orgId: "builder_io", role: "member" },
+    );
+    const orgDeletes = mockDeleteAppSecret.mock.calls
+      .map((c) => c[0])
+      .filter((c) => c.scope === "org");
+    expect(orgDeletes).toEqual([]);
+  });
+
+  it("writes happen AFTER deletes (so the cleanup doesn't race the new values)", async () => {
+    // Capture call order across both mocks. We must see every delete
+    // before any write, otherwise the cleanup could clobber the fresh row.
+    const order: Array<"delete" | "write"> = [];
+    mockDeleteAppSecret.mockImplementation(async () => {
+      order.push("delete");
+      return true;
+    });
+    mockWriteAppSecret.mockImplementation(async () => {
+      order.push("write");
+      return "id";
+    });
+    await writeBuilderCredentials(
+      "owner@b.com",
+      { privateKey: "pk", publicKey: "pub" },
+      { orgId: "builder_io", role: "owner" },
+    );
+    const firstWrite = order.indexOf("write");
+    const lastDelete = order.lastIndexOf("delete");
+    expect(firstWrite).toBeGreaterThan(-1);
+    expect(lastDelete).toBeGreaterThan(-1);
+    expect(lastDelete).toBeLessThan(firstWrite);
+  });
 });
 
 describe("deleteBuilderCredentials", () => {

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -299,6 +299,20 @@ const BUILDER_CREDENTIAL_KEYS = [
  * `scope: "user"` (the safe default that doesn't trample the org's shared
  * connection).
  *
+ * Stale-credential cleanup: before writing the new values we (1) clear ALL
+ * five BUILDER_* keys at the target scope, so optional fields the new
+ * connection doesn't carry (e.g. user picked a Builder space that returns
+ * no orgName) don't leave the previous connection's metadata behind, and
+ * (2) when writing at org scope, also clear the writer's own user-scope
+ * BUILDER_* rows so a stale personal override from an earlier connect
+ * doesn't shadow the new org write on resolution (user scope wins org
+ * scope by design — see `resolveScopedBuilderCredential`). The org-scope
+ * row is intentionally left alone when writing at user scope: that row is
+ * shared with the rest of the org and a single user's personal override
+ * shouldn't blow it away. (Victoria's "I signed in again with my Builder
+ * space and it still says no credits" report on 2026-05-11 was exactly
+ * this stale-shadow case.)
+ *
  * Returns the actual scope/scopeId used so the caller can show "Connected
  * for Builder.io" vs "Connected (personal)" in the UI.
  */
@@ -313,12 +327,31 @@ export async function writeBuilderCredentials(
   },
   options?: { orgId?: string | null; role?: string | null },
 ): Promise<{ scope: "user" | "org"; scopeId: string }> {
-  const { writeAppSecret } = await import("../secrets/storage.js");
+  const { writeAppSecret, deleteAppSecret } =
+    await import("../secrets/storage.js");
   const target = resolveCredentialWriteScope(
     email,
     options?.orgId ?? null,
     options?.role ?? null,
   );
+
+  // Clear stale rows before writing the new connection. See the function's
+  // doc comment for the two cases this handles.
+  const cleanups: Array<Promise<unknown>> = BUILDER_CREDENTIAL_KEYS.map((key) =>
+    deleteAppSecret({
+      key,
+      scope: target.scope,
+      scopeId: target.scopeId,
+    }).catch(() => {}),
+  );
+  if (target.scope === "org") {
+    for (const key of BUILDER_CREDENTIAL_KEYS) {
+      cleanups.push(
+        deleteAppSecret({ key, scope: "user", scopeId: email }).catch(() => {}),
+      );
+    }
+  }
+  await Promise.all(cleanups);
 
   const entries: Array<{ key: string; value: string }> = [
     { key: "BUILDER_PRIVATE_KEY", value: creds.privateKey },

--- a/scripts/dev-lazy.ts
+++ b/scripts/dev-lazy.ts
@@ -33,7 +33,6 @@ const TEMPLATES_DIR = path.join(ROOT, "templates");
 const CONFIG_PATH = path.join(ROOT, "packages/shared-app-config/templates.ts");
 const DEFAULT_GATEWAY_HOST = "127.0.0.1";
 const DEFAULT_GATEWAY_PORT = 8080;
-const FRAME_PORT = 3334;
 const PROXY_READY_RETRY_DELAY_MS = 250;
 const APP_RESTART_MAX_DELAY_MS = 10_000;
 const APP_IFRAME_ALLOW = "camera; microphone; display-capture; fullscreen";
@@ -63,7 +62,7 @@ Options:
   --apps <names>       Comma-separated templates to expose (default: core)
   --apps=<names>       Same as --apps <names>
   --all                Expose every template in packages/shared-app-config
-  --desktop            Also start the local frame and Electron desktop app
+  --desktop            Also start the clips-desktop tray (Tauri)
   --eager              Start every exposed template immediately
   --open               Open the gateway URL in the browser on ready
   --no-open            (legacy / no-op — auto-open is off by default)
@@ -187,9 +186,18 @@ function workspaceAppsJson(): string {
   );
 }
 
+// Strip ANSI SGR escapes so downstream regex matches work after FORCE_COLOR=1
+// makes children emit colored output (vite wraps the URL bullet in green, etc.).
+// eslint-disable-next-line no-control-regex
+const ANSI_REGEX = /\x1b\[[\d;]*[A-Za-z]/g;
+
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_REGEX, "");
+}
+
 function isChildDevServerUrlLine(line: string): boolean {
   return /^\s*->\s+(?:Local|Network):\s+https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\]):\d+(?:\/\S*)?\s*$/i.test(
-    line.replace(/\u279c/g, "->"),
+    stripAnsi(line).replace(/\u279c/g, "->"),
   );
 }
 
@@ -459,6 +467,10 @@ function startApp(app: TemplateApp): void {
       stdio: ["ignore", "pipe", "pipe"],
       env: {
         ...process.env,
+        // Children write to a pipe (not a TTY), so vite/pnpm/chalk/picocolors
+        // skip colors by default. FORCE_COLOR=1 re-enables them — the parent's
+        // stdout is a TTY, so ANSI codes pass straight through to the user.
+        FORCE_COLOR: "1",
         APP_NAME: app.id,
         AGENT_NATIVE_WORKSPACE: "1",
         AGENT_NATIVE_WORKSPACE_APPS_JSON: workspaceAppsJson(),
@@ -711,7 +723,7 @@ function startBackgroundProcess(
   const child = spawn(command, args, {
     cwd: ROOT,
     stdio: ["ignore", "pipe", "pipe"],
-    env,
+    env: { ...env, FORCE_COLOR: "1" },
     shell: process.platform === "win32",
   });
   backgroundProcesses.push(child);
@@ -724,7 +736,7 @@ function startBackgroundProcess(
   child.on("exit", (code) => {
     if (shuttingDown) return;
     process.stderr.write(`[${name}] exited with code ${code ?? 0}\n`);
-    if (name === "electron") shutdown(0);
+    if (name === "tray") shutdown(0);
   });
   return child;
 }
@@ -762,18 +774,13 @@ if (dryRun) {
     console.log(`[dev-lazy] ${app.id}: /${app.id} -> 127.0.0.1:${app.port}`);
   }
   if (includeDesktop) {
-    console.log(`[dev-lazy] frame: http://localhost:${FRAME_PORT}`);
-    console.log("[dev-lazy] electron: @agent-native/desktop-app dev");
+    console.log("[dev-lazy] tray: clips-desktop dev (Tauri)");
   }
   process.exit(0);
 }
 
 if (shouldKill) {
-  const ports = [
-    requestedGatewayPort,
-    ...(includeDesktop ? [FRAME_PORT] : []),
-    ...apps.map((app) => app.port),
-  ];
+  const ports = [requestedGatewayPort, ...apps.map((app) => app.port)];
   for (const port of ports) killPort(port);
 }
 
@@ -821,23 +828,15 @@ function listen(port: number, attempts = 20): void {
     }
 
     if (includeDesktop) {
-      const env = {
-        ...process.env,
-        AGENT_NATIVE_TEMPLATE_GATEWAY_URL: gatewayUrl,
-        VITE_AGENT_NATIVE_TEMPLATE_GATEWAY_URL: gatewayUrl,
-      };
-      startBackgroundProcess(
-        "frame",
-        "pnpm",
-        ["--filter", "@agent-native/frame", "dev"],
-        env,
-      );
-      startBackgroundProcess(
-        "electron",
-        "pnpm",
-        ["--filter", "@agent-native/desktop-app", "dev"],
-        env,
-      );
+      // Matches dev:all:desktop: boot the Tauri clips tray only. The Electron
+      // desktop-app + its frame renderer are intentionally skipped here — they
+      // require a working `electron` binary in node_modules and aren't what
+      // anyone reaches for via dev:lazy:desktop.
+      startBackgroundProcess("tray", "pnpm", [
+        "--filter",
+        "clips-desktop",
+        "dev",
+      ]);
     }
 
     openBrowser(`${gatewayUrl}/${defaultApp}`);

--- a/scripts/dev-lazy.ts
+++ b/scripts/dev-lazy.ts
@@ -195,6 +195,22 @@ function stripAnsi(value: string): string {
   return value.replace(ANSI_REGEX, "");
 }
 
+// Stable per-name prefix coloring so [tray]/[core]/[dispatch] are easy to scan
+// the same way concurrently colors prefixes in dev:all. Codes are SGR foreground
+// values; the palette skips black/white/red to avoid low contrast and "looks
+// like an error" false signals.
+const PREFIX_PALETTE = [33, 34, 35, 36, 32, 95, 94, 96, 92, 93];
+const prefixColors = new Map<string, number>();
+
+function colorPrefix(name: string): string {
+  let code = prefixColors.get(name);
+  if (code === undefined) {
+    code = PREFIX_PALETTE[prefixColors.size % PREFIX_PALETTE.length];
+    prefixColors.set(name, code);
+  }
+  return `\x1b[${code}m[${name}]\x1b[0m`;
+}
+
 function isChildDevServerUrlLine(line: string): boolean {
   return /^\s*->\s+(?:Local|Network):\s+https?:\/\/(?:localhost|127\.0\.0\.1|\[::1\]):\d+(?:\/\S*)?\s*$/i.test(
     stripAnsi(line).replace(/\u279c/g, "->"),
@@ -484,7 +500,7 @@ function startApp(app: TemplateApp): void {
   );
 
   app.process = child;
-  const prefix = `[${app.id}]`;
+  const prefix = colorPrefix(app.id);
   const stableTimer = setTimeout(() => {
     app.restartAttempts = 0;
   }, 5_000);
@@ -727,15 +743,16 @@ function startBackgroundProcess(
     shell: process.platform === "win32",
   });
   backgroundProcesses.push(child);
+  const prefix = colorPrefix(name);
   child.stdout?.on("data", (chunk) =>
-    pipeOutput(`[${name}]`, chunk, (value) => process.stdout.write(value)),
+    pipeOutput(prefix, chunk, (value) => process.stdout.write(value)),
   );
   child.stderr?.on("data", (chunk) =>
-    pipeOutput(`[${name}]`, chunk, (value) => process.stderr.write(value)),
+    pipeOutput(prefix, chunk, (value) => process.stderr.write(value)),
   );
   child.on("exit", (code) => {
     if (shuttingDown) return;
-    process.stderr.write(`[${name}] exited with code ${code ?? 0}\n`);
+    process.stderr.write(`${prefix} exited with code ${code ?? 0}\n`);
     if (name === "tray") shutdown(0);
   });
   return child;

--- a/templates/analytics/app/components/layout/CommandPalette.tsx
+++ b/templates/analytics/app/components/layout/CommandPalette.tsx
@@ -20,7 +20,7 @@ import {
 import { useTheme } from "next-themes";
 import { dashboards } from "@/pages/adhoc/registry";
 import { getIdToken } from "@/lib/auth";
-import { appApiPath, useChangeVersion } from "@agent-native/core/client";
+import { appApiPath, useChangeVersions } from "@agent-native/core/client";
 
 interface SavedConfig {
   id: string;
@@ -98,7 +98,7 @@ export function CommandPalette() {
     enabled: open,
   });
 
-  const dashboardsSync = useChangeVersion("dashboards");
+  const dashboardsSync = useChangeVersions(["dashboards", "action"]);
 
   const { data: explorerDashboards = [] } = useQuery({
     queryKey: ["explorer-dashboards-palette", dashboardsSync],

--- a/templates/analytics/app/components/layout/NewAnalysisDialog.tsx
+++ b/templates/analytics/app/components/layout/NewAnalysisDialog.tsx
@@ -76,21 +76,9 @@ export function NewAnalysisDialog() {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <button
-          disabled={isGenerating}
-          className={cn(
-            "flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-1.5 text-xs transition-all",
-            isGenerating
-              ? "text-primary cursor-wait"
-              : "text-muted-foreground/60 hover:text-primary hover:bg-sidebar-accent/50",
-          )}
-        >
-          {isGenerating ? (
-            <IconLoader2 className="h-3 w-3 animate-spin" />
-          ) : (
-            <IconPlus className="h-3 w-3" />
-          )}
-          {isGenerating ? "Generating..." : "New Analysis"}
+        <button className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-1.5 text-xs text-muted-foreground/60 hover:bg-sidebar-accent/50 hover:text-primary">
+          <IconPlus className="h-3 w-3" />
+          New Analysis
         </button>
       </PopoverTrigger>
       <PopoverContent

--- a/templates/analytics/app/components/layout/NewDashboardDialog.tsx
+++ b/templates/analytics/app/components/layout/NewDashboardDialog.tsx
@@ -5,8 +5,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { IconPlus, IconLoader2 } from "@tabler/icons-react";
-import { cn } from "@/lib/utils";
+import { IconPlus } from "@tabler/icons-react";
 
 const DASHBOARD_CONTEXT =
   "The user wants to create a new analytics dashboard. " +
@@ -37,21 +36,9 @@ export function NewDashboardDialog() {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <button
-          disabled={isGenerating}
-          className={cn(
-            "flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-1.5 text-xs transition-all",
-            isGenerating
-              ? "text-primary cursor-wait"
-              : "text-muted-foreground/60 hover:text-primary hover:bg-sidebar-accent/50",
-          )}
-        >
-          {isGenerating ? (
-            <IconLoader2 className="h-3 w-3 animate-spin" />
-          ) : (
-            <IconPlus className="h-3 w-3" />
-          )}
-          {isGenerating ? "Generating..." : "New Dashboard"}
+        <button className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-1.5 text-xs text-muted-foreground/60 hover:bg-sidebar-accent/50 hover:text-primary">
+          <IconPlus className="h-3 w-3" />
+          New Dashboard
         </button>
       </PopoverTrigger>
       <PopoverContent

--- a/templates/analytics/app/components/layout/Sidebar.tsx
+++ b/templates/analytics/app/components/layout/Sidebar.tsx
@@ -82,7 +82,7 @@ import {
   appApiPath,
   appPath,
   useActionMutation,
-  useChangeVersion,
+  useChangeVersions,
 } from "@agent-native/core/client";
 import { ExtensionsSidebarSection } from "@agent-native/core/client/extensions";
 import { NewDashboardDialog } from "./NewDashboardDialog";
@@ -1039,10 +1039,13 @@ export function Sidebar({ mobile }: { mobile?: boolean } = {}) {
   }, []);
 
   // Fold per-source counters into sidebar list query keys so agent-driven
-  // create/rename/archive/delete shows up without a manual refresh. See
-  // `use-change-version.ts` in @agent-native/core for the pattern.
-  const dashboardsSync = useChangeVersion("dashboards");
-  const analysesSync = useChangeVersion("analyses");
+  // create/rename/archive/delete shows up without a manual refresh. We
+  // depend on `action` too because the agent runner emits an `action`
+  // event for every successful tool call — even when the matching
+  // resource-table emit (`dashboards` / `analyses`) is missed (e.g. event
+  // batching). See `use-change-version.ts` in @agent-native/core.
+  const dashboardsSync = useChangeVersions(["dashboards", "action"]);
+  const analysesSync = useChangeVersions(["analyses", "action"]);
 
   const { data: sqlDashboards = [], isLoading: sqlDashboardsLoading } =
     useQuery({

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -56,7 +56,7 @@ import {
   useSession,
   agentNativePath,
   appApiPath,
-  useChangeVersion,
+  useChangeVersions,
   type CollabUser,
 } from "@agent-native/core/client";
 import { getIdToken } from "@/lib/auth";
@@ -175,14 +175,17 @@ export default function SqlDashboardPage() {
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const viewedDashboardIdRef = useRef<string | null>(null);
 
-  // Refetch the dashboard whenever the `dashboards` source bumps — that
-  // covers writes from update-dashboard (agent), the editor's own save, and
-  // cross-tab edits. Folding the counter into the queryKey is the framework
-  // pattern for "agent writes show up without a manual refresh"; see
-  // `use-change-version.ts`.
-  const dashboardsSync = useChangeVersion("dashboards");
+  // Refetch the dashboard whenever the `dashboards` source bumps OR any
+  // agent action runs. We depend on both because:
+  // - `dashboards` covers same-process writes from upsertDashboard
+  // - `action` covers every successful agent action and is emitted by the
+  //   agent runner unconditionally, which makes the refresh resilient even
+  //   if the dashboards-store emit is missed (different process, etc.).
+  // Folding counters into the queryKey is the framework pattern for "agent
+  // writes show up without a manual refresh"; see `use-change-version.ts`.
+  const sync = useChangeVersions(["dashboards", "action"]);
   const dashboardQuery = useQuery({
-    queryKey: ["data", "sql-dashboard", dashboardId, dashboardsSync],
+    queryKey: ["data", "sql-dashboard", dashboardId, sync],
     enabled: !!dashboardId,
     queryFn: async () => {
       if (!dashboardId) return null;

--- a/templates/analytics/app/pages/analyses/AnalysesList.tsx
+++ b/templates/analytics/app/pages/analyses/AnalysesList.tsx
@@ -14,7 +14,7 @@ import { getIdToken } from "@/lib/auth";
 import {
   appApiPath,
   useSendToAgentChat,
-  useChangeVersion,
+  useChangeVersions,
 } from "@agent-native/core/client";
 
 interface AnalysisSummary {
@@ -53,7 +53,7 @@ function formatRelativeDate(iso: string): string {
 }
 
 export default function AnalysesList() {
-  const analysesSync = useChangeVersion("analyses");
+  const analysesSync = useChangeVersions(["analyses", "action"]);
   const { data: analyses, isLoading } = useQuery({
     queryKey: ["analyses-list", analysesSync],
     queryFn: fetchAnalyses,

--- a/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
+++ b/templates/analytics/app/pages/analyses/AnalysisDetail.tsx
@@ -32,7 +32,7 @@ import { Link, useNavigate } from "react-router";
 import {
   ShareButton,
   appApiPath,
-  useChangeVersion,
+  useChangeVersions,
 } from "@agent-native/core/client";
 import { getIdToken } from "@/lib/auth";
 import { useSendToAgentChat } from "@agent-native/core/client";
@@ -93,7 +93,7 @@ export default function AnalysisDetail() {
   const queryClient = useQueryClient();
   const { send, isGenerating, codeRequiredDialog } = useSendToAgentChat();
 
-  const analysesSync = useChangeVersion("analyses");
+  const analysesSync = useChangeVersions(["analyses", "action"]);
   const { data: analysis, isLoading } = useQuery({
     queryKey: ["analysis-detail", id, analysesSync],
     queryFn: () => fetchAnalysis(id!),

--- a/templates/calendar/app/hooks/use-integrations.ts
+++ b/templates/calendar/app/hooks/use-integrations.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { agentNativePath } from "@agent-native/core/client";
+import { agentNativePath, useChangeVersions } from "@agent-native/core/client";
 import { appApiPath } from "@/lib/api-path";
 
 // ─── Generic integration credentials (via application-state) ────────────────
@@ -7,8 +7,12 @@ import { appApiPath } from "@/lib/api-path";
 type Provider = "apollo" | "hubspot" | "gong" | "pylon";
 
 function useIntegrationStatus(provider: Provider) {
+  // Refetch on any app-state write or agent action — covers both the local
+  // connect/disconnect mutations and agent-driven changes to the provider's
+  // application-state row. See `use-change-version.ts` in @agent-native/core.
+  const sync = useChangeVersions(["app-state", "action"]);
   const { data } = useQuery<{ apiKey?: string } | null>({
-    queryKey: ["integration-status", provider],
+    queryKey: ["integration-status", provider, sync],
     queryFn: async () => {
       const res = await fetch(
         agentNativePath(`/_agent-native/application-state/${provider}`),
@@ -18,6 +22,7 @@ function useIntegrationStatus(provider: Provider) {
       return res.json();
     },
     staleTime: 30_000,
+    placeholderData: (prev) => prev,
   });
   return !!data?.apiKey;
 }

--- a/templates/content/app/hooks/use-document-versions.ts
+++ b/templates/content/app/hooks/use-document-versions.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { appApiPath } from "@agent-native/core/client";
+import { appApiPath, useChangeVersion } from "@agent-native/core/client";
 import type { Document, DocumentVersionListResponse } from "@shared/api";
 
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
@@ -9,8 +9,14 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
 }
 
 export function useDocumentVersions(documentId: string | null) {
+  // Refetch the version list every time the agent runs a mutating action —
+  // `edit-document`, `update-document`, restore, etc. each create a new
+  // version row and emit `source: "action"` through the runner. Folding the
+  // counter into the queryKey is the framework pattern (see
+  // `use-change-version.ts` in @agent-native/core).
+  const sync = useChangeVersion("action");
   return useQuery({
-    queryKey: ["document-versions", documentId],
+    queryKey: ["document-versions", documentId, sync],
     queryFn: () =>
       fetchJson<DocumentVersionListResponse>(
         `/api/documents/${documentId}/versions`,
@@ -20,6 +26,7 @@ export function useDocumentVersions(documentId: string | null) {
       return Array.isArray(versions) ? versions : [];
     },
     enabled: !!documentId,
+    placeholderData: (prev) => prev,
   });
 }
 

--- a/templates/mail/app/pages/SettingsPage.tsx
+++ b/templates/mail/app/pages/SettingsPage.tsx
@@ -1,7 +1,11 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useSearchParams } from "react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { agentNativePath, useChatModels } from "@agent-native/core/client";
+import {
+  agentNativePath,
+  useChatModels,
+  useChangeVersions,
+} from "@agent-native/core/client";
 import { appApiPath } from "@/lib/api-path";
 import {
   IconUsers,
@@ -858,14 +862,18 @@ function AutomationsSection() {
     );
   }, [availableModels]);
 
+  // Refetch on any settings write or agent action so agent-driven changes
+  // (e.g. update-automation-settings) show up without a manual refresh.
+  const settingsSync = useChangeVersions(["settings", "action"]);
   const { data: autoSettings } = useQuery({
-    queryKey: ["automation-settings"],
+    queryKey: ["automation-settings", settingsSync],
     queryFn: async () => {
       const res = await fetch(appApiPath("/api/automations/settings"));
       if (!res.ok) return { engine: "anthropic", model: defaultModel };
       return res.json();
     },
     staleTime: 30_000,
+    placeholderData: (prev) => prev,
   });
 
   const queryClient = useQueryClient();

--- a/templates/slides/app/components/deck/SlideRenderer.tsx
+++ b/templates/slides/app/components/deck/SlideRenderer.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useLayoutEffect,
+  useCallback,
   type ReactNode,
 } from "react";
 import ReactMarkdown from "react-markdown";
@@ -215,6 +216,22 @@ function measureContentBounds(target: HTMLElement): {
   minY: number;
 } {
   const targetRect = target.getBoundingClientRect();
+  // `scrollWidth` / `clientWidth` return CSS pixels; `getBoundingClientRect`
+  // returns layout pixels after every ancestor transform. In presentation
+  // mode the outer canvas is scaled UP (--slide-scale > 1, e.g. 1.74), so
+  // child rects come back inflated relative to scrollWidth. Without
+  // normalization, `Math.max(scrollWidth, maxX - minX)` reads the inflated
+  // value as content overflow, computeSlideFitTransform clamps to
+  // MIN_AUTOFIT_SCALE (0.65), and every slide visibly shrinks. The editor
+  // didn't hit this because thumbnail mode scales DOWN, so scrollWidth
+  // always wins. Normalize child rects back to CSS-px space.
+  const cssWidth = target.clientWidth || target.scrollWidth || 0;
+  const cssHeight = target.clientHeight || target.scrollHeight || 0;
+  const invScaleX =
+    targetRect.width > 0 && cssWidth > 0 ? cssWidth / targetRect.width : 1;
+  const invScaleY =
+    targetRect.height > 0 && cssHeight > 0 ? cssHeight / targetRect.height : 1;
+
   let minX = 0;
   let minY = 0;
   let maxX = target.scrollWidth;
@@ -225,10 +242,15 @@ function measureContentBounds(target: HTMLElement): {
     const rect = el.getBoundingClientRect();
     if (rect.width === 0 && rect.height === 0) continue;
 
-    minX = Math.min(minX, rect.left - targetRect.left);
-    minY = Math.min(minY, rect.top - targetRect.top);
-    maxX = Math.max(maxX, rect.right - targetRect.left);
-    maxY = Math.max(maxY, rect.bottom - targetRect.top);
+    const left = (rect.left - targetRect.left) * invScaleX;
+    const top = (rect.top - targetRect.top) * invScaleY;
+    const right = (rect.right - targetRect.left) * invScaleX;
+    const bottom = (rect.bottom - targetRect.top) * invScaleY;
+
+    minX = Math.min(minX, left);
+    minY = Math.min(minY, top);
+    maxX = Math.max(maxX, right);
+    maxY = Math.max(maxY, bottom);
   }
 
   return {
@@ -726,33 +748,52 @@ function ScaleHelper({
   targetHeight?: number;
   mode?: "contain";
 }) {
+  // Stable ref callback so React doesn't churn the ResizeObserver on every
+  // render. Returns a cleanup so React 19 disconnects on unmount / identity
+  // change — the previous inline-arrow version stored cleanup on
+  // `el.__cleanup` and never invoked it, leaking an observer per render.
+  const refCallback = useCallback(
+    (el: HTMLDivElement | null) => {
+      if (!el) return;
+      const parent = el.parentElement;
+      if (!parent) return;
+
+      const updateScale = () => {
+        // Prefer offset*, fall back to getBoundingClientRect, then to
+        // viewport. If everything still reads 0, bail rather than write
+        // `--slide-scale: 0` — that would scale the slide to nothing and
+        // the bad value would stick on the parent until the next
+        // observer tick.
+        const rect = parent.getBoundingClientRect();
+        const w = parent.offsetWidth || rect.width || window.innerWidth;
+        const h = parent.offsetHeight || rect.height || window.innerHeight;
+        if (!w || !h) return;
+        if (mode === "contain" && targetHeight) {
+          const scale = Math.min(w / targetWidth, h / targetHeight);
+          parent.style.setProperty("--slide-scale", String(scale));
+        } else {
+          parent.style.setProperty("--slide-scale", String(w / targetWidth));
+        }
+      };
+
+      // Try sync (layout may already be settled) and defer one frame
+      // (in case it isn't — first paint of /present can lag the swap
+      // out of the loading fallback).
+      updateScale();
+      const raf = requestAnimationFrame(updateScale);
+
+      const observer = new ResizeObserver(updateScale);
+      observer.observe(parent);
+
+      return () => {
+        cancelAnimationFrame(raf);
+        observer.disconnect();
+      };
+    },
+    [targetWidth, targetHeight, mode],
+  );
+
   return (
-    <div
-      className="absolute inset-0 pointer-events-none"
-      ref={(el) => {
-        if (!el) return;
-        const parent = el.parentElement;
-        if (!parent) return;
-
-        const updateScale = () => {
-          const w = parent.offsetWidth;
-          const h = parent.offsetHeight;
-          if (mode === "contain" && targetHeight) {
-            // Scale to contain both dimensions (no cropping)
-            const scale = Math.min(w / targetWidth, h / targetHeight);
-            parent.style.setProperty("--slide-scale", String(scale));
-          } else {
-            // Scale to fit width
-            parent.style.setProperty("--slide-scale", String(w / targetWidth));
-          }
-        };
-        updateScale();
-
-        const observer = new ResizeObserver(updateScale);
-        observer.observe(parent);
-
-        (el as any).__cleanup = () => observer.disconnect();
-      }}
-    />
+    <div className="absolute inset-0 pointer-events-none" ref={refCallback} />
   );
 }

--- a/templates/slides/app/components/editor/SlideInlineEditor.tsx
+++ b/templates/slides/app/components/editor/SlideInlineEditor.tsx
@@ -352,15 +352,20 @@ function ScaleHelper({ targetWidth = 960 }: { targetWidth?: number }) {
       if (!parent) return;
 
       const updateScale = () => {
-        const w = parent.offsetWidth;
+        const w = parent.offsetWidth || parent.getBoundingClientRect().width;
+        if (!w) return;
         parent.style.setProperty("--slide-scale", String(w / targetWidth));
       };
       updateScale();
+      const raf = requestAnimationFrame(updateScale);
 
       const observer = new ResizeObserver(updateScale);
       observer.observe(parent);
-      (el as unknown as { __cleanup: () => void }).__cleanup = () =>
+
+      return () => {
+        cancelAnimationFrame(raf);
         observer.disconnect();
+      };
     },
     [targetWidth],
   );


### PR DESCRIPTION
## Summary

- **core/credential-provider — Builder reconnect clears stale credentials before writing.** Reconnecting with a different Builder space previously left old `orgName` / `orgKind` / `userId` rows in place, and a stale user-scope override could keep winning resolution over a fresh org-scope write. Both modes fixed: clear all five `BUILDER_*` keys at the target scope before writing, and on org writes also clear the writer's own user-scope rows (the org-scope row is intentionally untouched on user writes so a single user's override can't blow away the team's shared connection). 4 new spec cases cover the cleanup matrix. Reported on 2026-05-11.
- **slides/SlideRenderer — presentation-mode fit fix.** `measureContentBounds` was reading inflated layout-pixel rects when the outer canvas scaled UP (~1.74x in present mode), so `Math.max(scrollWidth, maxX - minX)` saw false overflow and the fit calculator clamped to the 0.65 minimum, visibly shrinking every slide. Normalize child rects back to CSS-pixel space. Companion fix: `ScaleHelper`'s ResizeObserver was leaking (the previous version stored cleanup on `el.__cleanup` and never invoked it — one observer leaked per render). New ref callback returns proper React 19 cleanup, defers one rAF for first-paint timing, and bails on `0×0` parents instead of writing `--slide-scale: 0`. Same pattern in `SlideInlineEditor`.
- **scripts/dev-lazy — `--desktop` boots the Tauri clips tray** instead of the Electron frame + desktop renderer pair, matching `dev:all:desktop`. Plus `FORCE_COLOR=1` for child processes so vite/pnpm output stays colored through the pipe, and an ANSI-strip helper so the URL-detection regex matches.
- **templates/analytics — drop spinner from new-analysis / new-dashboard buttons.** The buttons just open a popover; the loader was decorative and added a stuck cursor-wait state when something else in the same flow was generating.
- **(concurrent commit `10a8cf71d`) templates/analytics — fold `action` source into dashboards/analyses query keys** for resilience: depend on both so the refresh survives if the dashboards-store emit is missed (different process etc.).

## Test plan

- [ ] CI green (Build, Lint, Test, Typecheck, Scaffold E2E, Guard, changeset)
- [ ] Manual: reconnect Builder credentials with a different space — old `orgName`/metadata is cleared, gateway sees only the new connection
- [ ] Manual: open a deck in present mode — slides render at native scale, no 0.65-clamped shrink
- [ ] Manual: `pnpm dev:lazy:desktop` — Tauri tray boots, no Electron frame attempt