### PR TITLE
fix(migrate): scaffold ssr-entry + entry.server.tsx and add @types deps in generated apps

### DIFF
--- a/packages/migrate/src/adapters/agent-native-target.ts
+++ b/packages/migrate/src/adapters/agent-native-target.ts
@@ -54,7 +54,9 @@ export async function scaffoldAgentNativeTarget(
   await write("server/plugins/auth.ts", authPlugin());
   await write("server/plugins/agent-chat.ts", agentChatPlugin());
   await write("server/routes/[...page].get.ts", ssrRoute());
+  await write("ssr-entry.ts", ssrEntry());
   await write("app/routes.ts", routesTs());
+  await write("app/entry.server.tsx", entryServerTsx());
   await write("app/root.tsx", rootTsx());
   await write("app/global.css", globalCss());
   await write("app/routes/_index.tsx", indexRoute(context));
@@ -181,6 +183,9 @@ function packageJson(): string {
         "@react-router/dev": "^7.13.1",
         "@react-router/fs-routes": "^7.13.1",
         "@tailwindcss/vite": "^4.2.4",
+        "@types/node": "^25.8.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         typescript: "^6.0.3",
         vite: "8.0.3",
       },
@@ -306,11 +311,86 @@ export default createH3SSRHandler(() => import("virtual:react-router/server-buil
 `;
 }
 
+function ssrEntry(): string {
+  return `import { createRequestHandler } from "react-router";
+
+const handler = createRequestHandler(
+  () => import("virtual:react-router/server-build"),
+);
+
+export default {
+  async fetch(request: Request) {
+    return handler(request);
+  },
+};
+`;
+}
+
 function routesTs(): string {
   return `import { type RouteConfig } from "@react-router/dev/routes";
 import { flatRoutes } from "@react-router/fs-routes";
 
 export default flatRoutes() satisfies RouteConfig;
+`;
+}
+
+function entryServerTsx(): string {
+  return `import type { AppLoadContext, EntryContext } from "react-router";
+import { ServerRouter } from "react-router";
+import ReactDOMServer from "react-dom/server.browser";
+const { renderToReadableStream } = ReactDOMServer;
+import { isbot } from "isbot";
+import { wrapWithAnalytics } from "@agent-native/core/server";
+
+export const streamTimeout = 5_000;
+
+export default async function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext,
+  _loadContext: AppLoadContext,
+) {
+  if (request.method.toUpperCase() === "HEAD") {
+    return new Response(null, {
+      status: responseStatusCode,
+      headers: responseHeaders,
+    });
+  }
+
+  const userAgent = request.headers.get("user-agent");
+  const waitForAll = (userAgent && isbot(userAgent)) || routerContext.isSpaMode;
+
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(() => abortController.abort(), streamTimeout);
+
+  try {
+    const body = await renderToReadableStream(
+      <ServerRouter context={routerContext} url={request.url} />,
+      {
+        signal: abortController.signal,
+        onError(error: unknown) {
+          if (!abortController.signal.aborted) {
+            responseStatusCode = 500;
+            console.error(error);
+          }
+        },
+      },
+    );
+
+    if (waitForAll) {
+      await body.allReady;
+    }
+
+    responseHeaders.set("Content-Type", "text/html");
+    return new Response(wrapWithAnalytics(body), {
+      headers: responseHeaders,
+      status: responseStatusCode,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
 `;
 }
 

--- a/packages/migrate/src/recipes/agent-native.ts
+++ b/packages/migrate/src/recipes/agent-native.ts
@@ -132,7 +132,7 @@ function recipe(
     description: title,
     async selectTasks(context: MigrationContext) {
       return select(context.ir).map((task, index) => ({
-        id: `${name}-${index + 1}`,
+        id: `${context.run.id}:${name}-${index + 1}`,
         runId: context.run.id,
         recipeName: name,
         title: task.title,

--- a/packages/migrate/src/runtime.spec.ts
+++ b/packages/migrate/src/runtime.spec.ts
@@ -51,4 +51,56 @@ describe("migration runtime", () => {
       fs.stat(path.join(outputRoot, "actions/view-screen.ts")),
     ).resolves.toBeTruthy();
   });
+
+  it("namespaces task ids per run so repeated assessments can share a database", async () => {
+    const sourceRoot = path.join(
+      path.resolve(__dirname, "."),
+      "__fixtures__/next-pages",
+    );
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "an-migrate-ids-"));
+    const artifactRoot = path.join(tmp, "artifacts");
+
+    const firstRun = await createMigrationRun({
+      sourceRoot,
+      outputRoot: path.join(tmp, "first-output"),
+      artifactRoot,
+      id: "mig_first",
+    });
+    const secondRun = await createMigrationRun({
+      sourceRoot,
+      outputRoot: path.join(tmp, "second-output"),
+      artifactRoot,
+      id: "mig_second",
+    });
+
+    const firstDiscovered = await discoverMigration(
+      firstRun,
+      nextjsSourceAdapter,
+    );
+    const secondDiscovered = await discoverMigration(
+      secondRun,
+      nextjsSourceAdapter,
+    );
+    const firstPlan = await planMigration(
+      firstDiscovered.run,
+      firstDiscovered.ir,
+    );
+    const secondPlan = await planMigration(
+      secondDiscovered.run,
+      secondDiscovered.ir,
+    );
+
+    expect(firstPlan.tasks.length).toBeGreaterThan(0);
+    expect(secondPlan.tasks.length).toBe(firstPlan.tasks.length);
+    expect(
+      firstPlan.tasks.every((task) => task.id.startsWith("mig_first:")),
+    ).toBe(true);
+    expect(
+      secondPlan.tasks.every((task) => task.id.startsWith("mig_second:")),
+    ).toBe(true);
+    expect(
+      new Set([...firstPlan.tasks, ...secondPlan.tasks].map((task) => task.id))
+        .size,
+    ).toBe(firstPlan.tasks.length + secondPlan.tasks.length);
+  });
 });


### PR DESCRIPTION
## Summary

- \`agent-native-target\` adapter now writes \`ssr-entry.ts\` and \`app/entry.server.tsx\` so generated apps boot under React Router 7's SSR handler without missing-file errors.
- Generated \`package.json\` picks up \`@types/node\`, \`@types/react\`, \`@types/react-dom\`.
- New runtime spec coverage + a small recipe tweak.

## Test plan

- [x] \`pnpm run prep\` — Tests 1607 + 4 + 15 passed