### PR TITLE
Keep Builder reconnect alive when env fallback creds are rejected

### DIFF
--- a/.changeset/fresh-builder-reconnect.md
+++ b/.changeset/fresh-builder-reconnect.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Keep Builder reconnect flows alive while replacing rejected deploy fallback credentials.

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -91,6 +91,7 @@ describe("useBuilderConnectFlow", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -239,5 +240,109 @@ describe("useBuilderConnectFlow", () => {
     );
     expect(window.location.href).toBe("http://localhost:3000/settings");
     expect(container.textContent).not.toContain("Popup blocked");
+  });
+
+  it("does not abort a reconnect popup because the old credential was rejected", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T12:00:00.000Z"));
+    setUserAgent("Mozilla/5.0 Chrome/140.0");
+    const popup = createPopupStub();
+    openSpy.mockReturnValue(popup);
+    const signedConnectUrl =
+      "http://localhost:3000/_agent-native/builder/connect?_an_connect=signed";
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({
+        configured: false,
+        envManaged: true,
+        builderEnabled: true,
+        orgName: null,
+        connectUrl: signedConnectUrl,
+        appHost: "https://builder.io",
+        apiHost: "https://api.builder.io",
+        publicKeyConfigured: false,
+        privateKeyConfigured: false,
+        authError: {
+          message: "Private key does not match spaceId",
+          at: Date.now() - 60_000,
+        },
+      }),
+    );
+
+    await act(async () => {
+      root.render(<BuilderConnectProbe />);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain(
+      "Private key does not match spaceId",
+    );
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+    });
+
+    expect(openSpy).toHaveBeenCalledWith(
+      signedConnectUrl,
+      "_blank",
+      "width=600,height=700",
+    );
+    expect(container.textContent).toContain("not-configured connecting");
+    expect(container.textContent).not.toContain(
+      "Private key does not match spaceId",
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(container.textContent).toContain("not-configured connecting");
+    expect(container.textContent).not.toContain(
+      "Private key does not match spaceId",
+    );
+  });
+
+  it("ignores stale connect callback errors after starting a fresh reconnect", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T12:00:00.000Z"));
+    setUserAgent("Mozilla/5.0 Chrome/140.0");
+    const popup = createPopupStub();
+    openSpy.mockReturnValue(popup);
+    const signedConnectUrl =
+      "http://localhost:3000/_agent-native/builder/connect?_an_connect=signed";
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({
+        configured: false,
+        envManaged: false,
+        builderEnabled: true,
+        orgName: null,
+        connectUrl: signedConnectUrl,
+        appHost: "https://builder.io",
+        apiHost: "https://api.builder.io",
+        publicKeyConfigured: false,
+        privateKeyConfigured: false,
+        connectError: {
+          message: "No active connect flow found",
+          at: Date.now() - 60_000,
+        },
+      }),
+    );
+
+    await act(async () => {
+      root.render(<BuilderConnectProbe />);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("No active connect flow found");
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(container.textContent).toContain("not-configured connecting");
+    expect(container.textContent).not.toContain("No active connect flow found");
   });
 });

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -30,6 +30,12 @@ export interface BuilderStatus {
    * can stop with a clear message instead of timing out at 5min.
    */
   connectError?: { message: string; at: number };
+  /**
+   * Set when the currently effective Builder credential was rejected by
+   * Builder's API. Unlike connectError, this describes the old credential pair
+   * and should not abort a new reconnect attempt while the popup is open.
+   */
+  authError?: { message: string; at: number };
 }
 
 /**
@@ -182,6 +188,15 @@ function isFreshSignedConnectUrl(
   );
 }
 
+function isCurrentConnectError(
+  error: { message: string; at: number } | undefined,
+  startedAt: number | null,
+): error is { message: string; at: number } {
+  if (!error?.message) return false;
+  if (!startedAt) return true;
+  return typeof error.at !== "number" || error.at >= startedAt - 1000;
+}
+
 function showBuilderConnectPopupPlaceholder(opened: Window) {
   try {
     opened.opener = null;
@@ -326,6 +341,7 @@ export function useBuilderConnectFlow(
   // gesture path (browser/editor embeds).
   const statusConnectUrlAtRef = useRef<number | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const connectStartedAtRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
   const notifiedConnectedRef = useRef(false);
   // Keep onConnected in a ref so start() doesn't need to re-create when the
@@ -356,6 +372,7 @@ export function useBuilderConnectFlow(
         cliAuthUrl?: string;
         credentialSource?: "user" | "org" | "workspace" | "env";
         connectError?: { message: string; at: number };
+        authError?: { message: string; at: number };
       };
     } catch {
       return null;
@@ -386,6 +403,9 @@ export function useBuilderConnectFlow(
       statusConnectUrlAtRef.current = nextConnectUrl ? Date.now() : null;
       const org = s.orgName ?? null;
       setOrgName(org);
+      if (s.configured) {
+        connectStartedAtRef.current = null;
+      }
       if (s.configured && !notifiedConnectedRef.current) {
         notifiedConnectedRef.current = true;
         notifyAgentEngineConfiguredChanged("builder-status");
@@ -397,15 +417,14 @@ export function useBuilderConnectFlow(
       } else if (!s.configured) {
         notifiedConnectedRef.current = false;
       }
-      // Surface persisted auth-failure messages on every refresh — reload,
-      // first paint in a new tab, agent-engine:configured-changed, etc.
-      // Without this, useBuilderConnectFlow's start() is the only path that
-      // ever sets `error`, so users who reload after a rejection see the
-      // generic "Connect Builder" CTA with no explanation. Clear the error
-      // when status is configured again so a self-healed marker stops
-      // showing the stale message.
-      if (s.connectError?.message) {
+      // Surface persisted auth-failure messages on idle refreshes, but don't
+      // let an old rejected credential abort a new reconnect popup while the
+      // user is still choosing a Builder space.
+      const activeConnectStartedAt = connectStartedAtRef.current;
+      if (isCurrentConnectError(s.connectError, activeConnectStartedAt)) {
         setError(s.connectError.message);
+      } else if (!activeConnectStartedAt && s.authError?.message) {
+        setError(s.authError.message);
       } else if (s.configured) {
         setError(null);
       }
@@ -429,6 +448,8 @@ export function useBuilderConnectFlow(
 
   const start = useCallback(() => {
     stopPoll();
+    const started = Date.now();
+    connectStartedAtRef.current = started;
     setConnecting(true);
     setError(null);
 
@@ -475,6 +496,7 @@ export function useBuilderConnectFlow(
         features: "width=600,height=700",
       });
       if (!opened) {
+        connectStartedAtRef.current = null;
         setConnecting(false);
         setError("Couldn't open Builder. Allow popups and try again.");
         return;
@@ -486,6 +508,7 @@ export function useBuilderConnectFlow(
         features: "width=600,height=700",
       });
       if (!opened) {
+        connectStartedAtRef.current = null;
         setConnecting(false);
         setError("Couldn't open Builder. Allow popups and try again.");
         return;
@@ -527,6 +550,7 @@ export function useBuilderConnectFlow(
             // Ignore close failures.
           }
           stopPoll();
+          connectStartedAtRef.current = null;
           setConnecting(false);
           setError(
             "Couldn't start Builder connect. Refresh this page and try again.",
@@ -535,6 +559,7 @@ export function useBuilderConnectFlow(
         }
         if (!navigateBuilderConnectPopup(opened, freshUrl)) {
           stopPoll();
+          connectStartedAtRef.current = null;
           setConnecting(false);
           setError(
             "Couldn't navigate the Builder popup. Allow popups and try again.",
@@ -543,7 +568,6 @@ export function useBuilderConnectFlow(
       })();
     }
 
-    const started = Date.now();
     pollRef.current = setInterval(async () => {
       const s = await fetchStatus();
       if (!mountedRef.current) {
@@ -561,6 +585,7 @@ export function useBuilderConnectFlow(
         const org = s.orgName ?? null;
         setOrgName(org);
         setConnecting(false);
+        connectStartedAtRef.current = null;
         notifiedConnectedRef.current = true;
         notifyAgentEngineConfiguredChanged("builder-connect");
         try {
@@ -569,16 +594,18 @@ export function useBuilderConnectFlow(
           // Consumer's callback failed; we've already flipped the UI state
           // to connected. Swallow so we don't re-arm the flow.
         }
-      } else if (s?.connectError?.message) {
+      } else if (isCurrentConnectError(s?.connectError, started)) {
         // OAuth callback ran but writeBuilderCredentials threw — surface the
         // real error instead of letting the user wait 5 minutes for timeout.
         stopPoll();
+        connectStartedAtRef.current = null;
         setConnecting(false);
         setError(
           `Couldn't save Builder credentials: ${s.connectError.message}. Try again or contact support.`,
         );
       } else if (Date.now() - started > POLL_TIMEOUT_MS) {
         stopPoll();
+        connectStartedAtRef.current = null;
         setConnecting(false);
         trackEvent("builder connect failed", {
           feature: "builder",
@@ -605,6 +632,7 @@ export function useBuilderConnectFlow(
     let channel: BroadcastChannel | null = null;
     const handleError = (message: string) => {
       stopPoll();
+      connectStartedAtRef.current = null;
       setConnecting(false);
       setError(`Couldn't save Builder credentials: ${message}.`);
     };
@@ -622,6 +650,7 @@ export function useBuilderConnectFlow(
       const org = s.orgName ?? null;
       setOrgName(org);
       setConnecting(false);
+      connectStartedAtRef.current = null;
       notifiedConnectedRef.current = true;
       notifyAgentEngineConfiguredChanged("builder-connect-message");
       try {

--- a/packages/core/src/server/builder-browser.ts
+++ b/packages/core/src/server/builder-browser.ts
@@ -54,14 +54,20 @@ export interface BuilderBrowserStatus {
    */
   envManaged: boolean;
   credentialSource?: "user" | "org" | "workspace" | "env";
+  /**
+   * The currently effective Builder credential was rejected by Builder's API.
+   * This is durable status about the credential pair, not a failure of an
+   * in-progress cli-auth callback.
+   */
+  authError?: { message: string; at: number };
   connectError?: { message: string; at: number };
   appHost: string;
   apiHost: string;
   /**
-   * Ready-to-open Builder CLI auth URL for this request owner. This points
-   * directly at builder.io/cli-auth and carries signed callback state in the
-   * nested redirect_url so the popup never has to visit the app's connect
-   * trampoline first.
+   * Ready-to-open Builder CLI auth URL for this request owner, when the
+   * callback can return to the same deployment that minted the state. Preview
+   * deployments that must callback through a gateway omit this and use
+   * connectUrl so the server can write a pending-connect row first.
    */
   cliAuthUrl?: string;
   connectUrl: string;

--- a/packages/core/src/server/core-routes-plugin.ts
+++ b/packages/core/src/server/core-routes-plugin.ts
@@ -624,21 +624,30 @@ export function createCoreRoutesPlugin(
           status: T,
         ): T & { cliAuthUrl?: string } => {
           if (!userEmail) return status;
-          // Use the preview-aware origin (same one connectUrl uses) so
-          // Builder's CLI auth flow returns to the active preview deployment
-          // instead of bouncing through the gateway. getOrigin(event) falls
-          // back to the gateway on Builder preview hosts, which defeats the
-          // whole preview-aware isolation goal of this PR.
           const previewOrigin = getBuilderBrowserOriginForEvent(event);
           const callbackOrigin = getBuilderCliAuthCallbackOriginForEvent(event);
+          const statusWithConnectToken = {
+            ...status,
+            connectUrl: appendBuilderConnectToken(status.connectUrl, userEmail),
+          } as T & { cliAuthUrl?: string };
+          // Direct cli-auth only works when the callback lands on the same
+          // deployment that minted the signed state. Builder/Fusion previews
+          // often need a gateway callback origin; in that case use the
+          // /builder/connect trampoline so it can write the pending-connect
+          // row that the gateway callback validates against.
+          if (
+            previewOrigin.replace(/\/+$/, "") !==
+            callbackOrigin.replace(/\/+$/, "")
+          ) {
+            return statusWithConnectToken;
+          }
           const cliAuthUrl = buildBuilderCliAuthUrl(
             callbackOrigin,
             signBuilderCallbackState(userEmail),
             { previewOrigin },
           );
           return {
-            ...status,
-            connectUrl: appendBuilderConnectToken(status.connectUrl, userEmail),
+            ...statusWithConnectToken,
             cliAuthUrl,
           };
         };
@@ -724,10 +733,12 @@ export function createCoreRoutesPlugin(
                 orgName: undefined,
                 orgKind: undefined,
                 credentialSource: credentialSource ?? undefined,
-                // Surface the failure message so the UI can explain why the
-                // connection is broken instead of silently showing "Connect
-                // Builder" with no context.
-                connectError: {
+                // Surface durable credential rejection separately from
+                // one-shot cli-auth callback failures. The reconnect UI keeps
+                // polling through authError while the user chooses a new
+                // Builder space; connectError means the active callback itself
+                // failed and should stop the flow.
+                authError: {
                   message: authFailure.message,
                   at: authFailure.at,
                 },
@@ -1097,6 +1108,24 @@ export function createCoreRoutesPlugin(
         // /builder/connect) blocks CSRF and callback replay.
         const ownerContext = await resolveBuilderOwnerContext(event);
         const ownerEmail = ownerContext.email;
+        // Diagnostic: log the resolver's inputs for debugging "No active
+        // connect flow found" reports. Reveals session-vs-state owner
+        // mismatches and missing/forged _an_state without leaking the
+        // signed token itself.
+        try {
+          const debugSearch = new URLSearchParams(
+            (event.url?.search || "").replace(/^\?/, ""),
+          );
+          const stateRaw = debugSearch.get(BUILDER_STATE_PARAM);
+          const stateOwnerProbe =
+            verifyBuilderCallbackStateAndGetOwner(stateRaw);
+          const session = await getSession(event).catch(() => null);
+          console.log(
+            `[builder-callback] resolved-owner=${ownerEmail ?? "(none)"} session-email=${session?.email ?? "(none)"} state-owner=${stateOwnerProbe ?? "(none)"} state-present=${Boolean(stateRaw)} anon=${ownerContext.anonymous} host=${getHeader(event, "host") ?? "(none)"} sec-fetch-site=${getHeader(event, "sec-fetch-site") ?? "(none)"} origin=${getHeader(event, "origin") ?? "(none)"} referer=${getHeader(event, "referer") ?? "(none)"}`,
+          );
+        } catch {
+          // Diagnostic logging is best-effort; do not break the callback.
+        }
         if (!ownerEmail) {
           setResponseStatus(event, 401);
           return { error: "Authentication required" };
@@ -1200,6 +1229,12 @@ export function createCoreRoutesPlugin(
         }
 
         if (!pendingValid) {
+          // Diagnostic: log the exact reason pendingValid is false so we can
+          // distinguish "state didn't validate" from "no pending row" in
+          // production "No active connect flow found" reports.
+          console.warn(
+            `[builder-callback] pending-invalid owner=${ownerEmail} has-state-param=${Boolean(requestUrl.searchParams.get(BUILDER_STATE_PARAM))} state-validated=${hasValidCallbackState} pending-error=${pendingError ?? "(none)"}`,
+          );
           await trackBuilderLifecycle(
             event,
             "builder connect failed",

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -51,6 +51,11 @@ beforeEach(() => {
     process.env.NODE_ENV = ORIGINAL_NODE_ENV;
   }
   delete process.env.AGENT_ENGINE;
+  delete process.env.AGENT_NATIVE_WORKSPACE;
+  delete process.env.VITE_AGENT_NATIVE_WORKSPACE;
+  delete process.env.FUSION_ENVIRONMENT;
+  delete process.env.FUSION_ENV_ORIGIN;
+  delete process.env.VITE_FUSION_ENV_ORIGIN;
   delete process.env.BUILDER_PRIVATE_KEY;
   delete process.env.BUILDER_PUBLIC_KEY;
   delete process.env.OPENAI_API_KEY;
@@ -371,6 +376,24 @@ describe("resolveBuilderCredential", () => {
 
     expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBeNull();
     expect(canUseDeployCredentialFallbackForRequest()).toBe(false);
+  });
+
+  it("does not use deploy-level Builder keys for signed-in hosted workspace users", async () => {
+    process.env.NODE_ENV = "development";
+    process.env.AGENT_NATIVE_WORKSPACE = "1";
+    process.env.BUILDER_PRIVATE_KEY = "deploy-key";
+    process.env.BUILDER_PUBLIC_KEY = "space-id";
+    process.env.OPENAI_API_KEY = "openai-deploy-key";
+    mockIsLocalDatabase.mockReturnValue(false);
+    mockGetRequestUserEmail.mockReturnValue("a@b.com");
+    mockGetRequestOrgId.mockReturnValue("builder_io");
+    mockReadAppSecret.mockResolvedValue(null);
+
+    expect(await resolveBuilderCredential("BUILDER_PRIVATE_KEY")).toBeNull();
+    expect(await resolveSecret("BUILDER_PRIVATE_KEY")).toBeNull();
+    expect(await resolveBuilderCredentialSource()).toBeNull();
+    expect(await resolveSecret("OPENAI_API_KEY")).toBe("openai-deploy-key");
+    expect(canUseDeployCredentialFallbackForRequest()).toBe(true);
   });
 
   it("falls back to org scope when no user-scope row exists", async () => {

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -89,6 +89,38 @@ export function canUseDeployCredentialFallbackForRequest(): boolean {
   return isDeployCredentialFallbackAllowed();
 }
 
+const BUILDER_CREDENTIAL_KEYS = [
+  "BUILDER_PRIVATE_KEY",
+  "BUILDER_PUBLIC_KEY",
+  "BUILDER_USER_ID",
+  "BUILDER_ORG_NAME",
+  "BUILDER_ORG_KIND",
+] as const;
+
+function isBuilderCredentialKey(key: string): boolean {
+  return (BUILDER_CREDENTIAL_KEYS as readonly string[]).includes(key);
+}
+
+function isHostedWorkspaceRuntime(): boolean {
+  if (isLocalDatabase()) return false;
+  const hasFusionPreview = Boolean(
+    process.env.FUSION_ENVIRONMENT ||
+    process.env.FUSION_ENV_ORIGIN ||
+    process.env.VITE_FUSION_ENV_ORIGIN,
+  );
+  return (
+    /^(1|true)$/i.test(process.env.AGENT_NATIVE_WORKSPACE ?? "") ||
+    /^(1|true)$/i.test(process.env.VITE_AGENT_NATIVE_WORKSPACE ?? "") ||
+    hasFusionPreview
+  );
+}
+
+function canUseBuilderDeployCredentialFallbackForRequest(): boolean {
+  const email = getRequestUserEmail();
+  if (email && isHostedWorkspaceRuntime()) return false;
+  return canUseDeployCredentialFallbackForRequest();
+}
+
 // ---------------------------------------------------------------------------
 // Builder credential resolution:
 //
@@ -210,7 +242,7 @@ export async function resolveBuilderCredential(
 ): Promise<string | null> {
   const scoped = await resolveScopedBuilderCredential(key);
   if (scoped) return scoped.value;
-  if (!canUseDeployCredentialFallbackForRequest()) return null;
+  if (!canUseBuilderDeployCredentialFallbackForRequest()) return null;
   return readDeployCredentialEnv(key) ?? null;
 }
 
@@ -254,7 +286,7 @@ export async function resolveHasBuilderPrivateKey(): Promise<boolean> {
 export async function resolveBuilderCredentialSource(): Promise<BuilderCredentialSource | null> {
   const scoped = await resolveScopedBuilderCredential("BUILDER_PRIVATE_KEY");
   if (scoped) return scoped.source;
-  return canUseDeployCredentialFallbackForRequest() &&
+  return canUseBuilderDeployCredentialFallbackForRequest() &&
     process.env.BUILDER_PRIVATE_KEY
     ? "env"
     : null;
@@ -388,14 +420,6 @@ export async function clearBuilderCredentialAuthFailure(creds: {
     // A stale failure marker should not block writing fresh credentials.
   }
 }
-
-const BUILDER_CREDENTIAL_KEYS = [
-  "BUILDER_PRIVATE_KEY",
-  "BUILDER_PUBLIC_KEY",
-  "BUILDER_USER_ID",
-  "BUILDER_ORG_NAME",
-  "BUILDER_ORG_KIND",
-] as const;
 
 /**
  * Write Builder credentials to `app_secrets`.
@@ -629,7 +653,11 @@ export async function resolveSecret(key: string): Promise<string | null> {
     // The deploy-level value would silently impersonate the actual key
     // owner across every tenant. Local/single-tenant deployments keep the
     // original env fallback for BYO-server workflows.
-    const envFallback = canUseDeployCredentialFallbackForRequest()
+    const envFallback = (
+      isBuilderCredentialKey(key)
+        ? canUseBuilderDeployCredentialFallbackForRequest()
+        : canUseDeployCredentialFallbackForRequest()
+    )
       ? process.env[key] || null
       : null;
     if (traceLookup) {


### PR DESCRIPTION
## Summary

- Disable Builder env-fallback for authenticated users on hosted workspace runtime (`FUSION_ENVIRONMENT` / `AGENT_NATIVE_WORKSPACE`) so a container-template's mismatched `BUILDER_PRIVATE_KEY`/`BUILDER_PUBLIC_KEY` pair can't mask per-user credentials and 403 every chat.
- When `previewOrigin` and `callbackOrigin` differ (Fusion preview that has to bounce the cli-auth callback through the gateway), `/builder/status` now omits `cliAuthUrl` and uses the `/builder/connect` trampoline so the pending-connect row is written before the gateway-served callback validates.
- Surface durable credential rejection as a new `authError` field — distinct from one-shot `connectError` — so an old rejected key pair doesn't abort the user's in-flight reconnect popup.
- `useBuilderStatus` discriminates current vs stale connect errors via `connectStartedAtRef` + `isCurrentConnectError`, so the popup keeps polling while the user picks a Builder space instead of erroring out on the previous failure.
- `/builder/callback`: diagnostic logging for owner / state / pending-valid resolution to triage "No active connect flow found" reports.

Context: in Builder.io's hosted dev container, env-set `BUILDER_PRIVATE_KEY` and `BUILDER_PUBLIC_KEY` were from different spaces, the gateway 403'd every chat with `Private key does not match spaceId`, and reconnecting via the popup landed on "No active connect flow found" so users couldn't dig out. This stack fixes both halves.

## Test plan

- [ ] On a Fusion preview deployment with a connected Builder.io account, chat works without env Builder keys set.
- [ ] On a Fusion preview deployment with mismatched env Builder keys, an authenticated user is NOT routed through the bad env keys; chat shows "Connect Builder" instead of "auth failed."
- [ ] Reconnect popup from chat error card opens, lets the user pick a space, and the callback writes per-user credentials successfully.
- [ ] On a non-hosted local dev (no `FUSION_*` / `AGENT_NATIVE_WORKSPACE` env), env-fallback still works as before for unauthenticated/CLI contexts.
- [ ] `[builder-callback]` diagnostic lines appear in server logs on every callback request.