### PR TITLE
fix[clips]: builder clips transcription generation

### DIFF
--- a/.changeset/fix-builder-transcription-endpoint.md
+++ b/.changeset/fix-builder-transcription-endpoint.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix Builder-backed transcription by using the public Builder API endpoint with the required space/user headers.

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -28,6 +28,7 @@ import {
   resolveBuilderCredential,
   resolveBuilderCredentialSource,
   resolveSecret,
+  getBuilderProxyOrigin,
 } from "./credential-provider.js";
 
 const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
@@ -43,12 +44,26 @@ beforeEach(() => {
   delete process.env.BUILDER_PRIVATE_KEY;
   delete process.env.BUILDER_PUBLIC_KEY;
   delete process.env.OPENAI_API_KEY;
+  delete process.env.BUILDER_PROXY_ORIGIN;
+  delete process.env.AIR_HOST;
+  delete process.env.BUILDER_API_HOST;
   mockReadAppSecret.mockResolvedValue(null);
   mockWriteAppSecret.mockResolvedValue("id");
   mockDeleteAppSecret.mockResolvedValue(true);
   mockGetRequestUserEmail.mockReturnValue(undefined);
   mockGetRequestOrgId.mockReturnValue(undefined);
   mockIsLocalDatabase.mockReturnValue(true);
+});
+
+describe("getBuilderProxyOrigin", () => {
+  it("defaults Builder-hosted API calls to the public Builder API", () => {
+    expect(getBuilderProxyOrigin()).toBe("https://api.builder.io");
+  });
+
+  it("honors explicit Builder proxy origin overrides", () => {
+    process.env.BUILDER_PROXY_ORIGIN = "https://builder-proxy.test";
+    expect(getBuilderProxyOrigin()).toBe("https://builder-proxy.test");
+  });
 });
 
 describe("resolveCredentialWriteScope", () => {

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -553,13 +553,13 @@ export function hasBuilderPrivateKey(): boolean {
   return !!process.env.BUILDER_PRIVATE_KEY;
 }
 
-/** The origin for Builder-proxied API calls. Overridable for testing. */
+/** The origin for Builder-hosted API calls. Overridable for testing. */
 export function getBuilderProxyOrigin(): string {
   return (
     process.env.BUILDER_PROXY_ORIGIN ||
     process.env.AIR_HOST ||
     process.env.BUILDER_API_HOST ||
-    "https://ai-services.builder.io"
+    "https://api.builder.io"
   );
 }
 

--- a/packages/core/src/server/google-realtime-session.ts
+++ b/packages/core/src/server/google-realtime-session.ts
@@ -12,7 +12,10 @@ import { resolveCredential } from "../credentials/index.js";
 import { getSession } from "./auth.js";
 import { getOrgContext } from "../org/context.js";
 import { runWithRequestContext } from "./request-context.js";
-import { resolveBuilderCredentials } from "./credential-provider.js";
+import {
+  getBuilderProxyOrigin,
+  resolveBuilderCredentials,
+} from "./credential-provider.js";
 
 interface GoogleRealtimeSessionResponse {
   websocketUrl: string;
@@ -156,8 +159,7 @@ export function createGoogleRealtimeSessionHandler() {
         };
       }
 
-      const apiHost =
-        process.env.BUILDER_API_HOST || "https://ai-services.builder.io";
+      const apiHost = getBuilderProxyOrigin();
       const body = ((await readBody(event).catch(() => ({}))) || {}) as {
         language?: unknown;
       };

--- a/packages/core/src/transcription/builder-transcription.spec.ts
+++ b/packages/core/src/transcription/builder-transcription.spec.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockResolveBuilderCredentials = vi.fn();
+
+vi.mock("../server/credential-provider.js", () => ({
+  getBuilderProxyOrigin: () =>
+    process.env.BUILDER_PROXY_ORIGIN ||
+    process.env.AIR_HOST ||
+    process.env.BUILDER_API_HOST ||
+    "https://api.builder.io",
+  resolveBuilderCredentials: () => mockResolveBuilderCredentials(),
+}));
+
+import { transcribeWithBuilder } from "./builder-transcription.js";
+
+const successBody = {
+  text: "hello world",
+  language: "en",
+  durationSeconds: 1,
+  segments: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.BUILDER_PROXY_ORIGIN;
+  delete process.env.AIR_HOST;
+  delete process.env.BUILDER_API_HOST;
+  mockResolveBuilderCredentials.mockResolvedValue({
+    privateKey: "private-key",
+    publicKey: "space-id",
+    userId: "builder-user",
+    orgName: null,
+    orgKind: null,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("transcribeWithBuilder", () => {
+  it("posts audio to the public Builder API with private key, space id, and user id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(successBody), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      transcribeWithBuilder({
+        audioBytes: new Uint8Array([1, 2, 3]),
+        mimeType: "video/webm",
+        model: "gemini-3-1-flash-lite",
+        diarize: false,
+      }),
+    ).resolves.toEqual(successBody);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const parsed = new URL(url);
+    expect(`${parsed.origin}${parsed.pathname}`).toBe(
+      "https://api.builder.io/agent-native/transcribe-audio",
+    );
+    expect(parsed.searchParams.get("mimeType")).toBe("video/webm");
+    expect(parsed.searchParams.get("model")).toBe("gemini-3-1-flash-lite");
+    expect(parsed.searchParams.get("diarize")).toBe("false");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual(
+      expect.objectContaining({
+        Authorization: "Bearer private-key",
+        "x-builder-api-key": "space-id",
+        "x-builder-user-id": "builder-user",
+        "Content-Type": "application/octet-stream",
+      }),
+    );
+    expect(Buffer.from(init.body as ArrayBuffer)).toEqual(
+      Buffer.from([1, 2, 3]),
+    );
+  });
+
+  it("omits the optional user id header when Builder did not return one", async () => {
+    mockResolveBuilderCredentials.mockResolvedValue({
+      privateKey: "private-key",
+      publicKey: "space-id",
+      userId: null,
+      orgName: null,
+      orgKind: null,
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(successBody), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await transcribeWithBuilder({
+      audioBytes: new Uint8Array([1]),
+      mimeType: "audio/webm",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.headers).toEqual(
+      expect.not.objectContaining({ "x-builder-user-id": expect.anything() }),
+    );
+  });
+
+  it("fails before fetch when Builder space id is missing", async () => {
+    mockResolveBuilderCredentials.mockResolvedValue({
+      privateKey: "private-key",
+      publicKey: null,
+      userId: "builder-user",
+      orgName: null,
+      orgKind: null,
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      transcribeWithBuilder({
+        audioBytes: new Uint8Array([1]),
+        mimeType: "audio/webm",
+      }),
+    ).rejects.toThrow("Builder space ID not configured");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("respects a Builder proxy origin override", async () => {
+    process.env.BUILDER_PROXY_ORIGIN = "https://builder-proxy.test";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(successBody), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await transcribeWithBuilder({
+      audioBytes: new Uint8Array([1]),
+      mimeType: "audio/webm",
+    });
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(
+      /^https:\/\/builder-proxy\.test\/agent-native\/transcribe-audio\?/,
+    );
+  });
+});

--- a/packages/core/src/transcription/builder-transcription.ts
+++ b/packages/core/src/transcription/builder-transcription.ts
@@ -1,5 +1,5 @@
 import {
-  resolveBuilderAuthHeader,
+  resolveBuilderCredentials,
   getBuilderProxyOrigin,
 } from "../server/credential-provider.js";
 
@@ -42,10 +42,15 @@ function describeError(err: unknown): string {
 export async function transcribeWithBuilder(
   opts: BuilderTranscribeOptions,
 ): Promise<BuilderTranscribeResult> {
-  const authHeader = await resolveBuilderAuthHeader();
-  if (!authHeader) {
+  const builderCreds = await resolveBuilderCredentials();
+  if (!builderCreds.privateKey) {
     throw new Error(
       "Builder private key not configured. Connect your Builder.io account in Settings.",
+    );
+  }
+  if (!builderCreds.publicKey) {
+    throw new Error(
+      "Builder space ID not configured. Reconnect Builder.io in Settings so transcription can identify the target space.",
     );
   }
 
@@ -76,7 +81,11 @@ export async function transcribeWithBuilder(
     res = await fetch(url, {
       method: "POST",
       headers: {
-        Authorization: authHeader,
+        Authorization: `Bearer ${builderCreds.privateKey}`,
+        "x-builder-api-key": builderCreds.publicKey,
+        ...(builderCreds.userId
+          ? { "x-builder-user-id": builderCreds.userId }
+          : {}),
         "Content-Type": "application/octet-stream",
       },
       body,

--- a/templates/clips/actions/request-transcript.ts
+++ b/templates/clips/actions/request-transcript.ts
@@ -775,7 +775,7 @@ export default defineAction({
       if (preserved) return preserved;
 
       const reason = builderError
-        ? "No native transcript was captured, and backup transcription could not finish. Retry transcription or check microphone and speech permissions."
+        ? "Builder backup transcription could not finish. Retry transcription in a moment or reconnect Builder.io if this keeps happening."
         : "No transcript was captured by native speech recognition, and no backup transcription provider is configured.";
       await upsertTranscriptRow(db, {
         recordingId: args.recordingId,

--- a/templates/clips/app/components/player/transcript-panel.tsx
+++ b/templates/clips/app/components/player/transcript-panel.tsx
@@ -342,11 +342,7 @@ function isNoSpeechTranscriptFailure(
 ): boolean {
   if (!reason) return false;
   const normalized = reason.toLowerCase();
-  return (
-    normalized.includes("no speech") ||
-    normalized.includes("no native transcript was captured") ||
-    normalized.includes("no transcript was captured by native speech")
-  );
+  return normalized.includes("no speech");
 }
 
 function friendlyTranscriptFailure(reason: string | null | undefined): string {
@@ -358,14 +354,14 @@ function friendlyTranscriptFailure(reason: string | null | undefined): string {
     normalized.includes("fetch failed") ||
     normalized.includes("backup transcription could not finish")
   ) {
-    return "No speech was captured locally, and backup transcription did not finish. Retry or check microphone and speech permissions.";
+    return "Backup transcription could not finish. Retry in a moment or reconnect Builder.io if this keeps happening.";
   }
   if (
     normalized.includes("api key") ||
     normalized.includes("not configured") ||
     normalized.includes("connect builder")
   ) {
-    return "No speech was captured locally, and backup transcription is not set up.";
+    return "Backup transcription is not set up yet. Connect Builder.io or add a transcription key.";
   }
   return reason;
 }
@@ -551,7 +547,7 @@ function TranscriptSetupCard({
             {isProviderError
               ? "Your API key hit a quota or auth error. Switch to Builder.io or update your key."
               : isConnectedFallbackError
-                ? "No speech was captured locally, and backup transcription did not finish. Retry in a moment."
+                ? "Backup transcription did not finish. Retry in a moment or reconnect Builder.io if this keeps happening."
                 : "Unlock captions, transcript search, and summaries for this Clip."}
           </p>
         </div>


### PR DESCRIPTION
- Fix Builder-backed Clips transcription by using `https://api.builder.io` instead of the unreachable `ai-services.builder.io` default                                         
- Send required Builder space/user headers for transcription (`x-builder-api-key`, optional `x-builder-user-id`)                                                               
- Share the corrected Builder API origin with Google realtime transcription session creation                                                                                   
- Improve Clips transcript failure copy so provider/network failures don’t show as “No speech detected”                                                                        
- Add regression coverage for Builder transcription request URL/headers and Builder origin defaults                                                                            


<img width="1531" height="922" alt="image" src="https://github.com/user-attachments/assets/8a2754d1-b255-48c8-af26-395c87612070" />

<img width="1473" height="1051" alt="image" src="https://github.com/user-attachments/assets/780b4627-834d-4b5e-9d27-18b81d4006db" />
