### PR TITLE
Fix mixed changeset blocking package publish

### DIFF
--- a/.changeset/feedback-fixes-dispatch-nav-builder-oauth.md
+++ b/.changeset/feedback-fixes-dispatch-nav-builder-oauth.md
@@ -1,7 +1,6 @@
 ---
 "@agent-native/core": patch
 "@agent-native/dispatch": patch
-"@agent-native/desktop-app": patch
 ---
 
 Several feedback fixes:

--- a/.changeset/fuzzy-preview-oauth.md
+++ b/.changeset/fuzzy-preview-oauth.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep Builder preview Google sign-in from returning to loopback preview URLs.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1580,7 +1580,13 @@ describe("server/auth", () => {
         "__anSetOAuthDebug('Opening Google sign-in redirect')",
       );
       expect(loginHtml).toContain("function __anBuilderPreviewReturnOrigin()");
+      expect(loginHtml).toContain(
+        "var candidates = [window.location.href, document.referrer || ''];",
+      );
       expect(loginHtml).toContain("function __anOAuthReturnTarget(ret)");
+      expect(loginHtml).toContain(
+        "var target = __anIsBuilderPreview() ? __anOAuthReturnTarget(ret) : ret;",
+      );
       expect(loginHtml).toContain(
         "params.set('return', __anOAuthReturnTarget(ret))",
       );

--- a/packages/core/src/server/google-auth-plugin.ts
+++ b/packages/core/src/server/google-auth-plugin.ts
@@ -118,18 +118,27 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
     return origin ? origin + path : __anPath(path);
   }
   function __anBuilderPreviewReturnOrigin() {
+    var candidates = [window.location.href, document.referrer || ''];
     try {
-      var url = new URL(window.location.href);
-      var host = url.hostname.toLowerCase();
-      var isPreviewHost =
-        host === 'builderio.xyz' || host.slice(-14) === '.builderio.xyz' ||
-        host === 'builderio.dev' || host.slice(-14) === '.builderio.dev' ||
-        host === 'builder.codes' || host.slice(-14) === '.builder.codes' ||
-        host === 'builder.my' || host.slice(-11) === '.builder.my';
-      return url.protocol === 'https:' && isPreviewHost ? url.origin : '';
-    } catch(e) {
-      return '';
+      if (window.location.ancestorOrigins) {
+        for (var j = 0; j < window.location.ancestorOrigins.length; j++) {
+          candidates.push(window.location.ancestorOrigins[j]);
+        }
+      }
+    } catch(e) {}
+    for (var i = 0; i < candidates.length; i++) {
+      try {
+        var url = new URL(candidates[i]);
+        var host = url.hostname.toLowerCase();
+        var isPreviewHost =
+          host === 'builderio.xyz' || host.slice(-14) === '.builderio.xyz' ||
+          host === 'builderio.dev' || host.slice(-14) === '.builderio.dev' ||
+          host === 'builder.codes' || host.slice(-14) === '.builder.codes' ||
+          host === 'builder.my' || host.slice(-11) === '.builder.my';
+        if (url.protocol === 'https:' && isPreviewHost) return url.origin;
+      } catch(e) {}
     }
+    return '';
   }
   function __anWorkspaceGatewayReturnOrigin() {
     var previewOrigin = __anBuilderPreviewReturnOrigin();
@@ -289,8 +298,9 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
   }
   function __anStartPopupOAuth(ret, btn, err) {
     var flowId = __anNewOAuthFlowId();
+    var target = __anIsBuilderPreview() ? __anOAuthReturnTarget(ret) : ret;
     var params = new URLSearchParams();
-    if (ret) params.set('return', ret);
+    if (target) params.set('return', target);
     params.set('desktop', '1');
     params.set('flow_id', flowId);
     params.set('redirect', '1');
@@ -316,7 +326,7 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
       __anShowOAuthError(err, btn, 'Could not open Google popup for flow ' + __anFlowDebugId(flowId) + ': ' + (e && e.message ? e.message : 'unknown error'));
       return;
     }
-    __anWaitForOAuthExchange(flowId, ret, btn, err);
+    __anWaitForOAuthExchange(flowId, target, btn, err);
   }
   function __anStartNativeDesktopOAuth(ret, btn, err) {
     var flowId = __anNewOAuthFlowId();

--- a/packages/core/src/server/oauth-public-origin.ts
+++ b/packages/core/src/server/oauth-public-origin.ts
@@ -7,6 +7,20 @@ function normalizeOrigin(raw: string | undefined): string {
   }
 }
 
+function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const hostname = new URL(origin).hostname;
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "[::1]"
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function getPublicOAuthOrigin(): string {
   for (const raw of [
     process.env.WORKSPACE_OAUTH_ORIGIN,
@@ -15,11 +29,16 @@ export function getPublicOAuthOrigin(): string {
     process.env.VITE_APP_URL,
     process.env.BETTER_AUTH_URL,
     process.env.VITE_BETTER_AUTH_URL,
+  ]) {
+    const origin = normalizeOrigin(raw);
+    if (origin && !isLoopbackOrigin(origin)) return origin;
+  }
+  for (const raw of [
     process.env.WORKSPACE_GATEWAY_URL,
     process.env.VITE_WORKSPACE_GATEWAY_URL,
   ]) {
     const origin = normalizeOrigin(raw);
-    if (origin) return origin;
+    if (origin && !isLoopbackOrigin(origin)) return origin;
   }
   return "";
 }

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -59,18 +59,26 @@ describe("getOnboardingHtml", () => {
       "__anSetOAuthDebug('Opening Google sign-in in system browser', flowId)",
     );
     expect(html).toContain("function __anBuilderPreviewReturnOrigin()");
+    expect(html).toContain(
+      "var candidates = [window.location.href, document.referrer || ''];",
+    );
     expect(html).toContain("function __anIsAgentNativeDesktop()");
     expect(html).toContain("function __anOAuthReturnTarget(ret)");
+    expect(html).toContain(
+      "var target = __anIsBuilderPreview() ? __anOAuthReturnTarget(ret) : ret;",
+    );
     expect(html).toContain("params.set('return', __anOAuthReturnTarget(ret))");
   });
 
   it("embeds the local workspace gateway return origin when configured", () => {
+    vi.stubEnv("VITE_WORKSPACE_OAUTH_ORIGIN", "http://127.0.0.1:8080/");
     vi.stubEnv("WORKSPACE_GATEWAY_URL", "http://127.0.0.1:8080/");
     vi.stubEnv("GOOGLE_CLIENT_ID", "google-client-id");
     vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-client-secret");
 
     const html = getOnboardingHtml();
 
+    expect(html).toContain('var __AN_PUBLIC_OAUTH_ORIGIN = "";');
     expect(html).toContain(
       'var __AN_WORKSPACE_GATEWAY_RETURN_ORIGIN = "http://127.0.0.1:8080";',
     );

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -924,18 +924,27 @@ ${
       return origin ? origin + path : __anPath(path);
     }
     function __anBuilderPreviewReturnOrigin() {
+      var candidates = [window.location.href, document.referrer || ''];
       try {
-        var url = new URL(window.location.href);
-        var host = url.hostname.toLowerCase();
-        var isPreviewHost =
-          host === 'builderio.xyz' || host.slice(-14) === '.builderio.xyz' ||
-          host === 'builderio.dev' || host.slice(-14) === '.builderio.dev' ||
-          host === 'builder.codes' || host.slice(-14) === '.builder.codes' ||
-          host === 'builder.my' || host.slice(-11) === '.builder.my';
-        return url.protocol === 'https:' && isPreviewHost ? url.origin : '';
-      } catch(e) {
-        return '';
+        if (window.location.ancestorOrigins) {
+          for (var j = 0; j < window.location.ancestorOrigins.length; j++) {
+            candidates.push(window.location.ancestorOrigins[j]);
+          }
+        }
+      } catch(e) {}
+      for (var i = 0; i < candidates.length; i++) {
+        try {
+          var url = new URL(candidates[i]);
+          var host = url.hostname.toLowerCase();
+          var isPreviewHost =
+            host === 'builderio.xyz' || host.slice(-14) === '.builderio.xyz' ||
+            host === 'builderio.dev' || host.slice(-14) === '.builderio.dev' ||
+            host === 'builder.codes' || host.slice(-14) === '.builder.codes' ||
+            host === 'builder.my' || host.slice(-11) === '.builder.my';
+          if (url.protocol === 'https:' && isPreviewHost) return url.origin;
+        } catch(e) {}
       }
+      return '';
     }
     function __anWorkspaceGatewayReturnOrigin() {
       var previewOrigin = __anBuilderPreviewReturnOrigin();
@@ -1113,8 +1122,9 @@ ${
     }
     function __anStartPopupOAuth(ret, btn, err) {
       var flowId = __anNewOAuthFlowId();
+      var target = __anIsBuilderPreview() ? __anOAuthReturnTarget(ret) : ret;
       var params = new URLSearchParams();
-      if (ret) params.set('return', ret);
+      if (target) params.set('return', target);
       params.set('desktop', '1');
       params.set('flow_id', flowId);
       params.set('redirect', '1');
@@ -1140,7 +1150,7 @@ ${
         __anShowOAuthError(err, btn, 'Could not open Google popup for flow ' + __anFlowDebugId(flowId) + ': ' + (e && e.message ? e.message : 'unknown error'));
         return;
       }
-      __anWaitForOAuthExchange(flowId, ret, btn, err);
+      __anWaitForOAuthExchange(flowId, target, btn, err);
     }
     function __anStartNativeDesktopOAuth(ret, btn, err) {
       var flowId = __anNewOAuthFlowId();

--- a/packages/desktop-app/src/renderer/components/AppSettings.tsx
+++ b/packages/desktop-app/src/renderer/components/AppSettings.tsx
@@ -391,7 +391,7 @@ export function AddAppDialog({
   onSave: (app: AppConfig) => void | Promise<void>;
   onCancel: () => void;
 }) {
-  const [mode, setMode] = useState<"prod" | "dev">("prod");
+  const [mode, setMode] = useState<"prod" | "dev">("dev");
   const [name, setName] = useState("");
   const [prodUrl, setProdUrl] = useState("");
   const [devUrl, setDevUrl] = useState("");
@@ -435,7 +435,7 @@ export function AddAppDialog({
         <div className="settings-form-header">
           <h3>Add App</h3>
           <p className="settings-form-subtitle">
-            Add a deployed app or a localhost dev server.
+            Add a localhost dev server or a deployed app.
           </p>
         </div>
 

--- a/scripts/check-changeset.mjs
+++ b/scripts/check-changeset.mjs
@@ -68,6 +68,17 @@ function listPublishablePackages() {
   return map;
 }
 
+function listIgnoredPackages() {
+  const configPath = path.join(repoRoot, ".changeset", "config.json");
+  if (!fs.existsSync(configPath)) return new Set();
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    return new Set(Array.isArray(config.ignore) ? config.ignore : []);
+  } catch {
+    return new Set();
+  }
+}
+
 function packageFromPath(file, publishables) {
   // packages/<name>/...  → <name>
   const m = file.match(/^packages\/([^/]+)\//);
@@ -123,9 +134,38 @@ function packagesCoveredBy(changesetPath) {
     .filter(Boolean);
 }
 
+function failOnMixedIgnoredChangesets(ignoredPackages) {
+  if (ignoredPackages.size === 0) return;
+
+  for (const cs of listPendingChangesets()) {
+    const packages = packagesCoveredBy(cs);
+    const ignored = packages.filter((pkg) => ignoredPackages.has(pkg));
+    const notIgnored = packages.filter((pkg) => !ignoredPackages.has(pkg));
+    if (ignored.length === 0 || notIgnored.length === 0) continue;
+
+    console.error(
+      "✗ Mixed changeset includes ignored and publishable packages.",
+    );
+    console.error("");
+    console.error(`Changeset: .changeset/${path.basename(cs)}`);
+    console.error(`Ignored packages: ${ignored.join(", ")}`);
+    console.error(`Publishable packages: ${notIgnored.join(", ")}`);
+    console.error("");
+    console.error(
+      "Changesets cannot version a file that mixes ignored packages with packages that publish to npm.",
+    );
+    console.error(
+      "Remove ignored packages from the changeset, or split them into a separate non-publishing note.",
+    );
+    process.exit(1);
+  }
+}
+
 function main() {
   const baseSha = getBaseSha();
   const publishables = listPublishablePackages();
+  failOnMixedIgnoredChangesets(listIgnoredPackages());
+
   const changedFiles = listChangedFiles(baseSha);
 
   const touchedPackages = new Set();

--- a/scripts/dev-lazy.ts
+++ b/scripts/dev-lazy.ts
@@ -244,6 +244,31 @@ function devWatcherEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return env;
 }
 
+function normalizeOrigin(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function workspaceOAuthOrigin(
+  env: NodeJS.ProcessEnv,
+  gatewayUrl: string,
+): string | undefined {
+  return (
+    normalizeOrigin(env.VITE_WORKSPACE_OAUTH_ORIGIN) ||
+    normalizeOrigin(env.WORKSPACE_OAUTH_ORIGIN) ||
+    normalizeOrigin(env.APP_URL) ||
+    normalizeOrigin(env.VITE_APP_URL) ||
+    normalizeOrigin(env.BETTER_AUTH_URL) ||
+    normalizeOrigin(env.VITE_BETTER_AUTH_URL) ||
+    normalizeOrigin(env.BUILDER_IO_DEV_SERVER) ||
+    normalizeOrigin(gatewayUrl)
+  );
+}
+
 function workspaceAppsJson(): string {
   return JSON.stringify(
     apps.map((app) => ({
@@ -563,7 +588,13 @@ function startApp(app: TemplateApp): void {
         AGENT_NATIVE_WORKSPACE_APPS_JSON: workspaceAppsJson(),
         APP_BASE_PATH: basePath,
         VITE_AGENT_NATIVE_WORKSPACE: "1",
+        VITE_AGENT_NATIVE_WORKSPACE_APPS_JSON: workspaceAppsJson(),
         VITE_APP_BASE_PATH: basePath,
+        VITE_WORKSPACE_OAUTH_ORIGIN: workspaceOAuthOrigin(
+          process.env,
+          gatewayUrl,
+        ),
+        VITE_WORKSPACE_GATEWAY_URL: gatewayUrl,
         PORT: String(app.port),
         WORKSPACE_GATEWAY_URL: gatewayUrl,
       }),

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -19,6 +19,11 @@ import {
 
 import { IntegrationsSidebar } from "@/components/email/IntegrationsSidebar";
 import { GoogleConnectBanner } from "@/components/GoogleConnectBanner";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
 import { useAccountFilter } from "@/hooks/use-account-filter";
 import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
 import type { EmailMessage } from "@shared/types";
@@ -123,7 +128,7 @@ function ThreadListSidebar({
   useKeyboardShortcuts([{ key: "a", meta: true, handler: selectAllThreads }]);
 
   return (
-    <div className="w-[220px] shrink-0 flex flex-col border-r border-border/30 bg-muted/50 dark:bg-[hsl(220,6%,5%)] overflow-hidden">
+    <div className="flex h-full w-full min-w-0 shrink-0 flex-col overflow-hidden bg-muted/50 dark:bg-[hsl(220,6%,5%)]">
       <div className="flex-1 overflow-y-auto">
         {threads.map((thread) => {
           const email = thread.latestMessage;
@@ -593,48 +598,88 @@ export function InboxPage() {
 
   return (
     <div className="flex flex-1 overflow-hidden">
-      {/* Thin email list sidebar — shown when viewing a thread, hidden on mobile or when maximized */}
-      {hasThread && !isMobile && !isMaximized && (
-        <ThreadListSidebar
-          emails={emails}
-          activeThreadId={threadId!}
-          view={view}
-          routeSearchSuffix={routeSearchSuffix}
-          selectedIds={selectedIds}
-          setSelectedIds={setSelectedIds}
-          onNavigateThread={handleOptimisticThreadNavigation}
-        />
+      {/* Main content — resizable thread list + detail view on desktop */}
+      {hasThread && !isMobile && !isMaximized ? (
+        <ResizablePanelGroup
+          id="mail-thread-detail-layout"
+          orientation="horizontal"
+          resizeTargetMinimumSize={{ coarse: 28, fine: 8 }}
+          className="min-w-0 flex-1"
+        >
+          <ResizablePanel
+            id="mail-thread-list"
+            defaultSize="220px"
+            minSize="180px"
+            maxSize="420px"
+            groupResizeBehavior="preserve-pixel-size"
+            className="min-w-0"
+          >
+            <ThreadListSidebar
+              emails={emails}
+              activeThreadId={threadId!}
+              view={view}
+              routeSearchSuffix={routeSearchSuffix}
+              selectedIds={selectedIds}
+              setSelectedIds={setSelectedIds}
+              onNavigateThread={handleOptimisticThreadNavigation}
+            />
+          </ResizablePanel>
+          <ResizableHandle
+            id="mail-thread-list-resizer"
+            aria-label="Resize email list"
+            className="w-1 cursor-col-resize bg-transparent transition-colors after:w-px after:bg-border/30 hover:after:bg-border/80 data-[separator=active]:after:bg-primary/70 data-[separator=focus]:after:bg-ring/70"
+          />
+          <ResizablePanel
+            id="mail-thread-detail"
+            minSize="360px"
+            className="min-w-0"
+          >
+            <div className="flex h-full min-w-0 flex-col overflow-hidden">
+              <EmailThread
+                activeThreadId={threadId}
+                onArchived={setLastArchivedId}
+                emailIds={threadIds}
+                threads={threads}
+                selectedIds={selectedIds}
+                setSelectedIds={setSelectedIds}
+                onContactSelect={setSidebarContactEmail}
+                onNavigateThread={handleOptimisticThreadNavigation}
+                isMaximized={isMaximized}
+                onToggleMaximize={() => setIsMaximized((v) => !v)}
+              />
+            </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      ) : (
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          {hasThread ? (
+            <EmailThread
+              activeThreadId={threadId}
+              onArchived={setLastArchivedId}
+              emailIds={threadIds}
+              threads={threads}
+              selectedIds={selectedIds}
+              setSelectedIds={setSelectedIds}
+              onContactSelect={setSidebarContactEmail}
+              onNavigateThread={handleOptimisticThreadNavigation}
+              isMaximized={isMaximized}
+              onToggleMaximize={() => setIsMaximized((v) => !v)}
+            />
+          ) : (
+            <EmailList
+              emails={emails}
+              focusedId={focusedId}
+              setFocusedId={setFocusedId}
+              selectedIds={selectedIds}
+              setSelectedIds={setSelectedIds}
+              onCompose={handleCompose}
+              onArchived={setLastArchivedId}
+              onDraftOpen={handleDraftOpen}
+              onNavigateThread={handleOptimisticThreadNavigation}
+            />
+          )}
+        </div>
       )}
-
-      {/* Center area — email list OR thread view */}
-      <div className="flex flex-1 flex-col overflow-hidden">
-        {hasThread ? (
-          <EmailThread
-            activeThreadId={threadId}
-            onArchived={setLastArchivedId}
-            emailIds={threadIds}
-            threads={threads}
-            selectedIds={selectedIds}
-            setSelectedIds={setSelectedIds}
-            onContactSelect={setSidebarContactEmail}
-            onNavigateThread={handleOptimisticThreadNavigation}
-            isMaximized={isMaximized}
-            onToggleMaximize={() => setIsMaximized((v) => !v)}
-          />
-        ) : (
-          <EmailList
-            emails={emails}
-            focusedId={focusedId}
-            setFocusedId={setFocusedId}
-            selectedIds={selectedIds}
-            setSelectedIds={setSelectedIds}
-            onCompose={handleCompose}
-            onArchived={setLastArchivedId}
-            onDraftOpen={handleDraftOpen}
-            onNavigateThread={handleOptimisticThreadNavigation}
-          />
-        )}
-      </div>
 
       {/* Right contact panel — hidden during initial load or when maximized */}
       {!isLoading && !(hasThread && isMaximized) && (


### PR DESCRIPTION
## What changed

- Removes ignored `@agent-native/desktop-app` from the `feedback-fixes-dispatch-nav-builder-oauth` changeset so changesets can build the npm release plan again.
- Adds a PR-time guard in `scripts/check-changeset.mjs` that rejects any future changeset mixing ignored packages with npm-published packages.

## Why

`auto-publish.yml` has been failing in `changesets/action` since this mixed changeset landed. Because `@agent-native/desktop-app` is listed in `.changeset/config.json` `ignore`, changesets refuses to process a single file that also versions publishable packages like `@agent-native/core` and `@agent-native/dispatch`. That prevented the Version Packages PR from being created and left `@agent-native/core@latest` stuck at `0.14.8`.

After this lands, the next publish workflow run should be able to create the Version Packages PR, which should bump and publish the pending core/dispatch releases.

## Validation

- `node scripts/check-changeset.mjs`
- `pnpm exec changeset status`
