### PR TITLE
feat: show camera bubble during countdown

### DIFF
--- a/templates/clips/app/components/recorder/camera-bubble.tsx
+++ b/templates/clips/app/components/recorder/camera-bubble.tsx
@@ -141,7 +141,7 @@ export function CameraBubble({
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
       onDoubleClick={cycleSize}
-      className="fixed z-[90] cursor-grab select-none rounded-full border-4 border-white/80 bg-black shadow-2xl active:cursor-grabbing"
+      className="fixed z-[110] cursor-grab select-none rounded-full border-4 border-white/80 bg-black shadow-2xl active:cursor-grabbing"
       style={{
         width: sizePx,
         height: sizePx,

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -1705,16 +1705,19 @@ export default function RecordRoute() {
       )}
 
       {/* Preview (camera-only mode renders camera full-screen; screen modes
-          rely on the browser's "currently sharing" native pill). */}
-      {recordingMode === "camera" && showRecordingUi && (
-        <video
-          ref={previewVideoRef}
-          autoPlay
-          muted
-          playsInline
-          className="fixed inset-0 h-full w-full object-cover [transform:scaleX(-1)]"
-        />
-      )}
+          rely on the browser's "currently sharing" native pill). Also visible
+          during the countdown so users can frame themselves before recording
+          begins. */}
+      {recordingMode === "camera" &&
+        (showRecordingUi || uiState === "countdown") && (
+          <video
+            ref={previewVideoRef}
+            autoPlay
+            muted
+            playsInline
+            className="fixed inset-0 h-full w-full object-cover [transform:scaleX(-1)]"
+          />
+        )}
 
       {recordingMode !== "camera" && showRecordingUi && (
         <div className="pointer-events-none fixed inset-0 bg-gradient-to-br from-[#1a1a2e] via-[#16213e] to-[#0f0f1a] opacity-95">
@@ -1734,16 +1737,16 @@ export default function RecordRoute() {
         </div>
       )}
 
-      {/* Camera bubble — only visible while actively recording. During
-          uploading/compressing the overlay is semi-transparent (bg-black/70),
-          so a still-visible bubble in the corner makes it look like recording
-          is ongoing. */}
+      {/* Camera bubble — visible during the countdown so the user can frame
+          themselves, and while actively recording. During uploading/compressing
+          the overlay is semi-transparent (bg-black/70), so a still-visible
+          bubble in the corner makes it look like recording is ongoing. */}
       {showCameraBubble && (
         <CameraBubble
           stream={cameraStream}
           size={cameraSize}
           onSizeChange={setCameraSize}
-          hidden={uiState !== "recording"}
+          hidden={uiState !== "recording" && uiState !== "countdown"}
         />
       )}
 

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -1737,10 +1737,10 @@ export default function RecordRoute() {
         </div>
       )}
 
-      {/* Camera bubble — visible during the countdown so the user can frame
-          themselves, and while actively recording. During uploading/compressing
-          the overlay is semi-transparent (bg-black/70), so a still-visible
-          bubble in the corner makes it look like recording is ongoing. */}
+      {/* Camera bubble — visible during countdown (so the user can frame
+          themselves) and while actively recording. Hidden during
+          uploading/compressing so the save overlay isn't confused with an
+          ongoing recording. */}
       {showCameraBubble && (
         <CameraBubble
           stream={cameraStream}


### PR DESCRIPTION
Feature request to add the camera bubble during the countdown phase. I just think its nice so that I can frame myself and get prepared before the recording starts

<img width="1299" height="729" alt="image" src="https://github.com/user-attachments/assets/fce2ae06-d8fd-41e8-a7eb-0172f7a633ae" />
