### PR TITLE
fix: route signed-out share-link visitors through sign-in

### DIFF
--- a/.changeset/share-link-signin-redirect.md
+++ b/.changeset/share-link-signin-redirect.md
@@ -1,0 +1,11 @@
+---
+"@agent-native/core": patch
+---
+
+ErrorBoundary: "Go home" now triggers a full page reload (was client-side
+`<Link>`), so a signed-out visitor who lands on an error page is taken
+through the server auth guard's sign-in flow instead of getting stuck on
+a logged-in route with failing API calls. Also softens the 404 message
+to a plain "We couldn't find this page." for end users — the previous
+copy mentioned Dispatch and "shipping" routes, which only made sense to
+developers working on workspace apps.

--- a/packages/core/src/client/ErrorBoundary.tsx
+++ b/packages/core/src/client/ErrorBoundary.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import {
   isRouteErrorResponse,
-  Link,
   useInRouterContext,
   useRouteError,
 } from "react-router";
@@ -27,13 +26,7 @@ function useApplyThemeClass() {
   }, []);
 }
 
-function ErrorScreen({
-  error,
-  canUseRouterLink,
-}: {
-  error: unknown;
-  canUseRouterLink: boolean;
-}) {
+function ErrorScreen({ error }: { error: unknown }) {
   let status: number | null = null;
   let title = "Something went wrong";
   let details = "An unexpected error occurred.";
@@ -43,9 +36,7 @@ function ErrorScreen({
     status = error.status;
     if (error.status === 404) {
       title = "Page not found";
-      const path =
-        typeof window !== "undefined" ? window.location.pathname : "this path";
-      details = `The app does not define a route for ${path}. If this should be a workspace app, make sure it is added and enabled in Dispatch; if it is a new screen, it may need to be shipped first.`;
+      details = "We couldn't find this page.";
     } else {
       title = `${error.status} Error`;
       details = error.statusText || details;
@@ -84,15 +75,9 @@ function ErrorScreen({
         )}
         <h1 className="mt-3 text-2xl font-semibold">{title}</h1>
         <p className="mt-2 text-muted-foreground text-sm">{details}</p>
-        {canUseRouterLink ? (
-          <Link to="/" className={homeLinkClassName}>
-            Go home
-          </Link>
-        ) : (
-          <a href="/" className={homeLinkClassName}>
-            Go home
-          </a>
-        )}
+        <a href="/" className={homeLinkClassName}>
+          Go home
+        </a>
         <button
           type="button"
           onClick={() => window.location.reload()}
@@ -111,16 +96,11 @@ function ErrorScreen({
 }
 
 function RoutedErrorScreen() {
-  return <ErrorScreen error={useRouteError()} canUseRouterLink />;
+  return <ErrorScreen error={useRouteError()} />;
 }
 
 export function ErrorBoundary() {
   useApplyThemeClass();
-  const inRouterContext = useInRouterContext();
-
-  if (!inRouterContext) {
-    return <ErrorScreen error={undefined} canUseRouterLink={false} />;
-  }
-
+  if (!useInRouterContext()) return <ErrorScreen error={undefined} />;
   return <RoutedErrorScreen />;
 }

--- a/packages/core/src/client/ErrorBoundary.tsx
+++ b/packages/core/src/client/ErrorBoundary.tsx
@@ -4,6 +4,7 @@ import {
   useInRouterContext,
   useRouteError,
 } from "react-router";
+import { appPath } from "./api-path.js";
 
 const homeLinkClassName =
   "mt-6 inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 cursor-pointer";
@@ -75,7 +76,7 @@ function ErrorScreen({ error }: { error: unknown }) {
         )}
         <h1 className="mt-3 text-2xl font-semibold">{title}</h1>
         <p className="mt-2 text-muted-foreground text-sm">{details}</p>
-        <a href="/" className={homeLinkClassName}>
+        <a href={appPath("/")} className={homeLinkClassName}>
           Go home
         </a>
         <button

--- a/templates/content/app/routes/p.$id.tsx
+++ b/templates/content/app/routes/p.$id.tsx
@@ -4,8 +4,11 @@ import { eq } from "drizzle-orm";
 import { getDb, schema } from "../../server/db";
 import { useEffect, useState } from "react";
 import { IconMessageCircle } from "@tabler/icons-react";
-import { agentNativePath, appPath } from "@agent-native/core/client";
-import { getRequestUserEmail } from "@agent-native/core/server";
+import { agentNativePath } from "@agent-native/core/client";
+import {
+  getConfiguredAppBasePath,
+  getRequestUserEmail,
+} from "@agent-native/core/server";
 import { resolveAccess } from "@agent-native/core/sharing";
 import { VisualEditor } from "@/components/editor/VisualEditor";
 import { buildPublicDocumentDescription } from "@shared/og-description";
@@ -14,10 +17,17 @@ export async function loader({ params }: LoaderFunctionArgs) {
   const id = params.id;
   if (!id) throw new Response("Not found", { status: 404 });
 
+  // This is a server loader; use the server-side base-path helper
+  // (reads APP_BASE_PATH / VITE_APP_BASE_PATH at request time)
+  // instead of the client `appPath()` which relies on
+  // `import.meta.env` and is meant for browser code.
+  const basePath = getConfiguredAppBasePath();
+  const withBase = (path: string) => `${basePath}${path}`;
+
   const userEmail = getRequestUserEmail();
   if (userEmail) {
     const access = await resolveAccess("document", id);
-    if (access) throw redirect(`/page/${id}`);
+    if (access) throw redirect(withBase(`/page/${id}`));
   }
 
   const [doc] = await getDb()
@@ -40,13 +50,12 @@ export async function loader({ params }: LoaderFunctionArgs) {
   // sign-in so the access check above can route them to /page/<id>.
   if (!userEmail) {
     // Build both the outer sign-in URL and the inner return path
-    // through the basename helpers so mounted-app deployments
-    // (e.g. served under `/content`) land back on
-    // `/<base>/p/<id>` after authenticating, not on `/p/<id>` at
-    // the gateway root.
-    const returnPath = appPath(`/p/${id}`);
+    // with APP_BASE_PATH so mounted-app deployments (e.g. served
+    // under `/content`) land back on `/<base>/p/<id>` after
+    // authenticating, not on `/p/<id>` at the gateway root.
+    const returnPath = withBase(`/p/${id}`);
     throw redirect(
-      `${agentNativePath("/_agent-native/sign-in")}?return=${encodeURIComponent(returnPath)}`,
+      `${withBase("/_agent-native/sign-in")}?return=${encodeURIComponent(returnPath)}`,
     );
   }
 

--- a/templates/content/app/routes/p.$id.tsx
+++ b/templates/content/app/routes/p.$id.tsx
@@ -1,6 +1,6 @@
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { redirect, useLoaderData } from "react-router";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { getDb, schema } from "../../server/db";
 import { useEffect, useState } from "react";
 import { IconMessageCircle } from "@tabler/icons-react";
@@ -14,7 +14,8 @@ export async function loader({ params }: LoaderFunctionArgs) {
   const id = params.id;
   if (!id) throw new Response("Not found", { status: 404 });
 
-  if (getRequestUserEmail()) {
+  const userEmail = getRequestUserEmail();
+  if (userEmail) {
     const access = await resolveAccess("document", id);
     if (access) throw redirect(`/page/${id}`);
   }
@@ -25,18 +26,25 @@ export async function loader({ params }: LoaderFunctionArgs) {
       title: schema.documents.title,
       content: schema.documents.content,
       updatedAt: schema.documents.updatedAt,
+      visibility: schema.documents.visibility,
     })
     .from(schema.documents)
-    .where(
-      and(
-        eq(schema.documents.id, id),
-        eq(schema.documents.visibility, "public"),
-      ),
-    )
+    .where(eq(schema.documents.id, id))
     .limit(1);
 
   if (!doc) throw new Response("Not found", { status: 404 });
-  return { document: doc };
+  if (doc.visibility === "public") return { document: doc };
+
+  // Doc exists but isn't public. A signed-out visitor here likely
+  // arrived from a share-notification email — send them through
+  // sign-in so the access check above can route them to /page/<id>.
+  if (!userEmail) {
+    throw redirect(
+      `/_agent-native/sign-in?return=${encodeURIComponent(`/p/${id}`)}`,
+    );
+  }
+
+  throw new Response("Not found", { status: 404 });
 }
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {

--- a/templates/content/app/routes/p.$id.tsx
+++ b/templates/content/app/routes/p.$id.tsx
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { getDb, schema } from "../../server/db";
 import { useEffect, useState } from "react";
 import { IconMessageCircle } from "@tabler/icons-react";
-import { agentNativePath } from "@agent-native/core/client";
+import { agentNativePath, appPath } from "@agent-native/core/client";
 import { getRequestUserEmail } from "@agent-native/core/server";
 import { resolveAccess } from "@agent-native/core/sharing";
 import { VisualEditor } from "@/components/editor/VisualEditor";
@@ -39,8 +39,14 @@ export async function loader({ params }: LoaderFunctionArgs) {
   // arrived from a share-notification email — send them through
   // sign-in so the access check above can route them to /page/<id>.
   if (!userEmail) {
+    // Build both the outer sign-in URL and the inner return path
+    // through the basename helpers so mounted-app deployments
+    // (e.g. served under `/content`) land back on
+    // `/<base>/p/<id>` after authenticating, not on `/p/<id>` at
+    // the gateway root.
+    const returnPath = appPath(`/p/${id}`);
     throw redirect(
-      `/_agent-native/sign-in?return=${encodeURIComponent(`/p/${id}`)}`,
+      `${agentNativePath("/_agent-native/sign-in")}?return=${encodeURIComponent(returnPath)}`,
     );
   }
 


### PR DESCRIPTION
## Summary

- **templates/content/app/routes/p.\$id**: when a non-public document is requested by a signed-out visitor (typical for share-notification email links), redirect to `/_agent-native/sign-in` with a `return` URL so the loader's `resolveAccess` check can route them to `/page/<id>` after auth. Previously this returned a flat 404.
- **core/ErrorBoundary**: "Go home" now uses a plain `<a href="/">` for a full page reload, so a signed-out visitor on an error page is taken through the server auth guard's sign-in flow rather than getting stuck on a logged-in route with failing API calls. Also soften the 404 copy from the developer-flavored Dispatch-specific message to a neutral "We couldn't find this page."

## Test plan

- [ ] Open a private content share link while signed out → should land on sign-in then redirect to `/page/<id>`
- [ ] Open a non-existent route while signed out → "Page not found" with working "Go home"
- [ ] Public document still loads anonymously