### PR TITLE
forms fix broken link

### DIFF
--- a/templates/forms/app/pages/FormBuilderPage.tsx
+++ b/templates/forms/app/pages/FormBuilderPage.tsx
@@ -19,6 +19,7 @@ import {
   IconWebhook,
   IconDownload,
   IconRefresh,
+  IconLoader2,
 } from "@tabler/icons-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -104,6 +105,50 @@ const fieldTypeLabels: Record<FormFieldType, string> = {
   scale: "Scale",
 };
 
+const knownFieldTypes = Object.keys(fieldTypeLabels) as FormFieldType[];
+
+function normalizeFields(fields: FormField[] | undefined): FormField[] {
+  if (!Array.isArray(fields)) return [];
+  return fields.map((field) => {
+    // Preserve the stored type when it's a recognized string; only fall back
+    // to `text` when the value is missing or the wrong shape (object, number),
+    // so we don't silently drop user data.
+    const type: FormFieldType =
+      typeof field?.type === "string" && knownFieldTypes.includes(field.type)
+        ? field.type
+        : "text";
+    const out: FormField = { ...field, type };
+    if (Array.isArray(field?.options)) {
+      const seen = new Set<string>();
+      const cleaned: string[] = [];
+      for (const raw of field.options) {
+        let str: string;
+        if (typeof raw === "string") {
+          str = raw;
+        } else if (raw && typeof raw === "object") {
+          const v = raw as { label?: unknown; value?: unknown };
+          str =
+            typeof v.label === "string"
+              ? v.label
+              : typeof v.value === "string"
+                ? v.value
+                : "";
+        } else if (raw == null) {
+          continue;
+        } else {
+          str = String(raw);
+        }
+        const trimmed = str.trim();
+        if (!trimmed || seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        cleaned.push(trimmed);
+      }
+      out.options = cleaned;
+    }
+    return out;
+  });
+}
+
 export function FormBuilderPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -114,6 +159,11 @@ export function FormBuilderPage() {
   const [dragIdx, setDragIdx] = useState<number | null>(null);
   const [activeTab, setActiveTab] = useState("edit");
   const [copied, setCopied] = useState(false);
+  // Target status while a publish/unpublish is in flight (and until the cache
+  // refetch catches up). `null` once the displayed form.status matches it.
+  const [pendingStatus, setPendingStatus] = useState<
+    "published" | "draft" | null
+  >(null);
   const { isLocal } = useDbStatus();
   const [showCloudUpgrade, setShowCloudUpgrade] = useState(false);
   const publishedFormUrl =
@@ -141,7 +191,7 @@ export function FormBuilderPage() {
     form?.description ?? "",
   );
   const [localFields, setLocalFields] = useState<FormField[]>(
-    form?.fields || [],
+    normalizeFields(form?.fields),
   );
   const titleFocused = useRef(false);
   const titleMeasureRef = useRef<HTMLSpanElement>(null);
@@ -176,8 +226,17 @@ export function FormBuilderPage() {
       setLocalDescription(form.description || "");
   }, [form?.description]);
   useEffect(() => {
-    if (form && !fieldsDirty.current) setLocalFields(form.fields || []);
+    if (form && !fieldsDirty.current)
+      setLocalFields(normalizeFields(form.fields));
   }, [form?.fields]);
+
+  // Clear pending publish state once the refetched form reflects the new
+  // status — otherwise the spinner stops before the badge/label updates.
+  useEffect(() => {
+    if (pendingStatus && form?.status === pendingStatus) {
+      setPendingStatus(null);
+    }
+  }, [form?.status, pendingStatus]);
 
   // Auto-grow description textarea
   useEffect(() => {
@@ -383,6 +442,7 @@ export function FormBuilderPage() {
       setShowCloudUpgrade(true);
       return;
     }
+    setPendingStatus(newStatus);
     updateForm.mutate(
       { id: form.id, status: newStatus },
       {
@@ -392,6 +452,7 @@ export function FormBuilderPage() {
           ),
         // Errors (including publish-validation failures) are surfaced by
         // useUpdateForm's onError, which echoes the server's actual message.
+        onError: () => setPendingStatus(null),
       },
     );
   }
@@ -551,8 +612,22 @@ export function FormBuilderPage() {
           </Tooltip>
 
           {canEdit && (
-            <Button size="sm" className="text-xs" onClick={handleTogglePublish}>
-              {form.status === "published" ? "Unpublish" : "Publish"}
+            <Button
+              size="sm"
+              className="text-xs"
+              onClick={handleTogglePublish}
+              disabled={pendingStatus !== null}
+            >
+              {pendingStatus !== null && (
+                <IconLoader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+              )}
+              {pendingStatus === "published"
+                ? "Publishing…"
+                : pendingStatus === "draft"
+                  ? "Unpublishing…"
+                  : form.status === "published"
+                    ? "Unpublish"
+                    : "Publish"}
             </Button>
           )}
           <NotificationsBell />

--- a/templates/forms/app/pages/FormBuilderPage.tsx
+++ b/templates/forms/app/pages/FormBuilderPage.tsx
@@ -118,10 +118,14 @@ function normalizeFields(fields: FormField[] | undefined): FormField[] {
         ? field.type
         : "text";
     const out: FormField = { ...field, type };
-    if (Array.isArray(field?.options)) {
+    // Coerce when `options` is present in any shape — Array.isArray alone
+    // would let non-array values (e.g. `{ label: "A" }`) leak through and
+    // crash downstream `.map()` / `for…of` consumers.
+    if (field?.options !== undefined) {
+      const rawList = Array.isArray(field.options) ? field.options : [];
       const seen = new Set<string>();
       const cleaned: string[] = [];
-      for (const raw of field.options) {
+      for (const raw of rawList) {
         let str: string;
         if (typeof raw === "string") {
           str = raw;

--- a/templates/forms/server/lib/public-form-ssr.ts
+++ b/templates/forms/server/lib/public-form-ssr.ts
@@ -186,6 +186,13 @@ function renderField(field: FormField): string {
       input = `<div class="scale-group"><input type="range" name="${field.id}" class="slider" min="${min}" max="${max}" value="${min}" step="1"><div class="scale-labels"><span>${min}</span><span class="scale-val">${min}</span><span>${max}</span></div></div>`;
       break;
     }
+    default:
+      // Mirror the builder's normalizeFields fallback: an unrecognized stored
+      // type (e.g. agent wrote "dropdown" instead of "select", or stored an
+      // object) renders a plain text input rather than nothing — without this
+      // a required field would have no <input>, leaving the form unsubmittable.
+      input = `<input type="text" name="${field.id}" class="fi"${ph}${req}>`;
+      break;
   }
 
   return `<div class="field${widthClass}" data-field-id="${field.id}"${cond}>

--- a/templates/forms/server/lib/public-form-ssr.ts
+++ b/templates/forms/server/lib/public-form-ssr.ts
@@ -53,13 +53,42 @@ async function getFormBySlugOrId(slugOrId: string) {
 // Field rendering helpers
 // ---------------------------------------------------------------------------
 
-function escapeHtml(str: string): string {
-  return str
+// Canonical type is string, but the agent occasionally writes objects like
+// `{ label, value }` or numbers. Coerce everything to a string here so the
+// renderer never crashes on bad data.
+function toSafeString(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  if (typeof value === "object") {
+    const v = value as { label?: unknown; value?: unknown };
+    if (typeof v.label === "string") return v.label;
+    if (typeof v.value === "string") return v.value;
+    return "";
+  }
+  return String(value);
+}
+
+function escapeHtml(value: unknown): string {
+  return toSafeString(value)
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
+}
+
+// Mirror app/components/builder/FieldRenderer.tsx#dedupeRenderableOptions.
+function normalizeOptions(options: unknown): string[] {
+  if (!Array.isArray(options)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of options) {
+    const trimmed = toSafeString(raw).trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
 }
 
 /**
@@ -121,16 +150,32 @@ function renderField(field: FormField): string {
       input = `<input type="date" name="${field.id}" class="fi"${req}>`;
       break;
     case "select":
-      input = `<select name="${field.id}" class="fi"${req}><option value="">${field.placeholder || "Select..."}</option>${(field.options || []).map((o) => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join("")}</select>`;
+      input = `<select name="${field.id}" class="fi"${req}><option value="">${escapeHtml(field.placeholder) || "Select..."}</option>${normalizeOptions(
+        field.options,
+      )
+        .map(
+          (o) => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`,
+        )
+        .join("")}</select>`;
       break;
     case "multiselect":
-      input = `<div class="ms-group">${(field.options || []).map((o) => `<label class="cb-label"><input type="checkbox" name="${field.id}" value="${escapeHtml(o)}" class="cb"><span>${escapeHtml(o)}</span></label>`).join("")}</div>`;
+      input = `<div class="ms-group">${normalizeOptions(field.options)
+        .map(
+          (o) =>
+            `<label class="cb-label"><input type="checkbox" name="${field.id}" value="${escapeHtml(o)}" class="cb"><span>${escapeHtml(o)}</span></label>`,
+        )
+        .join("")}</div>`;
       break;
     case "checkbox":
       input = `<label class="cb-label"><input type="checkbox" name="${field.id}" class="cb"><span>${escapeHtml(field.placeholder || field.label)}</span></label>`;
       break;
     case "radio":
-      input = `<div class="radio-group">${(field.options || []).map((o) => `<label class="cb-label"><input type="radio" name="${field.id}" value="${escapeHtml(o)}" class="radio"><span>${escapeHtml(o)}</span></label>`).join("")}</div>`;
+      input = `<div class="radio-group">${normalizeOptions(field.options)
+        .map(
+          (o) =>
+            `<label class="cb-label"><input type="radio" name="${field.id}" value="${escapeHtml(o)}" class="radio"><span>${escapeHtml(o)}</span></label>`,
+        )
+        .join("")}</div>`;
       break;
     case "rating":
       input = `<div class="rating-group" data-name="${field.id}">${[1, 2, 3, 4, 5].map((s) => `<button type="button" class="star-btn" data-value="${s}" aria-label="${s} star${s > 1 ? "s" : ""}"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></button>`).join("")}</div><input type="hidden" name="${field.id}">`;


### PR DESCRIPTION
A few small fixes for the forms template.

 - The public form page (/f/<slug>) was 500-ing for some forms — escapeHtml got an object
  instead of a string because the agent had stored option entries as {label, value} objects.
  SSR now coerces non-string options before rendering, same way the React preview already
  does.

-   That same data was rendering as [object Object] in the builder's properties panel.
  Normalized fields on hydration (and on every refetch) so the panel/preview/autosave all see
   clean strings, and the data self-heals as the user edits.

-   Publish/Unpublish felt unresponsive — the success toast landed before form.status
  refetched, so the button label stayed on "Publish" for a beat after clicking. Added a
  pendingStatus flag + spinner so the button shows "Publishing…" / "Unpublishing…" and stays
  disabled until the displayed status actually matches what we asked for.


https://clips.agent-native.com/share/K6Udwrar8PuB