### PR TITLE
forms: fix XSS vurnability

### DIFF
--- a/templates/forms/actions/create-form.ts
+++ b/templates/forms/actions/create-form.ts
@@ -7,7 +7,7 @@ import { customAlphabet } from "nanoid";
 import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { assertIntegrationUrlsAllowed } from "../server/lib/integrations.js";
-import { assertValidFieldIds } from "../server/lib/validate-fields.js";
+import { assertValidFields } from "../server/lib/validate-fields.js";
 import type { FormField, FormSettings } from "../shared/types.js";
 
 const nanoid = customAlphabet(
@@ -62,7 +62,7 @@ export default defineAction({
         fields = args.fields as unknown as FormField[];
       }
     }
-    assertValidFieldIds(fields);
+    assertValidFields(fields);
 
     const defaultSettings: FormSettings = {
       submitText: "Submit",

--- a/templates/forms/actions/create-form.ts
+++ b/templates/forms/actions/create-form.ts
@@ -7,6 +7,7 @@ import { customAlphabet } from "nanoid";
 import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { assertIntegrationUrlsAllowed } from "../server/lib/integrations.js";
+import { assertValidFieldIds } from "../server/lib/validate-fields.js";
 import type { FormField, FormSettings } from "../shared/types.js";
 
 const nanoid = customAlphabet(
@@ -61,6 +62,7 @@ export default defineAction({
         fields = args.fields as unknown as FormField[];
       }
     }
+    assertValidFieldIds(fields);
 
     const defaultSettings: FormSettings = {
       submitText: "Submit",

--- a/templates/forms/actions/update-form.ts
+++ b/templates/forms/actions/update-form.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { assertIntegrationUrlsAllowed } from "../server/lib/integrations.js";
-import { assertValidFieldIds } from "../server/lib/validate-fields.js";
+import { assertValidFields } from "../server/lib/validate-fields.js";
 import type { FormField, FormSettings } from "../shared/types.js";
 
 function slugify(text: string): string {
@@ -75,7 +75,7 @@ export default defineAction({
       } else {
         parsedFields = args.fields;
       }
-      assertValidFieldIds(parsedFields);
+      assertValidFields(parsedFields);
       updates.fields = JSON.stringify(parsedFields);
     }
     if (args.settings !== undefined) {

--- a/templates/forms/actions/update-form.ts
+++ b/templates/forms/actions/update-form.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { getDb, schema } from "../server/db/index.js";
 import { assertIntegrationUrlsAllowed } from "../server/lib/integrations.js";
+import { assertValidFieldIds } from "../server/lib/validate-fields.js";
 import type { FormField, FormSettings } from "../shared/types.js";
 
 function slugify(text: string): string {
@@ -64,16 +65,18 @@ export default defineAction({
     if (args.description !== undefined) updates.description = args.description;
     if (args.slug !== undefined) updates.slug = args.slug;
     if (args.fields !== undefined) {
+      let parsedFields: unknown;
       if (typeof args.fields === "string") {
         try {
-          JSON.parse(args.fields);
-          updates.fields = args.fields;
+          parsedFields = JSON.parse(args.fields);
         } catch {
           throw new Error("--fields must be valid JSON");
         }
       } else {
-        updates.fields = JSON.stringify(args.fields);
+        parsedFields = args.fields;
       }
+      assertValidFieldIds(parsedFields);
+      updates.fields = JSON.stringify(parsedFields);
     }
     if (args.settings !== undefined) {
       let parsedSettings: FormSettings;

--- a/templates/forms/app/lib/normalize-fields.ts
+++ b/templates/forms/app/lib/normalize-fields.ts
@@ -1,0 +1,65 @@
+import type { FormField, FormFieldType } from "@shared/types";
+
+// Single source of truth for coercing FormField[] coming back from the API
+// into a renderable shape. Both the agent and the UI can write arbitrary
+// JSON into form.fields — this helper protects every React consumer from:
+//   - missing/object/numeric `type` (defaults to "text" rather than dropping
+//     the field, so the user doesn't silently lose data)
+//   - `options` being a non-array, or an array of {label,value} objects /
+//     numbers / blanks / duplicates (any of which would crash a downstream
+//     `.map()` or render duplicate React keys)
+// FieldRenderer keeps its own `dedupeRenderableOptions` for the *builder*
+// preview where the user is mid-typing — that handles transient live-edit
+// state, not stored data.
+const KNOWN_FIELD_TYPES: FormFieldType[] = [
+  "text",
+  "email",
+  "number",
+  "textarea",
+  "select",
+  "multiselect",
+  "checkbox",
+  "radio",
+  "date",
+  "rating",
+  "scale",
+];
+
+function coerceOptionToString(raw: unknown): string | null {
+  if (typeof raw === "string") return raw;
+  if (raw == null) return null;
+  if (typeof raw === "object") {
+    const v = raw as { label?: unknown; value?: unknown };
+    if (typeof v.label === "string") return v.label;
+    if (typeof v.value === "string") return v.value;
+    return "";
+  }
+  return String(raw);
+}
+
+export function normalizeFields(fields: FormField[] | undefined): FormField[] {
+  if (!Array.isArray(fields)) return [];
+  return fields.map((field) => {
+    const type: FormFieldType =
+      typeof field?.type === "string" &&
+      (KNOWN_FIELD_TYPES as string[]).includes(field.type)
+        ? (field.type as FormFieldType)
+        : "text";
+    const out: FormField = { ...field, type };
+    if (field?.options !== undefined) {
+      const rawList = Array.isArray(field.options) ? field.options : [];
+      const seen = new Set<string>();
+      const cleaned: string[] = [];
+      for (const raw of rawList) {
+        const str = coerceOptionToString(raw);
+        if (str == null) continue;
+        const trimmed = str.trim();
+        if (!trimmed || seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        cleaned.push(trimmed);
+      }
+      out.options = cleaned;
+    }
+    return out;
+  });
+}

--- a/templates/forms/app/pages/FormBuilderPage.tsx
+++ b/templates/forms/app/pages/FormBuilderPage.tsx
@@ -61,7 +61,8 @@ import {
 } from "@/components/ui/tooltip";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { normalizeFields } from "@/lib/normalize-fields";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { format } from "date-fns";
 import type {
   FormField,
@@ -104,54 +105,6 @@ const fieldTypeLabels: Record<FormFieldType, string> = {
   rating: "Rating",
   scale: "Scale",
 };
-
-const knownFieldTypes = Object.keys(fieldTypeLabels) as FormFieldType[];
-
-function normalizeFields(fields: FormField[] | undefined): FormField[] {
-  if (!Array.isArray(fields)) return [];
-  return fields.map((field) => {
-    // Preserve the stored type when it's a recognized string; only fall back
-    // to `text` when the value is missing or the wrong shape (object, number),
-    // so we don't silently drop user data.
-    const type: FormFieldType =
-      typeof field?.type === "string" && knownFieldTypes.includes(field.type)
-        ? field.type
-        : "text";
-    const out: FormField = { ...field, type };
-    // Coerce when `options` is present in any shape — Array.isArray alone
-    // would let non-array values (e.g. `{ label: "A" }`) leak through and
-    // crash downstream `.map()` / `for…of` consumers.
-    if (field?.options !== undefined) {
-      const rawList = Array.isArray(field.options) ? field.options : [];
-      const seen = new Set<string>();
-      const cleaned: string[] = [];
-      for (const raw of rawList) {
-        let str: string;
-        if (typeof raw === "string") {
-          str = raw;
-        } else if (raw && typeof raw === "object") {
-          const v = raw as { label?: unknown; value?: unknown };
-          str =
-            typeof v.label === "string"
-              ? v.label
-              : typeof v.value === "string"
-                ? v.value
-                : "";
-        } else if (raw == null) {
-          continue;
-        } else {
-          str = String(raw);
-        }
-        const trimmed = str.trim();
-        if (!trimmed || seen.has(trimmed)) continue;
-        seen.add(trimmed);
-        cleaned.push(trimmed);
-      }
-      out.options = cleaned;
-    }
-    return out;
-  });
-}
 
 export function FormBuilderPage() {
   const { id } = useParams<{ id: string }>();

--- a/templates/forms/app/pages/FormFillPage.tsx
+++ b/templates/forms/app/pages/FormFillPage.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { FieldRenderer } from "@/components/builder/FieldRenderer";
 import { Turnstile, PoweredByBadge } from "@agent-native/core/client";
 import { cn } from "@/lib/utils";
+import { normalizeFields } from "@/lib/normalize-fields";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { usePublicForm, useSubmitForm } from "@/hooks/use-forms";
 import { toast } from "sonner";
@@ -52,7 +53,10 @@ export function FormFillPage() {
     }
   }, []);
 
-  const fields: FormField[] = form?.fields || [];
+  const fields: FormField[] = useMemo(
+    () => normalizeFields(form?.fields),
+    [form?.fields],
+  );
   const settings: FormSettings = form?.settings || {};
 
   // Evaluate conditional visibility

--- a/templates/forms/app/pages/ResponsesPage.tsx
+++ b/templates/forms/app/pages/ResponsesPage.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { normalizeFields } from "@/lib/normalize-fields";
 import { useForm } from "@/hooks/use-forms";
 import { useFormResponses } from "@/hooks/use-responses";
 import type { FormField } from "@shared/types";
@@ -52,7 +53,10 @@ export function ResponsesPage() {
   const { data, isLoading, error, refetch } = useFormResponses(id!);
 
   const responses = data?.responses || [];
-  const fields: FormField[] = data?.fields || form?.fields || [];
+  const fields: FormField[] = useMemo(
+    () => normalizeFields(data?.fields || form?.fields),
+    [data?.fields, form?.fields],
+  );
   const total = data?.total ?? 0;
 
   const [search, setSearch] = useState("");

--- a/templates/forms/app/routes/form-preview.tsx
+++ b/templates/forms/app/routes/form-preview.tsx
@@ -1,5 +1,6 @@
 import { useSearchParams } from "react-router";
 import { useForm } from "@/hooks/use-forms";
+import { normalizeFields } from "@/lib/normalize-fields";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -106,7 +107,7 @@ export default function FormPreviewRoute() {
     );
   }
 
-  const fields = form.fields ?? [];
+  const fields = normalizeFields(form.fields);
   const inEmbed = isInAgentEmbed();
 
   return (

--- a/templates/forms/server/lib/public-form-ssr.ts
+++ b/templates/forms/server/lib/public-form-ssr.ts
@@ -119,6 +119,11 @@ export function safeRedirectUrl(value: unknown): string {
 }
 
 function renderField(field: FormField): string {
+  // field.id is also gated to /^[A-Za-z0-9_-]+$/ at write time by
+  // assertValidFieldIds (server/lib/validate-fields.ts), so escapeHtml here is
+  // defense-in-depth — if a malformed row ever slips into the DB through
+  // another path, the renderer still won't break out of the attribute.
+  const id = escapeHtml(field.id);
   const req = field.required ? " required" : "";
   const ph = field.placeholder
     ? ` placeholder="${escapeHtml(field.placeholder)}"`
@@ -135,22 +140,22 @@ function renderField(field: FormField): string {
 
   switch (field.type) {
     case "text":
-      input = `<input type="text" name="${field.id}" class="fi"${ph}${req}>`;
+      input = `<input type="text" name="${id}" class="fi"${ph}${req}>`;
       break;
     case "email":
-      input = `<input type="email" name="${field.id}" class="fi"${ph || ' placeholder="you@example.com"'}${req}>`;
+      input = `<input type="email" name="${id}" class="fi"${ph || ' placeholder="you@example.com"'}${req}>`;
       break;
     case "number":
-      input = `<input type="number" name="${field.id}" class="fi"${ph}${req}${field.validation?.min != null ? ` min="${field.validation.min}"` : ""}${field.validation?.max != null ? ` max="${field.validation.max}"` : ""}>`;
+      input = `<input type="number" name="${id}" class="fi"${ph}${req}${field.validation?.min != null ? ` min="${field.validation.min}"` : ""}${field.validation?.max != null ? ` max="${field.validation.max}"` : ""}>`;
       break;
     case "textarea":
-      input = `<textarea name="${field.id}" class="fi fi-ta" rows="4"${ph || ' placeholder="Type your answer..."'}${req}></textarea>`;
+      input = `<textarea name="${id}" class="fi fi-ta" rows="4"${ph || ' placeholder="Type your answer..."'}${req}></textarea>`;
       break;
     case "date":
-      input = `<input type="date" name="${field.id}" class="fi"${req}>`;
+      input = `<input type="date" name="${id}" class="fi"${req}>`;
       break;
     case "select":
-      input = `<select name="${field.id}" class="fi"${req}><option value="">${escapeHtml(field.placeholder) || "Select..."}</option>${normalizeOptions(
+      input = `<select name="${id}" class="fi"${req}><option value="">${escapeHtml(field.placeholder) || "Select..."}</option>${normalizeOptions(
         field.options,
       )
         .map(
@@ -162,28 +167,28 @@ function renderField(field: FormField): string {
       input = `<div class="ms-group">${normalizeOptions(field.options)
         .map(
           (o) =>
-            `<label class="cb-label"><input type="checkbox" name="${field.id}" value="${escapeHtml(o)}" class="cb"><span>${escapeHtml(o)}</span></label>`,
+            `<label class="cb-label"><input type="checkbox" name="${id}" value="${escapeHtml(o)}" class="cb"><span>${escapeHtml(o)}</span></label>`,
         )
         .join("")}</div>`;
       break;
     case "checkbox":
-      input = `<label class="cb-label"><input type="checkbox" name="${field.id}" class="cb"><span>${escapeHtml(field.placeholder || field.label)}</span></label>`;
+      input = `<label class="cb-label"><input type="checkbox" name="${id}" class="cb"><span>${escapeHtml(field.placeholder || field.label)}</span></label>`;
       break;
     case "radio":
       input = `<div class="radio-group">${normalizeOptions(field.options)
         .map(
           (o) =>
-            `<label class="cb-label"><input type="radio" name="${field.id}" value="${escapeHtml(o)}" class="radio"><span>${escapeHtml(o)}</span></label>`,
+            `<label class="cb-label"><input type="radio" name="${id}" value="${escapeHtml(o)}" class="radio"><span>${escapeHtml(o)}</span></label>`,
         )
         .join("")}</div>`;
       break;
     case "rating":
-      input = `<div class="rating-group" data-name="${field.id}">${[1, 2, 3, 4, 5].map((s) => `<button type="button" class="star-btn" data-value="${s}" aria-label="${s} star${s > 1 ? "s" : ""}"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></button>`).join("")}</div><input type="hidden" name="${field.id}">`;
+      input = `<div class="rating-group" data-name="${id}">${[1, 2, 3, 4, 5].map((s) => `<button type="button" class="star-btn" data-value="${s}" aria-label="${s} star${s > 1 ? "s" : ""}"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></button>`).join("")}</div><input type="hidden" name="${id}">`;
       break;
     case "scale": {
       const min = field.validation?.min ?? 1;
       const max = field.validation?.max ?? 10;
-      input = `<div class="scale-group"><input type="range" name="${field.id}" class="slider" min="${min}" max="${max}" value="${min}" step="1"><div class="scale-labels"><span>${min}</span><span class="scale-val">${min}</span><span>${max}</span></div></div>`;
+      input = `<div class="scale-group"><input type="range" name="${id}" class="slider" min="${min}" max="${max}" value="${min}" step="1"><div class="scale-labels"><span>${min}</span><span class="scale-val">${min}</span><span>${max}</span></div></div>`;
       break;
     }
     default:
@@ -191,11 +196,11 @@ function renderField(field: FormField): string {
       // type (e.g. agent wrote "dropdown" instead of "select", or stored an
       // object) renders a plain text input rather than nothing — without this
       // a required field would have no <input>, leaving the form unsubmittable.
-      input = `<input type="text" name="${field.id}" class="fi"${ph}${req}>`;
+      input = `<input type="text" name="${id}" class="fi"${ph}${req}>`;
       break;
   }
 
-  return `<div class="field${widthClass}" data-field-id="${field.id}"${cond}>
+  return `<div class="field${widthClass}" data-field-id="${id}"${cond}>
     <label class="field-label">${escapeHtml(field.label)}${field.required ? '<span class="req">*</span>' : ""}</label>
     ${desc}${input}</div>`;
 }

--- a/templates/forms/server/lib/public-form-ssr.ts
+++ b/templates/forms/server/lib/public-form-ssr.ts
@@ -120,7 +120,7 @@ export function safeRedirectUrl(value: unknown): string {
 
 function renderField(field: FormField): string {
   // field.id is also gated to /^[A-Za-z0-9_-]+$/ at write time by
-  // assertValidFieldIds (server/lib/validate-fields.ts), so escapeHtml here is
+  // assertValidFields (server/lib/validate-fields.ts), so escapeHtml here is
   // defense-in-depth — if a malformed row ever slips into the DB through
   // another path, the renderer still won't break out of the attribute.
   const id = escapeHtml(field.id);
@@ -146,7 +146,7 @@ function renderField(field: FormField): string {
       input = `<input type="email" name="${id}" class="fi"${ph || ' placeholder="you@example.com"'}${req}>`;
       break;
     case "number":
-      input = `<input type="number" name="${id}" class="fi"${ph}${req}${field.validation?.min != null ? ` min="${field.validation.min}"` : ""}${field.validation?.max != null ? ` max="${field.validation.max}"` : ""}>`;
+      input = `<input type="number" name="${id}" class="fi"${ph}${req}${field.validation?.min != null ? ` min="${Number(field.validation.min)}"` : ""}${field.validation?.max != null ? ` max="${Number(field.validation.max)}"` : ""}>`;
       break;
     case "textarea":
       input = `<textarea name="${id}" class="fi fi-ta" rows="4"${ph || ' placeholder="Type your answer..."'}${req}></textarea>`;
@@ -186,8 +186,8 @@ function renderField(field: FormField): string {
       input = `<div class="rating-group" data-name="${id}">${[1, 2, 3, 4, 5].map((s) => `<button type="button" class="star-btn" data-value="${s}" aria-label="${s} star${s > 1 ? "s" : ""}"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></button>`).join("")}</div><input type="hidden" name="${id}">`;
       break;
     case "scale": {
-      const min = field.validation?.min ?? 1;
-      const max = field.validation?.max ?? 10;
+      const min = Number(field.validation?.min ?? 1);
+      const max = Number(field.validation?.max ?? 10);
       input = `<div class="scale-group"><input type="range" name="${id}" class="slider" min="${min}" max="${max}" value="${min}" step="1"><div class="scale-labels"><span>${min}</span><span class="scale-val">${min}</span><span>${max}</span></div></div>`;
       break;
     }

--- a/templates/forms/server/lib/validate-fields.ts
+++ b/templates/forms/server/lib/validate-fields.ts
@@ -5,17 +5,28 @@
 // stored-XSS every anonymous submitter of a published form.
 export const FIELD_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
-export function assertValidFieldIds(fields: unknown): void {
-  if (!Array.isArray(fields)) return;
+export function assertValidFields(fields: unknown): void {
+  if (!Array.isArray(fields)) {
+    throw new Error("fields must be an array");
+  }
+  const seenIds = new Set<string>();
   for (const [idx, field] of fields.entries()) {
-    if (field == null || typeof field !== "object") continue;
+    if (field == null || typeof field !== "object") {
+      throw new Error(`field #${idx + 1} must be an object`);
+    }
     const f = field as Record<string, unknown>;
+
     const id = f.id;
     if (typeof id !== "string" || !FIELD_ID_PATTERN.test(id)) {
       throw new Error(
         `field #${idx + 1} has an invalid id ${JSON.stringify(id)} — must match ${FIELD_ID_PATTERN.source}`,
       );
     }
+    if (seenIds.has(id)) {
+      throw new Error(`duplicate field id "${id}" at position #${idx + 1}`);
+    }
+    seenIds.add(id);
+
     const cond = f.conditional;
     if (cond && typeof cond === "object") {
       const condFieldId = (cond as Record<string, unknown>).fieldId;
@@ -28,6 +39,19 @@ export function assertValidFieldIds(fields: unknown): void {
             `field #${idx + 1} conditional.fieldId ${JSON.stringify(condFieldId)} is invalid — must match ${FIELD_ID_PATTERN.source}`,
           );
         }
+      }
+    }
+
+    // validation.min / .max are interpolated into HTML attributes (min="..."
+    // max="...") by the SSR renderer — must be numeric to prevent XSS.
+    const validation = f.validation;
+    if (validation != null && typeof validation === "object") {
+      const v = validation as Record<string, unknown>;
+      if (v.min != null && !isFinite(Number(v.min))) {
+        throw new Error(`field #${idx + 1} validation.min must be a number`);
+      }
+      if (v.max != null && !isFinite(Number(v.max))) {
+        throw new Error(`field #${idx + 1} validation.max must be a number`);
       }
     }
   }

--- a/templates/forms/server/lib/validate-fields.ts
+++ b/templates/forms/server/lib/validate-fields.ts
@@ -1,0 +1,34 @@
+// Restrict every persisted FormField id (and conditional.fieldId reference)
+// to a safe character set. Field ids are interpolated into raw HTML attributes
+// by the public form SSR renderer and into CSS/JS selectors by the inline
+// runtime — an unrestricted id like `x" onfocus="alert(1)` would otherwise
+// stored-XSS every anonymous submitter of a published form.
+export const FIELD_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export function assertValidFieldIds(fields: unknown): void {
+  if (!Array.isArray(fields)) return;
+  for (const [idx, field] of fields.entries()) {
+    if (field == null || typeof field !== "object") continue;
+    const f = field as Record<string, unknown>;
+    const id = f.id;
+    if (typeof id !== "string" || !FIELD_ID_PATTERN.test(id)) {
+      throw new Error(
+        `field #${idx + 1} has an invalid id ${JSON.stringify(id)} — must match ${FIELD_ID_PATTERN.source}`,
+      );
+    }
+    const cond = f.conditional;
+    if (cond && typeof cond === "object") {
+      const condFieldId = (cond as Record<string, unknown>).fieldId;
+      if (condFieldId !== undefined) {
+        if (
+          typeof condFieldId !== "string" ||
+          !FIELD_ID_PATTERN.test(condFieldId)
+        ) {
+          throw new Error(
+            `field #${idx + 1} conditional.fieldId ${JSON.stringify(condFieldId)} is invalid — must match ${FIELD_ID_PATTERN.source}`,
+          );
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a stored XSS in the forms template's public SSR renderer, and moves `normalizeFields` to a shared helper so every React consumer sees the same shape.

### Stored XSS

`FormField.id` was interpolated raw into HTML attributes (`name="${field.id}"`, `data-field-id="${field.id}"`, etc.) in `public-form-ssr.ts`. A form author could persist `{"id": "x\" autofocus onfocus=\"alert(1)"}` and XSS every anonymous submitter of the published form.

Two layers of defense:

- **Write-time** — new `assertValidFieldIds` (regex `^[A-Za-z0-9_-]+$`) called from `create-form` and `update-form` rejects unsafe ids before they hit the DB.
- **Render-time** — `renderField` now wraps `field.id` in `escapeHtml()` everywhere it's interpolated.

UI-generated ids use `nanoid(8)` already, so legitimate forms keep working.

### normalizeFields cleanup

`normalizeFields()` was local to `FormBuilderPage`, leaving `FormFillPage`, `ResponsesPage`, and the form-preview route to consume raw API data. Moved to `app/lib/normalize-fields.ts` and applied at all four sites.

## Test plan

- [x] `update-form` rejects a payload with an id like `x" onfocus="alert(1)`.
- [x] `pnpm build && pnpm start`, load `/f/<slug>` — view-source shows escaped `field.id` everywhere.
- [x] Existing forms (nanoid ids) save and render unchanged.
- [x] Forms with malformed `options` (objects, numbers, dupes) render cleanly in every consumer.
