### PR TITLE
feat(core): polish Builder connect — skip loopback callbacks + refresh chat UI on connect

### DIFF
--- a/.changeset/polite-builder-connect.md
+++ b/.changeset/polite-builder-connect.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Polish Builder connect completion by avoiding loopback callback URLs and refreshing connected chat UI.

--- a/packages/core/src/client/AssistantChat.tsx
+++ b/packages/core/src/client/AssistantChat.tsx
@@ -2693,6 +2693,10 @@ function RunErrorRecoveryCard({
   });
   const canRecover = info.recoverable === true;
   const shouldShowBuilderReconnect = isBuilderReconnectRunError(info);
+  const builderReconnectResolved =
+    shouldShowBuilderReconnect &&
+    builderReconnect.hasFetchedStatus &&
+    builderReconnect.configured;
   const isQueryError = isProviderQueryRunError(info);
   const copyLabel =
     info.runId || info.errorCode || info.details ? "Copy debug" : "Copy";
@@ -2710,6 +2714,12 @@ function RunErrorRecoveryCard({
     setTimeout(() => setCopied(false), 1200);
   }, [info]);
 
+  useEffect(() => {
+    if (builderReconnectResolved) {
+      onDismiss();
+    }
+  }, [builderReconnectResolved, onDismiss]);
+
   return (
     <div className="rounded-lg border border-amber-500/25 bg-amber-500/[0.06] p-3 text-sm">
       <div className="flex items-start gap-2">
@@ -2725,7 +2735,7 @@ function RunErrorRecoveryCard({
           <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
             {info.message}
           </p>
-          {shouldShowBuilderReconnect && (
+          {shouldShowBuilderReconnect && !builderReconnectResolved && (
             <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
               The current Builder.io or model-provider credential was rejected.
               Reconnect Builder.io, then retry this message.
@@ -2769,7 +2779,7 @@ function RunErrorRecoveryCard({
         </button>
       </div>
       <div className="mt-3 flex flex-wrap items-center gap-2">
-        {shouldShowBuilderReconnect && (
+        {shouldShowBuilderReconnect && !builderReconnectResolved && (
           <button
             type="button"
             onClick={builderReconnect.start}

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -24,6 +24,10 @@ function BuilderConnectProbe({ popupUrl }: { popupUrl?: string }) {
       <button type="button" onClick={flow.start}>
         Connect
       </button>
+      <output data-testid="status">
+        {flow.configured ? "configured" : "not-configured"}{" "}
+        {flow.connecting ? "connecting" : "idle"}
+      </output>
       <output>{flow.error ?? ""}</output>
     </div>
   );
@@ -159,6 +163,62 @@ describe("useBuilderConnectFlow", () => {
     expect(popup.location.href).toBe(refreshedCliAuthUrl);
 
     resolveInitialFetch(jsonResponse({ configured: false }));
+  });
+
+  it("refreshes status when a Builder preview callback posts success", async () => {
+    setUserAgent("Mozilla/5.0 Chrome/140.0");
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        jsonResponse({
+          configured: false,
+          envManaged: false,
+          builderEnabled: true,
+          orgName: null,
+          cliAuthUrl: signedCliAuthUrl,
+          connectUrl:
+            "http://localhost:3000/_agent-native/builder/connect?_an_connect=signed",
+          appHost: "https://builder.io",
+          apiHost: "https://api.builder.io",
+          publicKeyConfigured: false,
+          privateKeyConfigured: false,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          configured: true,
+          envManaged: false,
+          builderEnabled: true,
+          orgName: "Builder space",
+          cliAuthUrl: signedCliAuthUrl,
+          connectUrl:
+            "http://localhost:3000/_agent-native/builder/connect?_an_connect=signed",
+          appHost: "https://builder.io",
+          apiHost: "https://api.builder.io",
+          publicKeyConfigured: true,
+          privateKeyConfigured: true,
+        }),
+      );
+
+    await act(async () => {
+      root.render(<BuilderConnectProbe />);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("not-configured");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin:
+            "https://940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz",
+          data: { type: "builder-connect-success" },
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("configured");
   });
 
   it("does not replace the desktop webview when Electron reports a handled popup as null", async () => {

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -229,6 +229,32 @@ function notifyAgentEngineConfiguredChanged(source: string) {
   );
 }
 
+function isTrustedBuilderConnectMessageOrigin(origin: string): boolean {
+  if (typeof window !== "undefined" && origin === window.location.origin) {
+    return true;
+  }
+  try {
+    const hostname = new URL(origin).hostname.toLowerCase();
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "builder.io" ||
+      hostname.endsWith(".builder.io") ||
+      hostname === "builder.my" ||
+      hostname.endsWith(".builder.my") ||
+      hostname === "builderio.xyz" ||
+      hostname.endsWith(".builderio.xyz") ||
+      hostname === "builderio.dev" ||
+      hostname.endsWith(".builderio.dev") ||
+      hostname === "builder.codes" ||
+      hostname.endsWith(".builder.codes")
+    );
+  } catch {
+    return false;
+  }
+}
+
 export interface OpenBuilderConnectPopupOptions {
   url?: string;
   source?: string;
@@ -553,7 +579,7 @@ export function useBuilderConnectFlow(
     }, POLL_INTERVAL_MS);
   }, [fetchStatus, popupUrl, statusConnectUrl, stopPoll, trackingSource]);
 
-  // Popup-side fast path: the error page broadcasts a message so we stop
+  // Popup-side fast path: the callback page broadcasts a message so we stop
   // polling immediately rather than waiting for the next 2s tick.
   //
   // We listen on BroadcastChannel (same-origin, works with noopener popups)
@@ -568,25 +594,57 @@ export function useBuilderConnectFlow(
       setConnecting(false);
       setError(`Couldn't save Builder credentials: ${message}.`);
     };
+    const handleSuccess = async () => {
+      const s = await fetchStatus();
+      if (!mountedRef.current || !s?.configured) return;
+      stopPoll();
+      setHasFetchedStatus(true);
+      setConfigured(true);
+      setEnvManaged(!!s.envManaged);
+      setBuilderEnabled(!!s.builderEnabled);
+      const nextConnectUrl = s.cliAuthUrl ?? s.connectUrl ?? null;
+      setStatusConnectUrl(nextConnectUrl);
+      statusConnectUrlAtRef.current = nextConnectUrl ? Date.now() : null;
+      const org = s.orgName ?? null;
+      setOrgName(org);
+      setConnecting(false);
+      notifiedConnectedRef.current = true;
+      notifyAgentEngineConfiguredChanged("builder-connect-message");
+      try {
+        await onConnectedRef.current?.({ orgName: org });
+      } catch {
+        // The caller's callback is a UI convenience; status is already set.
+      }
+    };
 
     try {
       channel = new BroadcastChannel(`builder-connect:${window.location.host}`);
       channel.onmessage = (e: MessageEvent) => {
         const data = e.data as { type?: string; message?: string } | undefined;
-        if (data?.type !== "builder-connect-error") return;
-        if (typeof data.message !== "string" || !data.message) return;
-        handleError(data.message);
+        if (data?.type === "builder-connect-success") {
+          void handleSuccess();
+          return;
+        }
+        if (data?.type === "builder-connect-error") {
+          if (typeof data.message !== "string" || !data.message) return;
+          handleError(data.message);
+        }
       };
     } catch {
       // BroadcastChannel not available (rare) \u2014 fall through to postMessage.
     }
 
     const handler = (e: MessageEvent) => {
-      if (e.origin !== window.location.origin) return;
+      if (!isTrustedBuilderConnectMessageOrigin(e.origin)) return;
       const data = e.data as { type?: string; message?: string } | undefined;
-      if (data?.type !== "builder-connect-error") return;
-      if (typeof data.message !== "string" || !data.message) return;
-      handleError(data.message);
+      if (data?.type === "builder-connect-success") {
+        void handleSuccess();
+        return;
+      }
+      if (data?.type === "builder-connect-error") {
+        if (typeof data.message !== "string" || !data.message) return;
+        handleError(data.message);
+      }
     };
     window.addEventListener("message", handler);
 
@@ -594,7 +652,7 @@ export function useBuilderConnectFlow(
       channel?.close();
       window.removeEventListener("message", handler);
     };
-  }, [stopPoll]);
+  }, [fetchStatus, stopPoll]);
 
   return {
     configured,

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -8,6 +8,7 @@ import {
   BUILDER_STATE_PARAM,
   getBuilderBranchProjectId,
   getBuilderBrowserConnectUrl,
+  getBuilderBrowserOriginForEvent,
   getBuilderBrowserStatusForEvent,
   isBuilderBranchingEnabled,
   runBuilderAgent,
@@ -370,6 +371,27 @@ describe("Builder callback CSRF state", () => {
         "x-forwarded-proto": "https",
       });
 
+      expect(getBuilderBrowserStatusForEvent(event).connectUrl).toBe(
+        "https://940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz/dispatch/_agent-native/builder/connect",
+      );
+    });
+
+    it("uses Fusion's public preview origin instead of a loopback gateway for Builder connect", () => {
+      process.env.NODE_ENV = "production";
+      process.env.AGENT_NATIVE_WORKSPACE = "1";
+      process.env.WORKSPACE_GATEWAY_URL = "http://127.0.0.1:8080";
+      process.env.FUSION_ENV_ORIGIN =
+        "https://940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz";
+      process.env.APP_BASE_PATH = "/dispatch";
+
+      const event = createBuilderBrowserEvent({
+        "x-forwarded-host": "127.0.0.1:8080",
+        "x-forwarded-proto": "http",
+      });
+
+      expect(getBuilderBrowserOriginForEvent(event)).toBe(
+        "https://940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz",
+      );
       expect(getBuilderBrowserStatusForEvent(event).connectUrl).toBe(
         "https://940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz/dispatch/_agent-native/builder/connect",
       );

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -241,7 +241,16 @@ function isAllowedBrowserReturnUrl(urlString: string): boolean {
       hostname === "127.0.0.1" ||
       hostname === "[::1]";
     const isBuilderDomain =
-      hostname === "builder.io" || hostname.endsWith(".builder.io");
+      hostname === "builder.io" ||
+      hostname.endsWith(".builder.io") ||
+      hostname === "builder.my" ||
+      hostname.endsWith(".builder.my") ||
+      hostname === "builderio.xyz" ||
+      hostname.endsWith(".builderio.xyz") ||
+      hostname === "builderio.dev" ||
+      hostname.endsWith(".builderio.dev") ||
+      hostname === "builder.codes" ||
+      hostname.endsWith(".builder.codes");
     const isAgentNativeDomain =
       hostname === "agent-native.com" || hostname.endsWith(".agent-native.com");
     return (
@@ -407,6 +416,43 @@ function isTrustedBuilderRequestHost(host: string | undefined): boolean {
   }
 }
 
+function isLoopbackBuilderRequestHost(host: string | undefined): boolean {
+  if (!host) return false;
+  try {
+    const hostname = new URL(`http://${host}`).hostname.toLowerCase();
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "[::1]"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function firstPublicBuilderPreviewOriginFromEnv(): string | null {
+  for (const key of [
+    "FUSION_ENV_ORIGIN",
+    "VITE_FUSION_ENV_ORIGIN",
+    "BUILDER_PREVIEW_URL",
+    "VITE_BUILDER_PREVIEW_URL",
+  ]) {
+    const raw = process.env[key];
+    if (!raw) continue;
+    try {
+      const url = new URL(raw);
+      if (url.protocol !== "http:" && url.protocol !== "https:") continue;
+      if (isLoopbackBuilderRequestHost(url.host)) continue;
+      if (!isTrustedBuilderRequestHost(url.host)) continue;
+      return url.origin;
+    } catch {
+      // Ignore malformed environment values.
+    }
+  }
+  return null;
+}
+
 /**
  * Builder CLI-auth does not need the workspace OAuth relay that Google uses.
  * In Builder/Fusion previews, keep connect + callback URLs on the actual app
@@ -419,6 +465,10 @@ export function getBuilderBrowserOriginForEvent(event: H3Event): string {
       readEventHeader(event, "host"),
   );
   if (!isTrustedBuilderRequestHost(headerHost)) return getOrigin(event);
+  if (isLoopbackBuilderRequestHost(headerHost)) {
+    const publicPreviewOrigin = firstPublicBuilderPreviewOriginFromEnv();
+    if (publicPreviewOrigin) return publicPreviewOrigin;
+  }
 
   const rawProto = firstHeaderValue(
     readEventHeader(event, "x-forwarded-proto"),
@@ -502,7 +552,7 @@ export function resolveSafePreviewUrl(
   if (previewUrl && isAllowedBrowserReturnUrl(previewUrl)) {
     return previewUrl;
   }
-  return getOrigin(event);
+  return getBuilderBrowserOriginForEvent(event);
 }
 
 /**
@@ -695,7 +745,7 @@ export function createBuilderBrowserCallbackPage(previewUrl: string): string {
         if (window.opener && !window.opener.closed) {
           window.opener.postMessage(
             { type: "builder-connect-success" },
-            window.location.origin,
+            "*",
           );
         }
       } catch (e) {}
@@ -789,7 +839,7 @@ export function createBuilderBrowserCallbackErrorPage(
           try {
             window.opener.postMessage(
               { type: "builder-connect-error", message: msg },
-              window.location.origin,
+              "*",
             );
           } catch (e) {}
         }


### PR DESCRIPTION
## Summary

- **core/server `builder-browser` + spec**: skip loopback origins (localhost / 127.0.0.1) when resolving the Builder callback URL. During local dev with a loopback origin in the env chain, the cli-auth request was getting a localhost callback baked in — the popup must land on a public host the user can actually reach.
- **core/client `AssistantChat` + `useBuilderStatus` + spec**: refresh the connected chat surface once status flips to configured — dismiss the inline reconnect card, re-enable input, no manual reload needed.

Changeset: \`polite-builder-connect\` (\`@agent-native/core\` patch) — *"Polish Builder connect completion by avoiding loopback callback URLs and refreshing connected chat UI."*

## Test plan

- [ ] Lint & format
- [ ] Typecheck
- [ ] Test (useBuilderStatus.spec + builder-browser.spec)
- [ ] Build
- [ ] Manual: connect Builder from dev with localhost origin → callback URL targets the public host; in chat, completing connect dismisses the reconnect card without a reload