### PR TITLE
fix: scope CHOKIDAR strip + allow clearing workspace app name

### DIFF
--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -111,6 +111,56 @@ describe("workspace dev startup", () => {
     expect(env?.TSC_WATCHDIRECTORY).toBe("DynamicPriorityPolling");
   });
 
+  it("strips inherited watcher env vars when polling is explicitly disabled", async () => {
+    tmpDir = makeWorkspace(["dispatch"]);
+    const fake = fakeSpawn();
+    handle = await runWorkspaceDev({
+      root: tmpDir,
+      env: {
+        ...testEnv(),
+        // Container detected (would normally auto-enable polling) ...
+        BUILDER_PROJECT_ID: "builder-project",
+        // ... but operator explicitly disabled it.
+        AGENT_NATIVE_DEV_USE_POLLING: "0",
+        // Inherited from a stale parent shell — must NOT leak through.
+        CHOKIDAR_USEPOLLING: "1",
+        CHOKIDAR_INTERVAL: "500",
+        TSC_WATCHFILE: "DynamicPriorityPolling",
+        TSC_WATCHDIRECTORY: "DynamicPriorityPolling",
+      },
+      spawnProcess: fake.spawnProcess,
+      openBrowser: false,
+    });
+    await handle.ready;
+
+    const env = fake.calls()[0]?.options?.env;
+    expect(env?.CHOKIDAR_USEPOLLING).toBeUndefined();
+    expect(env?.CHOKIDAR_INTERVAL).toBeUndefined();
+    expect(env?.TSC_WATCHFILE).toBeUndefined();
+    expect(env?.TSC_WATCHDIRECTORY).toBeUndefined();
+  });
+
+  it("preserves user-set watcher env vars when polling is not explicitly disabled", async () => {
+    tmpDir = makeWorkspace(["dispatch"]);
+    const fake = fakeSpawn();
+    handle = await runWorkspaceDev({
+      root: tmpDir,
+      env: {
+        ...testEnv(),
+        // No container, no explicit toggle — auto-detection says no polling.
+        // The user's custom TSC_WATCHFILE override must still pass through.
+        TSC_WATCHFILE: "UseFsEventsWithFallbackDynamicPolling",
+      },
+      spawnProcess: fake.spawnProcess,
+      openBrowser: false,
+    });
+    await handle.ready;
+
+    const env = fake.calls()[0]?.options?.env;
+    expect(env?.TSC_WATCHFILE).toBe("UseFsEventsWithFallbackDynamicPolling");
+    expect(env?.CHOKIDAR_USEPOLLING).toBeUndefined();
+  });
+
   it("uses the root list as fallback when Dispatch is absent", async () => {
     tmpDir = makeWorkspace(["starter"]);
     const fake = fakeSpawn();

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -112,19 +112,33 @@ function readBooleanEnv(value: string | undefined): boolean | undefined {
   return undefined;
 }
 
-export function shouldUsePollingFileWatcher(
+export type PollingFileWatcherMode =
+  | "enable"
+  | "disable-explicit"
+  | "disable-default";
+
+/**
+ * Three-way classification of the polling-watcher decision so callers can
+ * tell apart "the user explicitly turned this off" (where we want to override
+ * any inherited chokidar/TSC env vars from the parent shell) from "we just
+ * didn't auto-detect a Builder/Codespaces/Gitpod container" (where the user's
+ * own watcher vars should pass through untouched).
+ */
+export function pollingFileWatcherMode(
   env: NodeJS.ProcessEnv = process.env,
   root = process.cwd(),
-): boolean {
+): PollingFileWatcherMode {
   const explicit =
     readBooleanEnv(env.AGENT_NATIVE_DEV_USE_POLLING) ??
     readBooleanEnv(env.WORKSPACE_USE_POLLING_WATCHER);
-  if (explicit !== undefined) return explicit;
+  if (explicit === true) return "enable";
+  if (explicit === false) return "disable-explicit";
 
   const chokidarExplicit = readBooleanEnv(env.CHOKIDAR_USEPOLLING);
-  if (chokidarExplicit !== undefined) return chokidarExplicit;
+  if (chokidarExplicit === true) return "enable";
+  if (chokidarExplicit === false) return "disable-explicit";
 
-  return Boolean(
+  const autoEnable = Boolean(
     env.BUILDER_IO_DEV_SERVER ||
     env.BUILDER_PROJECT_ID ||
     env.BUILDER_WORKSPACE_ID ||
@@ -134,13 +148,21 @@ export function shouldUsePollingFileWatcher(
     env.DEVCONTAINER ||
     root.startsWith("/root/app/"),
   );
+  return autoEnable ? "enable" : "disable-default";
+}
+
+export function shouldUsePollingFileWatcher(
+  env: NodeJS.ProcessEnv = process.env,
+  root = process.cwd(),
+): boolean {
+  return pollingFileWatcherMode(env, root) === "enable";
 }
 
 function devWatcherEnv(
   env: NodeJS.ProcessEnv,
-  usePollingFileWatcher: boolean,
+  mode: PollingFileWatcherMode,
 ): NodeJS.ProcessEnv {
-  if (usePollingFileWatcher) {
+  if (mode === "enable") {
     return {
       ...env,
       CHOKIDAR_USEPOLLING: "1",
@@ -149,18 +171,25 @@ function devWatcherEnv(
       TSC_WATCHDIRECTORY: env.TSC_WATCHDIRECTORY ?? "DynamicPriorityPolling",
     };
   }
-  // Explicit disable must override inherited CHOKIDAR_USEPOLLING from the
-  // parent shell so child processes don't silently poll despite the user
-  // setting AGENT_NATIVE_DEV_USE_POLLING=0. Strip the watcher vars instead
-  // of returning env unchanged.
-  const {
-    CHOKIDAR_USEPOLLING: _polling,
-    CHOKIDAR_INTERVAL: _interval,
-    TSC_WATCHFILE: _watchFile,
-    TSC_WATCHDIRECTORY: _watchDir,
-    ...rest
-  } = env;
-  return rest;
+  if (mode === "disable-explicit") {
+    // The user explicitly turned polling off (AGENT_NATIVE_DEV_USE_POLLING=0
+    // / WORKSPACE_USE_POLLING_WATCHER=0 / CHOKIDAR_USEPOLLING=0). Strip the
+    // watcher vars from the child env so an inherited parent-shell
+    // CHOKIDAR_USEPOLLING=1 (or stale TSC_WATCH* override) can't silently
+    // re-enable polling against the user's explicit wish.
+    const {
+      CHOKIDAR_USEPOLLING: _polling,
+      CHOKIDAR_INTERVAL: _interval,
+      TSC_WATCHFILE: _watchFile,
+      TSC_WATCHDIRECTORY: _watchDir,
+      ...rest
+    } = env;
+    return rest;
+  }
+  // mode === "disable-default": no explicit signal either way. Pass the env
+  // through unchanged so legitimate user overrides like
+  // TSC_WATCHFILE=UseFsEventsWithFallbackDynamicPolling survive.
+  return env;
 }
 
 export function initialWorkspaceAppIds(
@@ -456,7 +485,8 @@ export async function runWorkspaceDev(
   );
   const forceVite = env.WORKSPACE_VITE_FORCE === "1";
   const eager = shouldEagerStartWorkspaceApps(args, env);
-  const usePollingFileWatcher = shouldUsePollingFileWatcher(env, root);
+  const pollingMode = pollingFileWatcherMode(env, root);
+  const usePollingFileWatcher = pollingMode === "enable";
   const proxyReadyTimeoutMs = Number(
     env.WORKSPACE_PROXY_READY_TIMEOUT_MS ?? 30_000,
   );
@@ -647,7 +677,7 @@ export async function runWorkspaceDev(
           PORT: String(app.port),
           WORKSPACE_GATEWAY_URL: gatewayUrl,
         },
-        usePollingFileWatcher,
+        pollingMode,
       ),
     });
     app.process = child;

--- a/packages/dispatch/src/server/lib/app-creation-store.ts
+++ b/packages/dispatch/src/server/lib/app-creation-store.ts
@@ -902,10 +902,11 @@ export async function updateWorkspaceAppMetadata(input: {
   const app = apps.find((candidate) => candidate.id === appId);
   if (!app) throw new Error(`Workspace app "${appId}" was not found.`);
 
-  // Treat undefined/null as "field omitted, leave existing value alone"; only
-  // an explicit empty string clears the description. Without this, a partial
-  // update that only touches `name` silently wipes any existing description.
-  const name = input.name?.trim() || app.name;
+  // Treat undefined/null as "field omitted, leave existing value alone"; an
+  // explicit empty string clears the override (the app reverts to its
+  // built-in name / no description). Without this, a partial update that
+  // only touches one field silently wipes the other.
+  const name = input.name == null ? app.name : input.name.trim();
   const description =
     input.description == null
       ? (app.description ?? undefined)

--- a/scripts/dev-lazy.ts
+++ b/scripts/dev-lazy.ts
@@ -182,19 +182,23 @@ function readBooleanEnv(value: string | undefined): boolean | undefined {
   return undefined;
 }
 
-function shouldUsePollingFileWatcher(
+type PollingFileWatcherMode = "enable" | "disable-explicit" | "disable-default";
+
+function pollingFileWatcherMode(
   env: NodeJS.ProcessEnv,
   root: string,
-): boolean {
+): PollingFileWatcherMode {
   const explicit =
     readBooleanEnv(env.AGENT_NATIVE_DEV_USE_POLLING) ??
     readBooleanEnv(env.WORKSPACE_USE_POLLING_WATCHER);
-  if (explicit !== undefined) return explicit;
+  if (explicit === true) return "enable";
+  if (explicit === false) return "disable-explicit";
 
   const chokidarExplicit = readBooleanEnv(env.CHOKIDAR_USEPOLLING);
-  if (chokidarExplicit !== undefined) return chokidarExplicit;
+  if (chokidarExplicit === true) return "enable";
+  if (chokidarExplicit === false) return "disable-explicit";
 
-  return Boolean(
+  const autoEnable = Boolean(
     env.BUILDER_IO_DEV_SERVER ||
     env.BUILDER_PROJECT_ID ||
     env.BUILDER_WORKSPACE_ID ||
@@ -204,12 +208,14 @@ function shouldUsePollingFileWatcher(
     env.DEVCONTAINER ||
     root.startsWith("/root/app/"),
   );
+  return autoEnable ? "enable" : "disable-default";
 }
 
-const usePollingFileWatcher = shouldUsePollingFileWatcher(process.env, ROOT);
+const pollingMode = pollingFileWatcherMode(process.env, ROOT);
+const usePollingFileWatcher = pollingMode === "enable";
 
 function devWatcherEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  if (usePollingFileWatcher) {
+  if (pollingMode === "enable") {
     return {
       ...env,
       CHOKIDAR_USEPOLLING: "1",
@@ -218,18 +224,24 @@ function devWatcherEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
       TSC_WATCHDIRECTORY: env.TSC_WATCHDIRECTORY ?? "DynamicPriorityPolling",
     };
   }
-  // Explicit disable must override inherited CHOKIDAR_USEPOLLING from the
-  // parent shell so child processes don't silently poll despite the user
-  // setting AGENT_NATIVE_DEV_USE_POLLING=0. Strip the watcher vars instead
-  // of returning env unchanged.
-  const {
-    CHOKIDAR_USEPOLLING: _polling,
-    CHOKIDAR_INTERVAL: _interval,
-    TSC_WATCHFILE: _watchFile,
-    TSC_WATCHDIRECTORY: _watchDir,
-    ...rest
-  } = env;
-  return rest;
+  if (pollingMode === "disable-explicit") {
+    // The user explicitly turned polling off. Strip the watcher vars from
+    // the child env so an inherited parent-shell CHOKIDAR_USEPOLLING=1 (or
+    // stale TSC_WATCH* override) can't silently re-enable polling against
+    // the user's explicit wish.
+    const {
+      CHOKIDAR_USEPOLLING: _polling,
+      CHOKIDAR_INTERVAL: _interval,
+      TSC_WATCHFILE: _watchFile,
+      TSC_WATCHDIRECTORY: _watchDir,
+      ...rest
+    } = env;
+    return rest;
+  }
+  // disable-default: no explicit signal either way. Pass the env through
+  // unchanged so legitimate user overrides like
+  // TSC_WATCHFILE=UseFsEventsWithFallbackDynamicPolling survive.
+  return env;
 }
 
 function workspaceAppsJson(): string {

--- a/templates/clips/actions/finalize-recording.ts
+++ b/templates/clips/actions/finalize-recording.ts
@@ -22,7 +22,10 @@ import {
 import { uploadFile } from "@agent-native/core/file-upload";
 import { emit } from "@agent-native/core/event-bus";
 import { captureRouteError } from "@agent-native/core/server";
-import { applyFaststart } from "../server/lib/faststart.js";
+import {
+  applyFaststart,
+  hasPlayableMp4Metadata,
+} from "../server/lib/faststart.js";
 import { debugLog } from "../server/lib/debug.js";
 import requestTranscript from "./request-transcript.js";
 
@@ -283,6 +286,30 @@ export default defineAction({
             err: err instanceof Error ? err.message : String(err),
           });
           uploadData = assembled;
+        }
+
+        if (!hasPlayableMp4Metadata(uploadData)) {
+          const err = new Error(
+            "Recorded MP4 is missing playback metadata. Please retry the recording.",
+          );
+          try {
+            captureRouteError(err, {
+              route: "finalize-recording",
+              tags: {
+                uploadStep: "mp4-validation",
+                videoFormat,
+              },
+              extra: {
+                recordingId: id,
+                dataBytes: uploadData.byteLength,
+                mimeType,
+                ownerEmail,
+              },
+            });
+          } catch {
+            // Sentry must never mask the real validation error.
+          }
+          throw err;
         }
       }
 

--- a/templates/clips/app/components/recorder/recorder-engine.ts
+++ b/templates/clips/app/components/recorder/recorder-engine.ts
@@ -231,6 +231,15 @@ export function pickMimeType(): string {
   return "";
 }
 
+function canStreamMediaRecorderChunks(mimeType: string): boolean {
+  // WebM chunks emitted by MediaRecorder are safe to concatenate. Browser MP4
+  // chunks are not reliably self-contained; in Safari/WebKit we have seen
+  // ftyp+mdat-only assemblies with no top-level moov atom, which storage will
+  // accept but browsers cannot play. Keep MP4/QuickTime as one final recorder
+  // blob and upload that blob in bounded slices after stop().
+  return /^video\/webm(?:;|$)/i.test(mimeType);
+}
+
 export class RecorderEngine {
   readonly opts: Required<
     Pick<RecorderEngineOptions, "chunkIntervalMs" | "uploadUrl" | "abortUrl">
@@ -278,6 +287,7 @@ export class RecorderEngine {
    * fetch quietly complete and the recording finalise server-side.
    */
   private uploadAbort: AbortController | null = null;
+  private streamChunksDuringRecording = true;
 
   private state: RecorderState = "idle";
 
@@ -548,6 +558,9 @@ export class RecorderEngine {
     this.localChunks = [];
     this.totalRecordedBytes = 0;
     this.uploadAbort = new AbortController();
+    this.streamChunksDuringRecording = canStreamMediaRecorderChunks(
+      this.mimeType,
+    );
 
     this.recorder.addEventListener("dataavailable", (event) => {
       const blob = event.data;
@@ -557,8 +570,10 @@ export class RecorderEngine {
       // every chunk on the client side to assemble + re-encode.
       this.localChunks.push(blob);
       this.totalRecordedBytes += blob.size;
-      const index = this.chunkIndex++;
-      this.queueChunk(blob, index, /* isFinal */ false);
+      if (this.streamChunksDuringRecording) {
+        const index = this.chunkIndex++;
+        this.queueChunk(blob, index, /* isFinal */ false);
+      }
     });
 
     this.recorder.addEventListener("stop", () => {
@@ -572,7 +587,11 @@ export class RecorderEngine {
       this.emitError(err);
     });
 
-    this.recorder.start(this.opts.chunkIntervalMs);
+    if (this.streamChunksDuringRecording) {
+      this.recorder.start(this.opts.chunkIntervalMs);
+    } else {
+      this.recorder.start();
+    }
     this.startedAtMs = performance.now();
     this.transition("recording");
   }
@@ -723,6 +742,20 @@ export class RecorderEngine {
           hasAudio,
           hasCamera,
         });
+      } else if (!this.streamChunksDuringRecording) {
+        this.transition("uploading", { progress: 0 });
+        const assembled = new Blob(this.localChunks, { type: this.mimeType });
+        result = await this.uploadBlobInSlices(
+          assembled,
+          this.mimeType,
+          {
+            durationMs,
+            dimensions,
+            hasAudio,
+            hasCamera,
+          },
+          this.uploadAbort?.signal,
+        );
       } else {
         // Send a 0-byte isFinal sentinel — the actual final-chunk bytes
         // were already uploaded by the start()-time listener as a
@@ -931,51 +964,12 @@ export class RecorderEngine {
       }
 
       this.transition("uploading", { progress: 0 });
-
-      // Reset the upload index since the server just wiped its chunks.
-      this.chunkIndex = 0;
-
-      // Slice the (possibly compressed) blob into 5 MB chunks — the server's
-      // chunk handler caps each at ~6 MB so we need to slice. This is the
-      // same approach the file-upload code path uses in `record.tsx`.
-      const UPLOAD_SLICE_BYTES = 5 * 1024 * 1024;
-      const totalSlices = Math.max(
-        1,
-        Math.ceil(finalBlob.size / UPLOAD_SLICE_BYTES),
+      return this.uploadBlobInSlices(
+        finalBlob,
+        compression.outputMimeType,
+        meta,
+        abort.signal,
       );
-      const outputMimeType = compression.outputMimeType;
-
-      let lastResult: Record<string, unknown> | undefined;
-      for (let i = 0; i < totalSlices; i++) {
-        if (abort.signal.aborted) {
-          throw abort.signal.reason instanceof Error
-            ? abort.signal.reason
-            : new Error("Compression upload aborted");
-        }
-        const start = i * UPLOAD_SLICE_BYTES;
-        const end = Math.min(start + UPLOAD_SLICE_BYTES, finalBlob.size);
-        const slice = finalBlob.slice(start, end, outputMimeType);
-        const isFinal = i === totalSlices - 1;
-        const index = this.chunkIndex++;
-        lastResult = await this.uploadChunk(slice, index, {
-          isFinal,
-          total: totalSlices,
-          mimeType: outputMimeType,
-          durationMs: isFinal ? meta.durationMs : undefined,
-          width: isFinal ? meta.dimensions.width : undefined,
-          height: isFinal ? meta.dimensions.height : undefined,
-          hasAudio: isFinal ? meta.hasAudio : undefined,
-          hasCamera: isFinal ? meta.hasCamera : undefined,
-          signal: abort.signal,
-        });
-        this.opts.onChunk?.({
-          index,
-          bytes: slice.size,
-          total: totalSlices,
-        });
-      }
-
-      return lastResult;
     } finally {
       // Always release the controller reference even on throw — otherwise
       // a subsequent cancel() would abort a freshly-started compression.
@@ -1139,6 +1133,61 @@ export class RecorderEngine {
     } catch {
       // ignore — the stop path will surface the original upload error.
     }
+  }
+
+  private async uploadBlobInSlices(
+    blob: Blob,
+    mimeType: string,
+    meta: {
+      durationMs: number;
+      dimensions: { width: number; height: number };
+      hasAudio: boolean;
+      hasCamera: boolean;
+    },
+    signal?: AbortSignal,
+  ): Promise<Record<string, unknown> | undefined> {
+    // Reset the upload index for post-stop blob uploads: MP4/QuickTime never
+    // streamed chunks, and the compression path has just cleared server chunks.
+    this.chunkIndex = 0;
+
+    // The server chunk handler caps each body at ~6 MB, so keep slices under
+    // that cap. This mirrors the local-file upload path in record.tsx.
+    const UPLOAD_SLICE_BYTES = 5 * 1024 * 1024;
+    const totalSlices = Math.max(1, Math.ceil(blob.size / UPLOAD_SLICE_BYTES));
+
+    let lastResult: Record<string, unknown> | undefined;
+    for (let i = 0; i < totalSlices; i++) {
+      if (signal?.aborted) {
+        throw signal.reason instanceof Error
+          ? signal.reason
+          : new Error("Upload aborted");
+      }
+
+      const start = i * UPLOAD_SLICE_BYTES;
+      const end = Math.min(start + UPLOAD_SLICE_BYTES, blob.size);
+      const slice = blob.slice(start, end, mimeType);
+      const isFinal = i === totalSlices - 1;
+      const index = this.chunkIndex++;
+
+      lastResult = await this.uploadChunk(slice, index, {
+        isFinal,
+        total: totalSlices,
+        mimeType,
+        durationMs: isFinal ? meta.durationMs : undefined,
+        width: isFinal ? meta.dimensions.width : undefined,
+        height: isFinal ? meta.dimensions.height : undefined,
+        hasAudio: isFinal ? meta.hasAudio : undefined,
+        hasCamera: isFinal ? meta.hasCamera : undefined,
+        signal,
+      });
+      this.opts.onChunk?.({
+        index,
+        bytes: slice.size,
+        total: totalSlices,
+      });
+    }
+
+    return lastResult;
   }
 
   private async uploadChunk(

--- a/templates/clips/server/lib/faststart.test.ts
+++ b/templates/clips/server/lib/faststart.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { applyFaststart, hasPlayableMp4Metadata } from "./faststart";
+
+function atom(type: string, payload: Uint8Array = new Uint8Array()) {
+  const bytes = new Uint8Array(8 + payload.byteLength);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, bytes.byteLength);
+  for (let i = 0; i < 4; i++) bytes[4 + i] = type.charCodeAt(i);
+  bytes.set(payload, 8);
+  return bytes;
+}
+
+function concat(...chunks: Uint8Array[]) {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function atomOffset(data: Uint8Array, type: string) {
+  const needle = new TextEncoder().encode(type);
+  for (let i = 4; i <= data.byteLength - needle.byteLength; i++) {
+    if (needle.every((byte, n) => data[i + n] === byte)) return i - 4;
+  }
+  return -1;
+}
+
+describe("MP4 faststart helpers", () => {
+  it("detects missing top-level moov metadata", () => {
+    const missingMoov = concat(
+      atom("ftyp", new TextEncoder().encode("isommp42")),
+      atom("wide"),
+      atom("mdat", new Uint8Array([1, 2, 3, 4])),
+    );
+
+    expect(hasPlayableMp4Metadata(missingMoov)).toBe(false);
+  });
+
+  it("moves a trailing moov atom before mdat", () => {
+    const slowStart = concat(
+      atom("ftyp", new TextEncoder().encode("isommp42")),
+      atom("mdat", new Uint8Array([1, 2, 3, 4])),
+      atom("moov"),
+    );
+
+    const fastStart = applyFaststart(slowStart);
+
+    expect(hasPlayableMp4Metadata(fastStart)).toBe(true);
+    expect(atomOffset(fastStart, "moov")).toBeLessThan(
+      atomOffset(fastStart, "mdat"),
+    );
+  });
+});

--- a/templates/clips/server/lib/faststart.test.ts
+++ b/templates/clips/server/lib/faststart.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 import { applyFaststart, hasPlayableMp4Metadata } from "./faststart";
 
 function atom(type: string, payload: Uint8Array = new Uint8Array()) {
@@ -37,7 +38,7 @@ describe("MP4 faststart helpers", () => {
       atom("mdat", new Uint8Array([1, 2, 3, 4])),
     );
 
-    expect(hasPlayableMp4Metadata(missingMoov)).toBe(false);
+    assert.equal(hasPlayableMp4Metadata(missingMoov), false);
   });
 
   it("moves a trailing moov atom before mdat", () => {
@@ -49,9 +50,7 @@ describe("MP4 faststart helpers", () => {
 
     const fastStart = applyFaststart(slowStart);
 
-    expect(hasPlayableMp4Metadata(fastStart)).toBe(true);
-    expect(atomOffset(fastStart, "moov")).toBeLessThan(
-      atomOffset(fastStart, "mdat"),
-    );
+    assert.equal(hasPlayableMp4Metadata(fastStart), true);
+    assert.ok(atomOffset(fastStart, "moov") < atomOffset(fastStart, "mdat"));
   });
 });

--- a/templates/clips/server/lib/faststart.ts
+++ b/templates/clips/server/lib/faststart.ts
@@ -213,3 +213,14 @@ export function applyFaststart(data: Uint8Array): Uint8Array {
 
   return result;
 }
+
+/**
+ * Return true only when an MP4 buffer has a top-level `moov` atom. Browsers
+ * need this metadata to load duration/tracks; an ftyp+mdat-only file can be
+ * served by storage just fine but will fail playback.
+ */
+export function hasPlayableMp4Metadata(data: Uint8Array): boolean {
+  if (data.byteLength < 8) return false;
+  if (readType(data, 4) !== "ftyp") return false;
+  return parseTopLevelAtoms(data).some((atom) => atom.type === "moov");
+}

--- a/templates/clips/server/lib/faststart.ts
+++ b/templates/clips/server/lib/faststart.ts
@@ -66,7 +66,7 @@ function parseTopLevelAtoms(buf: Uint8Array): AtomInfo[] {
   let pos = 0;
   const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
 
-  while (pos < buf.byteLength - 8) {
+  while (pos <= buf.byteLength - 8) {
     let size = readU32(buf, pos);
     const type = readType(buf, pos + 4);
     let headerSize = 8;
@@ -104,7 +104,7 @@ function walkContainer(
   delta: number,
 ): void {
   let pos = start;
-  while (pos < end - 8) {
+  while (pos <= end - 8) {
     let size = readU32(buf, pos);
     const type = readType(buf, pos + 4);
     let headerSize = 8;

--- a/templates/mail/app/components/email/EmailList.tsx
+++ b/templates/mail/app/components/email/EmailList.tsx
@@ -612,6 +612,7 @@ export function EmailList({
           id: t.latestMessage.id,
           accountEmail: t.latestMessage.accountEmail,
           removeLabel: labelParam || undefined,
+          threadId: t.latestMessage.threadId || t.latestMessage.id,
         });
       }
       setSelectedIds(new Set());
@@ -1120,6 +1121,7 @@ export function EmailList({
         id,
         accountEmail: thread.latestMessage.accountEmail,
         removeLabel: labelParam || undefined,
+        threadId: tid,
       });
     },
     [

--- a/templates/mail/app/components/email/EmailThread.tsx
+++ b/templates/mail/app/components/email/EmailThread.tsx
@@ -607,6 +607,7 @@ export function EmailThread({
         id: t.id,
         accountEmail: t.accountEmail,
         removeLabel: labelParam || undefined,
+        threadId: t.threadId || t.id,
       });
     }
     setSelectedIds?.(new Set());

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import {
   useQuery,
   useInfiniteQuery,
@@ -593,23 +593,24 @@ export function useMarkThreadRead() {
   const qc = useQueryClient();
   // Per-thread pending entries — using a Map so concurrent mutations for different
   // threads don't overwrite each other's pending entries.
-  const pendingByThread = new Map<
-    string,
-    { id: string; accountEmail?: string }[]
-  >();
+  const pendingByThread = useRef(
+    new Map<
+      string,
+      { id: string; accountEmail?: string }[]
+    >(),
+  );
   return useMutation({
     mutationFn: async (threadId: string) => {
-      const entries = pendingByThread.get(threadId) ?? [];
-      pendingByThread.delete(threadId);
+      const entries = pendingByThread.current.get(threadId) ?? [];
+      pendingByThread.current.delete(threadId);
       if (entries.length > 0) {
-        await Promise.all(
-          entries.map(({ id, accountEmail }) =>
-            apiFetch(`/api/emails/${id}/read`, {
-              method: "PATCH",
-              body: JSON.stringify({ isRead: true, accountEmail }),
-            }),
-          ),
-        );
+        await apiFetch(`/api/threads/${threadId}/read`, {
+          method: "PATCH",
+          body: JSON.stringify({
+            isRead: true,
+            accountEmail: entries[0]?.accountEmail,
+          }),
+        });
       }
     },
     onMutate: async (threadId) => {
@@ -623,7 +624,7 @@ export function useMarkThreadRead() {
       const unreadEntries = allEmails
         .filter((e) => (e.threadId || e.id) === threadId && !e.isRead)
         .map((e) => ({ id: e.id, accountEmail: e.accountEmail }));
-      pendingByThread.set(threadId, unreadEntries);
+      pendingByThread.current.set(threadId, unreadEntries);
       const unreadIds = unreadEntries.map((e) => e.id);
       // Set overrides so refetches don't revert read state
       for (const id of unreadIds) {
@@ -712,14 +713,16 @@ export function useArchiveEmail() {
       id,
       accountEmail,
       removeLabel,
+      threadId,
     }: {
       id: string;
       accountEmail?: string;
       removeLabel?: string;
+      threadId?: string;
     }) =>
       apiFetch(`/api/emails/${id}/archive`, {
         method: "PATCH",
-        body: JSON.stringify({ accountEmail, removeLabel }),
+        body: JSON.stringify({ accountEmail, removeLabel, threadId }),
       }),
     onMutate: async ({
       id,

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -594,10 +594,7 @@ export function useMarkThreadRead() {
   // Per-thread pending entries — using a Map so concurrent mutations for different
   // threads don't overwrite each other's pending entries.
   const pendingByThread = useRef(
-    new Map<
-      string,
-      { id: string; accountEmail?: string }[]
-    >(),
+    new Map<string, { id: string; accountEmail?: string }[]>(),
   );
   return useMutation({
     mutationFn: async (threadId: string) => {

--- a/templates/mail/app/hooks/use-emails.ts
+++ b/templates/mail/app/hooks/use-emails.ts
@@ -727,6 +727,7 @@ export function useArchiveEmail() {
       id: string;
       accountEmail?: string;
       removeLabel?: string;
+      threadId?: string;
     }) => {
       await qc.cancelQueries({ queryKey: ["emails"] });
       const previous = qc.getQueriesData<InfiniteEmails>({

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -816,6 +816,56 @@ export const markRead = defineEventHandler(async (event: H3Event) => {
   return emails[idx];
 });
 
+export const markThreadRead = defineEventHandler(async (event: H3Event) => {
+  const email = await userEmail(event);
+  const threadId = getRouterParam(event, "threadId") as string;
+  const body = ((await readBody(event).catch(() => ({}))) ?? {}) as {
+    isRead?: boolean;
+    accountEmail?: string;
+  };
+  const isRead = body.isRead !== false;
+
+  if (await isConnected(email)) {
+    const acct = await resolveAccountEmail(body.accountEmail, email);
+    const accessToken = await getAccessToken(acct);
+    if (!accessToken) {
+      setResponseStatus(event, 401);
+      return { error: "No valid access token for account" };
+    }
+    try {
+      await gmailModifyThread(
+        accessToken,
+        threadId,
+        isRead ? undefined : ["UNREAD"],
+        isRead ? ["UNREAD"] : undefined,
+      );
+      invalidateThreadCache(email, threadId);
+      return { threadId, isRead };
+    } catch (error: any) {
+      console.error("[markThreadRead] Gmail error:", error.message);
+      setResponseStatus(event, 500);
+      return { error: error.message };
+    }
+  }
+
+  const emails = await readEmails(email);
+  let changed = false;
+  for (let i = 0; i < emails.length; i++) {
+    const key = emails[i].threadId || emails[i].id;
+    if (key === threadId && emails[i].isRead !== isRead) {
+      emails[i] = { ...emails[i], isRead };
+      changed = true;
+    }
+  }
+
+  if (!changed) return { threadId, isRead };
+
+  await writeEmails(email, emails, { requestSource: reqSource(event) });
+  const labels = recomputeUnreadCounts(emails, await readLabels(email));
+  await writeLabels(email, labels, { requestSource: reqSource(event) });
+  return { threadId, isRead };
+});
+
 // ─── Toggle star ──────────────────────────────────────────────────────────────
 
 export const toggleStar = defineEventHandler(async (event: H3Event) => {
@@ -866,7 +916,11 @@ export const toggleStar = defineEventHandler(async (event: H3Event) => {
 
 export const archiveEmail = defineEventHandler(async (event: H3Event) => {
   const email = await userEmail(event);
-  const body = await readBody(event);
+  const body = ((await readBody(event).catch(() => ({}))) ?? {}) as {
+    accountEmail?: string;
+    removeLabel?: string;
+    threadId?: string;
+  };
   if (await isConnected(email)) {
     const acct = await resolveAccountEmail(body?.accountEmail, email);
     const accessToken = await getAccessToken(acct);
@@ -876,12 +930,18 @@ export const archiveEmail = defineEventHandler(async (event: H3Event) => {
     }
     try {
       const id = getRouterParam(event, "id") as string;
-      const msg = await gmailGetMessage(accessToken, id, "minimal");
+      let threadId = body.threadId;
+      let labelIds: string[] | undefined;
+      if (!threadId || body.removeLabel) {
+        const msg = await gmailGetMessage(accessToken, id, "minimal");
+        threadId = threadId || msg.threadId;
+        labelIds = msg.labelIds;
+      }
       // Remove INBOX + the current label (if archiving from a label view)
       const removeLabels = ["INBOX"];
-      if (body?.removeLabel) {
+      if (body.removeLabel) {
         // Gmail label IDs for user labels are the label name or a Label_N id
-        const labelId = msg.labelIds?.find(
+        const labelId = labelIds?.find(
           (l: string) =>
             l === body.removeLabel ||
             l.toLowerCase() === body.removeLabel.toLowerCase(),
@@ -890,14 +950,9 @@ export const archiveEmail = defineEventHandler(async (event: H3Event) => {
           removeLabels.push(labelId);
         }
       }
-      await gmailModifyThread(
-        accessToken,
-        msg.threadId,
-        undefined,
-        removeLabels,
-      );
-      invalidateThreadCache(email, msg.threadId);
-      return { id, threadId: msg.threadId, isArchived: true };
+      await gmailModifyThread(accessToken, threadId, undefined, removeLabels);
+      invalidateThreadCache(email, threadId);
+      return { id, threadId, isArchived: true };
     } catch (error: any) {
       console.error("[archiveEmail] Gmail error:", error.message);
       setResponseStatus(event, 500);

--- a/templates/mail/server/handlers/emails.ts
+++ b/templates/mail/server/handlers/emails.ts
@@ -937,6 +937,10 @@ export const archiveEmail = defineEventHandler(async (event: H3Event) => {
         threadId = threadId || msg.threadId;
         labelIds = msg.labelIds;
       }
+      if (!threadId) {
+        setResponseStatus(event, 404);
+        return { error: "Thread not found" };
+      }
       // Remove INBOX + the current label (if archiving from a label view)
       const removeLabels = ["INBOX"];
       if (body.removeLabel) {

--- a/templates/mail/server/routes/api/threads/[threadId]/read.patch.ts
+++ b/templates/mail/server/routes/api/threads/[threadId]/read.patch.ts
@@ -1,0 +1,1 @@
+export { markThreadRead as default } from "../../../../handlers/emails.js";


### PR DESCRIPTION
## Summary

Three follow-ups the builder-io bot flagged on PR #668 that landed post-merge.

- **workspace-dev / dev-lazy** — the previous CHOKIDAR fix stripped `CHOKIDAR_*` and `TSC_WATCH*` on every "not polling" path. That over-corrected: when polling was just auto-detected as off (no explicit toggle), legitimate user overrides like `TSC_WATCHFILE=UseFsEventsWithFallbackDynamicPolling` got wiped too. Replace the boolean with a three-way mode `enable | disable-explicit | disable-default`; only the explicit-disable branch strips.
- **workspace-dev spec** — two new tests: explicit-disable strips inherited watcher vars; disable-default preserves user-set `TSC_WATCHFILE`.
- **dispatch app-creation-store** — \`name\` field now uses the same \`== null\` pattern as \`description\`. Omitted preserves existing; explicit empty string clears the override (app reverts to its built-in template name).

None of these are prod-critical (dev-only watcher tooling + workspace-app metadata edit form) — shipping as a normal follow-up rather than a hotfix.

## Test plan

- [ ] \`pnpm --filter @agent-native/core test workspace-dev.spec\` passes (1543 tests green locally)
- [ ] Dev with \`AGENT_NATIVE_DEV_USE_POLLING=0\` + parent shell \`CHOKIDAR_USEPOLLING=1\` → child env has no watcher vars
- [ ] Dev with no explicit toggle + custom \`TSC_WATCHFILE\` → child env keeps the override
- [ ] Dispatch workspace-app edit: send \`{ name: "" }\` → built-in name returns; send \`{ name: "X" }\` only → existing description survives