### PR TITLE
fix: address PR #705 review — migration port, /docs canonical, generated-route JSX escaping

### DIFF
--- a/.changeset/migration-port-canonical-jsx.md
+++ b/.changeset/migration-port-canonical-jsx.md
@@ -1,0 +1,6 @@
+---
+"@agent-native/core": patch
+"@agent-native/migrate": patch
+---
+
+Fix migration template dev-port collision (8100 → 8101), emit a single canonical for /docs and /docs/getting-started, and JSON-escape generated route paths so Next.js dynamic segments can't break scaffolded TSX.

--- a/packages/core/src/cli/templates-meta.ts
+++ b/packages/core/src/cli/templates-meta.ts
@@ -156,7 +156,7 @@ export const TEMPLATES: TemplateMeta[] = [
     icon: "Route",
     color: "#0F766E",
     colorRgb: "15 118 110",
-    devPort: 8100,
+    devPort: 8101,
     defaultMode: "dev",
     hidden: true,
     requiredPackages: ["migrate"],

--- a/packages/docs/app/root.tsx
+++ b/packages/docs/app/root.tsx
@@ -95,10 +95,20 @@ export const meta = () => [
   { property: "og:site_name", content: "Agent-Native" },
 ];
 
+// Aliases that serve the same content under multiple paths. Both surfaces
+// link rel=canonical to the primary path so search engines don't see them
+// as duplicates. Keep in sync with the alias mapping in
+// `packages/docs/server/routes/[...page].get.ts` (currently /docs serves
+// docs/getting-started.md, so /docs/getting-started canonicalizes to /docs).
+const CANONICAL_ALIASES: Record<string, string> = {
+  "/docs/getting-started": "/docs",
+};
+
 function CanonicalLink() {
   const location = useLocation();
   const path = location.pathname.replace(/\/$/, "") || "/";
-  const canonical = `${SITE_URL}${path}`;
+  const canonicalPath = CANONICAL_ALIASES[path] ?? path;
+  const canonical = `${SITE_URL}${canonicalPath}`;
   return <link rel="canonical" href={canonical} />;
 }
 

--- a/packages/migrate/src/adapters/agent-native-target.ts
+++ b/packages/migrate/src/adapters/agent-native-target.ts
@@ -462,14 +462,22 @@ function generatedRoute(
   sourceFile: string,
   isPublic: boolean,
 ): string {
+  // Emit dynamic strings as JSON-stringified JSX expressions so route paths
+  // containing JSX-significant characters (`{`, `}`, `<`, `>`, `&`) or
+  // template-literal terminators (backticks, `${`) can't break the outer
+  // generated file. Next.js routes legitimately contain `[slug]`, `(group)`,
+  // and `@parallel` segments; any of those slipping into JSX text un-escaped
+  // would produce invalid TS.
+  const routePathExpr = JSON.stringify(routePath);
+  const sourceFileExpr = JSON.stringify(sourceFile);
   return `export default function MigratedRoute() {
   return (
     <main style={{ padding: 32, fontFamily: "system-ui, sans-serif" }}>
       <p style={{ textTransform: "uppercase", fontSize: 12, letterSpacing: 1, color: "#666" }}>
         ${isPublic ? "Public SSR route" : "Logged-in app route"}
       </p>
-      <h1>${routePath}</h1>
-      <p>Source: <code>${sourceFile}</code></p>
+      <h1>{${routePathExpr}}</h1>
+      <p>Source: <code>{${sourceFileExpr}}</code></p>
       <p>This route is a scaffolded migration placeholder. Continue the recipe sweep to port UI, actions, SQL, and app-state behavior.</p>
     </main>
   );

--- a/packages/shared-app-config/templates.ts
+++ b/packages/shared-app-config/templates.ts
@@ -212,7 +212,7 @@ export const TEMPLATES: TemplateMeta[] = [
     icon: "Route",
     color: "#0F766E",
     colorRgb: "15 118 110",
-    devPort: 8100,
+    devPort: 8101,
     defaultMode: "dev",
     hidden: true,
     requiredPackages: ["migrate"],


### PR DESCRIPTION
Follow-up to #705 (merged). Addresses all 3 Builder review findings:

## Summary

- **Migration template port conflict** — bumped `migration` devPort 8100 → 8101 in `shared-app-config/templates.ts` + `cli/templates-meta.ts` (8100 collided with `images`, breaking the qa-frame-desktop-smoke port-uniqueness invariant).
- **Duplicate canonical for /docs** — `CanonicalLink` now maps `/docs/getting-started` → `/docs` via a `CANONICAL_ALIASES` table, matching the alias already handled server-side in `[...page].get.ts`.
- **Unsanitized generated route JSX** — `generatedRoute()` emits `routePath`/`sourceFile` as JSON-stringified JSX expressions so Next.js `[slug]`/`(group)`/`@parallel` segments (and `{}<>&`/backtick/`${`) can't produce invalid TSX.

## Test plan

- [x] `pnpm run prep` — Tests 1607 + 4 + 15 passed