### PR TITLE
feat(core): signed Builder connect through workspace gateway origins

### DIFF
--- a/.changeset/builder-connect-workspace-gateway.md
+++ b/.changeset/builder-connect-workspace-gateway.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Allow signed Builder connect flows to complete through workspace gateway origins without requiring the iframe host's session cookie.

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -494,6 +494,75 @@ describe("server/auth", () => {
       );
     });
 
+    it("lets signed Builder connect URLs bypass the global auth guard", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      vi.stubEnv("BETTER_AUTH_SECRET", "builder-connect-secret");
+      vi.stubEnv("APP_BASE_PATH", "/todays-priorities");
+      const { autoMountAuth } = await import("./auth.js");
+      const { BUILDER_CONNECT_PARAM, signBuilderConnectToken } =
+        await import("./builder-browser.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const token = signBuilderConnectToken("jameson@builder.io");
+
+      await expect(
+        guard(
+          createMockEvent({
+            path: "/todays-priorities/_agent-native/builder/connect",
+            query: { [BUILDER_CONNECT_PARAM]: token },
+          }),
+        ),
+      ).resolves.toBeUndefined();
+
+      await expect(
+        guard(
+          createMockEvent({
+            path: "/todays-priorities/_agent-native/builder/connect",
+            query: { [BUILDER_CONNECT_PARAM]: `${token}.tampered` },
+          }),
+        ),
+      ).resolves.toEqual({ error: "Unauthorized" });
+    });
+
+    it("lets Builder connect callbacks with owner cookies bypass the global auth guard", async () => {
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("ACCESS_TOKEN", "my-secret");
+      vi.stubEnv("BETTER_AUTH_SECRET", "builder-connect-secret");
+      vi.stubEnv("APP_BASE_PATH", "/todays-priorities");
+      const { autoMountAuth } = await import("./auth.js");
+      const { BUILDER_CONNECT_OWNER_COOKIE, signBuilderConnectToken } =
+        await import("./builder-browser.js");
+
+      const app = createMockApp();
+      await autoMountAuth(app);
+
+      const guard = app.use.mock.calls
+        .map((call: any[]) => call[0])
+        .find((arg: unknown) => typeof arg === "function");
+      expect(guard).toBeTypeOf("function");
+
+      const token = signBuilderConnectToken("jameson@builder.io");
+
+      await expect(
+        guard(
+          createMockEvent({
+            path: "/todays-priorities/_agent-native/builder/callback",
+            headers: {
+              cookie: `${BUILDER_CONNECT_OWNER_COOKIE}=${token}`,
+            },
+          }),
+        ),
+      ).resolves.toBeUndefined();
+    });
+
     it("lets signed integration processor routes bypass the global auth guard", async () => {
       vi.stubEnv("NODE_ENV", "production");
       vi.stubEnv("ACCESS_TOKEN", "my-secret");
@@ -1576,7 +1645,7 @@ describe("server/auth", () => {
   });
 
   describe("onboarding Google sign-in", () => {
-    it("keeps popup OAuth for Builder preview surfaces", async () => {
+    it("uses redirect OAuth for Builder preview surfaces", async () => {
       vi.stubEnv("GOOGLE_CLIENT_ID", "google-client-id");
       vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-client-secret");
       vi.stubEnv("APP_URL", "https://agent-workspace.builder.io");
@@ -1607,9 +1676,17 @@ describe("server/auth", () => {
       expect(html).toContain("params.set('desktop', '1')");
       expect(html).toContain("params.set('flow_id', flowId)");
       expect(html).toContain("params.set('redirect', '1')");
+      expect(html).toContain("var __anBuilderPreviewSeen = false");
+      expect(html).toContain("function __anRememberBuilderPreview()");
+      expect(html).toContain(
+        "sessionStorage.setItem('__an_builder_preview_seen', '1')",
+      );
+      expect(html).toContain("function __anHasBuilderPreviewSignal()");
+      expect(html).toContain("params.has('builder.preview')");
+      expect(html).toContain("__anIsBuilderPreview();");
       expect(html).toContain("__anIsBuilderDesktop()");
       expect(html).toContain("__anIsAgentNativeDesktop()");
-      expect(html).toContain("if (__anIsBuilderPreview()) return 'popup'");
+      expect(html).toContain("if (__anIsBuilderPreview()) return 'redirect'");
       expect(html).toContain(
         "__anSetOAuthDebug('Opening Google sign-in in system browser', flowId)",
       );
@@ -1661,9 +1738,19 @@ describe("server/auth", () => {
       expect(loginHtml).toContain(
         "__anSetOAuthDebug('Google popup opened; waiting for callback', flowId)",
       );
+      expect(loginHtml).toContain("var __anBuilderPreviewSeen = false");
+      expect(loginHtml).toContain("function __anRememberBuilderPreview()");
+      expect(loginHtml).toContain(
+        "sessionStorage.setItem('__an_builder_preview_seen', '1')",
+      );
+      expect(loginHtml).toContain("function __anHasBuilderPreviewSignal()");
+      expect(loginHtml).toContain("params.has('builder.preview')");
+      expect(loginHtml).toContain("__anIsBuilderPreview();");
       expect(loginHtml).toContain("__anIsBuilderDesktop()");
       expect(loginHtml).toContain("__anIsAgentNativeDesktop()");
-      expect(loginHtml).toContain("if (__anIsBuilderPreview()) return 'popup'");
+      expect(loginHtml).toContain(
+        "if (__anIsBuilderPreview()) return 'redirect'",
+      );
       expect(loginHtml).toContain(
         "__anSetOAuthDebug('Opening Google sign-in in system browser', flowId)",
       );

--- a/packages/core/src/server/auth.ts
+++ b/packages/core/src/server/auth.ts
@@ -95,6 +95,11 @@ import {
   workspaceAppRouteAccessFromEnv,
   type WorkspaceAppAudience,
 } from "../shared/workspace-app-audience.js";
+import {
+  BUILDER_CONNECT_OWNER_COOKIE,
+  BUILDER_CONNECT_PARAM,
+  verifyBuilderConnectTokenAndGetOwner,
+} from "./builder-browser.js";
 
 /**
  * Get the configured session max age. Desktop SSO broker writes from
@@ -223,11 +228,10 @@ export interface AuthOptions {
   /**
    * Google sign-in flow: `'popup'`, `'redirect'`, or `'auto'` (default).
    *
-   * - `'auto'` — popup in normal browsers, redirect in Electron. Always uses
-   *   popup inside the Builder.io browser iframe (Google blocks framing).
+   * - `'auto'` — popup in normal browsers, redirect in Electron and Builder.io
+   *   preview/editor surfaces.
    * - `'popup'` — force popup everywhere.
-   * - `'redirect'` — force redirect everywhere except the Builder.io browser
-   *   iframe, which stays popup for technical reasons.
+   * - `'redirect'` — force redirect everywhere.
    *
    * Falls back to the `GOOGLE_AUTH_MODE` env var, then `'auto'`.
    */
@@ -1129,6 +1133,32 @@ function workspaceOAuthCallbackRelayResponse(
   });
 }
 
+function verifiedBuilderConnectOwnerFromUrl(url: string): string | null {
+  const queryStart = url.indexOf("?");
+  if (queryStart < 0) return null;
+  const token = new URLSearchParams(url.slice(queryStart + 1)).get(
+    BUILDER_CONNECT_PARAM,
+  );
+  return verifyBuilderConnectTokenAndGetOwner(token);
+}
+
+function shouldBypassAuthForBuilderConnect(event: H3Event, p: string): boolean {
+  if (p === "/_agent-native/builder/connect") {
+    const url = event.node?.req?.url ?? event.path ?? "/";
+    return Boolean(verifiedBuilderConnectOwnerFromUrl(url));
+  }
+
+  if (p === "/_agent-native/builder/callback") {
+    return Boolean(
+      verifyBuilderConnectTokenAndGetOwner(
+        getCookie(event, BUILDER_CONNECT_OWNER_COOKIE),
+      ),
+    );
+  }
+
+  return false;
+}
+
 function createAuthGuardFn(): (
   event: H3Event,
 ) => Promise<Response | object | string | void> {
@@ -1293,6 +1323,7 @@ function createAuthGuardFn(): (
     // route tree, no per-user data.
     if (p === "/__manifest") return;
     if (isPublicPath(normalizedUrl, publicPaths)) return;
+    if (shouldBypassAuthForBuilderConnect(event, p)) return;
     if (isPublicWorkspacePageRequest(event, p, config)) {
       return;
     }

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -13,6 +13,7 @@ import {
   signBuilderCallbackState,
   verifyBuilderConnectToken,
   verifyBuilderCallbackState,
+  verifyBuilderConnectTokenAndGetOwner,
 } from "./builder-browser.js";
 
 describe("Builder callback CSRF state", () => {
@@ -206,6 +207,22 @@ describe("Builder callback CSRF state", () => {
       const token = new URL(connectUrl).searchParams.get(BUILDER_CONNECT_PARAM);
       expect(token).toBeTruthy();
       expect(verifyBuilderConnectToken(token, "alice@example.com")).toBe(true);
+    });
+
+    it("extracts the owner email from a valid connect token", () => {
+      const token = signBuilderConnectToken("alice@example.com");
+
+      expect(verifyBuilderConnectTokenAndGetOwner(token)).toBe(
+        "alice@example.com",
+      );
+    });
+
+    it("does not extract an owner from a forged connect token", () => {
+      const token = signBuilderConnectToken("alice@example.com");
+      const parts = token.split(".");
+      parts[1] = Buffer.from("bob@example.com", "utf8").toString("base64url");
+
+      expect(verifyBuilderConnectTokenAndGetOwner(parts.join("."))).toBeNull();
     });
   });
 

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -20,6 +20,7 @@ export const BUILDER_CALLBACK_PATH = "/_agent-native/builder/callback";
  */
 export const BUILDER_STATE_PARAM = "_an_state";
 export const BUILDER_CONNECT_PARAM = "_an_connect";
+export const BUILDER_CONNECT_OWNER_COOKIE = "an_builder_connect_owner";
 
 const BUILDER_STATE_TTL_MS = 10 * 60 * 1000;
 
@@ -152,6 +153,25 @@ export function verifyBuilderConnectToken(
   ownerEmail: string,
 ): boolean {
   return verifyEmailBoundBuilderToken(token, ownerEmail, "connect");
+}
+
+export function verifyBuilderConnectTokenAndGetOwner(
+  token: string | null | undefined,
+): string | null {
+  if (typeof token !== "string" || token.length === 0) return null;
+  const parts = token.split(".");
+  if (parts.length !== 4) return null;
+  const emailEncoded = parts[1];
+  if (!emailEncoded) return null;
+
+  let ownerEmail: string;
+  try {
+    ownerEmail = Buffer.from(emailEncoded, "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+  if (!ownerEmail) return null;
+  return verifyBuilderConnectToken(token, ownerEmail) ? ownerEmail : null;
 }
 
 export function appendBuilderConnectToken(

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -13,6 +13,9 @@ import {
   setResponseHeader,
   getMethod,
   getHeader,
+  getCookie,
+  setCookie,
+  deleteCookie,
 } from "h3";
 import type { H3Event } from "h3";
 import path from "node:path";
@@ -23,6 +26,7 @@ import type { EnvKeyConfig } from "./create-server.js";
 import { readBody } from "./h3-helpers.js";
 import {
   BUILDER_CONNECT_PARAM,
+  BUILDER_CONNECT_OWNER_COOKIE,
   BUILDER_ENV_KEYS,
   appendBuilderConnectToken,
   buildBuilderCliAuthUrl,
@@ -33,6 +37,8 @@ import {
   resolveSafePreviewUrl,
   runBuilderAgent,
   verifyBuilderConnectToken,
+  verifyBuilderConnectTokenAndGetOwner,
+  signBuilderConnectToken,
 } from "./builder-browser.js";
 import {
   getState,
@@ -51,7 +57,7 @@ import {
   deleteUserSetting,
 } from "../settings/user-settings.js";
 import { getSession } from "./auth.js";
-import { getOrigin } from "./google-oauth.js";
+import { getAppBasePath, getOrigin } from "./google-oauth.js";
 import { findWorkspaceRoot } from "../scripts/utils.js";
 import { listOnboardingSteps } from "../onboarding/registry.js";
 import {
@@ -199,6 +205,40 @@ function stripAppBasePath(pathname: string): string {
     return pathname.slice(basePath.length) || "/";
   }
   return pathname;
+}
+
+function getBuilderConnectOwnerCookiePath(): string {
+  return getAppBasePath() || "/";
+}
+
+function readBuilderConnectOwnerCookie(event: H3Event): string | null {
+  return verifyBuilderConnectTokenAndGetOwner(
+    getCookie(event, BUILDER_CONNECT_OWNER_COOKIE),
+  );
+}
+
+function setBuilderConnectOwnerCookie(
+  event: H3Event,
+  ownerEmail: string,
+): void {
+  setCookie(
+    event,
+    BUILDER_CONNECT_OWNER_COOKIE,
+    signBuilderConnectToken(ownerEmail),
+    {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: getOrigin(event).startsWith("https://"),
+      path: getBuilderConnectOwnerCookiePath(),
+      maxAge: 10 * 60,
+    },
+  );
+}
+
+function clearBuilderConnectOwnerCookie(event: H3Event): void {
+  deleteCookie(event, BUILDER_CONNECT_OWNER_COOKIE, {
+    path: getBuilderConnectOwnerCookiePath(),
+  });
 }
 
 /**
@@ -518,6 +558,32 @@ export function createCoreRoutesPlugin(
         return { email: session.email, session, anonymous: false };
       }
 
+      const rawUrl = event.node?.req?.url ?? event.path ?? "/";
+      const queryStart = rawUrl.indexOf("?");
+      const rawPath = queryStart >= 0 ? rawUrl.slice(0, queryStart) : rawUrl;
+      const search = queryStart >= 0 ? rawUrl.slice(queryStart + 1) : "";
+      const path = stripAppBasePath(rawPath);
+
+      if (path === `${P}/builder/connect`) {
+        const ownerFromConnectToken = verifyBuilderConnectTokenAndGetOwner(
+          new URLSearchParams(search).get(BUILDER_CONNECT_PARAM),
+        );
+        if (ownerFromConnectToken) {
+          return {
+            email: ownerFromConnectToken,
+            session: null,
+            anonymous: false,
+          };
+        }
+      }
+
+      if (path === `${P}/builder/callback`) {
+        const ownerFromCookie = readBuilderConnectOwnerCookie(event);
+        if (ownerFromCookie) {
+          return { email: ownerFromCookie, session: null, anonymous: false };
+        }
+      }
+
       const anonymousOwner = await options.anonymousOwner?.(event);
       if (anonymousOwner) {
         return { email: anonymousOwner, session: null, anonymous: true };
@@ -809,6 +875,7 @@ export function createCoreRoutesPlugin(
             stage: "connect",
           },
         );
+        setBuilderConnectOwnerCookie(event, ownerEmail);
         // Build the cli-auth URL without embedding state in redirect_url:
         // Builder's /cli-auth appends params directly to redirect_url and
         // does not preserve any pre-existing query string we put there.
@@ -939,6 +1006,7 @@ export function createCoreRoutesPlugin(
           setResponseStatus(event, 401);
           return { error: "Authentication required" };
         }
+        clearBuilderConnectOwnerCookie(event);
 
         const requestUrl = new URL(
           `${event.url?.pathname || "/"}${event.url?.search || ""}`,

--- a/packages/core/src/server/google-auth-plugin.ts
+++ b/packages/core/src/server/google-auth-plugin.ts
@@ -13,8 +13,8 @@ export interface GoogleAuthPluginOptions {
   publicPaths?: string[];
   /**
    * Google sign-in flow: `'popup'`, `'redirect'`, or `'auto'` (default).
-   * Falls back to `GOOGLE_AUTH_MODE` env var, then `'auto'`. The Builder.io
-   * browser iframe always uses popup regardless (Google blocks framing).
+   * Falls back to `GOOGLE_AUTH_MODE` env var, then `'auto'`. Builder.io
+   * preview/editor surfaces always use redirect.
    */
   googleAuthMode?: GoogleAuthMode;
 }
@@ -187,18 +187,40 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
     __anSetOAuthDebug('OAuth exchange redeemed; returning to the app', flowId);
     window.location.href = ret || '/';
   }
-  function __anIsBuilderPreview() {
+  var __anBuilderPreviewSeen = false;
+  function __anRememberBuilderPreview() {
+    __anBuilderPreviewSeen = true;
+    try { sessionStorage.setItem('__an_builder_preview_seen', '1'); } catch(e) {}
+  }
+  function __anHasBuilderPreviewSignal() {
     try {
       var params = new URLSearchParams(window.location.search);
       if (params.has('builder.preview') || params.has('builder.frameEditing') || params.has('__builder_editing__')) return true;
     } catch(e) {}
+    return false;
+  }
+  function __anIsBuilderPreview() {
+    if (__anBuilderPreviewSeen) return true;
+    if (__anHasBuilderPreviewSignal()) {
+      __anRememberBuilderPreview();
+      return true;
+    }
+    try {
+      if (sessionStorage.getItem('__an_builder_preview_seen') === '1') {
+        __anBuilderPreviewSeen = true;
+        return true;
+      }
+    } catch(e) {}
     try {
       var ref = document.referrer || '';
-      return ref.indexOf('builder.io') !== -1 || ref.indexOf('builder.my') !== -1 || ref.indexOf('builderio.xyz') !== -1 || ref.indexOf('builderio.dev') !== -1 || ref.indexOf('builder.codes') !== -1;
+      var fromBuilder = ref.indexOf('builder.io') !== -1 || ref.indexOf('builder.my') !== -1 || ref.indexOf('builderio.xyz') !== -1 || ref.indexOf('builderio.dev') !== -1 || ref.indexOf('builder.codes') !== -1;
+      if (fromBuilder) __anRememberBuilderPreview();
+      return fromBuilder;
     } catch(e) {
       return false;
     }
   }
+  __anIsBuilderPreview();
   function __anIsBuilderDesktop() {
     try {
       var ua = navigator.userAgent || '';
@@ -222,7 +244,7 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
     }
   }
   function __anResolveAuthFlow() {
-    if (__anIsBuilderPreview()) return 'popup';
+    if (__anIsBuilderPreview()) return 'redirect';
     var mode = __AN_GOOGLE_AUTH_MODE || 'auto';
     if (mode === 'popup') return 'popup';
     if (mode === 'redirect') return 'redirect';

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -59,6 +59,15 @@ describe("getOnboardingHtml", () => {
       "__anSetOAuthDebug('Opening Google sign-in in system browser', flowId)",
     );
     expect(html).toContain("function __anBuilderPreviewReturnOrigin()");
+    expect(html).toContain("var __anBuilderPreviewSeen = false");
+    expect(html).toContain("function __anRememberBuilderPreview()");
+    expect(html).toContain(
+      "sessionStorage.setItem('__an_builder_preview_seen', '1')",
+    );
+    expect(html).toContain("function __anHasBuilderPreviewSignal()");
+    expect(html).toContain("params.has('builder.preview')");
+    expect(html).toContain("__anIsBuilderPreview();");
+    expect(html).toContain("if (__anIsBuilderPreview()) return 'redirect'");
     expect(html).toContain(
       "var candidates = [window.location.href, document.referrer || ''];",
     );

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -79,8 +79,8 @@ export interface OnboardingHtmlOptions {
   };
   /**
    * Google sign-in flow: `'popup'`, `'redirect'`, or `'auto'` (default).
-   * Falls back to `GOOGLE_AUTH_MODE` env var, then `'auto'`. The Builder.io
-   * browser iframe always uses popup regardless (Google blocks framing).
+   * Falls back to `GOOGLE_AUTH_MODE` env var, then `'auto'`. Builder.io
+   * preview/editor surfaces always use redirect.
    */
   googleAuthMode?: GoogleAuthMode;
 }
@@ -1000,18 +1000,40 @@ ${
       } catch(e) {}
       return window.location.pathname + window.location.search;
     }
-    function __anIsBuilderPreview() {
+    var __anBuilderPreviewSeen = false;
+    function __anRememberBuilderPreview() {
+      __anBuilderPreviewSeen = true;
+      try { sessionStorage.setItem('__an_builder_preview_seen', '1'); } catch(e) {}
+    }
+    function __anHasBuilderPreviewSignal() {
       try {
         var params = new URLSearchParams(window.location.search);
         if (params.has('builder.preview') || params.has('builder.frameEditing') || params.has('__builder_editing__')) return true;
       } catch(e) {}
+      return false;
+    }
+    function __anIsBuilderPreview() {
+      if (__anBuilderPreviewSeen) return true;
+      if (__anHasBuilderPreviewSignal()) {
+        __anRememberBuilderPreview();
+        return true;
+      }
+      try {
+        if (sessionStorage.getItem('__an_builder_preview_seen') === '1') {
+          __anBuilderPreviewSeen = true;
+          return true;
+        }
+      } catch(e) {}
       try {
         var ref = document.referrer || '';
-        return ref.indexOf('builder.io') !== -1 || ref.indexOf('builder.my') !== -1 || ref.indexOf('builderio.xyz') !== -1 || ref.indexOf('builderio.dev') !== -1 || ref.indexOf('builder.codes') !== -1;
+        var fromBuilder = ref.indexOf('builder.io') !== -1 || ref.indexOf('builder.my') !== -1 || ref.indexOf('builderio.xyz') !== -1 || ref.indexOf('builderio.dev') !== -1 || ref.indexOf('builder.codes') !== -1;
+        if (fromBuilder) __anRememberBuilderPreview();
+        return fromBuilder;
       } catch(e) {
         return false;
       }
     }
+    __anIsBuilderPreview();
     function __anIsBuilderDesktop() {
       try {
         var ua = navigator.userAgent || '';
@@ -1035,15 +1057,13 @@ ${
       }
     }
     function __anResolveAuthFlow() {
-      // Per-session override for ad-hoc testing: append ?authMode=popup
-      // or ?authMode=redirect to the sign-in URL. Wins over every other rule.
+      if (__anIsBuilderPreview()) return 'redirect';
+      // Per-session override for ad-hoc testing outside Builder: append
+      // ?authMode=popup or ?authMode=redirect to the sign-in URL.
       try {
         var qp = new URLSearchParams(window.location.search).get('authMode');
         if (qp === 'popup' || qp === 'redirect') return qp;
       } catch(e) {}
-      // Builder.io preview surfaces must use popup — Google sets
-      // X-Frame-Options: DENY so a redirect inside the webview/iframe fails.
-      if (__anIsBuilderPreview()) return 'popup';
       var mode = __AN_GOOGLE_AUTH_MODE || 'auto';
       if (mode === 'popup') return 'popup';
       if (mode === 'redirect') return 'redirect';

--- a/templates/mail/app/pages/InboxPage.tsx
+++ b/templates/mail/app/pages/InboxPage.tsx
@@ -19,11 +19,6 @@ import {
 
 import { IntegrationsSidebar } from "@/components/email/IntegrationsSidebar";
 import { GoogleConnectBanner } from "@/components/GoogleConnectBanner";
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from "@/components/ui/resizable";
 import { useAccountFilter } from "@/hooks/use-account-filter";
 import { useGoogleAuthStatus } from "@/hooks/use-google-auth";
 import type { EmailMessage } from "@shared/types";
@@ -45,7 +40,8 @@ function ContactPanel({
 }) {
   // Look up from already-cached list data instead of making a separate API call
   const email = useMemo(
-    () => emails.find((e) => e.id === emailId),
+    () =>
+      emails.find((e) => e.id === emailId || (e.threadId || e.id) === emailId),
     [emails, emailId],
   );
   // Always use inbox emails for "recent from contact" — shares React Query cache,
@@ -76,7 +72,7 @@ function ContactPanel({
       displayName={displayName || displayEmail}
       recentEmails={recentFromContact}
       threadId={email?.threadId}
-      focusedEmailId={emailId}
+      focusedEmailId={email?.id ?? emailId}
     />
   );
 }
@@ -128,7 +124,7 @@ function ThreadListSidebar({
   useKeyboardShortcuts([{ key: "a", meta: true, handler: selectAllThreads }]);
 
   return (
-    <div className="flex h-full w-full min-w-0 shrink-0 flex-col overflow-hidden bg-muted/50 dark:bg-[hsl(220,6%,5%)]">
+    <div className="flex h-full w-[220px] min-w-0 shrink-0 flex-col overflow-hidden border-r border-border/30 bg-muted/50 dark:bg-[hsl(220,6%,5%)]">
       <div className="flex-1 overflow-y-auto">
         {threads.map((thread) => {
           const email = thread.latestMessage;
@@ -598,88 +594,46 @@ export function InboxPage() {
 
   return (
     <div className="flex flex-1 overflow-hidden">
-      {/* Main content — resizable thread list + detail view on desktop */}
-      {hasThread && !isMobile && !isMaximized ? (
-        <ResizablePanelGroup
-          id="mail-thread-detail-layout"
-          orientation="horizontal"
-          resizeTargetMinimumSize={{ coarse: 28, fine: 8 }}
-          className="min-w-0 flex-1"
-        >
-          <ResizablePanel
-            id="mail-thread-list"
-            defaultSize="220px"
-            minSize="180px"
-            maxSize="420px"
-            groupResizeBehavior="preserve-pixel-size"
-            className="min-w-0"
-          >
-            <ThreadListSidebar
-              emails={emails}
-              activeThreadId={threadId!}
-              view={view}
-              routeSearchSuffix={routeSearchSuffix}
-              selectedIds={selectedIds}
-              setSelectedIds={setSelectedIds}
-              onNavigateThread={handleOptimisticThreadNavigation}
-            />
-          </ResizablePanel>
-          <ResizableHandle
-            id="mail-thread-list-resizer"
-            aria-label="Resize email list"
-            className="w-2 cursor-col-resize bg-transparent transition-colors after:w-px after:bg-border/30 hover:after:bg-border/80 data-[separator=active]:after:bg-primary/70 data-[separator=focus]:after:bg-ring/70"
-          />
-          <ResizablePanel
-            id="mail-thread-detail"
-            minSize="360px"
-            className="min-w-0"
-          >
-            <div className="flex h-full min-w-0 flex-col overflow-hidden">
-              <EmailThread
-                activeThreadId={threadId}
-                onArchived={setLastArchivedId}
-                emailIds={threadIds}
-                threads={threads}
-                selectedIds={selectedIds}
-                setSelectedIds={setSelectedIds}
-                onContactSelect={setSidebarContactEmail}
-                onNavigateThread={handleOptimisticThreadNavigation}
-                isMaximized={isMaximized}
-                onToggleMaximize={() => setIsMaximized((v) => !v)}
-              />
-            </div>
-          </ResizablePanel>
-        </ResizablePanelGroup>
-      ) : (
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          {hasThread ? (
-            <EmailThread
-              activeThreadId={threadId}
-              onArchived={setLastArchivedId}
-              emailIds={threadIds}
-              threads={threads}
-              selectedIds={selectedIds}
-              setSelectedIds={setSelectedIds}
-              onContactSelect={setSidebarContactEmail}
-              onNavigateThread={handleOptimisticThreadNavigation}
-              isMaximized={isMaximized}
-              onToggleMaximize={() => setIsMaximized((v) => !v)}
-            />
-          ) : (
-            <EmailList
-              emails={emails}
-              focusedId={focusedId}
-              setFocusedId={setFocusedId}
-              selectedIds={selectedIds}
-              setSelectedIds={setSelectedIds}
-              onCompose={handleCompose}
-              onArchived={setLastArchivedId}
-              onDraftOpen={handleDraftOpen}
-              onNavigateThread={handleOptimisticThreadNavigation}
-            />
-          )}
-        </div>
+      {/* Main content */}
+      {hasThread && !isMobile && !isMaximized && (
+        <ThreadListSidebar
+          emails={emails}
+          activeThreadId={threadId}
+          view={view}
+          routeSearchSuffix={routeSearchSuffix}
+          selectedIds={selectedIds}
+          setSelectedIds={setSelectedIds}
+          onNavigateThread={handleOptimisticThreadNavigation}
+        />
       )}
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        {hasThread ? (
+          <EmailThread
+            activeThreadId={threadId}
+            onArchived={setLastArchivedId}
+            emailIds={threadIds}
+            threads={threads}
+            selectedIds={selectedIds}
+            setSelectedIds={setSelectedIds}
+            onContactSelect={setSidebarContactEmail}
+            onNavigateThread={handleOptimisticThreadNavigation}
+            isMaximized={isMaximized}
+            onToggleMaximize={() => setIsMaximized((v) => !v)}
+          />
+        ) : (
+          <EmailList
+            emails={emails}
+            focusedId={focusedId}
+            setFocusedId={setFocusedId}
+            selectedIds={selectedIds}
+            setSelectedIds={setSelectedIds}
+            onCompose={handleCompose}
+            onArchived={setLastArchivedId}
+            onDraftOpen={handleDraftOpen}
+            onNavigateThread={handleOptimisticThreadNavigation}
+          />
+        )}
+      </div>
 
       {/* Right contact panel — hidden during initial load or when maximized */}
       {!isLoading && !(hasThread && isMaximized) && (


### PR DESCRIPTION
## Summary

- **core/auth + builder-browser + core-routes-plugin + google-auth-plugin + onboarding-html**: signed Builder-connect flows can now complete through workspace gateway origins (e.g. preview/workspace-deploy hosts) without requiring the iframe host's session cookie. Adds spec coverage in auth.spec, builder-browser.spec, onboarding-html.spec.
- **mail/InboxPage**: concurrent-agent refactor cleanup (-25 net lines).
- **changeset**: `builder-connect-workspace-gateway` (`@agent-native/core` patch).

## Test plan

- [ ] Lint & format
- [ ] Typecheck
- [ ] Build
- [ ] Test (auth + builder-browser + onboarding-html specs)
- [ ] Manual: signed Builder connect flow from a workspace gateway origin completes without session-cookie redirect loop