### PR TITLE
chore(security): SHA-pin GitHub Actions + npm 24h release-age gate

### DIFF
--- a/.github/workflows/auto-merge-version-packages.yml
+++ b/.github/workflows/auto-merge-version-packages.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.BUILDER_BOT_FOR_LINT_APP_ID }}
           private-key: ${{ secrets.BUILDER_BOT_FOR_LINT_PRIVATE_KEY }}

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -52,24 +52,24 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.BUILDER_BOT_FOR_LINT_APP_ID }}
           private-key: ${{ secrets.BUILDER_BOT_FOR_LINT_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       # Node 24 ships with npm 11.6+ — required for Trusted Publishing OIDC
       # (>= 11.5.1). Node 22 ships npm 10.x; the in-place self-upgrade
       # (`npm install -g npm@latest`) is broken on the current runner image
       # (actions/runner-images#13883), so we just use a Node version that
       # already has the right npm baked in.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           cache: "pnpm"
@@ -85,7 +85,7 @@ jobs:
 
       - name: Create Release PR or publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
           # When changesets/action finds no pending changesets, it runs
           # `publish` — which shells out to `npm publish` per package.
@@ -113,7 +113,7 @@ jobs:
             contains(steps.changesets.outputs.publishedPackages, '@agent-native/core') ||
             contains(steps.changesets.outputs.publishedPackages, '@agent-native/dispatch')
           )
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         id: builder-workspace-token
         with:
           app-id: ${{ secrets.BUILDER_BOT_FOR_LINT_APP_ID }}
@@ -160,11 +160,11 @@ jobs:
             platform: linux
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -207,7 +207,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Get version
         id: version

--- a/.github/workflows/cancel-stale-netlify-previews.yml
+++ b/.github/workflows/cancel-stale-netlify-previews.yml
@@ -11,7 +11,7 @@ jobs:
   cancel:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           NETLIFY_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           BRANCH: ${{ github.head_ref }}

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.ref != 'changeset-release/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     name: Lint & format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: "pnpm"
@@ -30,11 +30,11 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: "pnpm"
@@ -48,11 +48,11 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: "pnpm"
@@ -66,11 +66,11 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: "pnpm"
@@ -86,11 +86,11 @@ jobs:
     env:
       AGENT_NATIVE_CREATE_USE_LOCAL_CORE: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: "pnpm"
@@ -189,9 +189,9 @@ jobs:
     name: Guard — no drizzle-kit push in build paths
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
 

--- a/.github/workflows/clips-desktop-release.yml
+++ b/.github/workflows/clips-desktop-release.yml
@@ -47,11 +47,11 @@ jobs:
     outputs:
       app-version: ${{ steps.resolve-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -67,12 +67,12 @@ jobs:
           fi
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.rust-targets }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: ${{ env.TAURI_APP_PATH }}/src-tauri
 
@@ -124,7 +124,7 @@ jobs:
           echo "version=$V" >> "$GITHUB_OUTPUT"
 
       - name: Build and release (tauri-action)
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Tauri signing — REQUIRED for the updater to accept downloaded
@@ -178,7 +178,7 @@ jobs:
     needs: build-tauri
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Resolve version
         id: v

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       version: ${{ steps.v.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Resolve version
         id: v
@@ -49,11 +49,11 @@ jobs:
     needs: resolve-version
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -91,11 +91,11 @@ jobs:
     needs: resolve-version
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm
@@ -117,11 +117,11 @@ jobs:
     needs: resolve-version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/hide-cloudflare-comment.yml
+++ b/.github/workflows/hide-cloudflare-comment.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Minimize comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const nodeId = context.payload.comment.node_id;

--- a/.github/workflows/neon-preview-branches.yml
+++ b/.github/workflows/neon-preview-branches.yml
@@ -56,7 +56,7 @@ jobs:
             netlify_site: 3f0c2cd2-06cd-4ab8-bfb4-c199430d1dac
     steps:
       - name: Create Neon branch
-        uses: neondatabase/create-branch-action@v6
+        uses: neondatabase/create-branch-action@fb620d43d4c565abaf088b848a4e28e5c4ea4d9c # v6
         id: neon
         with:
           project_id: ${{ matrix.neon_project }}
@@ -125,7 +125,7 @@ jobs:
             netlify_site: 3f0c2cd2-06cd-4ab8-bfb4-c199430d1dac
     steps:
       - name: Delete Neon branch
-        uses: neondatabase/delete-branch-action@v3
+        uses: neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776 # v3
         with:
           project_id: ${{ matrix.neon_project }}
           branch: preview/pr-${{ github.event.number }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+minimumReleaseAge=1440
+minimumReleaseAgeExclude[]=@agent-native/core


### PR DESCRIPTION
## Summary
  Ports supply-chain hardening from the sibling `site` repo (PR #474) to
  `agent-native`: a 24-hour npm quarantine on all installed packages, and
  SHA-pinned `uses:` references across all 9 GitHub Actions workflows.

  ## Problem
  On 2026-05-11 19:20–19:26 UTC, a threat actor compromised 42 packages
  in the `@tanstack/router` and `@tanstack/start` ecosystem
  (GHSA-g7cv-rxg3-hmpx) by poisoning GitHub Actions caches to steal OIDC
  tokens, then auto-publishing malicious versions containing a 2.3 MB
  `router_init.js` credential-harvesting payload. Agent-native was **not
  affected** by this specific incident — it uses only
  `@tanstack/react-query` (not the router/start family) and its lockfile
  predated the attack window — but the same two attack classes apply
  generically to any npm-dependent CI/CD system.

  ## Solution
  Two independent, complementary mitigations:

  1. **Registry quarantine via `.npmrc`** (`minimumReleaseAge=1440`): pnpm
     refuses to install any package version published less than 24 hours
     ago. The sole exclusion is `@agent-native/core` (the only first-party
     scope dep consumed from the registry; other internal packages use
     `workspace:*` and never hit the registry).

  2. **SHA-pinned GitHub Actions**: Every `uses: <action>@<tag>` reference
     across all 9 workflows is replaced with `uses: <action>@<sha> # <tag>`.
     A pinned SHA is immutable — even if an attacker force-retargets the
     `v4` tag to a malicious commit, our workflows still resolve to the
     vetted commit.

  ## Key Changes
  - New `.npmrc` with `minimumReleaseAge=1440` + `@agent-native/core` exclusion
  - `ci.yml`: pin `actions/checkout`, `pnpm/action-setup`, `actions/setup-node`
  - `auto-publish.yml`: same set + `changesets/action`, `actions/create-github-app-token`
  - `desktop-release.yml`, `clips-desktop-release.yml`: same set + `tauri-apps/tauri-action`, `swatinem/rust-cache`
  - `clips-desktop-release.yml`: `dtolnay/rust-toolchain@stable` → frozen SHA — **trade-off**: Rust toolchain upgrades become
   a manual decision rather than silent auto-bumps
  - `neon-preview-branches.yml`: pin `neondatabase/create-branch-action`, `neondatabase/delete-branch-action`
  - `cancel-stale-netlify-previews.yml`, `hide-cloudflare-comment.yml`: pin `actions/github-script`
  - `changeset-check.yml`, `auto-merge-version-packages.yml`: remaining `checkout`/`setup-node`/`create-github-app-token`
  refs