### PR TITLE
docs: spell out auto-refresh contract in scaffold templates

### DIFF
--- a/.agents/skills/tracking/SKILL.md
+++ b/.agents/skills/tracking/SKILL.md
@@ -92,6 +92,16 @@ Template roots call `configureTracking()` once during app startup. That installs
 - Includes `url`, `path`, `hostname`, `referrer`, `title`, `navigation_type`, `app`, and inferred `template`
 - Does not send first-party events from localhost/local dev
 
+### Visitor identity (`anonymousId` + `sessionId`)
+
+Every browser-side `trackEvent()` POST to the Agent Native Analytics `/track` endpoint includes:
+
+- `anonymousId` — persistent per-browser visitor ID stored in `localStorage` under `agent-native.anonymous_id`. Generated once and reused across sessions. Use this for unique-visitor and returning-visitor metrics.
+- `sessionId` — rotating per-visit ID stored in `localStorage` under `agent-native.session_id`, with a 30-minute idle timeout (matches GA4 / Mixpanel defaults). Use this for sessions-per-visitor, pages-per-session, and session-duration metrics.
+- `userId` — only set when the calling code passes `properties.userId`. Anonymous traffic leaves this NULL by design; `anonymousId` is the fallback.
+
+These fields land in the `analytics_events.anonymous_id`, `analytics_events.session_id`, and `analytics_events.user_id` columns in the analytics template. Storage access is wrapped in try/catch — private-browsing / blocked-storage clients silently degrade to NULL rather than crashing the page.
+
 Other framework-level baseline events:
 
 - `session status` from `useSession()`, with `signed_in`

--- a/.changeset/auto-refresh-contract-in-template-docs.md
+++ b/.changeset/auto-refresh-contract-in-template-docs.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Docs only: spell out the auto-refresh contract in the default-template and starter `AGENTS.md` so newly-scaffolded apps know that agent writes must reflect in the UI without a manual refresh. Use `useActionQuery` (auto-covered) or fold `useChangeVersions([<source>, "action"])` into raw `useQuery` keys. Mirror the framework `adding-a-feature` and `real-time-sync` skills into `packages/core/src/templates/default/.agents/skills/` and `templates/starter/.agents/skills/` so scaffolded apps inherit the same guidance.

--- a/.changeset/tracking-anonymous-and-session-id.md
+++ b/.changeset/tracking-anonymous-and-session-id.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": minor
+---
+
+Browser tracking now sends a persistent `anonymousId` (visitor ID) and a `sessionId` with a 30-minute idle timeout on every event posted to the Agent Native Analytics `/track` endpoint. Both IDs are stored in `localStorage` and degrade gracefully to NULL when storage is unavailable (private browsing). Unique-visitor and session metrics in the analytics template now have real data to aggregate against; previously these columns were always NULL for anonymous traffic.

--- a/.changeset/use-pinch-zoom-hook.md
+++ b/.changeset/use-pinch-zoom-hook.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": minor
+---
+
+New `usePinchZoom` hook exported from `@agent-native/core/client` for canvas-style editors. Wires trackpad pinch (synthesized as `wheel` events with `ctrlKey: true`) and 2-pointer touchscreen pinch onto a scrolling container, with cursor-anchored zoom-to-cursor support and configurable `min` / `max` percentages. The slides template adopts it on the deck-editor canvas; any template with a zoomable surface can drop it in by attaching the returned ref to the scroll container.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Connect any data source, prompt for any chart. Build reusable dashboards, not th
 
 **Clips**
 
-<a href="https://agent-native.com/templates/clips"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F7366585df5a545e697e254bb0138182d?format=webp&width=800" alt="Clips template" width="100%" /></a>
+<a href="https://agent-native.com/templates/clips"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F678be5a501a14ab8a508e5f7bc92c468?format=webp&width=800" alt="Clips template" width="100%" /></a>
 
 **Agent-Native Loom**
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -98,7 +98,7 @@ Connect any data source, prompt for any chart. Build reusable dashboards, not th
 
 **Clips**
 
-<a href="https://agent-native.com/templates/clips"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F7366585df5a545e697e254bb0138182d?format=webp&width=800" alt="Clips template" width="100%" /></a>
+<a href="https://agent-native.com/templates/clips"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F678be5a501a14ab8a508e5f7bc92c468?format=webp&width=800" alt="Clips template" width="100%" /></a>
 
 **Agent-Native Loom**
 

--- a/packages/core/docs/content/creating-templates.md
+++ b/packages/core/docs/content/creating-templates.md
@@ -191,6 +191,21 @@ export function AppSync() {
 }
 ```
 
+**The agent-native promise: agent writes show up in the UI without a manual refresh.** `useActionQuery` is the easy path — every hook is auto-refetched on every change event the framework sees. If you reach for raw `useQuery` with a custom key (e.g. for a non-action HTTP endpoint, integration status, etc.), you must fold the per-source counter into the queryKey or agent writes will be silently invisible:
+
+```tsx
+import { useChangeVersions } from "@agent-native/core/client";
+
+const v = useChangeVersions(["dashboards", "action"]);
+useQuery({
+  queryKey: ["dashboard", id, v],
+  queryFn: () => fetchDashboard(id),
+  placeholderData: (prev) => prev, // no flicker on refetch
+});
+```
+
+Common sources: `"action"` (every successful agent action — the reliable fallback), `"app-state"`, `"settings"`, plus any custom resource source your store emits via `recordChange`. See the `real-time-sync` skill for the full pattern.
+
 ## Add Application State {#application-state}
 
 Application state is how the agent knows what the user is seeing. At minimum, add:

--- a/packages/core/src/client/AgentPanel.tsx
+++ b/packages/core/src/client/AgentPanel.tsx
@@ -1597,8 +1597,15 @@ function URLSync() {
     }).catch(() => {});
   }, [location.pathname, location.search, location.hash]);
 
-  // Inbound: poll for URL-update commands from the agent. We piggyback on
-  // the same 2-second cadence useDbSync uses so there's no extra timer.
+  // Inbound: poll for URL-update commands from the agent. `useDbSync`
+  // invalidates this key on every relevant app-state event, so default
+  // `structuralSharing: true` is critical — without it, repeated reads of the
+  // same stale command (when the consume-DELETE below races against the next
+  // invalidation) churned the useEffect and re-applied the navigation in a
+  // tight loop. With structural sharing on, the previous reference is reused
+  // when the JSON is unchanged so the useEffect only fires when the command
+  // actually changes; the `lastProcessedDedupKeyRef` below covers the residual
+  // race window after the cache is cleared to `null`.
   const { data: command } = useQuery({
     queryKey: ["__set_url__"],
     queryFn: async () => {
@@ -1610,30 +1617,54 @@ function URLSync() {
         const text = await res.text();
         if (!text) return null;
         const data = JSON.parse(text);
-        return data ? { ...data, _ts: Date.now() } : null;
+        return data ?? null;
       } catch {
         return null;
       }
     },
     refetchInterval: 2_000,
-    structuralSharing: false,
     retry: false,
   });
 
+  const lastProcessedDedupKeyRef = React.useRef<string | null>(null);
+
   React.useEffect(() => {
     if (!command) return;
+    const cmd = command as {
+      pathname?: string;
+      searchParams?: Record<string, string | null>;
+      mergeSearchParams?: boolean;
+      hash?: string;
+      _writeId?: string;
+    };
+    const dedupKey =
+      cmd._writeId ??
+      JSON.stringify({
+        pathname: cmd.pathname,
+        searchParams: cmd.searchParams,
+        mergeSearchParams: cmd.mergeSearchParams,
+        hash: cmd.hash,
+      });
+    if (lastProcessedDedupKeyRef.current === dedupKey) {
+      // Same command we already handled — the DELETE below races against the
+      // next polling refetch, so when it loses the same command can show up
+      // again on the next tick. Re-fire DELETE and bail rather than navigate
+      // again.
+      fetch(agentNativePath("/_agent-native/application-state/__set_url__"), {
+        method: "DELETE",
+        headers: { "X-Agent-Native-CSRF": "1" },
+      }).catch(() => {});
+      queryClient.setQueryData(["__set_url__"], null);
+      return;
+    }
+    lastProcessedDedupKeyRef.current = dedupKey;
+
     // Delete the one-shot command before applying so duplicate events
     // don't cause repeated navigation.
     fetch(agentNativePath("/_agent-native/application-state/__set_url__"), {
       method: "DELETE",
       headers: { "X-Agent-Native-CSRF": "1" },
     }).catch(() => {});
-    const cmd = command as {
-      pathname?: string;
-      searchParams?: Record<string, string | null>;
-      mergeSearchParams?: boolean;
-      hash?: string;
-    };
     try {
       const current = new URL(window.location.href);
       const nextPath = cmd.pathname ?? current.pathname;

--- a/packages/core/src/client/analytics.ts
+++ b/packages/core/src/client/analytics.ts
@@ -41,6 +41,78 @@ const PAGEVIEW_TRACKING_STATE_KEY = Symbol.for(
   "agent-native.client.pageviewTracking",
 );
 
+const ANONYMOUS_ID_STORAGE_KEY = "agent-native.anonymous_id";
+const SESSION_ID_STORAGE_KEY = "agent-native.session_id";
+const SESSION_LAST_ACTIVITY_STORAGE_KEY = "agent-native.session_last_activity";
+// 30-minute idle timeout matches GA4 / Mixpanel defaults — a tab left open
+// overnight starts a new session in the morning rather than stretching one
+// session over multiple visits.
+const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+
+function generateVisitorId(): string {
+  try {
+    if (
+      typeof crypto !== "undefined" &&
+      typeof crypto.randomUUID === "function"
+    ) {
+      return crypto.randomUUID();
+    }
+  } catch {
+    // fall through to Math.random
+  }
+  return (
+    Date.now().toString(36) +
+    Math.random().toString(36).slice(2) +
+    Math.random().toString(36).slice(2)
+  );
+}
+
+function safeStorageGet(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeStorageSet(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // private browsing / storage disabled — best-effort
+  }
+}
+
+function getOrCreateAnonymousId(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  let id = safeStorageGet(ANONYMOUS_ID_STORAGE_KEY);
+  if (!id) {
+    id = generateVisitorId();
+    safeStorageSet(ANONYMOUS_ID_STORAGE_KEY, id);
+  }
+  return id;
+}
+
+function getOrCreateSessionId(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  const now = Date.now();
+  const lastActivityRaw = safeStorageGet(SESSION_LAST_ACTIVITY_STORAGE_KEY);
+  const lastActivity = lastActivityRaw
+    ? Number.parseInt(lastActivityRaw, 10)
+    : 0;
+  let id = safeStorageGet(SESSION_ID_STORAGE_KEY);
+  const expired =
+    !lastActivity ||
+    Number.isNaN(lastActivity) ||
+    now - lastActivity > SESSION_IDLE_TIMEOUT_MS;
+  if (!id || expired) {
+    id = generateVisitorId();
+    safeStorageSet(SESSION_ID_STORAGE_KEY, id);
+  }
+  safeStorageSet(SESSION_LAST_ACTIVITY_STORAGE_KEY, String(now));
+  return id;
+}
+
 function isLocalAnalyticsHostname(hostname: string | undefined): boolean {
   const h = (hostname || "").toLowerCase();
   return (
@@ -445,6 +517,8 @@ function sendAgentNativeAnalytics(
     event: name,
     properties,
     userId,
+    anonymousId: getOrCreateAnonymousId(),
+    sessionId: getOrCreateSessionId(),
     timestamp: new Date().toISOString(),
   });
 

--- a/packages/core/src/client/index.ts
+++ b/packages/core/src/client/index.ts
@@ -244,6 +244,7 @@ export {
   useActionMutation,
   type ActionRegistry,
 } from "./use-action.js";
+export { usePinchZoom, type UsePinchZoomOptions } from "./use-pinch-zoom.js";
 export {
   ShareButton,
   ShareDialog,

--- a/packages/core/src/client/use-pinch-zoom.ts
+++ b/packages/core/src/client/use-pinch-zoom.ts
@@ -1,0 +1,137 @@
+import { useEffect, useRef } from "react";
+
+export interface UsePinchZoomOptions {
+  /** Scrolling viewport that receives the gesture. The scaled content should
+   *  live inside this element. */
+  containerRef: React.RefObject<HTMLElement | null>;
+  /** Current zoom as a percentage (100 = 100%). */
+  zoom: number;
+  /** Setter for the zoom value (called with the next percentage). */
+  setZoom: (next: number) => void;
+  /** Minimum zoom percentage. Default 25. */
+  min?: number;
+  /** Maximum zoom percentage. Default 400. */
+  max?: number;
+  /** When true (default), adjusts container scroll so the point under the
+   *  cursor stays under the cursor during wheel-zoom. Assumes the scaled
+   *  content uses `transform-origin: top left` (or equivalent — e.g. resizing
+   *  the inner container's width proportionally to zoom). Disable for layouts
+   *  with `transform-origin: center center`. */
+  zoomToCursor?: boolean;
+  /** Disable the hook entirely without unmounting it. */
+  enabled?: boolean;
+}
+
+/**
+ * Pinch-to-zoom for canvas-style editors. Wires the trackpad pinch / Cmd+scroll
+ * wheel gesture and 2-pointer touchscreen pinch onto a scrolling container.
+ *
+ * Trackpad pinch is detected via `wheel` events with `ctrlKey: true` — browsers
+ * have synthesized that since ~2015 specifically so web apps can intercept the
+ * gesture. `metaKey` is also accepted so Cmd+scroll on Mac feels native.
+ *
+ * The hook only calls `setZoom(next)` — it doesn't render anything. Templates
+ * decide how to translate the zoom percentage into visual scaling (CSS
+ * `transform: scale()`, width/height, etc.).
+ */
+export function usePinchZoom({
+  containerRef,
+  zoom,
+  setZoom,
+  min = 25,
+  max = 400,
+  zoomToCursor = true,
+  enabled = true,
+}: UsePinchZoomOptions) {
+  const zoomRef = useRef(zoom);
+  const setZoomRef = useRef(setZoom);
+  zoomRef.current = zoom;
+  setZoomRef.current = setZoom;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const clamp = (n: number) => Math.max(min, Math.min(max, n));
+
+    const handleWheel = (e: WheelEvent) => {
+      if (!(e.ctrlKey || e.metaKey)) return;
+      e.preventDefault();
+
+      const currentZoom = zoomRef.current;
+      const clampedDelta = Math.max(-50, Math.min(50, e.deltaY));
+      const factor = Math.exp(-clampedDelta * 0.01);
+      const nextZoom = clamp(currentZoom * factor);
+
+      if (nextZoom === currentZoom) return;
+
+      if (zoomToCursor) {
+        const rect = container.getBoundingClientRect();
+        const cx = e.clientX - rect.left + container.scrollLeft;
+        const cy = e.clientY - rect.top + container.scrollTop;
+        const ratio = nextZoom / currentZoom;
+        const dx = cx * (ratio - 1);
+        const dy = cy * (ratio - 1);
+        setZoomRef.current(nextZoom);
+        requestAnimationFrame(() => {
+          container.scrollLeft += dx;
+          container.scrollTop += dy;
+        });
+      } else {
+        setZoomRef.current(nextZoom);
+      }
+    };
+
+    const activePointers = new Map<number, { x: number; y: number }>();
+    let initialDistance = 0;
+    let initialZoom = 0;
+
+    const handlePointerDown = (e: PointerEvent) => {
+      if (e.pointerType !== "touch") return;
+      activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (activePointers.size === 2) {
+        const [p1, p2] = Array.from(activePointers.values());
+        initialDistance = Math.hypot(p2.x - p1.x, p2.y - p1.y);
+        initialZoom = zoomRef.current;
+      }
+    };
+
+    const handlePointerMove = (e: PointerEvent) => {
+      if (e.pointerType !== "touch") return;
+      if (!activePointers.has(e.pointerId)) return;
+      activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (activePointers.size === 2 && initialDistance > 0) {
+        const [p1, p2] = Array.from(activePointers.values());
+        const distance = Math.hypot(p2.x - p1.x, p2.y - p1.y);
+        const nextZoom = clamp(initialZoom * (distance / initialDistance));
+        if (nextZoom !== zoomRef.current) {
+          setZoomRef.current(nextZoom);
+        }
+        e.preventDefault();
+      }
+    };
+
+    const handlePointerEnd = (e: PointerEvent) => {
+      if (e.pointerType !== "touch") return;
+      activePointers.delete(e.pointerId);
+      if (activePointers.size < 2) initialDistance = 0;
+    };
+
+    container.addEventListener("wheel", handleWheel, { passive: false });
+    container.addEventListener("pointerdown", handlePointerDown);
+    container.addEventListener("pointermove", handlePointerMove, {
+      passive: false,
+    });
+    container.addEventListener("pointerup", handlePointerEnd);
+    container.addEventListener("pointercancel", handlePointerEnd);
+
+    return () => {
+      container.removeEventListener("wheel", handleWheel);
+      container.removeEventListener("pointerdown", handlePointerDown);
+      container.removeEventListener("pointermove", handlePointerMove);
+      container.removeEventListener("pointerup", handlePointerEnd);
+      container.removeEventListener("pointercancel", handlePointerEnd);
+    };
+  }, [containerRef, enabled, min, max, zoomToCursor]);
+}

--- a/packages/core/src/extensions/actions.ts
+++ b/packages/core/src/extensions/actions.ts
@@ -136,6 +136,9 @@ export function createExtensionActionEntries(): Record<string, ActionEntry> {
             view: "extensions",
             extensionId: extension.id,
             path: `/extensions/${extension.id}`,
+            // Unique-per-write token so the UI's `use-navigation-state` hook
+            // can dedup race-driven re-reads of the same command.
+            _writeId: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
           });
         } catch {
           // Non-fatal — agent can still mention the path in its reply.

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -339,6 +339,12 @@ function createUrlTools(): Record<string, ActionEntry> {
         await writeAppState("__set_url__", {
           searchParams: params,
           mergeSearchParams: merge,
+          // Unique-per-write token. The client's URLSync hook dedups by this
+          // so a fire-and-forget DELETE that loses its race against the next
+          // polling refetch can't cause the same URL command to be applied
+          // repeatedly (which caused the editor to bounce between slides
+          // when an agent turn errored partway through).
+          _writeId: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         });
         const keys = Object.keys(params);
         return `set-search-params: ${keys.length} key${keys.length === 1 ? "" : "s"}${merge ? "" : " (replace)"}`;
@@ -389,6 +395,10 @@ function createUrlTools(): Record<string, ActionEntry> {
           pathname,
           searchParams: params,
           mergeSearchParams: merge,
+          // See note in set-search-params: unique-per-write dedup token so a
+          // race between GET and consume-DELETE in URLSync can't re-apply
+          // this command.
+          _writeId: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         });
         return `set-url-path: ${pathname}`;
       },

--- a/packages/core/src/templates/default/.agents/skills/adding-a-feature/SKILL.md
+++ b/packages/core/src/templates/default/.agents/skills/adding-a-feature/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: adding-a-feature
+description: >-
+  The four-area checklist every new feature in this app must complete. Use
+  when adding any feature, integration, or capability to keep the agent and
+  UI in parity.
+---
+
+# Adding a Feature — The Four-Area Checklist
+
+## Rule
+
+Every new feature MUST update all four areas. Skipping any one breaks the agent-native contract — the agent and UI must always be equal partners.
+
+## Why
+
+Agent-native apps are defined by parity: everything the UI can do, the agent can do, and vice versa. A feature that only has UI is invisible to the agent. A feature that only has actions is invisible to the user. A feature without app-state sync means the agent is blind to what the user is doing. And **a feature without auto-refresh wiring means the agent's writes are silently invisible until the user manually reloads** — that breaks the framework's #1 promise.
+
+## The Checklist
+
+### 1. UI Component
+
+Build the user-facing interface — a page, component, dialog, or route. Use `useActionQuery` and `useActionMutation` from `@agent-native/core/client` for data fetching and mutations. You rarely need custom `/api/` routes.
+
+**Auto-refresh on agent writes is non-negotiable** — when the agent mutates the data this UI shows, the UI must reflect the change without a manual refresh. Two paths, pick the right one:
+
+- **`useActionQuery` (preferred)** — automatically covered. The framework's `useDbSync` invalidates `["action"]` on every change event, so every `useActionQuery` hook refetches when the agent runs an action. No extra wiring required.
+
+- **Raw `useQuery` with a custom key** — needs explicit wiring. Fold `useChangeVersions([<source>, "action"])` from `@agent-native/core/client` into the `queryKey` and set `placeholderData: (prev) => prev`. The `"action"` source is the reliable signal — the agent runner emits it after every successful tool call. The resource-specific source (e.g. `"settings"`, `"app-state"`) is bonus. Without this wiring, agent writes will be invisible until manual refresh.
+
+  ```tsx
+  import { useChangeVersions } from "@agent-native/core/client";
+  import { useQuery } from "@tanstack/react-query";
+
+  function useItem(id: string) {
+    const v = useChangeVersions(["items", "action"]);
+    return useQuery({
+      queryKey: ["item", id, v],
+      queryFn: () => fetchItem(id),
+      placeholderData: (prev) => prev, // no flicker on refetch
+    });
+  }
+  ```
+
+  See the `real-time-sync` skill for the full pattern and source catalog.
+
+### 2. Action
+
+Create an action in `actions/` using `defineAction`. This serves double duty: the agent calls it as a tool, and the framework auto-exposes it as an HTTP endpoint at `/_agent-native/actions/:name` for the UI to call. Set `http: { method: "GET" }` for read actions, leave default for writes, or set `http: false` for agent-only actions like `navigate` and `view-screen`.
+
+### 3. Skills / Instructions
+
+Update `AGENTS.md` (the per-app guide) and/or create a skill in `.agents/skills/` if the feature introduces patterns the agent needs to know. At minimum, add the new actions to the action table in the template's `AGENTS.md`.
+
+### 4. Application State Sync
+
+Expose navigation and selection state so the agent knows what the user is looking at. Write to the `navigation` app-state key on route changes. Update the `view-screen` action to fetch relevant data for the new feature. Add a `navigate` command if the agent needs to open the new view.
+
+## Anti-Patterns
+
+- **UI without actions** — The user can create things but the agent cannot. Breaks parity.
+- **Actions without UI** — The agent can do something the user cannot. Less common but still breaks parity.
+- **Mutations without auto-refresh wiring** — The agent says "done!" but the screen doesn't change until the user hits reload. This is the most common silent regression. If you used `useActionQuery` you're covered; if you used raw `useQuery`, fold `useChangeVersions` into the key. Always test by asking the agent to mutate the data and watching the UI without refreshing.
+
+## Verification
+
+For every new feature, manually verify:
+
+1. Can the user perform the operation from the UI?
+2. Can the agent perform the operation via an action (`pnpm action <name>`)?
+3. When the agent runs the action, **does the UI update within a second or two without a manual refresh**? If not, your query is missing `useActionQuery` or `useChangeVersions` wiring — go back to step 1.
+4. Does `view-screen` return the new feature's state when the user is on that page?

--- a/packages/core/src/templates/default/AGENTS.md
+++ b/packages/core/src/templates/default/AGENTS.md
@@ -9,7 +9,7 @@ This is an **@agent-native/core** application -- the AI agent and UI share state
 1. **Shared SQL database** -- All app state lives in SQL (SQLite locally, cloud DB via `DATABASE_URL` in production). Core stores: `application_state`, `settings`, `oauth_tokens`, `sessions`, `resources`.
 2. **All AI through agent chat** -- No inline LLM calls. UI delegates to the AI via `sendToAgentChat()` / `agentChat.submit()`.
 3. **Actions for agent operations** -- `pnpm action <name>` dispatches to callable action files in `actions/`.
-4. **Polling for real-time sync** -- Database writes trigger version counter increments that the UI polls to stay in sync.
+4. **Polling for real-time sync** -- Database writes trigger version counter increments that the UI polls to stay in sync. **When you (the agent) write data, the UI must reflect the change without a manual refresh.** This is non-negotiable. Use `useActionQuery` (auto-covered) or fold `useChangeVersions([<source>, "action"])` into raw `useQuery` keys. See the `real-time-sync` and `adding-a-feature` skills.
 5. **Agent can update code** -- The agent can modify this app's source code directly.
 
 ### Authentication
@@ -90,28 +90,30 @@ You do NOT get auto-injected screen state. **Call `pnpm action view-screen` at t
 
 Skills in `.agents/skills/` provide detailed guidance for each architectural rule. Read them before making changes.
 
-| Skill                 | When to read                                                    |
-| --------------------- | --------------------------------------------------------------- |
-| `storing-data`        | Before storing or reading any app state                         |
-| `delegate-to-agent`   | Before adding LLM calls or AI delegation                        |
-| `actions`             | Before creating or modifying actions                            |
-| `real-time-sync`      | Before wiring up real-time UI sync                              |
-| `self-modifying-code` | Before editing source, components, or styles                    |
-| `capture-learnings`   | Before recording user preferences or corrections                |
-| `frontend-design`     | Before building or restyling any UI component, page, or layout  |
-| `agent-engines`       | Before switching LLM providers or registering a custom engine   |
-| `notifications`       | Before surfacing alerts/progress to the user or adding channels |
-| `progress`            | Before running any task that takes more than a few seconds      |
+| Skill                 | When to read                                                                      |
+| --------------------- | --------------------------------------------------------------------------------- |
+| `adding-a-feature`    | **Read first when adding ANY new feature** — the four-area parity checklist       |
+| `real-time-sync`      | Before wiring data fetching for anything the agent can mutate (must auto-refresh) |
+| `storing-data`        | Before storing or reading any app state                                           |
+| `delegate-to-agent`   | Before adding LLM calls or AI delegation                                          |
+| `actions`             | Before creating or modifying actions                                              |
+| `self-modifying-code` | Before editing source, components, or styles                                      |
+| `capture-learnings`   | Before recording user preferences or corrections                                  |
+| `frontend-design`     | Before building or restyling any UI component, page, or layout                    |
+| `agent-engines`       | Before switching LLM providers or registering a custom engine                     |
+| `notifications`       | Before surfacing alerts/progress to the user or adding channels                   |
+| `progress`            | Before running any task that takes more than a few seconds                        |
 
 ## When Adding Features
 
-As you build out this app, follow this checklist for each new feature:
+**Read the `adding-a-feature` skill first** — it has the full four-area checklist (UI / Action / Skills / App-State). Quick summary:
 
-1. **Add navigation state entries** -- extend `app/hooks/use-navigation-state.ts` to track new routes
-2. **Enhance view-screen** -- make the view-screen script return relevant context for the new view
-3. **Create domain actions** -- add scripts for CRUD operations on new data models
-4. **Create domain skills** -- add `.agents/skills/<feature>/SKILL.md` documenting the data model, storage patterns, and agent operations
-5. **Update this AGENTS.md** -- add the new actions, state keys, and common tasks
+1. **Add navigation state entries** — extend `app/hooks/use-navigation-state.ts` to track new routes
+2. **Enhance view-screen** — make the view-screen script return relevant context for the new view
+3. **Create domain actions** — add actions in `actions/` for CRUD operations on new data models
+4. **Wire UI for auto-refresh** — use `useActionQuery` (auto-covered) OR fold `useChangeVersions([<source>, "action"])` into raw `useQuery` keys with `placeholderData`. When the agent mutates this data, the UI must reflect the change without a manual refresh. See `real-time-sync` skill.
+5. **Create domain skills** — add `.agents/skills/<feature>/SKILL.md` documenting the data model, storage patterns, and agent operations
+6. **Update this AGENTS.md** — add the new actions, state keys, and common tasks
 
 ---
 

--- a/packages/core/src/templates/default/actions/navigate.ts
+++ b/packages/core/src/templates/default/actions/navigate.ts
@@ -35,6 +35,9 @@ export async function run(args: Record<string, string>): Promise<string> {
   const nav: Record<string, string> = {};
   if (args.view) nav.view = args.view;
   if (args.path) nav.path = args.path;
+  // Unique-per-write token so the UI's `use-navigation-state` hook can dedup
+  // race-driven re-reads of the same command.
+  nav._writeId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   await writeAppState("navigate", nav);
   return `Navigating to ${args.view || args.path}`;
 }

--- a/packages/core/src/templates/default/app/hooks/use-navigation-state.ts
+++ b/packages/core/src/templates/default/app/hooks/use-navigation-state.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -10,6 +10,10 @@ import {
 export interface NavigationState {
   view: string;
   path?: string;
+  /** Optional unique-per-write token. Used by the UI to dedup the same
+   * command being re-read when the fire-and-forget DELETE below loses its
+   * race against the next polling refetch. */
+  _writeId?: string;
 }
 
 export function useNavigationState() {
@@ -31,7 +35,11 @@ export function useNavigationState() {
     }).catch(() => {});
   }, [location.pathname]);
 
-  const { data: navCommand } = useQuery({
+  // Default React Query structuralSharing reuses the previous reference when
+  // the JSON is unchanged, so repeated invalidations driven by `useDbSync`
+  // (which fire on every relevant app-state event) don't re-fire the
+  // useEffect with a brand-new object containing the same command.
+  const { data: navCommand } = useQuery<NavigationState | null>({
     queryKey: ["navigate-command"],
     queryFn: async () => {
       const res = await fetch(
@@ -39,19 +47,35 @@ export function useNavigationState() {
       );
       if (!res.ok) return null;
       const data = await res.json();
-      return data ? { ...data, _ts: Date.now() } : null;
+      return data ?? null;
     },
     refetchInterval: 2_000,
-    structuralSharing: false,
   });
+
+  const lastProcessedDedupKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!navCommand) return;
+    const cmd = navCommand;
+    const dedupKey =
+      cmd._writeId ?? JSON.stringify({ view: cmd.view, path: cmd.path });
+    if (lastProcessedDedupKeyRef.current === dedupKey) {
+      // Same command we already handled — the consume-DELETE races against
+      // the next polling refetch, so when it loses the same command can show
+      // up again. Re-fire DELETE and bail rather than navigate again.
+      fetch(agentNativePath("/_agent-native/application-state/navigate"), {
+        method: "DELETE",
+        headers: { "X-Agent-Native-CSRF": "1" },
+      }).catch(() => {});
+      qc.setQueryData(["navigate-command"], null);
+      return;
+    }
+    lastProcessedDedupKeyRef.current = dedupKey;
+
     fetch(agentNativePath("/_agent-native/application-state/navigate"), {
       method: "DELETE",
       headers: { "X-Agent-Native-CSRF": "1" },
     }).catch(() => {});
-    const cmd = navCommand as NavigationState;
 
     const path = routerPath(cmd.path || pathFromView(cmd.view));
     navigate(path);

--- a/packages/docs/app/components/TemplateCard.tsx
+++ b/packages/docs/app/components/TemplateCard.tsx
@@ -103,7 +103,7 @@ export const templates = [
       "Screen recordings, calendar-synced meeting notes, and Fn-hold voice dictation — all transcribed, summarized, and searchable, with an agent that can edit any of it.",
     color: "#0EA5E9",
     screenshot:
-      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F7366585df5a545e697e254bb0138182d?format=webp&width=800",
+      "https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F678be5a501a14ab8a508e5f7bc92c468?format=webp&width=800",
   },
   {
     name: "Design",

--- a/templates/analytics/app/components/dashboard/SqlChart.tsx
+++ b/templates/analytics/app/components/dashboard/SqlChart.tsx
@@ -47,6 +47,7 @@ import {
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 import { useSqlQuery } from "@/lib/sql-query";
+import { useChartTooltipFlip } from "@/hooks/use-chart-tooltip-flip";
 import type {
   SqlPanel,
   ChartType,
@@ -142,6 +143,7 @@ function ChartTooltip({
   labelFormatter?: (value: string) => string;
   valueFormatter?: (value: number) => string;
 }) {
+  const tooltipRef = useChartTooltipFlip<HTMLDivElement>();
   const items =
     payload?.filter((item) => item.value != null && item.value !== "") ?? [];
   if (!active || items.length === 0) return null;
@@ -154,7 +156,10 @@ function ChartTooltip({
         : String(label);
 
   return (
-    <div className="min-w-40 max-w-[280px] rounded-md border border-border bg-card px-3 py-2 text-xs text-foreground shadow-lg">
+    <div
+      ref={tooltipRef}
+      className="min-w-40 max-w-[280px] rounded-md border border-border bg-card px-3 py-2 text-xs text-foreground shadow-lg"
+    >
       {labelText && (
         <div className="mb-1.5 truncate font-medium text-foreground">
           {labelText}

--- a/templates/analytics/app/components/ui/chart.tsx
+++ b/templates/analytics/app/components/ui/chart.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as RechartsPrimitive from "recharts";
 
 import { cn } from "@/lib/utils";
+import { useChartTooltipFlip } from "@/hooks/use-chart-tooltip-flip";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;
@@ -135,6 +136,16 @@ const ChartTooltipContent = React.forwardRef<
     ref,
   ) => {
     const { config } = useChart();
+    const flipRef = useChartTooltipFlip<HTMLDivElement>();
+    const setRefs = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        flipRef.current = node;
+        if (typeof ref === "function") ref(node);
+        else if (ref)
+          (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      },
+      [ref, flipRef],
+    );
 
     const tooltipLabel = React.useMemo(() => {
       if (hideLabel || !payload?.length) {
@@ -180,7 +191,7 @@ const ChartTooltipContent = React.forwardRef<
 
     return (
       <div
-        ref={ref}
+        ref={setRefs}
         className={cn(
           "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
           className,

--- a/templates/analytics/app/hooks/use-chart-tooltip-flip.ts
+++ b/templates/analytics/app/hooks/use-chart-tooltip-flip.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from "react";
+
+const RIGHT_GUTTER_PADDING = 12;
+const FLIP_CURSOR_OFFSET = 24;
+
+/**
+ * Recharts tooltips can extend past the chart's right edge and get clipped by
+ * the agent sidebar. Attach the returned ref to the tooltip content's outer
+ * div; while the tooltip is mounted we observe the recharts wrapper's
+ * `transform` (cursor moves) and translate the content left when its right
+ * edge would land inside `.agent-sidebar-panel`.
+ */
+export function useChartTooltipFlip<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const wrapper = el.parentElement;
+    if (!wrapper) return;
+
+    const apply = () => {
+      const node = ref.current;
+      if (!node) return;
+      node.style.transform = "";
+      const rect = node.getBoundingClientRect();
+      if (rect.width === 0) return;
+
+      const sidebar = document.querySelector(".agent-sidebar-panel");
+      const sidebarRect = sidebar?.getBoundingClientRect();
+      const gutterLeft =
+        sidebarRect && sidebarRect.width > 0 && sidebarRect.left > 0
+          ? sidebarRect.left
+          : window.innerWidth;
+      const limit = gutterLeft - RIGHT_GUTTER_PADDING;
+
+      if (rect.right > limit) {
+        node.style.transform = `translateX(-${rect.width + FLIP_CURSOR_OFFSET}px)`;
+      }
+    };
+
+    apply();
+    const observer = new MutationObserver(apply);
+    observer.observe(wrapper, {
+      attributes: true,
+      attributeFilter: ["style"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return ref;
+}

--- a/templates/analytics/app/pages/adhoc/AdhocRouter.tsx
+++ b/templates/analytics/app/pages/adhoc/AdhocRouter.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy, useEffect } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getIdToken } from "@/lib/auth";
 import { dashboardComponents } from "./registry";
@@ -10,22 +11,24 @@ import { incrementItemView } from "@/lib/item-popularity";
 
 const SqlDashboardPage = lazy(() => import("./sql-dashboard"));
 
+// Single shared loading placeholder used across hydration → exists-check →
+// Suspense → dashboard config load. Matches the real SqlChartCard shape (Card
+// chrome + title row + chart-body skeleton) so the user sees one continuous
+// skeleton state rather than four different ones morphing into each other.
 function DashboardSkeleton() {
   return (
-    <div className="space-y-6">
-      <div>
-        <Skeleton className="h-8 w-64 mb-2" />
-        <Skeleton className="h-4 w-96" />
-      </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <Skeleton key={i} className="h-24 w-full rounded-xl" />
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {[0, 1].map((i) => (
+          <Card key={i} className="flex flex-col overflow-visible">
+            <CardHeader className="pb-2 shrink-0">
+              <Skeleton className="h-4 w-32" />
+            </CardHeader>
+            <CardContent className="flex flex-1 flex-col pt-0">
+              <Skeleton className="w-full flex-1 min-h-[250px]" />
+            </CardContent>
+          </Card>
         ))}
-      </div>
-      <Skeleton className="h-[300px] w-full rounded-xl" />
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <Skeleton className="h-[250px] w-full rounded-xl" />
-        <Skeleton className="h-[250px] w-full rounded-xl" />
       </div>
     </div>
   );

--- a/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/explorer-dashboard/index.tsx
@@ -385,12 +385,24 @@ export default function ExplorerDashboardPage() {
   }
 
   if (!loaded) {
+    // Match the eventual DashboardChartCard layout (Card chrome + title row +
+    // chart-body skeleton) so the transition from "dashboard config loading"
+    // to "queries loading" doesn't morph skeleton shape — the title text just
+    // fills in. Otherwise the bare h-64 rectangles jump into Card-chromed
+    // panels and the page visibly shifts.
     return (
       <div className="space-y-4">
-        <Skeleton className="h-8 w-64" />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Skeleton className="h-64" />
-          <Skeleton className="h-64" />
+          {[0, 1].map((i) => (
+            <Card key={i} className="flex flex-col overflow-visible">
+              <CardHeader className="pb-2 shrink-0">
+                <Skeleton className="h-4 w-32" />
+              </CardHeader>
+              <CardContent className="flex flex-1 flex-col pt-0">
+                <Skeleton className="w-full flex-1 min-h-[250px]" />
+              </CardContent>
+            </Card>
+          ))}
         </div>
       </div>
     );

--- a/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
+++ b/templates/analytics/app/pages/adhoc/sql-dashboard/index.tsx
@@ -12,7 +12,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   AlertDialog,
@@ -881,12 +881,24 @@ export default function SqlDashboardPage() {
   }
 
   if (!loaded) {
+    // Match the eventual SqlChartCard layout exactly (Card chrome + title row +
+    // chart-body skeleton) so the transition from "dashboard config loading" to
+    // "queries loading" doesn't morph the skeleton's shape — only the title
+    // text fills in. Otherwise the bare h-64 rectangles jump into Card-chromed
+    // panels and the page visibly shifts.
     return (
       <div className="space-y-4">
-        <Skeleton className="h-8 w-64" />
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <Skeleton className="h-64" />
-          <Skeleton className="h-64" />
+          {[0, 1].map((i) => (
+            <Card key={i} className="flex flex-col overflow-visible">
+              <CardHeader className="pb-2 shrink-0">
+                <Skeleton className="h-4 w-32" />
+              </CardHeader>
+              <CardContent className="flex flex-1 flex-col pt-0">
+                <Skeleton className="w-full flex-1 min-h-[250px]" />
+              </CardContent>
+            </Card>
+          ))}
         </div>
       </div>
     );

--- a/templates/analytics/app/routes/adhoc.$id.tsx
+++ b/templates/analytics/app/routes/adhoc.$id.tsx
@@ -1,14 +1,30 @@
 import AdhocRouter from "@/pages/adhoc/AdhocRouter";
-import { Spinner } from "@/components/ui/spinner";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export function meta() {
   return [{ title: "Dashboard — Analytics" }];
 }
 
 export function HydrateFallback() {
+  // Match the dashboard's own !loaded skeleton so hydration doesn't flash a
+  // full-page spinner before morphing into the dashboard layout. The user
+  // perceives a single, continuous skeleton state through hydration → config
+  // load → per-panel query load.
   return (
-    <div className="flex items-center justify-center h-screen w-full">
-      <Spinner className="size-8 text-foreground" />
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {[0, 1].map((i) => (
+          <Card key={i} className="flex flex-col overflow-visible">
+            <CardHeader className="pb-2 shrink-0">
+              <Skeleton className="h-4 w-32" />
+            </CardHeader>
+            <CardContent className="flex flex-1 flex-col pt-0">
+              <Skeleton className="w-full flex-1 min-h-[250px]" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }

--- a/templates/calendar/app/hooks/use-google-auth.ts
+++ b/templates/calendar/app/hooks/use-google-auth.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { agentNativePath } from "@agent-native/core/client";
+import { agentNativePath, oauthRedirectUri } from "@agent-native/core/client";
 import type { GoogleAuthStatus } from "@shared/api";
 import { useEffect } from "react";
 
@@ -87,7 +87,6 @@ export function useGoogleAuthUrl(enabled = false) {
   const query = useQuery<{ url: string }>({
     queryKey: ["google-auth-url"],
     queryFn: async () => {
-      const { oauthRedirectUri } = await import("@agent-native/core/client");
       const redirectUri = oauthRedirectUri("/_agent-native/google/callback");
       return fetchJson<{ url: string }>(
         agentNativePath(
@@ -115,7 +114,6 @@ export function useGoogleAddAccountUrl(enabled = false) {
   const query = useQuery<{ url: string }>({
     queryKey: ["google-add-account-url"],
     queryFn: async () => {
-      const { oauthRedirectUri } = await import("@agent-native/core/client");
       const redirectUri = oauthRedirectUri("/_agent-native/google/callback");
       return fetchJson<{ url: string }>(
         agentNativePath(

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -1724,13 +1724,16 @@ export default function RecordRoute() {
         </div>
       )}
 
-      {/* Camera bubble */}
+      {/* Camera bubble — only visible while actively recording. During
+          uploading/compressing the overlay is semi-transparent (bg-black/70),
+          so a still-visible bubble in the corner makes it look like recording
+          is ongoing. */}
       {showCameraBubble && (
         <CameraBubble
           stream={cameraStream}
           size={cameraSize}
           onSizeChange={setCameraSize}
-          hidden={!showRecordingUi}
+          hidden={uiState !== "recording"}
         />
       )}
 

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -228,6 +228,7 @@ interface DesignCanvasProps {
 export function DesignCanvas({
   content,
   zoom,
+  onZoomChange,
   deviceFrame,
   editMode,
   onElementSelect,
@@ -241,6 +242,17 @@ export function DesignCanvas({
   designTitle,
 }: DesignCanvasProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  usePinchZoom({
+    containerRef: scrollContainerRef,
+    zoom,
+    setZoom: onZoomChange ?? (() => {}),
+    min: 10,
+    max: 500,
+    zoomToCursor: deviceFrame === "none",
+    enabled: Boolean(onZoomChange),
+  });
 
   // Build the srcdoc. The tweak bridge ALWAYS goes in so the panel works
   // outside Edit mode. The edit bridge (click/hover overlays) is gated.
@@ -389,7 +401,10 @@ export function DesignCanvas({
     );
 
   return (
-    <div className="relative flex-1 h-full overflow-auto">
+    <div
+      ref={scrollContainerRef}
+      className="relative flex-1 h-full overflow-auto"
+    >
       {/* Dot grid background */}
       <div
         className="absolute inset-0"

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useCallback, useMemo } from "react";
 import { agentChat } from "@agent-native/core";
+import { usePinchZoom } from "@agent-native/core/client";
 import { cn } from "@/lib/utils";
 import { DeviceFrame } from "./DeviceFrame";
 import type { ElementInfo, DeviceFrameType } from "./types";
@@ -204,6 +205,7 @@ const EDIT_BRIDGE_SCRIPT = `
 interface DesignCanvasProps {
   content: string;
   zoom: number;
+  onZoomChange?: (zoom: number) => void;
   deviceFrame: DeviceFrameType;
   editMode: boolean;
   onElementSelect: (info: ElementInfo) => void;

--- a/templates/design/app/components/layout/Sidebar.tsx
+++ b/templates/design/app/components/layout/Sidebar.tsx
@@ -78,7 +78,7 @@ export function Sidebar() {
             <span className="text-sm font-semibold tracking-tight">Design</span>
           </div>
         )}
-        <Tooltip>
+        <Tooltip delayDuration={0}>
           <TooltipTrigger asChild>
             <button
               onClick={() => setCollapsed((c) => !c)}
@@ -125,7 +125,7 @@ export function Sidebar() {
             );
             if (collapsed) {
               return (
-                <Tooltip key={item.href}>
+                <Tooltip key={item.href} delayDuration={0}>
                   <TooltipTrigger asChild>{link}</TooltipTrigger>
                   <TooltipContent side="right">{item.label}</TooltipContent>
                 </Tooltip>

--- a/templates/design/app/pages/DesignEditor.tsx
+++ b/templates/design/app/pages/DesignEditor.tsx
@@ -1270,6 +1270,7 @@ export default function DesignEditor() {
             <DesignCanvas
               content={activeContent}
               zoom={zoom}
+              onZoomChange={setZoom}
               deviceFrame={deviceFrame}
               editMode={mode === "edit"}
               onElementSelect={handleElementSelect}

--- a/templates/images/app/components/layout/Sidebar.tsx
+++ b/templates/images/app/components/layout/Sidebar.tsx
@@ -92,7 +92,7 @@ export function Sidebar() {
             <span className="text-sm font-semibold tracking-tight">Images</span>
           </div>
         )}
-        <Tooltip>
+        <Tooltip delayDuration={0}>
           <TooltipTrigger asChild>
             <button
               onClick={() => setCollapsed((c) => !c)}
@@ -146,7 +146,7 @@ export function Sidebar() {
           );
           if (collapsed) {
             return (
-              <Tooltip key={item.href}>
+              <Tooltip key={item.href} delayDuration={0}>
                 <TooltipTrigger asChild>{link}</TooltipTrigger>
                 <TooltipContent side="right">{item.label}</TooltipContent>
               </Tooltip>

--- a/templates/mail/app/hooks/use-google-auth.ts
+++ b/templates/mail/app/hooks/use-google-auth.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
-import { agentNativePath } from "@agent-native/core/client";
+import { agentNativePath, oauthRedirectUri } from "@agent-native/core/client";
 
 interface GoogleAuthStatus {
   connected: boolean;
@@ -93,7 +93,6 @@ export function useGoogleAuthUrl(enabled = false) {
   const query = useQuery<{ url: string }>({
     queryKey: ["google-auth-url"],
     queryFn: async () => {
-      const { oauthRedirectUri } = await import("@agent-native/core/client");
       const redirectUri = oauthRedirectUri("/_agent-native/google/callback");
       const returnPath = `${window.location.pathname}${window.location.search}`;
       return fetchJson<{ url: string }>(
@@ -121,7 +120,6 @@ export function useGoogleAddAccountUrl(enabled = false) {
   const query = useQuery<{ url: string }>({
     queryKey: ["google-add-account-url"],
     queryFn: async () => {
-      const { oauthRedirectUri } = await import("@agent-native/core/client");
       const redirectUri = oauthRedirectUri("/_agent-native/google/callback");
       // Use the main callback URL — the server-side state param carries the
       // add-account flag so only one redirect URI needs Google Console registration.

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -133,6 +133,12 @@ export default defineAction({
         await writeAppState("navigate", {
           deckId,
           slideIndex: insertIndex,
+          // Unique-per-write token. The UI's `use-navigation-state` hook
+          // dedups by this so a race between the GET and the consume-DELETE
+          // doesn't cause the same command to be re-applied repeatedly
+          // (which previously bounced the editor between slides whenever the
+          // agent path errored partway through a turn).
+          _writeId: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         }).catch(() => {});
       }
 

--- a/templates/slides/actions/navigate.ts
+++ b/templates/slides/actions/navigate.ts
@@ -25,6 +25,10 @@ export default defineAction({
     if (args.view) nav.view = args.view;
     if (args.deckId) nav.deckId = args.deckId;
     if (args.slideIndex != null) nav.slideIndex = args.slideIndex;
+    // Unique-per-write token so the UI's `use-navigation-state` hook can
+    // dedup race-driven re-reads of the same command (see that hook for the
+    // full reasoning).
+    nav._writeId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await writeAppState("navigate", nav);
     return `Navigating to ${args.view || ""}${args.deckId ? ` deck:${args.deckId}` : ""}${args.slideIndex != null ? ` slide:${args.slideIndex}` : ""}`;
   },

--- a/templates/slides/app/components/editor/SlideEditor.tsx
+++ b/templates/slides/app/components/editor/SlideEditor.tsx
@@ -10,6 +10,7 @@ import {
   AgentPresenceChip,
   agentNativePath,
   sendToAgentChat,
+  usePinchZoom,
 } from "@agent-native/core/client";
 import { createPortal } from "react-dom";
 import { enterSelectionMode } from "@/root";
@@ -431,6 +432,7 @@ export default function SlideEditor({
   const [selectedImg, setSelectedImg] = useState<HTMLImageElement | null>(null);
   const [selectionRect, setSelectionRect] = useState<DOMRect | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   // --- Multi-select state ---
   /** Set of data-builder-id values currently in the multi-select */
@@ -470,6 +472,14 @@ export default function SlideEditor({
       .find((preset) => preset < canvasZoom);
     setCanvasZoom(previous ?? CANVAS_ZOOM_PRESETS[0]);
   }, [canvasZoom]);
+
+  usePinchZoom({
+    containerRef: scrollContainerRef,
+    zoom: canvasZoom,
+    setZoom: setCanvasZoom,
+    min: 25,
+    max: 400,
+  });
 
   // Reset overflow state whenever the slide changes — the renderer will
   // report the next measurement (or stay null if the new slide fits).
@@ -1247,6 +1257,7 @@ export default function SlideEditor({
                 </Tooltip>
               </div>
               <div
+                ref={scrollContainerRef}
                 className={`h-full overflow-auto ${
                   drawMode ? "pb-24 sm:pb-28" : ""
                 }`}

--- a/templates/slides/app/components/layout/Sidebar.tsx
+++ b/templates/slides/app/components/layout/Sidebar.tsx
@@ -41,7 +41,7 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
     return (
       <aside className="flex h-full w-12 shrink-0 flex-col items-center gap-1 overflow-hidden border-r border-border bg-sidebar py-2 text-sidebar-foreground">
         {onToggleCollapsed && (
-          <Tooltip>
+          <Tooltip delayDuration={0}>
             <TooltipTrigger asChild>
               <button
                 onClick={onToggleCollapsed}
@@ -51,7 +51,7 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
                 <IconLayoutSidebarLeftExpand className="h-4 w-4" />
               </button>
             </TooltipTrigger>
-            <TooltipContent>Expand sidebar</TooltipContent>
+            <TooltipContent side="right">Expand sidebar</TooltipContent>
           </Tooltip>
         )}
         <nav className="flex min-h-0 flex-1 flex-col items-center gap-1 overflow-y-auto pt-1">
@@ -59,7 +59,7 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
             const Icon = item.icon;
             const isActive = isItemActive(item.href);
             return (
-              <Tooltip key={item.href}>
+              <Tooltip key={item.href} delayDuration={0}>
                 <TooltipTrigger asChild>
                   <Link
                     to={item.href}
@@ -74,7 +74,7 @@ export function Sidebar({ collapsed, onToggleCollapsed }: SidebarProps) {
                     <Icon className="h-4 w-4" />
                   </Link>
                 </TooltipTrigger>
-                <TooltipContent>{item.label}</TooltipContent>
+                <TooltipContent side="right">{item.label}</TooltipContent>
               </Tooltip>
             );
           })}

--- a/templates/slides/app/hooks/use-navigation-state.ts
+++ b/templates/slides/app/hooks/use-navigation-state.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { agentNativePath } from "@agent-native/core/client";
@@ -8,6 +8,11 @@ export interface NavigationState {
   view: string;
   deckId?: string;
   slideIndex?: number;
+  /** Optional unique-per-write token. When present, the UI uses it to detect
+   * legitimate repeat writes (same payload, different `_writeId`) vs. the
+   * race where DELETE didn't land before the next polling refetch. Older
+   * writers may omit it; the dedup logic falls back to content equality.  */
+  _writeId?: string;
 }
 
 export function useNavigationState() {
@@ -57,8 +62,12 @@ export function useNavigationState() {
     }).catch(() => {});
   }, [location.pathname, location.search]);
 
-  // Listen for navigate commands from agent
-  const { data: navCommand } = useQuery({
+  // Listen for navigate commands from agent. Default React Query options
+  // (`structuralSharing: true`) deep-equal the response and reuse the previous
+  // reference when the value hasn't changed — so repeated invalidations
+  // triggered by `useDbSync` (which fire on every app-state event including
+  // unrelated keys like `slide-fit-check`) don't churn the useEffect below.
+  const { data: navCommand } = useQuery<NavigationState | null>({
     queryKey: ["navigate-command"],
     queryFn: async () => {
       const res = await fetch(
@@ -69,26 +78,55 @@ export function useNavigationState() {
       if (!text) return null;
       try {
         const data = JSON.parse(text);
-        if (data) {
-          // Return with a timestamp to ensure uniqueness
-          return { ...data, _ts: Date.now() };
-        }
+        return data ?? null;
       } catch {
-        // Empty or invalid JSON response — no navigate command
+        return null;
       }
-      return null;
     },
-    structuralSharing: false,
   });
+
+  // Dedup re-processing of the same navigate command. Two ways the same
+  // command can be read more than once: (1) the fire-and-forget DELETE below
+  // hasn't reached the server before the next `useDbSync`-driven refetch, so
+  // the GET still returns the old value, and (2) the agent error path leaves
+  // a stale command in `application_state` that every subsequent app-state
+  // event keeps re-reading. Without this dedup the editor visibly flips
+  // between slides — most painfully when both `navigate` and `__set_url__`
+  // have stale commands pointing at different slides, producing an
+  // oscillation between two slide indexes. Dedup key prefers the writer's
+  // `_writeId` (unique per write) and falls back to content equality so older
+  // writers that haven't been updated to include `_writeId` still benefit.
+  const lastProcessedDedupKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!navCommand) return;
+
+    const cmd = navCommand;
+    const dedupKey =
+      cmd._writeId ??
+      JSON.stringify({
+        view: cmd.view,
+        deckId: cmd.deckId,
+        slideIndex: cmd.slideIndex,
+      });
+    if (lastProcessedDedupKeyRef.current === dedupKey) {
+      // Same command we already handled. Re-fire the DELETE in case the
+      // earlier one lost its race, and clear the local cache so we don't
+      // re-enter on the next render.
+      fetch(agentNativePath("/_agent-native/application-state/navigate"), {
+        method: "DELETE",
+        headers: { "X-Agent-Native-CSRF": "1", "X-Request-Source": TAB_ID },
+      }).catch(() => {});
+      qc.setQueryData(["navigate-command"], null);
+      return;
+    }
+    lastProcessedDedupKeyRef.current = dedupKey;
+
     // Delete the one-shot command AFTER reading it
     fetch(agentNativePath("/_agent-native/application-state/navigate"), {
       method: "DELETE",
       headers: { "X-Agent-Native-CSRF": "1", "X-Request-Source": TAB_ID },
     }).catch(() => {});
-    const cmd = navCommand as NavigationState;
     let path = "/";
 
     if (cmd.deckId) {

--- a/templates/starter/.agents/skills/adding-a-feature/SKILL.md
+++ b/templates/starter/.agents/skills/adding-a-feature/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: adding-a-feature
+description: >-
+  The four-area checklist every new feature in this app must complete. Use
+  when adding any feature, integration, or capability to keep the agent and
+  UI in parity.
+---
+
+# Adding a Feature — The Four-Area Checklist
+
+## Rule
+
+Every new feature MUST update all four areas. Skipping any one breaks the agent-native contract — the agent and UI must always be equal partners.
+
+## Why
+
+Agent-native apps are defined by parity: everything the UI can do, the agent can do, and vice versa. A feature that only has UI is invisible to the agent. A feature that only has actions is invisible to the user. A feature without app-state sync means the agent is blind to what the user is doing. And **a feature without auto-refresh wiring means the agent's writes are silently invisible until the user manually reloads** — that breaks the framework's #1 promise.
+
+## The Checklist
+
+### 1. UI Component
+
+Build the user-facing interface — a page, component, dialog, or route. Use `useActionQuery` and `useActionMutation` from `@agent-native/core/client` for data fetching and mutations. You rarely need custom `/api/` routes.
+
+**Auto-refresh on agent writes is non-negotiable** — when the agent mutates the data this UI shows, the UI must reflect the change without a manual refresh. Two paths, pick the right one:
+
+- **`useActionQuery` (preferred)** — automatically covered. The framework's `useDbSync` invalidates `["action"]` on every change event, so every `useActionQuery` hook refetches when the agent runs an action. No extra wiring required.
+
+- **Raw `useQuery` with a custom key** — needs explicit wiring. Fold `useChangeVersions([<source>, "action"])` from `@agent-native/core/client` into the `queryKey` and set `placeholderData: (prev) => prev`. The `"action"` source is the reliable signal — the agent runner emits it after every successful tool call. The resource-specific source (e.g. `"settings"`, `"app-state"`) is bonus. Without this wiring, agent writes will be invisible until manual refresh.
+
+  ```tsx
+  import { useChangeVersions } from "@agent-native/core/client";
+  import { useQuery } from "@tanstack/react-query";
+
+  function useItem(id: string) {
+    const v = useChangeVersions(["items", "action"]);
+    return useQuery({
+      queryKey: ["item", id, v],
+      queryFn: () => fetchItem(id),
+      placeholderData: (prev) => prev, // no flicker on refetch
+    });
+  }
+  ```
+
+  See the `real-time-sync` skill for the full pattern and source catalog.
+
+### 2. Action
+
+Create an action in `actions/` using `defineAction`. This serves double duty: the agent calls it as a tool, and the framework auto-exposes it as an HTTP endpoint at `/_agent-native/actions/:name` for the UI to call. Set `http: { method: "GET" }` for read actions, leave default for writes, or set `http: false` for agent-only actions like `navigate` and `view-screen`.
+
+### 3. Skills / Instructions
+
+Update `AGENTS.md` (the per-app guide) and/or create a skill in `.agents/skills/` if the feature introduces patterns the agent needs to know. At minimum, add the new actions to the action table in the template's `AGENTS.md`.
+
+### 4. Application State Sync
+
+Expose navigation and selection state so the agent knows what the user is looking at. Write to the `navigation` app-state key on route changes. Update the `view-screen` action to fetch relevant data for the new feature. Add a `navigate` command if the agent needs to open the new view.
+
+## Anti-Patterns
+
+- **UI without actions** — The user can create things but the agent cannot. Breaks parity.
+- **Actions without UI** — The agent can do something the user cannot. Less common but still breaks parity.
+- **Mutations without auto-refresh wiring** — The agent says "done!" but the screen doesn't change until the user hits reload. This is the most common silent regression. If you used `useActionQuery` you're covered; if you used raw `useQuery`, fold `useChangeVersions` into the key. Always test by asking the agent to mutate the data and watching the UI without refreshing.
+
+## Verification
+
+For every new feature, manually verify:
+
+1. Can the user perform the operation from the UI?
+2. Can the agent perform the operation via an action (`pnpm action <name>`)?
+3. When the agent runs the action, **does the UI update within a second or two without a manual refresh**? If not, your query is missing `useActionQuery` or `useChangeVersions` wiring — go back to step 1.
+4. Does `view-screen` return the new feature's state when the user is on that page?

--- a/templates/starter/.agents/skills/real-time-sync/SKILL.md
+++ b/templates/starter/.agents/skills/real-time-sync/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: real-time-sync
+description: >-
+  How to keep the UI in sync with agent changes via polling. Use when wiring
+  query invalidation for new data models, debugging UI not updating, or
+  understanding jitter prevention.
+---
+
+# Real-Time Sync (Polling)
+
+## Rule
+
+The UI stays in sync with agent/script changes through database polling. When the agent writes to the database, the UI detects the change and updates automatically — no manual refresh needed.
+
+## Why
+
+The agent modifies data in SQL, but the UI runs in the browser. Polling bridges this gap: every database write increments a version counter, the `useDbSync()` hook polls for version changes, and React Query invalidates the relevant caches. This is what makes database writes feel real-time.
+
+## How It Works
+
+1. **Server** increments a version counter on every database write. The `/_agent-native/poll` endpoint returns the current version and any events since the last poll.
+
+2. **Client** polls for changes and updates per-source counters:
+
+   ```ts
+   import { useDbSync } from "@agent-native/core";
+   useDbSync({ queryClient });
+   ```
+
+3. **Templates fold a per-source counter into the relevant query key.** When the source advances, only the dependent query refetches:
+
+   ```ts
+   import { useChangeVersion } from "@agent-native/core/client";
+
+   const v = useChangeVersion("items"); // or "settings", "dashboards", "action", etc.
+   const { data } = useQuery({
+     queryKey: ["items", v],
+     queryFn: fetchItems,
+     placeholderData: (prev) => prev,
+   });
+   ```
+
+4. When the agent writes to the database, the server emits a `recordChange({ source, ... })` event. `useDbSync` bumps the matching counter; any query with that counter in its key refetches; everything else stays untouched.
+
+## Don't
+
+- Don't create manual polling loops — `useDbSync()` handles it (polls every 2 seconds by default)
+- Don't create your own fetch-based polling alongside `useDbSync` — use the `onEvent` callback for custom handling
+
+## Tuning refetch behavior
+
+`useDbSync` invalidates every active query on any non-own change event. The `onEvent` callback still fires with each change event, so templates can layer surgical extras on top — for example, invalidating an inactive query that wouldn't otherwise refetch:
+
+```ts
+useDbSync({
+  queryClient,
+  onEvent: (data) => {
+    if (data.source === "settings") {
+      // Force a refetch even when not actively observed
+      queryClient.invalidateQueries({
+        queryKey: ["settings"],
+        refetchType: "all",
+      });
+    }
+  },
+});
+```
+
+To prevent cache thrashing during rapid agent writes, set `staleTime` on your queries:
+
+```ts
+useQuery({
+  queryKey: ["items"],
+  queryFn: fetchItems,
+  staleTime: 2000, // don't refetch within 2 seconds
+});
+```
+
+## Troubleshooting
+
+| Symptom                            | Check                                                                                                    |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| UI not updating after agent writes | Is `useDbSync` called with the correct `queryClient`? Does the affected query have an active observer?  |
+| Poll endpoint not responding       | Is `/_agent-native/poll` accessible? Is the server running?                                              |
+| High CPU / event storms            | The agent is writing rapidly. Add `staleTime` to queries to debounce refetches.                          |
+
+## Jitter Prevention
+
+When the agent writes to application-state via script helpers (`writeAppState`, `deleteAppState`), the write is automatically tagged with `requestSource: "agent"`. This prevents the UI from overwriting active user edits when it receives the change event.
+
+### How it works
+
+1. **Agent writes** are tagged: the script helpers in `@agent-native/core/application-state` pass `{ requestSource: "agent" }` to the store.
+2. **UI writes** are tagged: templates send a per-tab ID via the `X-Request-Source` header on PUT/DELETE requests to application-state endpoints.
+3. **Polling filters**: `useDbSync()` accepts an `ignoreSource` option. The UI passes its own tab ID so it ignores events from its own writes — but still picks up events from agents, other tabs, and scripts.
+
+### Template setup
+
+```ts
+// app/lib/tab-id.ts
+export const TAB_ID = `tab-${Math.random().toString(36).slice(2, 8)}`;
+
+// app/root.tsx
+import { TAB_ID } from "@/lib/tab-id";
+
+useDbSync({
+  queryClient,
+  ignoreSource: TAB_ID,
+});
+```
+
+The `use-navigation-state.ts` hook sends the same `TAB_ID` in the `X-Request-Source` header when writing navigation state, so the tab that wrote the state does not refetch it.
+
+### Why this matters
+
+Without jitter prevention, a cycle occurs: the UI writes state, polling detects the change, the UI refetches and re-renders, potentially overwriting what the user is actively editing. With `ignoreSource`, the UI only reacts to changes from other sources (agent scripts, other browser tabs, other users).
+
+## Related Skills
+
+- **storing-data** — Application-state and settings are the data stores that sync via polling
+- **context-awareness** — Navigation state writes use jitter prevention to avoid overwriting active edits
+- **scripts** — Script outputs written to the database trigger poll events
+- **self-modifying-code** — Agent code edits trigger poll events; rapid edits can cause event storms

--- a/templates/starter/AGENTS.md
+++ b/templates/starter/AGENTS.md
@@ -2,7 +2,7 @@
 
 This app follows the agent-native core philosophy: the agent and UI are equal partners. Everything the UI can do, the agent can do via actions. The agent always knows what you're looking at via application state. See the root AGENTS.md for full framework documentation.
 
-This is an **@agent-native/core** application -- the AI agent and UI share state through a SQL database, with polling for real-time sync.
+This is an **@agent-native/core** application -- the AI agent and UI share state through a SQL database, with polling for real-time sync. **When you (the agent) write data, the UI must reflect the change without a manual refresh.** This is non-negotiable. Use `useActionQuery` (auto-covered) or fold `useChangeVersions([<source>, "action"])` into raw `useQuery` keys. See the `real-time-sync` and `adding-a-feature` skills.
 
 ## Resources
 
@@ -72,23 +72,26 @@ cd templates/starter && pnpm action <name> [args]
 
 ## Skills
 
-| Skill                 | When to read                                                   |
-| --------------------- | -------------------------------------------------------------- |
-| `storing-data`        | Before storing or reading any app state                        |
-| `delegate-to-agent`   | Before adding LLM calls or AI delegation                       |
-| `actions`             | Before creating or modifying scripts                           |
-| `self-modifying-code` | Before editing source, components, or styles                   |
-| `frontend-design`     | Before building or restyling any UI component, page, or layout |
+| Skill                 | When to read                                                                      |
+| --------------------- | --------------------------------------------------------------------------------- |
+| `adding-a-feature`    | **Read first when adding ANY new feature** — the four-area parity checklist       |
+| `real-time-sync`      | Before wiring data fetching for anything the agent can mutate (must auto-refresh) |
+| `storing-data`        | Before storing or reading any app state                                           |
+| `delegate-to-agent`   | Before adding LLM calls or AI delegation                                          |
+| `actions`             | Before creating or modifying actions                                              |
+| `self-modifying-code` | Before editing source, components, or styles                                      |
+| `frontend-design`     | Before building or restyling any UI component, page, or layout                    |
 
 ## When Adding Features
 
-As you build out this app, follow this checklist for each new feature:
+**Read the `adding-a-feature` skill first** — it has the full four-area checklist (UI / Action / Skills / App-State). Quick summary:
 
-1. **Add navigation state entries** -- extend `use-navigation-state.ts` to track new routes
-2. **Enhance view-screen** -- make the view-screen script return relevant context for the new view
-3. **Create domain scripts** -- add scripts for CRUD operations on new data models
-4. **Create domain skills** -- add `.agents/skills/<feature>/SKILL.md` documenting the data model, storage patterns, and agent operations
-5. **Update this AGENTS.md** -- add the new scripts, state keys, and common tasks
+1. **Add navigation state entries** — extend `use-navigation-state.ts` to track new routes
+2. **Enhance view-screen** — make the view-screen action return relevant context for the new view
+3. **Create domain actions** — add actions for CRUD operations on new data models
+4. **Wire UI for auto-refresh** — use `useActionQuery` (auto-covered) OR fold `useChangeVersions([<source>, "action"])` into raw `useQuery` keys with `placeholderData`. When the agent mutates this data, the UI must reflect the change without a manual refresh. See `real-time-sync` skill.
+5. **Create domain skills** — add `.agents/skills/<feature>/SKILL.md` documenting the data model, storage patterns, and agent operations
+6. **Update this AGENTS.md** — add the new actions, state keys, and common tasks
 
 ### Authentication
 


### PR DESCRIPTION
## Summary

- **default-template + starter `AGENTS.md`** — call out the auto-refresh contract directly in the per-template guide so newly-scaffolded apps see it without having to drill into skills. _"When you (the agent) write data, the UI must reflect the change without a manual refresh — non-negotiable. Use `useActionQuery` (auto-covered) or fold `useChangeVersions([<source>, "action"])` into raw `useQuery` keys."_
- **default-template + starter skill mirrors** — add `adding-a-feature/SKILL.md` and `real-time-sync/SKILL.md` under each template's `.agents/skills/` so a freshly-scaffolded app carries the same skill content as the framework, not a stale earlier version.

Was originally pushed to updates-302 a minute after PR #648 squash-merged (so it got stranded) — recovered here via cherry-pick.

## Test plan

- [ ] CI green (Build, Lint, Test, Typecheck, Scaffold E2E, Guard, changeset)
- [ ] Manual: scaffold a fresh app — the per-template `AGENTS.md` calls out the auto-refresh contract; `.agents/skills/adding-a-feature/` and `.agents/skills/real-time-sync/` are present