### PR TITLE
Fix: default API host fallback to api.builder.io

### DIFF
--- a/.changeset/fix-builder-api-host-fallback.md
+++ b/.changeset/fix-builder-api-host-fallback.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Fix: default the Builder API host fallback to `https://api.builder.io` instead of the unreachable `https://ai-services.builder.io`, so calls succeed when `BUILDER_API_HOST` / `BUILDER_PROXY_ORIGIN` / `AIR_HOST` are unset.

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -1424,7 +1424,7 @@ export function createCoreRoutesPlugin(
               return { error: "userMessage is required" };
             }
             const apiHost =
-              process.env.BUILDER_API_HOST || "https://ai-services.builder.io";
+              process.env.BUILDER_API_HOST || "https://api.builder.io";
             try {
               const res = await fetch(
                 `${apiHost}/agents/run?apiKey=${encodeURIComponent(creds.publicKey)}`,

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -559,15 +559,13 @@ export function getBuilderProxyOrigin(): string {
     process.env.BUILDER_PROXY_ORIGIN ||
     process.env.AIR_HOST ||
     process.env.BUILDER_API_HOST ||
-    "https://ai-services.builder.io"
+    "https://api.builder.io"
   );
 }
 
 /**
- * Base URL for the public Builder LLM gateway (distinct from the internal
- * proxy origin above — the public gateway lives at
- * api.builder.io/agent-native/gateway, while the internal origin is
- * ai-services.builder.io).
+ * Base URL for the public Builder LLM gateway, which lives at
+ * api.builder.io/agent-native/gateway.
  * Override via BUILDER_GATEWAY_BASE_URL for staging / testing.
  */
 export function getBuilderGatewayBaseUrl(): string {

--- a/packages/core/src/server/google-realtime-session.ts
+++ b/packages/core/src/server/google-realtime-session.ts
@@ -156,8 +156,7 @@ export function createGoogleRealtimeSessionHandler() {
         };
       }
 
-      const apiHost =
-        process.env.BUILDER_API_HOST || "https://ai-services.builder.io";
+      const apiHost = process.env.BUILDER_API_HOST || "https://api.builder.io";
       const body = ((await readBody(event).catch(() => ({}))) || {}) as {
         language?: unknown;
       };


### PR DESCRIPTION
### Summary
Fixes the default fallback URL for the Builder API host from the unreachable `https://ai-services.builder.io` to the correct `https://api.builder.io`, preventing socket hang-up errors when environment variables are not set.

### Problem
Agent-native calls were falling back to `https://ai-services.builder.io` when `BUILDER_API_HOST`, `BUILDER_PROXY_ORIGIN`, or `AIR_HOST` environment variables were unset. This host does not exist, causing socket hang-up errors and failed requests.

### Solution
Replace all hardcoded fallback references to `https://ai-services.builder.io` with `https://api.builder.io` across the affected files, and update the related code comment to remove the now-incorrect distinction between the two hosts.

### Key Changes
- Updated fallback URL in `core-routes-plugin.ts` for agent run calls
- Updated fallback URL in `credential-provider.ts` for `getBuilderProxyOrigin()`
- Updated fallback URL in `google-realtime-session.ts` for Google Realtime session handling
- Cleaned up the `getBuilderGatewayBaseUrl` JSDoc comment that referenced the old `ai-services.builder.io` host
- Added a changeset entry (`@agent-native/core` patch) documenting the fix


---

<a href="https://builder.io/app/projects/274d28fec94b48f2b2d68f2274d390eb/gaunt-crack-8tewn7km"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F226fa21c49ce4f95a5aba53aa594fe7a"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2F949e3db6dedf4252bf6ae0258f4a37de" alt="Edit in Builder"></picture></a>&nbsp;&nbsp;<a href="https://274d28fec94b48f2b2d68f2274d390eb-gaunt-crack-8tewn7km_v2.projects.builder.my/"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fe530b1333b5b4cedac9c41b8573c8268"><img src="https://cdn.builder.io/api/v1/image/assets%2FYJIGb4i01jvw0SRdL5Bt%2Fbf5aebbec0b448779c805d58bacf6278" alt="Preview"></picture></a>

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

---

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 698`

You can tag me at @builderio for anything you want me to fix or change



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>274d28fec94b48f2b2d68f2274d390eb</projectId>-->
<!--<branchName>gaunt-crack-8tewn7km</branchName>-->