### PR TITLE
dispatch catch-all url+path resolver; images settings gating on BUILDER_IMAGE_GENERATION_ENABLED

### DIFF
--- a/.changeset/dispatch-catch-all-url-and-path-normalization.md
+++ b/.changeset/dispatch-catch-all-url-and-path-normalization.md
@@ -1,0 +1,10 @@
+---
+"@agent-native/dispatch": patch
+---
+
+Fix two bugs in `resolveCatchAllTarget` (the `/dispatch/<appId>` fallback resolver, used when no explicit dispatch route matches):
+
+- Honour `app.url` from the workspace manifest. Workspaces can point at externally-hosted apps via an absolute URL on the manifest entry; the resolver was ignoring that field and falling through to the local path. `app.url` now takes precedence over `app.path`.
+- Normalize `app.path` instead of silently rewriting to `/${appId}`. When the manifest path doesn't start with a slash (`path: "my-forms"`) the previous code returned `/${appId}`, which routed to the wrong app whenever an entry's mounted path differed from its id. Now the leading slash is just prepended, preserving the path.
+
+Both surfaced by the Builder PR-review bot on #651.

--- a/packages/dispatch/src/lib/catch-all-target.spec.ts
+++ b/packages/dispatch/src/lib/catch-all-target.spec.ts
@@ -77,6 +77,60 @@ describe("resolveCatchAllTarget", () => {
     expect(resolveCatchAllTarget("todo")).toBe("/todo");
   });
 
+  it("uses app.path when id !== path (not /${appId})", () => {
+    // Before the fix, an entry whose mounted path differs from its id —
+    // e.g. id: "forms", path: "my-forms" without a leading slash — was
+    // silently rewritten to `/forms` (the appId) and routed to the wrong
+    // app. The normalizer now keeps the manifest path and only prepends
+    // the missing slash.
+    loadWorkspaceAppsManifestMock.mockReturnValue([
+      { id: "forms", name: "Forms", path: "my-forms" },
+    ]);
+    getBuiltinAgentsMock.mockReturnValue([]);
+
+    expect(resolveCatchAllTarget("forms")).toBe("/my-forms");
+  });
+
+  it("prefers app.url when the manifest entry has an externally-hosted URL", () => {
+    // Workspaces can point at remote deploys. The catch-all should bounce
+    // to the absolute URL instead of mounting a local path that doesn't
+    // exist inside the gateway.
+    loadWorkspaceAppsManifestMock.mockReturnValue([
+      {
+        id: "forms",
+        name: "Forms",
+        path: "/forms",
+        url: "https://forms.example.com",
+      },
+    ]);
+    getBuiltinAgentsMock.mockReturnValue([]);
+
+    expect(resolveCatchAllTarget("forms")).toBe("https://forms.example.com");
+  });
+
+  it("ignores an empty/whitespace app.url and falls back to path", () => {
+    loadWorkspaceAppsManifestMock.mockReturnValue([
+      {
+        id: "forms",
+        name: "Forms",
+        path: "/forms",
+        url: "   ",
+      },
+    ]);
+    getBuiltinAgentsMock.mockReturnValue([]);
+
+    expect(resolveCatchAllTarget("forms")).toBe("/forms");
+  });
+
+  it("falls back to /${appId} when the manifest entry has neither path nor url", () => {
+    loadWorkspaceAppsManifestMock.mockReturnValue([
+      { id: "forms", name: "Forms", path: "" },
+    ]);
+    getBuiltinAgentsMock.mockReturnValue([]);
+
+    expect(resolveCatchAllTarget("forms")).toBe("/forms");
+  });
+
   it("returns null when nothing matches", () => {
     loadWorkspaceAppsManifestMock.mockReturnValue([
       { id: "dispatch", name: "Dispatch", path: "/dispatch" },

--- a/packages/dispatch/src/lib/catch-all-target.ts
+++ b/packages/dispatch/src/lib/catch-all-target.ts
@@ -10,9 +10,15 @@ import {
  * Resolution order:
  *
  * 1. Workspace apps manifest (env, .agent-native/workspace-apps.json, or a
- *    filesystem scan of `apps/`). When `<appId>` is a sibling workspace
- *    app, return its mounted path so the user lands on the real app
- *    inside the workspace gateway instead of a 404 inside dispatch.
+ *    filesystem scan of `apps/`).
+ *    - `app.url` (absolute URL — externally hosted workspace app) wins if
+ *      present.
+ *    - Otherwise the `app.path` mounted under the workspace gateway is
+ *      used. Path is normalized to a leading slash if missing
+ *      (e.g. manifest entry `path: "my-forms"` → `/my-forms`), so an app
+ *      whose mounted path differs from its id ends up at the right place
+ *      instead of being silently rewritten to `/${appId}`.
+ *    - Bare entry with no path / url falls back to `/${appId}`.
  * 2. First-party template registry. When no workspace manifest matches
  *    (framework dev with each template on its own port, hosted dispatch
  *    with no sibling apps), return the matching template's deploy URL —
@@ -27,7 +33,22 @@ export function resolveCatchAllTarget(appId: string): string | null {
   if (apps) {
     const app = apps.find((entry) => entry?.id === appId);
     if (app) {
-      return app.path && app.path.startsWith("/") ? app.path : `/${appId}`;
+      // Explicit externally-hosted URL wins. Workspaces that point at a
+      // remote deploy (e.g. a sibling app on Netlify) set `url` and we
+      // should bounce the user there rather than mounting a local path
+      // that doesn't exist inside the gateway.
+      if (typeof app.url === "string" && app.url.trim()) {
+        return app.url.trim();
+      }
+      // Fall back to the mounted path. Normalize to leading slash so an
+      // entry whose path differs from its id (e.g. `id: "forms"`,
+      // `path: "my-forms"`) still lands on the correct gateway mount —
+      // not on `/${appId}`, which would silently route to the wrong app.
+      if (typeof app.path === "string" && app.path.trim()) {
+        const normalized = app.path.trim();
+        return normalized.startsWith("/") ? normalized : `/${normalized}`;
+      }
+      return `/${appId}`;
     }
   }
   const builtin = getBuiltinAgents("dispatch").find(

--- a/templates/images/actions/get-image-generation-config.ts
+++ b/templates/images/actions/get-image-generation-config.ts
@@ -1,0 +1,24 @@
+import { defineAction } from "@agent-native/core";
+import { z } from "zod";
+import { isBuilderImageGenerationEnabled } from "../server/lib/generation.js";
+
+/**
+ * Surface the server-side `BUILDER_IMAGE_GENERATION_ENABLED` env flag so
+ * the settings UI can decide whether to offer the "Connect Builder.io"
+ * path. With the flag set to `"false"` the generation pipeline refuses
+ * Builder-managed runs (see `generateWithManagedImageProvider` in
+ * `generation.ts:217`), so the settings page would otherwise lead users
+ * down a setup path that can't succeed.
+ *
+ * Kept advisory — generation actions still check the flag themselves.
+ */
+export default defineAction({
+  description:
+    "Returns the deployment's image-generation config: whether Builder-managed image generation is enabled by `BUILDER_IMAGE_GENERATION_ENABLED`.",
+  schema: z.object({}),
+  http: { method: "GET" },
+  readOnly: true,
+  run: async () => {
+    return { builderEnabled: isBuilderImageGenerationEnabled() };
+  },
+});

--- a/templates/images/app/routes/settings.tsx
+++ b/templates/images/app/routes/settings.tsx
@@ -70,10 +70,39 @@ export default function SettingsPage() {
 function ManageCredentialsSection() {
   const { status } = useBuilderStatus();
   const flow = useBuilderConnectFlow();
+  // `BUILDER_IMAGE_GENERATION_ENABLED=false` deployments reject Builder
+  // credentials in `generateWithManagedImageProvider` even when Builder is
+  // connected. Surface that here so the settings UI doesn't send users
+  // down a Connect-Builder path that can't succeed. The onboarding plugin
+  // already marks the corresponding setup step `disabled` in this case;
+  // this card mirrors the gating.
+  const { data: configData } = useActionQuery(
+    "get-image-generation-config",
+    {},
+  ) as { data?: { builderEnabled?: boolean } };
+  // While the flag query is loading, assume Builder is enabled (the
+  // production default) so the connect button doesn't briefly flash as
+  // disabled on first render.
+  const builderEnabled = configData?.builderEnabled ?? true;
   const configured = flow.hasFetchedStatus
     ? flow.configured
     : !!status?.configured;
   const orgName = flow.orgName ?? status?.orgName ?? null;
+
+  if (!builderEnabled) {
+    return (
+      <div className="rounded-lg border border-border p-4">
+        <h3 className="text-sm font-semibold">Manage credentials</h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Builder-managed image generation is disabled for this deployment by
+          the <code className="text-xs">BUILDER_IMAGE_GENERATION_ENABLED</code>{" "}
+          environment variable. Add a Gemini API key from the Setup checklist
+          above; the manual fallback is the only path that will succeed until
+          the flag is re-enabled.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="rounded-lg border border-border p-4">


### PR DESCRIPTION
## Summary

Addresses all 3 issues flagged by the Builder bot review on the previous PR: https://github.com/BuilderIO/agent-native/pull/651#pullrequestreview-4266520608.

- **🔴 `resolveCatchAllTarget` ignored `app.url`.** Workspaces can point at externally-hosted apps via an absolute URL on the manifest entry; the resolver was ignoring that field and falling through to the local path. `app.url` now takes precedence over `app.path`.
- **🔴 `resolveCatchAllTarget` silently rewrote `path: "my-forms"` to `/${appId}`.** When the manifest path didn't start with a slash, the previous code returned `/${appId}`, routing to the wrong app whenever an entry's mounted path differed from its id. Now the leading slash is just prepended, preserving the path. Spec coverage: 4 new cases (cross-id path, explicit url precedence, empty/whitespace url ignored, no-path-or-url fallback).
- **🟡 Images settings always offered Builder connect even when disabled.** `BUILDER_IMAGE_GENERATION_ENABLED=false` deployments reject Builder credentials in `generateWithManagedImageProvider`, so the new "Manage credentials" card was sending users down a Connect-Builder path that couldn't work. Added a tiny `get-image-generation-config` action that surfaces the server-side flag; the settings card now hides the Connect button and shows an explanatory note when the flag is off (matching what the onboarding plugin already does for the corresponding setup step).

## Test plan

- [ ] CI green (Build, Lint, Test, Typecheck, Scaffold E2E, Guard, changeset)
- [ ] `catch-all-target.spec.ts` 9/9 pass locally
- [ ] Manual: hit `/dispatch/forms` on a workspace where the manifest has `path: "my-forms"` → lands on `/my-forms`, not `/forms`
- [ ] Manual: hit `/dispatch/forms` on a workspace where the manifest has `url: "https://forms.example.com"` → bounces to that URL
- [ ] Manual: set `BUILDER_IMAGE_GENERATION_ENABLED=false` in images dev → Settings page hides the Connect Builder card and shows the explanatory note