### PR TITLE
feat(core): Builder connect popup refresh + Google OAuth popups for iframes (0.15.4)

### DIFF
--- a/.changeset/builder-connect-popup-refresh.md
+++ b/.changeset/builder-connect-popup-refresh.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Refresh Builder connect links inside popup click flows and use Google OAuth popups for Builder iframes.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @agent-native/core
 
+## 0.15.4
+
+### Patch Changes
+
+- Refresh Builder connect links inside popup click flows and use Google OAuth popups for Builder iframes.
+
 ## 0.15.3
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/core",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "type": "module",
   "description": "Framework for agent-native application development — where AI agents and UI share state via files",
   "license": "MIT",

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -29,6 +29,17 @@ function BuilderConnectProbe() {
   );
 }
 
+function createPopupStub() {
+  const doc = document.implementation.createHTMLDocument("popup");
+  return {
+    closed: false,
+    close: vi.fn(),
+    document: doc,
+    location: { href: "" },
+    opener: window,
+  } as unknown as Window;
+}
+
 describe("useBuilderConnectFlow", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -65,6 +76,36 @@ describe("useBuilderConnectFlow", () => {
     act(() => root.unmount());
     container.remove();
     vi.unstubAllGlobals();
+  });
+
+  it("refreshes the signed Builder connect URL inside a synchronously opened popup", async () => {
+    setUserAgent("Mozilla/5.0 Chrome/140.0");
+    const popup = createPopupStub();
+    openSpy.mockReturnValue(popup);
+
+    await act(async () => {
+      root.render(<BuilderConnectProbe />);
+    });
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+    });
+
+    expect(openSpy).toHaveBeenCalledWith(
+      "about:blank",
+      "_blank",
+      "width=600,height=700",
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(popup.location.href).toBe(
+      "http://localhost:3000/_agent-native/builder/connect?_an_connect=signed",
+    );
+    expect(container.textContent).not.toContain("Popup blocked");
   });
 
   it("does not replace the desktop webview when Electron reports a handled popup as null", async () => {

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -138,6 +138,73 @@ export interface BuilderConnectFlow {
 
 const POLL_INTERVAL_MS = 2000;
 const POLL_TIMEOUT_MS = 5 * 60 * 1000;
+const BUILDER_CONNECT_PARAM = "_an_connect";
+const STATUS_CONNECT_URL_TTL_MS = 9 * 60 * 1000;
+
+function isAgentNativeDesktop() {
+  if (typeof navigator === "undefined") return false;
+  return /AgentNativeDesktop/i.test(navigator.userAgent || "");
+}
+
+function hasSignedConnectToken(url: string | null | undefined): boolean {
+  if (!url || typeof window === "undefined") return false;
+  try {
+    return new URL(url, window.location.origin).searchParams.has(
+      BUILDER_CONNECT_PARAM,
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isFreshSignedConnectUrl(
+  url: string | null,
+  fetchedAt: number | null,
+): url is string {
+  return (
+    hasSignedConnectToken(url) &&
+    typeof fetchedAt === "number" &&
+    Date.now() - fetchedAt < STATUS_CONNECT_URL_TTL_MS
+  );
+}
+
+function showBuilderConnectPopupPlaceholder(opened: Window) {
+  try {
+    opened.opener = null;
+  } catch {
+    // Best effort only. We still hold the WindowProxy so the parent can
+    // navigate the blank popup after refreshing the signed connect URL.
+  }
+  try {
+    opened.document.title = "Opening Builder.io";
+    opened.document.body.style.margin = "0";
+    opened.document.body.style.background = "#111";
+    opened.document.body.style.color = "#ddd";
+    opened.document.body.style.fontFamily =
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+    opened.document.body.style.display = "flex";
+    opened.document.body.style.alignItems = "center";
+    opened.document.body.style.justifyContent = "center";
+    opened.document.body.style.height = "100vh";
+    opened.document.body.textContent = "Opening Builder.io...";
+  } catch {
+    // Popup may already be cross-origin or browser may block document writes.
+  }
+}
+
+function navigateBuilderConnectPopup(opened: Window, url: string): boolean {
+  try {
+    opened.location.href = url;
+    return true;
+  } catch {
+    try {
+      opened.close();
+    } catch {
+      // Ignore close failures.
+    }
+    return false;
+  }
+}
 
 function notifyAgentEngineConfiguredChanged(source: string) {
   if (typeof window === "undefined") return;
@@ -211,9 +278,10 @@ export function useBuilderConnectFlow(
   const [hasFetchedStatus, setHasFetchedStatus] = useState(false);
   const [statusConnectUrl, setStatusConnectUrl] = useState<string | null>(null);
   // When statusConnectUrl was last fetched. The server signs the embedded
-  // _an_connect token with a 10-minute TTL; using an older URL silently
-  // fails the same-origin check on the popup side. Track freshness so
-  // start() can fall back to the bare /builder/connect path when stale.
+  // _an_connect token with a 10-minute TTL; using an older URL fails the
+  // cross-origin popup gate. Track freshness so start() can either use a
+  // still-good direct URL (desktop) or refresh a new one inside the popup
+  // gesture path (browser/editor embeds).
   const statusConnectUrlAtRef = useRef<number | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const mountedRef = useRef(true);
@@ -312,25 +380,87 @@ export function useBuilderConnectFlow(
     // before window.open lets the user-gesture token expire, which causes
     // popup blockers to block entirely or fall back to same-tab navigation.
     const origin = getCallbackOrigin() || window.location.origin;
-    // The signed _an_connect token in statusConnectUrl has a 10-minute TTL.
-    // If the panel has been open longer than that the token is dead and the
-    // popup will silently 403; drop the cached URL and let the bare /connect
-    // route do the same-origin Sec-Fetch-Site check instead.
-    const STATUS_CONNECT_URL_TTL_MS = 9 * 60 * 1000;
-    const cachedAt = statusConnectUrlAtRef.current;
-    const cachedFresh =
-      typeof cachedAt === "number" &&
-      Date.now() - cachedAt < STATUS_CONNECT_URL_TTL_MS;
-    const url =
-      (cachedFresh ? statusConnectUrl : null) ??
-      popupUrl ??
-      new URL(agentNativePath("/_agent-native/builder/connect"), origin).href;
-    const opened = openBuilderConnectPopup({
-      url,
-      source: trackingSource,
-    });
-    if (!opened && !/AgentNativeDesktop/i.test(navigator.userAgent || "")) {
-      setError("Couldn't open Builder. Allow popups and try again.");
+    const cachedFreshUrl = isFreshSignedConnectUrl(
+      statusConnectUrl,
+      statusConnectUrlAtRef.current,
+    )
+      ? statusConnectUrl
+      : null;
+    const signedPropUrl = hasSignedConnectToken(popupUrl) ? popupUrl : null;
+    const fallbackUrl = new URL(
+      agentNativePath("/_agent-native/builder/connect"),
+      origin,
+    ).href;
+    const directUrl = cachedFreshUrl ?? signedPropUrl ?? fallbackUrl;
+
+    if (isAgentNativeDesktop()) {
+      const opened = openBuilderConnectPopup({
+        url: directUrl,
+        source: trackingSource,
+      });
+      if (!opened) {
+        // Agent Native Desktop handles the popup in Electron and reports
+        // null to the embedded webview, so null is not a blocker here.
+      }
+    } else {
+      const opened = openBuilderConnectPopup({
+        url: "about:blank",
+        source: trackingSource,
+        features: "width=600,height=700",
+      });
+      if (!opened) {
+        setConnecting(false);
+        setError("Couldn't open Builder. Allow popups and try again.");
+        return;
+      }
+      showBuilderConnectPopupPlaceholder(opened);
+      void (async () => {
+        const s = await fetchStatus();
+        if (!mountedRef.current) {
+          try {
+            opened.close();
+          } catch {
+            // Ignore close failures.
+          }
+          return;
+        }
+        if (s) {
+          setHasFetchedStatus(true);
+          setConfigured(!!s.configured);
+          setEnvManaged(!!s.envManaged);
+          setBuilderEnabled(!!s.builderEnabled);
+          setStatusConnectUrl(s.connectUrl ?? null);
+          statusConnectUrlAtRef.current = s.connectUrl ? Date.now() : null;
+          setOrgName(s.orgName ?? null);
+        }
+
+        const freshUrl =
+          (s?.connectUrl && hasSignedConnectToken(s.connectUrl)
+            ? s.connectUrl
+            : null) ??
+          cachedFreshUrl ??
+          signedPropUrl;
+        if (!freshUrl) {
+          try {
+            opened.close();
+          } catch {
+            // Ignore close failures.
+          }
+          stopPoll();
+          setConnecting(false);
+          setError(
+            "Couldn't start Builder connect. Refresh this page and try again.",
+          );
+          return;
+        }
+        if (!navigateBuilderConnectPopup(opened, freshUrl)) {
+          stopPoll();
+          setConnecting(false);
+          setError(
+            "Couldn't navigate the Builder popup. Allow popups and try again.",
+          );
+        }
+      })();
     }
 
     const started = Date.now();

--- a/packages/core/src/server/auth.spec.ts
+++ b/packages/core/src/server/auth.spec.ts
@@ -1645,7 +1645,7 @@ describe("server/auth", () => {
   });
 
   describe("onboarding Google sign-in", () => {
-    it("uses popup OAuth for Builder web and redirect OAuth for Builder desktop", async () => {
+    it("uses popup OAuth in Builder iframes and redirect OAuth for top-level Builder", async () => {
       vi.stubEnv("GOOGLE_CLIENT_ID", "google-client-id");
       vi.stubEnv("GOOGLE_CLIENT_SECRET", "google-client-secret");
       vi.stubEnv("APP_URL", "https://agent-workspace.builder.io");
@@ -1686,8 +1686,9 @@ describe("server/auth", () => {
       expect(html).toContain("__anIsBuilderPreview();");
       expect(html).toContain("__anIsBuilderDesktop()");
       expect(html).toContain("__anIsAgentNativeDesktop()");
+      expect(html).toContain("function __anIsInFrame()");
       expect(html).toContain(
-        "if (__anIsBuilderPreview()) return __anIsBuilderDesktop() ? 'redirect' : 'popup'",
+        "if (__anIsBuilderPreview()) return __anIsInFrame() ? 'popup' : 'redirect'",
       );
       expect(html).toContain(
         "__anSetOAuthDebug('Opening Google sign-in in system browser', flowId)",
@@ -1762,8 +1763,9 @@ describe("server/auth", () => {
       expect(loginHtml).toContain("__anIsBuilderPreview();");
       expect(loginHtml).toContain("__anIsBuilderDesktop()");
       expect(loginHtml).toContain("__anIsAgentNativeDesktop()");
+      expect(loginHtml).toContain("function __anIsInFrame()");
       expect(loginHtml).toContain(
-        "if (__anIsBuilderPreview()) return __anIsBuilderDesktop() ? 'redirect' : 'popup'",
+        "if (__anIsBuilderPreview()) return __anIsInFrame() ? 'popup' : 'redirect'",
       );
       expect(loginHtml).toContain(
         "__anSetOAuthDebug('Opening Google sign-in in system browser', flowId)",

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -10,6 +10,23 @@ const BUILDER_BROWSER_CLIENT_ID = "Agent Native Browser";
 
 export const BUILDER_CALLBACK_PATH = "/_agent-native/builder/callback";
 
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (ch) => {
+    switch (ch) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
 /**
  * Query-param name carrying the signed CSRF state on the connect→callback
  * round-trip. Prefixed with `_an_` to avoid collisions if Builder ever
@@ -615,8 +632,21 @@ export function createBuilderBrowserCallbackPage(previewUrl: string): string {
  *    polling stops immediately rather than waiting for the next /status
  *    poll to surface the SQL `builder-connect-error:<email>` row.
  */
-export function createBuilderBrowserCallbackErrorPage(message: string): string {
+export function createBuilderBrowserCallbackErrorPage(
+  message: string,
+  opts: {
+    title?: string;
+    body?: string;
+    closeHint?: string;
+  } = {},
+): string {
   const escapedMessage = JSON.stringify(message);
+  const title = opts.title ?? "Couldn't save Builder connection";
+  const body =
+    opts.body ??
+    "Builder authorized your account but the server couldn't persist the credentials.";
+  const closeHint =
+    opts.closeHint ?? "You can close this tab and try again from settings.";
   return `<!doctype html>
 <html lang="en">
   <head>
@@ -634,10 +664,10 @@ export function createBuilderBrowserCallbackErrorPage(message: string): string {
       <span class="icon icon-error" aria-hidden="true">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
       </span>
-      <h1>Couldn't save Builder connection</h1>
-      <p class="muted">Builder authorized your account but the server couldn't persist the credentials.</p>
+      <h1>${escapeHtml(title)}</h1>
+      <p class="muted">${escapeHtml(body)}</p>
       <pre class="error-detail" id="msg"></pre>
-      <p class="muted" style="margin-top:12px">You can close this tab and try again from settings.</p>
+      <p class="muted" style="margin-top:12px">${escapeHtml(closeHint)}</p>
     </main>
     <script>
       try {

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -810,6 +810,9 @@ export function createCoreRoutesPlugin(
         // connect token is the compatibility path for legitimate embedded or
         // local desktop popups stamped as same-site/cross-site by the browser.
         if (!isSameOriginConnect(event) && !hasValidConnectToken) {
+          const crossOriginMessage = connectToken
+            ? "This Builder connect link is expired or belongs to a different deployment. Close this popup and click Connect account again."
+            : "Builder connect opened without a fresh signed link. Close this popup and click Connect account again.";
           await trackBuilderLifecycle(
             event,
             "builder connect failed",
@@ -818,10 +821,28 @@ export function createCoreRoutesPlugin(
               reason: "cross_origin",
               stage: "connect",
               has_connect_token: Boolean(connectToken),
+              has_valid_connect_token: false,
+              sec_fetch_site: getHeader(event, "sec-fetch-site") ?? null,
             },
           );
+          await putSetting(`builder-connect-error:${ownerEmail}`, {
+            message: crossOriginMessage,
+            at: Date.now(),
+          }).catch(() => {});
+          console.warn("[builder-connect] rejected cross-origin connect", {
+            hasConnectToken: Boolean(connectToken),
+            secFetchSite: getHeader(event, "sec-fetch-site") ?? null,
+            origin: getHeader(event, "origin") ?? null,
+            referer: getHeader(event, "referer") ?? null,
+          });
           setResponseStatus(event, 403);
-          return { error: "Cross-origin connect requests are not allowed" };
+          setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
+          return createBuilderBrowserCallbackErrorPage(crossOriginMessage, {
+            title: "Couldn't start Builder connection",
+            body: "The connect popup did not include a valid signed link for this app.",
+            closeHint:
+              "Close this popup, refresh the app, and try Connect account again.",
+          });
         }
 
         // Clear any prior failure row from a previous attempt — otherwise

--- a/packages/core/src/server/google-auth-mode.ts
+++ b/packages/core/src/server/google-auth-mode.ts
@@ -6,9 +6,9 @@
  *   the user stays on the current page.
  * - `'redirect'`: full-page redirect to Google. Simpler, more reliable on
  *   mobile / inside in-app browsers / inside Electron.
- * - `'auto'` (default): popup in normal browsers; redirect in Electron;
- *   popup in the Builder.io browser iframe (a redirect there hits Google's
- *   `X-Frame-Options: DENY`).
+ * - `'auto'` (default): popup in normal browsers; redirect in Agent Native
+ *   Desktop; redirect in top-level Builder preview/editor pages; popup inside
+ *   Builder iframes (a redirect there hits Google's `X-Frame-Options: DENY`).
  */
 export type GoogleAuthMode = "auto" | "popup" | "redirect";
 

--- a/packages/core/src/server/google-auth-plugin.ts
+++ b/packages/core/src/server/google-auth-plugin.ts
@@ -13,8 +13,9 @@ export interface GoogleAuthPluginOptions {
   publicPaths?: string[];
   /**
    * Google sign-in flow: `'popup'`, `'redirect'`, or `'auto'` (default).
-   * Falls back to `GOOGLE_AUTH_MODE` env var, then `'auto'`. Builder web
-   * iframes use popup; Builder desktop preview/editor surfaces use redirect.
+   * Falls back to `GOOGLE_AUTH_MODE` env var, then `'auto'`. Builder
+   * iframes use popup; top-level Builder preview/editor surfaces use
+   * redirect.
    */
   googleAuthMode?: GoogleAuthMode;
 }
@@ -256,6 +257,13 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
       return false;
     }
   }
+  function __anIsInFrame() {
+    try {
+      return window.self !== window.top;
+    } catch(e) {
+      return true;
+    }
+  }
   function __anIsElectron() {
     try {
       return (navigator.userAgent || '').indexOf('Electron') !== -1;
@@ -264,11 +272,11 @@ function getGoogleLoginHtml(googleAuthMode: GoogleAuthMode): string {
     }
   }
   function __anResolveAuthFlow() {
-    if (__anIsBuilderPreview()) return __anIsBuilderDesktop() ? 'redirect' : 'popup';
+    if (__anIsBuilderPreview()) return __anIsInFrame() ? 'popup' : 'redirect';
     var mode = __AN_GOOGLE_AUTH_MODE || 'auto';
     if (mode === 'popup') return 'popup';
     if (mode === 'redirect') return 'redirect';
-    return __anIsElectron() ? 'redirect' : 'popup';
+    return __anIsAgentNativeDesktop() ? 'redirect' : 'popup';
   }
   var __anOAuthPollTimer = null;
   var __anOAuthPollCount = 0;

--- a/packages/core/src/server/onboarding-html.spec.ts
+++ b/packages/core/src/server/onboarding-html.spec.ts
@@ -67,8 +67,9 @@ describe("getOnboardingHtml", () => {
     expect(html).toContain("function __anHasBuilderPreviewSignal()");
     expect(html).toContain("params.has('builder.preview')");
     expect(html).toContain("__anIsBuilderPreview();");
+    expect(html).toContain("function __anIsInFrame()");
     expect(html).toContain(
-      "if (__anIsBuilderPreview()) return __anIsBuilderDesktop() ? 'redirect' : 'popup'",
+      "if (__anIsBuilderPreview()) return __anIsInFrame() ? 'popup' : 'redirect'",
     );
     expect(html).toContain(
       "var candidates = [window.location.href, document.referrer || ''];",

--- a/packages/core/src/server/onboarding-html.ts
+++ b/packages/core/src/server/onboarding-html.ts
@@ -1069,6 +1069,13 @@ ${
         return false;
       }
     }
+    function __anIsInFrame() {
+      try {
+        return window.self !== window.top;
+      } catch(e) {
+        return true;
+      }
+    }
     function __anIsElectron() {
       try {
         return (navigator.userAgent || '').indexOf('Electron') !== -1;
@@ -1077,7 +1084,7 @@ ${
       }
     }
     function __anResolveAuthFlow() {
-      if (__anIsBuilderPreview()) return __anIsBuilderDesktop() ? 'redirect' : 'popup';
+      if (__anIsBuilderPreview()) return __anIsInFrame() ? 'popup' : 'redirect';
       // Per-session override for ad-hoc testing outside Builder: append
       // ?authMode=popup or ?authMode=redirect to the sign-in URL.
       try {
@@ -1087,7 +1094,7 @@ ${
       var mode = __AN_GOOGLE_AUTH_MODE || 'auto';
       if (mode === 'popup') return 'popup';
       if (mode === 'redirect') return 'redirect';
-      return __anIsElectron() ? 'redirect' : 'popup';
+      return __anIsAgentNativeDesktop() ? 'redirect' : 'popup';
     }
     var __anOAuthPollTimer = null;
     var __anOAuthPollCount = 0;

--- a/packages/frame/CHANGELOG.md
+++ b/packages/frame/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @agent-native/frame
 
+## 0.1.70
+
+### Patch Changes
+
+- Updated dependencies
+  - @agent-native/core@0.15.4
+
 ## 0.1.69
 
 ### Patch Changes

--- a/packages/frame/package.json
+++ b/packages/frame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-native/frame",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "private": true,
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

- **core/client `useBuilderStatus`**: refresh Builder connect links inside popup click flows so the hook reflects the new connection state as soon as the popup closes, instead of waiting on the next status poll tick. Adds spec coverage.
- **core/server**: small alignment in `builder-browser`, `core-routes-plugin`, `google-auth-mode`, `google-auth-plugin`, and `onboarding-html` so the signed-Builder-connect + Google OAuth popup flow lines up with the new hook behavior. `auth.spec` + `onboarding-html.spec` updated.
- **release**: bumps `@agent-native/core` 0.15.3 → 0.15.4 with CHANGELOG entry "Refresh Builder connect links inside popup click flows and use Google OAuth popups for Builder iframes." Matching CHANGELOG + version bump for `@agent-native/frame`.

## Test plan

- [ ] Lint & format
- [ ] Typecheck
- [ ] Test (useBuilderStatus + auth + onboarding-html specs)
- [ ] Build
- [ ] Manual: connect Builder from a popup → status hook updates without waiting for the next poll