### PR TITLE
refactor(slides/server): shared resolveSlidesRequestAuthContext helper

### DIFF
--- a/.changeset/legacy-solo-sharing.md
+++ b/.changeset/legacy-solo-sharing.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow owners to manage legacy unscoped shared resources after joining an organization.

--- a/packages/core/src/sharing/access.spec.ts
+++ b/packages/core/src/sharing/access.spec.ts
@@ -193,10 +193,10 @@ describe("shareable resource access helpers", () => {
     // — public means "anyone with the link," not "appears in everyone's list."
     await expect(
       listVisible({ userEmail: ownerEmail, orgId }),
-    ).resolves.toEqual(["owned", "same-org", "shared-org"]);
+    ).resolves.toEqual(["owned", "owned-solo", "same-org", "shared-org"]);
     await expect(
       listVisible({ userEmail: ownerEmail, orgId: otherOrgId }),
-    ).resolves.toEqual(["other-org", "owned-other-org"]);
+    ).resolves.toEqual(["other-org", "owned-other-org", "owned-solo"]);
     await expect(listVisible({ userEmail: ownerEmail })).resolves.toEqual([
       "owned-solo",
     ]);
@@ -252,9 +252,9 @@ describe("shareable resource access helpers", () => {
       await expect(
         resolveAccess(resourceType, "doc-owned-other-org"),
       ).resolves.toBe(null);
-      await expect(resolveAccess(resourceType, "doc-owned-solo")).resolves.toBe(
-        null,
-      );
+      await expect(
+        assertAccess(resourceType, "doc-owned-solo", "owner"),
+      ).resolves.toMatchObject({ role: "owner" });
     });
 
     await runWithRequestContext(
@@ -404,5 +404,36 @@ describe("shareable resource access helpers", () => {
       principalId: viewerEmail,
       role: "admin",
     });
+  });
+
+  it("attaches legacy unscoped owner resources to the active org when making them org-visible", async () => {
+    await insertDoc({ id: "doc-legacy-solo", orgId: null });
+
+    await runWithRequestContext({ userEmail: ownerEmail, orgId }, async () => {
+      await expect(
+        listResourceShares.run({
+          resourceType,
+          resourceId: "doc-legacy-solo",
+        }),
+      ).resolves.toMatchObject({
+        role: "owner",
+        orgId: null,
+        visibility: "private",
+      });
+
+      await expect(
+        setResourceVisibility.run({
+          resourceType,
+          resourceId: "doc-legacy-solo",
+          visibility: "org",
+        }),
+      ).resolves.toEqual({ ok: true, visibility: "org" });
+    });
+
+    const [row] = await db
+      .select()
+      .from(docs)
+      .where(eq(docs.id, "doc-legacy-solo"));
+    expect(row).toMatchObject({ orgId, visibility: "org" });
   });
 });

--- a/packages/core/src/sharing/access.ts
+++ b/packages/core/src/sharing/access.ts
@@ -142,13 +142,22 @@ export function accessFilter(
 }
 
 function ownerScopeFilter(resourceTable: any, ctx: AccessContext): SQL {
-  if (ctx.orgId) return eq(resourceTable.orgId, ctx.orgId);
+  if (ctx.orgId) {
+    // Rows created before org-scoping, or in solo mode, have no org_id. Keep
+    // them manageable by their owner after the owner joins or switches into an
+    // organization, while still keeping rows from other orgs out of scope.
+    return or(
+      eq(resourceTable.orgId, ctx.orgId),
+      sql`${resourceTable.orgId} IS NULL`,
+    )!;
+  }
   return sql`${resourceTable.orgId} IS NULL`;
 }
 
 function ownerMatchesActiveScope(resource: any, ctx: AccessContext): boolean {
   const resourceOrgId = resource?.orgId ?? null;
-  return ctx.orgId ? resourceOrgId === ctx.orgId : !resourceOrgId;
+  if (!resourceOrgId) return true;
+  return ctx.orgId === resourceOrgId;
 }
 
 function minRoleSql(minRole: ShareRole): SQL {

--- a/packages/core/src/sharing/actions/set-resource-visibility.ts
+++ b/packages/core/src/sharing/actions/set-resource-visibility.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { defineAction } from "../../action.js";
+import { getRequestOrgId } from "../../server/request-context.js";
 import { assertAccess, ForbiddenError } from "../access.js";
 import { requireShareableResource } from "../registry.js";
 
@@ -22,11 +23,20 @@ export default defineAction({
         `${reg.displayName} cannot be made public — share with specific people or your organization instead.`,
       );
     }
-    await assertAccess(args.resourceType, args.resourceId, "admin");
+    const access = await assertAccess(
+      args.resourceType,
+      args.resourceId,
+      "admin",
+    );
     const db = reg.getDb() as any;
+    const update: Record<string, unknown> = { visibility: args.visibility };
+    const currentOrgId = getRequestOrgId();
+    if (args.visibility === "org" && currentOrgId && !access.resource?.orgId) {
+      update.orgId = currentOrgId;
+    }
     await db
       .update(reg.resourceTable)
-      .set({ visibility: args.visibility })
+      .set(update)
       .where(eq(reg.resourceTable.id, args.resourceId));
     return { ok: true, visibility: args.visibility };
   },

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -30,7 +30,7 @@ Ephemeral UI state is stored in the SQL `application_state` table, accessed via 
 
 | State Key          | Purpose                                                                                    | Direction                  |
 | ------------------ | ------------------------------------------------------------------------------------------ | -------------------------- |
-| `navigation`       | Current view, deck ID, slide index                                                         | UI -> Agent (read-only)    |
+| `navigation`       | Current view, deck ID, slide number (1-based, UI-facing) and internal slide index          | UI -> Agent (read-only)    |
 | `navigate`         | Navigate command (one-shot, auto-deleted)                                                  | Agent -> UI (auto-deleted) |
 | `show-questions`   | Trigger question flow overlay in the UI                                                    | Agent -> UI                |
 | `sidebarCollapsed` | Whether the left sidebar is collapsed (icon rail). Value: `{ "collapsed": true \| false }` | UI <-> Agent (both write)  |
@@ -43,11 +43,14 @@ The UI writes `navigation` whenever the user navigates:
 {
   "view": "editor",
   "deckId": "abc123",
+  "slideNumber": 3,
   "slideIndex": 2
 }
 ```
 
 Views: `"list"` (deck list), `"editor"` (editing a deck), `"present"` (presentation mode), `"settings"`.
+
+**Slide numbers are 1-indexed everywhere users see or say them.** If the user asks for "slide 1", they mean `slideNumber: 1`, the first slide in the UI, and internal `slideIndex: 0`. Prefer `slideNumber` and slide IDs in all agent-facing reasoning. Treat `slideIndex` as an internal zero-based compatibility field only.
 
 **Do NOT write to `navigation`** -- it is overwritten by the UI. Use `navigate` to move the user.
 
@@ -288,10 +291,10 @@ If the request is for a standalone visual, hero image, diagram, one-pager, poste
 
 ### Navigation
 
-| Action     | Args                               | Purpose                  |
-| ---------- | ---------------------------------- | ------------------------ |
-| `navigate` | `--deckId <id> [--slideIndex <n>]` | Navigate to a deck/slide |
-| `navigate` | `--view list`                      | Navigate to deck list    |
+| Action     | Args                                | Purpose                                                      |
+| ---------- | ----------------------------------- | ------------------------------------------------------------ |
+| `navigate` | `--deckId <id> [--slideNumber <n>]` | Navigate to a deck/slide using the UI's 1-based slide number |
+| `navigate` | `--view list`                       | Navigate to deck list                                        |
 
 ### Image Generation & Uploads
 
@@ -735,14 +738,15 @@ The agent can embed a single slide directly inside a chat message using the fram
 
 ````
 ```embed
-src: /slide?deckId=<id>&slideIndex=<n>
+src: /slide?deckId=<id>&slideNumber=<n>
 aspect: 16/9
 title: <slide title or description>
 ```
 ````
 
 - `deckId` — the deck's `id` field (required).
-- `slideIndex` — zero-based index of the slide to show (default: `0`).
+- `slideNumber` — 1-based slide number to show, matching the UI (default: `1`).
+- `slideIndex` — legacy zero-based index; avoid it unless maintaining an old embed URL.
 - `aspect: 16/9` — always use 16/9 for slides.
 - `title` — a short human-readable label shown above the iframe in chat.
 
@@ -752,7 +756,7 @@ The preview route (`app/routes/slide.tsx`) fetches the deck via `/api/decks/:id`
 
 ````
 ```embed
-src: /slide?deckId=abc123&slideIndex=1
+src: /slide?deckId=abc123&slideNumber=2
 aspect: 16/9
 title: Slide 2 — Key Metrics
 ```

--- a/templates/slides/AGENTS.md
+++ b/templates/slides/AGENTS.md
@@ -243,6 +243,16 @@ In the built-in agent chat, use the framework `manage-progress` tool for long-ru
 | `list-decks`  | `[--compact]`   | List all decks with metadata   |
 | `get-deck`    | `--id <deckId>` | Get a deck with all slides     |
 
+### Version History
+
+Slides keeps SQL-backed deck snapshots before meaningful edits, so accidental overwrites can be rolled back after reloads. Restoring a version snapshots the current deck first, making restore reversible.
+
+| Action                 | Args                                    | Purpose                                     |
+| ---------------------- | --------------------------------------- | ------------------------------------------- |
+| `list-deck-versions`   | `--deckId <id> [--limit 50]`            | List saved history snapshots for a deck     |
+| `get-deck-version`     | `--deckId <id> --versionId <versionId>` | Inspect one saved snapshot before restoring |
+| `restore-deck-version` | `--deckId <id> --versionId <versionId>` | Restore the deck to that saved snapshot     |
+
 ### Comments
 
 | Action                | Args                                                                 | Purpose                     |

--- a/templates/slides/actions/add-slide.test.ts
+++ b/templates/slides/actions/add-slide.test.ts
@@ -44,6 +44,10 @@ vi.mock("../server/handlers/decks.js", () => ({
   notifyClients: (...args: unknown[]) => mockNotifyClients(...args),
 }));
 
+vi.mock("../server/lib/deck-versions.js", () => ({
+  createDeckVersionSnapshot: vi.fn(async () => ({ created: true })),
+}));
+
 vi.mock("drizzle-orm", () => ({
   eq: (col: unknown, val: unknown) => ({ col, val }),
 }));
@@ -89,6 +93,7 @@ describe("add-slide", () => {
     expect(result).toMatchObject({
       deckId: "deck-1",
       slideId: "slide-new",
+      slideNumber: 2,
       position: 1,
       slideCount: 3,
     });

--- a/templates/slides/actions/add-slide.ts
+++ b/templates/slides/actions/add-slide.ts
@@ -9,6 +9,7 @@ import { getDb, schema } from "../server/db/index.js";
 import { assertAccess } from "@agent-native/core/sharing";
 import { notifyClients } from "../server/handlers/decks.js";
 import { normalizeSlidePadding } from "../app/lib/normalize-slide-padding.js";
+import { createDeckVersionSnapshot } from "../server/lib/deck-versions.js";
 import {
   awaitLayoutFitCheck,
   formatOverflowForTool,
@@ -36,7 +37,7 @@ export default defineAction({
     "Add a single slide to an existing deck. Use this to build decks slide-by-slide — " +
     "call it once per slide in slide order and wait for each result before adding the next slide. " +
     "Avoid parallel add-slide calls for the same deck; sequential writes keep the editor and agent connection stable. " +
-    "Returns the new slide ID and updated slide count.",
+    "Returns the new slide ID, 1-based slideNumber, and updated slide count.",
   schema: z.object({
     deckId: z.string().describe("Target deck ID"),
     content: z.string().describe("Full HTML content of the new slide"),
@@ -87,6 +88,15 @@ export default defineAction({
       }
 
       const row = rows[0];
+      await createDeckVersionSnapshot(
+        {
+          id: row.id,
+          title: row.title,
+          data: row.data,
+          ownerEmail: row.ownerEmail,
+        },
+        { label: "Before adding slide" },
+      );
       const deck = JSON.parse(row.data);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const slides: any[] = Array.isArray(deck.slides) ? deck.slides : [];
@@ -153,6 +163,7 @@ export default defineAction({
       const base = {
         deckId,
         slideId: newSlideId,
+        slideNumber: insertIndex + 1,
         position: insertIndex,
         slideCount: slides.length,
       };

--- a/templates/slides/actions/create-deck.test.ts
+++ b/templates/slides/actions/create-deck.test.ts
@@ -73,6 +73,10 @@ vi.mock("../server/handlers/decks.js", () => ({
   notifyClients: (...args: unknown[]) => mockNotifyClients(...args),
 }));
 
+vi.mock("../server/lib/deck-versions.js", () => ({
+  createDeckVersionSnapshot: vi.fn(async () => ({ created: true })),
+}));
+
 vi.mock("@agent-native/core/server/request-context", () => ({
   getRequestUserEmail: () => mockGetUserEmail(),
   getRequestOrgId: () => mockGetOrgId(),

--- a/templates/slides/actions/create-deck.ts
+++ b/templates/slides/actions/create-deck.ts
@@ -12,6 +12,7 @@ import { notifyClients } from "../server/handlers/decks.js";
 import { ASPECT_RATIO_VALUES } from "../shared/aspect-ratios.js";
 import { getDeckUrl } from "./_app-url.js";
 import { normalizeSlidePadding } from "../app/lib/normalize-slide-padding.js";
+import { createDeckVersionSnapshot } from "../server/lib/deck-versions.js";
 
 const SlideSchema = z.object({
   id: z.string().describe("Unique slide ID, e.g. 'slide-1'"),
@@ -94,6 +95,18 @@ export default defineAction({
         .from(schema.decks)
         .where(eq(schema.decks.id, deckId))
         .limit(1);
+      if (!existing[0]) {
+        throw new Error(`Deck not found: ${deckId}`);
+      }
+      await createDeckVersionSnapshot(
+        {
+          id: existing[0].id,
+          title: existing[0].title,
+          data: existing[0].data,
+          ownerEmail: existing[0].ownerEmail,
+        },
+        { force: true, label: "Before bulk replace" },
+      );
       const prevData = existing[0] ? JSON.parse(existing[0].data) : {};
       const data = {
         title,

--- a/templates/slides/actions/get-deck-version.ts
+++ b/templates/slides/actions/get-deck-version.ts
@@ -1,0 +1,52 @@
+import { defineAction } from "@agent-native/core";
+import { assertAccess } from "@agent-native/core/sharing";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "../server/db/index.js";
+
+export default defineAction({
+  description:
+    "Get one saved deck history snapshot, including the full slide data for previewing before restore.",
+  schema: z.object({
+    deckId: z.string().describe("Deck ID"),
+    versionId: z.string().describe("Version snapshot ID"),
+  }),
+  http: { method: "GET" },
+  run: async ({ deckId, versionId }) => {
+    const access = await assertAccess("deck", deckId, "viewer");
+    const ownerEmail = access.resource.ownerEmail as string;
+    const db = getDb();
+
+    const [version] = await db
+      .select()
+      .from(schema.deckVersions)
+      .where(
+        and(
+          eq(schema.deckVersions.id, versionId),
+          eq(schema.deckVersions.deckId, deckId),
+          eq(schema.deckVersions.ownerEmail, ownerEmail),
+        ),
+      )
+      .limit(1);
+
+    if (!version) {
+      throw new Error(`Deck version not found: ${versionId}`);
+    }
+
+    const data = JSON.parse(version.data);
+    const slides = Array.isArray(data?.slides) ? data.slides : [];
+
+    return {
+      id: version.id,
+      deckId: version.deckId,
+      title: version.title,
+      label: version.changeLabel,
+      createdAt: version.createdAt,
+      data,
+      slides,
+      slideCount: slides.length,
+      aspectRatio: data?.aspectRatio ?? null,
+      designSystemId: data?.designSystemId ?? null,
+    };
+  },
+});

--- a/templates/slides/actions/get-deck.test.ts
+++ b/templates/slides/actions/get-deck.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockResolveAccess = vi.fn();
+
+vi.mock("@agent-native/core/sharing", () => ({
+  resolveAccess: (...args: unknown[]) => mockResolveAccess(...args),
+}));
+
+vi.mock("../server/db/index.js", () => ({}));
+
+import action from "./get-deck";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResolveAccess.mockResolvedValue({
+    resource: {
+      id: "deck-1",
+      title: "Quarterly Review",
+      visibility: "private",
+      designSystemId: null,
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-02T00:00:00.000Z",
+      data: JSON.stringify({
+        title: "Quarterly Review",
+        slides: [
+          {
+            id: "slide-a",
+            layout: "title",
+            content: "<h1>Opening</h1>",
+          },
+          {
+            id: "slide-b",
+            layout: "content",
+            content: "<p>Metrics</p>",
+          },
+        ],
+      }),
+    },
+  });
+});
+
+describe("get-deck", () => {
+  it("returns 1-based slideNumber fields before internal zero-based indexes", async () => {
+    const result = (await action.run({ id: "deck-1" })) as any;
+
+    expect(result.slideNumbering).toContain("1-based");
+    expect(result.slides[0]).toMatchObject({
+      slideNumber: 1,
+      zeroBasedIndex: 0,
+      id: "slide-a",
+    });
+    expect(result.slides[1]).toMatchObject({
+      slideNumber: 2,
+      zeroBasedIndex: 1,
+      id: "slide-b",
+    });
+    expect(result.slides[0]).not.toHaveProperty("index");
+  });
+
+  it("uses the same numbering contract for compact output", async () => {
+    const result = (await action.run({
+      id: "deck-1",
+      compact: "true",
+    })) as any;
+
+    expect(result.slideNumbering).toContain("Slide 1");
+    expect(result.slides[0]).toMatchObject({
+      slideNumber: 1,
+      zeroBasedIndex: 0,
+      textPreview: "Opening",
+    });
+    expect(result.slides[0]).not.toHaveProperty("index");
+  });
+});

--- a/templates/slides/actions/get-deck.ts
+++ b/templates/slides/actions/get-deck.ts
@@ -15,7 +15,7 @@ function stripHtml(html: string): string {
 
 export default defineAction({
   description:
-    "Get a specific deck with all slides. Returns full deck JSON including slide content.",
+    "Get a specific deck with all slides. Returns full deck JSON including slide content. User-visible slide numbers are 1-based and match the UI: slide 1 is the first slide. Use slideId for edits.",
   schema: z.object({
     id: z.string().optional().describe("Deck ID (required)"),
     compact: z
@@ -45,8 +45,11 @@ export default defineAction({
         visibility: row.visibility,
         designSystemId: row.designSystemId ?? null,
         slideCount: slides.length,
+        slideNumbering:
+          'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
         slides: slides.map((s: any, i: number) => ({
-          index: i,
+          slideNumber: i + 1,
+          zeroBasedIndex: i,
           id: s.id,
           layout: s.layout ?? null,
           textPreview: stripHtml(s.content || "").slice(0, 120),
@@ -60,10 +63,13 @@ export default defineAction({
       visibility: row.visibility,
       designSystemId: row.designSystemId ?? null,
       slideCount: slides.length,
+      slideNumbering:
+        'User-visible slide numbers are 1-based and match the UI. "Slide 1" means slideNumber 1 / zeroBasedIndex 0. Use slideId for edits.',
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
       slides: slides.map((s: any, i: number) => ({
-        index: i,
+        slideNumber: i + 1,
+        zeroBasedIndex: i,
         id: s.id,
         layout: s.layout ?? null,
         content: s.content,

--- a/templates/slides/actions/list-deck-versions.ts
+++ b/templates/slides/actions/list-deck-versions.ts
@@ -1,0 +1,90 @@
+import { defineAction } from "@agent-native/core";
+import { assertAccess } from "@agent-native/core/sharing";
+import { and, desc, eq } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "../server/db/index.js";
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&[a-z]+;/gi, " ")
+    .replace(/&#x[0-9a-f]+;/gi, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function summarizeVersionData(rawData: string) {
+  try {
+    const data = JSON.parse(rawData);
+    const slides = Array.isArray(data?.slides) ? data.slides : [];
+    return {
+      slideCount: slides.length,
+      aspectRatio: data?.aspectRatio ?? null,
+      designSystemId: data?.designSystemId ?? null,
+      slidePreviews: slides.slice(0, 3).map((slide: any, index: number) => ({
+        slideNumber: index + 1,
+        id: slide?.id ?? null,
+        layout: slide?.layout ?? null,
+        textPreview:
+          typeof slide?.content === "string"
+            ? stripHtml(slide.content).slice(0, 120)
+            : "",
+      })),
+    };
+  } catch {
+    return {
+      slideCount: 0,
+      aspectRatio: null,
+      designSystemId: null,
+      slidePreviews: [],
+    };
+  }
+}
+
+export default defineAction({
+  description:
+    "List saved history snapshots for a deck. Use this before restoring a deck to an earlier point in time.",
+  schema: z.object({
+    deckId: z.string().describe("Deck ID"),
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+  }),
+  http: { method: "GET" },
+  run: async ({ deckId, limit }) => {
+    const access = await assertAccess("deck", deckId, "viewer");
+    const ownerEmail = access.resource.ownerEmail as string;
+    const db = getDb();
+
+    const versions = await db
+      .select({
+        id: schema.deckVersions.id,
+        deckId: schema.deckVersions.deckId,
+        title: schema.deckVersions.title,
+        data: schema.deckVersions.data,
+        changeLabel: schema.deckVersions.changeLabel,
+        createdAt: schema.deckVersions.createdAt,
+      })
+      .from(schema.deckVersions)
+      .where(
+        and(
+          eq(schema.deckVersions.deckId, deckId),
+          eq(schema.deckVersions.ownerEmail, ownerEmail),
+        ),
+      )
+      .orderBy(desc(schema.deckVersions.createdAt))
+      .limit(limit);
+
+    return {
+      deckId,
+      count: versions.length,
+      versions: versions.map((version) => ({
+        id: version.id,
+        deckId: version.deckId,
+        title: version.title,
+        label: version.changeLabel,
+        createdAt: version.createdAt,
+        ...summarizeVersionData(version.data),
+      })),
+    };
+  },
+});

--- a/templates/slides/actions/navigate.test.ts
+++ b/templates/slides/actions/navigate.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockWriteAppState = vi.fn();
+
+vi.mock("@agent-native/core/application-state", () => ({
+  writeAppState: (...args: unknown[]) => mockWriteAppState(...args),
+}));
+
+import action from "./navigate";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("navigate", () => {
+  it("treats slideNumber as the 1-based UI slide number", async () => {
+    const result = await action.run({
+      deckId: "deck-1",
+      slideNumber: 1,
+    });
+
+    expect(mockWriteAppState).toHaveBeenCalledWith(
+      "navigate",
+      expect.objectContaining({
+        deckId: "deck-1",
+        slideIndex: 0,
+      }),
+    );
+    expect(result).toContain("slide:1");
+  });
+
+  it("keeps legacy slideIndex as a zero-based internal value", async () => {
+    const result = await action.run({
+      deckId: "deck-1",
+      slideIndex: 1,
+    });
+
+    expect(mockWriteAppState).toHaveBeenCalledWith(
+      "navigate",
+      expect.objectContaining({
+        deckId: "deck-1",
+        slideIndex: 1,
+      }),
+    );
+    expect(result).toContain("slide:2");
+  });
+});

--- a/templates/slides/actions/navigate.ts
+++ b/templates/slides/actions/navigate.ts
@@ -11,10 +11,22 @@ export default defineAction({
       .optional()
       .describe("Top-level view to navigate to (list, settings)"),
     deckId: z.string().optional().describe("Deck ID to open in the editor"),
+    slideNumber: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "User-visible slide number to jump to (1-based, matching the UI). Prefer this when the user says 'slide N'. Slide 1 is the first slide.",
+      ),
     slideIndex: z.coerce
       .number()
+      .int()
+      .min(0)
       .optional()
-      .describe("Slide index to jump to (0-based)"),
+      .describe(
+        "Deprecated/internal zero-based slide index. Prefer slideNumber for user-visible slide references.",
+      ),
   }),
   http: false,
   run: async (args) => {
@@ -24,12 +36,14 @@ export default defineAction({
     const nav: Record<string, string | number> = {};
     if (args.view) nav.view = args.view;
     if (args.deckId) nav.deckId = args.deckId;
-    if (args.slideIndex != null) nav.slideIndex = args.slideIndex;
+    const internalSlideIndex =
+      args.slideNumber != null ? args.slideNumber - 1 : args.slideIndex;
+    if (internalSlideIndex != null) nav.slideIndex = internalSlideIndex;
     // Unique-per-write token so the UI's `use-navigation-state` hook can
     // dedup race-driven re-reads of the same command (see that hook for the
     // full reasoning).
     nav._writeId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     await writeAppState("navigate", nav);
-    return `Navigating to ${args.view || ""}${args.deckId ? ` deck:${args.deckId}` : ""}${args.slideIndex != null ? ` slide:${args.slideIndex}` : ""}`;
+    return `Navigating to ${args.view || ""}${args.deckId ? ` deck:${args.deckId}` : ""}${internalSlideIndex != null ? ` slide:${internalSlideIndex + 1}` : ""}`;
   },
 });

--- a/templates/slides/actions/restore-deck-version.ts
+++ b/templates/slides/actions/restore-deck-version.ts
@@ -1,0 +1,86 @@
+import { defineAction } from "@agent-native/core";
+import { writeAppState } from "@agent-native/core/application-state";
+import { assertAccess } from "@agent-native/core/sharing";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { getDb, schema } from "../server/db/index.js";
+import { notifyClients } from "../server/handlers/decks.js";
+import { createDeckVersionSnapshot } from "../server/lib/deck-versions.js";
+import { getDeckUrl } from "./_app-url.js";
+
+export default defineAction({
+  description:
+    "Restore a deck to a saved history snapshot. The current deck is snapshotted first, so restore is reversible.",
+  schema: z.object({
+    deckId: z.string().describe("Deck ID"),
+    versionId: z.string().describe("Version snapshot ID to restore"),
+  }),
+  run: async ({ deckId, versionId }) => {
+    const access = await assertAccess("deck", deckId, "editor");
+    const current = access.resource;
+    const ownerEmail = current.ownerEmail as string;
+    const db = getDb();
+
+    const [version] = await db
+      .select()
+      .from(schema.deckVersions)
+      .where(
+        and(
+          eq(schema.deckVersions.id, versionId),
+          eq(schema.deckVersions.deckId, deckId),
+          eq(schema.deckVersions.ownerEmail, ownerEmail),
+        ),
+      )
+      .limit(1);
+
+    if (!version) {
+      throw new Error(`Deck version not found: ${versionId}`);
+    }
+
+    await createDeckVersionSnapshot(
+      {
+        id: current.id,
+        title: current.title,
+        data: current.data,
+        ownerEmail,
+      },
+      { force: true, label: "Before restore" },
+    );
+
+    const data = JSON.parse(version.data);
+    const now = new Date().toISOString();
+    const title = version.title || data?.title || current.title || "Untitled";
+    data.title = title;
+    data.updatedAt = now;
+
+    const designSystemId =
+      typeof data.designSystemId === "string" && data.designSystemId
+        ? data.designSystemId
+        : null;
+
+    await db
+      .update(schema.decks)
+      .set({
+        title,
+        data: JSON.stringify(data),
+        designSystemId,
+        updatedAt: now,
+      })
+      .where(eq(schema.decks.id, deckId));
+
+    notifyClients(deckId);
+    await writeAppState("refresh-signal", {
+      ts: now,
+      source: "restore-deck-version",
+    });
+
+    return {
+      id: deckId,
+      title,
+      slideCount: Array.isArray(data?.slides) ? data.slides.length : 0,
+      restoredVersionId: versionId,
+      updatedAt: now,
+      url: getDeckUrl(deckId),
+    };
+  },
+});

--- a/templates/slides/actions/update-deck-aspect-ratio.test.ts
+++ b/templates/slides/actions/update-deck-aspect-ratio.test.ts
@@ -8,7 +8,9 @@ const mockAssertAccess = vi.fn();
 const mockWriteAppState = vi.fn();
 const mockNotifyClients = vi.fn();
 
-let mockDeckRow: { id: string; data: string } | undefined = undefined;
+let mockDeckRow:
+  | { id: string; title: string; data: string; ownerEmail: string }
+  | undefined = undefined;
 let updatedFields: Record<string, unknown> | undefined = undefined;
 
 const limitFn = vi.fn(async () => (mockDeckRow ? [mockDeckRow] : []));
@@ -42,6 +44,10 @@ vi.mock("../server/handlers/decks.js", () => ({
   notifyClients: (...args: unknown[]) => mockNotifyClients(...args),
 }));
 
+vi.mock("../server/lib/deck-versions.js", () => ({
+  createDeckVersionSnapshot: vi.fn(async () => ({ created: true })),
+}));
+
 vi.mock("drizzle-orm", () => ({
   eq: (col: unknown, val: unknown) => ({ col, val }),
 }));
@@ -53,6 +59,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockDeckRow = {
     id: "deck-1",
+    title: "T",
+    ownerEmail: "owner@example.com",
     data: JSON.stringify({
       title: "T",
       slides: [{ id: "s1" }],

--- a/templates/slides/actions/update-deck-aspect-ratio.ts
+++ b/templates/slides/actions/update-deck-aspect-ratio.ts
@@ -6,6 +6,7 @@ import { assertAccess } from "@agent-native/core/sharing";
 import { writeAppState } from "@agent-native/core/application-state";
 import { ASPECT_RATIO_VALUES } from "../shared/aspect-ratios.js";
 import { notifyClients } from "../server/handlers/decks.js";
+import { createDeckVersionSnapshot } from "../server/lib/deck-versions.js";
 
 export default defineAction({
   description:
@@ -24,6 +25,15 @@ export default defineAction({
       .where(eq(schema.decks.id, deckId))
       .limit(1);
     if (!rows.length) throw new Error(`Deck not found: ${deckId}`);
+    await createDeckVersionSnapshot(
+      {
+        id: rows[0].id,
+        title: rows[0].title,
+        data: rows[0].data,
+        ownerEmail: rows[0].ownerEmail,
+      },
+      { label: "Before aspect ratio change" },
+    );
     const data = JSON.parse(rows[0].data);
     data.aspectRatio = aspectRatio;
     const now = new Date().toISOString();

--- a/templates/slides/actions/update-slide.test.ts
+++ b/templates/slides/actions/update-slide.test.ts
@@ -27,6 +27,10 @@ vi.mock("../server/handlers/decks.js", () => ({
 
 vi.mock("../server/db/index.js", () => ({}));
 
+vi.mock("../server/lib/deck-versions.js", () => ({
+  createDeckVersionSnapshot: vi.fn(async () => ({ created: true })),
+}));
+
 vi.mock("./_await-fit-check.js", () => ({
   awaitLayoutFitCheck: async () => mockFitCheckResult ?? { status: "timeout" },
   formatOverflowForTool: (deckId: string, m: { verticalOverflow: number }) =>
@@ -38,10 +42,13 @@ import action from "./update-slide";
 beforeEach(() => {
   vi.clearAllMocks();
   mockExecute.mockImplementation(async (query: { sql: string }) => {
-    if (query.sql.startsWith("SELECT data FROM decks")) {
+    if (query.sql.startsWith("SELECT id, title, data")) {
       return {
         rows: [
           {
+            id: "deck-1",
+            title: "Deck",
+            owner_email: "owner@example.com",
             data: JSON.stringify({
               title: "Deck",
               updatedAt: "2026-01-01T00:00:00.000Z",

--- a/templates/slides/actions/update-slide.ts
+++ b/templates/slides/actions/update-slide.ts
@@ -11,6 +11,7 @@ import { notifyClients } from "../server/handlers/decks.js";
 import "../server/db/index.js"; // ensure registerShareableResource runs
 
 import { normalizeSlidePadding } from "../app/lib/normalize-slide-padding.js";
+import { createDeckVersionSnapshot } from "../server/lib/deck-versions.js";
 import {
   awaitLayoutFitCheck,
   formatOverflowForTool,
@@ -74,14 +75,25 @@ export default defineAction({
     // Read SQL deck for the slide-existence check and the local fallback
     // computation that keeps decks.data in sync.
     const existing = await client.execute({
-      sql: "SELECT data FROM decks WHERE id = ?",
+      sql: "SELECT id, title, data, owner_email, design_system_id FROM decks WHERE id = ?",
       args: [deckId],
     });
     if (!existing.rows?.length) {
       throw new Error(`Deck ${deckId} not found`);
     }
 
-    const deck = JSON.parse(existing.rows[0].data as string);
+    const row = existing.rows[0] as Record<string, unknown>;
+    await createDeckVersionSnapshot(
+      {
+        id: String(row.id ?? deckId),
+        title: String(row.title ?? "Untitled"),
+        data: String(row.data ?? ""),
+        ownerEmail: String(row.owner_email ?? ""),
+      },
+      { label: "Before slide edit" },
+    );
+
+    const deck = JSON.parse(row.data as string);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const slide = deck.slides?.find((s: any) => s.id === slideId);
     if (!slide) {

--- a/templates/slides/actions/view-screen.ts
+++ b/templates/slides/actions/view-screen.ts
@@ -47,6 +47,7 @@ export default defineAction({
         content?: string;
       }> = Array.isArray(deck?.slides) ? deck.slides : [];
       const slideIndex = navigation.slideIndex ?? 0;
+      const slideNumber = slideIndex + 1;
       const currentSlide = slides[slideIndex] ?? null;
 
       // Emit a compact, scannable format with IDs at the top. The agent
@@ -62,7 +63,13 @@ export default defineAction({
       lines.push(`deckTitle: ${rows[0].title ?? deck?.title ?? "(untitled)"}`);
       lines.push(`slideCount: ${slides.length}`);
       lines.push(
-        `currentSlideIndex: ${slideIndex}   (0-based; the user's UI shows this as "slide ${slideIndex + 1} of ${slides.length}" — use the 1-based number when talking to them)`,
+        `slideNumbering: User-visible slide numbers are 1-based and match the UI. "Slide 1" means the first slide, not internal index 1. Use slideId for edits.`,
+      );
+      lines.push(
+        `currentSlideNumber: ${slideNumber} of ${slides.length}   (1-based; matches the UI)`,
+      );
+      lines.push(
+        `currentSlideIndex: ${slideIndex}   (0-based internal value only; do not use this to interpret "slide N" from the user)`,
       );
       if (currentSlide) {
         lines.push(
@@ -71,7 +78,7 @@ export default defineAction({
         lines.push(`currentSlideLayout: ${currentSlide.layout ?? "(none)"}`);
       } else {
         lines.push(
-          `currentSlideId: (no slide at index ${slideIndex} — deck may be empty)`,
+          `currentSlideId: (no slide for slide number ${slideNumber} / internal index ${slideIndex} — deck may be empty)`,
         );
       }
       lines.push(``);
@@ -91,14 +98,14 @@ export default defineAction({
                   .slice(0, 60)
               : "";
           lines.push(
-            `${String(i).padStart(2, " ")}. id=${s.id}  layout=${s.layout ?? "-"}  "${contentPreview}"${marker}`,
+            `Slide ${i + 1}. id=${s.id}  internalIndex=${i}  layout=${s.layout ?? "-"}  "${contentPreview}"${marker}`,
           );
         }
       }
       if (currentSlide?.content) {
         lines.push(``);
         lines.push(
-          `### Current slide HTML (index ${slideIndex}, id ${currentSlide.id})`,
+          `### Current slide HTML (slide ${slideNumber}, internal index ${slideIndex}, id ${currentSlide.id})`,
         );
         lines.push("```html");
         lines.push(currentSlide.content);

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -157,6 +157,7 @@ function SortableSlideThumb({
   onSelect,
   onDuplicate,
   onDelete,
+  registerButtonRef,
   presenceUsers = [],
   aspectRatio,
 }: {
@@ -166,6 +167,7 @@ function SortableSlideThumb({
   onSelect: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
+  registerButtonRef: (slideId: string, node: HTMLButtonElement | null) => void;
   presenceUsers?: CollabUser[];
   aspectRatio?: AspectRatio;
 }) {
@@ -189,10 +191,15 @@ function SortableSlideThumb({
   return (
     <div ref={setNodeRef} style={style} className="group relative">
       <button
+        ref={(node) => registerButtonRef(slide.id, node)}
         onClick={onSelect}
+        onFocus={onSelect}
+        aria-label={`Select slide ${index + 1}`}
+        aria-current={isActive ? "true" : undefined}
+        data-slide-thumbnail-id={slide.id}
         className={`w-full text-left flex items-start gap-2 p-2 rounded-lg transition-all duration-150 ${
           isActive ? "bg-accent ring-1 ring-[#609FF8]/50" : "hover:bg-accent"
-        }`}
+        } focus:outline-none`}
       >
         {/* Drag handle */}
         <div
@@ -534,7 +541,19 @@ export default function EditorSidebar({
   const [addOpen, setAddOpen] = useState(false);
   const [addSlideGenerating, setAddSlideGenerating] = useState(false);
   const headerAddRef = useRef<HTMLButtonElement>(null);
+  const slideButtonRefs = useRef(new Map<string, HTMLButtonElement>());
   const { generating, submit: agentSubmit } = useAgentGenerating();
+
+  const registerSlideButton = useCallback(
+    (slideId: string, node: HTMLButtonElement | null) => {
+      if (node) {
+        slideButtonRefs.current.set(slideId, node);
+      } else {
+        slideButtonRefs.current.delete(slideId);
+      }
+    },
+    [],
+  );
 
   // Reset addSlideGenerating when global generating stops
   useEffect(() => {
@@ -564,7 +583,13 @@ export default function EditorSidebar({
           : Math.min(slides.length - 1, currentIndex + 1);
 
       if (nextIndex !== currentIndex) {
-        onSelectSlide(slides[nextIndex].id);
+        const nextSlideId = slides[nextIndex].id;
+        onSelectSlide(nextSlideId);
+        requestAnimationFrame(() => {
+          slideButtonRefs.current.get(nextSlideId)?.focus({
+            preventScroll: true,
+          });
+        });
       }
     };
 
@@ -611,6 +636,7 @@ export default function EditorSidebar({
               onSelect={() => onSelectSlide(slide.id)}
               onDuplicate={() => onDuplicateSlide(slide.id)}
               onDelete={() => onDeleteSlide(slide.id)}
+              registerButtonRef={registerSlideButton}
               presenceUsers={slidePresence?.get(slide.id) ?? []}
               aspectRatio={aspectRatio}
             />

--- a/templates/slides/app/components/editor/EditorToolbar.tsx
+++ b/templates/slides/app/components/editor/EditorToolbar.tsx
@@ -955,8 +955,7 @@ graph TD
         className="hidden"
       />
 
-      {/* Overflow — Import / History / Theme tucked away to clean the bar.
-          The historyButtonRef anchors the History popup below this trigger. */}
+      {/* Overflow — Import / History / Theme tucked away to clean the bar. */}
       <DropdownMenu>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -986,7 +985,7 @@ graph TD
           </DropdownMenuItem>
           <DropdownMenuItem onClick={onShowHistory}>
             <IconHistory className="w-4 h-4 mr-2" />
-            Edit history
+            Saved versions
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={() => setTheme(isDark ? "light" : "dark")}>

--- a/templates/slides/app/components/editor/HistoryPanel.tsx
+++ b/templates/slides/app/components/editor/HistoryPanel.tsx
@@ -1,138 +1,282 @@
-import { useRef, useEffect } from "react";
-import { createPortal } from "react-dom";
-import { IconHistory } from "@tabler/icons-react";
-import { useDecks, type HistoryEntry } from "@/context/DeckContext";
-import { shortcutLabel } from "@/lib/utils";
+import { useMemo, useState, type RefObject } from "react";
+import {
+  IconArrowLeft,
+  IconHistory,
+  IconLoader2,
+  IconRestore,
+} from "@tabler/icons-react";
+import type { Slide } from "@/context/DeckContext";
+import SlideRenderer from "@/components/deck/SlideRenderer";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "@/hooks/use-toast";
+import {
+  useDeckVersion,
+  useDeckVersions,
+  useRestoreDeckVersion,
+} from "@/hooks/use-deck-versions";
+import type { AspectRatio } from "@/lib/aspect-ratios";
+import type { DeckVersionSummary } from "../../../shared/api";
 
 interface HistoryPanelProps {
+  deckId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  anchorRef?: React.RefObject<HTMLButtonElement | null>;
+  canRestore?: boolean;
+  anchorRef?: RefObject<HTMLButtonElement | null>;
 }
 
-function formatTime(ts: number): string {
-  const d = new Date(ts);
-  return d.toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
+function formatRelativeTime(dateStr: string): string {
+  const then = new Date(dateStr).getTime();
+  if (!Number.isFinite(then)) return "Unknown time";
+  const diffMs = Date.now() - then;
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffHr = Math.floor(diffMs / 3_600_000);
+  const diffDay = Math.floor(diffMs / 86_400_000);
+
+  if (diffMin < 1) return "Just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHr < 24) return `${diffHr}h ago`;
+  if (diffDay < 7) return `${diffDay}d ago`;
+  return new Date(dateStr).toLocaleDateString();
 }
 
-function timeAgo(ts: number): string {
-  const diff = Date.now() - ts;
-  const secs = Math.floor(diff / 1000);
-  if (secs < 10) return "just now";
-  if (secs < 60) return `${secs}s ago`;
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  return `${Math.floor(mins / 60)}h ago`;
+function slideLabel(version: Pick<DeckVersionSummary, "slideCount">): string {
+  return `${version.slideCount} slide${version.slideCount === 1 ? "" : "s"}`;
+}
+
+function normalizeSlides(slides: DeckVersionSummary["slidePreviews"]): string {
+  return slides
+    .map((slide) => slide.textPreview)
+    .filter(Boolean)
+    .join(" / ");
 }
 
 export default function HistoryPanel({
+  deckId,
   open,
   onOpenChange,
-  anchorRef,
+  canRestore = true,
 }: HistoryPanelProps) {
-  const { history, historyIndex, restoreFromHistory } = useDecks();
-  const panelRef = useRef<HTMLDivElement>(null);
+  const [selectedVersionId, setSelectedVersionId] = useState<string | null>(
+    null,
+  );
+  const versionsQuery = useDeckVersions(open ? deckId : null);
+  const versionQuery = useDeckVersion(
+    open ? deckId : null,
+    selectedVersionId,
+  );
+  const restoreVersion = useRestoreDeckVersion();
 
-  useEffect(() => {
-    if (!open) return;
-    const handleClick = (e: MouseEvent) => {
-      if (
-        panelRef.current &&
-        !panelRef.current.contains(e.target as Node) &&
-        anchorRef?.current &&
-        !anchorRef.current.contains(e.target as Node)
-      ) {
-        onOpenChange(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open, onOpenChange, anchorRef]);
-
-  if (!open || !anchorRef?.current) return null;
-
-  const rect = anchorRef.current.getBoundingClientRect();
-  const vw = window.innerWidth;
-  const panelWidth = Math.min(300, vw - 16);
-  const left = Math.max(
-    8,
-    Math.min(rect.right - panelWidth, vw - panelWidth - 8),
+  const versions = versionsQuery.data?.versions ?? [];
+  const selectedVersion = versionQuery.data;
+  const selectedSlides = useMemo(
+    () =>
+      (selectedVersion?.slides ?? []).map((slide) => ({
+        notes: "",
+        layout: "blank",
+        ...slide,
+      })) as Slide[],
+    [selectedVersion?.slides],
   );
 
-  return createPortal(
-    <div
-      ref={panelRef}
-      className="fixed rounded-lg border border-border bg-popover shadow-2xl z-[200]"
-      style={{ top: rect.bottom + 6, left, width: panelWidth }}
-    >
-      <div className="px-3 py-2.5 border-b border-border flex items-center gap-2">
-        <IconHistory className="w-4 h-4 text-[#609FF8]" />
-        <span className="text-xs font-medium text-foreground/90">
-          Edit History
-        </span>
-        <span className="text-[10px] text-muted-foreground ml-auto">
-          {shortcutLabel("cmd+z")} / {shortcutLabel("cmd+shift+z")}
-        </span>
-      </div>
+  const handleClose = (nextOpen: boolean) => {
+    if (!nextOpen) setSelectedVersionId(null);
+    onOpenChange(nextOpen);
+  };
 
-      <div className="overflow-y-auto max-h-[50vh] p-1">
-        {history.length === 0 && (
-          <p className="text-xs text-muted-foreground text-center py-4">
-            No history yet
-          </p>
-        )}
-        {[...history].reverse().map((entry, reversedIdx) => {
-          const realIdx = history.length - 1 - reversedIdx;
-          const isCurrent = realIdx === historyIndex;
+  const handleRestore = async () => {
+    if (!selectedVersionId) return;
+    try {
+      await restoreVersion.mutateAsync({ deckId, versionId: selectedVersionId });
+      toast({
+        title: "Version restored",
+        description: "The deck was rolled back to the selected snapshot.",
+      });
+      handleClose(false);
+    } catch (error) {
+      toast({
+        title: "Restore failed",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Could not restore this deck version.",
+        variant: "destructive",
+      });
+    }
+  };
 
-          return (
-            <button
-              key={`${entry.timestamp}-${realIdx}`}
-              onClick={() => {
-                restoreFromHistory(realIdx);
-                onOpenChange(false);
-              }}
-              className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-md text-left transition-colors ${
-                isCurrent ? "bg-[#609FF8]/10" : "hover:bg-accent"
-              }`}
-            >
-              <div
-                className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
-                  isCurrent
-                    ? "bg-[#609FF8]"
-                    : realIdx < historyIndex
-                      ? "bg-muted-foreground/40"
-                      : "bg-muted-foreground/20"
-                }`}
-              />
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-1.5">
-                  <span
-                    className={`text-xs font-medium truncate ${
-                      isCurrent ? "text-[#609FF8]" : "text-muted-foreground"
-                    }`}
-                  >
-                    {entry.label}
-                  </span>
-                  {isCurrent && (
-                    <span className="text-[9px] px-1 py-0.5 rounded bg-[#609FF8]/20 text-[#609FF8] font-medium flex-shrink-0">
-                      Current
-                    </span>
-                  )}
+  return (
+    <Sheet open={open} onOpenChange={handleClose}>
+      <SheetContent side="right" className="w-[92vw] max-w-[640px] p-0">
+        <SheetHeader className="px-4 pt-4 pb-0">
+          <SheetTitle className="flex items-center gap-2 text-sm font-medium">
+            {selectedVersionId ? (
+              <button
+                type="button"
+                onClick={() => setSelectedVersionId(null)}
+                className="inline-flex min-w-0 items-center gap-1.5 text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <IconArrowLeft size={15} />
+                <span>Back to saved versions</span>
+              </button>
+            ) : (
+              <>
+                <IconHistory size={16} className="text-[#609FF8]" />
+                <span>Saved versions</span>
+              </>
+            )}
+          </SheetTitle>
+          <SheetDescription className="sr-only">
+            Browse saved deck versions and restore a previous snapshot.
+          </SheetDescription>
+        </SheetHeader>
+
+        <Separator className="mt-3" />
+
+        {selectedVersionId ? (
+          <div className="flex h-[calc(100%-60px)] flex-col">
+            <div className="border-b border-border px-4 py-3">
+              {versionQuery.isLoading ? (
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-2/3" />
+                  <Skeleton className="h-3 w-1/3" />
                 </div>
-                <span className="text-[10px] text-muted-foreground/70">
-                  {timeAgo(entry.timestamp)}
-                </span>
+              ) : (
+                <>
+                  <p className="truncate text-sm font-medium">
+                    {selectedVersion?.title || "Untitled"}
+                  </p>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    {selectedVersion
+                      ? `${new Date(selectedVersion.createdAt).toLocaleString()} · ${slideLabel(selectedVersion)}`
+                      : "Snapshot unavailable"}
+                  </p>
+                </>
+              )}
+            </div>
+
+            <ScrollArea className="flex-1">
+              <div className="grid grid-cols-1 gap-3 p-4 sm:grid-cols-2">
+                {versionQuery.isLoading ? (
+                  Array.from({ length: 4 }).map((_, index) => (
+                    <Skeleton
+                      key={index}
+                      className="aspect-video w-full rounded-lg"
+                    />
+                  ))
+                ) : selectedSlides.length ? (
+                  selectedSlides.map((slide, index) => (
+                    <div key={slide.id || index} className="min-w-0">
+                      <SlideRenderer
+                        slide={slide}
+                        aspectRatio={
+                          (selectedVersion?.aspectRatio ?? undefined) as
+                            | AspectRatio
+                            | undefined
+                        }
+                        className="border border-border bg-black"
+                      />
+                      <p className="mt-1.5 truncate text-[11px] text-muted-foreground">
+                        Slide {index + 1}
+                      </p>
+                    </div>
+                  ))
+                ) : (
+                  <div className="col-span-full py-12 text-center text-xs text-muted-foreground">
+                    No slides in this snapshot.
+                  </div>
+                )}
               </div>
-            </button>
-          );
-        })}
-      </div>
-    </div>,
-    document.body,
+            </ScrollArea>
+
+            {canRestore ? (
+              <div className="border-t border-border p-3">
+                <Button
+                  size="sm"
+                  className="w-full"
+                  onClick={handleRestore}
+                  disabled={restoreVersion.isPending || versionQuery.isLoading}
+                >
+                  {restoreVersion.isPending ? (
+                    <IconLoader2 size={15} className="mr-1.5 animate-spin" />
+                  ) : (
+                    <IconRestore size={15} className="mr-1.5" />
+                  )}
+                  Restore this version
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        ) : (
+          <ScrollArea className="h-[calc(100%-60px)]">
+            {versionsQuery.isLoading ? (
+              <div className="space-y-2 p-3">
+                {Array.from({ length: 5 }).map((_, index) => (
+                  <Skeleton key={index} className="h-16 w-full rounded-md" />
+                ))}
+              </div>
+            ) : versions.length ? (
+              <div className="p-2">
+                {versions.map((version) => {
+                  const preview = normalizeSlides(version.slidePreviews);
+                  return (
+                    <button
+                      key={version.id}
+                      type="button"
+                      onClick={() => setSelectedVersionId(version.id)}
+                      className="w-full rounded-md px-3 py-2.5 text-left transition-colors hover:bg-accent"
+                    >
+                      <div className="flex min-w-0 items-start gap-3">
+                        <div className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-[#609FF8]" />
+                        <div className="min-w-0 flex-1">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <p className="truncate text-sm font-medium">
+                              {version.title || "Untitled"}
+                            </p>
+                            <span className="flex-shrink-0 text-[10px] text-muted-foreground">
+                              {slideLabel(version)}
+                            </span>
+                          </div>
+                          <p className="mt-0.5 text-[11px] text-muted-foreground">
+                            {formatRelativeTime(version.createdAt)}
+                            {version.label ? ` · ${version.label}` : ""}
+                          </p>
+                          {preview ? (
+                            <p className="mt-1 truncate text-[11px] text-muted-foreground/80">
+                              {preview}
+                            </p>
+                          ) : null}
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="px-6 py-14 text-center">
+                <IconHistory
+                  size={24}
+                  className="mx-auto mb-3 text-muted-foreground/60"
+                />
+                <p className="text-sm font-medium">No saved versions yet</p>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  Versions are saved automatically before future deck edits.
+                </p>
+              </div>
+            )}
+          </ScrollArea>
+        )}
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/templates/slides/app/components/editor/HistoryPanel.tsx
+++ b/templates/slides/app/components/editor/HistoryPanel.tsx
@@ -71,10 +71,7 @@ export default function HistoryPanel({
     null,
   );
   const versionsQuery = useDeckVersions(open ? deckId : null);
-  const versionQuery = useDeckVersion(
-    open ? deckId : null,
-    selectedVersionId,
-  );
+  const versionQuery = useDeckVersion(open ? deckId : null, selectedVersionId);
   const restoreVersion = useRestoreDeckVersion();
 
   const versions = versionsQuery.data?.versions ?? [];
@@ -97,7 +94,10 @@ export default function HistoryPanel({
   const handleRestore = async () => {
     if (!selectedVersionId) return;
     try {
-      await restoreVersion.mutateAsync({ deckId, versionId: selectedVersionId });
+      await restoreVersion.mutateAsync({
+        deckId,
+        versionId: selectedVersionId,
+      });
       toast({
         title: "Version restored",
         description: "The deck was rolled back to the selected snapshot.",

--- a/templates/slides/app/hooks/use-deck-versions.ts
+++ b/templates/slides/app/hooks/use-deck-versions.ts
@@ -1,0 +1,41 @@
+import { useActionMutation, useActionQuery } from "@agent-native/core/client";
+import type { DeckVersion, DeckVersionListResponse } from "../../shared/api";
+
+export function useDeckVersions(deckId: string | null) {
+  return useActionQuery<DeckVersionListResponse>(
+    "list-deck-versions",
+    deckId ? { deckId } : undefined,
+    {
+      enabled: !!deckId,
+      placeholderData: (prev) => prev,
+    } as any,
+  );
+}
+
+export function useDeckVersion(
+  deckId: string | null,
+  versionId: string | null,
+) {
+  return useActionQuery<DeckVersion>(
+    "get-deck-version",
+    deckId && versionId ? { deckId, versionId } : undefined,
+    {
+      enabled: !!(deckId && versionId),
+      placeholderData: (prev) => prev,
+    } as any,
+  );
+}
+
+export function useRestoreDeckVersion() {
+  return useActionMutation<
+    {
+      id: string;
+      title: string;
+      slideCount: number;
+      restoredVersionId: string;
+      updatedAt: string;
+      url: string;
+    },
+    { deckId: string; versionId: string }
+  >("restore-deck-version");
+}

--- a/templates/slides/app/hooks/use-navigation-state.ts
+++ b/templates/slides/app/hooks/use-navigation-state.ts
@@ -7,6 +7,9 @@ import { TAB_ID } from "@/lib/tab-id";
 export interface NavigationState {
   view: string;
   deckId?: string;
+  /** User-visible slide number. 1-based and matches the editor UI. */
+  slideNumber?: number;
+  /** Internal zero-based slide index kept for backwards compatibility. */
   slideIndex?: number;
   /** Optional unique-per-write token. When present, the UI uses it to detect
    * legitimate repeat writes (same payload, different `_writeId`) vs. the
@@ -34,14 +37,15 @@ export function useNavigationState() {
         state.view = "present";
       }
       // The deck editor stores the active slide as a 1-based ?slide=N URL
-      // param. Convert to a 0-based index for the agent so view-screen can
-      // pick the correct slide; without this, the agent always thought the
-      // user was on slide 1 (off-by-one vs. the toolbar's "6 of 10").
+      // param. Write both the UI-facing slideNumber and the legacy
+      // zero-based slideIndex so agent context can be explicit without
+      // breaking older callers.
       const params = new URLSearchParams(location.search);
       const slideParam = params.get("slide");
       if (slideParam) {
         const oneBased = parseInt(slideParam, 10);
         if (Number.isFinite(oneBased) && oneBased >= 1) {
+          state.slideNumber = oneBased;
           state.slideIndex = oneBased - 1;
         }
       }
@@ -107,6 +111,7 @@ export function useNavigationState() {
       JSON.stringify({
         view: cmd.view,
         deckId: cmd.deckId,
+        slideNumber: cmd.slideNumber,
         slideIndex: cmd.slideIndex,
       });
     if (lastProcessedDedupKeyRef.current === dedupKey) {
@@ -133,15 +138,22 @@ export function useNavigationState() {
       path = `/deck/${cmd.deckId}`;
       if (cmd.view === "present") {
         path += "/present";
-      } else if (
-        typeof cmd.slideIndex === "number" &&
-        Number.isFinite(cmd.slideIndex) &&
-        cmd.slideIndex >= 0
-      ) {
-        // Convert agent's 0-based slideIndex back to the 1-based ?slide=N
-        // URL param the editor reads. Without this the deck always opened
-        // at slide 1 even when the agent asked for a different slide.
-        path += `?slide=${cmd.slideIndex + 1}`;
+      } else {
+        const internalSlideIndex =
+          typeof cmd.slideNumber === "number" &&
+          Number.isFinite(cmd.slideNumber) &&
+          cmd.slideNumber >= 1
+            ? cmd.slideNumber - 1
+            : cmd.slideIndex;
+        if (
+          typeof internalSlideIndex === "number" &&
+          Number.isFinite(internalSlideIndex) &&
+          internalSlideIndex >= 0
+        ) {
+          // Convert the internal zero-based value back to the 1-based
+          // ?slide=N URL param the editor reads.
+          path += `?slide=${internalSlideIndex + 1}`;
+        }
       }
     } else if (cmd.view === "settings") {
       path = "/settings";

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -991,8 +991,10 @@ export default function DeckEditor() {
         }
       />
       <HistoryPanel
+        deckId={id}
         open={historyOpen}
         onOpenChange={setHistoryOpen}
+        canRestore={canEdit}
         anchorRef={historyButtonRef}
       />
       <ImageDropPromptPopover

--- a/templates/slides/app/pages/DeckEditor.tsx
+++ b/templates/slides/app/pages/DeckEditor.tsx
@@ -449,7 +449,7 @@ export default function DeckEditor() {
   // externally" (agent navigate command, browser back/forward, deep link) apart
   // from "the URL is the same as last render, just other state moved". Without
   // this, the resolver short-circuited on external URL changes and the agent's
-  // navigate --slideIndex was effectively ignored.
+  // navigate --slideNumber / --slideIndex commands were effectively ignored.
   const lastUrlSlideParamRef = useRef<string | null>(null);
   const pendingUrlSlideIdRef = useRef<string | null>(null);
   useEffect(() => {

--- a/templates/slides/app/routes/slide.tsx
+++ b/templates/slides/app/routes/slide.tsx
@@ -34,6 +34,7 @@ function SlideError({ message }: { message: string }) {
 export default function SlideRoute() {
   const [params] = useSearchParams();
   const deckId = params.get("deckId");
+  const slideNumberParam = params.get("slideNumber");
   const slideIndexParam = params.get("slideIndex");
 
   const [slide, setSlide] = useState<Slide | null>(null);
@@ -43,13 +44,27 @@ export default function SlideRoute() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const slideNumber =
+    slideNumberParam !== null ? parseInt(slideNumberParam, 10) : null;
   const slideIndex =
-    slideIndexParam !== null ? parseInt(slideIndexParam, 10) : 0;
+    slideNumber !== null
+      ? slideNumber - 1
+      : slideIndexParam !== null
+        ? parseInt(slideIndexParam, 10)
+        : 0;
   const inEmbed = isInAgentEmbed();
 
   useEffect(() => {
     if (!deckId) {
       setError("Missing deckId parameter.");
+      setLoading(false);
+      return;
+    }
+    if (
+      slideNumberParam !== null &&
+      (slideNumber === null || isNaN(slideNumber) || slideNumber < 1)
+    ) {
+      setError("slideNumber must be a positive 1-based number.");
       setLoading(false);
       return;
     }
@@ -81,7 +96,7 @@ export default function SlideRoute() {
         setError(err instanceof Error ? err.message : "Could not load slide.");
         setLoading(false);
       });
-  }, [deckId, slideIndex, slideIndexParam]);
+  }, [deckId, slideIndex, slideIndexParam, slideNumber, slideNumberParam]);
 
   if (loading) {
     return <div className="h-screen w-screen bg-black" />;

--- a/templates/slides/server/db/schema.ts
+++ b/templates/slides/server/db/schema.ts
@@ -19,6 +19,16 @@ export const decks = table("decks", {
 
 export const deckShares = createSharesTable("deck_shares");
 
+export const deckVersions = table("deck_versions", {
+  id: text("id").primaryKey(),
+  ownerEmail: text("owner_email").notNull().default("local@localhost"),
+  deckId: text("deck_id").notNull(),
+  title: text("title").notNull(),
+  data: text("data").notNull(),
+  changeLabel: text("change_label"),
+  createdAt: text("created_at").notNull().default(now()),
+});
+
 export const designSystems = table("design_systems", {
   id: text("id").primaryKey(),
   title: text("title").notNull(),

--- a/templates/slides/server/handlers/decks.ts
+++ b/templates/slides/server/handlers/decks.ts
@@ -94,6 +94,28 @@ function validateDeckAspectRatio(
   return true;
 }
 
+function comparableDeckData(raw: unknown): string {
+  try {
+    const data = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const clone = JSON.parse(JSON.stringify(data ?? {}));
+    delete clone.updatedAt;
+    return JSON.stringify(clone);
+  } catch {
+    return String(raw ?? "");
+  }
+}
+
+function shouldSnapshotDeckWrite(
+  current: { title?: string | null; data?: string | null },
+  nextTitle: string,
+  nextDeck: Record<string, unknown>,
+): boolean {
+  return (
+    (current.title ?? "Untitled") !== nextTitle ||
+    comparableDeckData(current.data ?? "") !== comparableDeckData(nextDeck)
+  );
+}
+
 // SSE endpoint — client subscribes for real-time change notifications.
 // Per-deckId notifications carry only the id, no row contents, so we don't
 // gate this — but we do require an authenticated session so anonymous
@@ -288,15 +310,17 @@ export const updateDeck = defineEventHandler(async (event) => {
       }
       // Caller has editor+ access — perform the update. The access check
       // above already confirmed the row exists and the caller can write.
-      await createDeckVersionSnapshot(
-        {
-          id: access.resource.id,
-          title: access.resource.title,
-          data: access.resource.data,
-          ownerEmail: access.resource.ownerEmail as string,
-        },
-        { label: "Before editor save" },
-      );
+      if (shouldSnapshotDeckWrite(access.resource, title, deck)) {
+        await createDeckVersionSnapshot(
+          {
+            id: access.resource.id,
+            title: access.resource.title,
+            data: access.resource.data,
+            ownerEmail: access.resource.ownerEmail as string,
+          },
+          { label: "Before editor save" },
+        );
+      }
       await db
         .update(schema.decks)
         .set({

--- a/templates/slides/server/handlers/decks.ts
+++ b/templates/slides/server/handlers/decks.ts
@@ -6,11 +6,7 @@ import {
 } from "h3";
 import { eq, desc } from "drizzle-orm";
 import { getDb, schema } from "../db";
-import {
-  readBody,
-  getSession,
-  runWithRequestContext,
-} from "@agent-native/core/server";
+import { readBody } from "@agent-native/core/server";
 import {
   accessFilter,
   resolveAccess,
@@ -18,6 +14,10 @@ import {
   ForbiddenError,
 } from "@agent-native/core/sharing";
 import { ASPECT_RATIO_VALUES } from "../../shared/aspect-ratios.js";
+import {
+  resolveSlidesRequestAuthContext,
+  withSlidesRequestContext,
+} from "./request-auth-context.js";
 
 // --- SSE for change notifications ---
 type SSEPush = (data: string) => void;
@@ -71,20 +71,6 @@ export function notifyClients(deckId: string, type = "deck-changed") {
  * this — querying ownable tables without a request context is how data
  * leaks across users (see #SLI-2026-04-28).
  */
-async function withAuth<T>(
-  event: any,
-  fn: (session: { email?: string; orgId?: string }) => Promise<T>,
-): Promise<T> {
-  const session = await getSession(event).catch(() => null);
-  const ctx = {
-    userEmail: session?.email,
-    orgId: session?.orgId,
-  };
-  return runWithRequestContext(ctx, () =>
-    fn({ email: ctx.userEmail, orgId: ctx.orgId }),
-  );
-}
-
 function handleForbidden(event: any, err: unknown): { error: string } {
   if (err instanceof ForbiddenError) {
     setResponseStatus(event, err.statusCode);
@@ -113,8 +99,8 @@ function validateDeckAspectRatio(
 // callers can't tail the stream. (The agent path runs server-side and is
 // not affected.)
 export const deckEvents = defineEventHandler(async (event) => {
-  const session = await getSession(event).catch(() => null);
-  if (!session?.email) {
+  const session = await resolveSlidesRequestAuthContext(event);
+  if (!session.email) {
     setResponseStatus(event, 401);
     return { error: "Unauthorized" };
   }
@@ -138,7 +124,7 @@ export const deckEvents = defineEventHandler(async (event) => {
 
 // GET /api/decks — list decks the caller can see (own + shared + visibility match)
 export const listDecks = defineEventHandler(async (event) => {
-  return withAuth(event, async ({ email }) => {
+  return withSlidesRequestContext(event, async ({ email }) => {
     // Without an authenticated email, `accessFilter` would short-circuit to
     // `1=0` and return a 200/[] response — indistinguishable to the client
     // from "this user genuinely has no decks." That fires the deck-list
@@ -182,7 +168,7 @@ export const getDeck = defineEventHandler(async (event) => {
     return { error: "Deck id is required" };
   }
 
-  return withAuth(event, async () => {
+  return withSlidesRequestContext(event, async () => {
     try {
       const access = await assertAccess("deck", id, "viewer");
       const row = access.resource;
@@ -224,7 +210,7 @@ export const updateDeck = defineEventHandler(async (event) => {
     return { error: "Invalid aspect ratio" };
   }
 
-  return withAuth(event, async ({ email, orgId }) => {
+  return withSlidesRequestContext(event, async ({ email, orgId }) => {
     const db = getDb();
     const now = new Date().toISOString();
 
@@ -334,7 +320,7 @@ export const createDeck = defineEventHandler(async (event) => {
     return { error: "Invalid aspect ratio" };
   }
 
-  return withAuth(event, async ({ email, orgId }) => {
+  return withSlidesRequestContext(event, async ({ email, orgId }) => {
     if (!email) {
       return handleForbidden(
         event,
@@ -388,7 +374,7 @@ export const deleteDeck = defineEventHandler(async (event) => {
     return { error: "Deck id is required" };
   }
 
-  return withAuth(event, async () => {
+  return withSlidesRequestContext(event, async () => {
     try {
       // assertAccess loads the row and verifies the caller has admin
       // role on this resource — it must run BEFORE the delete (and in

--- a/templates/slides/server/handlers/decks.ts
+++ b/templates/slides/server/handlers/decks.ts
@@ -4,7 +4,7 @@ import {
   setResponseStatus,
   createEventStream,
 } from "h3";
-import { eq, desc } from "drizzle-orm";
+import { and, eq, desc } from "drizzle-orm";
 import { getDb, schema } from "../db";
 import { readBody } from "@agent-native/core/server";
 import {
@@ -18,6 +18,7 @@ import {
   resolveSlidesRequestAuthContext,
   withSlidesRequestContext,
 } from "./request-auth-context.js";
+import { createDeckVersionSnapshot } from "../lib/deck-versions.js";
 
 // --- SSE for change notifications ---
 type SSEPush = (data: string) => void;
@@ -287,6 +288,15 @@ export const updateDeck = defineEventHandler(async (event) => {
       }
       // Caller has editor+ access — perform the update. The access check
       // above already confirmed the row exists and the caller can write.
+      await createDeckVersionSnapshot(
+        {
+          id: access.resource.id,
+          title: access.resource.title,
+          data: access.resource.data,
+          ownerEmail: access.resource.ownerEmail as string,
+        },
+        { label: "Before editor save" },
+      );
       await db
         .update(schema.decks)
         .set({
@@ -380,8 +390,19 @@ export const deleteDeck = defineEventHandler(async (event) => {
       // role on this resource — it must run BEFORE the delete (and in
       // the same scope) so we don't leak existence to callers who lack
       // access.
-      await assertAccess("deck", id, "admin");
+      const access = await assertAccess("deck", id, "admin");
       const db = getDb();
+      await db
+        .delete(schema.deckVersions)
+        .where(
+          and(
+            eq(schema.deckVersions.deckId, id),
+            eq(
+              schema.deckVersions.ownerEmail,
+              access.resource.ownerEmail as string,
+            ),
+          ),
+        );
       const result = await db
         .delete(schema.decks)
         .where(eq(schema.decks.id, id))

--- a/templates/slides/server/handlers/design-systems.ts
+++ b/templates/slides/server/handlers/design-systems.ts
@@ -1,17 +1,14 @@
 import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
 import { eq, desc } from "drizzle-orm";
 import { getDb, schema } from "../db";
-import {
-  readBody,
-  getSession,
-  runWithRequestContext,
-} from "@agent-native/core/server";
+import { readBody } from "@agent-native/core/server";
 import {
   accessFilter,
   resolveAccess,
   assertAccess,
   ForbiddenError,
 } from "@agent-native/core/sharing";
+import { withSlidesRequestContext } from "./request-auth-context.js";
 
 /**
  * Resolve the caller's auth context from the request and run `fn` inside a
@@ -20,20 +17,6 @@ import {
  * through this — querying ownable tables without a request context is how
  * data leaks across users (see #SLI-2026-04-28).
  */
-async function withAuth<T>(
-  event: any,
-  fn: (session: { email?: string; orgId?: string }) => Promise<T>,
-): Promise<T> {
-  const session = await getSession(event).catch(() => null);
-  const ctx = {
-    userEmail: session?.email,
-    orgId: session?.orgId,
-  };
-  return runWithRequestContext(ctx, () =>
-    fn({ email: ctx.userEmail, orgId: ctx.orgId }),
-  );
-}
-
 function handleForbidden(event: any, err: unknown): { error: string } {
   if (err instanceof ForbiddenError) {
     setResponseStatus(event, err.statusCode);
@@ -45,7 +28,7 @@ function handleForbidden(event: any, err: unknown): { error: string } {
 // GET /api/design-systems — list design systems the caller can see
 // (own + shared + visibility match)
 export const listDesignSystems = defineEventHandler(async (event) => {
-  return withAuth(event, async () => {
+  return withSlidesRequestContext(event, async () => {
     const db = getDb();
     const rows = await db
       .select()
@@ -74,7 +57,7 @@ export const getDesignSystem = defineEventHandler(async (event) => {
     return { error: "Design system id is required" };
   }
 
-  return withAuth(event, async () => {
+  return withSlidesRequestContext(event, async () => {
     const access = await resolveAccess("design-system", id);
     if (!access) {
       // Return 404 (not 403) so we don't leak existence of design
@@ -106,7 +89,7 @@ export const createDesignSystem = defineEventHandler(async (event) => {
     return { error: "Design system must have an id" };
   }
 
-  return withAuth(event, async ({ email, orgId }) => {
+  return withSlidesRequestContext(event, async ({ email, orgId }) => {
     if (!email) {
       return handleForbidden(
         event,
@@ -155,7 +138,7 @@ export const updateDesignSystem = defineEventHandler(async (event) => {
     return { error: "Invalid design system data" };
   }
 
-  return withAuth(event, async () => {
+  return withSlidesRequestContext(event, async () => {
     try {
       // assertAccess loads the row and verifies the caller has editor+
       // role on this resource — it must run BEFORE the update (and in
@@ -207,7 +190,7 @@ export const deleteDesignSystem = defineEventHandler(async (event) => {
     return { error: "Design system id is required" };
   }
 
-  return withAuth(event, async () => {
+  return withSlidesRequestContext(event, async () => {
     try {
       // assertAccess loads the row and verifies the caller has admin
       // role on this resource — it must run BEFORE the delete (and in

--- a/templates/slides/server/handlers/request-auth-context.ts
+++ b/templates/slides/server/handlers/request-auth-context.ts
@@ -11,16 +11,26 @@ export async function resolveSlidesRequestAuthContext(
   event: H3Event,
 ): Promise<SlidesRequestAuthContext> {
   const session = await getSession(event).catch(() => null);
-  let orgId = session?.orgId ?? undefined;
 
-  if (session?.email && !orgId) {
+  // Prefer the live active org context over `session.orgId`. Better Auth's
+  // session.orgId is set at sign-in and not refreshed when the user switches
+  // orgs — so reading it directly returns the *previous* active org after
+  // any switch. `getOrgContext()` resolves the user's current active-org-id
+  // user-setting on every request, which is what we actually want.
+  let orgId: string | undefined;
+  if (session?.email) {
     try {
       const orgContext = await getOrgContext(event);
       orgId = orgContext.orgId ?? undefined;
     } catch {
-      // Org tables can be unavailable during first boot; keep the session-only
-      // context so unauthenticated and solo deployments continue to work.
+      // Org tables can be unavailable during first boot; fall back below.
     }
+  }
+  // Last-resort fallback: if `getOrgContext` threw or returned no orgId,
+  // accept the session-embedded value so first-boot / solo deployments
+  // and unauthenticated callers still work.
+  if (!orgId && session?.orgId) {
+    orgId = session.orgId;
   }
 
   return {
@@ -32,8 +42,10 @@ export async function resolveSlidesRequestAuthContext(
 export async function withSlidesRequestContext<T>(
   event: H3Event,
   fn: (session: SlidesRequestAuthContext) => Promise<T>,
+  preResolvedContext?: SlidesRequestAuthContext,
 ): Promise<T> {
-  const ctx = await resolveSlidesRequestAuthContext(event);
+  const ctx =
+    preResolvedContext ?? (await resolveSlidesRequestAuthContext(event));
   return runWithRequestContext({ userEmail: ctx.email, orgId: ctx.orgId }, () =>
     fn(ctx),
   );

--- a/templates/slides/server/handlers/request-auth-context.ts
+++ b/templates/slides/server/handlers/request-auth-context.ts
@@ -1,0 +1,40 @@
+import type { H3Event } from "h3";
+import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import { getOrgContext } from "@agent-native/core/org";
+
+export interface SlidesRequestAuthContext {
+  email?: string;
+  orgId?: string;
+}
+
+export async function resolveSlidesRequestAuthContext(
+  event: H3Event,
+): Promise<SlidesRequestAuthContext> {
+  const session = await getSession(event).catch(() => null);
+  let orgId = session?.orgId ?? undefined;
+
+  if (session?.email && !orgId) {
+    try {
+      const orgContext = await getOrgContext(event);
+      orgId = orgContext.orgId ?? undefined;
+    } catch {
+      // Org tables can be unavailable during first boot; keep the session-only
+      // context so unauthenticated and solo deployments continue to work.
+    }
+  }
+
+  return {
+    email: session?.email,
+    orgId,
+  };
+}
+
+export async function withSlidesRequestContext<T>(
+  event: H3Event,
+  fn: (session: SlidesRequestAuthContext) => Promise<T>,
+): Promise<T> {
+  const ctx = await resolveSlidesRequestAuthContext(event);
+  return runWithRequestContext({ userEmail: ctx.email, orgId: ctx.orgId }, () =>
+    fn(ctx),
+  );
+}

--- a/templates/slides/server/handlers/share.ts
+++ b/templates/slides/server/handlers/share.ts
@@ -29,14 +29,20 @@ export const shareDeck = defineEventHandler(async (event) => {
     return { error: "Deck id is required" };
   }
 
+  // Pre-resolve so we can 401 before opening the request-context scope,
+  // and pass the resolved context into `withSlidesRequestContext` so it
+  // doesn't re-resolve session + org on the same request (which would
+  // double the session/getOrgContext I/O per share).
   const session = await resolveSlidesRequestAuthContext(event);
   if (!session.email) {
     setResponseStatus(event, 401);
     return { error: "Unauthorized" };
   }
 
-  return withSlidesRequestContext(event, async () =>
-    createShareLink(event, deck.id),
+  return withSlidesRequestContext(
+    event,
+    async () => createShareLink(event, deck.id),
+    session,
   );
 });
 

--- a/templates/slides/server/handlers/share.ts
+++ b/templates/slides/server/handlers/share.ts
@@ -1,13 +1,13 @@
 import { defineEventHandler, getRouterParam, setResponseStatus } from "h3";
 import crypto from "crypto";
 import { eq, lt } from "drizzle-orm";
-import {
-  getSession,
-  readBody,
-  runWithRequestContext,
-} from "@agent-native/core/server";
+import { readBody } from "@agent-native/core/server";
 import { assertAccess, ForbiddenError } from "@agent-native/core/sharing";
 import { getDb, schema } from "../db";
+import {
+  resolveSlidesRequestAuthContext,
+  withSlidesRequestContext,
+} from "./request-auth-context.js";
 import type {
   ShareDeckRequest,
   ShareDeckResponse,
@@ -29,15 +29,14 @@ export const shareDeck = defineEventHandler(async (event) => {
     return { error: "Deck id is required" };
   }
 
-  const session = await getSession(event).catch(() => null);
-  if (!session?.email) {
+  const session = await resolveSlidesRequestAuthContext(event);
+  if (!session.email) {
     setResponseStatus(event, 401);
     return { error: "Unauthorized" };
   }
 
-  return runWithRequestContext(
-    { userEmail: session.email, orgId: session.orgId },
-    async () => createShareLink(event, deck.id),
+  return withSlidesRequestContext(event, async () =>
+    createShareLink(event, deck.id),
   );
 });
 

--- a/templates/slides/server/lib/deck-versions.ts
+++ b/templates/slides/server/lib/deck-versions.ts
@@ -1,0 +1,69 @@
+import { and, desc, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { getDb, schema } from "../db/index.js";
+
+const SNAPSHOT_INTERVAL_MS = 5 * 60 * 1000;
+
+export interface DeckSnapshotSource {
+  id: string;
+  title: string;
+  data: string;
+  ownerEmail: string;
+}
+
+export async function createDeckVersionSnapshot(
+  source: DeckSnapshotSource,
+  options: { force?: boolean; label?: string } = {},
+): Promise<{ created: boolean; id?: string; reason?: string }> {
+  if (!source.ownerEmail) {
+    throw new Error("Cannot snapshot deck version without an owner email");
+  }
+
+  const db = getDb();
+  const [latestVersion] = await db
+    .select({
+      title: schema.deckVersions.title,
+      data: schema.deckVersions.data,
+      createdAt: schema.deckVersions.createdAt,
+    })
+    .from(schema.deckVersions)
+    .where(
+      and(
+        eq(schema.deckVersions.deckId, source.id),
+        eq(schema.deckVersions.ownerEmail, source.ownerEmail),
+      ),
+    )
+    .orderBy(desc(schema.deckVersions.createdAt))
+    .limit(1);
+
+  if (
+    latestVersion &&
+    latestVersion.title === source.title &&
+    latestVersion.data === source.data
+  ) {
+    return { created: false, reason: "duplicate" };
+  }
+
+  if (!options.force && latestVersion?.createdAt) {
+    const latestAt = new Date(latestVersion.createdAt).getTime();
+    if (
+      Number.isFinite(latestAt) &&
+      Date.now() - latestAt < SNAPSHOT_INTERVAL_MS
+    ) {
+      return { created: false, reason: "interval" };
+    }
+  }
+
+  const id = nanoid();
+  await db.insert(schema.deckVersions).values({
+    id,
+    ownerEmail: source.ownerEmail,
+    deckId: source.id,
+    title: source.title,
+    data: source.data,
+    changeLabel: options.label,
+    createdAt: new Date().toISOString(),
+  });
+
+  return { created: true, id };
+}

--- a/templates/slides/server/plugins/db.ts
+++ b/templates/slides/server/plugins/db.ts
@@ -148,6 +148,19 @@ export default runMigrations(
       version: 17,
       sql: `ALTER TABLE design_systems ADD COLUMN IF NOT EXISTS custom_instructions TEXT NOT NULL DEFAULT ''`,
     },
+    {
+      version: 18,
+      sql: `CREATE TABLE IF NOT EXISTS deck_versions (
+    id TEXT PRIMARY KEY,
+    owner_email TEXT NOT NULL DEFAULT 'local@localhost',
+    deck_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    data TEXT NOT NULL,
+    change_label TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE INDEX IF NOT EXISTS deck_versions_deck_owner_created_idx ON deck_versions (deck_id, owner_email, created_at)`,
+    },
   ],
   { table: "slides_migrations" },
 );

--- a/templates/slides/shared/api.ts
+++ b/templates/slides/shared/api.ts
@@ -89,6 +89,44 @@ export interface SharedDeckResponse {
   aspectRatio?: import("./aspect-ratios").AspectRatio;
 }
 
+// --- Deck Version History ---
+
+export interface DeckVersionSlidePreview {
+  slideNumber: number;
+  id: string | null;
+  layout: string | null;
+  textPreview: string;
+}
+
+export interface DeckVersionSummary {
+  id: string;
+  deckId: string;
+  title: string;
+  label: string | null;
+  createdAt: string;
+  slideCount: number;
+  aspectRatio: import("./aspect-ratios").AspectRatio | null;
+  designSystemId: string | null;
+  slidePreviews: DeckVersionSlidePreview[];
+}
+
+export interface DeckVersionListResponse {
+  deckId: string;
+  count: number;
+  versions: DeckVersionSummary[];
+}
+
+export interface DeckVersion extends DeckVersionSummary {
+  data: Record<string, unknown>;
+  slides: Array<{
+    id: string;
+    content: string;
+    notes?: string;
+    layout?: string;
+    background?: string;
+  }>;
+}
+
 // --- Design Systems ---
 
 export interface DesignSystemData {


### PR DESCRIPTION
## Summary

Three slides API handlers (`decks`, `design-systems`, `share`) each had their own `withAuth` wrapper that resolved the session + org context and ran the handler inside `runWithRequestContext` so `accessFilter` / `resolveAccess` see the caller's `userEmail` + `orgId`. Identical 15-line block in three places, easy to miss when adding a fourth handler.

- New `templates/slides/server/handlers/request-auth-context.ts`:
  - `resolveSlidesRequestAuthContext(event)` — reads `getSession`, then falls back to `getOrgContext` when the session doesn't carry an `orgId` so org-scoped queries still work for users without an explicit active org. Org-table errors are swallowed for first-boot / solo deploys.
  - `withSlidesRequestContext(event, fn)` — runs `fn` inside `runWithRequestContext` populated from the resolved context.
- `decks.ts`, `design-systems.ts`, `share.ts` all import the shared helpers and drop their local `withAuth` copies.
- The SSE `deckEvents` 401 gate in `decks.ts` was also reusing the freshly-removed `getSession` import — switched it to `resolveSlidesRequestAuthContext` so the import isn't dangling.

## Test plan

- [ ] Hit each route (`GET /api/decks`, `GET /api/design-systems`, `POST /api/decks/:id/share`) and confirm `accessFilter` still scopes by orgId
- [ ] `GET /api/decks/events` (SSE) still requires auth and returns 401 for anonymous callers
- [ ] Solo deploy without org tables doesn't break — `getOrgContext` errors are caught and the session-only context is used