### PR TITLE
fix(builder-engine): handle invalid_request stop as non-retryable error

### DIFF
--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -577,6 +577,40 @@ describe("createBuilderEngine", () => {
     expect(stop?.error?.toLowerCase()).toContain("rate_limit");
   });
 
+  it("maps invalid_request stops into a non-retryable error stop preserving the gateway message and code", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonlResponse([
+          {
+            type: "stop",
+            reason: "invalid_request",
+            requestId: "req_bad_history",
+            error:
+              "messages.87: `tool_use` ids were found without `tool_result` blocks immediately after: history_tc_80.",
+            errorCode: "tool_message_shape_invalid",
+          },
+        ]),
+      ),
+    );
+
+    const engine = createBuilderEngine();
+    const events = await collectEvents(engine.stream(BASE_OPTS));
+
+    const stop = events.find((e) => e.type === "stop");
+    expect(stop?.reason).toBe("error");
+    expect(stop?.errorCode).toBe("tool_message_shape_invalid");
+    // The Anthropic diagnostic — including the offending block id — must
+    // survive end-to-end so callers can identify what to repair.
+    expect(stop?.error).toContain("history_tc_80");
+    // `tool_message_shape_invalid` contains none of production-agent's
+    // retry-trigger keywords (see isRetryableError), so the run-loop will
+    // not loop on the same malformed history. Lock that in.
+    expect(stop?.error?.toLowerCase()).not.toMatch(
+      /rate_limit|overloaded|503|504|gateway error|socket hang up|connection reset|too many requests|timeout/,
+    );
+  });
+
   it("marks no-detail gateway stop errors as retryable gateway errors", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -600,12 +600,8 @@ describe("createBuilderEngine", () => {
     const stop = events.find((e) => e.type === "stop");
     expect(stop?.reason).toBe("error");
     expect(stop?.errorCode).toBe("tool_message_shape_invalid");
-    // The Anthropic diagnostic — including the offending block id — must
-    // survive end-to-end so callers can identify what to repair.
     expect(stop?.error).toContain("history_tc_80");
-    // `tool_message_shape_invalid` contains none of production-agent's
-    // retry-trigger keywords (see isRetryableError), so the run-loop will
-    // not loop on the same malformed history. Lock that in.
+    // No retry-trigger keywords (see production-agent's isRetryableError).
     expect(stop?.error?.toLowerCase()).not.toMatch(
       /rate_limit|overloaded|503|504|gateway error|socket hang up|connection reset|too many requests|timeout/,
     );

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -506,6 +506,30 @@ async function* parseJsonlStream(
               error: `rate_limit exceeded: ${event.error ?? "upstream provider rate limited"}`,
               errorCode: "rate_limited",
             };
+          } else if (reason === "invalid_request") {
+            // Caller-input failure surfaced by the gateway (e.g.
+            // tool_use/tool_result mismatch). errorCode is a stable
+            // classifier and contains no retry-trigger keywords, so
+            // isRetryableError won't loop on the same broken history.
+            const errMsg =
+              event.error ||
+              event.message ||
+              "Builder gateway rejected the request as malformed.";
+            const errCode =
+              typeof event.errorCode === "string"
+                ? event.errorCode
+                : typeof event.code === "string"
+                  ? event.code
+                  : "invalid_request";
+            console.warn(
+              `[builder-engine] stop reason=invalid_request model=${model} code=${errCode} error=${errMsg}`,
+            );
+            yield {
+              type: "stop",
+              reason: "error",
+              error: errMsg,
+              errorCode: errCode,
+            };
           } else if (reason === "error") {
             // Surface every diagnostic the gateway gave us so the user (and
             // our logs) get more than a bare "Gateway error". The gateway

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -507,10 +507,8 @@ async function* parseJsonlStream(
               errorCode: "rate_limited",
             };
           } else if (reason === "invalid_request") {
-            // Caller-input failure surfaced by the gateway (e.g.
-            // tool_use/tool_result mismatch). errorCode is a stable
-            // classifier and contains no retry-trigger keywords, so
-            // isRetryableError won't loop on the same broken history.
+            // errorCode has no retry-trigger keywords, so isRetryableError
+            // won't loop on broken history.
             const errMsg =
               event.error ||
               event.message ||


### PR DESCRIPTION
depends on https://github.com/BuilderIO/ai-services/pull/5116

## Summary
  - The Builder.io LLM gateway now emits `stop` events with `reason: "invalid_request"` and `errorCode:
  "tool_message_shape_invalid"` when the caller's conversation history has mismatched `tool_use`/`tool_result` blocks (Anthropic 400). Previously this surfaced as a generic 500 with no diagnostic.
  - `builder-engine.ts` now branches on `reason === "invalid_request"` in the JSONL stop-event parser, forwarding the upstream error message and `errorCode` as an `"error"` stop — with no retry-trigger keywords in the error string, so `isRetryableError` in production-agent won't loop on the same broken history.
  - Preserves the offending tool_use id (e.g. `history_tc_80`) from the gateway message so it appears in logs and any user-facing error.