### PR TITLE
fix: save recording in the selected folder

### DIFF
--- a/templates/clips/app/components/library/empty-state.tsx
+++ b/templates/clips/app/components/library/empty-state.tsx
@@ -59,10 +59,16 @@ const COPY: Record<EmptyKind, { title: string; body: string; cta?: string }> = {
 interface EmptyStateProps {
   kind: EmptyKind;
   spaceId?: string | null;
+  folderId?: string | null;
   onCtaClick?: () => void;
 }
 
-export function EmptyState({ kind, spaceId, onCtaClick }: EmptyStateProps) {
+export function EmptyState({
+  kind,
+  spaceId,
+  folderId,
+  onCtaClick,
+}: EmptyStateProps) {
   const navigate = useNavigate();
   const Icon = ICONS[kind];
   const copy = COPY[kind];
@@ -71,9 +77,11 @@ export function EmptyState({ kind, spaceId, onCtaClick }: EmptyStateProps) {
     if (onCtaClick) {
       onCtaClick();
     } else {
-      navigate(
-        spaceId ? `/record?spaceId=${encodeURIComponent(spaceId)}` : "/record",
-      );
+      const params = new URLSearchParams();
+      if (spaceId) params.set("spaceId", spaceId);
+      if (folderId) params.set("folderId", folderId);
+      const qs = params.toString();
+      navigate(qs ? `/record?${qs}` : "/record");
     }
   };
 

--- a/templates/clips/app/components/library/library-grid.tsx
+++ b/templates/clips/app/components/library/library-grid.tsx
@@ -257,7 +257,11 @@ export function LibraryGrid({
               ))}
             </div>
           ) : recordings.length === 0 ? (
-            <EmptyState kind={resolvedEmptyKind} spaceId={spaceId} />
+            <EmptyState
+              kind={resolvedEmptyKind}
+              spaceId={spaceId}
+              folderId={folderId}
+            />
           ) : (
             <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(300px,1fr))]">
               {recordings.map((r: RecordingSummary) => (

--- a/templates/clips/app/routes/record.tsx
+++ b/templates/clips/app/routes/record.tsx
@@ -633,11 +633,15 @@ export default function RecordRoute() {
   const { isDesktopApp } = useDesktopPromo();
   const storageQuery = useVideoStorageStatus();
 
-  // When the user clicks "Record for this space", the empty-state CTA appends
-  // ?spaceId=... so the new recording lands in that space.
+  // When the user clicks "Record for this space/folder", the empty-state CTA
+  // appends ?spaceId or ?folderId so the new recording lands there.
   const spaceIdFromUrl = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return params.get("spaceId") || null;
+  }, [location.search]);
+  const folderIdFromUrl = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get("folderId") || null;
   }, [location.search]);
   const storageConfigured: boolean | null = storageQuery.isLoading
     ? null
@@ -898,6 +902,7 @@ export default function RecordRoute() {
               hasAudio: wantsMic,
               visibility: "public",
               spaceIds: spaceIdFromUrl ? [spaceIdFromUrl] : undefined,
+              folderId: folderIdFromUrl ?? undefined,
             }),
           },
         );
@@ -1165,6 +1170,7 @@ export default function RecordRoute() {
               width: meta.width,
               height: meta.height,
               spaceIds: spaceIdFromUrl ? [spaceIdFromUrl] : undefined,
+              folderId: folderIdFromUrl ?? undefined,
             }),
           },
         );


### PR DESCRIPTION
# feat(clips): thread folderId through empty-state CTA to record route

## What changed

When a user opens an empty folder in the Clips library and clicks "Record", the new recording now lands in that folder automatically.

Previously only `spaceId` was forwarded from the empty-state CTA. `folderId` was silently dropped, so recordings started from a folder's empty state weren't associated with it.

## Testing

1. Open Clips → navigate into any folder with no recordings
2. Click the "Start recording" CTA
3. Record and save — recording should appear in that folder
