### PR TITLE
feat(core): Builder cli-auth callback fallback + surface rejected credentials

### DIFF
--- a/.changeset/builder-cli-auth-fallback.md
+++ b/.changeset/builder-cli-auth-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Handle Builder cli-auth callback fallback for preview hosts not in Builder's allow-list, surface rejected credentials on status / Settings, scope callback postMessage to the parent origin, and self-heal credential auth-failure markers after a successful gateway call.

--- a/packages/core/src/agent/engine/builder-engine.spec.ts
+++ b/packages/core/src/agent/engine/builder-engine.spec.ts
@@ -12,6 +12,7 @@ const credentialState = vi.hoisted(() => ({
   builderPublicKey: "space-test" as string | null,
   builderUserId: "builder-user-123" as string | null,
   builderOrgName: null as string | null,
+  recordBuilderCredentialAuthFailure: vi.fn(async () => {}),
 }));
 
 // Mock the credential provider so tests do not hit the DB (app_secrets table).
@@ -32,6 +33,8 @@ vi.mock("../../server/credential-provider.js", async (importOriginal) => {
       const key = credentialState.builderPrivateKey;
       return key ? `Bearer ${key}` : null;
     }),
+    recordBuilderCredentialAuthFailure:
+      credentialState.recordBuilderCredentialAuthFailure,
     getBuilderGatewayBaseUrl: original.getBuilderGatewayBaseUrl,
   };
 });
@@ -78,6 +81,7 @@ describe("createBuilderEngine", () => {
     credentialState.builderPublicKey = "space-test";
     credentialState.builderUserId = "builder-user-123";
     credentialState.builderOrgName = null;
+    credentialState.recordBuilderCredentialAuthFailure.mockClear();
     vi.stubEnv("BUILDER_PRIVATE_KEY", "bpk-test");
     vi.stubEnv("BUILDER_PUBLIC_KEY", "space-test");
     vi.stubEnv("BUILDER_USER_ID", "builder-user-123");
@@ -393,6 +397,13 @@ describe("createBuilderEngine", () => {
     expect(stop?.reason).toBe("error");
     expect(stop?.errorCode).toBe("builder_auth_error");
     expect(stop?.error).toContain("Builder authentication failed");
+    expect(
+      credentialState.recordBuilderCredentialAuthFailure,
+    ).toHaveBeenCalledWith({
+      status: 401,
+      code: "unauthorized",
+      message: "Invalid key",
+    });
   });
 
   it("maps 403 invalid token to Builder auth stop-error", async () => {
@@ -412,6 +423,13 @@ describe("createBuilderEngine", () => {
     expect(stop?.reason).toBe("error");
     expect(stop?.errorCode).toBe("builder_auth_error");
     expect(stop?.error).toContain("Builder authentication failed");
+    expect(
+      credentialState.recordBuilderCredentialAuthFailure,
+    ).toHaveBeenCalledWith({
+      status: 403,
+      code: "http_403",
+      message: "Invalid token",
+    });
   });
 
   it("surfaces a non-JSON 4xx body (e.g. proxy HTML) in the error message", async () => {

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -28,6 +28,7 @@ import {
   resolveBuilderAuthHeader,
   resolveBuilderCredential,
   getBuilderGatewayBaseUrl,
+  recordBuilderCredentialAuthFailure,
 } from "../../server/credential-provider.js";
 import {
   normalizeReasoningEffortForModel,
@@ -294,6 +295,7 @@ async function* emitHttpError(response: Response): AsyncIterable<EngineEvent> {
     return;
   }
   if (status === 401 || code === "unauthorized") {
+    await recordBuilderCredentialAuthFailure({ status, code, message });
     yield {
       type: "stop",
       reason: "error",
@@ -311,6 +313,7 @@ async function* emitHttpError(response: Response): AsyncIterable<EngineEvent> {
       lowerMessage.includes("invalid_token") ||
       lowerMessage.includes("token invalid"))
   ) {
+    await recordBuilderCredentialAuthFailure({ status, code, message });
     yield {
       type: "stop",
       reason: "error",

--- a/packages/core/src/agent/engine/builder-engine.ts
+++ b/packages/core/src/agent/engine/builder-engine.ts
@@ -25,8 +25,10 @@ import {
   engineToolsToAnthropic,
 } from "./translate-anthropic.js";
 import {
+  clearBuilderCredentialAuthFailure,
   resolveBuilderAuthHeader,
   resolveBuilderCredential,
+  resolveBuilderCredentials,
   getBuilderGatewayBaseUrl,
   recordBuilderCredentialAuthFailure,
 } from "../../server/credential-provider.js";
@@ -219,6 +221,22 @@ class BuilderEngine implements AgentEngine {
       if (!response.ok) {
         yield* emitHttpError(response);
         return;
+      }
+
+      // A successful gateway call proves the connected credentials are valid
+      // again. Clear any prior auth-failure marker so status / chat-card
+      // surfaces stop flagging the connection as broken. This is the only
+      // self-healing path for workspace/env-managed credentials, which never
+      // flow through writeBuilderCredentials.
+      try {
+        const creds = await resolveBuilderCredentials();
+        await clearBuilderCredentialAuthFailure({
+          privateKey: creds.privateKey,
+          publicKey: creds.publicKey,
+        });
+      } catch {
+        // Marker clearing is best-effort; a stale marker just means the user
+        // sees "reconnect Builder" until the next successful call clears it.
       }
 
       const contentType = response.headers.get("content-type") ?? "";

--- a/packages/core/src/client/settings/SettingsPanel.tsx
+++ b/packages/core/src/client/settings/SettingsPanel.tsx
@@ -330,7 +330,7 @@ function UseBuilderCard({
   connected: boolean;
   orgName?: string;
   envManaged?: boolean;
-  credentialSource?: "user" | "org" | "env";
+  credentialSource?: "user" | "org" | "workspace" | "env";
   label?: string;
   subtitle?: string;
   dim?: boolean;
@@ -589,7 +589,7 @@ function LLMSectionInner({
   connected: boolean;
   orgName?: string;
   envManaged?: boolean;
-  credentialSource?: "user" | "org" | "env";
+  credentialSource?: "user" | "org" | "workspace" | "env";
   open?: boolean;
   onToggle?: () => void;
 }) {

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -248,7 +248,9 @@ function isTrustedBuilderConnectMessageOrigin(origin: string): boolean {
       hostname === "builderio.dev" ||
       hostname.endsWith(".builderio.dev") ||
       hostname === "builder.codes" ||
-      hostname.endsWith(".builder.codes")
+      hostname.endsWith(".builder.codes") ||
+      hostname === "agent-native.com" ||
+      hostname.endsWith(".agent-native.com")
     );
   } catch {
     return false;

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -12,7 +12,7 @@ export interface BuilderStatus {
    * and take precedence for that request.
    */
   envManaged?: boolean;
-  credentialSource?: "user" | "org" | "env";
+  credentialSource?: "user" | "org" | "workspace" | "env";
   connectUrl: string;
   cliAuthUrl?: string;
   appHost: string;
@@ -352,7 +352,7 @@ export function useBuilderConnectFlow(
         orgName?: string | null;
         connectUrl?: string;
         cliAuthUrl?: string;
-        credentialSource?: "user" | "org" | "env";
+        credentialSource?: "user" | "org" | "workspace" | "env";
         connectError?: { message: string; at: number };
       };
     } catch {

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -397,6 +397,18 @@ export function useBuilderConnectFlow(
       } else if (!s.configured) {
         notifiedConnectedRef.current = false;
       }
+      // Surface persisted auth-failure messages on every refresh — reload,
+      // first paint in a new tab, agent-engine:configured-changed, etc.
+      // Without this, useBuilderConnectFlow's start() is the only path that
+      // ever sets `error`, so users who reload after a rejection see the
+      // generic "Connect Builder" CTA with no explanation. Clear the error
+      // when status is configured again so a self-healed marker stops
+      // showing the stale message.
+      if (s.connectError?.message) {
+        setError(s.connectError.message);
+      } else if (s.configured) {
+        setError(null);
+      }
     };
     refresh();
     const onVisible = () => {

--- a/packages/core/src/server/agent-chat-plugin.ts
+++ b/packages/core/src/server/agent-chat-plugin.ts
@@ -1050,10 +1050,15 @@ function createBuilderBrowserTool(deps: {
         },
       },
       run: async (args) => {
-        const { resolveBuilderCredentials } =
+        const { getBuilderCredentialAuthFailure, resolveBuilderCredentials } =
           await import("./credential-provider.js");
         const creds = await resolveBuilderCredentials();
-        const configured = !!(creds.privateKey && creds.publicKey);
+        const authFailure = await getBuilderCredentialAuthFailure(creds);
+        const configured = !!(
+          creds.privateKey &&
+          creds.publicKey &&
+          !authFailure
+        );
         const branchProjectId = await resolveBuilderBranchProjectId();
         const prompt = typeof args?.prompt === "string" ? args.prompt : "";
         const origin = deps.getOrigin();

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -383,11 +383,20 @@ describe("Builder callback CSRF state", () => {
       const parsed = new URL(cliAuthUrl);
 
       expect(callbackOrigin).toBe("https://agent-workspace.builder.io");
-      expect(parsed.searchParams.get("redirect_url")).toContain(
+      const redirectUrl = parsed.searchParams.get("redirect_url");
+      expect(redirectUrl).toContain(
         "https://agent-workspace.builder.io/dispatch/_agent-native/builder/callback",
       );
-      expect(parsed.searchParams.get("redirect_url")).not.toContain(
-        "builderio.xyz",
+      // The callback origin (the part Builder validates against its allow-list)
+      // must be the gateway, not the preview host.
+      expect(new URL(redirectUrl!).origin).toBe(
+        "https://agent-workspace.builder.io",
+      );
+      // The original preview origin must still ride along inside the
+      // redirect_url query string so the callback can use it as the
+      // postMessage targetOrigin for the opener tab.
+      expect(new URL(redirectUrl!).searchParams.get("_an_opener")).toBe(
+        "https://940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz",
       );
       expect(parsed.searchParams.get("preview_url")).toBe(
         "https://agent-workspace.builder.io/dispatch",

--- a/packages/core/src/server/builder-browser.spec.ts
+++ b/packages/core/src/server/builder-browser.spec.ts
@@ -7,6 +7,7 @@ import {
   BUILDER_CONNECT_PARAM,
   BUILDER_STATE_PARAM,
   getBuilderBranchProjectId,
+  getBuilderCliAuthCallbackOriginForEvent,
   getBuilderBrowserConnectUrl,
   getBuilderBrowserOriginForEvent,
   getBuilderBrowserStatusForEvent,
@@ -356,6 +357,40 @@ describe("Builder callback CSRF state", () => {
         getBuilderBrowserConnectUrl("https://alice.agent-native.com/"),
       ).toBe(
         "https://alice.agent-native.com/docs/_agent-native/builder/connect",
+      );
+    });
+
+    it("uses a Builder-accepted gateway callback for preview-host cli-auth redirects", () => {
+      process.env.NODE_ENV = "production";
+      process.env.AGENT_NATIVE_WORKSPACE = "1";
+      process.env.APP_URL = "https://agent-workspace.builder.io";
+      process.env.WORKSPACE_GATEWAY_URL = "https://agent-workspace.builder.io";
+      process.env.APP_BASE_PATH = "/dispatch";
+
+      const event = createBuilderBrowserEvent({
+        "x-forwarded-host":
+          "940ebc5a83164aa6a37dde445e494f3a-fluid-crack-ctnhvsyb.builderio.xyz",
+        "x-forwarded-proto": "https",
+      });
+
+      const previewOrigin = getBuilderBrowserOriginForEvent(event);
+      const callbackOrigin = getBuilderCliAuthCallbackOriginForEvent(event);
+      const cliAuthUrl = buildBuilderCliAuthUrl(
+        callbackOrigin,
+        signBuilderCallbackState("alice@example.com"),
+        { previewOrigin },
+      );
+      const parsed = new URL(cliAuthUrl);
+
+      expect(callbackOrigin).toBe("https://agent-workspace.builder.io");
+      expect(parsed.searchParams.get("redirect_url")).toContain(
+        "https://agent-workspace.builder.io/dispatch/_agent-native/builder/callback",
+      );
+      expect(parsed.searchParams.get("redirect_url")).not.toContain(
+        "builderio.xyz",
+      );
+      expect(parsed.searchParams.get("preview_url")).toBe(
+        "https://agent-workspace.builder.io/dispatch",
       );
     });
 

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -53,7 +53,8 @@ export interface BuilderBrowserStatus {
    * account, which takes precedence for their request.
    */
   envManaged: boolean;
-  credentialSource?: "user" | "org" | "env";
+  credentialSource?: "user" | "org" | "workspace" | "env";
+  connectError?: { message: string; at: number };
   appHost: string;
   apiHost: string;
   /**
@@ -324,6 +325,52 @@ export async function resolveIsBuilderBranchingEnabled(): Promise<boolean> {
   return !!(await resolveBuilderBranchProjectId());
 }
 
+function isBuilderCliAuthAllowedOrigin(origin: string | null | undefined) {
+  if (!origin) return false;
+  try {
+    const parsed = new URL(origin);
+    const hostname = parsed.hostname.toLowerCase();
+    const isAllowedProtocol =
+      parsed.protocol === "http:" || parsed.protocol === "https:";
+    const isLocalhost =
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "[::1]";
+    const isBuilderDomain =
+      hostname === "builder.io" || hostname.endsWith(".builder.io");
+    const isAgentNativeDomain =
+      hostname === "agent-native.com" || hostname.endsWith(".agent-native.com");
+    return (
+      isAllowedProtocol &&
+      (isLocalhost || isBuilderDomain || isAgentNativeDomain)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function firstBuilderCliAuthCallbackOriginFromEnv(): string | null {
+  for (const key of [
+    "APP_URL",
+    "VITE_APP_URL",
+    "BETTER_AUTH_URL",
+    "VITE_BETTER_AUTH_URL",
+    "WORKSPACE_GATEWAY_URL",
+    "VITE_WORKSPACE_GATEWAY_URL",
+  ]) {
+    const raw = process.env[key];
+    if (!raw) continue;
+    try {
+      const origin = new URL(raw).origin;
+      if (isBuilderCliAuthAllowedOrigin(origin)) return origin;
+    } catch {
+      // Ignore malformed environment values.
+    }
+  }
+  return null;
+}
+
 /**
  * Build the Builder cli-auth URL for the connect popup. When a signed
  * `state` token is supplied it is embedded inside the `redirect_url`
@@ -332,20 +379,28 @@ export async function resolveIsBuilderBranchingEnabled(): Promise<boolean> {
  * api-key / etc., so we don't depend on Builder echoing a top-level
  * `state` parameter (it doesn't).
  *
- * The user-facing connect entry point is `/_agent-native/builder/connect`
- * (a server-side 302). Status / chat-card responses surface that path
- * rather than the cli-auth URL directly, so the 302 handler can mint a
- * fresh state bound to the current session on every click.
+ * Status responses can surface this URL directly; the legacy
+ * `/_agent-native/builder/connect` trampoline still calls this helper for
+ * clients that only know the app-local connect URL.
  */
 export function buildBuilderCliAuthUrl(
-  origin: string,
+  callbackOrigin: string,
   state: string | null = null,
+  options: { previewOrigin?: string } = {},
 ): string {
-  const normalizedOrigin = normalizeOrigin(origin);
+  const normalizedCallbackOrigin = normalizeOrigin(callbackOrigin);
+  const requestedPreviewOrigin = normalizeOrigin(
+    options.previewOrigin || callbackOrigin,
+  );
+  const normalizedPreviewOrigin = isBuilderCliAuthAllowedOrigin(
+    requestedPreviewOrigin,
+  )
+    ? requestedPreviewOrigin
+    : normalizedCallbackOrigin;
   const appBasePath = getAppBasePath();
   const callbackUrl = new URL(
     `${appBasePath}${BUILDER_CALLBACK_PATH}`,
-    normalizedOrigin,
+    normalizedCallbackOrigin,
   );
   if (state) {
     callbackUrl.searchParams.set(BUILDER_STATE_PARAM, state);
@@ -355,7 +410,10 @@ export function buildBuilderCliAuthUrl(
   url.searchParams.set("host", BUILDER_BROWSER_HOST);
   url.searchParams.set("client_id", BUILDER_BROWSER_CLIENT_ID);
   url.searchParams.set("redirect_url", callbackUrl.toString());
-  url.searchParams.set("preview_url", `${normalizedOrigin}${appBasePath}`);
+  url.searchParams.set(
+    "preview_url",
+    `${normalizedPreviewOrigin}${appBasePath}`,
+  );
   url.searchParams.set("framework", "agent-native");
   return url.toString();
 }
@@ -454,10 +512,9 @@ function firstPublicBuilderPreviewOriginFromEnv(): string | null {
 }
 
 /**
- * Builder CLI-auth does not need the workspace OAuth relay that Google uses.
- * In Builder/Fusion previews, keep connect + callback URLs on the actual app
- * preview origin so the signed connect token and pending row are verified by
- * the same deployment that minted them.
+ * User-visible Builder connect origin. In Builder/Fusion previews, keep the
+ * connect URL on the actual app preview origin so clicking Connect happens in
+ * the same deployment that minted the signed connect token.
  */
 export function getBuilderBrowserOriginForEvent(event: H3Event): string {
   const headerHost = firstHeaderValue(
@@ -480,6 +537,22 @@ export function getBuilderBrowserOriginForEvent(event: H3Event): string {
         ? "https"
         : "http";
   return `${proto}://${headerHost}`;
+}
+
+/**
+ * Builder's /cli-auth page currently only accepts localhost, *.builder.io,
+ * *.agent-native.com, or builder: redirect_url destinations. Preview hosts
+ * such as *.builderio.xyz and *.builder.codes are valid app origins for us,
+ * but Builder rejects them and falls back to http://localhost:10110/auth.
+ * Use a configured public gateway for the callback in those cases while
+ * leaving the surfaced connect URL on the user's active preview.
+ */
+export function getBuilderCliAuthCallbackOriginForEvent(
+  event: H3Event,
+): string {
+  const previewOrigin = getBuilderBrowserOriginForEvent(event);
+  if (isBuilderCliAuthAllowedOrigin(previewOrigin)) return previewOrigin;
+  return firstBuilderCliAuthCallbackOriginFromEnv() ?? previewOrigin;
 }
 
 export function getBuilderBrowserStatus(origin: string): BuilderBrowserStatus {

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -372,6 +372,29 @@ function firstBuilderCliAuthCallbackOriginFromEnv(): string | null {
 }
 
 /**
+ * Query param on the callback URL that carries the original preview opener
+ * origin when cli-auth's allow-list forces `preview_url` to the gateway.
+ * Read on the callback to derive the correct postMessage targetOrigin.
+ *
+ * Not signed: the receive-side trust check in `useBuilderStatus` still
+ * gates messages by allow-listed origin. The worst an attacker could do by
+ * crafting a different `_an_opener` value is target a postMessage to an
+ * origin that doesn't match the actual opener — postMessage drops the
+ * message in that case, identical to the legacy wildcard-fallback path.
+ */
+export const BUILDER_OPENER_PARAM = "_an_opener";
+
+function isBuilderOpenerOriginSafe(value: string | null | undefined): boolean {
+  if (!value) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Build the Builder cli-auth URL for the connect popup. When a signed
  * `state` token is supplied it is embedded inside the `redirect_url`
  * query string so it survives Builder's redirect verbatim — Builder
@@ -404,6 +427,19 @@ export function buildBuilderCliAuthUrl(
   );
   if (state) {
     callbackUrl.searchParams.set(BUILDER_STATE_PARAM, state);
+  }
+  // When the cli-auth allow-list forces preview_url onto the gateway origin,
+  // the callback would otherwise lose the real opener origin and post its
+  // success message to the gateway instead of the preview tab. Embed the
+  // original preview origin in the callback's own query string so the
+  // callback handler can recover it for parentOrigin / postMessage. Builder
+  // preserves the redirect_url's query verbatim, so this round-trips.
+  if (
+    requestedPreviewOrigin &&
+    requestedPreviewOrigin !== normalizedPreviewOrigin &&
+    isBuilderOpenerOriginSafe(requestedPreviewOrigin)
+  ) {
+    callbackUrl.searchParams.set(BUILDER_OPENER_PARAM, requestedPreviewOrigin);
   }
   const url = new URL("/cli-auth", getBuilderAppHost());
   url.searchParams.set("response_type", "code");

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -774,8 +774,27 @@ const BUILDER_CALLBACK_BASE_CSS = `
   }
 `;
 
-export function createBuilderBrowserCallbackPage(previewUrl: string): string {
+function safeOriginFromUrl(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function createBuilderBrowserCallbackPage(
+  previewUrl: string,
+  opts: { parentOrigin?: string } = {},
+): string {
   const escapedUrl = JSON.stringify(previewUrl);
+  const parentOrigin =
+    safeOriginFromUrl(opts.parentOrigin) ?? safeOriginFromUrl(previewUrl);
+  // postMessage requires a specific target origin for cross-origin opener
+  // delivery; only fall back to "*" when we have no usable origin (the
+  // BroadcastChannel path on the success page still works for same-origin
+  // openers in that case).
+  const escapedTargetOrigin = JSON.stringify(parentOrigin ?? "*");
   return `<!doctype html>
 <html lang="en">
   <head>
@@ -818,7 +837,7 @@ export function createBuilderBrowserCallbackPage(previewUrl: string): string {
         if (window.opener && !window.opener.closed) {
           window.opener.postMessage(
             { type: "builder-connect-success" },
-            "*",
+            ${escapedTargetOrigin},
           );
         }
       } catch (e) {}
@@ -859,9 +878,12 @@ export function createBuilderBrowserCallbackErrorPage(
     title?: string;
     body?: string;
     closeHint?: string;
+    parentOrigin?: string;
   } = {},
 ): string {
   const escapedMessage = JSON.stringify(message);
+  const parentOrigin = safeOriginFromUrl(opts.parentOrigin);
+  const escapedTargetOrigin = JSON.stringify(parentOrigin ?? "*");
   const title = opts.title ?? "Couldn't save Builder connection";
   const body =
     opts.body ??
@@ -912,7 +934,7 @@ export function createBuilderBrowserCallbackErrorPage(
           try {
             window.opener.postMessage(
               { type: "builder-connect-error", message: msg },
-              "*",
+              ${escapedTargetOrigin},
             );
           } catch (e) {}
         }

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -723,6 +723,13 @@ export function createCoreRoutesPlugin(
                 orgName: undefined,
                 orgKind: undefined,
                 credentialSource: credentialSource ?? undefined,
+                // Surface the failure message so the UI can explain why the
+                // connection is broken instead of silently showing "Connect
+                // Builder" with no context.
+                connectError: {
+                  message: authFailure.message,
+                  at: authFailure.at,
+                },
               });
             }
             if (creds.privateKey && creds.publicKey) {
@@ -1099,6 +1106,17 @@ export function createCoreRoutesPlugin(
           `${event.url?.pathname || "/"}${event.url?.search || ""}`,
           getOrigin(event),
         );
+        // postMessage from the callback success/error pages must target the
+        // original preview opener, not the callback server. On the fallback
+        // path the callback is served from the env-configured gateway while
+        // the opener lives on the preview origin. The previewUrl query param
+        // (echoed verbatim by Builder from cli-auth) is the only reliable
+        // source for that origin pre-write.
+        const callbackParentOrigin =
+          resolveSafePreviewUrl(
+            requestUrl.searchParams.get("preview-url"),
+            event,
+          ) || getBuilderBrowserOriginForEvent(event);
         const callbackStateOwner = verifyBuilderCallbackStateAndGetOwner(
           requestUrl.searchParams.get(BUILDER_STATE_PARAM),
         );
@@ -1165,7 +1183,7 @@ export function createCoreRoutesPlugin(
           setResponseStatus(event, 503);
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
           return createBuilderBrowserCallbackErrorPage(pendingError, {
-            parentOrigin: getBuilderBrowserOriginForEvent(event),
+            parentOrigin: callbackParentOrigin,
           });
         }
 
@@ -1199,7 +1217,7 @@ export function createCoreRoutesPlugin(
           setResponseStatus(event, 403);
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
           return createBuilderBrowserCallbackErrorPage(msg, {
-            parentOrigin: getBuilderBrowserOriginForEvent(event),
+            parentOrigin: callbackParentOrigin,
           });
         }
 
@@ -1229,7 +1247,7 @@ export function createCoreRoutesPlugin(
           setResponseStatus(event, 400);
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
           return createBuilderBrowserCallbackErrorPage(msg, {
-            parentOrigin: getBuilderBrowserOriginForEvent(event),
+            parentOrigin: callbackParentOrigin,
           });
         }
 
@@ -1313,7 +1331,7 @@ export function createCoreRoutesPlugin(
           setResponseStatus(event, 500);
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
           return createBuilderBrowserCallbackErrorPage(writeError, {
-            parentOrigin: getBuilderBrowserOriginForEvent(event),
+            parentOrigin: callbackParentOrigin,
           });
         }
 
@@ -1345,8 +1363,15 @@ export function createCoreRoutesPlugin(
           },
         );
         setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
+        // The parent (opener) is the original preview surface that started the
+        // connect flow, NOT the callback server's own origin — when the
+        // env-configured gateway is used as the callback fallback (because
+        // Builder rejects the preview host), the callback server and the
+        // opener live on different origins, and postMessage to the gateway
+        // origin would be dropped by the preview opener. Derive parentOrigin
+        // from previewUrl so the message is delivered correctly.
         return createBuilderBrowserCallbackPage(previewUrl, {
-          parentOrigin: getBuilderBrowserOriginForEvent(event),
+          parentOrigin: previewUrl,
         });
       }),
     );

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -898,6 +898,7 @@ export function createCoreRoutesPlugin(
             body: "The connect popup did not include a valid signed link for this app.",
             closeHint:
               "Close this popup, refresh the app, and try Connect account again.",
+            parentOrigin: getBuilderBrowserOriginForEvent(event),
           });
         }
 
@@ -942,7 +943,9 @@ export function createCoreRoutesPlugin(
           }).catch(() => {});
           setResponseStatus(event, 503);
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
-          return createBuilderBrowserCallbackErrorPage(msg);
+          return createBuilderBrowserCallbackErrorPage(msg, {
+            parentOrigin: getBuilderBrowserOriginForEvent(event),
+          });
         }
         await trackBuilderLifecycle(
           event,
@@ -1161,7 +1164,9 @@ export function createCoreRoutesPlugin(
           }).catch(() => {});
           setResponseStatus(event, 503);
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
-          return createBuilderBrowserCallbackErrorPage(pendingError);
+          return createBuilderBrowserCallbackErrorPage(pendingError, {
+            parentOrigin: getBuilderBrowserOriginForEvent(event),
+          });
         }
 
         if (!pendingValid) {
@@ -1193,7 +1198,9 @@ export function createCoreRoutesPlugin(
           }
           setResponseStatus(event, 403);
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
-          return createBuilderBrowserCallbackErrorPage(msg);
+          return createBuilderBrowserCallbackErrorPage(msg, {
+            parentOrigin: getBuilderBrowserOriginForEvent(event),
+          });
         }
 
         const privateKey = requestUrl.searchParams.get("p-key");
@@ -1221,7 +1228,9 @@ export function createCoreRoutesPlugin(
           }).catch(() => {});
           setResponseStatus(event, 400);
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
-          return createBuilderBrowserCallbackErrorPage(msg);
+          return createBuilderBrowserCallbackErrorPage(msg, {
+            parentOrigin: getBuilderBrowserOriginForEvent(event),
+          });
         }
 
         const userId = requestUrl.searchParams.get("user-id");
@@ -1303,7 +1312,9 @@ export function createCoreRoutesPlugin(
           }
           setResponseStatus(event, 500);
           setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
-          return createBuilderBrowserCallbackErrorPage(writeError);
+          return createBuilderBrowserCallbackErrorPage(writeError, {
+            parentOrigin: getBuilderBrowserOriginForEvent(event),
+          });
         }
 
         // Clear any legacy disconnect flag and any prior connect-error row
@@ -1334,7 +1345,9 @@ export function createCoreRoutesPlugin(
           },
         );
         setResponseHeader(event, "Content-Type", "text/html; charset=utf-8");
-        return createBuilderBrowserCallbackPage(previewUrl);
+        return createBuilderBrowserCallbackPage(previewUrl, {
+          parentOrigin: getBuilderBrowserOriginForEvent(event),
+        });
       }),
     );
 

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -28,6 +28,7 @@ import {
   BUILDER_CONNECT_PARAM,
   BUILDER_CONNECT_OWNER_COOKIE,
   BUILDER_ENV_KEYS,
+  BUILDER_OPENER_PARAM,
   BUILDER_STATE_PARAM,
   appendBuilderConnectToken,
   buildBuilderCliAuthUrl,
@@ -1109,14 +1110,25 @@ export function createCoreRoutesPlugin(
         // postMessage from the callback success/error pages must target the
         // original preview opener, not the callback server. On the fallback
         // path the callback is served from the env-configured gateway while
-        // the opener lives on the preview origin. The previewUrl query param
-        // (echoed verbatim by Builder from cli-auth) is the only reliable
-        // source for that origin pre-write.
+        // the opener lives on the preview origin. Three sources of opener
+        // origin, in priority order:
+        //   1. `_an_opener` — written into the callback URL's query by
+        //      buildBuilderCliAuthUrl when cli-auth's allow-list forced
+        //      preview_url onto the gateway. Survives Builder's redirect
+        //      verbatim (Builder preserves redirect_url's query string).
+        //   2. `preview-url` — Builder echoes the top-level preview_url back
+        //      as a query param on the callback. Reflects the gateway on
+        //      the fallback path, but matches the opener on the happy path.
+        //   3. The event's own origin — last-resort fallback.
+        const openerOriginFromQuery =
+          requestUrl.searchParams.get(BUILDER_OPENER_PARAM);
         const callbackParentOrigin =
+          resolveSafePreviewUrl(openerOriginFromQuery, event) ||
           resolveSafePreviewUrl(
             requestUrl.searchParams.get("preview-url"),
             event,
-          ) || getBuilderBrowserOriginForEvent(event);
+          ) ||
+          getBuilderBrowserOriginForEvent(event);
         const callbackStateOwner = verifyBuilderCallbackStateAndGetOwner(
           requestUrl.searchParams.get(BUILDER_STATE_PARAM),
         );
@@ -1368,10 +1380,11 @@ export function createCoreRoutesPlugin(
         // env-configured gateway is used as the callback fallback (because
         // Builder rejects the preview host), the callback server and the
         // opener live on different origins, and postMessage to the gateway
-        // origin would be dropped by the preview opener. Derive parentOrigin
-        // from previewUrl so the message is delivered correctly.
+        // origin would be dropped by the preview opener. callbackParentOrigin
+        // is the precomputed best-available opener origin (`_an_opener` →
+        // `preview-url` → event origin).
         return createBuilderBrowserCallbackPage(previewUrl, {
-          parentOrigin: previewUrl,
+          parentOrigin: callbackParentOrigin,
         });
       }),
     );

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -33,6 +33,7 @@ import {
   buildBuilderCliAuthUrl,
   createBuilderBrowserCallbackErrorPage,
   createBuilderBrowserCallbackPage,
+  getBuilderCliAuthCallbackOriginForEvent,
   getBuilderBrowserOriginForEvent,
   getBuilderBrowserStatusForEvent,
   resolveBuilderBranchProjectId,
@@ -627,10 +628,12 @@ export function createCoreRoutesPlugin(
           // instead of bouncing through the gateway. getOrigin(event) falls
           // back to the gateway on Builder preview hosts, which defeats the
           // whole preview-aware isolation goal of this PR.
-          const callbackOrigin = getBuilderBrowserOriginForEvent(event);
+          const previewOrigin = getBuilderBrowserOriginForEvent(event);
+          const callbackOrigin = getBuilderCliAuthCallbackOriginForEvent(event);
           const cliAuthUrl = buildBuilderCliAuthUrl(
             callbackOrigin,
             signBuilderCallbackState(userEmail),
+            { previewOrigin },
           );
           return {
             ...status,
@@ -703,12 +706,26 @@ export function createCoreRoutesPlugin(
             const {
               resolveBuilderCredentials,
               resolveBuilderCredentialSource,
+              getBuilderCredentialAuthFailure,
             } = await import("./credential-provider.js");
             const [creds, credentialSource] = await Promise.all([
               resolveBuilderCredentials(),
               resolveBuilderCredentialSource(),
             ]);
-            if (creds.privateKey) {
+            const authFailure = await getBuilderCredentialAuthFailure(creds);
+            if (authFailure) {
+              return withConnectToken({
+                ...requestStatus,
+                configured: false,
+                privateKeyConfigured: false,
+                publicKeyConfigured: false,
+                userId: undefined,
+                orgName: undefined,
+                orgKind: undefined,
+                credentialSource: credentialSource ?? undefined,
+              });
+            }
+            if (creds.privateKey && creds.publicKey) {
               return withConnectToken({
                 ...requestStatus,
                 configured: true,
@@ -943,8 +960,9 @@ export function createCoreRoutesPlugin(
         // clients, but still send it to Builder immediately and include signed
         // callback state so the callback does not depend on popup cookies.
         const cliAuthUrl = buildBuilderCliAuthUrl(
-          getBuilderBrowserOriginForEvent(event),
+          getBuilderCliAuthCallbackOriginForEvent(event),
           signBuilderCallbackState(ownerEmail),
+          { previewOrigin: getBuilderBrowserOriginForEvent(event) },
         );
         setResponseStatus(event, 302);
         setResponseHeader(event, "Location", cliAuthUrl);

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -3,6 +3,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockReadAppSecret = vi.fn();
 const mockWriteAppSecret = vi.fn();
 const mockDeleteAppSecret = vi.fn();
+const mockGetSetting = vi.fn();
+const mockPutSetting = vi.fn();
+const mockDeleteSetting = vi.fn();
 const mockGetRequestUserEmail = vi.fn<[], string | undefined>();
 const mockGetRequestOrgId = vi.fn<[], string | undefined>();
 const mockIsLocalDatabase = vi.fn<[], boolean>();
@@ -19,9 +22,17 @@ vi.mock("./request-context.js", () => ({
 vi.mock("../db/client.js", () => ({
   isLocalDatabase: () => mockIsLocalDatabase(),
 }));
+vi.mock("../settings/store.js", () => ({
+  getSetting: (...args: any[]) => mockGetSetting(...args),
+  putSetting: (...args: any[]) => mockPutSetting(...args),
+  deleteSetting: (...args: any[]) => mockDeleteSetting(...args),
+}));
 
 import {
+  builderCredentialFingerprint,
   canUseDeployCredentialFallbackForRequest,
+  getBuilderCredentialAuthFailure,
+  recordBuilderCredentialAuthFailure,
   resolveCredentialWriteScope,
   writeBuilderCredentials,
   deleteBuilderCredentials,
@@ -46,6 +57,9 @@ beforeEach(() => {
   mockReadAppSecret.mockResolvedValue(null);
   mockWriteAppSecret.mockResolvedValue("id");
   mockDeleteAppSecret.mockResolvedValue(true);
+  mockGetSetting.mockResolvedValue(null);
+  mockPutSetting.mockResolvedValue(undefined);
+  mockDeleteSetting.mockResolvedValue(true);
   mockGetRequestUserEmail.mockReturnValue(undefined);
   mockGetRequestOrgId.mockReturnValue(undefined);
   mockIsLocalDatabase.mockReturnValue(true);
@@ -222,6 +236,69 @@ describe("writeBuilderCredentials", () => {
     expect(firstWrite).toBeGreaterThan(-1);
     expect(lastDelete).toBeGreaterThan(-1);
     expect(lastDelete).toBeLessThan(firstWrite);
+  });
+
+  it("clears the auth-failure marker for the new key pair", async () => {
+    await writeBuilderCredentials(
+      "owner@b.com",
+      { privateKey: "pk-new", publicKey: "pub-new" },
+      { orgId: "builder_io", role: "owner" },
+    );
+    const fingerprint = builderCredentialFingerprint("pk-new", "pub-new");
+    expect(mockDeleteSetting).toHaveBeenCalledWith(
+      `builder-auth-failure:${fingerprint}`,
+    );
+  });
+});
+
+describe("Builder credential auth failure markers", () => {
+  it("records gateway auth failures against a fingerprint without storing raw keys in the setting key", async () => {
+    process.env.BUILDER_PRIVATE_KEY = "bpk-secret";
+    process.env.BUILDER_PUBLIC_KEY = "pub-secret";
+
+    await recordBuilderCredentialAuthFailure({
+      status: 401,
+      code: "unauthorized",
+      message: "Invalid key",
+    });
+
+    expect(mockPutSetting).toHaveBeenCalledTimes(1);
+    const [key, value] = mockPutSetting.mock.calls[0];
+    expect(key).toMatch(/^builder-auth-failure:[a-f0-9]{24}$/);
+    expect(key).not.toContain("bpk-secret");
+    expect(key).not.toContain("pub-secret");
+    expect(value).toMatchObject({
+      message: "Invalid key",
+      status: 401,
+      code: "unauthorized",
+      ownerEmail: null,
+      orgId: null,
+    });
+  });
+
+  it("reads an auth-failure marker for the same effective key pair", async () => {
+    mockGetSetting.mockResolvedValue({
+      message: "Invalid key",
+      status: 401,
+      code: "unauthorized",
+      at: 123,
+    });
+
+    const failure = await getBuilderCredentialAuthFailure({
+      privateKey: "bpk-secret",
+      publicKey: "pub-secret",
+    });
+
+    expect(failure).toMatchObject({
+      fingerprint: builderCredentialFingerprint("bpk-secret", "pub-secret"),
+      message: "Invalid key",
+      status: 401,
+      code: "unauthorized",
+      at: 123,
+    });
+    expect(mockGetSetting).toHaveBeenCalledWith(
+      `builder-auth-failure:${builderCredentialFingerprint("bpk-secret", "pub-secret")}`,
+    );
   });
 });
 

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -18,6 +18,7 @@
  * (e.g. additional Builder-hosted services) without rewrites.
  */
 
+import { createHash } from "node:crypto";
 import { getRequestUserEmail, getRequestOrgId } from "./request-context.js";
 import { isLocalDatabase } from "../db/client.js";
 
@@ -280,6 +281,114 @@ export async function resolveBuilderCredentials(): Promise<{
   return { privateKey, publicKey, userId, orgName, orgKind };
 }
 
+const BUILDER_AUTH_FAILURE_SETTING_PREFIX = "builder-auth-failure:";
+
+export interface BuilderCredentialAuthFailure {
+  fingerprint: string;
+  message: string;
+  status?: number;
+  code?: string;
+  at: number;
+  ownerEmail?: string | null;
+  orgId?: string | null;
+}
+
+export function builderCredentialFingerprint(
+  privateKey?: string | null,
+  publicKey?: string | null,
+): string | null {
+  if (!privateKey || !publicKey) return null;
+  return createHash("sha256")
+    .update(privateKey)
+    .update("\0")
+    .update(publicKey)
+    .digest("hex")
+    .slice(0, 24);
+}
+
+function builderAuthFailureSettingKey(fingerprint: string): string {
+  return `${BUILDER_AUTH_FAILURE_SETTING_PREFIX}${fingerprint}`;
+}
+
+export async function getBuilderCredentialAuthFailure(
+  creds: {
+    privateKey?: string | null;
+    publicKey?: string | null;
+  } = {},
+): Promise<BuilderCredentialAuthFailure | null> {
+  const fingerprint = builderCredentialFingerprint(
+    creds.privateKey,
+    creds.publicKey,
+  );
+  if (!fingerprint) return null;
+  try {
+    const { getSetting } = await import("../settings/store.js");
+    const row = await getSetting(builderAuthFailureSettingKey(fingerprint));
+    if (!row) return null;
+    return {
+      fingerprint,
+      message:
+        typeof row.message === "string" && row.message
+          ? row.message
+          : "Builder rejected the connected credentials. Reconnect Builder.io.",
+      status: typeof row.status === "number" ? row.status : undefined,
+      code: typeof row.code === "string" ? row.code : undefined,
+      at: typeof row.at === "number" ? row.at : Date.now(),
+      ownerEmail:
+        typeof row.ownerEmail === "string" ? row.ownerEmail : undefined,
+      orgId: typeof row.orgId === "string" ? row.orgId : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function recordBuilderCredentialAuthFailure(details?: {
+  status?: number;
+  code?: string;
+  message?: string;
+}): Promise<void> {
+  try {
+    const creds = await resolveBuilderCredentials();
+    const fingerprint = builderCredentialFingerprint(
+      creds.privateKey,
+      creds.publicKey,
+    );
+    if (!fingerprint) return;
+    const { putSetting } = await import("../settings/store.js");
+    await putSetting(builderAuthFailureSettingKey(fingerprint), {
+      fingerprint,
+      message:
+        details?.message ||
+        "Builder rejected the connected credentials. Reconnect Builder.io.",
+      ...(typeof details?.status === "number" && { status: details.status }),
+      ...(details?.code && { code: details.code }),
+      at: Date.now(),
+      ownerEmail: getRequestUserEmail() ?? null,
+      orgId: getRequestOrgId() ?? null,
+    });
+  } catch {
+    // Best-effort marker only; the chat error is still returned to the user.
+  }
+}
+
+export async function clearBuilderCredentialAuthFailure(creds: {
+  privateKey?: string | null;
+  publicKey?: string | null;
+}): Promise<void> {
+  const fingerprint = builderCredentialFingerprint(
+    creds.privateKey,
+    creds.publicKey,
+  );
+  if (!fingerprint) return;
+  try {
+    const { deleteSetting } = await import("../settings/store.js");
+    await deleteSetting(builderAuthFailureSettingKey(fingerprint));
+  } catch {
+    // A stale failure marker should not block writing fresh credentials.
+  }
+}
+
 const BUILDER_CREDENTIAL_KEYS = [
   "BUILDER_PRIVATE_KEY",
   "BUILDER_PUBLIC_KEY",
@@ -376,6 +485,10 @@ export async function writeBuilderCredentials(
       }),
     ),
   );
+  await clearBuilderCredentialAuthFailure({
+    privateKey: creds.privateKey,
+    publicKey: creds.publicKey,
+  });
   return target;
 }
 


### PR DESCRIPTION
## Summary

- Add `getBuilderCliAuthCallbackOriginForEvent` to fall back to an env-configured public origin when the active preview host is not in Builder's cli-auth allow-list (e.g. `*.builderio.xyz`, `*.builder.codes`). User-facing connect URL stays on the actual preview via new `previewOrigin` option on `buildBuilderCliAuthUrl`.
- Track Builder credential auth failures by fingerprint in `application_state` via new helpers in `credential-provider`. Expose `connectError` on `BuilderBrowserStatus` and treat rejected credentials as unconfigured in status / chat-card responses.
- Add `"workspace"` `credentialSource` and propagate it through `useBuilderStatus` and `SettingsPanel` so the UI reflects rejected workspace-managed credentials.

## Test plan

- [ ] Existing `builder-browser.spec.ts` and `credential-provider.spec.ts` cover the new helpers (added in this PR)
- [ ] `builder-engine.spec.ts` exercises rejected-credential propagation
- [ ] Manually verify connect popup callback succeeds when preview host is in Builder's allow-list and falls back via env-configured origin otherwise