### PR TITLE
fix[clips] waveform loading, media proxying, and share page responsiveness

### DIFF
--- a/templates/clips/app/components/editor/editor-layout.tsx
+++ b/templates/clips/app/components/editor/editor-layout.tsx
@@ -13,6 +13,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   agentNativePath,
+  appBasePath,
   useActionMutation,
   useActionQuery,
 } from "@agent-native/core/client";
@@ -81,6 +82,53 @@ export interface EditorLayoutProps {
 }
 
 const WAVEFORM_HEIGHT = 120;
+
+function shouldProxyWaveformUrl(videoUrl: string): boolean {
+  try {
+    const parsed = new URL(
+      videoUrl,
+      typeof window === "undefined"
+        ? "http://local.test"
+        : window.location.href,
+    );
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false;
+    }
+    if (
+      typeof window !== "undefined" &&
+      parsed.origin === window.location.origin
+    ) {
+      return false;
+    }
+    return /^https?:\/\//i.test(videoUrl);
+  } catch {
+    return false;
+  }
+}
+
+function getWaveformMediaUrl({
+  recordingId,
+  videoUrl,
+  password,
+  role,
+}: {
+  recordingId: string;
+  videoUrl: string | null;
+  password?: string | null;
+  role?: string | null;
+}): string | null {
+  if (!videoUrl) return null;
+  if (!shouldProxyWaveformUrl(videoUrl)) {
+    return videoUrl.startsWith("/") ? `${appBasePath()}${videoUrl}` : videoUrl;
+  }
+
+  const params = new URLSearchParams();
+  if (password && role !== "owner") params.set("password", password);
+  const qs = params.toString();
+  return `${appBasePath()}/api/video/${encodeURIComponent(recordingId)}${
+    qs ? `?${qs}` : ""
+  }`;
+}
 
 export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
   // --- server state -------------------------------------------------------
@@ -238,8 +286,19 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
 
   // --- waveform peaks, cached in application_state ------------------------
   const [peaks, setPeaks] = useState<WaveformPeaks | null>(null);
+  const waveformMediaUrl = useMemo(
+    () =>
+      getWaveformMediaUrl({
+        recordingId,
+        videoUrl,
+        password: recording?.password,
+        role: playerData?.role,
+      }),
+    [recording?.password, recordingId, playerData?.role, videoUrl],
+  );
+
   useEffect(() => {
-    if (!videoUrl) return;
+    if (!waveformMediaUrl) return;
     let cancelled = false;
     (async () => {
       // 1) Try cached peaks.
@@ -250,8 +309,9 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
         if (!cancelled) setPeaks(cached);
         return;
       }
-      // 2) Compute from the video URL.
-      const result = await computePeaks(videoUrl);
+      // 2) Compute from the video URL. Cross-origin provider URLs go through
+      // the same-origin /api/video proxy so CDN CORS cannot blank the waveform.
+      const result = await computePeaks(waveformMediaUrl);
       if (cancelled) return;
       setPeaks(result);
       if (result) {
@@ -261,7 +321,7 @@ export function EditorLayout({ recordingId, className }: EditorLayoutProps) {
     return () => {
       cancelled = true;
     };
-  }, [recordingId, videoUrl]);
+  }, [recordingId, waveformMediaUrl]);
 
   // --- actions ------------------------------------------------------------
   const trim = useActionMutation("trim-recording" as any);

--- a/templates/clips/app/components/editor/waveform.tsx
+++ b/templates/clips/app/components/editor/waveform.tsx
@@ -48,6 +48,32 @@ const getWaveColor = () => getBrandColorAlpha(0.55);
 const getWaveBg = () => getBrandColorAlpha(0.12);
 const EXCLUDED_FILL = "rgba(15, 23, 42, 0.72)";
 const EXCLUDED_STROKE = "rgba(148, 163, 184, 0.45)";
+const VISUAL_TARGET_PEAK = 0.78;
+const VISUAL_MAX_GAIN = 24;
+const VISUAL_GAIN_PERCENTILE = 0.95;
+const VISUAL_SILENCE_FLOOR = 0.001;
+
+function clampSample(value: number): number {
+  return Math.max(-1, Math.min(1, value));
+}
+
+function computeVisualGain(samples: number[]): number {
+  const amplitudes = samples
+    .map((value) => Math.abs(value))
+    .filter((value) => value > VISUAL_SILENCE_FLOOR)
+    .sort((a, b) => a - b);
+
+  if (amplitudes.length === 0) return 1;
+
+  const index = Math.min(
+    amplitudes.length - 1,
+    Math.floor(amplitudes.length * VISUAL_GAIN_PERCENTILE),
+  );
+  const reference = amplitudes[index] ?? amplitudes[amplitudes.length - 1];
+  if (!reference || reference >= VISUAL_TARGET_PEAK) return 1;
+
+  return Math.min(VISUAL_MAX_GAIN, VISUAL_TARGET_PEAK / reference);
+}
 
 /** Canvas-rendered waveform. Supports up to 50x zoom with horizontal scroll. */
 export function Waveform({
@@ -94,8 +120,10 @@ export function Waveform({
     );
 
     if (peaks && hasPeaks) {
-      // Map each x pixel to a bucket range. Use max abs so silent gaps stay visible.
+      // Map each x pixel to a bucket range. Use a visual-only auto-gain so
+      // quiet microphone recordings still read clearly in the trim track.
       const mid = height / 2;
+      const visualGain = computeVisualGain(peaks.peaks);
       ctx.strokeStyle = getWaveColor();
       ctx.lineWidth = 1;
       ctx.beginPath();
@@ -114,8 +142,16 @@ export function Waveform({
           if (lo < min) min = lo;
           if (hi > max) max = hi;
         }
-        const topY = mid + min * mid * 0.95;
-        const botY = mid + max * mid * 0.95;
+        let topY = mid + clampSample(min * visualGain) * mid * 0.95;
+        let botY = mid + clampSample(max * visualGain) * mid * 0.95;
+        if (
+          Math.max(Math.abs(min), Math.abs(max)) > VISUAL_SILENCE_FLOOR &&
+          botY - topY < 2
+        ) {
+          const centerY = (topY + botY) / 2;
+          topY = centerY - 1;
+          botY = centerY + 1;
+        }
         ctx.moveTo(x + 0.5, topY);
         ctx.lineTo(x + 0.5, botY);
       }

--- a/templates/clips/app/components/player/reactions-tray.tsx
+++ b/templates/clips/app/components/player/reactions-tray.tsx
@@ -36,7 +36,7 @@ export function ReactionsTray({ onReact, disabled }: ReactionsTrayProps) {
   }
 
   return (
-    <div className="relative flex items-center gap-1 rounded-full border border-border bg-card px-2 py-1 shadow-sm w-fit">
+    <div className="relative flex w-fit max-w-full items-center gap-0.5 rounded-full border border-border bg-card px-1.5 py-1 shadow-sm sm:gap-1 sm:px-2">
       {EMOJIS.map((emoji) => (
         <Tooltip key={emoji}>
           <TooltipTrigger asChild>
@@ -44,7 +44,7 @@ export function ReactionsTray({ onReact, disabled }: ReactionsTrayProps) {
               onClick={() => fire(emoji)}
               disabled={disabled}
               className={cn(
-                "h-9 w-9 rounded-full flex items-center justify-center text-xl",
+                "flex h-8 w-8 items-center justify-center rounded-full text-lg sm:h-9 sm:w-9 sm:text-xl",
                 disabled && "opacity-50 cursor-not-allowed",
               )}
             >

--- a/templates/clips/app/routes/share.$shareId.tsx
+++ b/templates/clips/app/routes/share.$shareId.tsx
@@ -379,33 +379,37 @@ export default function ShareRoute() {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
-      <div className="mx-auto max-w-6xl px-4 py-4 flex items-center justify-between">
-        <div className="flex items-center gap-2">
+      <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-3 px-4 py-4 sm:px-6">
+        <div className="flex min-w-0 items-center gap-2">
           <img
             src={appPath("/agent-native-icon-light.svg")}
             alt=""
             aria-hidden="true"
-            className="block h-4 w-auto dark:hidden"
+            className="block h-4 w-auto shrink-0 dark:hidden"
           />
           <img
             src={appPath("/agent-native-icon-dark.svg")}
             alt=""
             aria-hidden="true"
-            className="hidden h-4 w-auto dark:block"
+            className="hidden h-4 w-auto shrink-0 dark:block"
           />
-          <span className="font-medium">Clips</span>
+          <span className="truncate font-medium">Clips</span>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex w-full min-w-0 items-center justify-between gap-2 sm:w-auto sm:justify-end">
           {viewerCanEdit ? (
             <Button variant="ghost" size="sm" asChild>
-              <a href={appPath(`/r/${recording.id}`)} className="gap-1.5">
-                Open dashboard <IconExternalLink className="h-3.5 w-3.5" />
+              <a
+                href={appPath(`/r/${recording.id}`)}
+                className="min-w-0 gap-1.5"
+              >
+                <span className="truncate">Open dashboard</span>
+                <IconExternalLink className="h-3.5 w-3.5 shrink-0" />
               </a>
             </Button>
           ) : (
             <a
               href={appPath("/")}
-              className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
             >
               Try Clips <IconExternalLink className="h-3 w-3" />
             </a>
@@ -417,7 +421,7 @@ export default function ShareRoute() {
               videoUrl={recording.videoUrl}
               animatedThumbnailUrl={recording.animatedThumbnailUrl}
             >
-              <Button size="sm" className="gap-1.5">
+              <Button size="sm" className="shrink-0 gap-1.5">
                 <IconShare3 className="h-4 w-4" />
                 Share
               </Button>
@@ -426,7 +430,7 @@ export default function ShareRoute() {
         </div>
       </div>
 
-      <div className="mx-auto max-w-6xl px-4 pb-8 grid grid-cols-[1fr_360px] gap-6">
+      <div className="mx-auto grid w-full max-w-6xl grid-cols-1 gap-5 px-4 pb-8 sm:px-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:gap-6">
         <div className="min-w-0 space-y-4">
           <div className="aspect-video rounded-xl overflow-hidden bg-black">
             <VideoPlayer
@@ -448,48 +452,52 @@ export default function ShareRoute() {
             />
           </div>
 
-          <div className="flex items-start gap-3">
-            <div className="flex-1 min-w-0">
+          <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start">
+            <div className="min-w-0 flex-1">
               {showTitleSkeleton ? (
                 <Skeleton
                   aria-label="Generating title"
                   className="h-7 w-80 max-w-full"
                 />
               ) : (
-                <h1 className="text-xl font-semibold">{visibleTitle}</h1>
+                <h1 className="break-words text-lg font-semibold leading-tight sm:text-xl">
+                  {visibleTitle}
+                </h1>
               )}
               {recording.description ? (
-                <p className="text-sm text-foreground/70 mt-1 whitespace-pre-wrap">
+                <p className="mt-1 whitespace-pre-wrap break-words text-sm text-foreground/70">
                   {recording.description}
                 </p>
               ) : null}
             </div>
             {recording.enableReactions ? (
-              <ReactionsTray
-                onReact={(emoji) => {
-                  if (!session) {
-                    requireSignIn("react");
-                    return;
-                  }
-                  tracking.reportReaction(emoji);
-                  fetch(
-                    agentNativePath(
-                      "/_agent-native/actions/react-to-recording",
-                    ),
-                    {
-                      method: "POST",
-                      headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({
-                        recordingId: recording.id,
-                        emoji,
-                        videoTimestampMs: currentMs,
-                      }),
-                    },
-                  )
-                    .then(() => dataQ.refetch())
-                    .catch(() => {});
-                }}
-              />
+              <div className="max-w-full self-start">
+                <ReactionsTray
+                  onReact={(emoji) => {
+                    if (!session) {
+                      requireSignIn("react");
+                      return;
+                    }
+                    tracking.reportReaction(emoji);
+                    fetch(
+                      agentNativePath(
+                        "/_agent-native/actions/react-to-recording",
+                      ),
+                      {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({
+                          recordingId: recording.id,
+                          emoji,
+                          videoTimestampMs: currentMs,
+                        }),
+                      },
+                    )
+                      .then(() => dataQ.refetch())
+                      .catch(() => {});
+                  }}
+                />
+              </div>
             ) : null}
           </div>
 
@@ -499,14 +507,14 @@ export default function ShareRoute() {
               size="sm"
               onClick={downloadRecording}
               disabled={downloading}
-              className="border-foreground/20 bg-muted/50 hover:bg-accent text-foreground"
+              className="w-full border-foreground/20 bg-muted/50 text-foreground hover:bg-accent sm:w-auto"
             >
               {downloading ? "Downloading..." : "Download MP4"}
             </Button>
           ) : null}
         </div>
 
-        <aside className="min-w-0">
+        <aside className="min-w-0 lg:sticky lg:top-4 lg:self-start">
           <Tabs defaultValue="transcript" className="flex flex-col">
             <TabsList className="w-full bg-muted/50">
               <TabsTrigger value="transcript" className="flex-1">
@@ -519,7 +527,7 @@ export default function ShareRoute() {
               ) : null}
             </TabsList>
             <TabsContent value="transcript" className="mt-3">
-              <div className="rounded-lg border border-border bg-muted/50 h-[600px] overflow-hidden">
+              <div className="h-[420px] overflow-hidden rounded-lg border border-border bg-muted/50 sm:h-[520px] lg:h-[600px]">
                 <TranscriptPanel
                   segments={transcriptSegments}
                   fullText={transcriptFullText}
@@ -534,7 +542,7 @@ export default function ShareRoute() {
             </TabsContent>
             {recording.enableComments ? (
               <TabsContent value="comments" className="mt-3">
-                <div className="rounded-lg border border-border bg-muted/50 h-[600px] overflow-hidden">
+                <div className="h-[420px] overflow-hidden rounded-lg border border-border bg-muted/50 sm:h-[520px] lg:h-[600px]">
                   <CommentsPanel
                     recordingId={recording.id}
                     comments={comments}
@@ -558,7 +566,7 @@ export default function ShareRoute() {
         </aside>
       </div>
 
-      <div className="mx-auto max-w-6xl px-4 pb-6 flex justify-center">
+      <div className="mx-auto flex max-w-6xl justify-center px-4 pb-6 sm:px-6">
         <PoweredByBadge />
       </div>
 

--- a/templates/clips/server/routes/[...page].get.ts
+++ b/templates/clips/server/routes/[...page].get.ts
@@ -6,6 +6,7 @@ import {
   type H3Event,
 } from "h3";
 import { getSession, runWithRequestContext } from "@agent-native/core/server";
+import { getOrgContext } from "@agent-native/core/org";
 import { resolveAccess } from "@agent-native/core/sharing";
 import {
   MEDIA_CAPTURE_PERMISSIONS_POLICY,
@@ -46,14 +47,17 @@ async function redirectNonOwnerRecordingPath(
   const session = await getSession(event).catch(() => null);
   if (!session?.email) return shareRedirect(recordingId, url.search);
 
+  const orgCtx = await getOrgContext(event).catch(() => null);
+  const orgId = orgCtx?.orgId ?? session.orgId ?? undefined;
+
   try {
     const access = await runWithRequestContext(
-      { userEmail: session.email, orgId: session.orgId },
+      { userEmail: session.email, orgId },
       () => resolveAccess("recording", recordingId),
     );
-    if (access.role === "owner") return null;
+    if (access?.role === "owner") return null;
   } catch {
-    // Treat missing/inaccessible recordings the same as non-owner access here;
+    // Treat missing/inaccessible recordings the same as no access here;
     // the share route can render the canonical public/not-found state.
   }
 

--- a/templates/clips/server/routes/api/video/[recordingId].get.ts
+++ b/templates/clips/server/routes/api/video/[recordingId].get.ts
@@ -43,6 +43,7 @@ import {
   createSsrfSafeDispatcher,
   isBlockedExtensionUrlWithDns,
 } from "@agent-native/core/extensions/url-safety";
+import { getOrgContext } from "@agent-native/core/org";
 import { resolveAccess } from "@agent-native/core/sharing";
 import {
   getSession,
@@ -139,9 +140,11 @@ export default defineEventHandler(async (event: H3Event) => {
   }
 
   const session = await getSession(event).catch(() => null);
+  const orgCtx = await getOrgContext(event).catch(() => null);
+  const orgId = orgCtx?.orgId ?? session?.orgId ?? undefined;
 
   return runWithRequestContext(
-    { userEmail: session?.email, orgId: session?.orgId },
+    { userEmail: session?.email, orgId },
     async () => {
       const access = await resolveAccess("recording", recordingId);
       if (!access) {

--- a/templates/clips/server/routes/api/video/[recordingId].get.ts
+++ b/templates/clips/server/routes/api/video/[recordingId].get.ts
@@ -1,11 +1,14 @@
 /**
- * Serve the assembled video blob for a recording — dev-only fallback when no
- * file upload provider is configured. `finalize-recording` stashes the blob
- * in `application_state` under `recording-blob-:id` and points
- * `recordings.video_url` at this route.
+ * Serve recording media from same-origin.
  *
- * Production deployments register a real provider (Builder.io / R2 / S3) and
- * `video_url` points directly at that — this route never gets hit.
+ * Dev fallback: when no file upload provider is configured, `finalize-recording`
+ * stashes the assembled blob in `application_state` under
+ * `recording-blob-:id` and points `recordings.video_url` at this route.
+ *
+ * Production fallback: the editor can also hit this route as an authenticated
+ * media proxy for provider-hosted URLs (Builder.io / R2 / S3). This keeps
+ * browser-only consumers such as Web Audio waveform decoding from being blocked
+ * by cross-origin CDN fetches.
  *
  * Access rules (match `/api/public-recording.get.ts`):
  *   - public visibility: anyone can fetch, but a password (if set) must be
@@ -36,6 +39,10 @@ import {
   type H3Event,
 } from "h3";
 import { readAppState } from "@agent-native/core/application-state";
+import {
+  createSsrfSafeDispatcher,
+  isBlockedExtensionUrlWithDns,
+} from "@agent-native/core/extensions/url-safety";
 import { resolveAccess } from "@agent-native/core/sharing";
 import {
   getSession,
@@ -46,7 +53,82 @@ import {
 interface RecordingRow {
   expiresAt?: string | null;
   password?: string | null;
+  videoUrl?: string | null;
   visibility?: string | null;
+}
+
+const PROXIED_HEADER_NAMES = [
+  "accept-ranges",
+  "content-length",
+  "content-range",
+  "content-type",
+  "etag",
+  "last-modified",
+] as const;
+
+function isRecursiveVideoRouteUrl(value: string, recordingId: string): boolean {
+  try {
+    const parsed = new URL(value, "http://local.test");
+    const expected = `/api/video/${encodeURIComponent(recordingId)}`;
+    return parsed.pathname === expected || parsed.pathname.endsWith(expected);
+  } catch {
+    return false;
+  }
+}
+
+async function fetchProviderMedia(
+  sourceUrl: string,
+  rangeHeader: string | undefined,
+): Promise<Response | { error: string; status: number }> {
+  let currentUrl = sourceUrl;
+  const dispatcher = (await createSsrfSafeDispatcher()) ?? undefined;
+
+  for (let redirects = 0; redirects <= 4; redirects++) {
+    if (await isBlockedExtensionUrlWithDns(currentUrl)) {
+      return {
+        status: 403,
+        error: "Recording media URL points to a private/internal address",
+      };
+    }
+
+    const headers = new Headers();
+    if (rangeHeader?.startsWith("bytes=")) headers.set("Range", rangeHeader);
+
+    const fetchOptions: RequestInit & { dispatcher?: unknown } = {
+      headers,
+      redirect: "manual",
+    };
+    if (dispatcher) fetchOptions.dispatcher = dispatcher;
+
+    const upstream = await fetch(currentUrl, fetchOptions);
+    if (upstream.status < 300 || upstream.status >= 400) return upstream;
+
+    const location = upstream.headers.get("location");
+    if (!location) return upstream;
+    currentUrl = new URL(location, currentUrl).href;
+  }
+
+  return { status: 508, error: "Too many media redirects" };
+}
+
+function providerResponse(upstream: Response): Response {
+  const headers = new Headers();
+  for (const name of PROXIED_HEADER_NAMES) {
+    const value = upstream.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "application/octet-stream");
+  }
+  headers.set("Cache-Control", "private, max-age=0, no-store");
+  headers.set("Referrer-Policy", "no-referrer");
+  headers.set("X-Content-Type-Options", "nosniff");
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
 }
 
 export default defineEventHandler(async (event: H3Event) => {
@@ -107,9 +189,28 @@ export default defineEventHandler(async (event: H3Event) => {
 
       const blob = await readAppState(`recording-blob-${recordingId}`);
       const b64 = typeof blob?.data === "string" ? blob.data : null;
+      const rangeHeader = getRequestHeader(event, "range");
+
       if (!b64) {
-        setResponseStatus(event, 404);
-        return { error: "Blob not found" };
+        const sourceUrl = rec.videoUrl ?? "";
+        if (!sourceUrl) {
+          setResponseStatus(event, 404);
+          return { error: "Blob not found" };
+        }
+        if (
+          sourceUrl.startsWith("/") ||
+          isRecursiveVideoRouteUrl(sourceUrl, recordingId)
+        ) {
+          setResponseStatus(event, 404);
+          return { error: "Blob not found" };
+        }
+
+        const upstream = await fetchProviderMedia(sourceUrl, rangeHeader);
+        if (!(upstream instanceof Response)) {
+          setResponseStatus(event, upstream.status);
+          return { error: upstream.error };
+        }
+        return providerResponse(upstream);
       }
       const mimeType =
         typeof blob?.mimeType === "string" ? blob.mimeType : "video/webm";
@@ -124,7 +225,6 @@ export default defineEventHandler(async (event: H3Event) => {
       // Referer of any outbound link rendered alongside the player.
       setResponseHeader(event, "Referrer-Policy", "no-referrer");
 
-      const rangeHeader = getRequestHeader(event, "range");
       if (rangeHeader && rangeHeader.startsWith("bytes=")) {
         const spec = rangeHeader.slice(6).trim();
         let start: number;


### PR DESCRIPTION
- Fix recording route owner access checks with org context (today, if you are owner of a recording and you try to open it's dashboard directly on the browser ex, https://clips.agent-native.com/r/mZa9AJ5RN0Eg you will get redirected to /share/*. even open dashboard wont redirect correctly)
- Proxy remote recording media through same-origin `/api/video/:recordingId` for waveform decoding                                                                             
- Add SSRF-safe provider media fetching with range/header passthrough                                                                                                          
- Improve waveform visibility for quiet recordings with visual-only auto-gain                                                                                                  
- Polish Clips share page responsiveness on mobile/tablet                                                                                                                      
- Tighten reactions tray sizing to avoid overflow                                                                                                                              

share page:
<img width="503" height="1307" alt="image" src="https://github.com/user-attachments/assets/1ed0d86b-f804-4b66-8a46-5a45792f6e22" />

trim page audio visualizer:
<img width="2550" height="1314" alt="image" src="https://github.com/user-attachments/assets/e5f7959e-cbff-48ac-984e-da200ffd4552" />
