### PR TITLE
fix(core): clear inherited workspace app overrides via empty pkg.json paths

### DIFF
--- a/.changeset/collaborative-agent-coach.md
+++ b/.changeset/collaborative-agent-coach.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Coach users through stalled agent tasks with clearer troubleshooting and next-step guidance.

--- a/.changeset/empty-route-access-overrides.md
+++ b/.changeset/empty-route-access-overrides.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+`workspaceAppRouteAccessFromPackageJson` now returns optional `publicPaths` / `protectedPaths` so consumers can distinguish "field absent" from "field explicitly empty." `workspace-deploy`, `workspace-dev`, and `agent-discovery` prefer the package.json value whenever it was set (even `[]`), so an app owner can clear an inherited manifest override by writing `"publicPaths": []` in its `package.json`.

--- a/.changeset/stale-gateway-wakeup.md
+++ b/.changeset/stale-gateway-wakeup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Surface workspace app startup timeouts instead of looping forever on the gateway wake screen.

--- a/.changeset/vault-access-policy.md
+++ b/.changeset/vault-access-policy.md
@@ -3,4 +3,4 @@
 "@agent-native/dispatch": patch
 ---
 
-Default Dispatch vault access to all workspace apps, add manual grant mode, and fix org-scoped vault listing.
+Default Dispatch vault access to all workspace apps, add manual grant mode, sync vault keys into encrypted app secrets, and fix org-scoped vault listing.

--- a/packages/core/src/cli/workspace-dev.spec.ts
+++ b/packages/core/src/cli/workspace-dev.spec.ts
@@ -396,6 +396,35 @@ describe("workspace dev startup", () => {
     expect(html).toContain("@agent-native/example");
     expect(fake.startedApps()).toEqual(["dispatch"]);
   });
+
+  it("turns a never-ready child process into a visible retrying failure", async () => {
+    tmpDir = makeWorkspace(["dispatch"]);
+    const fake = fakeSpawn();
+    handle = await runWorkspaceDev({
+      root: tmpDir,
+      env: { ...testEnv(), WORKSPACE_PROXY_READY_TIMEOUT_MS: "50" },
+      spawnProcess: fake.spawnProcess,
+      openBrowser: false,
+    });
+    const { url } = await handle.ready;
+
+    const first = await fetch(`${url}/dispatch`, {
+      headers: { accept: "text/html" },
+    });
+    expect(await first.text()).toContain("Starting Dispatch");
+
+    await waitUntil(() => Boolean(handle?.apps[0]?.lastFailure), 500);
+
+    const res = await fetch(`${url}/dispatch`, {
+      headers: { accept: "text/html" },
+    });
+    const html = await res.text();
+
+    expect(html).toContain("App failed to start: Dispatch");
+    expect(html).toContain("Timed out waiting 50ms");
+    expect(html).toContain("127.0.0.1:");
+    expect(fake.calls().at(-1)?.child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
 });
 
 describe("workspace dev helpers", () => {

--- a/packages/core/src/cli/workspace-dev.ts
+++ b/packages/core/src/cli/workspace-dev.ts
@@ -255,8 +255,8 @@ function discoverApps(appsDir: string, appPortStart: number): WorkspaceApp[] {
         audience:
           workspaceAppAudienceFromPackageJson(pkg) ??
           DEFAULT_WORKSPACE_APP_AUDIENCE,
-        publicPaths: routeAccess.publicPaths,
-        protectedPaths: routeAccess.protectedPaths,
+        publicPaths: routeAccess.publicPaths ?? [],
+        protectedPaths: routeAccess.protectedPaths ?? [],
         dir,
         port: appPortStart,
       } satisfies WorkspaceApp;
@@ -327,6 +327,11 @@ function appRestartDelay(attempts: number): number {
     1_000 * 2 ** Math.max(0, attempts - 1),
     APP_RESTART_MAX_DELAY_MS,
   );
+}
+
+function formatProxyReadyTimeout(timeoutMs: number): string {
+  const seconds = timeoutMs / 1_000;
+  return Number.isInteger(seconds) ? `${seconds}s` : `${timeoutMs}ms`;
 }
 
 function probePort(port: number, timeoutMs = 1_000): Promise<boolean> {
@@ -744,6 +749,7 @@ export async function runWorkspaceDev(
       app.installing = false;
       app.ready = false;
       app.readinessProbe = undefined;
+      if (app.restartTimer) return;
       if (code === 0 || shuttingDown) {
         if (wasInstalling && code === 0 && !shuttingDown) {
           app.installAttempted = true;
@@ -752,28 +758,70 @@ export async function runWorkspaceDev(
         return;
       }
       if (wasInstalling) app.installAttempted = false;
-      app.restartAttempts = (app.restartAttempts ?? 0) + 1;
-      const delay = appRestartDelay(app.restartAttempts);
-      const nextRetryAt = Date.now() + delay;
-      app.lastFailure = {
+      scheduleAppRestart(app, {
         code,
         signal,
-        at: Date.now(),
         installing: wasInstalling,
         output: app.outputTail ?? "",
-        nextRetryAt,
-      };
-      stderr.write(
-        `${prefix} exited with code ${code}; retrying in ${Math.round(
-          delay / 1000,
-        )}s\n`,
-      );
-      app.restartTimer = setTimeout(() => {
-        app.restartTimer = undefined;
-        startApp(app);
-      }, delay);
-      app.restartTimer.unref();
+        logMessage: `exited with code ${code}`,
+      });
     });
+  }
+
+  function scheduleAppRestart(
+    app: WorkspaceApp,
+    input: {
+      code: number | null;
+      signal: NodeJS.Signals | null;
+      installing: boolean;
+      output: string;
+      logMessage: string;
+    },
+  ): void {
+    if (shuttingDown || app.restartTimer) return;
+    if (input.installing) app.installAttempted = false;
+    app.restartAttempts = (app.restartAttempts ?? 0) + 1;
+    const delay = appRestartDelay(app.restartAttempts);
+    const nextRetryAt = Date.now() + delay;
+    app.lastFailure = {
+      code: input.code,
+      signal: input.signal,
+      at: Date.now(),
+      installing: input.installing,
+      output: input.output,
+      nextRetryAt,
+    };
+    stderr.write(
+      `[${app.id}] ${input.logMessage}; retrying in ${Math.round(
+        delay / 1000,
+      )}s\n`,
+    );
+    app.restartTimer = setTimeout(() => {
+      app.restartTimer = undefined;
+      startApp(app);
+    }, delay);
+    app.restartTimer.unref();
+  }
+
+  function failAppStartupTimeout(app: WorkspaceApp): void {
+    if (app.installing || app.ready || app.restartTimer) return;
+    const timeout = formatProxyReadyTimeout(proxyReadyTimeoutMs);
+    const message =
+      `Timed out waiting ${timeout} for /${app.id} to accept ` +
+      `connections on 127.0.0.1:${app.port}.`;
+    const output = [message, app.outputTail?.trim()]
+      .filter(Boolean)
+      .join("\n\nLast child output:\n");
+    app.ready = false;
+    app.readinessProbe = undefined;
+    scheduleAppRestart(app, {
+      code: null,
+      signal: null,
+      installing: false,
+      output,
+      logMessage: message,
+    });
+    app.process?.kill("SIGTERM");
   }
 
   function forwardedProto(req: http.IncomingMessage): string {
@@ -812,10 +860,14 @@ export async function runWorkspaceDev(
   }
 
   function ensureReadinessProbe(app: WorkspaceApp): void {
-    if (app.ready || app.readinessProbe) return;
+    if (app.ready || app.readinessProbe || app.installing) return;
     app.readinessProbe = waitForPort(app.port, Date.now() + proxyReadyTimeoutMs)
       .then((ready) => {
-        if (ready) app.ready = true;
+        if (ready) {
+          app.ready = true;
+          return;
+        }
+        failAppStartupTimeout(app);
       })
       .finally(() => {
         app.readinessProbe = undefined;
@@ -882,6 +934,7 @@ export async function runWorkspaceDev(
     void waitForPort(app.port, Date.now() + proxyReadyTimeoutMs).then(
       (ready) => {
         if (!ready) {
+          failAppStartupTimeout(app);
           if (!res.headersSent) {
             res.writeHead(502, { "content-type": "text/plain" });
             res.end(
@@ -908,6 +961,7 @@ export async function runWorkspaceDev(
     void waitForPort(app.port, Date.now() + proxyReadyTimeoutMs).then(
       (ready) => {
         if (!ready) {
+          failAppStartupTimeout(app);
           socket.destroy();
           return;
         }

--- a/packages/core/src/deploy/workspace-deploy.ts
+++ b/packages/core/src/deploy/workspace-deploy.ts
@@ -897,14 +897,15 @@ function readWorkspaceAppManifest(
         explicit?.audience ??
         DEFAULT_WORKSPACE_APP_AUDIENCE;
       const packageRouteAccess = workspaceAppRouteAccessFromPackageJson(pkg);
+      // Prefer the package.json value whenever the field was set — including
+      // an explicit empty array, which is how a per-app package.json signals
+      // "clear any previously-published manifest override." Falling back on
+      // length > 0 would silently keep the explicit override even after the
+      // app owner blanked their list.
       const publicPaths =
-        packageRouteAccess.publicPaths.length > 0
-          ? packageRouteAccess.publicPaths
-          : (explicit?.publicPaths ?? []);
+        packageRouteAccess.publicPaths ?? explicit?.publicPaths ?? [];
       const protectedPaths =
-        packageRouteAccess.protectedPaths.length > 0
-          ? packageRouteAccess.protectedPaths
-          : (explicit?.protectedPaths ?? []);
+        packageRouteAccess.protectedPaths ?? explicit?.protectedPaths ?? [];
       return {
         id: app,
         name: pkg?.displayName || titleCase(app),

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1560,6 +1560,7 @@ const FRAMEWORK_CORE_COMPACT = `
 11. **Find tools when unsure** — Use \`tool-search\` to find the exact action/tool for a capability. It searches the live registry, including connected MCP server tools.
 12. **Relative dates use runtime context** — The \`<runtime-context>\` block gives the authoritative current date/time. Resolve "today", "yesterday", "last week", and similar phrases to explicit calendar dates before querying data or creating artifacts.
 13. **Make progress visible** — For work that takes more than a few seconds, keep the user oriented. Use \`manage-progress\` when available, emit concise status before long tool/action runs, and update after meaningful milestones so the chat never looks like it is spinning on nothing.
+14. **Collaborate through uncertainty** — If a task stalls, errors, or depends on setup the user may not know about, shift into builder-coach mode instead of repeating the same attempt. State what you verified, name the most likely next checks, and proactively try common unblockers you can inspect (for example prompt size, missing environment variables, unavailable connections, current screen state, or tool choice). When you finish a meaningful step, offer one or two concrete next steps or improvements so non-technical users can keep iterating.
 
 ### Resources
 
@@ -1761,6 +1762,7 @@ const FRAMEWORK_CORE = `
 11. **Find tools when unsure** — Use \`tool-search\` to find the exact action/tool for a capability. It searches the live registry, including connected MCP server tools added through config, settings, or the MCP hub.
 12. **Relative dates use runtime context** — The \`<runtime-context>\` block gives the authoritative current date/time. Resolve "today", "yesterday", "last week", and similar phrases to explicit calendar dates before querying data or creating artifacts. When answering factual questions, include the exact date or date range you used.
 13. **Make progress visible** — For work that takes more than a few seconds, keep the user oriented. Use \`manage-progress\` when available, emit concise status before long tool/action runs, and update after meaningful milestones so the chat never looks like it is spinning on nothing.
+14. **Collaborate through uncertainty** — If a task stalls, errors, or depends on setup the user may not know about, shift into builder-coach mode instead of repeating the same attempt. State what you verified, name the most likely next checks, and proactively try common unblockers you can inspect (for example prompt size, missing environment variables, unavailable connections, current screen state, or tool choice). When you finish a meaningful step, offer one or two concrete next steps or improvements so non-technical users can keep iterating.
 
 ### Resources
 

--- a/packages/core/src/server/agent-discovery.ts
+++ b/packages/core/src/server/agent-discovery.ts
@@ -522,8 +522,8 @@ function readWorkspaceAppsFromFilesystem(): WorkspaceAppManifestEntry[] | null {
         audience:
           workspaceAppAudienceFromPackageJson(pkg) ??
           DEFAULT_WORKSPACE_APP_AUDIENCE,
-        publicPaths: routeAccess.publicPaths,
-        protectedPaths: routeAccess.protectedPaths,
+        publicPaths: routeAccess.publicPaths ?? [],
+        protectedPaths: routeAccess.protectedPaths ?? [],
       } satisfies WorkspaceAppManifestEntry;
     })
     .filter((app): app is WorkspaceAppManifestEntry => !!app)

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -29,5 +29,6 @@ export {
   workspaceAppRouteAccessFromEnv,
   workspaceAppRouteAccessFromPackageJson,
   type WorkspaceAppRouteAccess,
+  type WorkspaceAppRouteAccessFromConfig,
   type WorkspaceAppAudience,
 } from "./workspace-app-audience.js";

--- a/packages/core/src/shared/workspace-app-audience.spec.ts
+++ b/packages/core/src/shared/workspace-app-audience.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeWorkspaceAppPathList,
+  workspaceAppRouteAccessFromPackageJson,
+} from "./workspace-app-audience.js";
+
+describe("workspaceAppRouteAccessFromPackageJson", () => {
+  it("returns undefined fields when keys are absent", () => {
+    expect(
+      workspaceAppRouteAccessFromPackageJson({
+        name: "demo",
+        "agent-native": {},
+      }),
+    ).toEqual({});
+  });
+
+  it("distinguishes explicitly empty array from missing field", () => {
+    const result = workspaceAppRouteAccessFromPackageJson({
+      "agent-native": { workspaceApp: { publicPaths: [] } },
+    });
+    expect(result.publicPaths).toEqual([]);
+    expect(result.protectedPaths).toBeUndefined();
+  });
+
+  it("ignores garbage scalar types so typos don't silently clear overrides", () => {
+    // false / 0 / {} all normalize to [] inside normalizeWorkspaceAppPathList;
+    // the guard must reject them before they become "explicitly empty".
+    for (const bad of [false, 0, {}, true]) {
+      expect(
+        workspaceAppRouteAccessFromPackageJson({
+          "agent-native": { workspaceApp: { publicPaths: bad } },
+        }),
+      ).toEqual({});
+    }
+  });
+
+  it("accepts string paths (parsed as JSON or comma-separated)", () => {
+    expect(
+      workspaceAppRouteAccessFromPackageJson({
+        "agent-native": {
+          workspaceApp: { publicPaths: '["/share","/embed"]' },
+        },
+      }),
+    ).toEqual({ publicPaths: ["/share", "/embed"] });
+    expect(
+      workspaceAppRouteAccessFromPackageJson({
+        "agent-native": { workspaceApp: { publicPaths: "/api,/share" } },
+      }),
+    ).toEqual({ publicPaths: ["/api", "/share"] });
+  });
+
+  it("treats null as absent (falls through the alias `??` chain)", () => {
+    // The alias resolution uses `??`, so null doesn't short-circuit. To
+    // clear an inherited override, use an empty array.
+    expect(
+      workspaceAppRouteAccessFromPackageJson({
+        "agent-native": { workspaceApp: { publicPaths: null } },
+      }),
+    ).toEqual({});
+  });
+});
+
+describe("normalizeWorkspaceAppPathList", () => {
+  it("preserves JSON-parsed scalar path", () => {
+    expect(normalizeWorkspaceAppPathList('"/api"')).toEqual(["/api"]);
+  });
+
+  it("filters and dedupes entries that don't start with /", () => {
+    expect(normalizeWorkspaceAppPathList(["/a", "/a", "no-slash", ""])).toEqual(
+      ["/a"],
+    );
+  });
+
+  it("strips trailing slash but keeps the root slash", () => {
+    expect(normalizeWorkspaceAppPathList(["/foo/"])).toEqual(["/foo"]);
+  });
+});

--- a/packages/core/src/shared/workspace-app-audience.ts
+++ b/packages/core/src/shared/workspace-app-audience.ts
@@ -112,13 +112,29 @@ export function workspaceAppRouteAccessFromPackageJson(
     config?.protectedPaths ??
     config?.root?.workspaceAppProtectedPaths;
   return {
-    ...(rawPublic === undefined
-      ? {}
-      : { publicPaths: normalizeWorkspaceAppPathList(rawPublic) }),
-    ...(rawProtected === undefined
-      ? {}
-      : { protectedPaths: normalizeWorkspaceAppPathList(rawProtected) }),
+    ...(isPathConfigValueSet(rawPublic)
+      ? { publicPaths: normalizeWorkspaceAppPathList(rawPublic) }
+      : {}),
+    ...(isPathConfigValueSet(rawProtected)
+      ? { protectedPaths: normalizeWorkspaceAppPathList(rawProtected) }
+      : {}),
   };
+}
+
+/**
+ * Only treat a package.json field as "explicitly set" when its raw value is a
+ * supported type — an array, a string, or explicit null. Garbage types like
+ * `false`, `0`, or `{}` are ignored (left as undefined) so a typo such as
+ * `"publicPaths": false` doesn't silently clear an inherited manifest
+ * override. (`normalizeWorkspaceAppPathList` happily turns those into `[]`,
+ * which without this guard would be indistinguishable from a deliberate
+ * empty array.)
+ */
+function isPathConfigValueSet(value: unknown): boolean {
+  if (value === undefined) return false;
+  if (value === null) return true;
+  if (Array.isArray(value)) return true;
+  return typeof value === "string";
 }
 
 function workspaceAppConfigFromPackageJson(pkg: unknown):

--- a/packages/core/src/shared/workspace-app-audience.ts
+++ b/packages/core/src/shared/workspace-app-audience.ts
@@ -82,26 +82,42 @@ export function workspaceAppAudienceFromPackageJson(
   return normalizeWorkspaceAppAudience(raw);
 }
 
+/**
+ * Per-app route-access config read from a `package.json`. Each field is
+ * `undefined` when the corresponding key is fully absent from every
+ * supported alias chain — that lets callers distinguish "user didn't say"
+ * from "user set [] to clear inherited overrides". `workspaceAppRouteAccess`
+ * always emits a full `WorkspaceAppRouteAccess` for runtime consumption.
+ */
+export interface WorkspaceAppRouteAccessFromConfig {
+  publicPaths?: string[];
+  protectedPaths?: string[];
+}
+
 export function workspaceAppRouteAccessFromPackageJson(
   pkg: unknown,
-): WorkspaceAppRouteAccess {
+): WorkspaceAppRouteAccessFromConfig {
   const config = workspaceAppConfigFromPackageJson(pkg);
+  const rawPublic =
+    config?.workspaceApp?.publicPaths ??
+    config?.workspaceApp?.publicPagePaths ??
+    config?.workspace?.publicPaths ??
+    config?.publicPaths ??
+    config?.root?.workspaceAppPublicPaths;
+  const rawProtected =
+    config?.workspaceApp?.protectedPaths ??
+    config?.workspaceApp?.privatePaths ??
+    config?.workspaceApp?.authRequiredPaths ??
+    config?.workspace?.protectedPaths ??
+    config?.protectedPaths ??
+    config?.root?.workspaceAppProtectedPaths;
   return {
-    publicPaths: normalizeWorkspaceAppPathList(
-      config?.workspaceApp?.publicPaths ??
-        config?.workspaceApp?.publicPagePaths ??
-        config?.workspace?.publicPaths ??
-        config?.publicPaths ??
-        config?.root?.workspaceAppPublicPaths,
-    ),
-    protectedPaths: normalizeWorkspaceAppPathList(
-      config?.workspaceApp?.protectedPaths ??
-        config?.workspaceApp?.privatePaths ??
-        config?.workspaceApp?.authRequiredPaths ??
-        config?.workspace?.protectedPaths ??
-        config?.protectedPaths ??
-        config?.root?.workspaceAppProtectedPaths,
-    ),
+    ...(rawPublic === undefined
+      ? {}
+      : { publicPaths: normalizeWorkspaceAppPathList(rawPublic) }),
+    ...(rawProtected === undefined
+      ? {}
+      : { protectedPaths: normalizeWorkspaceAppPathList(rawProtected) }),
   };
 }
 

--- a/packages/dispatch/src/server/lib/vault-store.spec.ts
+++ b/packages/dispatch/src/server/lib/vault-store.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  writeAppSecret: vi.fn(),
+}));
+
+vi.mock("@agent-native/core/secrets", () => ({
+  writeAppSecret: mocks.writeAppSecret,
+}));
+
+import {
+  credentialStoreScopeForVaultCtx,
+  syncSecretsToCredentialStore,
+} from "./vault-store.js";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("credentialStoreScopeForVaultCtx", () => {
+  it("uses org scope when vault sync runs inside an org", () => {
+    expect(
+      credentialStoreScopeForVaultCtx({
+        ownerEmail: "admin@example.test",
+        orgId: "org_123",
+      }),
+    ).toEqual({ scope: "org", scopeId: "org_123" });
+  });
+
+  it("uses workspace solo scope when no org is active", () => {
+    expect(
+      credentialStoreScopeForVaultCtx({
+        ownerEmail: "owner@example.test",
+        orgId: null,
+      }),
+    ).toEqual({
+      scope: "workspace",
+      scopeId: "solo:owner@example.test",
+    });
+  });
+});
+
+describe("syncSecretsToCredentialStore", () => {
+  it("writes vault secrets into app_secrets without returning values", async () => {
+    const result = await syncSecretsToCredentialStore(
+      [
+        {
+          name: "OpenAI API Key",
+          credentialKey: "OPENAI_API_KEY",
+          value: "sk-test-key",
+        } as any,
+      ],
+      { ownerEmail: "admin@example.test", orgId: "org_123" },
+    );
+
+    expect(mocks.writeAppSecret).toHaveBeenCalledWith({
+      key: "OPENAI_API_KEY",
+      value: "sk-test-key",
+      scope: "org",
+      scopeId: "org_123",
+      description: "Synced from Dispatch vault: OpenAI API Key",
+    });
+    expect(result).toEqual({
+      scope: "org",
+      scopeId: "org_123",
+      keys: ["OPENAI_API_KEY"],
+    });
+  });
+});

--- a/packages/dispatch/src/server/lib/vault-store.ts
+++ b/packages/dispatch/src/server/lib/vault-store.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import { and, desc, eq, isNull, or } from "drizzle-orm";
 import { discoverAgents } from "@agent-native/core/server/agent-discovery";
+import { writeAppSecret, type SecretScope } from "@agent-native/core/secrets";
 import {
   getOrgSetting,
   getUserSetting,
@@ -522,6 +523,40 @@ export async function revokeGrant(
   return getGrant(grantId, ctx);
 }
 
+// ─── Shared Credential Store Sync ─────────────────────────────────
+
+type VaultSecretRow = typeof schema.vaultSecrets.$inferSelect;
+
+export function credentialStoreScopeForVaultCtx(ctx: VaultCtx): {
+  scope: Extract<SecretScope, "org" | "workspace">;
+  scopeId: string;
+} {
+  if (ctx.orgId) return { scope: "org", scopeId: ctx.orgId };
+  return { scope: "workspace", scopeId: `solo:${ctx.ownerEmail}` };
+}
+
+export async function syncSecretsToCredentialStore(
+  secrets: VaultSecretRow[],
+  ctx: VaultCtx,
+) {
+  const target = credentialStoreScopeForVaultCtx(ctx);
+  const syncedKeys: string[] = [];
+
+  for (const secret of secrets) {
+    if (!secret.credentialKey || !secret.value) continue;
+    await writeAppSecret({
+      key: secret.credentialKey,
+      value: secret.value,
+      scope: target.scope,
+      scopeId: target.scopeId,
+      description: `Synced from Dispatch vault: ${secret.name}`,
+    });
+    syncedKeys.push(secret.credentialKey);
+  }
+
+  return { ...target, keys: syncedKeys };
+}
+
 // ─── Sync ──────────────────────────────────────────────────────
 
 export async function syncGrantsToApp(
@@ -534,7 +569,7 @@ export async function syncGrantsToApp(
   const agent = agents.find((a) => a.id === appId);
   if (!agent) throw new Error(`App "${appId}" not found in agent registry`);
 
-  const vars: Array<{ key: string; value: string }> = [];
+  const secretsToSync: VaultSecretRow[] = [];
   const activeGrants =
     access.mode === "manual"
       ? (await listGrants({ appId })).filter((g) => g.status === "active")
@@ -543,38 +578,64 @@ export async function syncGrantsToApp(
   if (access.mode === "all-apps") {
     const secrets = await listSecrets();
     for (const secret of secrets) {
-      vars.push({ key: secret.credentialKey, value: secret.value });
+      secretsToSync.push(secret);
     }
   } else {
     for (const grant of activeGrants) {
       const secret = await getSecret(grant.secretId, ctx);
       if (secret) {
-        vars.push({ key: secret.credentialKey, value: secret.value });
+        secretsToSync.push(secret);
       }
     }
   }
 
-  if (vars.length === 0) {
+  if (secretsToSync.length === 0) {
     return { appId, accessMode: access.mode, synced: 0, keys: [] };
   }
 
-  // Push to the app's env-vars endpoint
-  const res = await fetch(`${agent.url}/_agent-native/env-vars`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ vars }),
-  });
+  const credentialStoreSync = await syncSecretsToCredentialStore(
+    secretsToSync,
+    ctx,
+  );
+  const vars = secretsToSync.map((secret) => ({
+    key: secret.credentialKey,
+    value: secret.value,
+  }));
+  let envVarSync:
+    | { status: "synced"; keys: string[] }
+    | { status: "skipped"; reason: string }
+    | { status: "failed"; reason: string };
 
-  if (!res.ok) {
-    const err = await res.text().catch(() => "Unknown error");
-    throw new Error(`Failed to sync to ${appId}: ${err}`);
+  // Best-effort push to the app's env-vars endpoint for local/dev apps that
+  // still read process.env directly. Production/shared-DB apps intentionally
+  // reject env writes; the encrypted app_secrets sync above is the canonical
+  // path for request-scoped credentials.
+  try {
+    const res = await fetch(`${agent.url}/_agent-native/env-vars`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ vars }),
+    });
+
+    if (res.ok) {
+      const result = await res.json();
+      envVarSync = { status: "synced", keys: result.saved || [] };
+    } else {
+      const err = await res.text().catch(() => "Unknown error");
+      envVarSync = { status: "skipped", reason: err };
+    }
+  } catch (err) {
+    envVarSync = {
+      status: "failed",
+      reason: err instanceof Error ? err.message : String(err),
+    };
   }
 
-  const result = await res.json();
-  const syncedKeys: string[] = result.saved || [];
+  const syncedKeys = credentialStoreSync.keys;
   const timestamp = now();
 
-  // Update syncedAt on grants that were successfully pushed
+  // Update syncedAt on grants that were successfully pushed to the shared
+  // credential store. All-apps mode has no explicit grant rows to update.
   for (const grant of activeGrants) {
     const secret = await getSecret(grant.secretId, ctx);
     if (secret && syncedKeys.includes(secret.credentialKey)) {
@@ -589,7 +650,15 @@ export async function syncGrantsToApp(
     action: "secret.synced",
     appId,
     summary: `Synced ${syncedKeys.length} secret(s) to ${appId}: ${syncedKeys.join(", ")}`,
-    metadata: { syncedKeys, accessMode: access.mode },
+    metadata: {
+      syncedKeys,
+      accessMode: access.mode,
+      credentialStore: {
+        scope: credentialStoreSync.scope,
+        scopeId: credentialStoreSync.scopeId,
+      },
+      envVars: envVarSync,
+    },
   });
 
   return {
@@ -597,6 +666,12 @@ export async function syncGrantsToApp(
     accessMode: access.mode,
     synced: syncedKeys.length,
     keys: syncedKeys,
+    credentialStore: {
+      scope: credentialStoreSync.scope,
+      scopeId: credentialStoreSync.scopeId,
+      synced: credentialStoreSync.keys.length,
+    },
+    envVars: envVarSync,
   };
 }
 

--- a/templates/slides/app/components/editor/EditorSidebar.tsx
+++ b/templates/slides/app/components/editor/EditorSidebar.tsx
@@ -210,10 +210,24 @@ function SortableSlideThumb({
           <IconGripVertical className="w-3.5 h-3.5 text-muted-foreground/70" />
         </div>
 
-        {/* Index */}
-        <span className="flex-shrink-0 w-5 mt-2 text-[10px] font-medium text-muted-foreground/70">
-          {index + 1}
-        </span>
+        {/* Index and slide presence share the fixed rail so presence does not resize the row. */}
+        <div className="relative flex-shrink-0 w-5 self-stretch mt-2">
+          <span className="block text-center text-[10px] font-medium text-muted-foreground/70">
+            {index + 1}
+          </span>
+          {presenceUsers.length > 0 && (
+            <div className="absolute left-1/2 top-6 z-10 flex -translate-x-1/2 flex-col items-center gap-1">
+              {presenceUsers.slice(0, 4).map((u, i) => (
+                <PresenceAvatarTip key={i} user={u} size={16} />
+              ))}
+              {presenceUsers.length > 4 && (
+                <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-muted px-1 text-[8px] font-medium leading-none text-muted-foreground ring-1 ring-black/40">
+                  +{presenceUsers.length - 4}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
 
         {/* Thumbnail */}
         <div className="flex-1 min-w-0">
@@ -228,19 +242,6 @@ function SortableSlideThumb({
           >
             <SlideRenderer slide={slide} aspectRatio={aspectRatio} />
           </div>
-          {/* Presence avatars — show who's on this slide */}
-          {presenceUsers.length > 0 && (
-            <div className="flex items-center gap-0.5 mt-1 px-0.5">
-              {presenceUsers.slice(0, 4).map((u, i) => (
-                <PresenceAvatarTip key={i} user={u} size={16} />
-              ))}
-              {presenceUsers.length > 4 && (
-                <span className="text-[9px] text-muted-foreground/70 ml-0.5">
-                  +{presenceUsers.length - 4}
-                </span>
-              )}
-            </div>
-          )}
         </div>
       </button>
 


### PR DESCRIPTION
## Summary

- `workspaceAppRouteAccessFromPackageJson` now returns `{ publicPaths?, protectedPaths? }` so consumers can distinguish "field absent" from "field explicitly empty."
- `workspace-deploy`, `workspace-dev`, and `agent-discovery` prefer the per-app `package.json` value whenever it was set (even `[]`), and only fall back to the explicit workspace manifest override when the package.json key is absent. An app owner can now write `"publicPaths": []` in their `package.json` to blank an inherited override — the previous `length > 0` check silently kept the override forever.
- Addresses bot review on #671: https://github.com/BuilderIO/agent-native/pull/671#discussion_r3236663241

Also folds in concurrent-agent sweeps that landed during the prior branch:

- core/cli workspace-dev.ts + spec polish (`stale-gateway-wakeup` changeset)
- core/server agent-chat-plugin.ts coach-thread updates (`collaborative-agent-coach` changeset)
- slides EditorSidebar tweaks

## Test plan

- [ ] `pnpm --filter @agent-native/core test src/shared/workspace-app-audience src/deploy/workspace-deploy`
- [ ] Build / Typecheck / Lint
- [ ] Scaffold E2E