### PR TITLE
Slides fixes

### DIFF
--- a/templates/slides/app/components/deck/DeckCard.tsx
+++ b/templates/slides/app/components/deck/DeckCard.tsx
@@ -40,6 +40,7 @@ export default function DeckCard({
   const [menuOpen, setMenuOpen] = useState(false);
   const [renameValue, setRenameValue] = useState(deck.title);
   const inputRef = useRef<HTMLInputElement>(null);
+  const pendingRenameRef = useRef(false);
 
   useEffect(() => {
     if (isRenaming) {
@@ -72,8 +73,8 @@ export default function DeckCard({
   };
 
   const startRename = () => {
+    pendingRenameRef.current = true;
     setMenuOpen(false);
-    window.setTimeout(() => setIsRenaming(true), 0);
   };
 
   return (
@@ -152,7 +153,17 @@ export default function DeckCard({
               <IconDots className="w-3.5 h-3.5 text-foreground/70" />
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-40">
+          <DropdownMenuContent
+            align="end"
+            className="w-40"
+            onCloseAutoFocus={(e) => {
+              if (pendingRenameRef.current) {
+                e.preventDefault();
+                pendingRenameRef.current = false;
+                setIsRenaming(true);
+              }
+            }}
+          >
             <DropdownMenuItem
               onSelect={(e) => {
                 e.preventDefault();

--- a/templates/slides/app/components/deck/ExcalidrawSlide.tsx
+++ b/templates/slides/app/components/deck/ExcalidrawSlide.tsx
@@ -10,6 +10,7 @@ import DOMPurify from "dompurify";
 import { Skeleton } from "@/components/ui/skeleton";
 
 const Excalidraw = lazy(async () => {
+  await import("@excalidraw/excalidraw/index.css");
   const mod = await import("@excalidraw/excalidraw");
   return { default: mod.Excalidraw };
 });

--- a/templates/slides/app/components/deck/MermaidRenderer.tsx
+++ b/templates/slides/app/components/deck/MermaidRenderer.tsx
@@ -40,6 +40,8 @@ export function MermaidRenderer({
   const [svg, setSvg] = useState<string>("");
   const [error, setError] = useState<string>("");
 
+  console.log(`shomix - ${definition}`);
+
   useEffect(() => {
     if (!definition.trim()) return;
     initMermaid();
@@ -57,6 +59,14 @@ export function MermaidRenderer({
         // SVG-borne XSS (foreignObject scripts, javascript: hrefs, etc.).
         const sanitized = DOMPurify.sanitize(renderedSvg, {
           USE_PROFILES: { svg: true, svgFilters: true },
+          ADD_TAGS: ["foreignObject", "text", "tspan", "textPath"],
+          ADD_ATTR: [
+            "dominant-baseline",
+            "text-anchor",
+            "dy",
+            "font-family",
+            "font-size",
+          ],
         });
         setSvg(sanitized);
         setError("");

--- a/templates/slides/app/components/deck/SlideRenderer.tsx
+++ b/templates/slides/app/components/deck/SlideRenderer.tsx
@@ -433,9 +433,22 @@ function BlankSlideContent({ content }: { content: string }) {
   // includes the per-block `contentEditable="true"` set by SlideEditor's
   // double-click-to-edit flow, which made inline text editing appear to do nothing.
   const { mermaidBlocks, htmlWithPlaceholders, dangerousHtml } = useMemo(() => {
+    // Extract mermaid blocks BEFORE sanitization. The sanitizer round-trips
+    // HTML through DOMParser + innerHTML, which HTML-escapes `>` in text
+    // nodes to `&gt;` — that mangles diagram arrows like `A --> B` into
+    // `A --&gt; B` and breaks the mermaid parser.
+    const blocks: string[] = [];
+    const contentWithPlaceholders = content.replace(
+      /<div\s+class="mermaid"[^>]*>([\s\S]*?)<\/div>/gi,
+      (_, definition) => {
+        blocks.push(String(definition).trim());
+        return `<div data-mermaid-index="${blocks.length - 1}"></div>`;
+      },
+    );
+
     // Apply white filter to all logo images (brandfetch, logo.dev, etc.) for dark backgrounds
     const processed = sanitizeSlideHtml(
-      content.replace(
+      contentWithPlaceholders.replace(
         /(<img\s+(?=[^>]*src="[^"]*(?:brandfetch|logo\.dev)[^"]*")[^>]*)(\/?>)/gi,
         (_match, before, close) => {
           if (before.includes('style="')) {
@@ -451,19 +464,9 @@ function BlankSlideContent({ content }: { content: string }) {
       ),
     );
 
-    // Extract mermaid blocks from HTML content for React-based rendering
-    const blocks: string[] = [];
-    const withPlaceholders = processed.replace(
-      /<div\s+class="mermaid"[^>]*>([\s\S]*?)<\/div>/gi,
-      (_, definition) => {
-        blocks.push(definition.trim());
-        return `<div data-mermaid-index="${blocks.length - 1}"></div>`;
-      },
-    );
-
     return {
       mermaidBlocks: blocks,
-      htmlWithPlaceholders: withPlaceholders,
+      htmlWithPlaceholders: processed,
       dangerousHtml: { __html: processed },
     };
   }, [content]);

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -13,6 +13,7 @@ import {
   IconTrash,
   IconLoader2,
   IconX,
+  IconSquarePlus,
 } from "@tabler/icons-react";
 import type { Slide } from "@/context/DeckContext";
 import type { AspectRatio } from "@/lib/aspect-ratios";
@@ -42,6 +43,7 @@ interface EditorSidebarProps {
   onSelectSlide: (id: string) => void;
   onDuplicateSlide: (id: string) => void;
   onDeleteSlide: (id: string) => void;
+  onAddEmptySlide: () => void;
   /** Presence map: slideId → list of users currently viewing that slide */
   slidePresence?: Map<string, CollabUser[]>;
   /** Deck aspect ratio (defaults to 16:9 when omitted) */
@@ -311,6 +313,7 @@ function AddSlidePopover({
   activeSlideIndex,
   agentSubmit,
   onDuplicateCurrent,
+  onAddEmpty,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -323,6 +326,7 @@ function AddSlidePopover({
   generating: boolean;
   agentSubmit: (message: string, context: string) => void;
   onDuplicateCurrent?: () => void;
+  onAddEmpty?: () => void;
 }) {
   const panelRef = useRef<HTMLDivElement>(null);
   const [promptText, setPromptText] = useState("");
@@ -452,22 +456,40 @@ function AddSlidePopover({
       <p className="px-1 pb-2 text-sm font-medium text-foreground/90">
         Add slides
       </p>
-      {onDuplicateCurrent && slideCount > 0 && (
+      {(onAddEmpty || (onDuplicateCurrent && slideCount > 0)) && (
         <>
-          <button
-            type="button"
-            onClick={() => {
-              onDuplicateCurrent();
-              onOpenChange(false);
-            }}
-            className="w-full mb-2 px-2.5 py-2 text-left text-sm rounded-md hover:bg-accent transition-colors flex items-center gap-2 text-foreground/90 cursor-pointer"
-          >
-            <IconCopy className="w-4 h-4 text-muted-foreground" />
-            <span>Duplicate current slide</span>
-            <span className="ml-auto text-[11px] text-muted-foreground">
-              no AI
-            </span>
-          </button>
+          {onAddEmpty && (
+            <button
+              type="button"
+              onClick={() => {
+                onAddEmpty();
+                onOpenChange(false);
+              }}
+              className="w-full mb-1 px-2.5 py-2 text-left text-sm rounded-md hover:bg-accent transition-colors flex items-center gap-2 text-foreground/90 cursor-pointer"
+            >
+              <IconSquarePlus className="w-4 h-4 text-muted-foreground" />
+              <span>Add empty slide</span>
+              <span className="ml-auto text-[11px] text-muted-foreground">
+                no AI
+              </span>
+            </button>
+          )}
+          {onDuplicateCurrent && slideCount > 0 && (
+            <button
+              type="button"
+              onClick={() => {
+                onDuplicateCurrent();
+                onOpenChange(false);
+              }}
+              className="w-full mb-2 px-2.5 py-2 text-left text-sm rounded-md hover:bg-accent transition-colors flex items-center gap-2 text-foreground/90 cursor-pointer"
+            >
+              <IconCopy className="w-4 h-4 text-muted-foreground" />
+              <span>Duplicate current slide</span>
+              <span className="ml-auto text-[11px] text-muted-foreground">
+                no AI
+              </span>
+            </button>
+          )}
           <div className="-mx-3 mb-2 h-px bg-border" />
         </>
       )}
@@ -504,6 +526,7 @@ export default function EditorSidebar({
   onSelectSlide,
   onDuplicateSlide,
   onDeleteSlide,
+  onAddEmptySlide,
   slidePresence,
   aspectRatio,
 }: EditorSidebarProps) {
@@ -618,6 +641,7 @@ export default function EditorSidebar({
         onDuplicateCurrent={
           activeSlideId ? () => onDuplicateSlide(activeSlideId) : undefined
         }
+        onAddEmpty={onAddEmptySlide}
       />
     </div>
   );

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -30,7 +30,7 @@ import {
   IconLoader2,
 } from "@tabler/icons-react";
 import type { Deck, Slide, SlideLayout } from "@/context/DeckContext";
-import { useSaveState } from "@/context/DeckContext";
+import { useSaveState, defaultSlideContent } from "@/context/DeckContext";
 import { SaveStatusIndicator } from "@/components/visual-editor";
 import {
   ASPECT_RATIO_VALUES,
@@ -272,6 +272,14 @@ export default function EditorToolbar({
   const saveState = useSaveState();
   const [layoutOpen, setLayoutOpen] = useState(false);
   const layoutRef = useRef<HTMLButtonElement>(null);
+
+  const handleLayoutSelect = (layout: SlideLayout) => {
+    if (!currentSlide || !onUpdateSlide) return;
+    if (currentSlide.layout !== layout) {
+      onUpdateSlide({ layout, content: defaultSlideContent[layout] });
+    }
+    setLayoutOpen(false);
+  };
   const [toolsOpen, setToolsOpen] = useState(false);
   const toolsRef = useRef<HTMLButtonElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -473,9 +481,7 @@ export default function EditorToolbar({
               {slideLayoutOptions.map((opt) => (
                 <button
                   key={opt.value}
-                  onClick={() => {
-                    onUpdateSlide({ layout: opt.value });
-                  }}
+                  onClick={() => handleLayoutSelect(opt.value)}
                   className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs transition-colors ${
                     currentSlide.layout === opt.value
                       ? "text-[#609FF8] bg-accent/50"

--- a/templates/slides/app/components/editor/HistoryPanel.tsx
+++ b/templates/slides/app/components/editor/HistoryPanel.tsx
@@ -72,7 +72,7 @@ export default function HistoryPanel({
       <div className="px-3 py-2.5 border-b border-border flex items-center gap-2">
         <IconHistory className="w-4 h-4 text-[#609FF8]" />
         <span className="text-xs font-medium text-foreground/90">
-          Edit IconHistory
+          Edit History
         </span>
         <span className="text-[10px] text-muted-foreground ml-auto">
           {shortcutLabel("cmd+z")} / {shortcutLabel("cmd+shift+z")}

--- a/templates/slides/app/context/DeckContext.tsx
+++ b/templates/slides/app/context/DeckContext.tsx
@@ -103,7 +103,11 @@ interface DeckContextType {
     updates: Partial<Omit<Deck, "id" | "createdAt">>,
   ) => void;
   getDeck: (id: string) => Deck | undefined;
-  addSlide: (deckId: string, layout?: SlideLayout, afterIndex?: number) => void;
+  addSlide: (
+    deckId: string,
+    layout?: SlideLayout,
+    afterIndex?: number,
+  ) => string;
   updateSlide: (
     deckId: string,
     slideId: string,
@@ -245,7 +249,7 @@ async function createDeckOnAPI(deck: Deck): Promise<void> {
   }
 }
 
-const defaultSlideContent: Record<SlideLayout, string> = {
+export const defaultSlideContent: Record<SlideLayout, string> = {
   title: `<div class="fmd-slide" style="padding: 80px 110px; justify-content: space-between;">
   <div>
     <div style="font-size: 16px; font-weight: 800; color: #fff; letter-spacing: 0; font-family: 'Poppins', sans-serif;">Deck</div>
@@ -291,7 +295,9 @@ const defaultSlideContent: Record<SlideLayout, string> = {
   "full-image": `<div class="fmd-slide" style="padding: 0; align-items: center; justify-content: center;">
   <div class="fmd-img-placeholder" style="width: 100%; height: 100%;">Full-bleed image or screenshot</div>
 </div>`,
-  blank: "",
+  blank: `<div class="fmd-slide" style="padding: 80px 110px; display: flex; flex-direction: column; justify-content: center; align-items: flex-start; font-family: 'Poppins', sans-serif;">
+  <div style="font-size: 28px; font-weight: 600; color: rgba(255,255,255,0.4); line-height: 1.3; font-family: 'Poppins', sans-serif;">Double-click to edit</div>
+</div>`,
 };
 
 export function DeckProvider({ children }: { children: ReactNode }) {
@@ -784,6 +790,7 @@ export function DeckProvider({ children }: { children: ReactNode }) {
           return { ...d, slides, updatedAt: new Date().toISOString() };
         }),
       );
+      return newSlide.id;
     },
     [setDecksWithHistory],
   );

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -82,6 +82,7 @@ export default function DeckEditor() {
     deleteSlide,
     duplicateSlide,
     duplicateDeck,
+    addSlide,
     reorderSlides,
     undo,
     redo,
@@ -740,6 +741,17 @@ export default function DeckEditor() {
                     if (window.innerWidth < 768) setSidebarOpen(false);
                   }}
                   onDuplicateSlide={(slideId) => duplicateSlide(id, slideId)}
+                  onAddEmptySlide={() => {
+                    const activeIdx = deck.slides.findIndex(
+                      (s) => s.id === activeSlideId,
+                    );
+                    const newId = addSlide(
+                      id,
+                      "blank",
+                      activeIdx >= 0 ? activeIdx : undefined,
+                    );
+                    setActiveSlideId(newId);
+                  }}
                   onDeleteSlide={(slideId) => {
                     const idx = deck.slides.findIndex((s) => s.id === slideId);
                     const nextSlide =


### PR DESCRIPTION
 A handful of small fixes and polish to the slides editor.

  - Mermaid diagrams render correctly. Extracting mermaid blocks before sanitization preserves the -->
  arrows (the DOMParser round-trip in the sanitizer was HTML-escaping > to &gt;, which broke the parser).
  Also widened DOMPurify's SVG allow-list to keep label text (foreignObject, text, tspan, font + text-anchor
   attrs).
  - Excalidraw works again. The Excalidraw bundle's CSS is now eagerly imported alongside the lazy
  component, so the canvas renders instead of appearing blank.
  - Layout switch seeds content. Picking a layout in the toolbar now also drops in that layout's default
  HTML, instead of leaving the existing content stranded under the new layout name.
  - Empty blank slide is no longer empty. Inserting a blank slide now shows a faint "Double-click to edit"
  hint so users have something to click on.
  - "Add empty slide" entry in the sidebar's Add Slides popover (next to "Duplicate current slide"), for a
  no-AI starting point.
  - Deck rename from the card menu is more reliable — replaced the setTimeout hack with onCloseAutoFocus on
  the dropdown so the rename input focuses every time.
  - Typo fix: "Edit IconHistory" → "Edit History" in the history panel.
  
  https://clips.agent-native.com/share/Q5ab3qBNkUGa