### PR TITLE
feat(core): refresh signed Builder cli-auth URL in web popup + add authError

### DIFF
--- a/.changeset/refresh-builder-cli-auth-popup.md
+++ b/.changeset/refresh-builder-cli-auth-popup.md
@@ -1,0 +1,5 @@
+---
+"@agent-native/core": patch
+---
+
+Always refresh the Builder cli-auth URL inside a freshly-opened about:blank popup on web (desktop keeps direct path), add a stable `authError` field to BuilderStatus for persisted old-credential rejection, and keep Fusion/workspace-runtime deploy keys out of the identity fallback when a signed-in user is present.

--- a/packages/core/src/client/settings/useBuilderStatus.spec.tsx
+++ b/packages/core/src/client/settings/useBuilderStatus.spec.tsx
@@ -95,7 +95,7 @@ describe("useBuilderConnectFlow", () => {
     vi.unstubAllGlobals();
   });
 
-  it("opens the signed Builder cli-auth URL directly", async () => {
+  it("opens a blank web popup and navigates to a freshly fetched cli-auth URL", async () => {
     setUserAgent("Mozilla/5.0 Chrome/140.0");
     const popup = createPopupStub();
     openSpy.mockReturnValue(popup);
@@ -108,14 +108,16 @@ describe("useBuilderConnectFlow", () => {
 
     await act(async () => {
       container.querySelector("button")?.click();
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
     expect(openSpy).toHaveBeenCalledWith(
-      signedCliAuthUrl,
+      "about:blank",
       "_blank",
       "width=600,height=700",
     );
-    expect(popup.location.href).toBe("");
+    expect(popup.location.href).toBe(signedCliAuthUrl);
     expect(container.textContent).not.toContain("Popup blocked");
   });
 
@@ -250,7 +252,7 @@ describe("useBuilderConnectFlow", () => {
     openSpy.mockReturnValue(popup);
     const signedConnectUrl =
       "http://localhost:3000/_agent-native/builder/connect?_an_connect=signed";
-    vi.mocked(fetch).mockResolvedValue(
+    vi.mocked(fetch).mockImplementation(async () =>
       jsonResponse({
         configured: false,
         envManaged: true,
@@ -279,13 +281,16 @@ describe("useBuilderConnectFlow", () => {
 
     await act(async () => {
       container.querySelector("button")?.click();
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
     expect(openSpy).toHaveBeenCalledWith(
-      signedConnectUrl,
+      "about:blank",
       "_blank",
       "width=600,height=700",
     );
+    expect(popup.location.href).toBe(signedConnectUrl);
     expect(container.textContent).toContain("not-configured connecting");
     expect(container.textContent).not.toContain(
       "Private key does not match spaceId",
@@ -309,7 +314,7 @@ describe("useBuilderConnectFlow", () => {
     openSpy.mockReturnValue(popup);
     const signedConnectUrl =
       "http://localhost:3000/_agent-native/builder/connect?_an_connect=signed";
-    vi.mocked(fetch).mockResolvedValue(
+    vi.mocked(fetch).mockImplementation(async () =>
       jsonResponse({
         configured: false,
         envManaged: false,

--- a/packages/core/src/client/settings/useBuilderStatus.ts
+++ b/packages/core/src/client/settings/useBuilderStatus.ts
@@ -463,20 +463,16 @@ export function useBuilderConnectFlow(
     )
       ? statusConnectUrl
       : null;
-    // popupUrl prop (e.g. from a chat ConnectBuilderCard) may be a signed
-    // URL that was minted minutes-to-days ago — we don't have a mint
-    // timestamp for it, so we can't be sure it's still within the signed
-    // TTL. Use it as a *direct* popup URL only for desktop (where the
-    // about:blank refresh-in-popup path doesn't exist); on web, fall
-    // through to the refresh-in-popup branch so a stale prop URL doesn't
-    // open an expired popup.
+    // popupUrl props and statusConnectUrl are signed URLs minted before the
+    // click. In web browsers, always refresh inside an about:blank popup so a
+    // server/package restart cannot leave the user with a stale signed state.
+    // Desktop keeps the direct path because the Electron shell owns the popup.
     const signedPropUrl = hasSignedConnectToken(popupUrl) ? popupUrl : null;
     const signedCliPropUrl = hasSignedCallbackState(popupUrl) ? popupUrl : null;
     const fallbackUrl = new URL(
       agentNativePath("/_agent-native/builder/connect"),
       origin,
     ).href;
-    const hasDirectSignedUrl = Boolean(cachedFreshUrl);
     const directUrl =
       cachedFreshUrl ?? signedCliPropUrl ?? signedPropUrl ?? fallbackUrl;
 
@@ -488,18 +484,6 @@ export function useBuilderConnectFlow(
       if (!opened) {
         // Agent Native Desktop handles the popup in Electron and reports
         // null to the embedded webview, so null is not a blocker here.
-      }
-    } else if (hasDirectSignedUrl) {
-      const opened = openBuilderConnectPopup({
-        url: directUrl,
-        source: trackingSource,
-        features: "width=600,height=700",
-      });
-      if (!opened) {
-        connectStartedAtRef.current = null;
-        setConnecting(false);
-        setError("Couldn't open Builder. Allow popups and try again.");
-        return;
       }
     } else {
       const opened = openBuilderConnectPopup({
@@ -535,14 +519,7 @@ export function useBuilderConnectFlow(
           setOrgName(s.orgName ?? null);
         }
 
-        const freshUrl =
-          (s?.cliAuthUrl && hasSignedCallbackState(s.cliAuthUrl)
-            ? s.cliAuthUrl
-            : null) ??
-          (s?.connectUrl && hasSignedConnectToken(s.connectUrl)
-            ? s.connectUrl
-            : null) ??
-          cachedFreshUrl;
+        const freshUrl = s?.cliAuthUrl ?? s?.connectUrl ?? null;
         if (!freshUrl) {
           try {
             opened.close();

--- a/packages/core/src/server/credential-provider.spec.ts
+++ b/packages/core/src/server/credential-provider.spec.ts
@@ -384,7 +384,10 @@ describe("resolveBuilderCredential", () => {
     process.env.BUILDER_PRIVATE_KEY = "deploy-key";
     process.env.BUILDER_PUBLIC_KEY = "space-id";
     process.env.OPENAI_API_KEY = "openai-deploy-key";
-    mockIsLocalDatabase.mockReturnValue(false);
+    // Fusion/workspace dev servers can still look "local" to DB detection
+    // during startup, but their Builder env fallback must not impersonate the
+    // signed-in user.
+    mockIsLocalDatabase.mockReturnValue(true);
     mockGetRequestUserEmail.mockReturnValue("a@b.com");
     mockGetRequestOrgId.mockReturnValue("builder_io");
     mockReadAppSecret.mockResolvedValue(null);

--- a/packages/core/src/server/credential-provider.ts
+++ b/packages/core/src/server/credential-provider.ts
@@ -102,7 +102,6 @@ function isBuilderCredentialKey(key: string): boolean {
 }
 
 function isHostedWorkspaceRuntime(): boolean {
-  if (isLocalDatabase()) return false;
   const hasFusionPreview = Boolean(
     process.env.FUSION_ENVIRONMENT ||
     process.env.FUSION_ENV_ORIGIN ||
@@ -117,6 +116,10 @@ function isHostedWorkspaceRuntime(): boolean {
 
 function canUseBuilderDeployCredentialFallbackForRequest(): boolean {
   const email = getRequestUserEmail();
+  // Builder workspace previews can run with NODE_ENV=development and their DB
+  // detection can look local during early startup. Once a real signed-in user
+  // is present, hosted workspace flags are enough to make deployment-level
+  // Builder keys unsafe as an identity fallback.
   if (email && isHostedWorkspaceRuntime()) return false;
   return canUseDeployCredentialFallbackForRequest();
 }


### PR DESCRIPTION
## Summary

- Always open the connect popup to \`about:blank\` on web and navigate to a freshly fetched cli-auth URL — a stale signed URL minted before a server/package restart can no longer reach Builder. Desktop keeps the direct path.
- New \`BuilderStatus.authError\` field carries persisted credential-rejection messages stably across reloads without aborting an active reconnect; gated by \`isCurrentConnectError\` against the in-flight connect's started-at timestamp.
- \`credential-provider.isHostedWorkspaceRuntime\` drops the \`isLocalDatabase\` short-circuit; \`canUseBuilderDeployCredentialFallbackForRequest\` keeps deploy-level Builder keys out of identity fallback whenever a signed-in user is present in a hosted workspace runtime (Fusion/workspace dev servers can look "local" during startup).

## Test plan

- [x] \`pnpm run prep\` — Test Files 164 passed (164), Tests 1589 passed (1589)