### PR TITLE
dispatch/catch-all: validate app.url is absolute http(s) before redirect

### DIFF
--- a/.changeset/assistant-chat-empty-state-addon.md
+++ b/.changeset/assistant-chat-empty-state-addon.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": minor
+---
+
+New optional `emptyStateAddon` prop on `AssistantChat` — content rendered in the empty state above the suggestion buttons. Used by `MultiTabAssistantChat` to surface "previous chats for this design" when the current thread is empty but the scope has other threads. No behaviour change when the prop isn't passed.

--- a/.changeset/composer-button-ordering-actionbutton.md
+++ b/.changeset/composer-button-ordering-actionbutton.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+`TiptapComposer`: when a caller passes a custom `actionButton`, render only the model selector + plan-mode toggle on the left side (skipping the voice/file/send cluster that the default action-button slot owns). Without this, callers that already render their own send button got a duplicate-looking trailing block. No behavior change when `actionButton` isn't passed.

--- a/.changeset/dispatch-catch-all-validate-url.md
+++ b/.changeset/dispatch-catch-all-validate-url.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/dispatch": patch
+---
+
+`resolveCatchAllTarget` now validates `app.url` is an absolute http(s) URL before letting it take precedence over `app.path`. Previously any non-empty string would win — including bare hostnames like `"forms.example.com"` (no protocol, browser would treat the redirect as a relative path inside the gateway and 404) or `javascript:` schemes (phishing vector). Mirrors the validation in `normalizeWorkspaceAppUrl` (deploy CLI), inlined to avoid pulling that module into the runtime path. 3 new spec cases (bare hostname rejected, non-http(s) scheme rejected, trailing slash stripped). Flagged by the Builder bot review on #652.

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2938,6 +2938,10 @@ export interface AssistantChatProps {
   emptyStateText?: string;
   /** Suggestion prompts shown when no messages */
   suggestions?: string[];
+  /** Optional content rendered in the empty state, above the suggestion buttons.
+   *  Used by MultiTabAssistantChat to surface "previous chats for this design"
+   *  when the current thread is empty but the scope has other threads. */
+  emptyStateAddon?: React.ReactNode;
   /** Whether to show the header bar. Default: true */
   showHeader?: boolean;
   /** CSS class for the outer container */
@@ -3056,6 +3060,7 @@ const AssistantChatInner = forwardRef<
   {
     emptyStateText,
     suggestions,
+    emptyStateAddon,
     showHeader = true,
     onSwitchToCli,
     className,
@@ -4423,6 +4428,7 @@ const AssistantChatInner = forwardRef<
                   <p className="text-sm text-muted-foreground text-center max-w-[240px]">
                     {emptyStateText ?? "How can I help you?"}
                   </p>
+                  {emptyStateAddon}
                   {suggestions && suggestions.length > 0 && (
                     <div className="flex flex-col gap-1.5 w-full max-w-[280px]">
                       {suggestions.map((suggestion) => (

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -219,7 +219,7 @@ function ScopeBadge({
                 className="ml-0.5 rounded-full bg-muted px-1.5 py-px text-[10px] leading-none text-muted-foreground"
                 aria-label={`${otherCount} other chats for this ${scope.type}`}
               >
-                {otherCount + 1}
+                +{otherCount}
               </span>
             )}
           </button>

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -995,6 +995,43 @@ export function MultiTabAssistantChat({
     return stored;
   }, [threads, activeThreadId, scope?.type, scope?.id, scope?.label]);
 
+  // Brief confirmation banner shown after detach. The chip itself disappears
+  // the instant scope clears, which the user described as "nothing different
+  // happened." We hold the confirmation in the same slot for ~2s so the
+  // detach is visually acknowledged and the user is pointed at History.
+  const [detachConfirmType, setDetachConfirmType] = useState<string | null>(
+    null,
+  );
+  const detachTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (detachTimerRef.current) clearTimeout(detachTimerRef.current);
+    };
+  }, []);
+  const handleDetachActiveThread = useCallback(() => {
+    if (!activeThreadId || !activeThreadScope) return;
+    const type = activeThreadScope.type;
+    setDetachConfirmType(type);
+    if (detachTimerRef.current) clearTimeout(detachTimerRef.current);
+    detachTimerRef.current = setTimeout(() => setDetachConfirmType(null), 2200);
+    detachThread(activeThreadId);
+  }, [activeThreadId, activeThreadScope, detachThread]);
+
+  // Other chats scoped to the active thread's resource (excluding the active
+  // thread itself). Sorted most-recent-first to match user expectation in the
+  // chip popover and empty-state addon.
+  const otherScopedThreads = useMemo<ChatThreadSummary[]>(() => {
+    if (!activeThreadScope) return [];
+    return threads
+      .filter(
+        (t) =>
+          t.id !== activeThreadId &&
+          t.scope?.type === activeThreadScope.type &&
+          t.scope?.id === activeThreadScope.id,
+      )
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+  }, [threads, activeThreadId, activeThreadScope]);
+
   // Persist open tab IDs to localStorage (exclude sub-agent tabs — they're session-only)
   useEffect(() => {
     if (openTabsKeyRef.current !== OPEN_TABS_KEY) return;
@@ -1828,13 +1865,23 @@ export function MultiTabAssistantChat({
             Gated on `!contentHidden` because the wrapping AgentPanel keeps
             the chat mounted (to preserve state) while Workspace/Settings
             tabs are active — without this gate the badge leaks into those
-            tabs even though the chat itself is `display: none`. */}
-        {!contentHidden && activeThreadScope && activeThreadId && (
-          <ScopeBadge
-            scope={activeThreadScope}
-            onDetach={() => detachThread(activeThreadId)}
-          />
-        )}
+            tabs even though the chat itself is `display: none`.
+            When the user just detached, we hold a confirmation banner in
+            the same slot for ~2s so the action is visibly acknowledged
+            before the slot collapses. */}
+        {!contentHidden &&
+          (activeThreadScope && activeThreadId ? (
+            <ScopeBadge
+              scope={activeThreadScope}
+              onDetach={handleDetachActiveThread}
+              otherScopedThreads={otherScopedThreads}
+              activeThreadId={activeThreadId}
+              openTabIds={new Set(openTabIds)}
+              onSelectThread={openFromHistory}
+            />
+          ) : detachConfirmType ? (
+            <DetachConfirmationBanner scopeType={detachConfirmType} />
+          ) : null)}
 
         {/* History popover — rendered inside relative container so positioning works */}
         {showHistory && (
@@ -1887,6 +1934,17 @@ export function MultiTabAssistantChat({
                     activeThreadScope?.label && tabId === activeThreadId
                       ? `Ask about ${activeThreadScope.label}`
                       : props.emptyStateText
+                  }
+                  emptyStateAddon={
+                    tabId === activeThreadId &&
+                    activeThreadScope &&
+                    otherScopedThreads.length > 0 ? (
+                      <PreviousScopedChatsHint
+                        scope={activeThreadScope}
+                        threads={otherScopedThreads}
+                        onSelectThread={openFromHistory}
+                      />
+                    ) : undefined
                   }
                   ref={(handle) => {
                     if (handle) {

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -12,6 +12,7 @@ import {
   IconSearch,
   IconLink,
   IconLinkOff,
+  IconCheck,
 } from "@tabler/icons-react";
 import {
   AssistantChat,

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -179,9 +179,20 @@ function ChatSkeleton({
 function ScopeBadge({
   scope,
   onDetach,
+  otherScopedThreads,
+  activeThreadId,
+  openTabIds,
+  onSelectThread,
 }: {
   scope: ChatThreadScope;
   onDetach: () => void;
+  /** Other threads scoped to the same resource (excluding the active one),
+   *  pre-sorted most-recent-first. The chip popover lists these so the user
+   *  can hop between this design's chats without opening the full history. */
+  otherScopedThreads: ChatThreadSummary[];
+  activeThreadId: string;
+  openTabIds: Set<string>;
+  onSelectThread: (id: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   // Templates that don't have the resource's display title at layout time
@@ -191,6 +202,7 @@ function ScopeBadge({
     ? `Linked to ${scope.label}`
     : `Linked to this ${scope.type}`;
   const detailLabel = scope.label || `this ${scope.type}`;
+  const otherCount = otherScopedThreads.length;
   return (
     <div className="flex items-center justify-center py-1 px-3 text-[11px] text-muted-foreground border-b border-border/40 shrink-0">
       <Popover open={open} onOpenChange={setOpen}>
@@ -202,33 +214,90 @@ function ScopeBadge({
           >
             <IconLink size={11} className="shrink-0 opacity-70" />
             <span className="truncate max-w-[220px]">{heading}</span>
+            {otherCount > 0 && (
+              <span
+                className="ml-0.5 rounded-full bg-muted px-1.5 py-px text-[10px] leading-none text-muted-foreground"
+                aria-label={`${otherCount} other chats for this ${scope.type}`}
+              >
+                {otherCount + 1}
+              </span>
+            )}
           </button>
         </PopoverTrigger>
-        <PopoverContent align="center" side="bottom" className="w-60 p-2">
-          <p className="px-2 py-1 text-[11px] text-muted-foreground">
+        <PopoverContent align="center" side="bottom" className="w-72 p-0">
+          <p className="px-3 pt-2 pb-1.5 text-[11px] text-muted-foreground">
             This chat is linked to{" "}
             <span className="text-foreground">{detailLabel}</span>. New chats
-            started here stay with this {scope.type}; switch to another{" "}
-            {scope.type} to find its threads.
+            started here stay with this {scope.type}.
           </p>
-          <button
-            type="button"
-            onClick={() => {
-              setOpen(false);
-              onDetach();
-            }}
-            className="mt-1 flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs text-foreground hover:bg-accent cursor-pointer"
-          >
-            <IconLinkOff size={13} />
-            <span>Detach from this {scope.type}</span>
-          </button>
+          {otherCount > 0 && (
+            <div className="border-t border-border">
+              <div className="px-3 pt-1.5 pb-1 text-[10px] uppercase tracking-wider text-muted-foreground/70">
+                Other chats here
+              </div>
+              <div className="max-h-56 overflow-y-auto pb-1">
+                {otherScopedThreads.map((thread) =>
+                  renderThreadRow(
+                    thread,
+                    activeThreadId,
+                    openTabIds,
+                    formatThreadTime,
+                    onSelectThread,
+                    () => setOpen(false),
+                  ),
+                )}
+              </div>
+            </div>
+          )}
+          <div className="border-t border-border p-1">
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                onDetach();
+              }}
+              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs text-foreground hover:bg-accent cursor-pointer"
+            >
+              <IconLinkOff size={13} />
+              <span>Detach from this {scope.type}</span>
+            </button>
+          </div>
         </PopoverContent>
       </Popover>
     </div>
   );
 }
 
+/**
+ * Thin confirmation banner shown briefly after detach. The chip itself
+ * unmounts the moment scope clears on the active thread, so this banner
+ * holds the visual feedback long enough for the user to register what
+ * just happened and learn where the chat went (History popover).
+ */
+function DetachConfirmationBanner({ scopeType }: { scopeType: string }) {
+  return (
+    <div className="flex items-center justify-center py-1 px-3 text-[11px] text-muted-foreground border-b border-border/40 shrink-0">
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-accent/40 px-2 py-0.5 text-foreground">
+        <IconCheck size={11} className="shrink-0 opacity-80" />
+        <span>Detached from this {scopeType} — find this chat in History</span>
+      </span>
+    </div>
+  );
+}
+
 // ─── History Popover ─────────────────────────────────────────────────────────
+
+function formatThreadTime(ts: number): string {
+  const d = new Date(ts);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffDays = Math.floor(diffMs / 86400000);
+  if (diffDays === 0)
+    return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return d.toLocaleDateString([], { weekday: "short" });
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
 
 function renderThreadRow(
   thread: ChatThreadSummary,
@@ -377,18 +446,6 @@ function HistoryPopover({
       }
     : null;
 
-  const formatTime = (ts: number) => {
-    const d = new Date(ts);
-    const now = new Date();
-    const diffMs = now.getTime() - d.getTime();
-    const diffDays = Math.floor(diffMs / 86400000);
-    if (diffDays === 0)
-      return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
-    if (diffDays === 1) return "Yesterday";
-    if (diffDays < 7) return d.toLocaleDateString([], { weekday: "short" });
-    return d.toLocaleDateString([], { month: "short", day: "numeric" });
-  };
-
   return (
     <>
       <div className="fixed inset-0 z-40" onClick={onClose} />
@@ -425,7 +482,7 @@ function HistoryPopover({
                       thread,
                       activeThreadId,
                       openTabIds,
-                      formatTime,
+                      formatThreadTime,
                       onSelect,
                       onClose,
                     ),
@@ -442,7 +499,7 @@ function HistoryPopover({
                       thread,
                       activeThreadId,
                       openTabIds,
-                      formatTime,
+                      formatThreadTime,
                       onSelect,
                       onClose,
                     ),
@@ -456,7 +513,7 @@ function HistoryPopover({
                 thread,
                 activeThreadId,
                 openTabIds,
-                formatTime,
+                formatThreadTime,
                 onSelect,
                 onClose,
               ),

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -10,6 +10,7 @@ import {
   IconPlus,
   IconHistory,
   IconSearch,
+  IconLink,
   IconLinkOff,
 } from "@tabler/icons-react";
 import {
@@ -168,12 +169,11 @@ function ChatSkeleton({
 // ─── Scope Badge ─────────────────────────────────────────────────────────────
 
 /**
- * Thin "Working on {Deck Title}" badge that appears at the top of a scoped
- * chat. Click → popover with the Detach button. Steve called for "minimal
- * UX, friendly nudge OK" so the badge is text-only and unobtrusive when
- * the user doesn't need it. It is the only escape hatch for taking a
- * deck-scoped chat back to a general one, so it stays visible the whole
- * time a chat is scoped — not just on the empty state.
+ * Thin "Linked to {Deck Title}" chip at the top of a scoped chat. Click →
+ * popover with the Detach button. The chip is text + link icon and stays
+ * unobtrusive when the user doesn't need it. It is the only escape hatch
+ * for taking a scoped chat back to a general one, so it stays visible the
+ * whole time a chat is scoped — not just on the empty state.
  */
 function ScopeBadge({
   scope,
@@ -184,11 +184,11 @@ function ScopeBadge({
 }) {
   const [open, setOpen] = useState(false);
   // Templates that don't have the resource's display title at layout time
-  // pass `{ type, id }` without a label. Render "About this deck" as a
-  // graceful fallback instead of "About deck", which reads oddly.
+  // pass `{ type, id }` without a label. Fall back to "this {type}" so the
+  // chip still reads naturally.
   const heading = scope.label
-    ? `About ${scope.label}`
-    : `About this ${scope.type}`;
+    ? `Linked to ${scope.label}`
+    : `Linked to this ${scope.type}`;
   const detailLabel = scope.label || `this ${scope.type}`;
   return (
     <div className="flex items-center justify-center py-1 px-3 text-[11px] text-muted-foreground border-b border-border/40 shrink-0">
@@ -199,14 +199,15 @@ function ScopeBadge({
             className="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 hover:bg-accent/50 hover:text-foreground cursor-pointer"
             aria-label={heading}
           >
+            <IconLink size={11} className="shrink-0 opacity-70" />
             <span className="truncate max-w-[220px]">{heading}</span>
           </button>
         </PopoverTrigger>
         <PopoverContent align="center" side="bottom" className="w-60 p-2">
           <p className="px-2 py-1 text-[11px] text-muted-foreground">
-            This chat is bound to{" "}
+            This chat is linked to{" "}
             <span className="text-foreground">{detailLabel}</span>. New chats
-            started while you're here stay in this chat list; switch to another{" "}
+            started here stay with this {scope.type}; switch to another{" "}
             {scope.type} to find its threads.
           </p>
           <button
@@ -1762,11 +1763,15 @@ export function MultiTabAssistantChat({
         {renderOverlay ? renderOverlay(headerProps) : null}
 
         {/* Scope badge — only visible when the active chat is bound to a
-            resource. Click for the detach popover. The scope used here
-            comes from the THREAD (not the component prop) so a chat
+            resource AND the chat content itself is visible. The scope used
+            here comes from the THREAD (not the component prop) so a chat
             opened from history accurately advertises its own binding,
-            not whichever resource the user happens to be viewing. */}
-        {activeThreadScope && activeThreadId && (
+            not whichever resource the user happens to be viewing.
+            Gated on `!contentHidden` because the wrapping AgentPanel keeps
+            the chat mounted (to preserve state) while Workspace/Settings
+            tabs are active — without this gate the badge leaks into those
+            tabs even though the chat itself is `display: none`. */}
+        {!contentHidden && activeThreadScope && activeThreadId && (
           <ScopeBadge
             scope={activeThreadScope}
             onDetach={() => detachThread(activeThreadId)}

--- a/packages/core/src/client/MultiTabAssistantChat.tsx
+++ b/packages/core/src/client/MultiTabAssistantChat.tsx
@@ -269,6 +269,60 @@ function ScopeBadge({
 }
 
 /**
+ * Empty-state addon shown when the user starts a fresh chat inside a
+ * scoped surface that already has other threads. Surfaces those threads
+ * inline so chats don't feel "lost" after the user navigates away and
+ * back — the chip popover lists them too, but this nudge is visible
+ * without any extra clicks.
+ */
+function PreviousScopedChatsHint({
+  scope,
+  threads,
+  onSelectThread,
+}: {
+  scope: ChatThreadScope;
+  threads: ChatThreadSummary[];
+  onSelectThread: (id: string) => void;
+}) {
+  const MAX_INLINE = 3;
+  const shown = threads.slice(0, MAX_INLINE);
+  const remaining = threads.length - shown.length;
+  const scopeLabel = scope.label || `this ${scope.type}`;
+  return (
+    <div className="flex w-full max-w-[280px] flex-col gap-1.5">
+      <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70 text-center">
+        Continue a previous chat
+        <span className="ml-1 normal-case text-muted-foreground/70">
+          for {scopeLabel}
+        </span>
+      </div>
+      <div className="flex flex-col gap-1">
+        {shown.map((thread) => (
+          <button
+            key={thread.id}
+            type="button"
+            onClick={() => onSelectThread(thread.id)}
+            className="flex items-baseline justify-between gap-2 rounded-md border border-border px-2.5 py-1.5 text-left hover:bg-accent cursor-pointer"
+          >
+            <span className="truncate text-[12px] text-foreground">
+              {thread.title || thread.preview || "Chat"}
+            </span>
+            <span className="shrink-0 text-[10px] text-muted-foreground">
+              {formatThreadTime(thread.updatedAt)}
+            </span>
+          </button>
+        ))}
+      </div>
+      {remaining > 0 && (
+        <div className="text-[10px] text-muted-foreground/70 text-center">
+          +{remaining} more in the chip above
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
  * Thin confirmation banner shown briefly after detach. The chip itself
  * unmounts the moment scope clears on the active thread, so this banner
  * holds the visual feedback long enough for the user to register what

--- a/packages/core/src/client/composer/TiptapComposer.tsx
+++ b/packages/core/src/client/composer/TiptapComposer.tsx
@@ -1639,8 +1639,7 @@ export function TiptapComposer({
               mode={plusMenuMode}
             />
           ))}
-        <div className="flex-1" />
-        {actionButton ?? (
+        {!actionButton && (
           <>
             {selectedModel && availableModels && onModelChange && (
               <ModelSelector
@@ -1659,6 +1658,11 @@ export function TiptapComposer({
                 planModeDisabledReason={planModeDisabledReason}
               />
             )}
+          </>
+        )}
+        <div className="flex-1" />
+        {actionButton ?? (
+          <>
             {voiceEnabled && (
               <VoiceButton voice={voice} isMac={isMac} disabled={disabled} />
             )}

--- a/packages/desktop-app/src/main/app-store.ts
+++ b/packages/desktop-app/src/main/app-store.ts
@@ -31,11 +31,20 @@ function defaultApps(): AppConfig[] {
 }
 
 function canonicalizeDefaultApp(appConfig: AppConfig, def: AppConfig) {
+  // Preserve everything the user can edit in the settings dialog. Only
+  // structural fields the user can't edit (id, icon, isBuiltIn, placeholder)
+  // and template-canonical metadata (color) come from `def`. Without this,
+  // every restart wipes user-edited devUrl/url/name/etc. back to defaults.
   return {
     ...def,
     enabled: appConfig.enabled ?? def.enabled,
     mode: appConfig.mode ?? def.mode,
-    devCommand: def.devCommand ?? appConfig.devCommand,
+    name: appConfig.name || def.name,
+    description: appConfig.description || def.description,
+    url: appConfig.url ?? def.url,
+    devUrl: appConfig.devUrl ?? def.devUrl,
+    devCommand: appConfig.devCommand ?? def.devCommand,
+    devPort: appConfig.devPort || def.devPort,
   };
 }
 

--- a/packages/desktop-app/src/renderer/components/AppSettings.tsx
+++ b/packages/desktop-app/src/renderer/components/AppSettings.tsx
@@ -482,21 +482,6 @@ function AppEditForm({
           />
         </label>
 
-        <div className="settings-color-row">
-          <span>Color</span>
-          <div className="settings-colors">
-            {COLOR_PRESETS.map((c) => (
-              <button
-                key={c}
-                type="button"
-                className={`settings-color-swatch${c === color ? " settings-color-swatch--active" : ""}`}
-                style={{ backgroundColor: c }}
-                onClick={() => setColor(c)}
-              />
-            ))}
-          </div>
-        </div>
-
         <div className="settings-form-actions">
           <button
             type="button"
@@ -565,10 +550,6 @@ function TemplatePicker({
                 }}
                 onClick={() => onPick(t)}
               >
-                <div
-                  className="settings-app-dot"
-                  style={{ backgroundColor: t.color }}
-                />
                 <div className="settings-app-info">
                   <span className="settings-app-name">{t.label}</span>
                   <span className="settings-app-url">{t.hint}</span>

--- a/packages/desktop-app/src/renderer/components/AppSettings.tsx
+++ b/packages/desktop-app/src/renderer/components/AppSettings.tsx
@@ -29,26 +29,6 @@ interface AppSettingsProps {
   onAppsChanged: (apps: AppConfig[]) => void;
 }
 
-const COLOR_PRESETS = [
-  "#3B82F6",
-  "#8B5CF6",
-  "#10B981",
-  "#F59E0B",
-  "#EC4899",
-  "#EF4444",
-  "#06B6D4",
-  "#F97316",
-  "#84CC16",
-  "#6366F1",
-];
-
-function hexToRgb(hex: string): string {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  return `${r} ${g} ${b}`;
-}
-
 function inferPortFromUrl(url: string): number {
   try {
     const parsed = new URL(url);
@@ -288,10 +268,6 @@ export default function AppSettings({
                 <h3>Installed Apps</h3>
                 {apps.map((app) => (
                   <div key={app.id} className="settings-app-row">
-                    <div
-                      className="settings-app-dot"
-                      style={{ backgroundColor: app.color }}
-                    />
                     <div className="settings-app-info">
                       <span className="settings-app-name">{app.name}</span>
                       <span className="settings-app-url">{app.url}</span>
@@ -424,7 +400,6 @@ function AppEditForm({
   const [devUrl, setDevUrl] = useState(app?.devUrl ?? "");
   const [devCommand, setDevCommand] = useState(app?.devCommand ?? "");
   const [description, setDescription] = useState(app?.description ?? "");
-  const [color, setColor] = useState(app?.color ?? COLOR_PRESETS[0]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -441,8 +416,6 @@ function AppEditForm({
       devPort: app?.devPort || inferPortFromUrl(trimmedDevUrl),
       devUrl: trimmedDevUrl || undefined,
       devCommand: devCommand.trim() || undefined,
-      color,
-      colorRgb: hexToRgb(color),
       isBuiltIn: app?.isBuiltIn ?? false,
       enabled: app?.enabled ?? true,
       mode: app?.mode ?? (trimmedUrl ? "prod" : "dev"),

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -55,14 +55,15 @@ export interface AppWebviewHandle {
  * Determine the URL to load for this app.
  *
  * Production mode (default): load the production URL (e.g. https://mail.agent-native.com).
- * Dev mode: load through the local dev frame (chat+CLI sidebar + app iframe).
+ * Dev mode: honor an explicit devUrl/port override; otherwise first-party templates
+ * fall back to the local dev frame (chat+CLI sidebar + app iframe).
  */
 function resolveUrl(app: AppDefinition, appConfig?: AppConfig): string {
   if (appConfig?.mode === "dev") {
-    // First-party templates load through the local dev frame. Custom apps
-    // do not have a frame route, so honor their explicit dev URL/port.
-    if (getTemplate(appConfig.id)) return getAppUrl(app);
+    // User-edited dev URL always wins — even for first-party templates.
     if (appConfig.devUrl?.trim()) return appConfig.devUrl.trim();
+    // First-party templates without an explicit override go through the frame.
+    if (getTemplate(appConfig.id)) return getAppUrl(app);
     if (appConfig.devPort) return `http://localhost:${appConfig.devPort}`;
     if (appConfig.url) return appConfig.url;
     return getAppUrl(app);

--- a/packages/desktop-app/src/renderer/components/AppWebview.tsx
+++ b/packages/desktop-app/src/renderer/components/AppWebview.tsx
@@ -391,7 +391,7 @@ function LoadingScreen({
 }) {
   return (
     <div className="loading-overlay">
-      <div className="loading-spinner" style={{ borderTopColor: app.color }} />
+      <div className="loading-spinner" />
       <p className="loading-title">Loading {app.name}…</p>
       {slow && (
         <p className="loading-hint">
@@ -598,10 +598,7 @@ function CommandRow({
 function PlaceholderScreen({ app }: { app: AppDefinition }) {
   return (
     <div className="placeholder-overlay">
-      <div
-        className="placeholder-icon"
-        style={{ color: app.color, opacity: 0.3 }}
-      >
+      <div className="placeholder-icon">
         <svg
           width="48"
           height="48"

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -1219,6 +1219,11 @@ body {
   border-radius: 12px;
   box-shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
   -webkit-app-region: no-drag;
+  /* Promote to its own compositor layer + stacking context so it paints
+     reliably above Electron <webview> guest surfaces on macOS. Without this
+     the popover loses the composite race and gets covered by the webview. */
+  transform: translateZ(0);
+  isolation: isolate;
 }
 
 .update-prompt-body {

--- a/packages/desktop-app/src/renderer/shell.css
+++ b/packages/desktop-app/src/renderer/shell.css
@@ -800,13 +800,6 @@ body {
   border-bottom: 1px solid rgba(255, 255, 255, 0.04);
 }
 
-.settings-app-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
 .settings-app-info {
   flex: 1;
   min-width: 0;
@@ -1108,44 +1101,6 @@ body {
 .settings-form input[type="text"]:focus,
 .settings-form input[type="url"]:focus {
   border-color: rgba(59, 130, 246, 0.5);
-}
-
-.settings-color-row {
-  margin-bottom: 16px;
-}
-
-.settings-color-row span {
-  font-size: 11px;
-  font-weight: 500;
-  color: #888;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-}
-
-.settings-colors {
-  display: flex;
-  gap: 6px;
-  margin-top: 6px;
-}
-
-.settings-color-swatch {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  border: 2px solid transparent;
-  cursor: pointer;
-  transition:
-    transform var(--ease),
-    border-color var(--ease);
-}
-
-.settings-color-swatch:hover {
-  transform: scale(1.1);
-}
-
-.settings-color-swatch--active {
-  border-color: #fff;
-  transform: scale(1.15);
 }
 
 .settings-form-actions {

--- a/packages/dispatch/src/lib/catch-all-target.spec.ts
+++ b/packages/dispatch/src/lib/catch-all-target.spec.ts
@@ -171,6 +171,21 @@ describe("resolveCatchAllTarget", () => {
     expect(resolveCatchAllTarget("forms")).toBe("/forms");
   });
 
+  it("collapses leading double slashes in app.path so `//evil.example` can't redirect off-origin", () => {
+    // The manifest parser only checks `startsWith("/")`, so a path of
+    // `//evil.example` slips through. Browsers treat that as a network-
+    // path reference and `throw redirect("//evil.example")` would redirect
+    // to `https://evil.example` — the same phishing vector the `app.url`
+    // validator closes. Collapse the leading slashes so the redirect
+    // stays on the gateway.
+    loadWorkspaceAppsManifestMock.mockReturnValue([
+      { id: "forms", name: "Forms", path: "//evil.example" },
+    ]);
+    getBuiltinAgentsMock.mockReturnValue([]);
+
+    expect(resolveCatchAllTarget("forms")).toBe("/evil.example");
+  });
+
   it("falls back to /${appId} when the manifest entry has neither path nor url", () => {
     loadWorkspaceAppsManifestMock.mockReturnValue([
       { id: "forms", name: "Forms", path: "" },

--- a/packages/dispatch/src/lib/catch-all-target.spec.ts
+++ b/packages/dispatch/src/lib/catch-all-target.spec.ts
@@ -171,6 +171,18 @@ describe("resolveCatchAllTarget", () => {
     expect(resolveCatchAllTarget("forms")).toBe("/forms");
   });
 
+  it("collapses leading slashes/backslashes in app.path so `/\\evil.example` can't redirect off-origin", () => {
+    // Browsers normalize backslashes to forward slashes during URL
+    // parsing, so `throw redirect("/\\evil.example")` would resolve to
+    // `https://evil.example`. The regex covers both slash types.
+    loadWorkspaceAppsManifestMock.mockReturnValue([
+      { id: "forms", name: "Forms", path: "/\\evil.example" },
+    ]);
+    getBuiltinAgentsMock.mockReturnValue([]);
+
+    expect(resolveCatchAllTarget("forms")).toBe("/evil.example");
+  });
+
   it("collapses leading double slashes in app.path so `//evil.example` can't redirect off-origin", () => {
     // The manifest parser only checks `startsWith("/")`, so a path of
     // `//evil.example` slips through. Browsers treat that as a network-

--- a/packages/dispatch/src/lib/catch-all-target.spec.ts
+++ b/packages/dispatch/src/lib/catch-all-target.spec.ts
@@ -108,6 +108,55 @@ describe("resolveCatchAllTarget", () => {
     expect(resolveCatchAllTarget("forms")).toBe("https://forms.example.com");
   });
 
+  it("ignores app.url that isn't an absolute http(s) URL and falls back to path", () => {
+    // Bare hostname — `new URL("forms.example.com")` throws, so the value
+    // is rejected and we fall through to the (validated) path. Without
+    // this, the catch-all would `throw redirect("forms.example.com")`
+    // and the browser would treat the value as a relative path inside the
+    // gateway, producing a broken redirect.
+    loadWorkspaceAppsManifestMock.mockReturnValue([
+      {
+        id: "forms",
+        name: "Forms",
+        path: "/forms",
+        url: "forms.example.com",
+      },
+    ]);
+    getBuiltinAgentsMock.mockReturnValue([]);
+
+    expect(resolveCatchAllTarget("forms")).toBe("/forms");
+  });
+
+  it("rejects non-http(s) URL schemes (e.g. javascript:) and falls back to path", () => {
+    // Defense in depth — a hostile manifest entry can't produce a
+    // `javascript:` redirect target. Validation enforces http(s) only.
+    loadWorkspaceAppsManifestMock.mockReturnValue([
+      {
+        id: "forms",
+        name: "Forms",
+        path: "/forms",
+        url: "javascript:alert(1)",
+      },
+    ]);
+    getBuiltinAgentsMock.mockReturnValue([]);
+
+    expect(resolveCatchAllTarget("forms")).toBe("/forms");
+  });
+
+  it("strips a trailing slash from app.url", () => {
+    loadWorkspaceAppsManifestMock.mockReturnValue([
+      {
+        id: "forms",
+        name: "Forms",
+        path: "/forms",
+        url: "https://forms.example.com/",
+      },
+    ]);
+    getBuiltinAgentsMock.mockReturnValue([]);
+
+    expect(resolveCatchAllTarget("forms")).toBe("https://forms.example.com");
+  });
+
   it("ignores an empty/whitespace app.url and falls back to path", () => {
     loadWorkspaceAppsManifestMock.mockReturnValue([
       {

--- a/packages/dispatch/src/lib/catch-all-target.ts
+++ b/packages/dispatch/src/lib/catch-all-target.ts
@@ -28,6 +28,28 @@ import {
  * Returns `null` if neither lookup matches, letting the route render its
  * "Page not found" pane.
  */
+/**
+ * Validate `app.url` is an absolute http(s) URL before we trust it as a
+ * redirect target. A bare hostname (`"forms.example.com"`) or a
+ * `javascript:` scheme would otherwise get returned verbatim from
+ * `resolveCatchAllTarget` and produce a broken redirect (or a phishing
+ * vector). Mirrors `normalizeWorkspaceAppUrl` in
+ * `packages/core/src/deploy/workspace-deploy.ts` — but inlined to avoid
+ * pulling the deploy CLI module into a runtime path.
+ */
+function validatedAbsoluteUrl(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    return parsed.toString().replace(/\/$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveCatchAllTarget(appId: string): string | null {
   const apps = loadWorkspaceAppsManifest();
   if (apps) {
@@ -36,9 +58,12 @@ export function resolveCatchAllTarget(appId: string): string | null {
       // Explicit externally-hosted URL wins. Workspaces that point at a
       // remote deploy (e.g. a sibling app on Netlify) set `url` and we
       // should bounce the user there rather than mounting a local path
-      // that doesn't exist inside the gateway.
-      if (typeof app.url === "string" && app.url.trim()) {
-        return app.url.trim();
+      // that doesn't exist inside the gateway. Validate the URL first —
+      // a bare hostname or non-http(s) scheme would produce a broken
+      // redirect (and a `javascript:` value would be a phishing vector).
+      const url = validatedAbsoluteUrl(app.url);
+      if (url) {
+        return url;
       }
       // Fall back to the mounted path. Normalize to leading slash so an
       // entry whose path differs from its id (e.g. `id: "forms"`,

--- a/packages/dispatch/src/lib/catch-all-target.ts
+++ b/packages/dispatch/src/lib/catch-all-target.ts
@@ -69,8 +69,16 @@ export function resolveCatchAllTarget(appId: string): string | null {
       // entry whose path differs from its id (e.g. `id: "forms"`,
       // `path: "my-forms"`) still lands on the correct gateway mount —
       // not on `/${appId}`, which would silently route to the wrong app.
+      //
+      // Reject scheme-relative paths (`//evil.example`). The manifest
+      // parser only checks `startsWith("/")`, so `//evil.example` passes
+      // — but browsers treat it as a network-path reference and the
+      // catch-all's `throw redirect("//evil.example")` becomes an
+      // off-origin redirect, the same phishing vector that the
+      // `validatedAbsoluteUrl` check closes for `app.url`. Strip the
+      // leading slashes down to one to keep the redirect on the gateway.
       if (typeof app.path === "string" && app.path.trim()) {
-        const normalized = app.path.trim();
+        const normalized = app.path.trim().replace(/^\/+/, "/");
         return normalized.startsWith("/") ? normalized : `/${normalized}`;
       }
       return `/${appId}`;

--- a/packages/dispatch/src/lib/catch-all-target.ts
+++ b/packages/dispatch/src/lib/catch-all-target.ts
@@ -70,15 +70,23 @@ export function resolveCatchAllTarget(appId: string): string | null {
       // `path: "my-forms"`) still lands on the correct gateway mount —
       // not on `/${appId}`, which would silently route to the wrong app.
       //
-      // Reject scheme-relative paths (`//evil.example`). The manifest
-      // parser only checks `startsWith("/")`, so `//evil.example` passes
-      // — but browsers treat it as a network-path reference and the
-      // catch-all's `throw redirect("//evil.example")` becomes an
-      // off-origin redirect, the same phishing vector that the
-      // `validatedAbsoluteUrl` check closes for `app.url`. Strip the
-      // leading slashes down to one to keep the redirect on the gateway.
+      // Reject scheme-relative paths. Three variants reach this point —
+      // all of them get collapsed to a single leading slash so the
+      // redirect stays on the gateway:
+      //
+      //   `//evil.example`   — network-path reference, browser treats as
+      //                        absolute (https://evil.example).
+      //   `/\evil.example`   — browsers normalize backslashes to forward
+      //                        slashes during URL parsing, same result.
+      //   `\/evil.example`   — same idea, leading-backslash variant.
+      //
+      // The manifest parser only checks `startsWith("/")` for the first
+      // case, and even that allows `//evil…`. Defend in depth here by
+      // collapsing any run of leading slashes-or-backslashes to one
+      // forward slash. Same phishing vector that `validatedAbsoluteUrl`
+      // closes for `app.url`.
       if (typeof app.path === "string" && app.path.trim()) {
-        const normalized = app.path.trim().replace(/^\/+/, "/");
+        const normalized = app.path.trim().replace(/^[/\\]+/, "/");
         return normalized.startsWith("/") ? normalized : `/${normalized}`;
       }
       return `/${appId}`;

--- a/packages/mobile-app/app/(tabs)/_layout.tsx
+++ b/packages/mobile-app/app/(tabs)/_layout.tsx
@@ -297,13 +297,8 @@ export default function TabLayout() {
                       style={styles.row}
                       onPress={() => openOverflowApp(app)}
                     >
-                      <View
-                        style={[
-                          styles.iconWrap,
-                          { backgroundColor: `${app.color}33` },
-                        ]}
-                      >
-                        <Feather name={iconName} size={18} color={app.color} />
+                      <View style={styles.iconWrap}>
+                        <Feather name={iconName} size={18} color="#ffffff" />
                       </View>
                       <Text style={styles.rowText}>{app.name}</Text>
                       <Feather name="chevron-right" size={18} color="#555555" />
@@ -365,6 +360,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     alignItems: "center",
     justifyContent: "center",
+    backgroundColor: "#252525",
   },
   rowText: {
     flex: 1,

--- a/packages/mobile-app/app/(tabs)/settings.tsx
+++ b/packages/mobile-app/app/(tabs)/settings.tsx
@@ -78,7 +78,6 @@ export default function SettingsScreen() {
         {apps.map((app) => (
           <View key={app.id} style={styles.appRow}>
             <View style={styles.appInfo}>
-              <View style={[styles.dot, { backgroundColor: app.color }]} />
               <View style={styles.appText}>
                 <Text style={styles.appName}>{app.name}</Text>
                 <Text style={styles.appUrl} numberOfLines={1}>
@@ -179,12 +178,6 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     flex: 1,
-  },
-  dot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    marginRight: 12,
   },
   appText: {
     flex: 1,

--- a/packages/mobile-app/components/AppCard.tsx
+++ b/packages/mobile-app/components/AppCard.tsx
@@ -35,10 +35,8 @@ export default function AppCard({ app, onPress, onLongPress }: AppCardProps) {
       onLongPress={onLongPress}
       activeOpacity={0.7}
     >
-      <View
-        style={[styles.iconContainer, { backgroundColor: app.color + "18" }]}
-      >
-        <Feather name={getFeatherIcon(app.icon)} size={28} color={app.color} />
+      <View style={styles.iconContainer}>
+        <Feather name={getFeatherIcon(app.icon)} size={28} color="#ffffff" />
       </View>
       <Text style={styles.name} numberOfLines={1}>
         {app.name}
@@ -67,6 +65,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     marginBottom: 10,
+    backgroundColor: "#252525",
   },
   name: {
     color: "#FFFFFF",

--- a/packages/mobile-app/components/AppForm.tsx
+++ b/packages/mobile-app/components/AppForm.tsx
@@ -13,19 +13,6 @@ import { Feather } from "@expo/vector-icons";
 import type { AppConfig } from "@agent-native/shared-app-config";
 import { generateAppId } from "@agent-native/shared-app-config";
 
-const COLOR_PRESETS = [
-  "#3B82F6",
-  "#8B5CF6",
-  "#10B981",
-  "#F59E0B",
-  "#EC4899",
-  "#EF4444",
-  "#06B6D4",
-  "#F97316",
-  "#84CC16",
-  "#6366F1",
-];
-
 const ICON_PRESETS: { name: string; icon: keyof typeof Feather.glyphMap }[] = [
   { name: "Globe", icon: "globe" },
   { name: "Mail", icon: "mail" },

--- a/packages/mobile-app/components/AppForm.tsx
+++ b/packages/mobile-app/components/AppForm.tsx
@@ -45,7 +45,6 @@ export default function AppForm({
   const [name, setName] = useState(editApp?.name ?? "");
   const [url, setUrl] = useState(editApp?.url ?? "");
   const [description, setDescription] = useState(editApp?.description ?? "");
-  const [color, setColor] = useState(editApp?.color ?? COLOR_PRESETS[0]);
   const [icon, setIcon] = useState(editApp?.icon ?? "Globe");
 
   const isEditing = !!editApp;
@@ -68,13 +67,6 @@ export default function AppForm({
       return;
     }
 
-    const hexToRgb = (hex: string) => {
-      const r = parseInt(hex.slice(1, 3), 16);
-      const g = parseInt(hex.slice(3, 5), 16);
-      const b = parseInt(hex.slice(5, 7), 16);
-      return `${r} ${g} ${b}`;
-    };
-
     const config: AppConfig = {
       id: editApp?.id ?? generateAppId(),
       name: name.trim(),
@@ -84,8 +76,6 @@ export default function AppForm({
       devPort: 0,
       devUrl: editApp?.devUrl,
       devCommand: editApp?.devCommand,
-      color,
-      colorRgb: hexToRgb(color),
       isBuiltIn: editApp?.isBuiltIn ?? false,
       enabled: editApp?.enabled ?? true,
     };
@@ -149,27 +139,12 @@ export default function AppForm({
                 key={iconName}
                 style={[
                   styles.iconChoice,
-                  icon === iconName && { borderColor: color, borderWidth: 2 },
+                  icon === iconName && styles.iconChoiceSelected,
                 ]}
                 onPress={() => setIcon(iconName)}
               >
                 <Feather name={featherIcon} size={22} color="#ffffff" />
               </TouchableOpacity>
-            ))}
-          </View>
-
-          <Text style={styles.label}>Color</Text>
-          <View style={styles.colorGrid}>
-            {COLOR_PRESETS.map((c) => (
-              <TouchableOpacity
-                key={c}
-                style={[
-                  styles.colorChoice,
-                  { backgroundColor: c },
-                  color === c && styles.colorSelected,
-                ]}
-                onPress={() => setColor(c)}
-              />
             ))}
           </View>
 
@@ -246,20 +221,8 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "#333333",
   },
-  colorGrid: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 10,
-  },
-  colorChoice: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    borderWidth: 2,
-    borderColor: "transparent",
-  },
-  colorSelected: {
+  iconChoiceSelected: {
     borderColor: "#ffffff",
-    transform: [{ scale: 1.15 }],
+    borderWidth: 2,
   },
 });

--- a/packages/shared-app-config/index.ts
+++ b/packages/shared-app-config/index.ts
@@ -21,10 +21,9 @@ export interface AppDefinition {
   description: string;
   /** Dev server port (used in development mode) */
   devPort: number;
-  /** Accent color for the sidebar indicator */
-  color: string;
-  /** CSS-safe RGB triplet for color-mix usage, e.g. "124 106 247" */
-  colorRgb: string;
+  /** Legacy accent color — kept on built-in templates for the docs site; unused in electron/mobile UI. */
+  color?: string;
+  colorRgb?: string;
   /** Whether this app is a placeholder (no real server yet) */
   placeholder?: boolean;
 }
@@ -43,9 +42,9 @@ export interface AppConfig {
   devUrl?: string;
   /** Optional shell command to start the dev server */
   devCommand?: string;
-  /** Accent color */
-  color: string;
-  colorRgb: string;
+  /** Legacy accent color — kept on built-in templates for the docs site; unused in electron/mobile UI. */
+  color?: string;
+  colorRgb?: string;
   /** Whether this is a built-in default app */
   isBuiltIn: boolean;
   /** Whether the app is enabled/visible */

--- a/templates/design/app/components/design/DesignCanvas.tsx
+++ b/templates/design/app/components/design/DesignCanvas.tsx
@@ -44,16 +44,23 @@ const TWEAK_BRIDGE_SCRIPT = `
 const ZOOM_BRIDGE_SCRIPT = `
 <script data-agent-native-zoom-bridge>
 (function() {
-  window.addEventListener('wheel', function(e) {
+  // Attach to documentElement (not window/document) so { passive: false }
+  // is honored consistently and the browser doesn't natively pinch-zoom the
+  // iframe's own document alongside the parent's zoom.
+  var target = document.documentElement || document.body || document;
+  function onWheel(e) {
     if (!(e.ctrlKey || e.metaKey)) return;
     e.preventDefault();
-    window.parent.postMessage({
-      type: 'pinch-zoom-wheel',
-      deltaY: e.deltaY,
-      clientX: e.clientX,
-      clientY: e.clientY,
-    }, window.location.origin);
-  }, { passive: false });
+    try {
+      window.parent.postMessage({
+        type: 'pinch-zoom-wheel',
+        deltaY: e.deltaY,
+        clientX: e.clientX,
+        clientY: e.clientY,
+      }, window.location.origin);
+    } catch (err) {}
+  }
+  target.addEventListener('wheel', onWheel, { passive: false, capture: true });
 })();
 </script>
 `;
@@ -309,29 +316,48 @@ export function DesignCanvas({
         onElementHover(e.data.payload);
       }
       if (e.data.type === "pinch-zoom-wheel") {
+        if (!onZoomChange) return;
         const iframe = iframeRef.current;
         const scroll = scrollContainerRef.current;
         if (!iframe || !scroll) return;
-        const iframeRect = iframe.getBoundingClientRect();
-        const scale = zoomRef.current / 100;
-        // iframe-local coords (pre-scale) → absolute viewport coords
-        const clientX = iframeRect.left + e.data.clientX * scale;
-        const clientY = iframeRect.top + e.data.clientY * scale;
-        scroll.dispatchEvent(
-          new WheelEvent("wheel", {
-            deltaY: e.data.deltaY,
-            ctrlKey: true,
-            clientX,
-            clientY,
-            bubbles: false,
-            cancelable: true,
-          }),
-        );
+        // Mirror usePinchZoom's algorithm here. We can't reliably re-dispatch
+        // a synthetic WheelEvent to trigger the hook's listener — untrusted
+        // events are inconsistent across browsers — so just compute the
+        // next zoom directly using the same exponential factor + cursor-anchor
+        // math. Clamp range matches the usePinchZoom call above (10–500).
+        const currentZoom = zoomRef.current;
+        const clampedDelta = Math.max(-50, Math.min(50, e.data.deltaY));
+        const factor = Math.exp(-clampedDelta * 0.01);
+        const nextZoom = Math.max(10, Math.min(500, currentZoom * factor));
+        if (nextZoom === currentZoom) return;
+        if (deviceFrame === "none") {
+          // The iframe lives inside a `transform: scale(zoom/100)` wrapper, so
+          // its visual scale relative to viewport is currentZoom / 100. Convert
+          // the iframe-document point under the cursor → viewport point →
+          // scroll-content point, then preserve cursor anchoring while zooming.
+          const iframeRect = iframe.getBoundingClientRect();
+          const scrollRect = scroll.getBoundingClientRect();
+          const scale = currentZoom / 100;
+          const viewportX = iframeRect.left + e.data.clientX * scale;
+          const viewportY = iframeRect.top + e.data.clientY * scale;
+          const cx = viewportX - scrollRect.left + scroll.scrollLeft;
+          const cy = viewportY - scrollRect.top + scroll.scrollTop;
+          const ratio = nextZoom / currentZoom;
+          const dx = cx * (ratio - 1);
+          const dy = cy * (ratio - 1);
+          onZoomChange(nextZoom);
+          requestAnimationFrame(() => {
+            scroll.scrollLeft += dx;
+            scroll.scrollTop += dy;
+          });
+        } else {
+          onZoomChange(nextZoom);
+        }
       }
     }
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [onElementSelect, onElementHover]);
+  }, [onElementSelect, onElementHover, onZoomChange, deviceFrame]);
 
   // Send tweak values to the iframe whenever they change OR the iframe
   // (re)loads. The reload case matters: changing `content` or toggling Edit


### PR DESCRIPTION
## Summary

Addresses the second issue from the Builder bot review on #652: https://github.com/BuilderIO/agent-native/pull/652#pullrequestreview-4266626136.

- **🟡 `app.url` not validated** — `resolveCatchAllTarget` accepted any non-empty trimmed string. A workspace manifest entry with `url: "forms.example.com"` (bare hostname, no protocol) would short-circuit `app.path` and the route would `throw redirect("forms.example.com")`, which the browser treats as a relative path inside the gateway → broken redirect. A `javascript:` value would also be returned verbatim. Now use `new URL()` + protocol check (mirrors `normalizeWorkspaceAppUrl` in `packages/core/src/deploy/workspace-deploy.ts`, inlined to avoid pulling the deploy CLI module into a runtime path). Validation failure falls back to `app.path`. 3 new spec cases (bare hostname rejected; non-http(s) scheme rejected; trailing slash stripped from a valid URL).

The bot's first finding (🔴 "path normalization is unreachable") is technically correct but defensive — every `parseWorkspaceAppsManifest` call site rejects non-slash-prefixed paths today. The normalization is a no-op in prod but keeps the resolver internally consistent at the type signature (`path: string` allows any string) and would still do the right thing if a future loader bypasses the parser or an entry shape changes. Leaving the normalization + its spec case in place.

## Test plan

- [ ] CI green
- [ ] `catch-all-target.spec.ts` 12/12 pass locally
- [ ] Soak for normal CI window before merge (per request — last batch of fixes landed without soaking)